### PR TITLE
(maint) Properly require addressable

### DIFF
--- a/lib/bolt/node_uri.rb
+++ b/lib/bolt/node_uri.rb
@@ -1,4 +1,4 @@
-require 'addressable'
+require 'addressable/uri'
 
 module Bolt
   class NodeURI


### PR DESCRIPTION
Previously, we were requiring 'addressable', which is a helper available
in addressable 2.4.0 that will require both 'addressable/uri' and
'addressable/tempalte'. Because we don't have a dependency on
addressable >= 2.4.0, it's possible that the require will fail for some
users.

The fixes for this are either to change the dependency on addressable or
require 'addressable/uri'. The recommended way to use the library is to
require only 'addressable/uri' if 'addressable/template' isn't needed,
which is our use case. Therefore, we keep our previous addressable
dependency and update the require.

Fixes #178.