### PR TITLE
(BOLT-193) Avoid dependency on public_suffix for ruby 2.0

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = "~> 2.0"
 
-  spec.add_dependency "addressable", "~> 2.4"
+  spec.add_dependency "addressable", '< 2.5.0'
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "net-sftp", "~> 2.0"
   spec.add_dependency "net-ssh", "~> 4.0"


### PR DESCRIPTION
Require addressable < 2.5.0 to avoid a dependency on public_suffix whose
version 3.0 requires ruby 2.1 or greater.

We can revert back to addressable ~> 2.4 when we drop ruby 2.0 support.