### PR TITLE
(BOLT-84) Accept ruby 2.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.0
 
 # Checks for if and unless statements that would fit on one line if written as a
 # modifier if/unless.

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-- 2.4.1
-- 2.1
+- 2.4
+- 2.0
 before_script:
 - cat Gemfile.lock
 script:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 
 To use Bolt, you'll need to install:
 
-* Ruby 2.1 or greater
+* Ruby 2.0 or greater
 * gcc and related dependencies (except on Windows)
 * Bolt gem
 * Puppet gem (optional dependency to run tasks)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ systems using ssh and winrm.
 ## Supported Platforms
 
 * Linux, OSX, Windows
-* Ruby 2.1+
+* Ruby 2.0+
 
 ## Overview
 
@@ -220,9 +220,9 @@ To exclude tests that rely on vagrant run:
 
 ## FAQ
 
-### Bolt requires ruby >= 2.1
+### Bolt requires ruby >= 2.0
 
-Trying to install bolt on ruby 1.9 or 2.0 will fail. You must use ruby 2.1 or
+Trying to install bolt on ruby 1.9 will fail. You must use ruby 2.0 or
 greater.
 
 ### Bolt fails to install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ matrix:
 
 environment:
   matrix:
-    - RUBY_VERSION: 21
+    - RUBY_VERSION: 200
     - RUBY_VERSION: 24
 
 install:

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = "~> 2.1"
+  spec.required_ruby_version = "~> 2.0"
 
   spec.add_dependency "net-ssh", "~> 4.0"
   spec.add_dependency "net-sftp", "~> 2.0"


### PR DESCRIPTION
Previously we required ruby 2.1 or greater. Relax that to ruby 2.0 since
some platforms like Redhat 7 ship with ruby 2.0 and we don't require
ruby 2.1 specific features.