### PR TITLE
(BOLT-225) use scp instead of sftp to copy files

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "addressable", '< 2.5.0'
   spec.add_dependency "concurrent-ruby", "~> 1.0"
-  spec.add_dependency "net-sftp", "~> 2.0"
+  spec.add_dependency "net-scp", "~> 1.2"
   spec.add_dependency "net-ssh", "~> 4.2"
   spec.add_dependency "orchestrator_client", "~> 0.2.1"
   spec.add_dependency "winrm", "~> 2.0"

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -43,7 +43,11 @@ module Bolt
             rescue StandardError => ex
               Bolt::Result.from_exception(ex)
             ensure
-              node.disconnect
+              begin
+                node.disconnect
+              rescue StandardError => ex
+                @logger.info("Failed to close connection to #{node.uri} : #{ex.message}")
+              end
             end
           results[node] = result
           if callback

--- a/lib/bolt/node/ssh.rb
+++ b/lib/bolt/node/ssh.rb
@@ -1,7 +1,7 @@
 require 'json'
 require 'shellwords'
 require 'net/ssh'
-require 'net/sftp'
+require 'net/scp'
 require 'bolt/node/output'
 
 module Bolt
@@ -124,10 +124,7 @@ module Bolt
     end
 
     def write_remote_file(source, destination)
-      conn = Net::SFTP::Session.new(@session).connect!
-      # This provides a slighter better error for sftp misconfiguration
-      raise "SFTP connection closed before #{destination} could be written" unless conn.open?
-      conn.upload!(source, destination)
+      @session.scp.upload!(source, destination)
     rescue StandardError => e
       raise FileError.new(e.message, 'WRITE_ERROR')
     end


### PR DESCRIPTION
This commit changes the ssh transport to use scp instead of sftp for
file uploads. This allows users to upload files, scripts and tasks
regardelss of whether sshd on the target is configured to support sftp
or the user has sftp permissions.