### PR TITLE
(BOLT-45) Support JSON format

### DIFF
--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -8,7 +8,8 @@ module Bolt
                       :insecure,
                       :transport,
                       :log_level,
-                      :log_destination) do
+                      :log_destination,
+                      :format) do
     DEFAULTS = {
       concurrency: 100,
       tty: false,

--- a/lib/bolt/outputter.rb
+++ b/lib/bolt/outputter.rb
@@ -1,0 +1,21 @@
+module Bolt
+  class Outputter
+    def self.for_format(format)
+      case format
+      when 'human'
+        Bolt::Outputter::Human.new
+      when 'json'
+        Bolt::Outputter::JSON.new
+      when nil
+        raise "Cannot use outputter before parsing."
+      end
+    end
+
+    def initialize(stream = $stdout)
+      @stream = stream
+    end
+  end
+end
+
+require 'bolt/outputter/human'
+require 'bolt/outputter/json'

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -1,0 +1,30 @@
+module Bolt
+  class Outputter
+    class Human < Bolt::Outputter
+      def print_head; end
+
+      def print_result(node, result)
+        color = result.success? ? "\033[32m" : "\033[31m"
+        @stream.print color if @stream.isatty
+        @stream.puts "#{node.host}:"
+        @stream.print "\033[0m" if @stream.isatty
+        @stream.puts
+        @stream.puts result.message
+        @stream.puts
+      end
+
+      def print_summary(results, elapsed_time)
+        @stream.puts format("Ran on %d node%s in %.2f seconds",
+                            results.size,
+                            results.size > 1 ? 's' : '',
+                            elapsed_time)
+      end
+
+      def print_plan(result)
+        @stream.puts result
+      end
+
+      def fatal_error(e); end
+    end
+  end
+end

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -1,0 +1,51 @@
+module Bolt
+  class Outputter
+    class JSON < Bolt::Outputter
+      def initialize(stream = $stdout)
+        @items_open = false
+        @object_open = false
+        @preceding_item = false
+        super(stream)
+      end
+
+      def print_head
+        @stream.puts '{ "items": ['
+        @preceding_item = false
+        @items_open = true
+        @object_open = true
+      end
+
+      def print_result(node, result)
+        item = {
+          name: node.uri,
+          status: result.is_a?(Bolt::ErrorResult) ? 'failure' : 'success',
+          result: result.to_result
+        }
+
+        @stream.puts ',' if @preceding_item
+        @stream.puts item.to_json
+        @preceding_item = true
+      end
+
+      def print_summary(results, elapsed_time)
+        @stream.puts "],\n"
+        @preceding_item = false
+        @items_open = false
+        @stream.puts format('"node_count": %d, "elapsed_time": %d }',
+                            results.size,
+                            elapsed_time)
+      end
+
+      def print_plan(result)
+        @stream.puts result.to_json
+      end
+
+      def fatal_error(e)
+        @stream.puts "],\n" if @items_open
+        @stream.puts '"_error": ' if @object_open
+        @stream.puts e.to_json
+        @stream.puts '}' if @object_open
+      end
+    end
+  end
+end

--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -20,6 +20,10 @@ module Bolt
       { 'value' => value }
     end
 
+    def to_result
+      value
+    end
+
     def success?
       true
     end
@@ -35,6 +39,16 @@ module Bolt
     def to_h
       {
         'error' => {
+          'issue_code' => @issue_code,
+          'kind' => @kind,
+          'msg' => @message
+        }
+      }
+    end
+
+    def to_result
+      {
+        '_error' => {
           'issue_code' => @issue_code,
           'kind' => @kind,
           'msg' => @message
@@ -64,6 +78,10 @@ module Bolt
       }
     end
 
+    def to_result
+      value
+    end
+
     def success?
       @exit_code.zero?
     end
@@ -86,6 +104,12 @@ module Bolt
       @object || @stdout
     end
 
+    def to_result
+      result = @object
+      result['_error'] = @error if @error
+      result
+    end
+
     def to_h
       hash = super
       hash['error'] = error if error
@@ -95,12 +119,15 @@ module Bolt
     private
 
     def output_to_json_hash(output)
-      obj = JSON.parse(output)
-      if obj.is_a? Hash
-        obj
+      begin
+        obj = JSON.parse(output)
+        unless obj.is_a? Hash
+          obj = nil
+        end
+      rescue JSON::ParserError
+        nil
       end
-    rescue JSON::ParserError
-      nil
+      obj || { '_output' => output }
     end
   end
 

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -419,8 +419,11 @@ NODES
     before :each do
       allow(Bolt::Executor).to receive(:new).and_return(executor)
       allow(executor).to receive(:from_uris).and_return(nodes)
-      allow(cli).to receive(:print_summary)
-      allow(cli).to receive(:print_result)
+
+      @output = StringIO.new
+      outputter = Bolt::Outputter::JSON.new(@output)
+
+      allow(cli).to receive(:outputter).and_return(outputter)
     end
 
     it "executes the 'whoami' command" do
@@ -430,9 +433,13 @@ NODES
         .and_return({})
 
       options = {
-        nodes: node_names, mode: 'command', action: 'run', object: 'whoami'
+        nodes: node_names,
+        mode: 'command',
+        action: 'run',
+        object: 'whoami'
       }
       cli.execute(options)
+      expect(JSON.parse(@output.string)).to be
     end
 
     describe "when running a script" do
@@ -451,6 +458,7 @@ NODES
           .and_return({})
 
         cli.execute(options)
+        expect(JSON.parse(@output.string)).to be
       end
 
       it "errors for non-existent scripts" do
@@ -459,6 +467,7 @@ NODES
         expect { cli.execute(options) }.to raise_error(
           Bolt::CLIError, /The script '#{script}' does not exist/
         )
+        expect(JSON.parse(@output.string)).to be
       end
 
       it "errors for unreadable scripts" do
@@ -467,6 +476,7 @@ NODES
         expect { cli.execute(options) }.to raise_error(
           Bolt::CLIError, /The script '#{script}' is unreadable/
         )
+        expect(JSON.parse(@output.string)).to be
       end
 
       it "errors for scripts that aren't files" do
@@ -475,6 +485,7 @@ NODES
         expect { cli.execute(options) }.to raise_error(
           Bolt::CLIError, /The script '#{script}' is not a file/
         )
+        expect(JSON.parse(@output.string)).to be
       end
     end
 
@@ -499,6 +510,7 @@ NODES
         modulepath: [File.join(__FILE__, '../../fixtures/modules')]
       }
       cli.execute(options)
+      expect(JSON.parse(@output.string)).to be
     end
 
     it "errors for non-existent modules" do
@@ -516,6 +528,7 @@ NODES
       expect { cli.execute(options) }.to raise_error(
         Bolt::CLIError, /Could not find module/
       )
+      expect(JSON.parse(@output.string)).to be
     end
 
     it "errors for non-existent tasks" do
@@ -534,6 +547,7 @@ NODES
         Bolt::CLIError,
         /Could not find task '#{task_name}' in module 'sample'/
       )
+      expect(JSON.parse(@output.string)).to be
     end
 
     it "runs an init task given a module name" do
@@ -557,6 +571,7 @@ NODES
         modulepath: [File.join(__FILE__, '../../fixtures/modules')]
       }
       cli.execute(options)
+      expect(JSON.parse(@output.string)).to be
     end
 
     it "runs a task passing input on stdin" do
@@ -579,6 +594,7 @@ NODES
         modulepath: [File.join(__FILE__, '../../fixtures/modules')]
       }
       cli.execute(options)
+      expect(JSON.parse(@output.string)).to be
     end
 
     it "runs a powershell task passing input on stdin" do
@@ -601,6 +617,7 @@ NODES
         modulepath: [File.join(__FILE__, '../../fixtures/modules')]
       }
       cli.execute(options)
+      expect(JSON.parse(@output.string)).to be
     end
 
     describe "file uploading" do
@@ -625,6 +642,7 @@ NODES
           .and_return({})
 
         cli.execute(options)
+        expect(JSON.parse(@output.string)).to be
       end
 
       it "raises if the local file doesn't exist" do
@@ -633,6 +651,7 @@ NODES
         expect { cli.execute(options) }.to raise_error(
           Bolt::CLIError, /The source file '#{source}' does not exist/
         )
+        expect(JSON.parse(@output.string)).to be
       end
 
       it "errors if the local file is unreadable" do
@@ -641,6 +660,7 @@ NODES
         expect { cli.execute(options) }.to raise_error(
           Bolt::CLIError, /The source file '#{source}' is unreadable/
         )
+        expect(JSON.parse(@output.string)).to be
       end
 
       it "errors if the local file is a directory" do
@@ -649,6 +669,7 @@ NODES
         expect { cli.execute(options) }.to raise_error(
           Bolt::CLIError, /The source file '#{source}' is not a file/
         )
+        expect(JSON.parse(@output.string)).to be
       end
     end
   end

--- a/spec/bolt/node_spec.rb
+++ b/spec/bolt/node_spec.rb
@@ -69,7 +69,7 @@ describe Bolt::Node do
       expect(node).to receive(:_run_task).and_return(result)
 
       expect(node.run_task('generic', 'stdin', {}).to_h)
-        .to eq('value' => 'some output')
+        .to eq('value' => { '_output' => 'some output' })
     end
 
     it "on failure converts json on stdout if it conforms to expectations" do
@@ -96,7 +96,7 @@ describe Bolt::Node do
       expect(node).to receive(:_run_task).and_return(result)
 
       expect(node.run_task('generic', 'stdin', {}).to_h)
-        .to eq('value' => 'an error occurred',
+        .to eq('value' => { '_output' => 'an error occurred' },
                'error' => { 'kind' => 'puppetlabs.tasks/task-error',
                             'issue_code' => 'TASK_ERROR',
                             'msg' => 'The task failed with exit code 1',

--- a/spec/bolt/outputter/json_spec.rb
+++ b/spec/bolt/outputter/json_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+require 'bolt/outputter'
+require 'bolt/cli'
+
+describe "Bolt::Outputter::JSON" do
+  let(:output) { StringIO.new }
+  let(:outputter) { Bolt::Outputter::JSON.new(output) }
+  let(:results) { { node1: Bolt::Result.new("ok") } }
+  let(:config)  { Bolt::Config.new }
+
+  it "starts items in head" do
+    outputter.print_head
+    expect(output.string).to match(/"items": \[\w*\Z/)
+  end
+
+  it "allows empty items" do
+    outputter.print_head
+    outputter.print_summary(results, 10.0)
+    parsed = JSON.parse(output.string)
+    expect(parsed['items']).to eq([])
+  end
+
+  it "prints multiple items" do
+    outputter.print_head
+    outputter.print_result(Bolt::Node.from_uri('node1', config: config),
+                           Bolt::Result.new("ok"))
+    outputter.print_result(Bolt::Node.from_uri('node2', config: config),
+                           Bolt::Result.new("ok"))
+    outputter.print_summary(results, 10.0)
+    parsed = JSON.parse(output.string)
+    expect(parsed['items'].size).to eq(2)
+  end
+
+  it "handles fatal errors" do
+    outputter.print_head
+    outputter.print_result(Bolt::Node.from_uri('node1', config: config),
+                           Bolt::Result.new("ok"))
+    outputter.print_result(Bolt::Node.from_uri('node2', config: config),
+                           Bolt::Result.new("ok"))
+    outputter.fatal_error(Bolt::CLIError.new("oops"))
+    parsed = JSON.parse(output.string)
+    expect(parsed['items'].size).to eq(2)
+    expect(parsed['_error']['kind']).to eq("bolt/cli-error")
+  end
+end

--- a/spec/bolt/result_spec.rb
+++ b/spec/bolt/result_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'json'
+require 'bolt'
+require 'bolt/result'
+
+describe Bolt::TaskResult do
+  it 'parses json objects' do
+    obj = { "key" => "val" }
+    result = Bolt::TaskResult.new(obj.to_json, '', 0)
+    expect(result.to_result).to eq(obj)
+  end
+
+  it "doesn't parse arrays" do
+    stdout = '[1, 2, 3]'
+    result = Bolt::TaskResult.new(stdout, '', 0)
+    expect(result.to_result).to eq('_output' => stdout)
+  end
+
+  it 'handles errors' do
+    obj = { "key" => "val",
+            "_error" => { "kind" => "error" } }
+    result = Bolt::TaskResult.new(obj.to_json, '', 1)
+    expect(result.to_result).to eq(obj)
+  end
+end


### PR DESCRIPTION
This commit adds support for the --format flag and the json format
option. When specified the format is used for results of the action
printed to stdout. It does not effect logging to stderr.

Once the functions are moved into bolt it will be easier to clean up the relationship between results in bolt and execution results in puppet.