### PR TITLE
(maint) Add required ruby version to gemspec

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  
+
   spec.required_ruby_version = "~> 2.1"
 
   spec.add_dependency "net-ssh", "~> 4.0"


### PR DESCRIPTION
The readme states that the required ruby version is 2.1+,
so this commit codifies it in the gemspec to anything 
`>= 2.1.0` and `< 3` (`~> 2.1`).