### PR TITLE
(docs) Update README with submodule command

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,10 @@ ERROR:  Error installing bolt:
 
 See [Native Extensions](./INSTALL.md#native-extensions) for installation instructions.
 
+### Bolt raises the error `Puppet must be installed to execute tasks`
+
+When using the bolt gem from source, you may receive the error `Puppet must be installed to execute tasks` when trying to run tasks or plans. See [INSTALL.md](./INSTALL.md) on how to install Bolt from source.
+
 ### Bolt does not support submitting task arguments via stdin to PowerShell
 
 Tasks written in PowerShell can receive arguments only as environment variables.


### PR DESCRIPTION
Previously, the bolt gem would throw an error of `Puppet must be installed to
execute tasks` if Puppet and associated gems were not vendored via git
submodule.  However this error message was misleading as it did not explain
how or where to install Puppet.  This commit updates the README explaining how
to install puppet into bolt.