### PR TITLE
Add a uniq function to nodes array to ensure we deduplicate list

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -216,7 +216,7 @@ HELP
 
     def parse_nodes(nodes)
       list = get_arg_input(nodes)
-      list.split(/[[:space:],]+/).reject(&:empty?)
+      list.split(/[[:space:],]+/).reject(&:empty?).uniq
     end
 
     def parse_params(params)

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -105,6 +105,11 @@ NODES
       end
     end
 
+    it "accepts multiple nodes but is uniq" do
+      cli = Bolt::CLI.new(%w[command run --nodes foo,bar,foo])
+      expect(cli.parse).to include(nodes: %w[foo bar])
+    end
+
     it "generates an error message if no nodes given" do
       cli = Bolt::CLI.new(%w[command run --nodes])
       expect {


### PR DESCRIPTION
In the event we execute a list that happens to have a node twice the command will be executed twice, simply running a uniq on the array to ensure it is a unique set.