### PR TITLE
Add a Quick Start section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,17 @@
 # Contributing
 
+## Quick Start
+
+    $ git clone git@github.com:puppetlabs/bolt.git
+    $ cd bolt
+    $ git submodule init
+    $ git submodule update
+    $ bundle install --path .bundle/gems/
+    $ bundle exec rake unit
+
+Expected output are passing unit tests.  If you receive some failures, it's
+likely your sub-modules aren't initialized and up to date.
+
 ## Issues
 
 Please submit new issues on the GitHub issue tracker: https://github.com/puppetlabs/bolt/issues


### PR DESCRIPTION
Four failing tests tripped me up while getting started.  I initially went down
the route of adding puppet_pal and puppet to the Gemfile to get the tests
passing, then later discovered the submodule while reading through the gemspec.

This patch provides a hint to shorten the path to `bundle exec rake unit`
passing for new contributors.