### PR TITLE
(BOLT-185) Drop use of PAL run_plan

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -16,7 +16,8 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['exe/*'] +
                        Dir['lib/**/*.rb'] +
                        Dir['vendored/*.rb'] +
-                       Dir['vendored/*/lib/**/*.rb']
+                       Dir['vendored/*/lib/**/*.rb'] +
+                       Dir['modules/boltlib/lib/**/*.rb']
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -94,6 +94,7 @@ HELP
     MODES = %w[command script task plan file].freeze
     ACTIONS = %w[run upload download].freeze
     TRANSPORTS = %w[ssh winrm pcp].freeze
+    BOLTLIB_PATH = File.join(__FILE__, '../../../modules')
 
     attr_reader :parser, :config
     attr_accessor :options
@@ -525,8 +526,10 @@ HELP
           cli << "--#{setting}" << dir
         end
         Puppet.initialize_settings(cli)
-        Puppet::Pal.in_tmp_environment('bolt', modulepath: modulepath) do |pal|
-          puts pal.run_plan(plan, plan_args: args)
+        Puppet::Pal.in_tmp_environment('bolt', modulepath: [BOLTLIB_PATH] + modulepath) do |pal|
+          pal.with_script_compiler do |compiler|
+            compiler.call_function('run_plan', plan, args)
+          end
         end
       end
     end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -546,6 +546,30 @@ NODES
       expect(JSON.parse(@output.string)).to be
     end
 
+    it "runs a plan given a name" do
+      plan_name = 'sample::single_task'
+      plan_params = { 'nodes' => nodes.join(',') }
+      input_method = 'both'
+
+      expect(executor)
+        .to receive(:run_task)
+        .with(
+          nodes,
+          %r{modules/sample/tasks/echo.sh$}, input_method, 'message' => 'hi there'
+        ).and_return({})
+
+      options = {
+        nodes: node_names,
+        mode: 'plan',
+        action: 'run',
+        object: plan_name,
+        task_options: plan_params,
+        modulepath: [File.join(__FILE__, '../../fixtures/modules')]
+      }
+      cli.execute(options)
+      expect(@output.string).to eq("\"ExecutionResult({})\"\n")
+    end
+
     it "errors for non-existent modules" do
       task_name = 'dne::task1'
       task_params = { 'message' => 'hi' }


### PR DESCRIPTION
Use call_function instead of deprecated run_plan to invoke a plan.

Ensures boltlib is packaged as part of the gem, and that we include it
in modulepath when executing a plan.