### PR TITLE
(maint) Pin to rubocop 0.50.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 gemspec
 
 group(:test) do
-  gem "rubocop", require: false
+  gem "rubocop", '0.50.0', require: false
 end
 
 if File.exist? "Gemfile.local"

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -23,15 +23,16 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = "~> 2.0"
 
-  spec.add_dependency "net-ssh", "~> 4.0"
+  spec.add_dependency "addressable", "~> 2.5"
+  spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "net-sftp", "~> 2.0"
+  spec.add_dependency "net-ssh", "~> 4.0"
+  spec.add_dependency "orchestrator_client", "~> 0.2.1"
   spec.add_dependency "winrm", "~> 2.0"
   spec.add_dependency "winrm-fs", "~> 1.0"
-  spec.add_dependency "concurrent-ruby", "~> 1.0"
-  spec.add_dependency "addressable", "~> 2.5"
-  spec.add_dependency "orchestrator_client", "~> 0.2.1"
 
   # Dependencies of our vendored puppet, etc
+  spec.add_dependency "CFPropertyList", "~> 2.2"
   spec.add_dependency "gettext-setup", "< 1", ">= 0.10"
   spec.add_dependency "locale", "~> 2.1"
   spec.add_dependency "minitar", "~> 0.6.1"
@@ -39,7 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "win32-process", "= 0.7.5"
   spec.add_dependency "win32-security", "= 0.2.5"
   spec.add_dependency "win32-service", "= 0.8.8"
-  spec.add_dependency "CFPropertyList", "~> 2.2"
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/exe/bolt
+++ b/exe/bolt
@@ -10,6 +10,6 @@ begin
 rescue Bolt::CLIExit
   exit
 rescue Bolt::CLIError => e
-  $stderr.puts e.message
+  warn e.message
   exit e.error_code
 end


### PR DESCRIPTION
Rubocop dropped support for Ruby 2.0 analysis, see commit
https://github.com/bbatsov/rubocop/commit/2f6f3f297cd957def22419d8d70a1afd9410e497.

Pin to rubocop 0.50.0, while fixing rubocop errors that occur with
0.51.0.