### PR TITLE
(TASKS-47) Update CLI to UX spec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,7 +30,7 @@ Metrics/MethodLength:
   Enabled: false
 
 Metrics/ClassLength:
-  Max: 150
+  Enabled: false
 
 Layout/IndentHeredoc:
   Enabled: false

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-sftp", "~> 2.0"
   spec.add_dependency "winrm", "~> 2.0"
   spec.add_dependency "winrm-fs", "~> 1.0"
-  spec.add_dependency "trollop", "~> 2.0"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 1.14"


### PR DESCRIPTION
This reimplements the CLI using ruby's built-in OptionParser, following
the spec in ux/bolt-CLI-spec.md. It may not yet be complete.