### PR TITLE
(BOLT-226) Fix sudo-password so password is actually optional (#163)

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -190,7 +190,13 @@ HELP
         end
         opts.on('--sudo-password [PASSWORD]',
                 'Password for privilege escalation') do |password|
-          options[:sudo_password] = password
+          if password.nil?
+            STDOUT.print "Please enter your privilege escalation password: "
+            results[:sudo_password] = STDIN.noecho(&:gets).chomp
+            STDOUT.puts
+          else
+            results[:sudo_password] = password
+          end
         end
         opts.on_tail('--[no-]tty',
                      "Request a pseudo TTY on nodes that support it") do |tty|

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -267,6 +267,22 @@ NODES
     end
   end
 
+  describe "sudo-password" do
+    it "accepts a password" do
+      cli = Bolt::CLI.new(%w[command run --sudo-password opensez --nodes foo])
+      expect(cli.parse).to include(sudo_password: 'opensez')
+    end
+
+    it "prompts the user for sudo-password if not specified" do
+      allow(STDIN).to receive(:noecho).and_return('opensez')
+      pw_prompt = 'Please enter your privilege escalation password: '
+      allow(STDOUT).to receive(:print).with(pw_prompt)
+      allow(STDOUT).to receive(:puts)
+      cli = Bolt::CLI.new(%w[command run --nodes foo --sudo-password])
+      expect(cli.parse).to include(sudo_password: 'opensez')
+    end
+  end
+
   describe "transport" do
     it "defaults to 'ssh'" do
       cli = Bolt::CLI.new(%w[command run --nodes foo whoami])


### PR DESCRIPTION
Prompts for the privelege escalation password if `sudo-password` is
passed on the CLI with no value.