### PR TITLE
(maint) Use empty facts when running plans

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -527,7 +527,7 @@ HELP
           cli << "--#{setting}" << dir
         end
         Puppet.initialize_settings(cli)
-        Puppet::Pal.in_tmp_environment('bolt', modulepath: [BOLTLIB_PATH] + modulepath) do |pal|
+        Puppet::Pal.in_tmp_environment('bolt', modulepath: [BOLTLIB_PATH] + modulepath, facts: {}) do |pal|
           pal.with_script_compiler do |compiler|
             compiler.call_function('run_plan', plan, args)
           end


### PR DESCRIPTION
This commit runs plans with empty facts instead of running facter from
bolt. This cuts 2s off of most plan runs and will allow us to discover
which facts if any are useful to expose to plans.