### PR TITLE
(BOLT-158) execute_process expects an array of args

### DIFF
--- a/spec/fixtures/modules/sample/tasks/winstdin.ps1
+++ b/spec/fixtures/modules/sample/tasks/winstdin.ps1
@@ -1,3 +1,3 @@
-$line = [Console]::In.ReadLine
+$line = [Console]::In.ReadLine()
 Write-Output "STDIN: $line"
 Write-Output "ENV: $env:PT_message_one $env:PT_message_two"


### PR DESCRIPTION
Commit 4ce307fef1 changed the execute_process method to expect an array
instead of a string. But when I rebased 30049627fa on top, the code path
for puppet apply passed in a string.

Pass an array of args for the puppet apply case. Ensure files are quoted for
powershell, ruby and puppet, and for bolt script run. Set the working directory
to the parent directory of the resolved executable, so that puppet.bat can load
environment.bat in the same directory. It's also more consistent with how
scripts are likely to be written. Also Add tests for how arguments are
generated.