### PR TITLE
(BOLT-192) Require at least net-ssh 4.2, but less than 5.0

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "addressable", "~> 2.4"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "net-sftp", "~> 2.0"
-  spec.add_dependency "net-ssh", "~> 4.0"
+  spec.add_dependency "net-ssh", "~> 4.2"
   spec.add_dependency "orchestrator_client", "~> 0.2.1"
   spec.add_dependency "winrm", "~> 2.0"
   spec.add_dependency "winrm-fs", "~> 1.0"


### PR DESCRIPTION
The net-ssh library renamed the `paranoid` key to `verify_host_key` in
commit net-ssh#c4fbcdc882[1]. Using the latter key fails if net-ssh < 4.2,
so bump our minimum net-ssh runtime dependency.

[1] https://github.com/net-ssh/net-ssh/commit/c3fbcdc882f6763fa718f6adbd9d1d60eaf04b62