### PR TITLE
(BOLT-143) Find Windows executables based on file extension

### DIFF
--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -28,6 +28,9 @@ module Bolt
     def shell_init
       return Bolt::Node::Success.new if @shell_initialized
       result = execute(<<-PS)
+
+$ENV:PATH += ";${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\sys\\ruby\\bin\\"
+
 function Invoke-Interpreter
 {
   [CmdletBinding()]


### PR DESCRIPTION
- Very simple mapping of file extension -> executable for the sake of being able to run Ruby cross-platform tasks, like https://github.com/puppetlabs/puppetlabs-package

Requires #67 to be reviewed / merged first