### PR TITLE
(BOLT-152) Default to secure ssh authentication

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -130,6 +130,11 @@ HELP
                 "Parameters to a task or plan") do |params|
           results[:task_options] = parse_params(params)
         end
+        results[:insecure] = false
+        opts.on('-k', '--insecure',
+                "Whether to connect insecurely ") do |insecure|
+          results[:insecure] = insecure
+        end
         opts.on_tail('--[no-]tty',
                      "Request a pseudo TTY on nodes that support it") do |tty|
           results[:tty] = tty
@@ -285,7 +290,7 @@ HELP
       else
         nodes = options[:nodes].map do |node|
           Bolt::Node.from_uri(node, options[:user], options[:password],
-                              tty: options[:tty])
+                              tty: options[:tty], insecure: options[:insecure])
         end
 
         results = nil

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -22,6 +22,8 @@ module Bolt
             begin
               node.connect
               yield node
+            rescue Bolt::Node::BaseError => ex
+              Bolt::ErrorResult.new(ex.message, ex.issue_code, ex.kind)
             rescue StandardError => ex
               node.logger.error(ex)
               Bolt::ExceptionResult.new(ex)

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -74,6 +74,7 @@ module Bolt
   end
 end
 
+require 'bolt/node/errors'
 require 'bolt/node/ssh'
 require 'bolt/node/winrm'
 require 'bolt/node/orch'

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -30,12 +30,14 @@ module Bolt
 
     def initialize(host, port = nil, user = nil,
                    password = nil, tty: false, uri: nil,
+                   insecure: false,
                    log_level: Bolt.log_level || Logger::WARN)
       @host = host
       @user = user
       @port = port
       @password = password
       @tty = tty
+      @insecure = insecure
       @uri = uri
 
       @logger = init_logger(level: log_level)

--- a/lib/bolt/node/errors.rb
+++ b/lib/bolt/node/errors.rb
@@ -1,0 +1,22 @@
+module Bolt
+  class Node
+    class BaseError < StandardError
+      attr_reader :issue_code
+
+      def initialize(message, issue_code)
+        super(message)
+        @issue_code = issue_code
+      end
+
+      def kind
+        'puppetlabs.tasks/node-error'
+      end
+    end
+
+    class ConnectError < BaseError
+      def kind
+        'puppetlabs.tasks/connect-error'
+      end
+    end
+  end
+end

--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -25,6 +25,28 @@ module Bolt
     end
   end
 
+  class ErrorResult < Result
+    def initialize(message, issue_code, kind)
+      super(message)
+      @issue_code = issue_code
+      @kind = kind
+    end
+
+    def to_h
+      {
+        'error' => {
+          'issue_code' => @issue_code,
+          'kind' => @kind,
+          'msg' => @message
+        }
+      }
+    end
+
+    def success?
+      false
+    end
+  end
+
   class CommandResult < Result
     attr_reader :stdout, :stderr, :exit_code
 

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -122,6 +122,23 @@ describe "Bolt::CLI" do
     end
   end
 
+  describe "insecure" do
+    it "accepts `-k`" do
+      cli = Bolt::CLI.new(%w[command run -k --nodes foo])
+      expect(cli.parse).to include(insecure: true)
+    end
+
+    it "accepts `--insecure`" do
+      cli = Bolt::CLI.new(%w[command run --insecure --nodes foo])
+      expect(cli.parse).to include(insecure: true)
+    end
+
+    it "defaults to false" do
+      cli = Bolt::CLI.new(%w[command run --nodes foo])
+      expect(cli.parse).to include(insecure: false)
+    end
+  end
+
   describe "modules" do
     it "accepts a modules directory" do
       cli = Bolt::CLI.new(%w[command run --modules ./modules --nodes foo])

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -55,7 +55,21 @@ describe "Bolt::Executor" do
     end
   end
 
-  it "returns an exception result if the connect raises" do
+  it "returns an error result if the connect raises a base error" do
+    node = mock_node 'node'
+    expect(node)
+      .to receive(:connect)
+      .and_raise(
+        Bolt::Node::ConnectError.new('Authentication failed', 'AUTH_ERROR')
+      )
+
+    results = Bolt::Executor.new([node]).run_command(command)
+    results.each_pair do |_, result|
+      expect(result).to be_instance_of(Bolt::ErrorResult)
+    end
+  end
+
+  it "returns an exception result if the connect raises an unhandled error" do
     logger = double('logger', error: nil)
     node = mock_node 'node'
     allow(node).to receive(:logger).and_return(logger)

--- a/spec/bolt/node/ssh_spec.rb
+++ b/spec/bolt/node/ssh_spec.rb
@@ -13,65 +13,69 @@ describe Bolt::SSH do
   let(:command) { "pwd" }
   let(:ssh) { Bolt::SSH.new(hostname, port, user, password) }
 
-  before(:each) { ssh.connect }
-  after(:each) { ssh.disconnect }
+  context "when executing" do
+    before(:each) { ssh.connect }
+    after(:each) { ssh.disconnect }
 
-  it "executes a command on a host", vagrant: true do
-    expect(ssh.execute(command).value).to eq("/home/vagrant\n")
-  end
-
-  it "captures stderr from a host", vagrant: true do
-    expect(ssh.execute("ssh -V").output.stderr.string).to match(/OpenSSH/)
-  end
-
-  it "can upload a file to a host", vagrant: true do
-    contents = "kljhdfg"
-    with_tempfile_containing('upload-test', contents) do |file|
-      ssh.upload(file.path, "/home/vagrant/upload-test")
-
-      expect(ssh.execute("cat /home/vagrant/upload-test").value).to eq(contents)
-
-      ssh.execute("rm /home/vagrant/upload-test")
+    it "executes a command on a host", vagrant: true do
+      expect(ssh.execute(command).value).to eq("/home/vagrant\n")
     end
-  end
 
-  it "can run a script remotely", vagrant: true do
-    contents = "#!/bin/sh\necho hellote"
-    with_tempfile_containing('script test', contents) do |file|
-      expect(ssh._run_script(file.path).value).to eq("hellote\n")
+    it "captures stderr from a host", vagrant: true do
+      expect(ssh.execute("ssh -V").output.stderr.string).to match(/OpenSSH/)
     end
-  end
 
-  it "can run a task", vagrant: true do
-    contents = "#!/bin/sh\necho -n ${PT_message_one} ${PT_message_two}"
-    arguments = { message_one: 'Hello from task', message_two: 'Goodbye' }
-    with_tempfile_containing('tasks test', contents) do |file|
-      expect(ssh._run_task(file.path, 'environment', arguments).value)
-        .to eq('Hello from task Goodbye')
+    it "can upload a file to a host", vagrant: true do
+      contents = "kljhdfg"
+      with_tempfile_containing('upload-test', contents) do |file|
+        ssh.upload(file.path, "/home/vagrant/upload-test")
+
+        expect(
+          ssh.execute("cat /home/vagrant/upload-test").value
+        ).to eq(contents)
+
+        ssh.execute("rm /home/vagrant/upload-test")
+      end
     end
-  end
 
-  it "can run a task passing input on stdin", vagrant: true do
-    contents = "#!/bin/sh\ngrep 'message_one'"
-    arguments = { message_one: 'Hello from task', message_two: 'Goodbye' }
-    with_tempfile_containing('tasks test stdin', contents) do |file|
-      expect(ssh._run_task(file.path, 'stdin', arguments).value)
-        .to match(/{"message_one":"Hello from task","message_two":"Goodbye"}/)
+    it "can run a script remotely", vagrant: true do
+      contents = "#!/bin/sh\necho hellote"
+      with_tempfile_containing('script test', contents) do |file|
+        expect(ssh._run_script(file.path).value).to eq("hellote\n")
+      end
     end
-  end
 
-  it "can run a task passing input on stdin and environment", vagrant: true do
-    contents = <<SHELL
+    it "can run a task", vagrant: true do
+      contents = "#!/bin/sh\necho -n ${PT_message_one} ${PT_message_two}"
+      arguments = { message_one: 'Hello from task', message_two: 'Goodbye' }
+      with_tempfile_containing('tasks test', contents) do |file|
+        expect(ssh._run_task(file.path, 'environment', arguments).value)
+          .to eq('Hello from task Goodbye')
+      end
+    end
+
+    it "can run a task passing input on stdin", vagrant: true do
+      contents = "#!/bin/sh\ngrep 'message_one'"
+      arguments = { message_one: 'Hello from task', message_two: 'Goodbye' }
+      with_tempfile_containing('tasks test stdin', contents) do |file|
+        expect(ssh._run_task(file.path, 'stdin', arguments).value)
+          .to match(/{"message_one":"Hello from task","message_two":"Goodbye"}/)
+      end
+    end
+
+    it "can run a task passing input on stdin and environment", vagrant: true do
+      contents = <<SHELL
 #!/bin/sh
 echo -n ${PT_message_one} ${PT_message_two}
 grep 'message_one'
 SHELL
-    arguments = { message_one: 'Hello from task', message_two: 'Goodbye' }
-    with_tempfile_containing('tasks-test-both', contents) do |file|
-      expect(ssh._run_task(file.path, 'both', arguments).value).to eq(<<SHELL)
+      arguments = { message_one: 'Hello from task', message_two: 'Goodbye' }
+      with_tempfile_containing('tasks-test-both', contents) do |file|
+        expect(ssh._run_task(file.path, 'both', arguments).value).to eq(<<SHELL)
 Hello from task Goodbye{\"message_one\":\
 \"Hello from task\",\"message_two\":\"Goodbye\"}
 SHELL
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,4 +29,8 @@ RSpec.configure do |config|
   config.example_status_persistence_file_path = "spec/examples.txt"
 
   # config.warnings = true
+
+  config.before :each do |_|
+    Bolt.config.clear
+  end
 end


### PR DESCRIPTION
This commit modifies bolt to use the `secure` verifier by default. The
connection will be allowed if the remote host has an entry in our known_hosts
file and the key presented by the host matches our local copy.

Add a command line option (either -k or --insecure) to fallback to the old
lenient behavior. The other net-ssh verifiers `null` and `strict` are not
supported.