### PR TITLE
(BOLT-149) Wrap rubocop in gem group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,9 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 gemspec
 
-gem "rubocop", require: false
+group(:test) do
+  gem "rubocop", require: false
+end
 
 if File.exist? "Gemfile.local"
   eval_gemfile "Gemfile.local"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,6 +38,13 @@ to install `ruby.devkit`, as ffi already publishes precompiled gems for Windows 
     choco install ruby
     refreshenv
 
+If you wish to use `rubocop` on Windows it is necessary to install the `ruby.devkit` and the
+MSYS2 base package.
+
+    choco install ruby.devkit
+    refreshenv
+    ridk install    # Choose the base install and complete the Wizard selections.
+
 ## Installing Bolt
 
 Bolt can be installed 3 ways depending on your use case. The most common case is
@@ -52,8 +59,12 @@ Or add this to your Gemfile if you are using [Bundler](https://bundler.io)
 Or if running from source
 
     git submodule update --init --recursive
-    bundle install --path .bundle
+    bundle install --path .bundle --without test
     bundle exec bolt ...
+
+If you wish to use `rubocop`, perform the bundle install with no exclusions
+
+    bundle install --path .bundle
 
 See `bolt --help` for more details.
 


### PR DESCRIPTION
This commit places the `rubocop` dependency into a gem group so that
it can be excluded when desired. This is necessary to enable a `bundle
install` on Windows when the MSYS2 environment is not installed.

Installation documentation is also updated.