### PR TITLE
(BOLT-145) Do not dump a stacktrace when 'run plan' for syntax errors

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -322,9 +322,13 @@ HELP
 
     def execute_plan(options)
       Bolt.config = options
-      result = run_plan(options[:object],
-                        options[:task_options],
-                        options[:modules])
+      begin
+        result = run_plan(options[:object],
+                          options[:task_options],
+                          options[:modules])
+      rescue Puppet::Error
+        raise Bolt::CLIError, "Exiting because of an error in Puppet code"
+      end
       puts result
     end
 


### PR DESCRIPTION
When 'bolt run plan' encounters a syntax error, Puppet does its usual thing
to display that error and then raises a Puppet::Error. Unfortunately, bolt
does not catch that, which leads to a stacktrace on the user's console.

This change suppresses that stacktrace. This is really only a bandaid to
make bolt more useable; in particular, there should be a control to enable
that stacktrace if it is ever needed.