### PR TITLE
(BOLT-141) Always rescue StandardError during ssh and winrm connect

### DIFF
--- a/lib/bolt/node/ssh.rb
+++ b/lib/bolt/node/ssh.rb
@@ -31,7 +31,7 @@ module Bolt
         "Host key verification failed for #{@uri}: #{e.message}",
         'HOST_KEY_ERROR'
       )
-    rescue Net::SSH::Exception, SocketError, SystemCallError => e
+    rescue StandardError => e
       raise Bolt::Node::ConnectError.new(
         "Failed to connect to #{@uri}: #{e.message}",
         'CONNECT_ERROR'

--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -19,15 +19,15 @@ module Bolt
       @session = @connection.shell(@shell)
       @session.run('$PSVersionTable.PSVersion')
       @logger.debug { "Opened session" }
-    rescue SocketError, SystemCallError => e
-      raise Bolt::Node::ConnectError.new(
-        "Failed to connect to #{@uri}: #{e.message}",
-        'CONNECT_ERROR'
-      )
     rescue ::WinRM::WinRMAuthorizationError
       raise Bolt::Node::ConnectError.new(
         "Authentication failed for #{@endpoint}",
         'AUTH_ERROR'
+      )
+    rescue StandardError => e
+      raise Bolt::Node::ConnectError.new(
+        "Failed to connect to #{@uri}: #{e.message}",
+        'CONNECT_ERROR'
       )
     end
 

--- a/spec/bolt/node/winrm_spec.rb
+++ b/spec/bolt/node/winrm_spec.rb
@@ -3,6 +3,7 @@ require 'bolt_spec/errors'
 require 'bolt_spec/files'
 require 'bolt/node'
 require 'bolt/node/winrm'
+require 'httpclient'
 
 describe Bolt::WinRM do
   include BoltSpec::Errors
@@ -42,6 +43,17 @@ describe Bolt::WinRM do
         Errno::ECONNREFUSED,
         "Connection refused - connect(2) for \"#{host}\" port #{port}"
       )
+
+      expect_node_error(Bolt::Node::ConnectError,
+                        'CONNECT_ERROR',
+                        /Failed to connect to/) do
+        winrm.connect
+      end
+    end
+
+    it "raises Node::ConnectError if the connection times out" do
+      winrm = Bolt::WinRM.new(host, port, user, password)
+      stub_winrm_to_raise(HTTPClient::ConnectTimeoutError, 'execution expired')
 
       expect_node_error(Bolt::Node::ConnectError,
                         'CONNECT_ERROR',


### PR DESCRIPTION
The winrm library wraps httpclient which can raise subclasses of
HTTPClient::TimeoutError during a connect, instead of Errno::ETIMEDOUT or WinRM
specific errors. As a result, we weren't handling connect/receive/send timeouts
or BadResponseErrors at the SOAP layer[1].

Always rescue StandardError from which RuntimeError, SocketError,
SystemCallError, and Net::SSH::Exception derive from.

[1] https://github.com/nahi/httpclient/blob/82929c4baae14c2319c3f9aba49488c6f6def875/lib/httpclient.rb#L249-L281