### PR TITLE
Add new connection scheme `local` that allows to execute command on host that executes bolt

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,16 @@ Bolt can use the Puppet orchestrator to target nodes using the `pcp` protocol wh
     Usage: bolt <subcommand> <action> [options]
     ...
 
+### Run a command locally
+
+    $ bolt command run 'ssh -V' --nodes local://localhost
+    localhost:
+
+    OpenSSH_5.3p1, OpenSSL 1.0.1e-fips 11 Feb 2013
+
+    Ran on 1 node in 0.27 seconds
+
+
 ### Run a command over SSH
 
     $ bolt command run 'ssh -V' --nodes neptune

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -16,6 +16,8 @@ module Bolt
                 Bolt::WinRM
               when 'pcp'
                 Bolt::Orch
+              when 'local'
+                Bolt::Local
               else
                 Bolt::SSH
               end

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -77,6 +77,7 @@ module Bolt
 end
 
 require 'bolt/node/errors'
+require 'bolt/node/local'
 require 'bolt/node/ssh'
 require 'bolt/node/winrm'
 require 'bolt/node/orch'

--- a/lib/bolt/node/local.rb
+++ b/lib/bolt/node/local.rb
@@ -1,0 +1,117 @@
+require 'json'
+require 'open3'
+require 'bolt/node/result'
+
+module Bolt
+  class Local < Node
+    def connect
+      # this is a local connection, just passing there...
+    end
+
+    def disconnect
+      # this is a local connection, just passing there...
+    end
+
+    def execute(command, options = {})
+      result_output = Bolt::Node::ResultOutput.new
+      status = {}
+
+      @logger.debug { "Executing: #{command}" }
+
+      if options[:stdin]
+        stdout, stderr, rc = Open3.capture3(command, :stdin_data => options[:stdin])
+      else
+        stdout, stderr, rc = Open3.capture3(command)
+      end
+
+      result_output.stdout << stdout.strip unless stdout.nil?
+      @logger.debug { "stdout: #{data}" }
+
+      result_output.stderr << stderr.strip unless stderr.nil?
+      @logger.debug { "stderr: #{data}" }
+
+      status[:exit_code] = rc.to_i
+
+      if status[:exit_code].zero?
+        @logger.debug { "Command returned successfully" }
+        Bolt::Node::Success.new(result_output.stdout.string, result_output)
+      else
+        @logger.info { "Command failed with exit code #{status[:exit_code]}" }
+        Bolt::Node::Failure.new(status[:exit_code], result_output)
+      end
+    end
+
+    def _upload(source, destination)
+      FileUtils.copy_file(source, destination)
+      Bolt::Node::Success.new
+    rescue StandardError => e
+      Bolt::Node::ExceptionFailure.new(e)
+    end
+
+    def make_tempdir
+      # Note(riton): Should be developed to support os that does not have mktemp
+      Bolt::Node::Success.new(`mktemp -d`.chomp)
+    rescue StandardError => e
+      Bolt::Node::ExceptionFailure.new(e)
+    end
+
+    def with_remote_file(file)
+      remote_path = ''
+      dir = ''
+      result = nil
+
+      make_tempdir.then do |value|
+        dir = value
+        local_path = "#{dir}/#{File.basename(file)}"
+        Bolt::Node::Success.new
+      end.then do
+        _upload(file, local_path)
+      end.then do
+        execute("chmod u+x '#{local_path}'")
+      end.then do
+        result = yield local_path
+      end.then do
+        execute("rm -f '#{local_path}'")
+      end.then do
+        execute("rmdir '#{dir}'")
+        result
+      end
+    end
+
+    def _run_command(command)
+      execute(command)
+    end
+
+    def _run_script(script)
+      @logger.info { "Running script '#{script}'" }
+      execute(script)
+    end
+
+    def _run_task(task, input_method, arguments)
+      export_args = {}
+      stdin = nil
+
+      @logger.info { "Running task '#{task}'" }
+      @logger.debug { "arguments: #{arguments}\ninput_method: #{input_method}" }
+
+      if STDIN_METHODS.include?(input_method)
+        stdin = JSON.dump(arguments)
+      end
+
+      if ENVIRONMENT_METHODS.include?(input_method)
+        export_args = arguments.map do |env, val|
+          "PT_#{env}='#{val}'"
+        end.join(' ')
+      end
+
+      with_remote_file(task) do |remote_path|
+        command = if export_args.empty?
+                    "'#{remote_path}'"
+                  else
+                    "export #{export_args} && '#{remote_path}'"
+                  end
+        execute(command, stdin: stdin)
+      end
+    end
+  end
+end

--- a/lib/bolt/node/local.rb
+++ b/lib/bolt/node/local.rb
@@ -56,7 +56,7 @@ module Bolt
     end
 
     def with_remote_file(file)
-      remote_path = ''
+      local_path = ''
       dir = ''
       result = nil
 

--- a/lib/bolt/node_uri.rb
+++ b/lib/bolt/node_uri.rb
@@ -6,11 +6,11 @@ module Bolt
 
     def parse(string)
       case string
-      when %r{^(ssh|winrm|pcp)://.*:\d+$}
+      when %r{^(local|ssh|winrm|pcp)://.*:\d+$}
         URI(string)
       when %r{^pcp://}
         URI(string)
-      when %r{^(ssh|winrm)://}
+      when %r{^(local|ssh|winrm)://}
         uri = URI(string)
         uri.port = 5985 if uri.scheme == 'winrm'
         uri


### PR DESCRIPTION
This is still a work in progress and has not been heavily tested.

I'm opening this issue to open a discussion about the idea of a `local://` scheme.

Example of what it does:

```
riton@myhost $ bundle exec bolt command run -n local://localhost whoami
localhost:

riton

Ran on 1 node in 0.00 seconds
```
