### PR TITLE
Allow --nodes to be declared multiple times

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -91,8 +91,10 @@ HELP
     attr_accessor :options
 
     def initialize(argv)
-      @argv = argv
-      @options = {}
+      @argv    = argv
+      @options = {
+        nodes: []
+      }
 
       @parser = create_option_parser(@options)
     end
@@ -111,7 +113,8 @@ HELP
           '* protocol is `ssh` by default, may be `ssh` or `winrm`',
           '* port is `22` by default for SSH, `5985` for winrm (Optional)'
         ) do |nodes|
-          results[:nodes] = parse_nodes(nodes)
+          results[:nodes] += parse_nodes(nodes)
+          results[:nodes].uniq!
         end
         opts.on('-u', '--user USER',
                 "User to authenticate as (Optional)") do |user|
@@ -283,7 +286,7 @@ HELP
               "unknown argument(s) #{options[:leftovers].join(', ')}"
       end
 
-      unless options[:nodes] || options[:mode] == 'plan'
+      unless !options[:nodes].empty? || options[:mode] == 'plan'
         raise Bolt::CLIError, "option --nodes must be specified"
       end
 

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -73,6 +73,11 @@ describe "Bolt::CLI" do
       expect(cli.parse).to include(nodes: %w[foo bar])
     end
 
+    it "accepts multiple nodes across multiple declarations" do
+      cli = Bolt::CLI.new(%w[command run --nodes foo,bar --nodes bar,more,bars])
+      expect(cli.parse).to include(nodes: %w[foo bar more bars])
+    end
+
     it "reads from stdin when --nodes is '-'" do
       nodes = <<NODES
 foo
@@ -255,7 +260,7 @@ NODES
       cli = Bolt::CLI.new(%w[plan run my::plan kj=2hv iuhg=iube 2whf=lcv
                              --modulepath .])
       result = cli.parse
-      expect(result[:task_options]).to eq('kj' => '2hv',
+      expect(result[:task_options]).to eq('kj'   => '2hv',
                                           'iuhg' => 'iube',
                                           '2whf' => 'lcv')
     end
@@ -265,7 +270,7 @@ NODES
       cli = Bolt::CLI.new(['plan', 'run', 'my::plan', '--params', json_args,
                            '--modulepath', '.'])
       result = cli.parse
-      expect(result[:task_options]).to eq('kj' => '2hv',
+      expect(result[:task_options]).to eq('kj'   => '2hv',
                                           'iuhg' => 'iube',
                                           '2whf' => 'lcv')
     end
@@ -292,7 +297,7 @@ NODES
         cli = Bolt::CLI.new(%W[plan run my::plan --params @#{file.path}
                                --modulepath .])
         result = cli.parse
-        expect(result[:task_options]).to eq('kj' => '2hv',
+        expect(result[:task_options]).to eq('kj'   => '2hv',
                                             'iuhg' => 'iube',
                                             '2whf' => 'lcv')
       end
@@ -313,7 +318,7 @@ NODES
       cli = Bolt::CLI.new(%w[plan run my::plan --params - --modulepath .])
       allow(STDIN).to receive(:read).and_return(json_args)
       result = cli.parse
-      expect(result[:task_options]).to eq('kj' => '2hv',
+      expect(result[:task_options]).to eq('kj'   => '2hv',
                                           'iuhg' => 'iube',
                                           '2whf' => 'lcv')
     end


### PR DESCRIPTION
- Allow for the user to declare --nodes multiple times along a cli and merge them   into a single array, previously it would allow for last nodes declaration to win and miss any previous   calls on cli