### PR TITLE
(BOLT-163) Configurable connection timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,25 +61,27 @@ ssh:
 
 ### Global configuration options
 
-`concurrency`: The number of threads to use when executing on remote nodes(default 100)
+`concurrency`: The number of threads to use when executing on remote nodes (default: 100)
 
-`format`: The format to use when printing results. Options are `human` and `json`(default `human`)
+`format`: The format to use when printing results. Options are `human` and `json` (default: `human`)
 
-`modulepath`: The module path to load tasks and plan code from. This is a list of directories seperated byt the OS specific file path seperator.
+`modulepath`: The module path to load tasks and plan code from. This is a list of directories separated by the OS-specific path separator (`:` on Linux/macOS, `;` on Windows).
 
 ### `ssh` transport configuration options
 
-`insecure`: Whether to perform host key validation when connecting over ssh.(default false)
+`insecure`: If true, host key validation will be skipped when connecting over SSH. (default: false)
 
-`private-key`: The path to the private key file to use for ssh authentication.
+`private-key`: The path to the private key file to use for SSH authentication.
+
+`connect-timeout`: Maximum amount of time to allow for an SSH connection to be established, in seconds
 
 ### `winrm` transport configuration options
 
-There are currenlty no options for the winrm transport
+`connect-timeout`: Maximum amount of time to allow for a WinRM connection to be established, in seconds
 
 ### `pcp` transport configuration options
 
-There are currenlty no options for the pcp orchestrator transport
+There are currently no options for the PCP orchestrator transport
 
 
 ## Usage examples

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -144,9 +144,9 @@ HELP
                 "(Optional, defaults to 100)") do |concurrency|
           results[:concurrency] = concurrency
         end
-        opts.on('--timeout TIMEOUT', Integer,
+        opts.on('--connect-timeout TIMEOUT', Integer,
                 "Connection timeout (Optional)") do |timeout|
-          results[:timeout] = timeout
+          results[:connect_timeout] = timeout
         end
         opts.on('--modulepath MODULES',
                 "List of directories containing modules, " \

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -144,6 +144,10 @@ HELP
                 "(Optional, defaults to 100)") do |concurrency|
           results[:concurrency] = concurrency
         end
+        opts.on('--timeout TIMEOUT', Integer,
+                "Connection timeout (Optional)") do |timeout|
+          results[:timeout] = timeout
+        end
         opts.on('--modulepath MODULES',
                 "List of directories containing modules, " \
                 "separated by #{File::PATH_SEPARATOR}") do |modulepath|

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -23,7 +23,7 @@ module Bolt
     TRANSPORT_OPTIONS = %i[insecure password run_as sudo sudo_password key tty user connect_timeout].freeze
 
     TRANSPORT_DEFAULTS = {
-      connect_timeout: 1,
+      connect_timeout: 10,
       insecure: false,
       tty: false
     }.freeze

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -94,6 +94,15 @@ module Bolt
         if data['ssh']['insecure']
           self[:transports][:ssh][:insecure] = data['ssh']['insecure']
         end
+        if data['ssh']['connect-timeout']
+          self[:transports][:ssh][:connect_timeout] = data['ssh']['connect-timeout']
+        end
+      end
+
+      if data['winrm']
+        if data['winrm']['connect-timeout']
+          self[:transports][:winrm][:connect_timeout] = data['winrm']['connect-timeout']
+        end
       end
       # if data['pcp']
       # end

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -20,10 +20,10 @@ module Bolt
       log_destination: STDERR
     }.freeze
 
-    TRANSPORT_OPTIONS = %i[insecure password run_as sudo sudo_password key tty user timeout].freeze
+    TRANSPORT_OPTIONS = %i[insecure password run_as sudo sudo_password key tty user connect_timeout].freeze
 
     TRANSPORT_DEFAULTS = {
-      timeout: 1,
+      connect_timeout: 1,
       insecure: false,
       tty: false
     }.freeze

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -20,9 +20,10 @@ module Bolt
       log_destination: STDERR
     }.freeze
 
-    TRANSPORT_OPTIONS = %i[insecure password run_as sudo sudo_password key tty user].freeze
+    TRANSPORT_OPTIONS = %i[insecure password run_as sudo sudo_password key tty user timeout].freeze
 
     TRANSPORT_DEFAULTS = {
+      timeout: 1,
       insecure: false,
       tty: false
     }.freeze

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -29,7 +29,7 @@ module Bolt
 
     def self.initialize_transport(_logger); end
 
-    attr_reader :logger, :host, :uri, :user, :password, :timeout
+    attr_reader :logger, :host, :uri, :user, :password, :connect_timeout
 
     def initialize(host, port = nil, user = nil, password = nil, uri: nil,
                    config: Bolt::Config.new)
@@ -43,7 +43,7 @@ module Bolt
       @key = transport_conf[:key]
       @tty = transport_conf[:tty]
       @insecure = transport_conf[:insecure]
-      @timeout = transport_conf[:timeout]
+      @connect_timeout = transport_conf[:connect_timeout]
       @sudo = transport_conf[:sudo]
       @sudo_password = transport_conf[:sudo_password]
       @run_as = transport_conf[:run_as]

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -29,7 +29,7 @@ module Bolt
 
     def self.initialize_transport(_logger); end
 
-    attr_reader :logger, :host, :uri, :user, :password
+    attr_reader :logger, :host, :uri, :user, :password, :timeout
 
     def initialize(host, port = nil, user = nil, password = nil, uri: nil,
                    config: Bolt::Config.new)
@@ -43,6 +43,7 @@ module Bolt
       @key = transport_conf[:key]
       @tty = transport_conf[:tty]
       @insecure = transport_conf[:insecure]
+      @timeout = transport_conf[:timeout]
       @sudo = transport_conf[:sudo]
       @sudo_password = transport_conf[:sudo_password]
       @run_as = transport_conf[:run_as]

--- a/lib/bolt/node/ssh.rb
+++ b/lib/bolt/node/ssh.rb
@@ -32,6 +32,7 @@ module Bolt
                                   else
                                     Net::SSH::Verifiers::Secure.new
                                   end
+      options[:timeout] = @timeout if @timeout
 
       @session = Net::SSH.start(@host, @user, options)
       @logger.debug { "Opened session" }

--- a/lib/bolt/node/ssh.rb
+++ b/lib/bolt/node/ssh.rb
@@ -32,7 +32,7 @@ module Bolt
                                   else
                                     Net::SSH::Verifiers::Secure.new
                                   end
-      options[:timeout] = @timeout if @timeout
+      options[:timeout] = @connect_timeout if @connect_timeout
 
       @session = Net::SSH.start(@host, @user, options)
       @logger.debug { "Opened session" }

--- a/lib/bolt/node/ssh.rb
+++ b/lib/bolt/node/ssh.rb
@@ -46,6 +46,11 @@ module Bolt
         "Host key verification failed for #{@uri}: #{e.message}",
         'HOST_KEY_ERROR'
       )
+    rescue Net::SSH::ConnectionTimeout
+      raise Bolt::Node::ConnectError.new(
+        "Timeout after #{@connect_timeout} seconds connecting to #{@uri}",
+        'CONNECT_ERROR'
+      )
     rescue StandardError => e
       raise Bolt::Node::ConnectError.new(
         "Failed to connect to #{@uri}: #{e.message}",

--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -22,10 +22,10 @@ module Bolt
                   password: @password,
                   retry_limit: 1 }
 
-      if @timeout
-        options[:receive_timeout] = @timeout + 1
+      if @connect_timeout
+        options[:receive_timeout] = @connect_timeout + 1
         # NOTE: must be set to at least 1, else winrm gem throws an error (boo)
-        options[:operation_timeout] = @timeout
+        options[:operation_timeout] = @connect_timeout
       end
       @connection = ::WinRM::Connection.new(options)
       @connection.logger = @transport_logger

--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -32,7 +32,7 @@ module Bolt
       end
     rescue Timeout::Error
       raise Bolt::Node::ConnectError.new(
-        "Timeout connecting to #{@endpoint}",
+        "Timeout after #{@connect_timeout} seconds connecting to #{@endpoint}",
         'CONNECT_ERROR'
       )
     rescue ::WinRM::WinRMAuthorizationError

--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -17,9 +17,17 @@ module Bolt
     end
 
     def connect
-      @connection = ::WinRM::Connection.new(endpoint: @endpoint,
-                                            user: @user,
-                                            password: @password)
+      options = { endpoint: @endpoint,
+                  user: @user,
+                  password: @password,
+                  retry_limit: 1 }
+
+      if @timeout
+        options[:receive_timeout] = @timeout + 1
+        # NOTE: must be set to at least 1, else winrm gem throws an error (boo)
+        options[:operation_timeout] = @timeout
+      end
+      @connection = ::WinRM::Connection.new(options)
       @connection.logger = @transport_logger
 
       @session = @connection.shell(@shell)

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -256,18 +256,18 @@ NODES
       end
     end
 
-    describe "timeout" do
+    describe "connect_timeout" do
       it "accepts a specific timeout" do
-        cli = Bolt::CLI.new(%w[command run --timeout 123 --nodes foo])
-        expect(cli.parse).to include(timeout: 123)
+        cli = Bolt::CLI.new(%w[command run --connect-timeout 123 --nodes foo])
+        expect(cli.parse).to include(connect_timeout: 123)
       end
 
       it "generates an error message if no timeout value is given" do
-        cli = Bolt::CLI.new(%w[command run --nodes foo --timeout])
+        cli = Bolt::CLI.new(%w[command run --nodes foo --connect-timeout])
         expect {
           cli.parse
         }.to raise_error(Bolt::CLIError,
-                         /Option '--timeout' needs a parameter/)
+                         /Option '--connect-timeout' needs a parameter/)
       end
     end
 

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -256,17 +256,25 @@ NODES
       end
     end
 
+    describe "timeout" do
+      it "accepts a specific timeout" do
+        cli = Bolt::CLI.new(%w[command run --timeout 123 --nodes foo])
+        expect(cli.parse).to include(timeout: 123)
+      end
+
+      it "generates an error message if no timeout value is given" do
+        cli = Bolt::CLI.new(%w[command run --nodes foo --timeout])
+        expect {
+          cli.parse
+        }.to raise_error(Bolt::CLIError,
+                         /Option '--timeout' needs a parameter/)
+      end
+    end
+
     describe "modulepath" do
       it "accepts a modulepath directory" do
         cli = Bolt::CLI.new(%w[command run --modulepath ./modules --nodes foo])
         expect(cli.parse).to include(modulepath: ['./modules'])
-      end
-
-      it "accepts a list of module directories" do
-        modulepath = %w[modules more].join(File::PATH_SEPARATOR)
-        cli = Bolt::CLI.new(%W[command run --modulepath #{modulepath}
-                               --nodes foo])
-        expect(cli.parse).to include(modulepath: %w[modules more])
       end
 
       it "generates an error message if no value is given" do

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -777,8 +777,12 @@ NODES
         'concurrency' => 14,
         'format' => 'json',
         'ssh' => {
-          "private-key" => '/bar/foo',
-          "insecure" => true
+          'private-key' => '/bar/foo',
+          'insecure' => true,
+          'connect-timeout' => 4
+        },
+        'winrm' => {
+          'connect-timeout' => 7
         } }
     end
 
@@ -819,6 +823,15 @@ NODES
         cli = Bolt::CLI.new(%W[command run --configfile #{conf.path} --nodes foo --insecure])
         cli.parse
         expect(cli.config[:transports][:ssh][:insecure]).to eq(true)
+      end
+    end
+
+    it 'reads separate connect-timeout for ssh and winrm' do
+      with_tempfile_containing('conf', YAML.dump(complete_config)) do |conf|
+        cli = Bolt::CLI.new(%W[command run --configfile #{conf.path} --nodes foo --insecure])
+        cli.parse
+        expect(cli.config[:transports][:ssh][:connect_timeout]).to eq(4)
+        expect(cli.config[:transports][:winrm][:connect_timeout]).to eq(7)
       end
     end
 

--- a/spec/bolt/node/ssh_spec.rb
+++ b/spec/bolt/node/ssh_spec.rb
@@ -109,7 +109,7 @@ BASH
         .and_raise(Net::SSH::ConnectionTimeout)
       expect_node_error(Bolt::Node::ConnectError,
                         'CONNECT_ERROR',
-                        /Failed to connect to/) do
+                        /Timeout after \d+ seconds connecting to/) do
         ssh.connect
       end
     end

--- a/spec/bolt/node/ssh_spec.rb
+++ b/spec/bolt/node/ssh_spec.rb
@@ -135,7 +135,7 @@ BASH
       TCPServer.open(0) do |server|
         port = server.addr[1]
 
-        timeout = { config: Bolt::Config.new(transports: { ssh: { timeout: 2 } }) }
+        timeout = { config: Bolt::Config.new(transports: { ssh: { connect_timeout: 2 } }) }
         ssh = Bolt::SSH.new(hostname, port, 'bad', 'password', **timeout)
 
         exec_time = Time.now

--- a/spec/bolt/node/ssh_spec.rb
+++ b/spec/bolt/node/ssh_spec.rb
@@ -114,23 +114,6 @@ BASH
       end
     end
 
-    it "takes < 2 seconds to fail by default when connecting to a non-SSH port", ssh: true do
-      TCPServer.open(0) do |server|
-        server.addr[1]
-
-        # CLI failures present on a dead port like:
-        # Failed to connect to ssh://localhost:2222:
-        #   connection closed by remote host
-        #
-        # Ran on 1 node in 438.96 seconds
-        ssh = Bolt::SSH.new(hostname, port, 'bad', 'password')
-
-        expect {
-          Timeout.timeout(2) { ssh.connect }
-        }.to raise_error(Bolt::Node::ConnectError)
-      end
-    end
-
     it "adheres to specified connection timeout when connecting to a non-SSH port", ssh: true do
       TCPServer.open(0) do |server|
         port = server.addr[1]

--- a/spec/bolt/node/winrm_spec.rb
+++ b/spec/bolt/node/winrm_spec.rb
@@ -70,7 +70,7 @@ PS
         Timeout.timeout(3) do
           expect_node_error(Bolt::Node::ConnectError,
                             'CONNECT_ERROR',
-                            /Timeout connecting to/) do
+                            /Timeout after \d+ seconds connecting to/) do
             winrm.connect
           end
         end


### PR DESCRIPTION
Supercedes #81 

Needs a few more tests:

- [x] bad hostname
- [x] port that is open but cannot be connected to given specific protocol (i.e. try WinRM connection to SSH port)
- [x] port that is not open

Needs some extra info on why WinRM is now configured as such.