### PR TITLE
(BOLT-124) Use Addressable to parse URIs

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "winrm", "~> 2.0"
   spec.add_dependency "winrm-fs", "~> 1.0"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
+  spec.add_dependency "addressable", "~> 2.5"
   spec.add_dependency "orchestrator_client", "~> 0.2.1"
 
   # Dependencies of our vendored puppet, etc

--- a/lib/bolt/node_uri.rb
+++ b/lib/bolt/node_uri.rb
@@ -5,18 +5,13 @@ module Bolt
     end
 
     def parse(string)
-      case string
-      when %r{^(ssh|winrm|pcp)://.*:\d+$}
-        URI(string)
-      when %r{^pcp://}
-        URI(string)
-      when %r{^(ssh|winrm)://}
-        uri = URI(string)
-        uri.port = 5985 if uri.scheme == 'winrm'
-        uri
-      else
-        URI("ssh://#{string}")
-      end
+      uri = if string =~ %r{^(ssh|winrm|pcp)://}
+              Addressable::URI.parse(string)
+            else
+              Addressable::URI.parse("ssh://#{string}")
+            end
+      uri.port ||= 5985 if uri.scheme == 'winrm'
+      uri
     end
 
     def hostname

--- a/lib/bolt/node_uri.rb
+++ b/lib/bolt/node_uri.rb
@@ -1,3 +1,5 @@
+require 'addressable'
+
 module Bolt
   class NodeURI
     def initialize(string)
@@ -23,11 +25,15 @@ module Bolt
     end
 
     def user
-      @uri.user
+      Addressable::URI.unencode_component(
+        @uri.user
+      )
     end
 
     def password
-      @uri.password
+      Addressable::URI.unencode_component(
+        @uri.password
+      )
     end
 
     def scheme

--- a/spec/bolt/node_uri_spec.rb
+++ b/spec/bolt/node_uri_spec.rb
@@ -2,6 +2,82 @@ require 'spec_helper'
 require 'bolt/node_uri'
 
 describe Bolt::NodeURI do
+  describe "when parsing userinfo" do
+    let(:user)     { 'günther' }
+    let(:password) { 'foobar' }
+
+    it "accepts userinfo when a port is specified" do
+      uri = Bolt::NodeURI.new("ssh://#{user}:#{password}@neptune:2222")
+      expect(uri.user).to eq(user)
+      expect(uri.password).to eq(password)
+    end
+
+    it "accepts userinfo without a port" do
+      uri = Bolt::NodeURI.new("ssh://#{user}:#{password}@neptune")
+      expect(uri.user).to eq(user)
+      expect(uri.password).to eq(password)
+    end
+
+    it "accepts userinfo when using the default scheme" do
+      uri = Bolt::NodeURI.new("#{user}:#{password}@neptune")
+      expect(uri.user).to eq(user)
+      expect(uri.password).to eq(password)
+    end
+
+    it "rejects unescaped special characters" do
+      expect {
+        Bolt::NodeURI.new("#{user}:a/b@neptune")
+      }.to raise_error(Addressable::URI::InvalidURIError,
+                       /Invalid port number/)
+    end
+
+    it "accepts escaped special characters in password" do
+      table = {
+        "\n" => '%0A',
+        ' '  => '%20',
+        '!'  => '!',
+        '"'  => '%22',
+        '#'  => '%23',
+        '$'  => '$',
+        '%'  => '%25',
+        '&'  => '&',
+        '\'' => '\'',
+        '('  => '(',
+        ')'  => ')',
+        '*'  => '*',
+        '+'  => '+',
+        '-'  => '-',
+        '.'  => '.',
+        '/'  => '%2F',
+        '0'  => '0',
+        ':'  => '%3A',
+        ';'  => ';',
+        '<'  => '%3C',
+        '='  => '=',
+        '>'  => '%3E',
+        '?'  => '%3F',
+        '@'  => '@',
+        'A'  => 'A',
+        '['  => '%5B',
+        '\\' => '%5C',
+        ']'  => '%5D',
+        '^'  => '%5E',
+        '_'  => '%5F',
+        '`'  => '%60'
+      }
+      unencoded = ''
+      encoded = ''
+      table.each_pair do |k, v|
+        unencoded.concat(k)
+        encoded.concat(v)
+      end
+
+      uri = Bolt::NodeURI.new("#{encoded}:#{encoded}@neptune")
+      expect(uri.user).to eq(unencoded)
+      expect(uri.password).to eq(unencoded)
+    end
+  end
+
   describe "with winrm" do
     it "accepts 'winrm://host:port'" do
       uri = Bolt::NodeURI.new('winrm://neptune:55985')

--- a/spec/bolt/node_uri_spec.rb
+++ b/spec/bolt/node_uri_spec.rb
@@ -47,4 +47,20 @@ describe Bolt::NodeURI do
       expect(uri.port).to be_nil
     end
   end
+
+  describe "with pcp" do
+    it "accepts 'pcp://pluto:666'" do
+      uri = Bolt::NodeURI.new('pcp://pluto:666')
+      expect(uri.scheme).to eq('pcp')
+      expect(uri.hostname).to eq('pluto')
+      expect(uri.port).to eq(666)
+    end
+
+    it "accepts 'pcp://pluto' without a port" do
+      uri = Bolt::NodeURI.new('pcp://pluto')
+      expect(uri.scheme).to eq('pcp')
+      expect(uri.hostname).to eq('pluto')
+      expect(uri.port).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Ruby's URI class does not correctly parse special characters in the `userinfo`
section of a URI. Use Addressable instead. Note it requires ruby 2.0 and
up, which is compatible with Bolt.