### PR TITLE
Add orchestrator transport to bolt

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,3 +59,6 @@ Metrics/ParameterLists:
 
 Metrics/PerceivedComplexity:
   Enabled: false
+
+Metrics/LineLength:
+    Max: 130

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ gemspec
 
 gem "rubocop", require: false
 
+gem 'orchestrator_client', git: 'git@github.com:puppetlabs/orchestrator_api-ruby.git', branch: 'master'
+
 if File.exist? "Gemfile.local"
   eval_gemfile "Gemfile.local"
 end

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Tasks can receive input as either environment variables or a JSON hash on standa
 
 When executing the task, specify the parameter value on the command line in the format `parameter=value`. Pass multiple parameters as a space-separated list.
 
-For example, to run mysql tasks against a database called 'mydatabase', specify the database parameter as `database=mydatabase`. 
+For example, to run mysql tasks against a database called 'mydatabase', specify the database parameter as `database=mydatabase`.
 
 When you run a command with this parameter, Bolt sets the task's `database` value to mydatabase before it executes the task. It also submits the parameters as JSON to stdin:
 
@@ -169,6 +169,19 @@ For example, in your `params.json` file, specify:
 ```
 
 Then specify that file on the command line with the parameters flag: `--params @params.json`
+
+### Configuring Puppet Orchestrator for Bolt
+
+Bolt can use the Puppet orchestrator to target nodes using the `pcp` protocol when running on linux.
+
+1. Configure `~/.puppetlabs/client-tools/orchestrator.conf` to include
+   service-url and cacert options to connect to you puppet master.
+1. Store a PE RBAC token in `~/.puppetlabs/token`.
+1. Install the bolt helper task `tasks/init` by installing this repository into
+   the production environment on your puppet master. Without this task the
+   exec, script and file commands will not work in Bolt.
+1. To run tasks over orchestrator the tasks must be installed both on the bolt
+   node and into the production environment on the master
 
 ## Usage examples
 
@@ -206,9 +219,9 @@ Then specify that file on the command line with the parameters flag: `--params @
     pluto:
 
     Updating policy...
-    
+
     Computer Policy update has completed successfully.
-    
+
     User Policy update has completed successfully.
 
     Ran on 1 node in 11.21 seconds

--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,11 @@ RSpec::Core::RakeTask.new(:unit) do |t|
   t.rspec_opts = '--tag ~vagrant'
 end
 
+desc "Run RSpec tests that don't require VM fixtures or orchestrator"
+RSpec::Core::RakeTask.new(:windows) do |t|
+  t.rspec_opts = '--tag ~vagrant --tag ~orchestrator'
+end
+
 RuboCop::RakeTask.new(:rubocop) do |t|
   t.options = ['--display-cop-names', '--display-style-guide']
 end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,4 +26,4 @@ before_test:
   - type Gemfile.lock
 
 test_script:
-  - bundle exec rake unit
+  - bundle exec rake windows

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -11,8 +11,11 @@ module Bolt
     def self.from_uri(uri_string, default_user = nil, default_password = nil,
                       **kwargs)
       uri = NodeURI.new(uri_string)
-      klass = if uri.scheme == 'winrm'
+      klass = case uri.scheme
+              when 'winrm'
                 Bolt::WinRM
+              when 'pcp'
+                Bolt::Orch
               else
                 Bolt::SSH
               end
@@ -73,3 +76,4 @@ end
 
 require 'bolt/node/ssh'
 require 'bolt/node/winrm'
+require 'bolt/node/orch'

--- a/lib/bolt/node/orch.rb
+++ b/lib/bolt/node/orch.rb
@@ -1,0 +1,97 @@
+require 'base64'
+require 'json'
+require 'orchestrator_client'
+
+module Bolt
+  class Orch < Node
+    CONF_FILE = File.expand_path('~/.puppetlabs/client-tools/orchestrator.conf')
+
+    def connect; end
+
+    def disconnect; end
+
+    def make_client
+      OrchestratorClient.new({}, true)
+    end
+
+    def client
+      @client ||= make_client
+    end
+
+    def _run_task(task, _input_method, arguments)
+      body = { task: task,
+               params: arguments,
+               scope: {
+                 nodes: [@host]
+               } }
+      # Should we handle errors here or let them propagate?
+      results = client.run_task(body)
+      node_result = results[0]
+      state = node_result['state']
+      result = node_result['result']
+
+      result_output = Bolt::Node::ResultOutput.new
+      result_output.stdout << result.to_json
+      if state == 'finished'
+        Bolt::Node::Success.new(result.to_json, result_output)
+      else
+        # Try to extract the exit_code from _error
+        begin
+          exit_code = result['_error']['details']['exit_code'] || 'unknown'
+        rescue NoMethodError
+          exit_code = 'unknown'
+        end
+        Bolt::Node::Failure.new(exit_code, result_output)
+      end
+    end
+
+    # run_task generates a result that makes sense for a generic task which
+    # needs to be unwrapped to extract stdout/stderr/exitcode.
+    #
+    def unwrap_bolt_result(result)
+      task_result = JSON.parse(result.output.stdout.string)
+      if task_result['exit_code'].nil?
+        # something went wrong return the failure
+        return result
+      end
+
+      # Otherwise create a new result with the captured output
+      result_output = Bolt::Node::ResultOutput.new
+      result_output.stdout << task_result['stdout']
+      result_output.stderr << task_result['stderr']
+      if (task_result['exit_code']).zero?
+        Bolt::Node::Success.new(task_result['stdout'], result_output)
+      else
+        Bolt::Node::Failure.new(task_result['exit_code'], result_output)
+      end
+    end
+
+    def _run_command(command, options = {})
+      result = _run_task('bolt', 'stdin', action: 'command', command: command, options: options)
+      unwrap_bolt_result(result)
+    end
+
+    def _upload(source, destination)
+      content = File.open(source, &:read)
+      content = Base64.encode64(content)
+      mode = File.stat(source).mode
+      params = {
+        action: 'upload',
+        path: destination,
+        content: content,
+        mode: mode
+      }
+      _run_task('bolt', 'stdin', params)
+    end
+
+    def _run_script(script)
+      content = File.open(script, &:read)
+      content = Base64.encode64(content)
+      params = {
+        action: 'script',
+        content: content
+      }
+      unwrap_bolt_result(_run_task('bolt', 'stdin', params))
+    end
+  end
+end

--- a/lib/bolt/node_uri.rb
+++ b/lib/bolt/node_uri.rb
@@ -6,7 +6,9 @@ module Bolt
 
     def parse(string)
       case string
-      when %r{^(ssh|winrm)://.*:\d+$}
+      when %r{^(ssh|winrm|pcp)://.*:\d+$}
+        URI(string)
+      when %r{^pcp://}
         URI(string)
       when %r{^(ssh|winrm)://}
         uri = URI(string)

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "puppetlabs-bolt",
+  "version": "0.1.0",
+  "author": "puppetlabs",
+  "summary": "bolt ",
+  "license": "Apache-2.0",
+  "source": "https://github.com/puppetlabs/bolt",
+  "project_page": "https://github.com/puppetlabs/bolt",
+  "issues_url": "https://tickets.puppetlabs.com/browse/BOLT/",
+  "dependencies": [],
+  "data_provider": null
+}
+

--- a/spec/bolt/node/orch_spec.rb
+++ b/spec/bolt/node/orch_spec.rb
@@ -1,0 +1,251 @@
+require 'spec_helper'
+require 'bolt_spec/files'
+require 'bolt/node'
+require 'bolt/node/ssh'
+require 'bolt/cli'
+require 'open3'
+
+describe Bolt::Orch, orchestrator: true do
+  include BoltSpec::Files
+
+  let(:hostname) { "localhost" }
+  let(:user) { "nil" }
+  let(:password) { "nil" }
+  let(:port) { nil }
+  let(:orch) { Bolt::Orch.new(@hostname) }
+
+  let(:task) { @task = "foo" }
+  let(:params) { { param: 'val' } }
+  let(:scope) { { nodes: [@hostname] } }
+  let(:result_state) { 'finished' }
+  let(:result) { { '_output' => 'ok' } }
+  let(:base_path) do
+    File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..'))
+  end
+
+  before(:each) do
+    Bolt.log_level = Logger::WARN
+    @task = "foo"
+    @params =  { param: 'val' }
+    @scope = { nodes: [@hostname] }
+    @result_state = 'finished'
+    @result = { '_output' => 'ok' }
+  end
+
+  def mock_client
+    body = { task: @task, params: @params, scope: @scope }
+    results = [{ 'state' => @result_state, 'result' => @result }]
+
+    orch_client = instance_double("OrchestratorClient")
+    orch.instance_variable_set(:@client, orch_client)
+
+    expect(orch_client).to(receive(:run_task).with(body).and_return(results))
+  end
+
+  def bolt_task_client
+    bolt_task = File.expand_path(File.join(base_path, 'tasks', 'init.rb'))
+    body = { task: 'bolt', params: @params, scope: @scope }
+
+    orch_client = instance_double("OrchestratorClient")
+    orch.instance_variable_set(:@client, orch_client)
+    allow(orch_client).to(receive(:run_task).with(body) do
+      Open3.popen3("ruby #{bolt_task};") do |stdin, stdout, stderr, wt|
+        stdin.write(@params.to_json)
+        stdin.close
+        output = stdout.read
+        err = stderr.read
+        exit_code = wt.value.exitstatus
+        expect(err).to be_empty
+        expect(exit_code).to eq(0)
+        result = JSON.parse(output)
+        [{ 'state' => 'finished', 'result' => result }]
+      end
+    end)
+  end
+
+  def set_exec_params(command, options = {})
+    @params = { action: 'command', command: command, options: options }
+  end
+
+  def set_upload_params(source, destination)
+    content = File.open(source, &:read)
+    content = Base64.encode64(content)
+    mode = File.stat(source).mode
+    @params = {
+      action: 'upload',
+      path: destination,
+      content: content,
+      mode: mode
+    }
+  end
+
+  def set_script_params(path, _options = {})
+    content = File.open(path, &:read)
+    content = Base64.encode64(content)
+    @params = { action: 'script', content: content }
+  end
+
+  describe :_run_task do
+    it "executes a task on a host" do
+      mock_client
+      expect(orch._run_task(@task, 'stdin', @params).value).to eq(@result.to_json)
+    end
+
+    it "returns a success" do
+      mock_client
+      expect(orch._run_task(@task, 'stdin', @params).class).to eq(Bolt::Node::Success)
+    end
+
+    context "the task failed" do
+      before(:each) { @result_state = 'failed' }
+
+      it "returns a failure for failed" do
+        mock_client
+        expect(orch._run_task(@task, 'stdin', @params).class).to eq(Bolt::Node::Failure)
+      end
+
+      it "adds an unkown exitcode when absent" do
+        mock_client
+        expect(orch._run_task(@task, 'stdin', @params).exit_code).to eq('unknown')
+      end
+
+      it "uses the exitcode when present" do
+        @result = { '_error' => { 'details' => { 'exit_code' => '3' } } }
+        mock_client
+        expect(orch._run_task(task, 'stdin', params).exit_code).to eq('3')
+      end
+    end
+  end
+
+  describe :_run_command do
+    context 'when it succeeds' do
+      before(:each) do
+        @command = 'echo hi!; echo bye >&2'
+        set_exec_params(@command)
+        bolt_task_client
+      end
+
+      it 'it returns the output' do
+        expect(orch._run_command(@command).value).to eq("hi!\n")
+      end
+
+      it 'it is a success' do
+        expect(orch._run_command(@command).class).to eq(Bolt::Node::Success)
+      end
+
+      it 'captures stderr' do
+        result = orch._run_command(@command)
+        result.output.stderr.rewind
+        expect(result.output.stderr.read).to eq("bye\n")
+      end
+    end
+
+    context 'when it fails' do
+      before(:each) do
+        @command = 'echo hi!; echo bye >&2; exit 23'
+        set_exec_params(@command)
+        bolt_task_client
+      end
+      it 'is a failure' do
+        expect(orch._run_command(@command).class).to eq(Bolt::Node::Failure)
+      end
+
+      it 'captures the exit_code' do
+        expect(orch._run_command(@command).exit_code).to eq(23)
+      end
+
+      it 'captures stdout' do
+        result = orch._run_command(@command)
+        result.output.stdout.rewind
+        expect(result.output.stdout.read).to eq("hi!\n")
+      end
+
+      it 'captures stderr' do
+        result = orch._run_command(@command)
+        result.output.stderr.rewind
+        expect(result.output.stderr.read).to eq("bye\n")
+      end
+    end
+  end
+
+  describe :_upload do
+    it 'should write the file' do
+      Dir.mktmpdir(nil, '/tmp') do |dir|
+        source_path = File.join(base_path, 'spec', 'fixtures', 'scripts', 'success.sh')
+        dest_path = File.join(dir, "success.sh")
+
+        set_upload_params(source_path, dest_path)
+        bolt_task_client
+        result = orch._upload(source_path, dest_path)
+
+        expect(result.class).to eq(Bolt::Node::Success)
+
+        source_mode = File.stat(source_path).mode
+        dest_mode = File.stat(dest_path).mode
+        expect(dest_mode).to eq(source_mode)
+
+        source_content = File.open(source_path, &:read)
+        dest_content = File.open(dest_path, &:read)
+        expect(dest_content).to eq(source_content)
+      end
+    end
+  end
+
+  describe :_run_script do
+    context "the script succeeds" do
+      let(:script_path) do
+        File.expand_path(File.join(base_path, 'spec', 'fixtures', 'scripts', 'success.sh'))
+      end
+
+      before(:each) do
+        set_script_params(script_path)
+        bolt_task_client
+      end
+
+      it 'is a success' do
+        expect(orch._run_script(script_path).class).to eq(Bolt::Node::Success)
+      end
+
+      it 'captures stdout' do
+        expect(orch._run_script(script_path).value).to eq("standard out\n")
+      end
+
+      it 'captures stderr' do
+        result = orch._run_script(script_path)
+        result.output.stderr.rewind
+        expect(result.output.stderr.read).to eq("standard error\n")
+      end
+    end
+
+    context "when the script fails" do
+      let(:script_path) do
+        File.expand_path(File.join(base_path, 'spec', 'fixtures', 'scripts', 'failure.sh'))
+      end
+
+      before(:each) do
+        set_script_params(script_path)
+        bolt_task_client
+      end
+
+      it 'returns a failure' do
+        expect(orch._run_script(script_path).class).to eq(Bolt::Node::Failure)
+      end
+
+      it 'captures exit_code' do
+        expect(orch._run_script(script_path).exit_code).to eq(34)
+      end
+
+      it 'captures stdout' do
+        result = orch._run_script(script_path)
+        result.output.stdout.rewind
+        expect(result.output.stdout.read).to eq("standard out\n")
+      end
+
+      it 'captures stderr' do
+        result = orch._run_script(script_path)
+        result.output.stderr.rewind
+        expect(result.output.stderr.read).to eq("standard error\n")
+      end
+    end
+  end
+end

--- a/spec/fixtures/scripts/failure.sh
+++ b/spec/fixtures/scripts/failure.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# A simple test script
+echo "standard out"
+echo "standard error"  >&2
+exit 34

--- a/spec/fixtures/scripts/success.sh
+++ b/spec/fixtures/scripts/success.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "standard out"
+echo "standard error" >&2

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -1,0 +1,3 @@
+{
+  "description": "This task serves a bridge between bolt and orchestrator and is not intended to be run directly"
+}

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -1,0 +1,44 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+
+require 'base64'
+require 'json'
+require 'open3'
+require 'tempfile'
+
+def write_file(path, content, mode)
+  source = Base64.decode64(content)
+  File.open(path, 'w') do |f|
+    f.chmod(mode)
+    f.write(source)
+  end
+  { success: true }
+end
+
+def command(command)
+  stdout, stderr, p = Open3.capture3(command)
+  { stdout: stdout,
+    stderr: stderr,
+    exit_code: p.exitstatus }
+end
+
+def script(content)
+  tf = Tempfile.new('bolt_script')
+  source = Base64.decode64(content)
+  tf.chmod(0o700)
+  tf.write(source)
+  tf.close
+  command(tf.path)
+end
+
+params = JSON.parse(STDIN.read)
+
+result = case params['action']
+         when 'command'
+           command(params['command'])
+         when 'upload'
+           write_file(params['path'], params['content'], params['mode'])
+         when 'script'
+           script(params['content'])
+         end
+
+puts result.to_json


### PR DESCRIPTION
This adds an orchestrator transport to bolt. It uses a task inside bolt
to support file copying and other transport API features orch doesn't
support natively. It uses the local orch client tools configuration to
connect to orchestrator for any node with a 'pcp' protocol.

TODO:
- [x] error handling
- [x] release orch_api Gem
- [x] better config management.
- [x] tests