### PR TITLE
(BOLT-197) Validate plan and task names

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -287,6 +287,16 @@ HELP
               "unknown argument(s) #{options[:leftovers].join(', ')}"
       end
 
+      if %w[task plan].include?(options[:mode])
+        if options[:object].nil?
+          raise Bolt::CLIError, "must specify a #{options[:mode]} to run"
+        end
+        # This may mean that we parsed a parameter as the object
+        unless options[:object] =~ /\A([a-z][a-z0-9_]*)?(::[a-z][a-z0-9_]*)*\Z/
+          raise Bolt::CLIError, "invalid #{options[:mode]}: #{options[:object]}"
+        end
+      end
+
       unless !options[:nodes].empty? || options[:mode] == 'plan'
         raise Bolt::CLIError, "option --nodes must be specified"
       end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -324,6 +324,38 @@ NODES
     end
   end
 
+  describe 'task' do
+    it "errors without a task" do
+      cli = Bolt::CLI.new(%w[task run -n example.com --modulepath .])
+      expect {
+        cli.parse
+      }.to raise_error(Bolt::CLIError, /must specify/)
+    end
+
+    it "errors if task is a parameter" do
+      cli = Bolt::CLI.new(%w[task run -n example.com --modulepath . p1=v1])
+      expect {
+        cli.parse
+      }.to raise_error(Bolt::CLIError, /invalid task/)
+    end
+  end
+
+  describe 'plan' do
+    it "errors without a plan" do
+      cli = Bolt::CLI.new(%w[plan run -n example.com --modulepath .])
+      expect {
+        cli.parse
+      }.to raise_error(Bolt::CLIError, /must specify/)
+    end
+
+    it "errors if plan is a parameter" do
+      cli = Bolt::CLI.new(%w[plan run -n example.com --modulepath . p1=v1])
+      expect {
+        cli.parse
+      }.to raise_error(Bolt::CLIError, /invalid plan/)
+    end
+  end
+
   describe "execute" do
     let(:executor) { double('executor') }
     let(:cli) { Bolt::CLI.new({}) }

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -416,6 +416,42 @@ NODES
       cli.execute(options)
     end
 
+    it "errors for non-existent modules" do
+      task_name = 'dne::task1'
+      task_params = { 'message' => 'hi' }
+
+      options = {
+        nodes: node_names,
+        mode: 'task',
+        action: 'run',
+        object: task_name,
+        task_options: task_params,
+        modulepath: [File.join(__FILE__, '../../fixtures/modules')]
+      }
+      expect { cli.execute(options) }.to raise_error(
+        Bolt::CLIError,
+        /Could not find module/
+      )
+    end
+
+    it "errors for non-existent tasks" do
+      task_name = 'sample::dne'
+      task_params = { 'message' => 'hi' }
+
+      options = {
+        nodes: node_names,
+        mode: 'task',
+        action: 'run',
+        object: task_name,
+        task_options: task_params,
+        modulepath: [File.join(__FILE__, '../../fixtures/modules')]
+      }
+      expect { cli.execute(options) }.to raise_error(
+        Bolt::CLIError,
+        /Task .* not found/
+      )
+    end
+
     it "runs an init task given a module name" do
       task_name = 'sample'
       task_params = { 'message' => 'hi' }


### PR DESCRIPTION
Failing to specify a plan or task name to run task previously resulted
in a stack trace. After this commit the plan or task name is validated
for the plan or task command.