### PR TITLE
(maint) Add empty .fixtures.yml for PSH 2.6.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,1 @@
+fixtures:

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "win32-service", "= 0.8.8"
 
   # there is a bug in puppetlabs_spec_helper for modules without fixtures
-  spec.add_development_dependency "puppetlabs_spec_helper", "2.5.1"
+  spec.add_development_dependency "puppetlabs_spec_helper", "~> 2.6"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
 - puppetlabs_spec_helper 2.6.0 release introduced a new bug that
 requires that a .fixtures.yml exists with a fixtures: section in
 it. There are 3 options to address this:

 * Land a fix in PSH and wait for a new gem release
 * Pin to 2.5.1 of PSH (done already in #186)
 * Add a dummy .fixtures.yml to make the PSH problem disappear

 There is a fix up for PSH, but it may be some time before a new gem
 is released, so an empty .fixtures.yml can be used in the interim.