### PR TITLE
(BOLT-28) Improve help for password prompting

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -118,7 +118,8 @@ HELP
           results[:user] = user
         end
         opts.on('-p', '--password [PASSWORD]',
-                "Password to authenticate as (Optional)") do |password|
+                'Password to authenticate with (Optional).',
+                'Omit the value to prompt for the password.') do |password|
           if password.nil?
             STDOUT.print "Please enter your password: "
             results[:password] = STDIN.noecho(&:gets).chomp

--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -9,13 +9,14 @@ module Bolt
 
       @shell = shell
       @endpoint = "http://#{host}:#{port}/wsman"
+    end
+
+    def connect
       @connection = ::WinRM::Connection.new(endpoint: @endpoint,
                                             user: @user,
                                             password: @password)
       @connection.logger = @transport_logger
-    end
 
-    def connect
       @session = @connection.shell(@shell)
       @session.run('$PSVersionTable.PSVersion')
       @logger.debug { "Opened session" }
@@ -26,7 +27,7 @@ module Bolt
       )
     rescue StandardError => e
       raise Bolt::Node::ConnectError.new(
-        "Failed to connect to #{@uri}: #{e.message}",
+        "Failed to connect to #{@endpoint}: #{e.message}",
         'CONNECT_ERROR'
       )
     end

--- a/spec/bolt/node/winrm_spec.rb
+++ b/spec/bolt/node/winrm_spec.rb
@@ -74,6 +74,28 @@ describe Bolt::WinRM do
         winrm.connect
       end
     end
+
+    it "raises Node::ConnectError if user is absent" do
+      winrm = Bolt::WinRM.new(host, port, nil, password)
+
+      expect_node_error(
+        Bolt::Node::ConnectError, 'CONNECT_ERROR',
+        /Failed to connect to .*: user is a required option/
+      ) do
+        winrm.connect
+      end
+    end
+
+    it "raises Node::ConnectError if password is absent" do
+      winrm = Bolt::WinRM.new(host, port, user, nil)
+
+      expect_node_error(
+        Bolt::Node::ConnectError, 'CONNECT_ERROR',
+        /Failed to connect to .*: password is a required option/
+      ) do
+        winrm.connect
+      end
+    end
   end
 
   it "executes a command on a host", vagrant: true do


### PR DESCRIPTION
Update help so that it's clear to omit the `--password` value to be
prompted for the password.

Also winrm printed an ugly stack trace if the password is omitted,
because the WinRM connection was created in our initialize method
instead of connect. Move it to the latter so that we gracefully handle
exceptions.