### PR TITLE
(BOLT-208) Execute WinRM scripts by whitelist

### DIFF
--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -272,9 +272,9 @@ PS
     def _run_script(script, arguments)
       @logger.info { "Running script '#{script}'" }
       with_remote_file(script) do |remote_path|
-        args = [*PS_ARGS, '-File', "\"#{remote_path}\""]
+        path, args = *process_from_extension(remote_path)
         args += escape_arguments(arguments)
-        execute_process('powershell.exe', args)
+        execute_process(path, args)
       end
     end
 


### PR DESCRIPTION
- Change the WinRM _run_script helper to behave similarly to
   _run_task. Look up whitelisted file extensions to determine what
   may be executed on the remote host - currently this includes .rb,
   .ps1 and .pp

- Add some basic mocked tests demonstrating scripts may be invoked
   in this fashion

- Update wording on some tests so its clear when PowerShell is being
   invoked.