### PR TITLE
Prototype of adding a docker node type

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "winrm-fs", "~> 1.0"
   spec.add_dependency "trollop", "~> 2.0"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
+  spec.add_dependency "docker-api", "~> 1.3"
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -4,9 +4,9 @@ module Bolt
   class Node
     def self.parse_uri(node)
       case node
-      when %r{^(ssh|winrm)://.*:\d+$}
+      when %r{^(ssh|winrm|docker)://.*:\d+$}
         URI(node)
-      when %r{^(ssh|winrm)://}
+      when %r{^(ssh|winrm|docker)://}
         uri = URI(node)
         uri.port = uri.scheme == 'ssh' ? 22 : 5985
         uri
@@ -21,6 +21,8 @@ module Bolt
       uri = parse_uri(uri_string)
       klass = if uri.scheme == 'winrm'
                 Bolt::WinRM
+              elsif uri.scheme == 'docker'
+                Bolt::Docker
               else
                 Bolt::SSH
               end
@@ -52,3 +54,4 @@ end
 
 require 'bolt/node/ssh'
 require 'bolt/node/winrm'
+require 'bolt/node/docker'

--- a/lib/bolt/node/docker.rb
+++ b/lib/bolt/node/docker.rb
@@ -1,0 +1,60 @@
+require 'docker'
+
+module Bolt
+  class Docker < Node
+    def connect
+      @container = ::Docker::Container.get(@host)
+    end
+
+    def disconnect; end
+
+    def execute(command)
+      result_output = Bolt::ResultOutput.new
+      out, err, code = @container.exec([command])
+      result_output.stdout << out
+      result_output.stderr << err
+      if code.zero?
+        Bolt::Success.new(out, result_output)
+      else
+        Bolt::Failure.new(code, result_output)
+      end
+    end
+
+    def copy(source, destination)
+      contents = File.open(source, 'rb', &:read)
+      @container.store_file(destination, contents)
+      Bolt::Success.new
+    rescue => e
+      Bolt::ExceptionFailure.new(e)
+    end
+
+    def make_tempdir
+      Bolt::Success.new(@container.exec(['mktemp -d']))
+    rescue => e
+      Bolt::ExceptionFailure.new(e)
+    end
+
+    def run_script(script)
+      remote_path = ''
+      dir = ''
+      result = nil
+
+      make_tempdir.then do |value|
+        dir = value
+        remote_path = "#{dir}/#{File.basename(script)}"
+        Bolt::Success.new
+      end.then do
+        copy(script, remote_path)
+      end.then do
+        execute("chmod u+x '#{remote_path}'")
+      end.then do
+        result = execute("'#{remote_path}'")
+      end.then do
+        execute("rm -f '#{remote_path}'")
+      end.then do
+        execute("rmdir '#{dir}'")
+        result
+      end
+    end
+  end
+end


### PR DESCRIPTION
This isn't tested or even likely complete, but it hopefully shows how
bolt could be used to execute commands in the context of a Docker
container, via the Docker exec API.

```
$ docker ps
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS               NAMES
71d421dd5133        ubuntu              "/bin/sh -c 'while..."   2 hours ago         Up 2 hours                              admiring_archimedes
$ bundle exec bolt exec -n docker://admiring_archimedes command=uptime
admiring_archimedes: [" 13:53:10 up  1:42,  0 users,  load average: 0.00, 0.00, 0.00\n"][]
bundle exec bolt exec -n docker://admiring_archimedes command="date"
admiring_archimedes: ["Tue Aug 29 13:57:45 UTC 2017\n"][]
```

Client configuration is done via the standard `DOCKER_URL` env supported by most docker tooling (including the underlying Ruby library used here).

Just putting out there as I'd been having a look at Bolt, and considering in the context of the Cloud and Containers demos at PuppetConf. If there is interest in this let me know and I'll look to find time to clean up.