### PR TITLE
(BOLT-90) Ensure that plan options includes nodes with non empty strings

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -297,8 +297,13 @@ HELP
     end
 
     def execute_plan(options)
+      planOptions = options[:task_options] || {}
+      nodes = planOptions[:nodes]
+
+      # :nodes must be an array, either empty or containing non empty strings
+      planOptions['nodes'] = nodes == nil ? [] : nodes.reject { |node| node == nil || node == '' }
       result = run_plan(options[:object],
-                        options[:task_options],
+                        planOptions,
                         options[:modules])
       puts result
     end


### PR DESCRIPTION
Before this commit, the second argument to `run_plan` could be undef,
a hash lacking the 'nodes' entry, or have a 'nodes' entry that contained
empty strings. This is now changed so that a 'nodes' entry is always
present and either an empty array or an array with non-empty strings.