### PR TITLE
(BOLT-206) Correctly handle winrm exit status

### DIFF
--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -149,8 +149,9 @@ $invokeArgs = @{
   #{stdin.nil? ? '' : "StdinInput = @'\n" + stdin + "\n'@"}
 }
 
-# winrm gem relies on $LASTEXITCODE
-$LASTEXITCODE = Invoke-Interpreter @invokeArgs
+# winrm gem checks $? prior to using $LASTEXITCODE
+# making it necessary to exit with the desired code to propagate status properly
+exit $(Invoke-Interpreter @invokeArgs)
 PS
     end
 

--- a/spec/bolt/node/winrm_spec.rb
+++ b/spec/bolt/node/winrm_spec.rb
@@ -242,7 +242,7 @@ PS
                '-ExecutionPolicy', 'Bypass', '-File', /^".*"$/],
               anything)
         .and_return(Bolt::Node::Success.new("42"))
-      with_tempfile_containing('task-rb-winrm', contents, '.ps1') do |file|
+      with_tempfile_containing('task-ps1-winrm', contents, '.ps1') do |file|
         expect(
           winrm._run_task(file.path, 'stdin', {}).value
         ).to eq("42")
@@ -275,7 +275,7 @@ OUTPUT
               ['apply', /^".*"$/],
               anything)
         .and_return(Bolt::Node::Success.new(output))
-      with_tempfile_containing('task-pp-winrm', "notice('hi)", '.pp') do |file|
+      with_tempfile_containing('task-pp-winrm', "notice('hi')", '.pp') do |file|
         expect(
           winrm._run_task(file.path, 'stdin', {}).value
         ).to eq(output)


### PR DESCRIPTION
(BOLT-206) Correctly handle winrm exit status

 - Given the winrm command first looks to the $? automatic variable,
   failure status of running PowerShell code could be misinterpreted.

   $? is the status of the last operation in the context of PowerShell
   and doesn't reflect the status of calling the Invoke-Interperter
   function. So with the success of the function executing, the winrm
   gem is considering the operation a success.

   PowerShell does not allow for setting $? manually (a good thing),
   so there are a few options for handling a scenario in which the
   PowerShell helper code ran correctly, but the invoked executable
   (powershell.exe, ruby.exe, puppet.bat, etc) return a non-zero
   exit status:

   * Generate a failing command that doesn't pollute the PowerShell
     $Error collection (which requires some ugly hacks), so that
     $LASTEXITCODE is returned through the winrm gem
   * Call `exit` explicitly with the desired exit code, which appears
     to behave as expected given the new tests


FYI - there are additional tests around exit status behavior in https://github.com/puppetlabs/puppetlabs-powershell/blob/master/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb that we may want to investigate in the future.