### PR TITLE
(BOLT-200) Prevent WinRM stream reading deadlock

### DIFF
--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -83,7 +83,7 @@ function Invoke-Interpreter
   }
   catch
   {
-    Write-Error $_
+    $Host.UI.WriteErrorLine($_)
     return 1
   }
 
@@ -98,7 +98,7 @@ function Invoke-Interpreter
   # https://msdn.microsoft.com/en-us/library/system.diagnostics.process.standarderror(v=vs.110).aspx#Anchor_2
   $process.StandardOutput.ReadToEnd() | Out-Host
   $stderr = $process.StandardError.ReadToEnd()
-  if ($stderr) { Write-Error $stderr }
+  if ($stderr) { $Host.UI.WriteErrorLine($stderr) }
   $process.WaitForExit($Timeout) | Out-Null
 
   return $process.ExitCode

--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -115,13 +115,13 @@ function Invoke-Interpreter
 
   # park current thread until the PS event is signaled upon process exit
   # OR the timeout has elapsed
-  $waitResult = Wait-Event -SourceIdentifier $invocationId -Timeout ($Timeout / 1000)
+  $waitResult = Wait-Event -SourceIdentifier $invocationId -Timeout $Timeout
 
   @($stdoutEvent, $stderrEvent, $exitedEvent) | % { Unregister-Event -SourceIdentifier $_.Name }
 
   if (! ($process.HasExited))
   {
-    $Host.UI.WriteErrorLine("Process $Path did not complete in $($Timeout / 1000) seconds")
+    $Host.UI.WriteErrorLine("Process $Path did not complete in $Timeout seconds")
     try { $process.Kill() } catch { $Host.UI.WriteErrorLine("Failed To Kill Process $Path") }
     $process.Dispose()
     return 1
@@ -158,11 +158,11 @@ PS
       end
     end
 
-    # 10 minutes in milliseconds
-    DEFAULT_EXECUTION_TIMEOUT = 10 * 60 * 1000
+    # 10 minutes in seconds
+    DEFAULT_EXECUTION_TIMEOUT = 10 * 60
 
     def execute_process(path = '', arguments = [], stdin = nil,
-                        timeout_ms = DEFAULT_EXECUTION_TIMEOUT)
+                        timeout = DEFAULT_EXECUTION_TIMEOUT)
       quoted_args = arguments.map do |arg|
         "'" + arg.gsub("'", "''") + "'"
       end.join(',')
@@ -175,7 +175,7 @@ $quoted_array = @(
 $invokeArgs = @{
   Path = "#{path}"
   Arguments = $quoted_array -Join ' '
-  Timeout = #{timeout_ms}
+  Timeout = #{timeout}
   #{stdin.nil? ? '' : "StdinInput = @'\n" + stdin + "\n'@"}
 }
 

--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -72,6 +72,7 @@ function Invoke-Interpreter
   $startInfo = New-Object System.Diagnostics.ProcessStartInfo($Path, $Arguments)
   $startInfo.UseShellExecute = $false
   $startInfo.WorkingDirectory = Split-Path -Parent (Get-Command $Path).Path
+  $startInfo.CreateNoWindow = $true
   if ($StdinInput) { $startInfo.RedirectStandardInput = $true }
   $startInfo.RedirectStandardOutput = $true
   $startInfo.RedirectStandardError = $true

--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -84,6 +84,7 @@ function Invoke-Interpreter
   catch
   {
     $Host.UI.WriteErrorLine($_)
+    if ($process -ne $Null) { $process.Dispose() }
     return 1
   }
 
@@ -105,10 +106,14 @@ function Invoke-Interpreter
   {
     $Host.UI.WriteErrorLine("Process $Path did not complete in $($Timeout / 1000) seconds")
     try { $process.Kill() } catch { $Host.UI.WriteErrorLine("Failed To Kill Process $Path") }
+    $process.Dispose()
     return 1
   }
 
-  return $process.ExitCode
+  $exitCode = $process.ExitCode
+  $process.Dispose()
+
+  return $exitCode
 }
 PS
       @shell_initialized = true

--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -101,6 +101,13 @@ function Invoke-Interpreter
   if ($stderr) { $Host.UI.WriteErrorLine($stderr) }
   $process.WaitForExit($Timeout) | Out-Null
 
+  if (! ($process.HasExited))
+  {
+    $Host.UI.WriteErrorLine("Process $Path did not complete in $($Timeout / 1000) seconds")
+    try { $process.Kill() } catch { $Host.UI.WriteErrorLine("Failed To Kill Process $Path") }
+    return 1
+  }
+
   return $process.ExitCode
 }
 PS

--- a/spec/bolt/node/winrm_spec.rb
+++ b/spec/bolt/node/winrm_spec.rb
@@ -127,7 +127,7 @@ PS
     with_tempfile_containing('script-test-winrm', contents) do |file|
       expect(
         winrm._run_script(file.path, []).value
-      ).to eq("hellote\r\n\r\n")
+      ).to eq("hellote\r\n")
     end
   end
 
@@ -150,7 +150,6 @@ with spaces\r
 'a b'\r
 a 'b' c\r
 a 'b' c\r
-\r
 QUOTED
     end
   end
@@ -172,7 +171,6 @@ a\r
 b\r
 a b c\r
 a b c\r
-\r
 QUOTED
     end
   end
@@ -186,8 +184,18 @@ QUOTED
         ).value
       ).to eq(<<SHELLWORDS)
 echo $env:path\r
-\r
 SHELLWORDS
+    end
+  end
+
+  it "does not deadlock scripts that write > 4k to stderr", winrm: true do
+    contents = <<-PS
+    $bytes_in_k = (1024 * 4) + 1
+    [Text.Encoding]::UTF8.GetString((New-Object Byte[] ($bytes_in_k))) | Write-Error
+    PS
+
+    with_tempfile_containing('script-test-winrm', contents) do |file|
+      expect(winrm._run_script(file.path, [])).to be_success
     end
   end
 
@@ -197,7 +205,7 @@ SHELLWORDS
                   :"message two" => 'task has run' }
     with_tempfile_containing('task-test-winrm', contents) do |file|
       expect(winrm._run_task(file.path, 'environment', arguments).value)
-        .to eq("task is running\r\ntask has run\r\n\r\n")
+        .to eq("task is running\r\ntask has run\r\n")
     end
   end
 
@@ -223,10 +231,11 @@ PS
     with_tempfile_containing('tasks-test-both-winrm', contents) do |file|
       expect(
         winrm._run_task(file.path, 'both', arguments).value
-      ).to eq(['Hello from task',
-               'Goodbye',
-               '{"message_one":"Hello from task","message_two":"Goodbye"}',
-               "\r\n"].join("\r\n"))
+      ).to eq([
+        "Hello from task\r\n",
+        "Goodbye\r\n",
+        "{\"message_one\":\"Hello from task\",\"message_two\":\"Goodbye\"}\r\n"
+      ].join(''))
     end
   end
 


### PR DESCRIPTION
 - Previously, the stdout stream was read / parsed synchronously prior
   to draining the stderr stream, which could lead to a deadlock if
   too much output was produced on stderr

 - The correct way to drain stdout / stderr is by responding to events
   and sending them directly to the host. Add a few ScriptBlocks to
   handle OutputDataReceived and ErrorDataReceived from the process.

 - Note for output to not appear correctly on stderr, the code had
   to stop using the Write-Error cmdlet and had to move to using
   $Host.UI.WriteErrorLine

   This has the side effect of not appending the extra newlines
   that were introduced as part of
   9fff248