### PR TITLE
(BOLT-127) Unwrap output and don't prefix with underscores

### DIFF
--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -61,12 +61,12 @@ module Bolt
     end
 
     def value
-      @object || { '_output' => @stdout }
+      @object || @stdout
     end
 
     def to_h
       hash = super
-      hash['_error'] = error if error
+      hash['error'] = error if error
       hash
     end
 
@@ -125,7 +125,7 @@ module Bolt
     end
 
     def to_h
-      { '_error' => error }
+      { 'error' => error }
     end
 
     def message


### PR DESCRIPTION
Bolt emits output and value keys without underscores.

If output is present, emit that as the value, not wrapped in a hash.

Add a test for run_command if an exception occurs.