### PR TITLE
(BOLT-29) Allow hosts to be specified in file or stdin

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -98,16 +98,18 @@ HELP
     def create_option_parser(results)
       OptionParser.new('') do |opts|
         opts.on(
-          '-n', '--nodes x,y,z', Array,
+          '-n', '--nodes NODES',
           'Node(s) to connect to in URI format [protocol://]host[:port]',
           'Eg. --nodes bolt.puppet.com',
           'Eg. --nodes localhost,ssh://nix.com:2222,winrm://windows.puppet.com',
           "\n",
+          '* NODES can either be comma-separated, \'@<file>\' to read',
+          '* nodes from a file, or \'-\' to read from stdin',
           '* Windows nodes must specify protocol with winrm://',
           '* protocol is `ssh` by default, may be `ssh` or `winrm`',
           '* port is `22` by default for SSH, `5985` for winrm (Optional)'
         ) do |nodes|
-          results[:nodes] = nodes
+          results[:nodes] = parse_nodes(nodes)
         end
         opts.on('-u', '--user USER',
                 "User to authenticate as (Optional)") do |user|
@@ -210,6 +212,11 @@ HELP
                         BANNER
                       end
       puts parser.help
+    end
+
+    def parse_nodes(nodes)
+      list = get_arg_input(nodes)
+      list.split(/[[:space:],]+/).reject(&:empty?)
     end
 
     def parse_params(params)

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -59,6 +59,38 @@ describe "Bolt::CLI" do
       expect(cli.parse).to include(nodes: %w[foo bar])
     end
 
+    it "reads from stdin when --nodes is '-'" do
+      nodes = <<NODES
+foo
+bar
+NODES
+      cli = Bolt::CLI.new(%w[command run --nodes -])
+      allow(STDIN).to receive(:read).and_return(nodes)
+      result = cli.parse
+      expect(result[:nodes]).to eq(%w[foo bar])
+    end
+
+    it "reads from a file when --nodes starts with @" do
+      nodes = <<NODES
+foo
+bar
+NODES
+      with_tempfile_containing('nodes-args', nodes) do |file|
+        cli = Bolt::CLI.new(%W[command run --nodes @#{file.path}])
+        result = cli.parse
+        expect(result[:nodes]).to eq(%w[foo bar])
+      end
+    end
+
+    it "strips leading and trailing whitespace" do
+      nodes = "  foo\nbar  \nbaz\nqux  "
+      with_tempfile_containing('nodes-args', nodes) do |file|
+        cli = Bolt::CLI.new(%W[command run --nodes @#{file.path}])
+        result = cli.parse
+        expect(result[:nodes]).to eq(%w[foo bar baz qux])
+      end
+    end
+
     it "generates an error message if no nodes given" do
       cli = Bolt::CLI.new(%w[command run --nodes])
       expect {


### PR DESCRIPTION
Allow hosts to be specified on stdin `--nodes -`, or from a file,
`--nodes @file.txt`. In both cases, the nodes should be specified
one node URI per line. Leading and trailing spaces will be
stripped. Bolt still accepts comma-separated list of nodes.