### PR TITLE
(maint) Fix ordering sensitivity with debug and verbose

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -145,10 +145,10 @@ HELP
           results[:help] = true
         end
         opts.on_tail('--verbose', 'Display verbose logging') do |_|
-          Bolt.log_level = Logger::INFO
+          results[:verbose] = true
         end
         opts.on_tail('--debug', 'Display debug logging') do |_|
-          Bolt.log_level = Logger::DEBUG
+          results[:debug] = true
         end
         opts.on_tail('--version', 'Display the version') do |_|
           puts Bolt::VERSION
@@ -177,6 +177,12 @@ HELP
 
       options[:action] = remaining.shift
       options[:object] = remaining.shift
+
+      if options[:debug]
+        Bolt.log_level = Logger::DEBUG
+      elsif options[:verbose]
+        Bolt.log_level = Logger::INFO
+      end
 
       if options[:help]
         print_help(options[:mode])

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -168,6 +168,14 @@ NODES
     end
   end
 
+  describe "log level" do
+    it "is not sensitive to ordering of debug and verbose" do
+      cli = Bolt::CLI.new(%w[command run --nodes foo --debug --verbose])
+      cli.parse
+      expect(Bolt.log_level).to eq(Logger::DEBUG)
+    end
+  end
+
   describe "insecure" do
     it "accepts `-k`" do
       cli = Bolt::CLI.new(%w[command run -k --nodes foo])


### PR DESCRIPTION
If verbose was specified on the command line after debug it would override the
log level.