### PR TITLE
(BOLT-137) Don't force default SSH port

### DIFF
--- a/lib/bolt/node_uri.rb
+++ b/lib/bolt/node_uri.rb
@@ -10,12 +10,10 @@ module Bolt
         URI(string)
       when %r{^(ssh|winrm)://}
         uri = URI(string)
-        uri.port = uri.scheme == 'ssh' ? 22 : 5985
+        uri.port = 5985 if uri.scheme == 'winrm'
         uri
-      when /.*:\d+$/
-        URI("ssh://#{string}")
       else
-        URI("ssh://#{string}:22")
+        URI("ssh://#{string}")
       end
     end
 

--- a/spec/bolt/node_uri_spec.rb
+++ b/spec/bolt/node_uri_spec.rb
@@ -26,11 +26,11 @@ describe Bolt::NodeURI do
       expect(uri.port).to eq(2224)
     end
 
-    it "defaults the ssh port to 22" do
+    it "does not default the ssh port" do
       uri = Bolt::NodeURI.new('ssh://pluto')
       expect(uri.scheme).to eq('ssh')
       expect(uri.hostname).to eq('pluto')
-      expect(uri.port).to eq(22)
+      expect(uri.port).to be_nil
     end
 
     it "accepts 'host:port' without a scheme" do
@@ -40,11 +40,11 @@ describe Bolt::NodeURI do
       expect(uri.port).to eq(2224)
     end
 
-    it "defaults the ssh port to 22 without a scheme" do
+    it "does not default the ssh port without a scheme" do
       uri = Bolt::NodeURI.new('pluto')
       expect(uri.scheme).to eq('ssh')
       expect(uri.hostname).to eq('pluto')
-      expect(uri.port).to eq(22)
+      expect(uri.port).to be_nil
     end
   end
 end


### PR DESCRIPTION
This was preventing the ssh port from a user's .ssh/config from being
used. We should leave it nil when unspecified and the net-ssh library
will do the right thing.