### PR TITLE
(maint) Fix reference to undefined variable

### DIFF
--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -75,7 +75,7 @@ module Bolt
     end
 
     def run_script(script, arguments)
-      @logger.info { "Running script: #{command}" }
+      @logger.info { "Running script: #{script}" }
       _run_script(script, arguments)
     end
 


### PR DESCRIPTION
This was copy-pasted from the `run_command` function and resulted in script invocations failing in verbose or debug mode.