### PR TITLE
(BOLT-142) Include incorrect subcommand and action in message

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -238,12 +238,15 @@ HELP
 
     def validate(options)
       unless MODES.include?(options[:mode])
-        raise Bolt::CLIError, "Expected mode to be one of #{MODES.join(', ')}"
+        raise Bolt::CLIError,
+              "Expected subcommand '#{options[:mode]}' to be one of " \
+              "#{MODES.join(', ')}"
       end
 
       unless ACTIONS.include?(options[:action])
         raise Bolt::CLIError,
-              "Expected action to be one of #{ACTIONS.join(', ')}"
+              "Expected action '#{options[:action]}' to be one of " \
+              "#{ACTIONS.join(', ')}"
       end
 
       if options[:mode] != 'file' && !options[:leftovers].empty?

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -12,6 +12,20 @@ describe "Bolt::CLI" do
     }.to raise_error(Bolt::CLIError, /unknown argument '--unknown'/)
   end
 
+  it "generates an error message if an unknown subcommand is given" do
+    cli = Bolt::CLI.new(%w[-n bolt1 bolt2 command run whoami])
+    expect {
+      cli.parse
+    }.to raise_error(Bolt::CLIError, /Expected subcommand 'bolt2' to be one of/)
+  end
+
+  it "generates an error message if an unknown action is given" do
+    cli = Bolt::CLI.new(%w[-n bolt1 command oops whoami])
+    expect {
+      cli.parse
+    }.to raise_error(Bolt::CLIError, /Expected action 'oops' to be one of/)
+  end
+
   # it "includes unparsed arguments" do
   #   cli = Bolt::CLI.new(%w[exec run what --nodes foo])
   #   expect(cli.parse).to include(leftovers: %w[what])


### PR DESCRIPTION
Include the incorrect subcommand or action in the raised exception so it's clear
what part of the CLI is incorrect.