### PR TITLE
(BOLT-28) Make --password optional and prompt the user if value is missing

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -6,6 +6,7 @@ require 'json'
 require 'bolt/node'
 require 'bolt/version'
 require 'bolt/executor'
+require 'io/console'
 
 module Bolt
   class CLIError < RuntimeError
@@ -115,9 +116,14 @@ HELP
                 "User to authenticate as (Optional)") do |user|
           results[:user] = user
         end
-        opts.on('-p', '--password PASSWORD',
+        opts.on('-p', '--password [PASSWORD]',
                 "Password to authenticate as (Optional)") do |password|
-          results[:password] = password
+          if password.nil?
+            puts "Please enter your password:"
+            results[:password] = STDIN.noecho(&:gets).chomp
+          else
+            results[:password] = password
+          end
         end
         results[:concurrency] = 100
         opts.on('-c', '--concurrency CONCURRENCY', Integer,

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -119,8 +119,9 @@ HELP
         opts.on('-p', '--password [PASSWORD]',
                 "Password to authenticate as (Optional)") do |password|
           if password.nil?
-            puts "Please enter your password:"
+            STDOUT.print "Please enter your password: "
             results[:password] = STDIN.noecho(&:gets).chomp
+            STDOUT.puts
           else
             results[:password] = password
           end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -147,6 +147,8 @@ NODES
 
     it "prompts the user for password if not specified" do
       allow(STDIN).to receive(:noecho).and_return('opensesame')
+      allow(STDOUT).to receive(:print).with('Please enter your password: ')
+      allow(STDOUT).to receive(:puts)
       cli = Bolt::CLI.new(%w[command run --nodes foo --password])
       expect(cli.parse).to include(password: 'opensesame')
     end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -145,11 +145,10 @@ NODES
       expect(cli.parse).to include(password: 'opensesame')
     end
 
-    it "generates an error message if no password value is given" do
+    it "prompts the user for password if not specified" do
+      allow(STDIN).to receive(:noecho).and_return('opensesame')
       cli = Bolt::CLI.new(%w[command run --nodes foo --password])
-      expect {
-        cli.parse
-      }.to raise_error(Bolt::CLIError, /option '--password' needs a parameter/)
+      expect(cli.parse).to include(password: 'opensesame')
     end
   end
 


### PR DESCRIPTION
Supersedes PR #121 