### PR TITLE
(BOLT-52) Verify orch handles script args correctly

### DIFF
--- a/spec/bolt/node/orch_spec.rb
+++ b/spec/bolt/node/orch_spec.rb
@@ -215,7 +215,7 @@ describe Bolt::Orch, orchestrator: true do
   end
 
   describe :_run_script do
-    let(:args) { ['with spaces', 'nospaces'] }
+    let(:args) { ['with spaces', 'nospaces', 'echo $HOME; cat /etc/passwd'] }
 
     context "the script succeeds" do
       let(:script_path) do
@@ -237,6 +237,7 @@ describe Bolt::Orch, orchestrator: true do
         ).to eq(<<OUT)
 arg: with spaces
 arg: nospaces
+arg: echo $HOME; cat /etc/passwd
 standard out
 OUT
       end


### PR DESCRIPTION
Update unit test to verify script args can be passed through
orchestrator without shell interpolation.
