### PR TITLE
(TASKS-22) Add help and version options

### DIFF
--- a/exe/bolt
+++ b/exe/bolt
@@ -8,6 +8,8 @@ cli = Bolt::CLI.new(ARGV)
 begin
   opts = cli.parse
   cli.execute(opts)
+rescue Bolt::CLIExit
+  exit
 rescue Bolt::CLIError => e
   $stderr.puts e.message
   exit e.error_code

--- a/lib/bolt/version.rb
+++ b/lib/bolt/version.rb
@@ -1,0 +1,3 @@
+module Bolt
+  VERSION = "0.0.1"
+end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -14,6 +14,37 @@ describe "Bolt::CLI" do
     expect(cli.parse).to include(:leftovers => %w[exec])
   end
 
+  describe "help" do
+    it "generates help when no arguments are specified" do
+      cli = Bolt::CLI.new([])
+      expect {
+        expect {
+          cli.parse
+        }.to raise_error(Bolt::CLIExit)
+      }.to output(/Runs ad-hoc tasks on your hosts/).to_stdout
+    end
+
+    it "accepts --help" do
+      cli = Bolt::CLI.new(%w[--help])
+      expect {
+        expect {
+          cli.parse
+        }.to raise_error(Bolt::CLIExit)
+      }.to output(/Runs ad-hoc tasks on your hosts/).to_stdout
+    end
+  end
+
+  describe "version" do
+    it "emits a version string" do
+      cli = Bolt::CLI.new(%w[--version])
+      expect {
+        expect {
+          cli.parse
+        }.to raise_error(Bolt::CLIExit)
+      }.to output(/\d+\.\d+\.\d+/).to_stdout
+    end
+  end
+
   describe "hosts" do
     it "accepts a single host" do
       cli = Bolt::CLI.new(%w[exec --hosts foo])


### PR DESCRIPTION
Add --version and --help options. Note -h is short for --hosts, so doesn't
generate help.