### PR TITLE
(BOLT-78) Allow parameters to be passed as JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,16 @@ accept nodes when applicable, as in the next example.
     $ bolt plan run sample::single_task nodes=neptune --modules spec/fixtures/modules
     neptune got passed the message: hi there
 
+### Run the `single_task` plan passing nodes with JSON
+
+The `--params` can be used to specify plan and task arguments using JSON.
+
+    $ bolt plan run sample::single_task --modules spec/fixtures/modules --params '{"nodes": ["neptune"]}'
+
+If the value passed to `--params` starts with `@`, it will be treated as the
+name of a file containing JSON arguments. If it is a single `-`, the JSON will
+be read from standard input.
+
 ## Kudos
 
 Thank you to [Marcin Bunsch](https://github.com/marcinbunsch) for allowing


### PR DESCRIPTION
Add a --params flag that accepts parameters as a json string on the command
line, read from a file, or from stdin.

It will read from a file if the value to --params starts with @, and read from
stdin if the value is -