### PR TITLE
(BOLT-165) Format ExecutionResult returned from a plan

### DIFF
--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -78,7 +78,17 @@ module Bolt
       end
 
       def print_plan(result)
-        @stream.puts result
+        # If a hash or array, pretty-print as JSON
+        if result.is_a?(Hash) || result.is_a?(Array)
+          if result.empty?
+            # Avoids extra lines for an empty result
+            @stream.puts(result.to_json)
+          else
+            @stream.puts(::JSON.pretty_generate(result))
+          end
+        else
+          @stream.puts result.to_s
+        end
       end
 
       def fatal_error(e); end

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -44,6 +44,7 @@ module Bolt
       end
 
       def print_plan(result)
+        # Ruby JSON patches most objects to have a to_json method.
         @stream.puts result.to_json
       end
 

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -51,6 +51,39 @@ describe "Bolt::Outputter::Human" do
     expect(lines).to match(/^    "key": "val"$/)
   end
 
+  it "prints empty results from a plan" do
+    outputter.print_plan([])
+    expect(output.string).to eq("[]\n")
+  end
+
+  it "formats unwrapped ExecutionResult from a plan" do
+    result = [
+      { 'node' => 'node1', 'status' => 'finished', 'result' => { '_output' => 'yes' } },
+      { 'node' => 'node2', 'status' => 'failed', 'result' =>
+        { '_error' => { 'message' => 'The command failed with exit code 2',
+                        'kind' => 'puppetlabs.tasks/command-error',
+                        'issue_code' => 'COMMAND_ERROR',
+                        'partial_result' => { 'stdout' => 'no', 'stderr' => '', 'exit_code' => 2 },
+                        'details' => { 'exit_code' => 2 } } } }
+    ]
+    outputter.print_plan(result)
+
+    result_hash = JSON.parse(output.string)
+    expect(result_hash).to eq(result)
+  end
+
+  it "formats hash results from a plan" do
+    result = { 'some' => 'data' }
+    outputter.print_plan(result)
+    expect(JSON.parse(output.string)).to eq(result)
+  end
+
+  it "prints simple output from a plan" do
+    result = "some data"
+    outputter.print_plan(result)
+    expect(output.string.strip).to eq(result)
+  end
+
   it "handles fatal errors" do
     outputter.fatal_error(Bolt::CLIError.new("oops"))
     expect(output.string).to eq('')

--- a/spec/bolt/outputter/json_spec.rb
+++ b/spec/bolt/outputter/json_spec.rb
@@ -33,6 +33,28 @@ describe "Bolt::Outputter::JSON" do
     expect(parsed['items'][1]['status']).to eq('failure')
   end
 
+  it "formats ExecutionResult from a plan" do
+    result = [
+      { 'node' => 'node1', 'status' => 'finished', 'result' => { '_output' => 'yes' } },
+      { 'node' => 'node2', 'status' => 'failed', 'result' =>
+        { '_error' => { 'message' => 'The command failed with exit code 2',
+                        'kind' => 'puppetlabs.tasks/command-error',
+                        'issue_code' => 'COMMAND_ERROR',
+                        'partial_result' => { 'stdout' => 'no', 'stderr' => '', 'exit_code' => 2 },
+                        'details' => { 'exit_code' => 2 } } } }
+    ]
+    outputter.print_plan(result)
+
+    result_hash = JSON.parse(output.string)
+    expect(result_hash).to eq(result)
+  end
+
+  it "prints non-ExecutionResult from a plan" do
+    result = "some data"
+    outputter.print_plan(result)
+    expect(output.string.strip).to eq('"' + result + '"')
+  end
+
   it "handles fatal errors" do
     outputter.print_head
     outputter.print_result(Bolt::Node.from_uri('node1', config: config),


### PR DESCRIPTION
Apply special formatting when an ExecutionResult is the final output from running a plan.

Example output would be something like
```
[
  {
    "node": "node1",
    "status": "finished",
    "result": {
      "_output": "foo\n"
    }
  },
  {
    "node": "node2",
    "status": "failed",
    "result": {
      "_error": "bar\n"
    }
  }
]
```