### PR TITLE
(BOLT-149) Simplify what files are packaged in the gem

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -3,13 +3,6 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'bolt/version'
 
-# --recurse-submodules only available in newer git
-output = `git submodule -q foreach 'git ls-files lib | sed "s|^|$path/|"'`
-vendored_files = output.split
-bolt_files = `git ls-files -z`.split("\x0").reject do |f|
-  f.match(%r{^(test|spec|features)/})
-end
-
 Gem::Specification.new do |spec|
   spec.name          = "bolt"
   spec.version       = Bolt::VERSION
@@ -20,7 +13,10 @@ Gem::Specification.new do |spec|
   spec.description   = "Execute commands remotely over SSH and WinRM"
   spec.homepage      = "https://github.com/puppetlabs/bolt"
   spec.license       = "Apache-2.0"
-  spec.files         = bolt_files + vendored_files
+  spec.files         = Dir['exe/*'] +
+                       Dir['lib/**/*.rb'] +
+                       Dir['vendored/*.rb'] +
+                       Dir['vendored/*/lib/**/*.rb']
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
The old approach of `git ls-files` relied on commands which don't
typically exist on Windows, so `bundle install` would fail.

Also we were shipping unnecessary files, like the docs pdf, example
tasks, etc. According to the rubygems specification, `files` should only
contain require-able files[1].

Reduce the set of files that are packaged in the gem to only what is
needed.

[1] http://guides.rubygems.org/specification-reference/#files