### PR TITLE
(BOLT-150) Configurable threadpool size

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -117,6 +117,11 @@ HELP
                 "Password to authenticate as (Optional)") do |password|
           results[:password] = password
         end
+        results[:concurrency] = 100
+        opts.on('-c', '--concurrency CONCURRENCY', Integer,
+                "Maximum number of simultaneous connections (Optional, defaults to 100)") do |concurrency|
+          results[:concurrency] = concurrency
+        end
         opts.on('--modules MODULES', "Path to modules directory") do |modules|
           results[:modules] = modules
         end
@@ -284,7 +289,7 @@ HELP
 
         results = nil
         elapsed_time = Benchmark.realtime do
-          executor = Bolt::Executor.new(nodes)
+          executor = Bolt::Executor.new(nodes, options[:concurrency])
           results =
             case options[:mode]
             when 'command'

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -7,14 +7,15 @@ module Bolt
       new(uris.map { |uri| Bolt::Node.from_uri(uri) })
     end
 
-    def initialize(nodes)
+    def initialize(nodes, max_threads = 100)
       @nodes = nodes
+      @poolsize = [nodes.length, max_threads].min
     end
 
     def on_each
       results = Concurrent::Map.new
 
-      pool = Concurrent::FixedThreadPool.new(5)
+      pool = Concurrent::FixedThreadPool.new(@poolsize)
       @nodes.each { |node|
         pool.post do
           results[node] =

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -102,6 +102,25 @@ describe "Bolt::CLI" do
     end
   end
 
+  describe "concurrency" do
+    it "accepts a concurrency limit" do
+      cli = Bolt::CLI.new(%w[command run --concurrency 10 --nodes foo])
+      expect(cli.parse).to include(concurrency: 10)
+    end
+
+    it "defaults to 100" do
+      cli = Bolt::CLI.new(%w[command run --nodes foo])
+      expect(cli.parse).to include(concurrency: 100)
+    end
+
+    it "generates an error message if no concurrency value is given" do
+      cli = Bolt::CLI.new(%w[command run --nodes foo --concurrency])
+      expect {
+        cli.parse
+      }.to raise_error(Bolt::CLIError, /option '--concurrency' needs a parameter/)
+    end
+  end
+
   describe "modules" do
     it "accepts a modules directory" do
       cli = Bolt::CLI.new(%w[command run --modules ./modules --nodes foo])


### PR DESCRIPTION
Increase the default threadpool size to 100, and make it configurable.
If we're operating upon a number of nodes smaller than the indicated
threadpool size, don't bother allocating excess threads we won't need.