### PR TITLE
(maint) Don't pretty-print plan results

### DIFF
--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -74,7 +74,7 @@ module Bolt
       end
 
       def print_plan(result)
-        @stream.puts ::JSON.pretty_generate(result)
+        @stream.puts result
       end
 
       def fatal_error(e); end


### PR DESCRIPTION
Plan results may be any object and cannot always be pretty printed.