### PR TITLE
[For discussion] Rub some release engineering on it 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ Gemfile.local
 
 .vagrant/
 .byebug_history
+bolt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+
+
+VERSION=$(shell ruby -r './lib/bolt/version' -e "puts Bolt::VERSION")
+TARGET=bolt
+TMPDIR=`mktemp -d`
+PLATFORM=$(shell uname | awk '{print tolower($$0)}')
+
+#TODO make this work on Windows (cleanly)
+
+all: $(TARGET)
+
+fat-binary: $(TARGET)
+
+$(TARGET):
+	rubyc -d $(TMPDIR) -o $(TARGET)-$(VERSION) -c --auto-update-url=http://updates.puppet.com/$(TARGET)/$(PLATFORM) --auto-update-base=$(VERSION)  exe/$(TARGET)
+
+clean:
+	rm -rf $(TARGET)-* /tmp/rubyc ~/.libautoupdate $(TARGET)


### PR DESCRIPTION
As a prototype for a delivery vehicle for bolt, a Makefile has been
added which builds bolt into a single executable (fat binary) which
includes all of the runtime and bolt itself. It also will auto-update
given the proper server that conforms to the libautoupdate protocol
expectations.

To build bolt into a single executable for Mac or Linux, simply type
`make` after installing [rubyc](https://github.com/pmq20/ruby-packer),
squashfs-tools, bison, ruby (devel headers as well) and gcc.

This doens't quite work for Windows yet, but should after a few more
rounds of debugging with somebody who knows a little more about Windows
than me.

This fat binary also autoupdates using
[libautoateupdate](https://github.com/pmq20/libautoupdate). A basic
server can be run to test autoupdates found at
[puppetlabs/libautoupdate_server](https://github.com/puppetlabs/libautoupdate_server).

Signed-off-by: Michael Stahnke <stahnma@puppet.com>