### PR TITLE
(maint) Relax addressable gem constraint

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = "~> 2.0"
 
-  spec.add_dependency "addressable", "~> 2.5"
+  spec.add_dependency "addressable", "~> 2.4"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "net-sftp", "~> 2.0"
   spec.add_dependency "net-ssh", "~> 4.0"


### PR DESCRIPTION
Puppet requires addressable < 2.5.0, because that version includes a
dependency that doesn't support ruby 1.9. In order to use puppet and
bolt gems together, e.g. when running `puppet script`, we need to relax
bolt's addressable gem dependency.