### PR TITLE
(TASKS-50) Run the init task when given a module name

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -84,12 +84,13 @@ END
         when 'task'
           name = options[:leftovers][0]
           unless task_file?(name)
-            name = load_task_file(name, options[:modules])
-            if name.nil?
+            path = load_task_file(name, options[:modules])
+            if path.nil?
               raise Bolt::CLIError.new(
-                "Failed to load task file for #{name}", 1
+                "Failed to load task file for '#{name}'", 1
               )
             end
+            name = path
           end
           executor.run_task(name, options[:task_options])
         end
@@ -120,6 +121,7 @@ END
       end
 
       module_name, file_name = name.split('::', 2)
+      file_name ||= 'init'
 
       env = Puppet::Node::Environment.create('bolt', [modules])
       Puppet.override(environments: Puppet::Environments::Static.new(env)) do

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -187,5 +187,23 @@ describe "Bolt::CLI" do
       }
       cli.execute(options)
     end
+
+    it "runs an init task given a module name" do
+      task_name = 'sample'
+      task_params = { 'message' => 'hi' }
+      expect(executor)
+        .to receive(:run_task)
+        .with(%r{modules/sample/tasks/init.sh$}, task_params).and_return({})
+      expect(cli).to receive(:task_file?).with(task_name).and_return(false)
+
+      options = {
+        nodes: nodes,
+        mode: 'task',
+        leftovers: [task_name],
+        task_options: task_params,
+        modules: File.join(__FILE__, '../../fixtures/modules')
+      }
+      cli.execute(options)
+    end
   end
 end

--- a/spec/fixtures/modules/sample/tasks/init.sh
+++ b/spec/fixtures/modules/sample/tasks/init.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo $PT_message


### PR DESCRIPTION
If the task name does not contain '::', then it refers to a module, and we
should assume we're running the module's `init` task. The file on disk may have
an extension, e.g. init.sh, ignore the extension if present.

Also fix the exception message so that it includes the original task
name, not the nil value returned from `load_task_file`.