### PR TITLE
Add to the CLI the possibility to choose a specific ssh Private Key 

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -135,6 +135,10 @@ HELP
           end
         end
         results[:concurrency] = 100
+        opts.on('--private-key KEY',
+                "Private ssh key to authenticate with (Optional)") do |key|
+          results[:key] = key
+        end
         opts.on('-c', '--concurrency CONCURRENCY', Integer,
                 "Maximum number of simultaneous connections " \
                 "(Optional, defaults to 100)") do |concurrency|

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -4,6 +4,7 @@ module Bolt
   Config = Struct.new(:concurrency,
                       :user,
                       :password,
+                      :key,
                       :tty,
                       :insecure,
                       :transport,

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -37,6 +37,7 @@ module Bolt
       @port = port
       @user = user || config[:user]
       @password = password || config[:password]
+      @key = config[:key]
       @tty = config[:tty]
       @insecure = config[:insecure]
       @uri = uri

--- a/lib/bolt/node/ssh.rb
+++ b/lib/bolt/node/ssh.rb
@@ -22,6 +22,7 @@ module Bolt
 
       options[:port] = @port if @port
       options[:password] = @password if @password
+      options[:keys] = @key if @key
       options[:verify_host_key] = if @insecure
                                     Net::SSH::Verifiers::Lenient.new
                                   else

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -183,6 +183,23 @@ NODES
     end
   end
 
+  describe "private-key" do
+    it "accepts a private key" do
+      cli = Bolt::CLI.new(%w[  command run
+                               --private-key ~/.ssh/google_compute_engine
+                               --nodes foo])
+      expect(cli.parse).to include(key: '~/.ssh/google_compute_engine')
+    end
+
+    it "generates an error message if no key value is given" do
+      cli = Bolt::CLI.new(%w[command run --nodes foo --private-key])
+      expect {
+        cli.parse
+      }.to raise_error(Bolt::CLIError,
+                       /Option '--private-key' needs a parameter/)
+    end
+  end
+
   describe "concurrency" do
     it "accepts a concurrency limit" do
       cli = Bolt::CLI.new(%w[command run --concurrency 10 --nodes foo])

--- a/spec/bolt/node/ssh_spec.rb
+++ b/spec/bolt/node/ssh_spec.rb
@@ -15,6 +15,10 @@ describe Bolt::SSH do
   let(:port) { 2224 }
   let(:command) { "pwd" }
   let(:ssh) { Bolt::SSH.new(hostname, port, user, password) }
+  let(:key) {
+    { config: Bolt::Config.new(key: Dir[".vagrant/**/private_key"],
+                               insecure: true) }
+  }
   let(:insecure) { { config: Bolt::Config.new(insecure: true) } }
   let(:echo_script) { <<BASH }
 for var in "$@"
@@ -96,6 +100,120 @@ BASH
                         'CONNECT_ERROR',
                         /Failed to connect to/) do
         ssh.connect
+      end
+    end
+  end
+
+  context "when executing with private key" do
+    let(:ssh) { Bolt::SSH.new(hostname, port, user, **key) }
+
+    before(:each) { ssh.connect }
+    after(:each) { ssh.disconnect }
+
+    it "executes a command on a host", vagrant: true do
+      expect(ssh.execute(command).value).to eq("/home/vagrant\n")
+    end
+
+    it "captures stderr from a host", vagrant: true do
+      expect(ssh.execute("ssh -V").output.stderr.string).to match(/OpenSSH/)
+    end
+
+    it "can upload a file to a host", vagrant: true do
+      contents = "kljhdfg"
+      with_tempfile_containing('upload-test', contents) do |file|
+        ssh.upload(file.path, "/home/vagrant/upload-test")
+
+        expect(
+          ssh.execute("cat /home/vagrant/upload-test").value
+        ).to eq(contents)
+
+        ssh.execute("rm /home/vagrant/upload-test")
+      end
+    end
+
+    it "can run a script remotely", vagrant: true do
+      contents = "#!/bin/sh\necho hellote"
+      with_tempfile_containing('script test', contents) do |file|
+        expect(
+          ssh._run_script(file.path, []).value
+        ).to eq("hellote\n")
+      end
+    end
+
+    it "can run a script remotely with quoted arguments", vagrant: true do
+      with_tempfile_containing('script-test-ssh-quotes', echo_script) do |file|
+        expect(
+          ssh._run_script(
+            file.path,
+            ['nospaces',
+             'with spaces',
+             "\"double double\"",
+             "'double single'",
+             '\'single single\'',
+             '"single double"',
+             "double \"double\" double",
+             "double 'single' double",
+             'single "double" single',
+             'single \'single\' single']
+          ).value
+        ).to eq(<<QUOTED)
+nospaces
+with spaces
+"double double"
+'double single'
+'single single'
+"single double"
+double "double" double
+double 'single' double
+single "double" single
+single 'single' single
+QUOTED
+      end
+    end
+
+    it "escapes unsafe shellwords in arguments", vagrant: true do
+      with_tempfile_containing('script-test-ssh-escape', echo_script) do |file|
+        expect(
+          ssh._run_script(
+            file.path,
+            ['echo $HOME; cat /etc/passwd']
+          ).value
+        ).to eq(<<SHELLWORDS)
+echo $HOME; cat /etc/passwd
+SHELLWORDS
+      end
+    end
+
+    it "can run a task", vagrant: true do
+      contents = "#!/bin/sh\necho -n ${PT_message_one} ${PT_message_two}"
+      arguments = { message_one: 'Hello from task', message_two: 'Goodbye' }
+      with_tempfile_containing('tasks test', contents) do |file|
+        expect(ssh._run_task(file.path, 'environment', arguments).value)
+          .to eq('Hello from task Goodbye')
+      end
+    end
+
+    it "can run a task passing input on stdin", vagrant: true do
+      contents = "#!/bin/sh\ngrep 'message_one'"
+      arguments = { message_one: 'Hello from task', message_two: 'Goodbye' }
+      with_tempfile_containing('tasks test stdin', contents) do |file|
+        expect(ssh._run_task(file.path, 'stdin', arguments).value)
+          .to match(/{"message_one":"Hello from task","message_two":"Goodbye"}/)
+      end
+    end
+
+    it "can run a task passing input on stdin and environment", vagrant: true do
+      contents = <<SHELL
+#!/bin/sh
+echo -n ${PT_message_one} ${PT_message_two}
+grep 'message_one'
+SHELL
+      arguments = { message_one: 'Hello from task', message_two: 'Goodbye' }
+      with_tempfile_containing('tasks-test-both', contents) do |file|
+        expect(ssh._run_task(file.path, 'both', arguments).value).to eq(<<SHELL)
+Hello from task Goodbye{\"message_one\":\
+\"Hello from task\",\"message_two\":\"Goodbye\"}
+SHELL
       end
     end
   end


### PR DESCRIPTION
**The problem:**
When connecting to a remote VM without the default ssh private key (for example google_compute_engine), I was not able to choose which private key I want to use through CLI.

**2 Options:** 

1. You can : ```$eval `ssh-add` && ssh-add ~/.ssh/<PRIVATE-KEY>```
2. Run `$bolt -i ~/.ssh/google_compute_engine ...` or `$bolt --private-key ~/.ssh/google_compute_engine`

I added tests for the CLI and to try connecting with specific private key using the Vagrantfile provided.