### PR TITLE
(maint) Rake improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ rvm:
 before_script:
 - cat Gemfile.lock
 script:
-- bundle exec rspec --tag ~vagrant
-- bundle exec rubocop
+- bundle exec rake unit rubocop
 notifications:
   email: false
   hipchat:

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,22 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require "rubocop/rake_task"
 
+desc "Run all RSpec tests"
 RSpec::Core::RakeTask.new(:spec)
 
-task(default: :spec)
+desc "Run RSpec tests that don't require VM fixtures"
+RSpec::Core::RakeTask.new(:unit) do |t|
+  t.rspec_opts = '--tag ~vagrant'
+end
+
+RuboCop::RakeTask.new(:rubocop) do |t|
+  t.options = ['--display-cop-names', '--display-style-guide']
+end
+
+desc "Run tests and style checker"
+task test: %w[spec rubocop]
+
+task :default do
+  system "rake --tasks"
+end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,4 +25,4 @@ before_test:
   - type Gemfile.lock
 
 test_script:
-  - bundle exec rspec spec --tag ~vagrant
+  - bundle exec rake unit


### PR DESCRIPTION
Add rake tasks for useful combinations of test running.
Rake unit runs specs not tagged `vagrant`, rake test runs all specs and
rubocop. Use the unit task in CI.