### PR TITLE
(BOLT-53) Global transport

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -95,7 +95,8 @@ HELP
       @argv    = argv
       @options = {
         nodes: [],
-        transport: 'ssh'
+        transport: 'ssh',
+        insecure: false
       }
       @parser = create_option_parser(@options)
     end
@@ -147,7 +148,6 @@ HELP
                 "Parameters to a task or plan") do |params|
           results[:task_options] = parse_params(params)
         end
-        results[:insecure] = false
         opts.on('-k', '--insecure',
                 "Whether to connect insecurely ") do |insecure|
           results[:insecure] = insecure

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -86,6 +86,7 @@ HELP
 
     MODES = %w[command script task plan file].freeze
     ACTIONS = %w[run upload download].freeze
+    TRANSPORTS = %w[ssh winrm pcp].freeze
 
     attr_reader :parser
     attr_accessor :options
@@ -93,9 +94,9 @@ HELP
     def initialize(argv)
       @argv    = argv
       @options = {
-        nodes: []
+        nodes: [],
+        transport: 'ssh'
       }
-
       @parser = create_option_parser(@options)
     end
 
@@ -150,6 +151,10 @@ HELP
         opts.on('-k', '--insecure',
                 "Whether to connect insecurely ") do |insecure|
           results[:insecure] = insecure
+        end
+        opts.on('--transport TRANSPORT', TRANSPORTS,
+                "Specify a default transport: #{TRANSPORTS.join(', ')}") do |t|
+          options[:transport] = t
         end
         opts.on_tail('--[no-]tty',
                      "Request a pseudo TTY on nodes that support it") do |tty|

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -331,7 +331,8 @@ HELP
                                 user: options[:user],
                                 password: options[:password],
                                 tty: options[:tty],
-                                insecure: options[:insecure])
+                                insecure: options[:insecure],
+                                transport: options[:transport])
       executor = Bolt::Executor.new(config)
 
       if options[:mode] == 'plan'

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -3,12 +3,14 @@ module Bolt
                       :user,
                       :password,
                       :tty,
-                      :insecure) do
+                      :insecure,
+                      :transport) do
 
     DEFAULTS = {
       concurrency: 100,
       tty: false,
-      insecure: false
+      insecure: false,
+      transport: 'ssh'
     }.freeze
 
     def initialize(**kwargs)

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -10,7 +10,7 @@ module Bolt
     ENVIRONMENT_METHODS = %w[both environment].freeze
 
     def self.from_uri(uri_string, **kwargs)
-      uri = NodeURI.new(uri_string)
+      uri = NodeURI.new(uri_string, kwargs[:config][:transport])
       klass = case uri.scheme
               when 'winrm'
                 Bolt::WinRM

--- a/lib/bolt/node_uri.rb
+++ b/lib/bolt/node_uri.rb
@@ -2,19 +2,20 @@ require 'addressable'
 
 module Bolt
   class NodeURI
-    def initialize(string)
-      @uri = parse(string)
+    def initialize(string, transport = 'ssh')
+      @uri = parse(string, transport)
     end
 
-    def parse(string)
+    def parse(string, transport)
       uri = if string =~ %r{^(ssh|winrm|pcp)://}
               Addressable::URI.parse(string)
             else
-              Addressable::URI.parse("ssh://#{string}")
+              Addressable::URI.parse("#{transport}://#{string}")
             end
       uri.port ||= 5985 if uri.scheme == 'winrm'
       uri
     end
+    private :parse
 
     def hostname
       @uri.hostname

--- a/lib/bolt/node_uri.rb
+++ b/lib/bolt/node_uri.rb
@@ -7,7 +7,7 @@ module Bolt
     end
 
     def parse(string, transport)
-      uri = if string =~ %r{^(ssh|winrm|pcp)://}
+      uri = if string =~ %r{^[^:]+://}
               Addressable::URI.parse(string)
             else
               Addressable::URI.parse("#{transport}://#{string}")

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -226,6 +226,36 @@ NODES
     end
   end
 
+  describe "transport" do
+    it "defaults to 'ssh'" do
+      cli = Bolt::CLI.new(%w[command run --nodes foo whoami])
+      expect(cli.parse[:transport]).to eq('ssh')
+    end
+
+    it "accepts ssh" do
+      cli = Bolt::CLI.new(%w[command run --transport ssh --nodes foo id])
+      expect(cli.parse[:transport]).to eq('ssh')
+    end
+
+    it "accepts winrm" do
+      cli = Bolt::CLI.new(%w[command run --transport winrm --nodes foo id])
+      expect(cli.parse[:transport]).to eq('winrm')
+    end
+
+    it "accepts pcp" do
+      cli = Bolt::CLI.new(%w[command run --transport pcp --nodes foo id])
+      expect(cli.parse[:transport]).to eq('pcp')
+    end
+
+    it "rejects invalid transports" do
+      cli = Bolt::CLI.new(%w[command run --transport holodeck --nodes foo id])
+      expect {
+        cli.parse
+      }.to raise_error(OptionParser::InvalidArgument,
+                       /invalid argument: --transport holodeck/)
+    end
+  end
+
   describe "command" do
     it "interprets whoami as the command" do
       cli = Bolt::CLI.new(%w[command run --nodes foo whoami])

--- a/spec/bolt/node_spec.rb
+++ b/spec/bolt/node_spec.rb
@@ -5,23 +5,26 @@ require 'bolt/node'
 
 describe Bolt::Node do
   describe "initializing nodes from uri" do
+    let(:config) { Bolt::Config.new }
     it "understands user and password" do
-      node = Bolt::Node.from_uri('ssh://iuyergkj:123456@whitehouse.gov')
+      node = Bolt::Node.from_uri('ssh://iuyergkj:123456@whitehouse.gov',
+                                 config: config)
       expect(node.user).to eq('iuyergkj')
       expect(node.password).to eq('123456')
       expect(node.uri).to eq('ssh://iuyergkj:123456@whitehouse.gov')
     end
 
     it "defaults to specified user and password" do
-      config = Bolt::Config.new(user: 'somebody', password: 'very secure')
+      config[:user] = 'somebody'
+      config[:password] = 'very secure'
       node = Bolt::Node.from_uri('ssh://localhost', config: config)
       expect(node.user).to eq('somebody')
       expect(node.password).to eq('very secure')
     end
 
     it "uri overrides specified user and password" do
-      config = Bolt::Config.new(user: 'somebody', password: 'very secure')
-
+      config[:user] = 'somebody'
+      config[:password] = 'very secure'
       node = Bolt::Node.from_uri('ssh://toor:better@localhost', config: config)
       expect(node.user).to eq('toor')
       expect(node.password).to eq('better')
@@ -30,7 +33,7 @@ describe Bolt::Node do
     it "strips brackets from ipv6 addresses in a uri" do
       expect(Bolt::SSH).to receive(:new).with('::1', any_args)
 
-      Bolt::Node.from_uri('ssh://[::1]:22')
+      Bolt::Node.from_uri('ssh://[::1]:22', config: config)
     end
   end
 

--- a/spec/bolt/node_uri_spec.rb
+++ b/spec/bolt/node_uri_spec.rb
@@ -92,6 +92,13 @@ describe Bolt::NodeURI do
       expect(uri.hostname).to eq('neptune')
       expect(uri.port).to eq(5985)
     end
+
+    it "uses 'winrm' when it's the default transport" do
+      uri = Bolt::NodeURI.new('neptune', 'winrm')
+      expect(uri.scheme).to eq('winrm')
+      expect(uri.hostname).to eq('neptune')
+      expect(uri.port).to eq(5985)
+    end
   end
 
   describe "with ssh" do

--- a/spec/bolt/node_uri_spec.rb
+++ b/spec/bolt/node_uri_spec.rb
@@ -146,4 +146,13 @@ describe Bolt::NodeURI do
       expect(uri.port).to be_nil
     end
   end
+
+  describe "with unsupported http scheme" do
+    it "accepts 'http://pluto:666'" do
+      uri = Bolt::NodeURI.new('http://pluto:666')
+      expect(uri.scheme).to eq('http')
+      expect(uri.hostname).to eq('pluto')
+      expect(uri.port).to eq(666)
+    end
+  end
 end


### PR DESCRIPTION
Adds a `--transport` command line option for specifying the default transport to use if one is not specified. The default transport is ssh. This is handy for Windows as you don't need to repeat winrm in each node URI:

```
$ bolt command run whoami --nodes={hghi7uvplkq8kki,qksuptpp9h5gunc}.delivery.puppetlabs.net --transport winrm -u Administrator -p
Please enter your password:
qksuptpp9h5gunc.delivery.puppetlabs.net:

qksuptpp9h5gunc\administrator


hghi7uvplkq8kki.delivery.puppetlabs.net:

hghi7uvplkq8kki\administrator


Ran on 2 nodes in 0.65 seconds
```