### PR TITLE
(BOLT-227) Catch wrong password and fail the node

### DIFF
--- a/lib/bolt/node/errors.rb
+++ b/lib/bolt/node/errors.rb
@@ -18,6 +18,12 @@ module Bolt
       end
     end
 
+    class EscalateError < BaseError
+      def kind
+        'puppetlabs.tasks/escalate-error'
+      end
+    end
+
     class FileError < BaseError
       def kind
         'puppetlabs.tasks/task_file_error'

--- a/lib/bolt/node/ssh.rb
+++ b/lib/bolt/node/ssh.rb
@@ -54,10 +54,41 @@ module Bolt
       end
     end
 
+    def sudo_prompt
+      '[sudo] Bolt needs to run as another user, password: '
+    end
+
+    def handled_sudo(channel, data)
+      if data == sudo_prompt
+        if @sudo_password
+          channel.send_data "#{@sudo_password}\n"
+          channel.wait
+          return true
+        else
+          raise Bolt::Node::EscalateError.new(
+            "Sudo password for user #{@user} was not provided for #{@uri}",
+            'NO_PASSWORD'
+          )
+        end
+      elsif data =~ /^#{@user} is not in the sudoers file\./
+        @logger.info { data }
+        raise Bolt::Node::EscalateError.new(
+          "User #{@user} does not have sudo permission on #{@uri}",
+          'SUDO_DENIED'
+        )
+      elsif data =~ /^Sorry, try again\./
+        @logger.info { data }
+        raise Bolt::Node::EscalateError.new(
+          "Sudo password for user #{@user} not recognized on #{@uri}",
+          'BAD_PASSWORD'
+        )
+      end
+      false
+    end
+
     def execute(command, sudoable: false, **options)
       result_output = Bolt::Node::Output.new
       use_sudo = sudoable && (@sudo || @run_as)
-      sudo_prompt = '[sudo] Bolt needs to run as another user, password: '
       if use_sudo
         user_clause = if @run_as
                         "-u #{@run_as}"
@@ -82,32 +113,14 @@ module Bolt
           end
 
           channel.on_data do |_, data|
-            if use_sudo && data == sudo_prompt
-              channel.send_data "#{@sudo_password}\n"
-              channel.wait
-            elsif use_sudo && data =~ /^Sorry, try again\./
-              @logger.info { data }
-              raise Bolt::Node::EscalateError.new(
-                "Sudo-password not recognized for #{@uri}",
-                'BAD_PASSWORD'
-              )
-            else
+            unless use_sudo && handled_sudo(channel, data)
               result_output.stdout << data
             end
             @logger.debug { "stdout: #{data}" }
           end
 
           channel.on_extended_data do |_, _, data|
-            if use_sudo && data == sudo_prompt
-              channel.send_data "#{@sudo_password}\n"
-              channel.wait
-            elsif use_sudo && data =~ /^Sorry, try again\./
-              @logger.info { data }
-              raise Bolt::Node::EscalateError.new(
-                "Sudo-password not recognized for #{@uri}",
-                'BAD_PASSWORD'
-              )
-            else
+            unless use_sudo && handled_sudo(channel, data)
               result_output.stderr << data
             end
             @logger.debug { "stderr: #{data}" }


### PR DESCRIPTION
If an incorrect password is provided for privilege escalation, the
channel previously blocked as it didn't identify the request to retry.
Add handling to identify retry after incorrect password and error on the
node (the password's not going to "get better").