### PR TITLE
(BOLT-262) Report skipped nodes as such

### DIFF
--- a/lib/bolt/node/orch.rb
+++ b/lib/bolt/node/orch.rb
@@ -58,6 +58,18 @@ module Bolt
 
       if state == 'finished'
         exit_code = 0
+      elsif state == 'skipped'
+        return Bolt::TaskResult.new(
+          JSON.dump(
+            '_error' => {
+              'kind' => 'puppetlabs.tasks/skipped-node',
+              'msg' => "Node #{@host} was skipped",
+              'details' => {}
+            }
+          ),
+          nil,
+          nil
+        )
       else
         # Try to extract the exit_code from _error
         begin

--- a/spec/bolt/node/orch_spec.rb
+++ b/spec/bolt/node/orch_spec.rb
@@ -85,6 +85,22 @@ describe Bolt::Orch, orchestrator: true do
       expect(orch._run_task(taskpath, 'stdin', params)).to be_success
     end
 
+    context "when the task target node was skipped" do
+      let(:result_state) { 'skipped' }
+
+      it 'returns a failure' do
+        expect(orch._run_task(taskpath, 'stdin', params)).not_to be_success
+      end
+
+      it 'includes an appropriate error in the returned result' do
+        expect(orch._run_task(taskpath, 'stdin', params).error).to eq(
+          'kind' => 'puppetlabs.tasks/skipped-node',
+          'msg' => "Node #{hostname} was skipped",
+          'details' => {}
+        )
+      end
+    end
+
     context "when the task failed" do
       let(:result_state) { 'failed' }
 

--- a/spec/bolt/node/orch_spec.rb
+++ b/spec/bolt/node/orch_spec.rb
@@ -9,33 +9,22 @@ describe Bolt::Orch, orchestrator: true do
   include BoltSpec::Files
 
   let(:hostname) { "localhost" }
-  let(:user) { "nil" }
-  let(:password) { "nil" }
-  let(:port) { nil }
-  let(:orch) { Bolt::Orch.new(@hostname) }
+  let(:orch) { Bolt::Orch.new(hostname) }
 
-  let(:task) { @task = "foo" }
+  let(:task) { "foo" }
+  let(:task_environment) { 'production' }
+  let(:taskpath) { "foo/tasks/init" }
   let(:params) { { param: 'val' } }
-  let(:scope) { { nodes: [@hostname] } }
+  let(:scope) { { nodes: [hostname] } }
+
   let(:result_state) { 'finished' }
   let(:result) { { '_output' => 'ok' } }
-  let(:base_path) do
-    File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..'))
-  end
 
-  before(:each) do
-    @task = "foo"
-    @taskpath = "foo/tasks/init"
-    @task_environment = 'production'
-    @params =  { param: 'val' }
-    @scope = { nodes: [@hostname] }
-    @result_state = 'finished'
-    @result = { '_output' => 'ok' }
-  end
+  let(:base_path) { File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..')) }
 
   def mock_client
-    body = { task: @task, environment: @task_environment, params: @params, scope: @scope }
-    results = [{ 'state' => @result_state, 'result' => @result }]
+    body = { task: task, environment: task_environment, params: params, scope: scope }
+    results = [{ 'state' => result_state, 'result' => result }]
 
     orch_client = instance_double("OrchestratorClient")
     orch.instance_variable_set(:@client, orch_client)
@@ -45,45 +34,22 @@ describe Bolt::Orch, orchestrator: true do
 
   def bolt_task_client
     bolt_task = File.expand_path(File.join(base_path, 'tasks', 'init.rb'))
-    body = { task: 'bolt', environment: @task_environment, params: @params, scope: @scope }
+    body = { task: 'bolt', environment: task_environment, params: params, scope: scope }
 
     orch_client = instance_double("OrchestratorClient")
     orch.instance_variable_set(:@client, orch_client)
     allow(orch_client).to(receive(:run_task).with(body) do
       Open3.popen3("ruby #{bolt_task};") do |stdin, stdout, stderr, wt|
-        stdin.write(@params.to_json)
+        stdin.write(params.to_json)
         stdin.close
         output = stdout.read
         err = stderr.read
         exit_code = wt.value.exitstatus
         expect(err).to be_empty
         expect(exit_code).to eq(0)
-        result = JSON.parse(output)
-        [{ 'state' => 'finished', 'result' => result }]
+        [{ 'state' => 'finished', 'result' => JSON.parse(output) }]
       end
     end)
-  end
-
-  def set_exec_params(command, options = {})
-    @params = { action: 'command', command: command, options: options }
-  end
-
-  def set_upload_params(source, destination)
-    content = File.open(source, &:read)
-    content = Base64.encode64(content)
-    mode = File.stat(source).mode
-    @params = {
-      action: 'upload',
-      path: destination,
-      content: content,
-      mode: mode
-    }
-  end
-
-  def set_script_params(path, arguments)
-    content = File.open(path, &:read)
-    content = Base64.encode64(content)
-    @params = { action: 'script', content: content, arguments: arguments }
   end
 
   describe :task_name_from_path do
@@ -106,153 +72,174 @@ describe Bolt::Orch, orchestrator: true do
   end
 
   describe :_run_task do
-    it "executes a task on a host" do
+    before(:each) do
       mock_client
-      expect(orch._run_task(@taskpath, 'stdin', @params).to_result)
-        .to eq(@result)
+    end
+
+    it "executes a task on a host" do
+      expect(orch._run_task(taskpath, 'stdin', params).to_result)
+        .to eq(result)
     end
 
     it "returns a success" do
-      mock_client
-      expect(orch._run_task(@taskpath, 'stdin', @params)).to be_success
+      expect(orch._run_task(taskpath, 'stdin', params)).to be_success
     end
 
-    context "the task failed" do
-      before(:each) { @result_state = 'failed' }
+    context "when the task failed" do
+      let(:result_state) { 'failed' }
 
-      it "returns a failure for failed" do
-        mock_client
-        expect(orch._run_task(@taskpath, 'stdin', @params)).not_to be_success
+      it "returns a failure" do
+        expect(orch._run_task(taskpath, 'stdin', params)).not_to be_success
       end
 
-      it "does not report success when there is an error and no exitcode" do
-        mock_client
-        expect(orch._run_task(@taskpath, 'stdin', @params)).not_to be_success
+      context "when there is an error and no exitcode" do
+        it "does not report success" do
+          expect(orch._run_task(taskpath, 'stdin', params)).not_to be_success
+        end
       end
 
-      it "does not report success when there is an exit_code" do
-        @result = { '_error' => { 'details' => { 'exit_code' => '3' } } }
-        mock_client
-        expect(orch._run_task(@taskpath, 'stdin', params)).not_to be_success
+      context "when there is an exit_code" do
+        let(:result) { { '_error' => { 'details' => { 'exit_code' => '3' } } } }
+
+        it "does not report success" do
+          expect(orch._run_task(taskpath, 'stdin', params)).not_to be_success
+        end
       end
     end
   end
 
   describe :_run_command do
+    let(:options) { {} }
+    let(:params) {
+      {
+        action: 'command',
+        command: command,
+        options: options
+      }
+    }
+
+    before(:each) do
+      bolt_task_client
+    end
+
     context 'when it succeeds' do
-      before(:each) do
-        @command = 'echo hi!; echo bye >&2'
-        set_exec_params(@command)
-        bolt_task_client
+      let(:command) { 'echo hi!; echo bye >&2' }
+
+      it 'returns a success' do
+        expect(orch._run_command(command)).to be_success
       end
 
-      it 'it returns the output' do
-        expect(orch._run_command(@command).stdout).to eq("hi!\n")
-      end
-
-      it 'it is a success' do
-        expect(orch._run_command(@command)).to be_success
+      it 'captures stdout' do
+        expect(orch._run_command(command).stdout).to eq("hi!\n")
       end
 
       it 'captures stderr' do
-        result = orch._run_command(@command)
-        expect(result.stderr).to eq("bye\n")
+        expect(orch._run_command(command).stderr).to eq("bye\n")
       end
     end
 
     context 'when it fails' do
-      before(:each) do
-        @command = 'echo hi!; echo bye >&2; exit 23'
-        set_exec_params(@command)
-        bolt_task_client
-      end
-      it 'is a failure' do
-        expect(orch._run_command(@command)).not_to be_success
+      let(:command) { 'echo hi!; echo bye >&2; exit 23' }
+
+      it 'returns a failure' do
+        expect(orch._run_command(command)).not_to be_success
       end
 
-      it 'captures the exit_code' do
-        expect(orch._run_command(@command).exit_code).to eq(23)
+      it 'captures exit_code' do
+        expect(orch._run_command(command).exit_code).to eq(23)
       end
 
       it 'captures stdout' do
-        result = orch._run_command(@command)
-        expect(result.stdout).to eq("hi!\n")
+        expect(orch._run_command(command).stdout).to eq("hi!\n")
       end
 
       it 'captures stderr' do
-        result = orch._run_command(@command)
-        expect(result.stderr).to eq("bye\n")
+        expect(orch._run_command(command).stderr).to eq("bye\n")
       end
     end
   end
 
   describe :_upload do
-    it 'should write the file' do
+    let(:source_path) { File.join(base_path, 'spec', 'fixtures', 'scripts', 'success.sh') }
+    let(:dest_path) { 'success.sh' } # to be prepended with a temp dir in the 'around(:each)' block
+    let(:params) {
+      content = Base64.encode64(File.read(source_path))
+      mode = File.stat(source_path).mode
+
+      {
+        action: 'upload',
+        path: dest_path,
+        content: content,
+        mode: mode
+      }
+    }
+
+    around(:each) do |example|
       Dir.mktmpdir(nil, '/tmp') do |dir|
-        source_path = File.join(base_path, 'spec', 'fixtures',
-                                'scripts', 'success.sh')
-        dest_path = File.join(dir, "success.sh")
+        dest_path.replace(File.join(dir, dest_path)) # prepend the temp dir to the dest_path
 
-        set_upload_params(source_path, dest_path)
-        bolt_task_client
-        result = orch._upload(source_path, dest_path)
-
-        expect(result).to be_success
-
-        source_mode = File.stat(source_path).mode
-        dest_mode = File.stat(dest_path).mode
-        expect(dest_mode).to eq(source_mode)
-
-        source_content = File.open(source_path, &:read)
-        dest_content = File.open(dest_path, &:read)
-        expect(dest_content).to eq(source_content)
+        example.run
       end
+    end
+
+    before(:each) do
+      bolt_task_client
+    end
+
+    it 'should write the file' do
+      expect(orch._upload(source_path, dest_path)).to be_success
+
+      source_mode = File.stat(source_path).mode
+      dest_mode = File.stat(dest_path).mode
+      expect(dest_mode).to eq(source_mode)
+
+      source_content = File.read(source_path)
+      dest_content = File.read(dest_path)
+      expect(dest_content).to eq(source_content)
     end
   end
 
   describe :_run_script do
     let(:args) { ['with spaces', 'nospaces', 'echo $HOME; cat /etc/passwd'] }
+    let(:params) {
+      content = Base64.encode64(File.read(script_path))
 
-    context "the script succeeds" do
-      let(:script_path) do
-        File.join(base_path, 'spec', 'fixtures', 'scripts', 'success.sh')
-      end
+      {
+        action: 'script',
+        content: content,
+        arguments: args
+      }
+    }
 
-      before(:each) do
-        set_script_params(script_path, args)
-        bolt_task_client
-      end
+    before(:each) do
+      bolt_task_client
+    end
 
-      it 'is a success' do
+    context "when the script succeeds" do
+      let(:script_path) { File.join(base_path, 'spec', 'fixtures', 'scripts', 'success.sh') }
+
+      it 'returns a success' do
         expect(orch._run_script(script_path, args)).to be_success
       end
 
       it 'captures stdout' do
         expect(
           orch._run_script(script_path, args).stdout
-        ).to eq(<<OUT)
+        ).to eq(<<-OUT)
 arg: with spaces
 arg: nospaces
 arg: echo $HOME; cat /etc/passwd
 standard out
-OUT
+        OUT
       end
 
       it 'captures stderr' do
-        result = orch._run_script(script_path, args)
-        expect(result.stderr).to eq("standard error\n")
+        expect(orch._run_script(script_path, args).stderr).to eq("standard error\n")
       end
     end
 
     context "when the script fails" do
-      let(:script_path) do
-        File.join(base_path, 'spec', 'fixtures', 'scripts', 'failure.sh')
-      end
-
-      before(:each) do
-        set_script_params(script_path, args)
-        bolt_task_client
-      end
+      let(:script_path) { File.join(base_path, 'spec', 'fixtures', 'scripts', 'failure.sh') }
 
       it 'returns a failure' do
         expect(orch._run_script(script_path, args)).not_to be_success
@@ -263,13 +250,11 @@ OUT
       end
 
       it 'captures stdout' do
-        result = orch._run_script(script_path, args)
-        expect(result.stdout).to eq("standard out\n")
+        expect(orch._run_script(script_path, args).stdout).to eq("standard out\n")
       end
 
       it 'captures stderr' do
-        result = orch._run_script(script_path, args)
-        expect(result.stderr).to eq("standard error\n")
+        expect(orch._run_script(script_path, args).stderr).to eq("standard error\n")
       end
     end
   end


### PR DESCRIPTION
Make sure the error reported when a task target node is skipped indicates the fact.