### PR TITLE
(BOLT-202) Improve winrm missing executable error

### DIFF
--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -71,6 +71,11 @@ function Invoke-Interpreter
 
   try
   {
+    if (-not (Get-Command $Path -ErrorAction SilentlyContinue))
+    {
+      throw "Could not find executable '$Path' in ${ENV:PATH} on target node"
+    }
+
     $startInfo = New-Object System.Diagnostics.ProcessStartInfo($Path, $Arguments)
     $startInfo.UseShellExecute = $false
     $startInfo.WorkingDirectory = Split-Path -Parent (Get-Command $Path).Path

--- a/spec/bolt/node/winrm_spec.rb
+++ b/spec/bolt/node/winrm_spec.rb
@@ -428,5 +428,14 @@ OUTPUT
         ).to eq(output)
       end
     end
+
+    it "returns a friendly stderr msg with puppet.bat missing", winrm: true do
+      with_tempfile_containing('task-pp-winrm', "notice('hi')", '.pp') do |file|
+        result = winrm._run_task(file.path, 'stdin', {})
+        stderr = result.output.stderr.string
+        expect(stderr).to match(/^Could not find executable 'puppet\.bat'/)
+        expect(stderr).to_not match(/CommandNotFoundException/)
+      end
+    end
   end
 end


### PR DESCRIPTION
Requires #110 be merged first ... 

 - Previously, the winrm executor may have produced an error like:

```
Exception calling "Start" with "1" argument(s): "The system cannot find the file specified"
At line:11 char:17
+ $LASTEXITCODE = Invoke-Interpreter @invokeArgs
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,Invoke-Interpreter
```

   This is unhelpful to an end user, who typically would prefer to
   know tha their system could not find `ruby.exe` or `puppet.bat`

   This changes the error message to the more acceptable:

```
Could not find executable 'puppet.bat' in C:\ProgramData\Boxstarter;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Program Files\Git\cmd;C:\Packer\SysInternals;C:\Program Files\Puppet Labs\Puppet\bin\;C:\Program Files\Puppet Labs\Puppet\sys\ruby\bin\ on target node
```