### PR TITLE
(BOLT-183) Apply CLI options when running plans

### DIFF
--- a/lib/bolt.rb
+++ b/lib/bolt.rb
@@ -3,10 +3,7 @@ require 'logger'
 module Bolt
   class << self
     attr_accessor :log_level
-    attr_accessor :config
   end
-
-  @config = {}
 
   require 'bolt/executor'
   require 'bolt/node'

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -6,6 +6,7 @@ require 'json'
 require 'bolt/node'
 require 'bolt/version'
 require 'bolt/executor'
+require 'bolt/config'
 require 'io/console'
 
 module Bolt
@@ -308,11 +309,12 @@ HELP
                              end
       end
 
-      executor = Bolt::Executor.new(concurrency: options[:concurrency],
-                                    user: options[:user],
-                                    password: options[:password],
-                                    tty: options[:tty],
-                                    insecure: options[:insecure])
+      config = Bolt::Config.new(concurrency: options[:concurrency],
+                                user: options[:user],
+                                password: options[:password],
+                                tty: options[:tty],
+                                insecure: options[:insecure])
+      executor = Bolt::Executor.new(config)
 
       if options[:mode] == 'plan'
         execute_plan(executor, options)

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -1,0 +1,19 @@
+module Bolt
+  Config = Struct.new(:concurrency,
+                      :user,
+                      :password,
+                      :tty,
+                      :insecure) do
+
+    DEFAULTS = {
+      concurrency: 100,
+      tty: false,
+      insecure: false
+    }.freeze
+
+    def initialize(**kwargs)
+      super()
+      DEFAULTS.merge(kwargs).each { |k, v| self[k] = v }
+    end
+  end
+end

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -3,29 +3,20 @@ require 'bolt/result'
 
 module Bolt
   class Executor
-    def initialize(concurrency: 100, user: nil, password: nil,
-                   tty: false, insecure: false)
-      @concurrency = concurrency
-      @user = user
-      @password = password
-      @tty = tty
-      @insecure = insecure
+    def initialize(config)
+      @config = config
     end
 
     def from_uris(nodes)
       nodes.map do |node|
-        Bolt::Node.from_uri(node,
-                            user: @user,
-                            password: @password,
-                            tty: @tty,
-                            insecure: @insecure)
+        Bolt::Node.from_uri(node, config: @config)
       end
     end
 
     def on(nodes)
       results = Concurrent::Map.new
 
-      poolsize = [nodes.length, @concurrency].min
+      poolsize = [nodes.length, @config[:concurrency]].min
       pool = Concurrent::FixedThreadPool.new(poolsize)
       nodes.each { |node|
         pool.post do

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -1,9 +1,10 @@
 require 'concurrent'
 require 'bolt/result'
+require 'bolt/config'
 
 module Bolt
   class Executor
-    def initialize(config)
+    def initialize(config = Bolt::Config.new)
       @config = config
     end
 

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -2,13 +2,14 @@ require 'logger'
 require 'bolt/node_uri'
 require 'bolt/node/formatter'
 require 'bolt/result'
+require 'bolt/config'
 
 module Bolt
   class Node
     STDIN_METHODS       = %w[both stdin].freeze
     ENVIRONMENT_METHODS = %w[both environment].freeze
 
-    def self.from_uri(uri_string, user: nil, password: nil, **kwargs)
+    def self.from_uri(uri_string, **kwargs)
       uri = NodeURI.new(uri_string)
       klass = case uri.scheme
               when 'winrm'
@@ -20,24 +21,23 @@ module Bolt
               end
       klass.new(uri.hostname,
                 uri.port,
-                uri.user || user,
-                uri.password || password,
+                uri.user,
+                uri.password,
                 uri: uri_string,
                 **kwargs)
     end
 
     attr_reader :logger, :host, :uri, :user, :password
 
-    def initialize(host, port = nil, user = nil,
-                   password = nil, tty: false, uri: nil,
-                   insecure: false,
+    def initialize(host, port = nil, user = nil, password = nil, uri: nil,
+                   config: Bolt::Config.new,
                    log_level: Bolt.log_level || Logger::WARN)
       @host = host
-      @user = user
       @port = port
-      @password = password
-      @tty = tty
-      @insecure = insecure
+      @user = user || config[:user]
+      @password = password || config[:password]
+      @tty = config[:tty]
+      @insecure = config[:insecure]
       @uri = uri
 
       @logger = init_logger(level: log_level)

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -8,8 +8,7 @@ module Bolt
     STDIN_METHODS       = %w[both stdin].freeze
     ENVIRONMENT_METHODS = %w[both environment].freeze
 
-    def self.from_uri(uri_string, default_user = nil, default_password = nil,
-                      **kwargs)
+    def self.from_uri(uri_string, user: nil, password: nil, **kwargs)
       uri = NodeURI.new(uri_string)
       klass = case uri.scheme
               when 'winrm'
@@ -21,9 +20,10 @@ module Bolt
               end
       klass.new(uri.hostname,
                 uri.port,
-                uri.user || default_user || Bolt.config[:user],
-                uri.password || default_password || Bolt.config[:password],
-                uri: uri_string, **kwargs)
+                uri.user || user,
+                uri.password || password,
+                uri: uri_string,
+                **kwargs)
     end
 
     attr_reader :logger, :host, :uri, :user, :password

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -309,27 +309,35 @@ NODES
   describe "execute" do
     let(:executor) { double('executor') }
     let(:cli) { Bolt::CLI.new({}) }
-    let(:nodes) { ['foo'] }
+    let(:node_names) { ['foo'] }
+    let(:nodes) { [double('node', host: 'foo')] }
 
     before :each do
       allow(Bolt::Executor).to receive(:new).and_return(executor)
+      allow(executor).to receive(:from_uris).and_return(nodes)
       allow(cli).to receive(:print_results)
     end
 
     it "executes the 'whoami' command" do
-      expect(executor).to receive(:run_command).with('whoami').and_return({})
+      expect(executor)
+        .to receive(:run_command)
+        .with(nodes, 'whoami')
+        .and_return({})
 
       options = {
-        nodes: nodes, mode: 'command', action: 'run', object: 'whoami'
+        nodes: node_names, mode: 'command', action: 'run', object: 'whoami'
       }
       cli.execute(options)
     end
 
     it "runs a script" do
-      expect(executor).to receive(:run_script).with('bar.sh').and_return({})
+      expect(executor)
+        .to receive(:run_script)
+        .with(nodes, 'bar.sh')
+        .and_return({})
 
       options = {
-        nodes: nodes, mode: 'script', action: 'run', object: 'bar.sh'
+        nodes: node_names, mode: 'script', action: 'run', object: 'bar.sh'
       }
       cli.execute(options)
     end
@@ -341,11 +349,13 @@ NODES
 
       expect(executor)
         .to receive(:run_task)
-        .with(%r{modules/sample/tasks/echo.sh$}, input_method, task_params)
-        .and_return({})
+        .with(
+          nodes,
+          %r{modules/sample/tasks/echo.sh$}, input_method, task_params
+        ).and_return({})
 
       options = {
-        nodes: nodes,
+        nodes: node_names,
         mode: 'task',
         action: 'run',
         object: task_name,
@@ -362,11 +372,13 @@ NODES
 
       expect(executor)
         .to receive(:run_task)
-        .with(%r{modules/sample/tasks/init.sh$}, input_method, task_params)
-        .and_return({})
+        .with(
+          nodes,
+          %r{modules/sample/tasks/init.sh$}, input_method, task_params
+        ).and_return({})
 
       options = {
-        nodes: nodes,
+        nodes: node_names,
         mode: 'task',
         action: 'run',
         object: task_name,
@@ -383,11 +395,12 @@ NODES
 
       expect(executor)
         .to receive(:run_task)
-        .with(%r{modules/sample/tasks/stdin.sh$}, input_method, task_params)
+        .with(nodes,
+              %r{modules/sample/tasks/stdin.sh$}, input_method, task_params)
         .and_return({})
 
       options = {
-        nodes: nodes,
+        nodes: node_names,
         mode: 'task',
         action: 'run',
         object: task_name,
@@ -404,11 +417,12 @@ NODES
 
       expect(executor)
         .to receive(:run_task)
-        .with(%r{modules/sample/tasks/winstdin.ps1$}, input_method, task_params)
+        .with(nodes,
+              %r{modules/sample/tasks/winstdin.ps1$}, input_method, task_params)
         .and_return({})
 
       options = {
-        nodes: nodes,
+        nodes: node_names,
         mode: 'task',
         action: 'run',
         object: task_name,
@@ -422,7 +436,7 @@ NODES
       it "uploads a file via scp" do
         expect(executor)
           .to receive(:file_upload)
-          .with('/path/to/local', '/path/to/remote')
+          .with(nodes, '/path/to/local', '/path/to/remote')
           .and_return({})
         expect(cli)
           .to receive(:file_exist?)
@@ -430,7 +444,7 @@ NODES
           .and_return(true)
 
         options = {
-          nodes: nodes,
+          nodes: node_names,
           mode: 'file',
           action: 'upload',
           object: '/path/to/local',
@@ -446,7 +460,7 @@ NODES
           .and_return(false)
 
         options = {
-          nodes: nodes,
+          nodes: node_names,
           mode: 'file',
           action: 'upload',
           object: '/path/to/local',

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'bolt/config'
+
+describe Bolt::Config do
+  let(:config) { Bolt::Config.new }
+
+  describe "when initializing" do
+    it "accepts keyword values" do
+      config = Bolt::Config.new(concurrency: 200)
+      expect(config.concurrency).to eq(200)
+    end
+
+    it "uses a default value when none is given" do
+      config = Bolt::Config.new
+      expect(config.concurrency).to eq(100)
+    end
+
+    it "does not use a default value when nil is given" do
+      config = Bolt::Config.new(concurrency: nil)
+      expect(config.concurrency).to eq(nil)
+    end
+
+    it "rejects unknown keys" do
+      expect {
+        Bolt::Config.new(what: 'why')
+      }.to raise_error(NameError)
+    end
+  end
+end

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 require 'bolt/executor'
 
 describe "Bolt::Executor" do
-  let(:executor) { Bolt::Executor.new }
+  let(:config) { Bolt::Config.new }
+  let(:executor) { Bolt::Executor.new(config) }
   let(:command) { "hostname" }
   let(:script) { '/path/to/script.sh' }
   let(:success) { Bolt::Node::Success.new }

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'bolt/executor'
 
 describe "Bolt::Executor" do
+  let(:executor) { Bolt::Executor.new }
   let(:command) { "hostname" }
   let(:script) { '/path/to/script.sh' }
   let(:success) { Bolt::Node::Success.new }
@@ -21,7 +22,7 @@ describe "Bolt::Executor" do
     node2 = mock_node 'node2'
     expect(node2).to receive(:run_command).with(command).and_return(success)
 
-    Bolt::Executor.new([node1, node2]).run_command(command)
+    executor.run_command([node1, node2], command)
   end
 
   it "runs a script on all nodes" do
@@ -30,7 +31,7 @@ describe "Bolt::Executor" do
     node2 = mock_node 'node2'
     expect(node2).to receive(:run_script).with(script).and_return(success)
 
-    results = Bolt::Executor.new([node1, node2]).run_script(script)
+    results = executor.run_script([node1, node2], script)
     results.each_pair do |_, result|
       expect(result).to be_instance_of(Bolt::Node::Success)
     end
@@ -48,8 +49,7 @@ describe "Bolt::Executor" do
       .with(task, 'both', task_arguments)
       .and_return(success)
 
-    results = Bolt::Executor.new([node1, node2])
-                            .run_task(task, 'both', task_arguments)
+    results = executor.run_task([node1, node2], task, 'both', task_arguments)
     results.each_pair do |_, result|
       expect(result).to be_instance_of(Bolt::Node::Success)
     end
@@ -63,7 +63,7 @@ describe "Bolt::Executor" do
         Bolt::Node::ConnectError.new('Authentication failed', 'AUTH_ERROR')
       )
 
-    results = Bolt::Executor.new([node]).run_command(command)
+    results = executor.run_command([node], command)
     results.each_pair do |_, result|
       expect(result).to be_instance_of(Bolt::ErrorResult)
     end
@@ -75,16 +75,16 @@ describe "Bolt::Executor" do
     allow(node).to receive(:logger).and_return(logger)
     expect(node).to receive(:connect).and_raise("reset")
 
-    results = Bolt::Executor.new([node]).run_command(command)
+    results = executor.run_command([node], command)
     results.each_pair do |_, result|
       expect(result).to be_instance_of(Bolt::ExceptionResult)
     end
   end
 
-  it "can be created with a list of uris" do
+  it "generates node objects from a list of uris" do
     expect(Bolt::SSH).to receive(:new).with('a.net', any_args)
     expect(Bolt::WinRM).to receive(:new).with('b.com', any_args)
 
-    Bolt::Executor.from_uris(['ssh://a.net', 'winrm://b.com'])
+    executor.from_uris(['ssh://a.net', 'winrm://b.com'])
   end
 end

--- a/spec/bolt/node/ssh_spec.rb
+++ b/spec/bolt/node/ssh_spec.rb
@@ -72,7 +72,7 @@ describe Bolt::SSH do
     end
 
     it "returns Node::ConnectError if the connection is refused" do
-      ssh = Bolt::SSH.new(hostname, 65535, user, password, insecure: true)
+      ssh = Bolt::SSH.new(hostname, 65535, user, password)
       expect_node_error(Bolt::Node::ConnectError,
                         'CONNECT_ERROR',
                         /Failed to connect to/) do
@@ -84,8 +84,6 @@ describe Bolt::SSH do
       allow(Net::SSH)
         .to receive(:start)
         .and_raise(Net::SSH::ConnectionTimeout)
-
-      ssh = Bolt::SSH.new(hostname, port, user, password, insecure: true)
       expect_node_error(Bolt::Node::ConnectError,
                         'CONNECT_ERROR',
                         /Failed to connect to/) do

--- a/spec/bolt/node/ssh_spec.rb
+++ b/spec/bolt/node/ssh_spec.rb
@@ -3,6 +3,7 @@ require 'bolt_spec/errors'
 require 'bolt_spec/files'
 require 'bolt/node'
 require 'bolt/node/ssh'
+require 'bolt/config'
 
 describe Bolt::SSH do
   include BoltSpec::Errors
@@ -14,6 +15,7 @@ describe Bolt::SSH do
   let(:port) { 2224 }
   let(:command) { "pwd" }
   let(:ssh) { Bolt::SSH.new(hostname, port, user, password) }
+  let(:insecure) { { config: Bolt::Config.new(insecure: true) } }
 
   context "when connecting", vagrant: true do
     it "performs secure host key verification by default" do
@@ -28,7 +30,7 @@ describe Bolt::SSH do
     end
 
     it "downgrades to lenient if insecure is true" do
-      ssh = Bolt::SSH.new(hostname, port, user, password, insecure: true)
+      ssh = Bolt::SSH.new(hostname, port, user, password, **insecure)
 
       allow(Net::SSH)
         .to receive(:start)
@@ -49,7 +51,7 @@ describe Bolt::SSH do
     end
 
     it "raises ConnectError if authentication fails" do
-      ssh = Bolt::SSH.new(hostname, port, user, password, insecure: true)
+      ssh = Bolt::SSH.new(hostname, port, user, password, **insecure)
 
       allow(Net::SSH)
         .to receive(:start)
@@ -93,7 +95,7 @@ describe Bolt::SSH do
   end
 
   context "when executing" do
-    let(:ssh) { Bolt::SSH.new(hostname, port, user, password, insecure: true) }
+    let(:ssh) { Bolt::SSH.new(hostname, port, user, password, **insecure) }
 
     before(:each) { ssh.connect }
     after(:each) { ssh.disconnect }

--- a/spec/bolt/node_spec.rb
+++ b/spec/bolt/node_spec.rb
@@ -13,18 +13,16 @@ describe Bolt::Node do
     end
 
     it "defaults to specified user and password" do
-      config = { user: 'somebody',
-                 password: 'very secure' }
-      node = Bolt::Node.from_uri('ssh://localhost', config)
+      config = Bolt::Config.new(user: 'somebody', password: 'very secure')
+      node = Bolt::Node.from_uri('ssh://localhost', config: config)
       expect(node.user).to eq('somebody')
       expect(node.password).to eq('very secure')
     end
 
     it "uri overrides specified user and password" do
-      config = { user: 'somebody',
-                 password: 'very secure' }
+      config = Bolt::Config.new(user: 'somebody', password: 'very secure')
 
-      node = Bolt::Node.from_uri('ssh://toor:better@localhost', config)
+      node = Bolt::Node.from_uri('ssh://toor:better@localhost', config: config)
       expect(node.user).to eq('toor')
       expect(node.password).to eq('better')
     end

--- a/spec/bolt/node_spec.rb
+++ b/spec/bolt/node_spec.rb
@@ -12,22 +12,19 @@ describe Bolt::Node do
       expect(node.uri).to eq('ssh://iuyergkj:123456@whitehouse.gov')
     end
 
-    it "defaults to globally set user and password" do
+    it "defaults to specified user and password" do
       config = { user: 'somebody',
                  password: 'very secure' }
-      allow(Bolt).to receive(:config).and_return(config)
-
-      node = Bolt::Node.from_uri('ssh://localhost')
+      node = Bolt::Node.from_uri('ssh://localhost', config)
       expect(node.user).to eq('somebody')
       expect(node.password).to eq('very secure')
     end
 
-    it "uri overrides global user and password" do
+    it "uri overrides specified user and password" do
       config = { user: 'somebody',
                  password: 'very secure' }
-      allow(Bolt).to receive(:config).and_return(config)
 
-      node = Bolt::Node.from_uri('ssh://toor:better@localhost')
+      node = Bolt::Node.from_uri('ssh://toor:better@localhost', config)
       expect(node.user).to eq('toor')
       expect(node.password).to eq('better')
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,8 +29,4 @@ RSpec.configure do |config|
   config.example_status_persistence_file_path = "spec/examples.txt"
 
   # config.warnings = true
-
-  config.before :each do |_|
-    Bolt.config.clear
-  end
 end


### PR DESCRIPTION
Apply CLI options when running a plan, such as `--user`, `--password`, `--tty`, etc.