### PR TITLE
(BOLT-28) Always read password if --password is specified

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -117,14 +117,14 @@ HELP
                 "User to authenticate as (Optional)") do |user|
           results[:user] = user
         end
-        opts.on('-p', '--password [PASSWORD]',
-                "Password to authenticate as (Optional)") do |password|
-          if password.nil?
+        opts.on('-p', '--password',
+                "To prompt for the password to authenticate as (Optional)") do
+          if STDIN.tty?
             STDOUT.print "Please enter your password: "
             results[:password] = STDIN.noecho(&:gets).chomp
             STDOUT.puts
           else
-            results[:password] = password
+            results[:password] = STDIN.read.chomp
           end
         end
         results[:concurrency] = 100

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -140,15 +140,17 @@ NODES
   end
 
   describe "password" do
-    it "accepts a password" do
-      cli = Bolt::CLI.new(%w[command run --password opensesame --nodes foo])
-      expect(cli.parse).to include(password: 'opensesame')
-    end
-
     it "prompts the user for password if not specified" do
       allow(STDIN).to receive(:noecho).and_return('opensesame')
       allow(STDOUT).to receive(:print).with('Please enter your password: ')
       allow(STDOUT).to receive(:puts)
+      cli = Bolt::CLI.new(%w[command run --nodes foo --password])
+      expect(cli.parse).to include(password: 'opensesame')
+    end
+
+    it "reads the password from stdin if there is no tty" do
+      allow(STDIN).to receive(:tty?).and_return(false)
+      allow(STDIN).to receive(:read).and_return('opensesame')
       cli = Bolt::CLI.new(%w[command run --nodes foo --password])
       expect(cli.parse).to include(password: 'opensesame')
     end

--- a/spec/bolt/node/winrm_spec.rb
+++ b/spec/bolt/node/winrm_spec.rb
@@ -74,6 +74,28 @@ describe Bolt::WinRM do
         winrm.connect
       end
     end
+
+    it "raises Node::ConnectError if user is absent" do
+      winrm = Bolt::WinRM.new(host, port, nil, password)
+
+      expect_node_error(
+        Bolt::Node::ConnectError, 'AUTH_ERROR',
+        'A user must be specified when using WinRM'
+      ) do
+        winrm.connect
+      end
+    end
+
+    it "raises Node::ConnectError if password is absent" do
+      winrm = Bolt::WinRM.new(host, port, user, nil)
+
+      expect_node_error(
+        Bolt::Node::ConnectError, 'AUTH_ERROR',
+        'A password must be specified when using WinRM'
+      ) do
+        winrm.connect
+      end
+    end
   end
 
   it "executes a command on a host", vagrant: true do


### PR DESCRIPTION
Previously, it wasn't intuitive that `--password` should be specified
without an argument in order for bolt to prompt for the password. And it
isn't secure to allow users to enter their passwords on the command
line.

This commit changes --password so that if specified and stdin is a tty,
then prompt for the password. If not a tty, then read from stdin, to
enable the password to be piped to bolt.

Also user and password are required for winrm, so print a meaningful error
message if either is missing.