### PR TITLE
(maint) Remove PSH 2.5.1 pin

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "win32-service", "= 0.8.8"
 
   # there is a bug in puppetlabs_spec_helper for modules without fixtures
-  spec.add_development_dependency "puppetlabs_spec_helper", "2.5.1"
+  spec.add_development_dependency "puppetlabs_spec_helper", "~> 2.6"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
 - puppetlabs_spec_helper 2.6.0 release introduced a new bug that
 requires that a .fixtures.yml exists with a fixtures: section in
 it. A temporary pin to 2.5.1 was made until the issue could be
 fixed, which it has now with a 2.6.1 gem release