### PR TITLE
(BOLT-143) Configure Windows RUBYLIB for Ruby code

### DIFF
--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -30,6 +30,10 @@ module Bolt
       result = execute(<<-PS)
 
 $ENV:PATH += ";${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\sys\\ruby\\bin\\"
+$ENV:RUBYLIB = "${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\puppet\\lib;" +
+  "${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\facter\\lib;" +
+  "${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\hiera\\lib;" +
+  $ENV:RUBYLIB
 
 function Invoke-Interpreter
 {


### PR DESCRIPTION
 - As a follow-up to adding Puppets Ruby directory to PATH so that
   Ruby tasks may use the puppet agent runtime, additionally configure
   RUBYLIB so that loading Puppet / Facter works properly.

   This is typically handled by `environment.bat` in the puppet-agent
   package, and is necessary to consume Puppet / Facter / Hiera from
   inside a task