### PR TITLE
(BOLT-73) Set puppet root settings to temp dir

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -319,9 +319,15 @@ HELP
     def run_plan(plan, args, modules)
       modulepath = modules ? [modules] : []
 
-      Puppet.initialize_settings
-      Puppet::Pal.in_tmp_environment('bolt', modulepath: modulepath) do |pal|
-        puts pal.run_plan(plan, plan_args: args)
+      Dir.mktmpdir('bolt') do |dir|
+        cli = []
+        Puppet::Settings::REQUIRED_APP_SETTINGS.each do |setting|
+          cli << "--#{setting}" << dir
+        end
+        Puppet.initialize_settings(cli)
+        Puppet::Pal.in_tmp_environment('bolt', modulepath: modulepath) do |pal|
+          puts pal.run_plan(plan, plan_args: args)
+        end
       end
     end
   end


### PR DESCRIPTION
Previously, running `bolt plan run` would create directories like
`/etc/puppetlabs` because puppet automatically creates ancestor directories
for required app settings[1].

This commit generates a secure temp dir and points each required app
setting, e.g. confdir, at that directory. This way bolt does not
conflict with a normal puppet install. Note the Dir.mktmpdir method
automatically removes the tempdir and its contents.

[1] https://github.com/puppetlabs/puppet/blob/5.2.0/lib/puppet/settings.rb#L346-L348