### PR TITLE
(BOLT-52) Allow arguments to be passed to scripts

### DIFF
--- a/lib/bolt/node/orch.rb
+++ b/lib/bolt/node/orch.rb
@@ -105,12 +105,13 @@ module Bolt
       _run_task(BOLT_MOCK_FILE, 'stdin', params)
     end
 
-    def _run_script(script, _)
+    def _run_script(script, arguments)
       content = File.open(script, &:read)
       content = Base64.encode64(content)
       params = {
         action: 'script',
-        content: content
+        content: content,
+        arguments: arguments
       }
       unwrap_bolt_result(_run_task(BOLT_MOCK_FILE, 'stdin', params))
     end

--- a/lib/bolt/node/ssh.rb
+++ b/lib/bolt/node/ssh.rb
@@ -136,14 +136,15 @@ module Bolt
       @logger.debug { "arguments: #{arguments}" }
 
       with_remote_file(script) do |remote_path|
-        # should each arg be quoted?
-        command = "'#{remote_path}'"
-        unless arguments.empty?
-          command += " "
-          command += arguments.join(' ')
+        command = ["'#{remote_path}'"]
+        command += arguments.map do |arg|
+          if arg =~ / /
+            "\"#{arg}\""
+          else
+            arg
+          end
         end
-
-        execute(command)
+        execute(command.join(' '))
       end
     end
 

--- a/lib/bolt/node/ssh.rb
+++ b/lib/bolt/node/ssh.rb
@@ -1,6 +1,7 @@
+require 'json'
+require 'shellwords'
 require 'net/ssh'
 require 'net/sftp'
-require 'json'
 require 'bolt/node/result'
 
 module Bolt
@@ -136,15 +137,7 @@ module Bolt
       @logger.debug { "arguments: #{arguments}" }
 
       with_remote_file(script) do |remote_path|
-        command = ["'#{remote_path}'"]
-        command += arguments.map do |arg|
-          if arg =~ / /
-            "\"#{arg}\""
-          else
-            arg
-          end
-        end
-        execute(command.join(' '))
+        execute("'#{remote_path}' #{Shellwords.join(arguments)}")
       end
     end
 

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -14,20 +14,20 @@ def write_file(path, content, mode)
   { success: true }
 end
 
-def command(command)
-  stdout, stderr, p = Open3.capture3(command)
+def command(command, arguments = [])
+  stdout, stderr, p = Open3.capture3(command, *arguments)
   { stdout: stdout,
     stderr: stderr,
     exit_code: p.exitstatus }
 end
 
-def script(content)
+def script(content, arguments)
   tf = Tempfile.new('bolt_script')
   source = Base64.decode64(content)
   tf.chmod(0o700)
   tf.write(source)
   tf.close
-  command(tf.path)
+  command(tf.path, arguments)
 end
 
 params = JSON.parse(STDIN.read)
@@ -38,7 +38,7 @@ result = case params['action']
          when 'upload'
            write_file(params['path'], params['content'], params['mode'])
          when 'script'
-           script(params['content'])
+           script(params['content'], params['arguments'])
          end
 
 puts result.to_json


### PR DESCRIPTION
Bolt now accepts arguments to scripts. If an argument contains spaces it must be
quoted, e.g. bolt script run script.sh 'arg with spaces'

```
$ bx bolt script run spec/fixtures/scripts/success.sh 'one two' three -n o4np54hfrljr5wo.delivery.puppetlabs.net -k
o4np54hfrljr5wo.delivery.puppetlabs.net:

arg: one two
arg: three
standard out

standard error

Ran on 1 node in 0.79 seconds
```

```
$ bx bolt script run spec/fixtures/scripts/success.ps1 "one two" three -n winrm://mllw3jr0io5r4zo.delivery.puppetlabs.net -k -u Administrator -p
....
mllw3jr0io5r4zo.delivery.puppetlabs.net:

arg: one two
arg: three
standard output



Ran on 1 node in 2.09 seconds
```
