### PR TITLE
(BOLT-141) Rescue Net::SSH:Exception

### DIFF
--- a/lib/bolt/node/ssh.rb
+++ b/lib/bolt/node/ssh.rb
@@ -21,11 +21,6 @@ module Bolt
 
       @session = Net::SSH.start(@host, @user, options)
       @logger.debug { "Opened session" }
-    rescue SocketError, SystemCallError => e
-      raise Bolt::Node::ConnectError.new(
-        "Failed to connect to #{@uri}: #{e.message}",
-        'CONNECT_ERROR'
-      )
     rescue Net::SSH::AuthenticationFailed => e
       raise Bolt::Node::ConnectError.new(
         e.message,
@@ -35,6 +30,11 @@ module Bolt
       raise Bolt::Node::ConnectError.new(
         "Host key verification failed for #{@uri}: #{e.message}",
         'HOST_KEY_ERROR'
+      )
+    rescue Net::SSH::Exception, SocketError, SystemCallError => e
+      raise Bolt::Node::ConnectError.new(
+        "Failed to connect to #{@uri}: #{e.message}",
+        'CONNECT_ERROR'
       )
     end
 

--- a/spec/bolt/node/ssh_spec.rb
+++ b/spec/bolt/node/ssh_spec.rb
@@ -79,6 +79,19 @@ describe Bolt::SSH do
         ssh.connect
       end
     end
+
+    it "returns Node::ConnectError if the connection times out" do
+      allow(Net::SSH)
+        .to receive(:start)
+        .and_raise(Net::SSH::ConnectionTimeout)
+
+      ssh = Bolt::SSH.new(hostname, port, user, password, insecure: true)
+      expect_node_error(Bolt::Node::ConnectError,
+                        'CONNECT_ERROR',
+                        /Failed to connect to/) do
+        ssh.connect
+      end
+    end
   end
 
   context "when executing" do


### PR DESCRIPTION
Rescue all Net::SSH::Exceptions, as net-ssh rescues ETIMEDOUT and rethrows as Net::SSH::ConnectionTimeout.

The order of rescue block is changed since AuthenticationFailed and HostKeyError derive from the Net::SSH::Exception super class.

```
$ bundle exec bolt command run 'hostname -f' --nodes 8.8.8.8
8.8.8.8:

Failed to connect to 8.8.8.8: Net::SSH::ConnectionTimeout

Ran on 1 node in 75.44 seconds
```