### PR TITLE
(BOLT-151) Yield node results as they finish

### DIFF
--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -3,6 +3,7 @@ require 'concurrent'
 require 'bolt/result'
 require 'bolt/config'
 require 'bolt/formatter'
+require 'bolt/notifier'
 
 module Bolt
   class Executor
@@ -12,6 +13,7 @@ module Bolt
       @logger.progname = 'executor'
       @logger.level = config[:log_level]
       @logger.formatter = Bolt::Formatter.new
+      @notifier = Bolt::Notifier.new
     end
 
     def from_uris(nodes)
@@ -20,7 +22,7 @@ module Bolt
       end
     end
 
-    def on(nodes)
+    def on(nodes, callback = nil)
       results = Concurrent::Map.new
 
       poolsize = [nodes.length, @config[:concurrency]].min
@@ -33,7 +35,7 @@ module Bolt
 
       nodes.each { |node|
         pool.post do
-          results[node] =
+          result =
             begin
               node.connect
               yield node
@@ -45,34 +47,47 @@ module Bolt
             ensure
               node.disconnect
             end
+          results[node] = result
+          @notifier.notify(callback, node, result) if callback
+          result
         end
       }
       pool.shutdown
       pool.wait_for_termination
 
+      @notifier.shutdown
+
       results_to_hash(results)
     end
 
     def run_command(nodes, command)
-      on(nodes) do |node|
+      callback = block_given? ? Proc.new : nil
+
+      on(nodes, callback) do |node|
         node.run_command(command)
       end
     end
 
     def run_script(nodes, script, arguments)
-      on(nodes) do |node|
+      callback = block_given? ? Proc.new : nil
+
+      on(nodes, callback) do |node|
         node.run_script(script, arguments)
       end
     end
 
     def run_task(nodes, task, input_method, arguments)
-      on(nodes) do |node|
+      callback = block_given? ? Proc.new : nil
+
+      on(nodes, callback) do |node|
         node.run_task(task, input_method, arguments)
       end
     end
 
     def file_upload(nodes, source, destination)
-      on(nodes) do |node|
+      callback = block_given? ? Proc.new : nil
+
+      on(nodes, callback) do |node|
         node.upload(source, destination)
       end
     end

--- a/lib/bolt/notifier.rb
+++ b/lib/bolt/notifier.rb
@@ -1,0 +1,20 @@
+require 'concurrent'
+
+module Bolt
+  class Notifier
+    def initialize(executor = Concurrent::SingleThreadExecutor.new)
+      @executor = executor
+    end
+
+    def notify(callback, node, result)
+      @executor.post do
+        callback.call(node, result)
+      end
+    end
+
+    def shutdown
+      @executor.shutdown
+      @executor.wait_for_termination
+    end
+  end
+end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -419,7 +419,8 @@ NODES
     before :each do
       allow(Bolt::Executor).to receive(:new).and_return(executor)
       allow(executor).to receive(:from_uris).and_return(nodes)
-      allow(cli).to receive(:print_results)
+      allow(cli).to receive(:print_summary)
+      allow(cli).to receive(:print_result)
     end
 
     it "executes the 'whoami' command" do

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -9,6 +9,7 @@ describe "Bolt::Executor" do
   let(:success) { Bolt::Node::Success.new }
   let(:task) { 'service::restart' }
   let(:task_arguments) { { 'name' => 'apache' } }
+  let(:nodes) { [mock_node('node1'), mock_node('node2')] }
 
   def mock_node(name)
     transport = double('holodeck')
@@ -22,39 +23,33 @@ describe "Bolt::Executor" do
   end
 
   it "executes a command on all nodes" do
-    node1 = mock_node 'node1'
-    expect(node1).to receive(:run_command).with(command).and_return(success)
-    node2 = mock_node 'node2'
-    expect(node2).to receive(:run_command).with(command).and_return(success)
+    nodes.each do |node|
+      expect(node).to receive(:run_command).with(command).and_return(success)
+    end
 
-    executor.run_command([node1, node2], command)
+    executor.run_command(nodes, command)
   end
 
   it "runs a script on all nodes" do
-    node1 = mock_node 'node1'
-    expect(node1).to receive(:run_script).with(script, []).and_return(success)
-    node2 = mock_node 'node2'
-    expect(node2).to receive(:run_script).with(script, []).and_return(success)
+    nodes.each do |node|
+      expect(node).to receive(:run_script).with(script, []).and_return(success)
+    end
 
-    results = executor.run_script([node1, node2], script, [])
+    results = executor.run_script(nodes, script, [])
     results.each_pair do |_, result|
       expect(result).to be_instance_of(Bolt::Node::Success)
     end
   end
 
   it "runs a task on all nodes" do
-    node1 = mock_node 'node1'
-    expect(node1)
-      .to receive(:run_task)
-      .with(task, 'both', task_arguments)
-      .and_return(success)
-    node2 = mock_node 'node2'
-    expect(node2)
-      .to receive(:run_task)
-      .with(task, 'both', task_arguments)
-      .and_return(success)
+    nodes.each do |node|
+      expect(node)
+        .to receive(:run_task)
+        .with(task, 'both', task_arguments)
+        .and_return(success)
+    end
 
-    results = executor.run_task([node1, node2], task, 'both', task_arguments)
+    results = executor.run_task(nodes, task, 'both', task_arguments)
     results.each_pair do |_, result|
       expect(result).to be_instance_of(Bolt::Node::Success)
     end

--- a/spec/bolt/notifier_spec.rb
+++ b/spec/bolt/notifier_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+module Bolt
+  class MockCallback
+    attr_reader :results
+
+    def call(node, result)
+      @results = [node, result]
+    end
+  end
+end
+
+describe "Bolt::Notifier" do
+  let(:executor) { Concurrent::ImmediateExecutor.new }
+  let(:success) { Bolt::Node::Success.new }
+  let(:callback) { Bolt::MockCallback.new }
+
+  def mock_node(name)
+    transport = double('holodeck')
+    allow(transport).to receive(:initialize_transport)
+
+    node = double(name, name: name)
+    allow(node).to receive(:class).and_return(transport)
+    allow(node).to receive(:connect)
+    allow(node).to receive(:disconnect)
+    node
+  end
+
+  it "notifies the caller" do
+    node = mock_node('node1')
+    notifier = Bolt::Notifier.new(executor)
+    notifier.notify(callback, node, success)
+
+    expect(callback.results).to eq([node, success])
+  end
+
+  it "shuts down the executor and waits for pending tasks to finish" do
+    node = mock_node('node1')
+    notifier = Bolt::Notifier.new(executor)
+    notifier.notify(callback, node, success)
+
+    expect(executor).to receive(:shutdown)
+    expect(executor).to receive(:wait_for_termination)
+
+    notifier.shutdown
+  end
+end


### PR DESCRIPTION
All of the run_* methods now take an optional block. If one is provided, then
the node and its result will be yielded to the block as the operation finishes.
Only one result will be yielded at a time, so callers do not need to worry about
concurrency issues. For example, colorize modifies the global stdout stream
color and doesn't need to worry about concurrency issues.