### PR TITLE
(TASKS-56) Collect stderr from SSH connections

### DIFF
--- a/lib/bolt/node/ssh.rb
+++ b/lib/bolt/node/ssh.rb
@@ -27,10 +27,12 @@ module Bolt
           channel.on_data do |_, data|
             result_output.stdout << data
           end
-          channel.on_extended_data do |_, data|
+
+          channel.on_extended_data do |_, _, data|
             result_output.stderr << data
           end
-          channel.on_request "exit-status" do |_, data|
+
+          channel.on_request("exit-status") do |_, data|
             status[:exit_code] = data.read_long
           end
 

--- a/spec/bolt/node/ssh_spec.rb
+++ b/spec/bolt/node/ssh_spec.rb
@@ -20,6 +20,10 @@ describe Bolt::SSH do
     expect(ssh.execute(command).value).to eq("/home/vagrant\n")
   end
 
+  it "captures stderr from a host", vagrant: true do
+    expect(ssh.execute("ssh -V").output.stderr.string).to match(/OpenSSH/)
+  end
+
   it "can copy a file to a host", vagrant: true do
     contents = "kljhdfg"
     with_tempfile_containing('copy-test', contents) do |file|


### PR DESCRIPTION
A previous commit broke how we collect stderr on SSH, such as when executing
`ssh -V`. In net-ssh 4.x, the on_extended_data block is passed 3 arguments, not
2. The second argument is the type, which we were previously reporting as the
stderr data.