### PR TITLE
(BOLT-241) Load config from file

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ before_test:
       $computer = [ADSI]"WinNT://."
       $user = $computer.Create('user', $ENV:BOLT_WINRM_USER)
       Add-Type -AssemblyName System.Web
-      $ENV:BOLT_WINRM_PASSWORD = [System.Web.Security.Membership]::GeneratePassword(10, 3)
+      $ENV:BOLT_WINRM_PASSWORD = "&aA4" + [System.Web.Security.Membership]::GeneratePassword(10, 3)
       $user.SetPassword($ENV:BOLT_WINRM_PASSWORD)
       $user.SetInfo()
       $group = [ADSI]"WinNT://./Remote Management Users,group"

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -1,37 +1,140 @@
 require 'logger'
+require 'yaml'
 
 module Bolt
   Config = Struct.new(
     :concurrency,
     :format,
-    :insecure,
     :log_destination,
     :log_level,
-    :password,
-    :run_as,
-    :sudo,
-    :sudo_password,
+    :modulepath,
     :transport,
-    :key,
-    :tty,
-    :user
+    :transports
   ) do
+
     DEFAULTS = {
       concurrency: 100,
-      tty: false,
-      insecure: false,
       transport: 'ssh',
+      format: 'human',
       log_level: Logger::WARN,
       log_destination: STDERR
     }.freeze
 
+    TRANSPORT_OPTIONS = %i[insecure password run_as sudo sudo_password key tty user].freeze
+
+    TRANSPORT_DEFAULTS = {
+      insecure: false,
+      tty: false
+    }.freeze
+
+    TRANSPORTS = %i[ssh winrm pcp].freeze
+
     def initialize(**kwargs)
       super()
       DEFAULTS.merge(kwargs).each { |k, v| self[k] = v }
+
+      self[:transports] ||= {}
+      TRANSPORTS.each do |transport|
+        unless self[:transports][transport]
+          self[:transports][transport] = {}
+        end
+        TRANSPORT_DEFAULTS.each do |k, v|
+          unless self[:transports][transport][k]
+            self[:transports][transport][k] = v
+          end
+        end
+      end
     end
 
-    def escalate?
-      sudo || run_as
+    def default_path
+      path = ['.puppetlabs', 'bolt.yml']
+      root_path = '~'
+      File.join(root_path, *path)
+    end
+
+    def read_config_file(path)
+      path_passed = path
+      path ||= default_path
+      path = File.expand_path(path)
+      # safe_load doesn't work with psych in ruby 2.0
+      # The user controls the configfile so this isn't a problem
+      # rubocop:disable YAMLLoad
+      File.open(path, "r:UTF-8") { |f| YAML.load(f.read) }
+    rescue Errno::ENOENT
+      if path_passed
+        raise Bolt::CLIError, "Could not read config file: #{path}"
+      end
+    # In older releases of psych SyntaxError is not a subclass of Exception
+    rescue Psych::SyntaxError
+      raise Bolt::CLIError, "Could not parse config file: #{path}"
+    rescue Psych::Exception
+      raise Bolt::CLIError, "Could not parse config file: #{path}"
+    rescue IOError, SystemCallError
+      raise Bolt::CLIError, "Could not read config file: #{path}"
+    end
+
+    def update_from_file(data)
+      if data['modulepath']
+        self[:modulepath] = data['modulepath'].split(File::PATH_SEPARATOR)
+      end
+
+      if data['concurrency']
+        self[:concurrency] = data['concurrency']
+      end
+
+      if data['format']
+        self[:format] = data['format'] if data['format']
+      end
+
+      if data['ssh']
+        if data['ssh']['private-key']
+          self[:transports][:ssh][:key] = data['ssh']['private-key']
+        end
+        if data['ssh']['insecure']
+          self[:transports][:ssh][:insecure] = data['ssh']['insecure']
+        end
+      end
+      # if data['pcp']
+      # end
+      # if data['winrm']
+      # end
+    end
+
+    def load_file(path)
+      data = read_config_file(path)
+      update_from_file(data) if data
+    end
+
+    def update_from_cli(options)
+      %i[concurrency transport format modulepath].each do |key|
+        self[key] = options[key] if options[key]
+      end
+
+      if options[:debug]
+        self[:log_level] = Logger::DEBUG
+      elsif options[:verbose]
+        self[:log_level] = Logger::INFO
+      end
+
+      TRANSPORT_OPTIONS.each do |key|
+        # TODO: We should eventually make these transport specific
+        TRANSPORTS.each do |transport|
+          self[:transports][transport][key] = options[key] if options[key]
+        end
+      end
+    end
+
+    def validate
+      TRANSPORTS.each do |transport|
+        tconf = self[:transports][transport]
+        if tconf[:sudo] && tconf[:sudo] != 'sudo'
+          raise Bolt::CLIError, "Only 'sudo' is supported for privilege escalation."
+        end
+      end
+
+      unless %w[human json].include? self[:format]
+        raise Bolt::CLIError, "Unsupported format: '#{self[:format]}'"
+      end
     end
   end
 end

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -35,15 +35,17 @@ module Bolt
                    config: Bolt::Config.new)
       @host = host
       @port = port
-      @user = user || config[:user]
-      @password = password || config[:password]
-      @key = config[:key]
-      @tty = config[:tty]
-      @insecure = config[:insecure]
       @uri = uri
-      @sudo = config[:sudo]
-      @sudo_password = config[:sudo_password]
-      @run_as = config[:run_as]
+
+      transport_conf = config[:transports][protocol.to_sym]
+      @user = user || transport_conf[:user]
+      @password = password || transport_conf[:password]
+      @key = transport_conf[:key]
+      @tty = transport_conf[:tty]
+      @insecure = transport_conf[:insecure]
+      @sudo = transport_conf[:sudo]
+      @sudo_password = transport_conf[:sudo_password]
+      @run_as = transport_conf[:run_as]
 
       @logger = init_logger(config[:log_destination], config[:log_level])
       @transport_logger = init_logger(config[:log_destination], Logger::WARN)

--- a/lib/bolt/node/orch.rb
+++ b/lib/bolt/node/orch.rb
@@ -11,6 +11,10 @@ module Bolt
 
     def disconnect; end
 
+    def protocol
+      'pcp'
+    end
+
     def make_client
       OrchestratorClient.new({}, true)
     end

--- a/lib/bolt/node/ssh.rb
+++ b/lib/bolt/node/ssh.rb
@@ -14,6 +14,10 @@ module Bolt
       }
     end
 
+    def protocol
+      'ssh'
+    end
+
     def connect
       options = {
         logger: @transport_logger,

--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -4,6 +4,10 @@ require 'bolt/result'
 
 module Bolt
   class WinRM < Node
+    def protocol
+      'winrm'
+    end
+
     def initialize(host, port, user, password, shell: :powershell, **kwargs)
       super(host, port, user, password, **kwargs)
 

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -29,378 +29,411 @@ describe "Bolt::CLI" do
     allow(cli).to receive(:file_stat).with(path).and_return(stat)
   end
 
-  it "generates an error message if an unknown argument is given" do
-    cli = Bolt::CLI.new(%w[command run --unknown])
-    expect {
-      cli.parse
-    }.to raise_error(Bolt::CLIError, /Unknown argument '--unknown'/)
+  def stub_config(file_content = nil, base = nil)
+    file_content ||= {}
+    base ||= {}
+    config = Bolt::Config.new(**base)
+    allow(config).to receive(:read_config_file).and_return(file_content)
+    allow(Bolt::Config).to receive(:new).and_return(config)
   end
 
-  it "generates an error message if an unknown subcommand is given" do
-    cli = Bolt::CLI.new(%w[-n bolt1 bolt2 command run whoami])
-    expect {
-      cli.parse
-    }.to raise_error(Bolt::CLIError, /Expected subcommand 'bolt2' to be one of/)
-  end
+  context "without a config file" do
+    before(:each) { stub_config }
 
-  it "generates an error message if an unknown action is given" do
-    cli = Bolt::CLI.new(%w[-n bolt1 command oops whoami])
-    expect {
-      cli.parse
-    }.to raise_error(Bolt::CLIError, /Expected action 'oops' to be one of/)
-  end
-
-  # it "includes unparsed arguments" do
-  #   cli = Bolt::CLI.new(%w[exec run what --nodes foo])
-  #   expect(cli.parse).to include(leftovers: %w[what])
-  # end
-
-  describe "help" do
-    it "generates help when no arguments are specified" do
-      cli = Bolt::CLI.new([])
+    it "generates an error message if an unknown argument is given" do
+      cli = Bolt::CLI.new(%w[command run --unknown])
       expect {
-        expect {
-          cli.parse
-        }.to raise_error(Bolt::CLIExit)
-      }.to output(/Usage: bolt/).to_stdout
+        cli.parse
+      }.to raise_error(Bolt::CLIError, /Unknown argument '--unknown'/)
     end
 
-    it "accepts --help" do
-      cli = Bolt::CLI.new(%w[--help])
+    it "generates an error message if an unknown subcommand is given" do
+      cli = Bolt::CLI.new(%w[-n bolt1 bolt2 command run whoami])
       expect {
-        expect {
-          cli.parse
-        }.to raise_error(Bolt::CLIExit)
-      }.to output(/Usage: bolt/).to_stdout
+        cli.parse
+      }.to raise_error(Bolt::CLIError, /Expected subcommand 'bolt2' to be one of/)
     end
-  end
 
-  describe "version" do
-    it "emits a version string" do
-      cli = Bolt::CLI.new(%w[--version])
+    it "generates an error message if an unknown action is given" do
+      cli = Bolt::CLI.new(%w[-n bolt1 command oops whoami])
       expect {
+        cli.parse
+      }.to raise_error(Bolt::CLIError, /Expected action 'oops' to be one of/)
+    end
+
+    describe "help" do
+      it "generates help when no arguments are specified" do
+        cli = Bolt::CLI.new([])
         expect {
-          cli.parse
-        }.to raise_error(Bolt::CLIExit)
-      }.to output(/\d+\.\d+\.\d+/).to_stdout
-    end
-  end
+          expect {
+            cli.parse
+          }.to raise_error(Bolt::CLIExit)
+        }.to output(/Usage: bolt/).to_stdout
+      end
 
-  describe "nodes" do
-    it "accepts a single node" do
-      cli = Bolt::CLI.new(%w[command run --nodes foo])
-      expect(cli.parse).to include(nodes: ['foo'])
-    end
-
-    it "accepts multiple nodes" do
-      cli = Bolt::CLI.new(%w[command run --nodes foo,bar])
-      expect(cli.parse).to include(nodes: %w[foo bar])
-    end
-
-    it "accepts multiple nodes across multiple declarations" do
-      cli = Bolt::CLI.new(%w[command run --nodes foo,bar --nodes bar,more,bars])
-      expect(cli.parse).to include(nodes: %w[foo bar more bars])
+      it "accepts --help" do
+        cli = Bolt::CLI.new(%w[--help])
+        expect {
+          expect {
+            cli.parse
+          }.to raise_error(Bolt::CLIExit)
+        }.to output(/Usage: bolt/).to_stdout
+      end
     end
 
-    it "reads from stdin when --nodes is '-'" do
-      nodes = <<NODES
+    describe "version" do
+      it "emits a version string" do
+        cli = Bolt::CLI.new(%w[--version])
+        expect {
+          expect {
+            cli.parse
+          }.to raise_error(Bolt::CLIExit)
+        }.to output(/\d+\.\d+\.\d+/).to_stdout
+      end
+    end
+
+    describe "nodes" do
+      it "accepts a single node" do
+        cli = Bolt::CLI.new(%w[command run --nodes foo])
+        expect(cli.parse).to include(nodes: ['foo'])
+      end
+
+      it "accepts multiple nodes" do
+        cli = Bolt::CLI.new(%w[command run --nodes foo,bar])
+        expect(cli.parse).to include(nodes: %w[foo bar])
+      end
+
+      it "accepts multiple nodes across multiple declarations" do
+        cli = Bolt::CLI.new(%w[command run --nodes foo,bar --nodes bar,more,bars])
+        expect(cli.parse).to include(nodes: %w[foo bar more bars])
+      end
+
+      it "reads from stdin when --nodes is '-'" do
+        nodes = <<NODES
 foo
 bar
 NODES
-      cli = Bolt::CLI.new(%w[command run --nodes -])
-      allow(STDIN).to receive(:read).and_return(nodes)
-      result = cli.parse
-      expect(result[:nodes]).to eq(%w[foo bar])
-    end
-
-    it "reads from a file when --nodes starts with @" do
-      nodes = <<NODES
-foo
-bar
-NODES
-      with_tempfile_containing('nodes-args', nodes) do |file|
-        cli = Bolt::CLI.new(%W[command run --nodes @#{file.path}])
+        cli = Bolt::CLI.new(%w[command run --nodes -])
+        allow(STDIN).to receive(:read).and_return(nodes)
         result = cli.parse
         expect(result[:nodes]).to eq(%w[foo bar])
       end
-    end
 
-    it "strips leading and trailing whitespace" do
-      nodes = "  foo\nbar  \nbaz\nqux  "
-      with_tempfile_containing('nodes-args', nodes) do |file|
-        cli = Bolt::CLI.new(%W[command run --nodes @#{file.path}])
-        result = cli.parse
-        expect(result[:nodes]).to eq(%w[foo bar baz qux])
+      it "reads from a file when --nodes starts with @" do
+        nodes = <<NODES
+foo
+bar
+NODES
+        with_tempfile_containing('nodes-args', nodes) do |file|
+          cli = Bolt::CLI.new(%W[command run --nodes @#{file.path}])
+          result = cli.parse
+          expect(result[:nodes]).to eq(%w[foo bar])
+        end
+      end
+
+      it "strips leading and trailing whitespace" do
+        nodes = "  foo\nbar  \nbaz\nqux  "
+        with_tempfile_containing('nodes-args', nodes) do |file|
+          cli = Bolt::CLI.new(%W[command run --nodes @#{file.path}])
+          result = cli.parse
+          expect(result[:nodes]).to eq(%w[foo bar baz qux])
+        end
+      end
+
+      it "accepts multiple nodes but is uniq" do
+        cli = Bolt::CLI.new(%w[command run --nodes foo,bar,foo])
+        expect(cli.parse).to include(nodes: %w[foo bar])
+      end
+
+      it "generates an error message if no nodes given" do
+        cli = Bolt::CLI.new(%w[command run --nodes])
+        expect {
+          cli.parse
+        }.to raise_error(Bolt::CLIError, /Option '--nodes' needs a parameter/)
+      end
+
+      it "generates an error message if nodes is omitted" do
+        cli = Bolt::CLI.new(%w[command run])
+        expect {
+          cli.parse
+        }.to raise_error(Bolt::CLIError, /Option '--nodes' must be specified/)
       end
     end
 
-    it "accepts multiple nodes but is uniq" do
-      cli = Bolt::CLI.new(%w[command run --nodes foo,bar,foo])
-      expect(cli.parse).to include(nodes: %w[foo bar])
+    describe "user" do
+      it "accepts a user" do
+        cli = Bolt::CLI.new(%w[command run --user root --nodes foo])
+        expect(cli.parse).to include(user: 'root')
+      end
+
+      it "generates an error message if no user value is given" do
+        cli = Bolt::CLI.new(%w[command run --nodes foo --user])
+        expect {
+          cli.parse
+        }.to raise_error(Bolt::CLIError, /Option '--user' needs a parameter/)
+      end
     end
 
-    it "generates an error message if no nodes given" do
-      cli = Bolt::CLI.new(%w[command run --nodes])
-      expect {
+    describe "password" do
+      it "accepts a password" do
+        cli = Bolt::CLI.new(%w[command run --password opensesame --nodes foo])
+        expect(cli.parse).to include(password: 'opensesame')
+      end
+
+      it "prompts the user for password if not specified" do
+        allow(STDIN).to receive(:noecho).and_return('opensesame')
+        allow(STDOUT).to receive(:print).with('Please enter your password: ')
+        allow(STDOUT).to receive(:puts)
+        cli = Bolt::CLI.new(%w[command run --nodes foo --password])
+        expect(cli.parse).to include(password: 'opensesame')
+      end
+    end
+
+    describe "private-key" do
+      it "accepts a private key" do
+        cli = Bolt::CLI.new(%w[  command run
+                                 --private-key ~/.ssh/google_compute_engine
+                                 --nodes foo])
+        expect(cli.parse).to include(key: '~/.ssh/google_compute_engine')
+        expect(cli.config[:transports][:ssh][:key]).to eq('~/.ssh/google_compute_engine')
+      end
+
+      it "generates an error message if no key value is given" do
+        cli = Bolt::CLI.new(%w[command run --nodes foo --private-key])
+        expect {
+          cli.parse
+        }.to raise_error(Bolt::CLIError,
+                         /Option '--private-key' needs a parameter/)
+      end
+    end
+
+    describe "concurrency" do
+      it "accepts a concurrency limit" do
+        cli = Bolt::CLI.new(%w[command run --concurrency 10 --nodes foo])
+        expect(cli.parse).to include(concurrency: 10)
+      end
+
+      it "defaults to 100" do
+        cli = Bolt::CLI.new(%w[command run --nodes foo])
         cli.parse
-      }.to raise_error(Bolt::CLIError, /Option '--nodes' needs a parameter/)
+        expect(cli.config[:concurrency]).to eq(100)
+      end
+
+      it "generates an error message if no concurrency value is given" do
+        cli = Bolt::CLI.new(%w[command run --nodes foo --concurrency])
+        expect {
+          cli.parse
+        }.to raise_error(Bolt::CLIError,
+                         /Option '--concurrency' needs a parameter/)
+      end
     end
 
-    it "generates an error message if nodes is omitted" do
-      cli = Bolt::CLI.new(%w[command run])
-      expect {
+    describe "log level" do
+      it "is not sensitive to ordering of debug and verbose" do
+        cli = Bolt::CLI.new(%w[command run --nodes foo --debug --verbose])
         cli.parse
-      }.to raise_error(Bolt::CLIError, /Option '--nodes' must be specified/)
-    end
-  end
-
-  describe "user" do
-    it "accepts a user" do
-      cli = Bolt::CLI.new(%w[command run --user root --nodes foo])
-      expect(cli.parse).to include(user: 'root')
+        expect(cli.config[:log_level]).to eq(Logger::DEBUG)
+      end
     end
 
-    it "generates an error message if no user value is given" do
-      cli = Bolt::CLI.new(%w[command run --nodes foo --user])
-      expect {
+    describe "insecure" do
+      it "accepts `-k`" do
+        cli = Bolt::CLI.new(%w[command run -k --nodes foo])
         cli.parse
-      }.to raise_error(Bolt::CLIError, /Option '--user' needs a parameter/)
-    end
-  end
+        expect(cli.config[:transports][:ssh][:insecure]).to eq(true)
+      end
 
-  describe "password" do
-    it "accepts a password" do
-      cli = Bolt::CLI.new(%w[command run --password opensesame --nodes foo])
-      expect(cli.parse).to include(password: 'opensesame')
+      it "accepts `--insecure`" do
+        cli = Bolt::CLI.new(%w[command run --insecure --nodes foo])
+        cli.parse
+        expect(cli.config[:transports][:ssh][:insecure]).to eq(true)
+      end
+
+      it "defaults to false" do
+        cli = Bolt::CLI.new(%w[command run --nodes foo])
+        cli.parse
+        expect(cli.config[:transports][:ssh][:insecure]).to eq(false)
+      end
     end
 
-    it "prompts the user for password if not specified" do
-      allow(STDIN).to receive(:noecho).and_return('opensesame')
-      allow(STDOUT).to receive(:print).with('Please enter your password: ')
-      allow(STDOUT).to receive(:puts)
-      cli = Bolt::CLI.new(%w[command run --nodes foo --password])
-      expect(cli.parse).to include(password: 'opensesame')
-    end
-  end
+    describe "modulepath" do
+      it "accepts a modulepath directory" do
+        cli = Bolt::CLI.new(%w[command run --modulepath ./modules --nodes foo])
+        expect(cli.parse).to include(modulepath: ['./modules'])
+      end
 
-  describe "private-key" do
-    it "accepts a private key" do
-      cli = Bolt::CLI.new(%w[  command run
-                               --private-key ~/.ssh/google_compute_engine
+      it "accepts a list of module directories" do
+        modulepath = %w[modules more].join(File::PATH_SEPARATOR)
+        cli = Bolt::CLI.new(%W[command run --modulepath #{modulepath}
                                --nodes foo])
-      expect(cli.parse).to include(key: '~/.ssh/google_compute_engine')
-      expect(cli.config[:key]).to eq('~/.ssh/google_compute_engine')
-    end
+        expect(cli.parse).to include(modulepath: %w[modules more])
+      end
 
-    it "generates an error message if no key value is given" do
-      cli = Bolt::CLI.new(%w[command run --nodes foo --private-key])
-      expect {
-        cli.parse
-      }.to raise_error(Bolt::CLIError,
-                       /Option '--private-key' needs a parameter/)
-    end
-  end
-
-  describe "concurrency" do
-    it "accepts a concurrency limit" do
-      cli = Bolt::CLI.new(%w[command run --concurrency 10 --nodes foo])
-      expect(cli.parse).to include(concurrency: 10)
-    end
-
-    it "defaults to 100" do
-      cli = Bolt::CLI.new(%w[command run --nodes foo])
-      expect(cli.parse).to include(concurrency: 100)
-    end
-
-    it "generates an error message if no concurrency value is given" do
-      cli = Bolt::CLI.new(%w[command run --nodes foo --concurrency])
-      expect {
-        cli.parse
-      }.to raise_error(Bolt::CLIError,
-                       /Option '--concurrency' needs a parameter/)
-    end
-  end
-
-  describe "log level" do
-    it "is not sensitive to ordering of debug and verbose" do
-      cli = Bolt::CLI.new(%w[command run --nodes foo --debug --verbose])
-      cli.parse
-      expect(cli.config[:log_level]).to eq(Logger::DEBUG)
-    end
-  end
-
-  describe "insecure" do
-    it "accepts `-k`" do
-      cli = Bolt::CLI.new(%w[command run -k --nodes foo])
-      expect(cli.parse).to include(insecure: true)
-    end
-
-    it "accepts `--insecure`" do
-      cli = Bolt::CLI.new(%w[command run --insecure --nodes foo])
-      expect(cli.parse).to include(insecure: true)
-    end
-
-    it "defaults to false" do
-      cli = Bolt::CLI.new(%w[command run --nodes foo])
-      expect(cli.parse).to include(insecure: false)
-    end
-  end
-
-  describe "modulepath" do
-    it "accepts a modulepath directory" do
-      cli = Bolt::CLI.new(%w[command run --modulepath ./modules --nodes foo])
-      expect(cli.parse).to include(modulepath: ['./modules'])
-    end
-
-    it "accepts a list of module directories" do
-      modulepath = %w[modules more].join(File::PATH_SEPARATOR)
-      cli = Bolt::CLI.new(%W[command run --modulepath #{modulepath}
-                             --nodes foo])
-      expect(cli.parse).to include(modulepath: %w[modules more])
-    end
-
-    it "generates an error message if no value is given" do
-      cli = Bolt::CLI.new(%w[command run --nodes foo --modulepath])
-      expect {
-        cli.parse
-      }.to raise_error(Bolt::CLIError,
-                       /Option '--modulepath' needs a parameter/)
-    end
-  end
-
-  describe "sudo" do
-    it "defaults method to sudo" do
-      cli = Bolt::CLI.new(%w[command run --nodes foo whoami --sudo])
-      expect(cli.parse[:sudo]).to eq('sudo')
-    end
-
-    it "rejects unsupported methods" do
-      cli = Bolt::CLI.new(%w[command run --nodes foo whoami --sudo rm])
-      expect { cli.parse[:sudo] }.to raise_error(Bolt::CLIError)
-    end
-
-    it "supports running as a user" do
-      cli = Bolt::CLI.new(%w[command run --nodes foo whoami --run-as root])
-      expect(cli.parse[:run_as]).to eq('root')
-    end
-  end
-
-  describe "sudo-password" do
-    it "accepts a password" do
-      cli = Bolt::CLI.new(%w[command run --sudo-password opensez --nodes foo])
-      expect(cli.parse).to include(sudo_password: 'opensez')
-    end
-
-    it "prompts the user for sudo-password if not specified" do
-      allow(STDIN).to receive(:noecho).and_return('opensez')
-      pw_prompt = 'Please enter your privilege escalation password: '
-      allow(STDOUT).to receive(:print).with(pw_prompt)
-      allow(STDOUT).to receive(:puts)
-      cli = Bolt::CLI.new(%w[command run --nodes foo --sudo-password])
-      expect(cli.parse).to include(sudo_password: 'opensez')
-    end
-  end
-
-  describe "transport" do
-    it "defaults to 'ssh'" do
-      cli = Bolt::CLI.new(%w[command run --nodes foo whoami])
-      expect(cli.parse[:transport]).to eq('ssh')
-    end
-
-    it "accepts ssh" do
-      cli = Bolt::CLI.new(%w[command run --transport ssh --nodes foo id])
-      expect(cli.parse[:transport]).to eq('ssh')
-    end
-
-    it "accepts winrm" do
-      cli = Bolt::CLI.new(%w[command run --transport winrm --nodes foo id])
-      expect(cli.parse[:transport]).to eq('winrm')
-    end
-
-    it "accepts pcp" do
-      cli = Bolt::CLI.new(%w[command run --transport pcp --nodes foo id])
-      expect(cli.parse[:transport]).to eq('pcp')
-    end
-
-    it "rejects invalid transports" do
-      cli = Bolt::CLI.new(%w[command run --transport holodeck --nodes foo id])
-      expect {
-        cli.parse
-      }.to raise_error(OptionParser::InvalidArgument,
-                       /invalid argument: --transport holodeck/)
-    end
-  end
-
-  describe "command" do
-    it "interprets whoami as the command" do
-      cli = Bolt::CLI.new(%w[command run --nodes foo whoami])
-      expect(cli.parse[:object]).to eq('whoami')
-    end
-  end
-
-  it "distinguishes subcommands" do
-    cli = Bolt::CLI.new(%w[script run --nodes foo])
-    expect(cli.parse).to include(mode: 'script')
-  end
-
-  describe "file" do
-    describe "upload" do
-      it "uploads a file" do
-        cli = Bolt::CLI.new(%w[file upload ./src /path/dest --nodes foo])
-        result = cli.parse
-        expect(result[:object]).to eq('./src')
-        expect(result[:leftovers].first).to eq('/path/dest')
+      it "generates an error message if no value is given" do
+        cli = Bolt::CLI.new(%w[command run --nodes foo --modulepath])
+        expect {
+          cli.parse
+        }.to raise_error(Bolt::CLIError,
+                         /Option '--modulepath' needs a parameter/)
       end
     end
-  end
 
-  describe "handling parameters" do
-    it "returns {} if none are specified" do
-      cli = Bolt::CLI.new(%w[plan run my::plan --modulepath .])
-      result = cli.parse
-      expect(result[:task_options]).to eq({})
-    end
-
-    it "reads params on the command line" do
-      cli = Bolt::CLI.new(%w[plan run my::plan kj=2hv iuhg=iube 2whf=lcv
-                             --modulepath .])
-      result = cli.parse
-      expect(result[:task_options]).to eq('kj'   => '2hv',
-                                          'iuhg' => 'iube',
-                                          '2whf' => 'lcv')
-    end
-
-    it "reads params in json with the params flag" do
-      json_args = '{"kj":"2hv","iuhg":"iube","2whf":"lcv"}'
-      cli = Bolt::CLI.new(['plan', 'run', 'my::plan', '--params', json_args,
-                           '--modulepath', '.'])
-      result = cli.parse
-      expect(result[:task_options]).to eq('kj'   => '2hv',
-                                          'iuhg' => 'iube',
-                                          '2whf' => 'lcv')
-    end
-
-    it "raises a cli error when json parsing fails" do
-      json_args = '{"k'
-      cli = Bolt::CLI.new(['plan', 'run', 'my::plan', '--params', json_args])
-      expect {
+    describe "sudo" do
+      it "defaults method to sudo" do
+        cli = Bolt::CLI.new(%w[command run --nodes foo whoami --sudo])
         cli.parse
-      }.to raise_error(Bolt::CLIError, /unexpected token/)
+        expect(cli.config[:transports][:ssh][:sudo]).to eq('sudo')
+      end
+
+      it "rejects unsupported methods" do
+        cli = Bolt::CLI.new(%w[command run --nodes foo whoami --sudo rm])
+        expect { cli.parse }.to raise_error(Bolt::CLIError)
+      end
+
+      it "supports running as a user" do
+        cli = Bolt::CLI.new(%w[command run --nodes foo whoami --run-as root])
+        expect(cli.parse[:run_as]).to eq('root')
+      end
     end
 
-    it "raises a cli error when specifying params both ways" do
-      cli = Bolt::CLI.new(%w[plan run my::plan --params {"a":"b"} c=d
-                             --modulepath .])
-      expect {
+    describe "sudo-password" do
+      it "accepts a password" do
+        cli = Bolt::CLI.new(%w[command run --sudo-password opensez --nodes foo])
+        expect(cli.parse).to include(sudo_password: 'opensez')
+      end
+
+      it "prompts the user for sudo-password if not specified" do
+        allow(STDIN).to receive(:noecho).and_return('opensez')
+        pw_prompt = 'Please enter your privilege escalation password: '
+        allow(STDOUT).to receive(:print).with(pw_prompt)
+        allow(STDOUT).to receive(:puts)
+        cli = Bolt::CLI.new(%w[command run --nodes foo --sudo-password])
+        expect(cli.parse).to include(sudo_password: 'opensez')
+      end
+    end
+
+    describe "transport" do
+      it "defaults to 'ssh'" do
+        cli = Bolt::CLI.new(%w[command run --nodes foo whoami])
         cli.parse
-      }.to raise_error(Bolt::CLIError, /not both/)
+        expect(cli.config[:transport]).to eq('ssh')
+      end
+
+      it "accepts ssh" do
+        cli = Bolt::CLI.new(%w[command run --transport ssh --nodes foo id])
+        expect(cli.parse[:transport]).to eq('ssh')
+      end
+
+      it "accepts winrm" do
+        cli = Bolt::CLI.new(%w[command run --transport winrm --nodes foo id])
+        expect(cli.parse[:transport]).to eq('winrm')
+      end
+
+      it "accepts pcp" do
+        cli = Bolt::CLI.new(%w[command run --transport pcp --nodes foo id])
+        expect(cli.parse[:transport]).to eq('pcp')
+      end
+
+      it "rejects invalid transports" do
+        cli = Bolt::CLI.new(%w[command run --transport holodeck --nodes foo id])
+        expect {
+          cli.parse
+        }.to raise_error(OptionParser::InvalidArgument,
+                         /invalid argument: --transport holodeck/)
+      end
     end
 
-    it "reads json from a file when --params starts with @" do
-      json_args = '{"kj":"2hv","iuhg":"iube","2whf":"lcv"}'
-      with_tempfile_containing('json-args', json_args) do |file|
-        cli = Bolt::CLI.new(%W[plan run my::plan --params @#{file.path}
+    describe "command" do
+      it "interprets whoami as the command" do
+        cli = Bolt::CLI.new(%w[command run --nodes foo whoami])
+        expect(cli.parse[:object]).to eq('whoami')
+      end
+    end
+
+    it "distinguishes subcommands" do
+      cli = Bolt::CLI.new(%w[script run --nodes foo])
+      expect(cli.parse).to include(mode: 'script')
+    end
+
+    describe "file" do
+      describe "upload" do
+        it "uploads a file" do
+          cli = Bolt::CLI.new(%w[file upload ./src /path/dest --nodes foo])
+          result = cli.parse
+          expect(result[:object]).to eq('./src')
+          expect(result[:leftovers].first).to eq('/path/dest')
+        end
+      end
+    end
+
+    describe "handling parameters" do
+      it "returns {} if none are specified" do
+        cli = Bolt::CLI.new(%w[plan run my::plan --modulepath .])
+        result = cli.parse
+        expect(result[:task_options]).to eq({})
+      end
+
+      it "reads params on the command line" do
+        cli = Bolt::CLI.new(%w[plan run my::plan kj=2hv iuhg=iube 2whf=lcv
                                --modulepath .])
+        result = cli.parse
+        expect(result[:task_options]).to eq('kj'   => '2hv',
+                                            'iuhg' => 'iube',
+                                            '2whf' => 'lcv')
+      end
+
+      it "reads params in json with the params flag" do
+        json_args = '{"kj":"2hv","iuhg":"iube","2whf":"lcv"}'
+        cli = Bolt::CLI.new(['plan', 'run', 'my::plan', '--params', json_args,
+                             '--modulepath', '.'])
+        result = cli.parse
+        expect(result[:task_options]).to eq('kj'   => '2hv',
+                                            'iuhg' => 'iube',
+                                            '2whf' => 'lcv')
+      end
+
+      it "raises a cli error when json parsing fails" do
+        json_args = '{"k'
+        cli = Bolt::CLI.new(['plan', 'run', 'my::plan', '--params', json_args])
+        expect {
+          cli.parse
+        }.to raise_error(Bolt::CLIError, /unexpected token/)
+      end
+
+      it "raises a cli error when specifying params both ways" do
+        cli = Bolt::CLI.new(%w[plan run my::plan --params {"a":"b"} c=d
+                               --modulepath .])
+        expect {
+          cli.parse
+        }.to raise_error(Bolt::CLIError, /not both/)
+      end
+
+      it "reads json from a file when --params starts with @" do
+        json_args = '{"kj":"2hv","iuhg":"iube","2whf":"lcv"}'
+        with_tempfile_containing('json-args', json_args) do |file|
+          cli = Bolt::CLI.new(%W[plan run my::plan --params @#{file.path}
+                                 --modulepath .])
+          result = cli.parse
+          expect(result[:task_options]).to eq('kj'   => '2hv',
+                                              'iuhg' => 'iube',
+                                              '2whf' => 'lcv')
+        end
+      end
+
+      it "raises a cli error when reading the params file fails" do
+        Dir.mktmpdir do |dir|
+          cli = Bolt::CLI.new(%W[plan run my::plan --params @#{dir}/nope
+                                 --modulepath .])
+          expect {
+            cli.parse
+          }.to raise_error(Bolt::CLIError, /No such file/)
+        end
+      end
+
+      it "reads json from stdin when --params is just '-'" do
+        json_args = '{"kj":"2hv","iuhg":"iube","2whf":"lcv"}'
+        cli = Bolt::CLI.new(%w[plan run my::plan --params - --modulepath .])
+        allow(STDIN).to receive(:read).and_return(json_args)
         result = cli.parse
         expect(result[:task_options]).to eq('kj'   => '2hv',
                                             'iuhg' => 'iube',
@@ -408,344 +441,392 @@ NODES
       end
     end
 
-    it "raises a cli error when reading the params file fails" do
-      Dir.mktmpdir do |dir|
-        cli = Bolt::CLI.new(%W[plan run my::plan --params @#{dir}/nope
-                               --modulepath .])
+    describe 'task' do
+      it "errors without a task" do
+        cli = Bolt::CLI.new(%w[task run -n example.com --modulepath .])
         expect {
           cli.parse
-        }.to raise_error(Bolt::CLIError, /No such file/)
+        }.to raise_error(Bolt::CLIError, /Must specify/)
+      end
+
+      it "errors if task is a parameter" do
+        cli = Bolt::CLI.new(%w[task run -n example.com --modulepath . p1=v1])
+        expect {
+          cli.parse
+        }.to raise_error(Bolt::CLIError, /Invalid task/)
       end
     end
 
-    it "reads json from stdin when --params is just '-'" do
-      json_args = '{"kj":"2hv","iuhg":"iube","2whf":"lcv"}'
-      cli = Bolt::CLI.new(%w[plan run my::plan --params - --modulepath .])
-      allow(STDIN).to receive(:read).and_return(json_args)
-      result = cli.parse
-      expect(result[:task_options]).to eq('kj'   => '2hv',
-                                          'iuhg' => 'iube',
-                                          '2whf' => 'lcv')
-    end
-  end
+    describe 'plan' do
+      it "errors without a plan" do
+        cli = Bolt::CLI.new(%w[plan run -n example.com --modulepath .])
+        expect {
+          cli.parse
+        }.to raise_error(Bolt::CLIError, /Must specify/)
+      end
 
-  describe 'task' do
-    it "errors without a task" do
-      cli = Bolt::CLI.new(%w[task run -n example.com --modulepath .])
-      expect {
-        cli.parse
-      }.to raise_error(Bolt::CLIError, /Must specify/)
+      it "errors if plan is a parameter" do
+        cli = Bolt::CLI.new(%w[plan run -n example.com --modulepath . p1=v1])
+        expect {
+          cli.parse
+        }.to raise_error(Bolt::CLIError, /Invalid plan/)
+      end
     end
 
-    it "errors if task is a parameter" do
-      cli = Bolt::CLI.new(%w[task run -n example.com --modulepath . p1=v1])
-      expect {
-        cli.parse
-      }.to raise_error(Bolt::CLIError, /Invalid task/)
-    end
-  end
+    describe "execute" do
+      let(:executor) { double('executor') }
+      let(:cli) { Bolt::CLI.new({}) }
+      let(:node_names) { ['foo'] }
+      let(:nodes) { [double('node', host: 'foo')] }
 
-  describe 'plan' do
-    it "errors without a plan" do
-      cli = Bolt::CLI.new(%w[plan run -n example.com --modulepath .])
-      expect {
-        cli.parse
-      }.to raise_error(Bolt::CLIError, /Must specify/)
-    end
+      before :each do
+        allow(Bolt::Executor).to receive(:new).and_return(executor)
+        allow(executor).to receive(:from_uris).and_return(nodes)
 
-    it "errors if plan is a parameter" do
-      cli = Bolt::CLI.new(%w[plan run -n example.com --modulepath . p1=v1])
-      expect {
-        cli.parse
-      }.to raise_error(Bolt::CLIError, /Invalid plan/)
-    end
-  end
+        @output = StringIO.new
+        outputter = Bolt::Outputter::JSON.new(@output)
 
-  describe "execute" do
-    let(:executor) { double('executor') }
-    let(:cli) { Bolt::CLI.new({}) }
-    let(:node_names) { ['foo'] }
-    let(:nodes) { [double('node', host: 'foo')] }
+        allow(cli).to receive(:outputter).and_return(outputter)
+      end
 
-    before :each do
-      allow(Bolt::Executor).to receive(:new).and_return(executor)
-      allow(executor).to receive(:from_uris).and_return(nodes)
-
-      @output = StringIO.new
-      outputter = Bolt::Outputter::JSON.new(@output)
-
-      allow(cli).to receive(:outputter).and_return(outputter)
-    end
-
-    it "executes the 'whoami' command" do
-      expect(executor)
-        .to receive(:run_command)
-        .with(nodes, 'whoami')
-        .and_return({})
-
-      options = {
-        nodes: node_names,
-        mode: 'command',
-        action: 'run',
-        object: 'whoami'
-      }
-      cli.execute(options)
-      expect(JSON.parse(@output.string)).to be
-    end
-
-    describe "when running a script" do
-      let(:script) { 'bar.sh' }
-      let(:options) {
-        { nodes: node_names, mode: 'script', action: 'run', object: script,
-          leftovers: [] }
-      }
-
-      it "runs a script" do
-        stub_file(script)
-
+      it "executes the 'whoami' command" do
         expect(executor)
-          .to receive(:run_script)
-          .with(nodes, script, [])
+          .to receive(:run_command)
+          .with(nodes, 'whoami')
           .and_return({})
 
-        cli.execute(options)
-        expect(JSON.parse(@output.string)).to be
-      end
-
-      it "errors for non-existent scripts" do
-        stub_non_existent_file(script)
-
-        expect { cli.execute(options) }.to raise_error(
-          Bolt::CLIError, /The script '#{script}' does not exist/
-        )
-        expect(JSON.parse(@output.string)).to be
-      end
-
-      it "errors for unreadable scripts" do
-        stub_unreadable_file(script)
-
-        expect { cli.execute(options) }.to raise_error(
-          Bolt::CLIError, /The script '#{script}' is unreadable/
-        )
-        expect(JSON.parse(@output.string)).to be
-      end
-
-      it "errors for scripts that aren't files" do
-        stub_directory(script)
-
-        expect { cli.execute(options) }.to raise_error(
-          Bolt::CLIError, /The script '#{script}' is not a file/
-        )
-        expect(JSON.parse(@output.string)).to be
-      end
-    end
-
-    it "runs a task given a name" do
-      task_name = 'sample::echo'
-      task_params = { 'message' => 'hi' }
-      input_method = 'both'
-
-      expect(executor)
-        .to receive(:run_task)
-        .with(
-          nodes,
-          %r{modules/sample/tasks/echo.sh$}, input_method, task_params
-        ).and_return({})
-
-      options = {
-        nodes: node_names,
-        mode: 'task',
-        action: 'run',
-        object: task_name,
-        task_options: task_params,
-        modulepath: [File.join(__FILE__, '../../fixtures/modules')]
-      }
-      cli.execute(options)
-      expect(JSON.parse(@output.string)).to be
-    end
-
-    it "runs a plan given a name" do
-      plan_name = 'sample::single_task'
-      plan_params = { 'nodes' => nodes.join(',') }
-      input_method = 'both'
-
-      expect(executor)
-        .to receive(:run_task)
-        .with(
-          nodes,
-          %r{modules/sample/tasks/echo.sh$}, input_method, 'message' => 'hi there'
-        ).and_return({})
-
-      options = {
-        nodes: node_names,
-        mode: 'plan',
-        action: 'run',
-        object: plan_name,
-        task_options: plan_params,
-        modulepath: [File.join(__FILE__, '../../fixtures/modules')]
-      }
-      cli.execute(options)
-      expect(@output.string).to eq("\"ExecutionResult({})\"\n")
-    end
-
-    it "errors for non-existent modules" do
-      task_name = 'dne::task1'
-      task_params = { 'message' => 'hi' }
-
-      options = {
-        nodes: node_names,
-        mode: 'task',
-        action: 'run',
-        object: task_name,
-        task_options: task_params,
-        modulepath: [File.join(__FILE__, '../../fixtures/modules')]
-      }
-      expect { cli.execute(options) }.to raise_error(
-        Bolt::CLIError, /Could not find module/
-      )
-      expect(JSON.parse(@output.string)).to be
-    end
-
-    it "errors for non-existent tasks" do
-      task_name = 'sample::dne'
-      task_params = { 'message' => 'hi' }
-
-      options = {
-        nodes: node_names,
-        mode: 'task',
-        action: 'run',
-        object: task_name,
-        task_options: task_params,
-        modulepath: [File.join(__FILE__, '../../fixtures/modules')]
-      }
-      expect { cli.execute(options) }.to raise_error(
-        Bolt::CLIError,
-        /Could not find task '#{task_name}' in module 'sample'/
-      )
-      expect(JSON.parse(@output.string)).to be
-    end
-
-    it "runs an init task given a module name" do
-      task_name = 'sample'
-      task_params = { 'message' => 'hi' }
-      input_method = 'both'
-
-      expect(executor)
-        .to receive(:run_task)
-        .with(
-          nodes,
-          %r{modules/sample/tasks/init.sh$}, input_method, task_params
-        ).and_return({})
-
-      options = {
-        nodes: node_names,
-        mode: 'task',
-        action: 'run',
-        object: task_name,
-        task_options: task_params,
-        modulepath: [File.join(__FILE__, '../../fixtures/modules')]
-      }
-      cli.execute(options)
-      expect(JSON.parse(@output.string)).to be
-    end
-
-    it "runs a task passing input on stdin" do
-      task_name = 'sample::stdin'
-      task_params = { 'message' => 'hi' }
-      input_method = 'stdin'
-
-      expect(executor)
-        .to receive(:run_task)
-        .with(nodes,
-              %r{modules/sample/tasks/stdin.sh$}, input_method, task_params)
-        .and_return({})
-
-      options = {
-        nodes: node_names,
-        mode: 'task',
-        action: 'run',
-        object: task_name,
-        task_options: task_params,
-        modulepath: [File.join(__FILE__, '../../fixtures/modules')]
-      }
-      cli.execute(options)
-      expect(JSON.parse(@output.string)).to be
-    end
-
-    it "runs a powershell task passing input on stdin" do
-      task_name = 'sample::winstdin'
-      task_params = { 'message' => 'hi' }
-      input_method = 'stdin'
-
-      expect(executor)
-        .to receive(:run_task)
-        .with(nodes,
-              %r{modules/sample/tasks/winstdin.ps1$}, input_method, task_params)
-        .and_return({})
-
-      options = {
-        nodes: node_names,
-        mode: 'task',
-        action: 'run',
-        object: task_name,
-        task_options: task_params,
-        modulepath: [File.join(__FILE__, '../../fixtures/modules')]
-      }
-      cli.execute(options)
-      expect(JSON.parse(@output.string)).to be
-    end
-
-    describe "file uploading" do
-      let(:source) { '/path/to/local' }
-      let(:dest) { '/path/to/remote' }
-      let(:options) {
-        {
+        options = {
           nodes: node_names,
-          mode: 'file',
-          action: 'upload',
-          object: source,
-          leftovers: [dest]
+          mode: 'command',
+          action: 'run',
+          object: 'whoami'
         }
-      }
-
-      it "uploads a file via scp" do
-        stub_file(source)
-
-        expect(executor)
-          .to receive(:file_upload)
-          .with(nodes, source, dest)
-          .and_return({})
-
         cli.execute(options)
         expect(JSON.parse(@output.string)).to be
       end
 
-      it "raises if the local file doesn't exist" do
-        stub_non_existent_file(source)
+      describe "when running a script" do
+        let(:script) { 'bar.sh' }
+        let(:options) {
+          { nodes: node_names, mode: 'script', action: 'run', object: script,
+            leftovers: [] }
+        }
 
+        it "runs a script" do
+          stub_file(script)
+
+          expect(executor)
+            .to receive(:run_script)
+            .with(nodes, script, [])
+            .and_return({})
+
+          cli.execute(options)
+          expect(JSON.parse(@output.string)).to be
+        end
+
+        it "errors for non-existent scripts" do
+          stub_non_existent_file(script)
+
+          expect { cli.execute(options) }.to raise_error(
+            Bolt::CLIError, /The script '#{script}' does not exist/
+          )
+          expect(JSON.parse(@output.string)).to be
+        end
+
+        it "errors for unreadable scripts" do
+          stub_unreadable_file(script)
+
+          expect { cli.execute(options) }.to raise_error(
+            Bolt::CLIError, /The script '#{script}' is unreadable/
+          )
+          expect(JSON.parse(@output.string)).to be
+        end
+
+        it "errors for scripts that aren't files" do
+          stub_directory(script)
+
+          expect { cli.execute(options) }.to raise_error(
+            Bolt::CLIError, /The script '#{script}' is not a file/
+          )
+          expect(JSON.parse(@output.string)).to be
+        end
+      end
+
+      it "runs a task given a name" do
+        task_name = 'sample::echo'
+        task_params = { 'message' => 'hi' }
+        input_method = 'both'
+
+        expect(executor)
+          .to receive(:run_task)
+          .with(
+            nodes,
+            %r{modules/sample/tasks/echo.sh$}, input_method, task_params
+          ).and_return({})
+
+        options = {
+          nodes: node_names,
+          mode: 'task',
+          action: 'run',
+          object: task_name,
+          task_options: task_params
+        }
+        cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
+        cli.execute(options)
+        expect(JSON.parse(@output.string)).to be
+      end
+
+      it "runs a plan given a name" do
+        plan_name = 'sample::single_task'
+        plan_params = { 'nodes' => nodes.join(',') }
+        input_method = 'both'
+
+        expect(executor)
+          .to receive(:run_task)
+          .with(
+            nodes,
+            %r{modules/sample/tasks/echo.sh$}, input_method, 'message' => 'hi there'
+          ).and_return({})
+
+        options = {
+          nodes: node_names,
+          mode: 'plan',
+          action: 'run',
+          object: plan_name,
+          task_options: plan_params
+        }
+        cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
+        cli.execute(options)
+        expect(@output.string).to eq("\"ExecutionResult({})\"\n")
+      end
+
+      it "errors for non-existent modules" do
+        task_name = 'dne::task1'
+        task_params = { 'message' => 'hi' }
+
+        options = {
+          nodes: node_names,
+          mode: 'task',
+          action: 'run',
+          object: task_name,
+          task_options: task_params
+        }
+        cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
         expect { cli.execute(options) }.to raise_error(
-          Bolt::CLIError, /The source file '#{source}' does not exist/
+          Bolt::CLIError, /Could not find module/
         )
         expect(JSON.parse(@output.string)).to be
       end
 
-      it "errors if the local file is unreadable" do
-        stub_unreadable_file(source)
+      it "errors for non-existent tasks" do
+        task_name = 'sample::dne'
+        task_params = { 'message' => 'hi' }
 
+        options = {
+          nodes: node_names,
+          mode: 'task',
+          action: 'run',
+          object: task_name,
+          task_options: task_params
+        }
+        cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
         expect { cli.execute(options) }.to raise_error(
-          Bolt::CLIError, /The source file '#{source}' is unreadable/
+          Bolt::CLIError,
+          /Could not find task '#{task_name}' in module 'sample'/
         )
         expect(JSON.parse(@output.string)).to be
       end
 
-      it "errors if the local file is a directory" do
-        stub_directory(source)
+      it "runs an init task given a module name" do
+        task_name = 'sample'
+        task_params = { 'message' => 'hi' }
+        input_method = 'both'
 
-        expect { cli.execute(options) }.to raise_error(
-          Bolt::CLIError, /The source file '#{source}' is not a file/
-        )
+        expect(executor)
+          .to receive(:run_task)
+          .with(
+            nodes,
+            %r{modules/sample/tasks/init.sh$}, input_method, task_params
+          ).and_return({})
+
+        options = {
+          nodes: node_names,
+          mode: 'task',
+          action: 'run',
+          object: task_name,
+          task_options: task_params
+        }
+        cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
+        cli.execute(options)
         expect(JSON.parse(@output.string)).to be
       end
+
+      it "runs a task passing input on stdin" do
+        task_name = 'sample::stdin'
+        task_params = { 'message' => 'hi' }
+        input_method = 'stdin'
+
+        expect(executor)
+          .to receive(:run_task)
+          .with(nodes,
+                %r{modules/sample/tasks/stdin.sh$}, input_method, task_params)
+          .and_return({})
+
+        options = {
+          nodes: node_names,
+          mode: 'task',
+          action: 'run',
+          object: task_name,
+          task_options: task_params
+        }
+        cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
+        cli.execute(options)
+        expect(JSON.parse(@output.string)).to be
+      end
+
+      it "runs a powershell task passing input on stdin" do
+        task_name = 'sample::winstdin'
+        task_params = { 'message' => 'hi' }
+        input_method = 'stdin'
+
+        expect(executor)
+          .to receive(:run_task)
+          .with(nodes,
+                %r{modules/sample/tasks/winstdin.ps1$}, input_method, task_params)
+          .and_return({})
+
+        options = {
+          nodes: node_names,
+          mode: 'task',
+          action: 'run',
+          object: task_name,
+          task_options: task_params
+        }
+        cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
+        cli.execute(options)
+        expect(JSON.parse(@output.string)).to be
+      end
+
+      describe "file uploading" do
+        let(:source) { '/path/to/local' }
+        let(:dest) { '/path/to/remote' }
+        let(:options) {
+          {
+            nodes: node_names,
+            mode: 'file',
+            action: 'upload',
+            object: source,
+            leftovers: [dest]
+          }
+        }
+
+        it "uploads a file via scp" do
+          stub_file(source)
+
+          expect(executor)
+            .to receive(:file_upload)
+            .with(nodes, source, dest)
+            .and_return({})
+
+          cli.execute(options)
+          expect(JSON.parse(@output.string)).to be
+        end
+
+        it "raises if the local file doesn't exist" do
+          stub_non_existent_file(source)
+
+          expect { cli.execute(options) }.to raise_error(
+            Bolt::CLIError, /The source file '#{source}' does not exist/
+          )
+          expect(JSON.parse(@output.string)).to be
+        end
+
+        it "errors if the local file is unreadable" do
+          stub_unreadable_file(source)
+
+          expect { cli.execute(options) }.to raise_error(
+            Bolt::CLIError, /The source file '#{source}' is unreadable/
+          )
+          expect(JSON.parse(@output.string)).to be
+        end
+
+        it "errors if the local file is a directory" do
+          stub_directory(source)
+
+          expect { cli.execute(options) }.to raise_error(
+            Bolt::CLIError, /The source file '#{source}' is not a file/
+          )
+          expect(JSON.parse(@output.string)).to be
+        end
+      end
+    end
+  end
+
+  describe 'configfile' do
+    let(:configdir) { File.join(__dir__, '..', 'fixtures', 'configs') }
+    let(:complete_config) do
+      { 'modulepath' => "/foo/bar#{File::PATH_SEPARATOR}/baz/qux",
+        'concurrency' => 14,
+        'format' => 'json',
+        'ssh' => {
+          "private-key" => '/bar/foo',
+          "insecure" => true
+        } }
+    end
+
+    it 'reads modulepath' do
+      with_tempfile_containing('conf', YAML.dump(complete_config)) do |conf|
+        cli = Bolt::CLI.new(%W[command run --configfile #{conf.path} --nodes foo --insecure])
+        cli.parse
+        expect(cli.config[:modulepath]).to eq(['/foo/bar', '/baz/qux'])
+      end
+    end
+
+    it 'reads concurrency' do
+      with_tempfile_containing('conf', YAML.dump(complete_config)) do |conf|
+        cli = Bolt::CLI.new(%W[command run --configfile #{conf.path} --nodes foo --insecure])
+        cli.parse
+        expect(cli.config[:concurrency]).to eq(14)
+      end
+    end
+
+    it 'reads format' do
+      with_tempfile_containing('conf', YAML.dump(complete_config)) do |conf|
+        cli = Bolt::CLI.new(%W[command run --configfile #{conf.path} --nodes foo --insecure])
+        cli.parse
+        expect(cli.config[:format]).to eq('json')
+      end
+    end
+
+    it 'reads private-key for ssh' do
+      with_tempfile_containing('conf', YAML.dump(complete_config)) do |conf|
+        cli = Bolt::CLI.new(%W[command run --configfile #{conf.path} --nodes foo --insecure])
+        cli.parse
+        expect(cli.config[:transports][:ssh][:key]).to eq('/bar/foo')
+      end
+    end
+
+    it 'reads insecure for ssh' do
+      with_tempfile_containing('conf', YAML.dump(complete_config)) do |conf|
+        cli = Bolt::CLI.new(%W[command run --configfile #{conf.path} --nodes foo --insecure])
+        cli.parse
+        expect(cli.config[:transports][:ssh][:insecure]).to eq(true)
+      end
+    end
+
+    it 'CLI flags override config' do
+      with_tempfile_containing('conf', YAML.dump(complete_config)) do |conf|
+        cli = Bolt::CLI.new(%W[command run --configfile #{conf.path} --nodes foo --concurrency 12])
+        cli.parse
+        expect(cli.config.concurrency).to eq(12)
+      end
+    end
+
+    it 'raises an error if a config file is specified and invalid' do
+      cli = Bolt::CLI.new(%W[command run --configfile #{File.join(configdir, 'invalid.yml')} --nodes foo --insecure])
+      expect {
+        cli.parse
+      }.to raise_error(Bolt::CLIError, /Could not parse/)
     end
   end
 end

--- a/spec/bolt/node_spec.rb
+++ b/spec/bolt/node_spec.rb
@@ -15,16 +15,16 @@ describe Bolt::Node do
     end
 
     it "defaults to specified user and password" do
-      config[:user] = 'somebody'
-      config[:password] = 'very secure'
+      config[:transports][:ssh][:user] = 'somebody'
+      config[:transports][:ssh][:password] = 'very secure'
       node = Bolt::Node.from_uri('ssh://localhost', config: config)
       expect(node.user).to eq('somebody')
       expect(node.password).to eq('very secure')
     end
 
     it "uri overrides specified user and password" do
-      config[:user] = 'somebody'
-      config[:password] = 'very secure'
+      config[:transports][:ssh][:user] = 'somebody'
+      config[:transports][:ssh][:password] = 'very secure'
       node = Bolt::Node.from_uri('ssh://toor:better@localhost', config: config)
       expect(node.user).to eq('toor')
       expect(node.password).to eq('better')

--- a/spec/fixtures/configs/invalid.yml
+++ b/spec/fixtures/configs/invalid.yml
@@ -1,0 +1,1 @@
+this : isn't a : yaml file is it"?

--- a/spec/integration/ssh_spec.rb
+++ b/spec/integration/ssh_spec.rb
@@ -1,0 +1,58 @@
+require 'bolt_spec/conn'
+require 'bolt_spec/files'
+require 'bolt_spec/integration'
+require 'bolt/cli'
+
+describe "when runnning over the ssh transport", ssh: true do
+  include BoltSpec::Conn
+  include BoltSpec::Files
+  include BoltSpec::Integration
+
+  let(:whoami) { "whoami" }
+  let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
+  let(:stdin_task) { "sample::stdin" }
+  let(:uri) { conn_uri('ssh') }
+  let(:password) { conn_info('ssh')[:password] }
+
+  context 'when using CLI options' do
+    let(:config_flags) { %W[--nodes #{uri} --insecure --format json --modulepath #{modulepath} --password #{password}] }
+
+    it 'runs a command' do
+      result = run_one_node(%W[command run #{whoami}] + config_flags)
+      expect(result['stdout'].strip).to eq(
+        conn_info('ssh')[:user]
+      )
+    end
+
+    it 'runs a task' do
+      result = run_one_node(%W[task run #{stdin_task} message=somemessage] + config_flags)
+      expect(result['message'].strip).to eq("somemessage")
+    end
+  end
+
+  context 'when using a configfile' do
+    let(:config) do
+      { 'format' => 'json',
+        'modulepath' => modulepath,
+        'ssh' => {
+          'insecure' => true
+        } }
+    end
+
+    let(:config_flags) { %W[--nodes #{uri} --password #{password}] }
+
+    it 'runs a command' do
+      with_tempfile_containing('conf', YAML.dump(config)) do |conf|
+        result = run_one_node(%W[command run #{whoami} --configfile #{conf.path}] + config_flags)
+        expect(result['stdout'].strip).to eq(conn_info('ssh')[:user])
+      end
+    end
+
+    it 'runs a task' do
+      with_tempfile_containing('conf', YAML.dump(config)) do |conf|
+        result = run_one_node(%W[task run #{stdin_task} message=somemessage --configfile #{conf.path}] + config_flags)
+        expect(result['message'].strip).to eq("somemessage")
+      end
+    end
+  end
+end

--- a/spec/integration/winrm_spec.rb
+++ b/spec/integration/winrm_spec.rb
@@ -1,0 +1,50 @@
+require 'bolt_spec/conn'
+require 'bolt_spec/files'
+require 'bolt_spec/integration'
+require 'bolt/cli'
+
+describe "when runnning over the winrm transport", winrm: true do
+  include BoltSpec::Conn
+  include BoltSpec::Files
+  include BoltSpec::Integration
+
+  let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
+  let(:whoami) { "echo $env:UserName" }
+  let(:stdin_task) { "sample::winstdin" }
+  let(:uri) { conn_uri('winrm') }
+  let(:password) { conn_info('winrm')[:password] }
+  let(:user) { conn_info('winrm')[:user] }
+
+  context 'when using CLI options' do
+    let(:config_flags) { %W[--nodes #{uri} --insecure --format json --modulepath #{modulepath} --password #{password}] }
+
+    it 'runs a command' do
+      result = run_one_node(%W[command run #{whoami}] + config_flags)
+      expect(result['stdout'].strip).to eq(user)
+    end
+
+    it 'runs a task' do
+      result = run_one_node(%W[task run #{stdin_task} message=somemessage] + config_flags)
+      expect(result['_output'].strip).to match(/STDIN: {"messa/)
+    end
+  end
+
+  context 'when using a configfile' do
+    let(:config) { { 'format' => 'json', 'modulepath' => modulepath } }
+    let(:config_flags) { %W[--nodes #{uri} --password #{password}] }
+
+    it 'runs a command' do
+      with_tempfile_containing('conf', YAML.dump(config)) do |conf|
+        result = run_one_node(%W[command run #{whoami} --configfile #{conf.path}] + config_flags)
+        expect(result['stdout'].strip).to eq(user)
+      end
+    end
+
+    it 'runs a task' do
+      with_tempfile_containing('conf', YAML.dump(config)) do |conf|
+        result = run_one_node(%W[task run #{stdin_task} message=somemessage --configfile #{conf.path}] + config_flags)
+        expect(result['_output'].strip).to match(/STDIN: {"messa/)
+      end
+    end
+  end
+end

--- a/spec/lib/bolt_spec/conn.rb
+++ b/spec/lib/bolt_spec/conn.rb
@@ -1,0 +1,28 @@
+module BoltSpec
+  module Conn
+    def conn_info(transport)
+      tu = transport.upcase
+      default_port = case transport
+                     when 'ssh'
+                       2224
+                     when 'winrm'
+                       55985
+                     end
+
+      {
+        protocol: transport,
+        host: ENV["BOLT_#{tu}_HOST"] || "localhost",
+        user: ENV["BOLT_#{tu}_USER"] || "vagrant",
+        password: ENV["BOLT_#{tu}_PASSWORD"] || "vagrant",
+        port: ENV["BOLT_#{tu}_PORT"] || default_port,
+        key: ENV["BOLT_#{tu}_KEY"] || Dir[".vagrant/**/private_key"]
+      }
+    end
+
+    def conn_uri(transport, include_password = false)
+      conn = conn_info(transport)
+      passwd = include_password ? ":#{conn[:password]}" : ''
+      "#{conn[:protocol]}://#{conn[:user]}#{passwd}@#{conn[:host]}:#{conn[:port]}"
+    end
+  end
+end

--- a/spec/lib/bolt_spec/integration.rb
+++ b/spec/lib/bolt_spec/integration.rb
@@ -1,0 +1,33 @@
+module BoltSpec
+  module Integration
+    def run_cli(arguments)
+      cli = Bolt::CLI.new(arguments)
+
+      # prevent tests from reading users config
+      allow(cli.config).to receive(:default_path).and_return(File.join('.', 'path', 'does not exist'))
+      output =  StringIO.new
+      outputter = Bolt::Outputter::JSON.new(output)
+      allow(cli).to receive(:outputter).and_return(outputter)
+
+      opts = cli.parse
+      cli.execute(opts)
+      output.string
+    end
+
+    def run_one_node(arguments)
+      output = run_cli(arguments)
+
+      begin
+        result = JSON.parse(output)
+      rescue JSON::ParserError
+        expect(output.string).to eq("Output should be JSON")
+      end
+
+      if result['_error'] ||
+         (result['items'] && result['items'][0] && result['items'][0]['status'] != 'success')
+        expect(result).to eq("Should have succeed on node" => true)
+      end
+      result['items'][0]['result']
+    end
+  end
+end


### PR DESCRIPTION
This commit adds the ability to load config options from a file. This
required a small refactor to seperate config-like options from
command-options. Config like options are all flags and are passed around
with config but may not be read from the config file. The Command
options are those that are not prefaced with flags and are only exposed
to the execute function of the CLI not passed around with the config.

There is a further distinction between global config options and those
that are transport specific. Transport specific options are specified
for each transport in the config file but only map to a single flag for
all transports as command line flags. Most of these flags only work with
the ssh transport now.