### PR TITLE
(maint) Update inline --nodes documentation

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -97,7 +97,16 @@ HELP
 
     def create_option_parser(results)
       OptionParser.new('') do |opts|
-        opts.on('-n', '--nodes x,y,z', Array, 'Nodes to connect to') do |nodes|
+        opts.on(
+          '-n', '--nodes x,y,z', Array,
+          'Node(s) to connect to in URI format [protocol://]host[:port]',
+          'Eg. --nodes bolt.puppet.com',
+          'Eg. --nodes localhost,ssh://nix.com:2222,winrm://windows.puppet.com',
+          "\n",
+          '* Windows nodes must specify protocol with winrm://',
+          '* protocol is `ssh` by default, may be `ssh` or `winrm`',
+          '* port is `22` by default for SSH, `5985` for winrm (Optional)'
+        ) do |nodes|
           results[:nodes] = nodes
         end
         opts.on('-u', '--user USER',


### PR DESCRIPTION
 - Include additional information so that Windows users know that they
   must specify a protocol to connect to hosts.

   Additionally mention that ports may be specified