### PR TITLE
(maint) Enable AppVeyor WinRM testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ To use `rubocop`, perform the bundle install with no exclusions
 
 ## Testing
 
-Some tests require a Windows or Linux VM. Execute `vagrant up` to bring these up with the Vagrantfile included with the `bolt` gem. Any tests that require this are tagged with `:vagrant` in rspec.
+Some tests require a Windows or Linux VM. Execute `vagrant up` to bring these up with the Vagrantfile included with the `bolt` gem. Any tests that require this are tagged with `:winrm` or `:ssh` in rspec.
 
 To run all tests, run:
 

--- a/Rakefile
+++ b/Rakefile
@@ -7,12 +7,17 @@ RSpec::Core::RakeTask.new(:spec)
 
 desc "Run RSpec tests that don't require VM fixtures"
 RSpec::Core::RakeTask.new(:unit) do |t|
-  t.rspec_opts = '--tag ~vagrant'
+  t.rspec_opts = '--tag ~ssh --tag ~winrm'
 end
 
 desc "Run RSpec tests that don't require VM fixtures or orchestrator"
 RSpec::Core::RakeTask.new(:windows) do |t|
-  t.rspec_opts = '--tag ~vagrant --tag ~orchestrator'
+  t.rspec_opts = '--tag ~ssh --tag ~winrm --tag ~orchestrator'
+end
+
+desc "Run RSpec tests for AppVeyor that don't require SSH or orchestrator"
+RSpec::Core::RakeTask.new(:appveyor) do |t|
+  t.rspec_opts = '--tag ~ssh --tag ~orchestrator'
 end
 
 RuboCop::RakeTask.new(:rubocop) do |t|

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ matrix:
   fast_finish: true
 
 environment:
+  BOLT_WINRM_USER: roddypiper
   matrix:
     - RUBY_VERSION: 200
     - RUBY_VERSION: 24
@@ -25,6 +26,16 @@ before_test:
       gem -v
       bundle -v
       type Gemfile.lock
+      $computer = [ADSI]"WinNT://."
+      $user = $computer.Create('user', $ENV:BOLT_WINRM_USER)
+      Add-Type -AssemblyName System.Web
+      $ENV:BOLT_WINRM_PASSWORD = [System.Web.Security.Membership]::GeneratePassword(10, 3)
+      $user.SetPassword($ENV:BOLT_WINRM_PASSWORD)
+      $user.SetInfo()
+      $group = [ADSI]"WinNT://./Remote Management Users,group"
+      # cannot use '.' for host in the user path per
+      # https://stackoverflow.com/questions/20286306/error-while-adding-a-local-group-to-local-user-using-powershell
+      $group.Add("WinNT://$ENV:COMPUTERNAME/$ENV:BOLT_WINRM_USER,user")
 
 test_script:
   - bundle exec rake windows

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,10 +20,11 @@ install:
 build: off
 
 before_test:
-  - ruby -v
-  - gem -v
-  - bundle -v
-  - type Gemfile.lock
+  - ps: |
+      ruby -v
+      gem -v
+      bundle -v
+      type Gemfile.lock
 
 test_script:
   - bundle exec rake windows

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,8 @@ matrix:
 
 environment:
   BOLT_WINRM_USER: roddypiper
+  BOLT_WINRM_HOST: localhost
+  BOLT_WINRM_PORT: 5985
   matrix:
     - RUBY_VERSION: 200
     - RUBY_VERSION: 24
@@ -38,4 +40,4 @@ before_test:
       $group.Add("WinNT://$ENV:COMPUTERNAME/$ENV:BOLT_WINRM_USER,user")
 
 test_script:
-  - bundle exec rake windows
+  - bundle exec rake appveyor

--- a/spec/bolt/node/ssh_spec.rb
+++ b/spec/bolt/node/ssh_spec.rb
@@ -23,7 +23,7 @@ do
 done
 BASH
 
-  context "when connecting", vagrant: true do
+  context "when connecting", ssh: true do
     it "performs secure host key verification by default" do
       allow(Net::SSH)
         .to receive(:start)
@@ -106,15 +106,15 @@ BASH
     before(:each) { ssh.connect }
     after(:each) { ssh.disconnect }
 
-    it "executes a command on a host", vagrant: true do
+    it "executes a command on a host", ssh: true do
       expect(ssh.execute(command).value).to eq("/home/vagrant\n")
     end
 
-    it "captures stderr from a host", vagrant: true do
+    it "captures stderr from a host", ssh: true do
       expect(ssh.execute("ssh -V").output.stderr.string).to match(/OpenSSH/)
     end
 
-    it "can upload a file to a host", vagrant: true do
+    it "can upload a file to a host", ssh: true do
       contents = "kljhdfg"
       with_tempfile_containing('upload-test', contents) do |file|
         ssh.upload(file.path, "/home/vagrant/upload-test")
@@ -127,7 +127,7 @@ BASH
       end
     end
 
-    it "can run a script remotely", vagrant: true do
+    it "can run a script remotely", ssh: true do
       contents = "#!/bin/sh\necho hellote"
       with_tempfile_containing('script test', contents) do |file|
         expect(
@@ -136,7 +136,7 @@ BASH
       end
     end
 
-    it "can run a script remotely with quoted arguments", vagrant: true do
+    it "can run a script remotely with quoted arguments", ssh: true do
       with_tempfile_containing('script-test-ssh-quotes', echo_script) do |file|
         expect(
           ssh._run_script(
@@ -167,7 +167,7 @@ QUOTED
       end
     end
 
-    it "escapes unsafe shellwords in arguments", vagrant: true do
+    it "escapes unsafe shellwords in arguments", ssh: true do
       with_tempfile_containing('script-test-ssh-escape', echo_script) do |file|
         expect(
           ssh._run_script(
@@ -180,7 +180,7 @@ SHELLWORDS
       end
     end
 
-    it "can run a task", vagrant: true do
+    it "can run a task", ssh: true do
       contents = "#!/bin/sh\necho -n ${PT_message_one} ${PT_message_two}"
       arguments = { message_one: 'Hello from task', message_two: 'Goodbye' }
       with_tempfile_containing('tasks test', contents) do |file|
@@ -189,7 +189,7 @@ SHELLWORDS
       end
     end
 
-    it "can run a task passing input on stdin", vagrant: true do
+    it "can run a task passing input on stdin", ssh: true do
       contents = "#!/bin/sh\ngrep 'message_one'"
       arguments = { message_one: 'Hello from task', message_two: 'Goodbye' }
       with_tempfile_containing('tasks test stdin', contents) do |file|
@@ -198,7 +198,7 @@ SHELLWORDS
       end
     end
 
-    it "can run a task passing input on stdin and environment", vagrant: true do
+    it "can run a task passing input on stdin and environment", ssh: true do
       contents = <<SHELL
 #!/bin/sh
 echo -n ${PT_message_one} ${PT_message_two}

--- a/spec/bolt/node/winrm_spec.rb
+++ b/spec/bolt/node/winrm_spec.rb
@@ -32,7 +32,7 @@ PS
     allow(shell).to receive(:run).and_raise(klass, message)
   end
 
-  context "when connecting fails", vagrant: true do
+  context "when connecting fails", winrm: true do
     it "raises Node::ConnectError if the node name can't be resolved" do
       winrm = Bolt::WinRM.new('totally-not-there', port, user, password)
       expect_node_error(Bolt::Node::ConnectError,
@@ -104,11 +104,11 @@ PS
     end
   end
 
-  it "executes a command on a host", vagrant: true do
+  it "executes a command on a host", winrm: true do
     expect(winrm.execute(command).value).to eq("#{user}\r\n")
   end
 
-  it "can upload a file to a host", vagrant: true do
+  it "can upload a file to a host", winrm: true do
     contents = "934jklnvf"
     remote_path = 'C:\Windows\Temp\upload-test-winrm'
     with_tempfile_containing('upload-test-winrm', contents) do |file|
@@ -122,7 +122,7 @@ PS
     end
   end
 
-  it "can run a script remotely", vagrant: true do
+  it "can run a script remotely", winrm: true do
     contents = "Write-Output \"hellote\""
     with_tempfile_containing('script-test-winrm', contents) do |file|
       expect(
@@ -131,7 +131,7 @@ PS
     end
   end
 
-  it "can run a script remotely with quoted arguments", vagrant: true do
+  it "can run a script remotely with quoted arguments", winrm: true do
     with_tempfile_containing('script-test-winrm-quotes', echo_script) do |file|
       expect(
         winrm._run_script(
@@ -155,7 +155,7 @@ QUOTED
     end
   end
 
-  it "loses track of embedded double quotes", vagrant: true do
+  it "loses track of embedded double quotes", winrm: true do
     with_tempfile_containing('script-test-winrm-buggy', echo_script) do |file|
       expect(
         winrm._run_script(
@@ -177,7 +177,7 @@ QUOTED
     end
   end
 
-  it "escapes unsafe shellwords", vagrant: true do
+  it "escapes unsafe shellwords", winrm: true do
     with_tempfile_containing('script-test-winrm-escape', echo_script) do |file|
       expect(
         winrm._run_script(
@@ -191,7 +191,7 @@ SHELLWORDS
     end
   end
 
-  it "can run a task remotely", vagrant: true do
+  it "can run a task remotely", winrm: true do
     contents = 'Write-Output "$env:PT_message_one" ${env:PT_message two}'
     arguments = { :message_one => 'task is running',
                   :"message two" => 'task has run' }
@@ -201,7 +201,7 @@ SHELLWORDS
     end
   end
 
-  it "can run a task passing input on stdin", vagrant: true do
+  it "can run a task passing input on stdin", winrm: true do
     contents = <<PS
 $line = [Console]::In.ReadLine()
 Write-Output $line
@@ -213,7 +213,7 @@ PS
     end
   end
 
-  it "can run a task passing input on stdin and environment", vagrant: true do
+  it "can run a task passing input on stdin and environment", winrm: true do
     contents = <<PS
 Write-Output "$env:PT_message_one" "$env:PT_message_two"
 $line = [Console]::In.ReadLine()
@@ -230,7 +230,7 @@ PS
     end
   end
 
-  it "can apply a puppet manifest for a '.pp' task", vagrant: true do
+  it "can apply a puppet manifest for a '.pp' task", winrm: true do
     output = <<OUTPUT
 Notice: Scope(Class[main]): hi
 Notice: Compiled catalog for x.y.z in environment production in 0.04 seconds

--- a/spec/bolt/node/winrm_spec.rb
+++ b/spec/bolt/node/winrm_spec.rb
@@ -9,10 +9,10 @@ describe Bolt::WinRM do
   include BoltSpec::Errors
   include BoltSpec::Files
 
-  let(:host) { 'localhost' }
-  let(:port) { 55985 }
-  let(:user) { "vagrant" }
-  let(:password) { "vagrant" }
+  let(:host) { ENV['BOLT_WINRM_HOST'] || 'localhost' }
+  let(:port) { ENV['BOLT_WINRM_PORT'] || 55985 }
+  let(:user) { ENV['BOLT_WINRM_USER'] || "vagrant" }
+  let(:password) { ENV['BOLT_WINRM_PASSWORD'] || "vagrant" }
   let(:command) { "echo $env:UserName" }
   let(:winrm) { Bolt::WinRM.new(host, port, user, password) }
   let(:echo_script) { <<PS }
@@ -105,12 +105,12 @@ PS
   end
 
   it "executes a command on a host", vagrant: true do
-    expect(winrm.execute(command).value).to eq("vagrant\r\n")
+    expect(winrm.execute(command).value).to eq("#{user}\r\n")
   end
 
   it "can upload a file to a host", vagrant: true do
     contents = "934jklnvf"
-    remote_path = 'C:\Users\vagrant\upload-test-winrm'
+    remote_path = 'C:\Windows\Temp\upload-test-winrm'
     with_tempfile_containing('upload-test-winrm', contents) do |file|
       winrm.upload(file.path, remote_path)
 


### PR DESCRIPTION
Turns on WinRM tests in AppVeyor, so that connection behavior is tested on PRs.

This results in some additional runtime, but appears to be < 10% in a few PRs I've spot checked.