### PR TITLE
(BOLT-164) Refer to tasks by name not path

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -297,13 +297,10 @@ HELP
             when 'script'
               executor.run_script(options[:object])
             when 'task'
-              path = options[:object]
-              input_method = nil
+              task_name = options[:object]
 
-              unless file_exist?(path)
-                path, metadata = load_task_data(path, options[:modules])
-                input_method = metadata['input_method']
-              end
+              path, metadata = load_task_data(task_name, options[:modules])
+              input_method = metadata['input_method']
 
               input_method ||= 'both'
               executor.run_task(path, input_method, options[:task_options])

--- a/lib/bolt/node/orch.rb
+++ b/lib/bolt/node/orch.rb
@@ -21,7 +21,8 @@ module Bolt
 
     # This avoids a refactor to pass more task data around
     def task_name_from_path(path)
-      parts = File.absolute_path(path).split(File::Separator)
+      path = File.absolute_path(path)
+      parts = path.split(File::Separator)
       if parts.length < 3 || parts[-2] != 'tasks'
         raise ArgumentError, "Task path was not inside a module."
       end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -256,27 +256,6 @@ describe "Bolt::CLI" do
       cli.execute(options)
     end
 
-    it "runs a task" do
-      task_path = '/path/to/task'
-      task_params = { 'name' => 'apache', 'action' => 'restart' }
-      input_method = 'both'
-
-      expect(executor)
-        .to receive(:run_task)
-        .with(task_path, input_method, task_params)
-        .and_return({})
-      expect(cli).to receive(:file_exist?).with(task_path).and_return(true)
-
-      options = {
-        nodes: nodes,
-        mode: 'task',
-        action: 'run',
-        object: task_path,
-        task_options: task_params
-      }
-      cli.execute(options)
-    end
-
     it "runs a task given a name" do
       task_name = 'sample::echo'
       task_params = { 'message' => 'hi' }
@@ -286,7 +265,6 @@ describe "Bolt::CLI" do
         .to receive(:run_task)
         .with(%r{modules/sample/tasks/echo.sh$}, input_method, task_params)
         .and_return({})
-      expect(cli).to receive(:file_exist?).with(task_name).and_return(false)
 
       options = {
         nodes: nodes,
@@ -308,7 +286,6 @@ describe "Bolt::CLI" do
         .to receive(:run_task)
         .with(%r{modules/sample/tasks/init.sh$}, input_method, task_params)
         .and_return({})
-      expect(cli).to receive(:file_exist?).with(task_name).and_return(false)
 
       options = {
         nodes: nodes,
@@ -330,7 +307,6 @@ describe "Bolt::CLI" do
         .to receive(:run_task)
         .with(%r{modules/sample/tasks/stdin.sh$}, input_method, task_params)
         .and_return({})
-      expect(cli).to receive(:file_exist?).with(task_name).and_return(false)
 
       options = {
         nodes: nodes,
@@ -352,7 +328,6 @@ describe "Bolt::CLI" do
         .to receive(:run_task)
         .with(%r{modules/sample/tasks/winstdin.ps1$}, input_method, task_params)
         .and_return({})
-      expect(cli).to receive(:file_exist?).with(task_name).and_return(false)
 
       options = {
         nodes: nodes,

--- a/spec/bolt/node/orch_spec.rb
+++ b/spec/bolt/node/orch_spec.rb
@@ -91,8 +91,12 @@ describe Bolt::Orch, orchestrator: true do
       expect(orch.task_name_from_path('foo/tasks/bar.sh')).to eq('foo::bar')
     end
 
-    it 'finds the init task' do
+    it 'finds the init task with extension' do
       expect(orch.task_name_from_path('foo/tasks/init.sh')).to eq('foo')
+    end
+
+    it 'finds the init task without extension' do
+      expect(orch.task_name_from_path('foo/tasks/init')).to eq('foo')
     end
 
     it 'errors when not in a module' do


### PR DESCRIPTION
BOLT-164 was caused by bolt preferring to treat the argument to task run
as a path instead of a task name. If you tried to run the 'init' task
from the moduledir bolt would use the relative path to the module as the
task path. This commit removes the ability to run a task by path instead
of by task name to prevent this issue.