### PR TITLE
(BOLT-267) Add ExecutionResult and Target data types to Bolt

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -401,6 +401,10 @@ HELP
                              end
       end
 
+      # ExecutionResult loaded here so that it can get puppet features if
+      # puppet is present
+      require 'bolt/execution_result'
+
       if options[:action] == 'show'
         if options[:mode] == 'task'
           if options[:object]
@@ -574,10 +578,9 @@ HELP
 
     # Expects to be called with a configured Puppet compiler or error.instance? will fail
     def unwrap_execution_result(result)
-      if result.instance_of? Puppet::Pops::Types::ExecutionResult
-        error = Puppet::Pops::Types::TypeFactory.error
+      if result.instance_of? Bolt::ExecutionResult
         result.iterator.map do |node, output|
-          if error.instance?(output)
+          if output.is_a?(Puppet::DataTypes::Error)
             # Get the original error hash used to initialize the Error type object.
             { node: node, status: 'failed', result: { '_error' => output._pcore_init_hash } }
           else

--- a/lib/bolt/execution_result.rb
+++ b/lib/bolt/execution_result.rb
@@ -1,0 +1,109 @@
+module Bolt
+class ExecutionResult
+
+  if Object.const_defined?(:Puppet) && Puppet.const_defined?(:Pops)
+    include Puppet::Pops::Types::Iterable
+    include Puppet::Pops::Types::IteratorProducer
+
+    def iterator
+      tc = Puppet::Pops::Types::TypeFactory
+      Puppet::Pops::Types::Iterable.on(
+        @result_hash,
+        tc.tuple([tc.string, tc.data], Puppet::Pops::Types::PHashType::KEY_PAIR_TUPLE_SIZE))
+    end
+
+    def to_s
+      Puppet::Pops::Types::StringConverter.singleton.convert(self)
+    end
+  else
+    def iterator
+      @result_hash.each
+    end
+  end
+
+  # Creates a pure Data hash from a result hash returned from the Bolt::Executor
+  # @return [Hash{String => Data}] The data hash
+  def self.from_bolt(result_hash)
+    data_result = {}
+    result_hash.each_pair { |k, v| data_result[k.uri] = v.to_h }
+    self.new(data_result)
+  end
+
+  attr_reader :result_hash
+
+  def initialize(result_hash, final=false)
+    result_hash = convert_errors(result_hash) unless final
+    @result_hash = result_hash
+  end
+
+  def count
+    @result_hash.size
+  end
+
+  def empty
+    @result_hash.empty?
+  end
+  alias_method :empty?, :empty
+
+  def error_nodes
+    result = {}
+    @result_hash.each_pair { |k, v| result[k] = v if v.is_a?(Error) }
+    self.class.new(result, true)
+  end
+
+  def names
+    @result_hash.keys
+  end
+
+  def ok
+    !@result_hash.values.any? { |v| v.is_a?(Error) }
+  end
+  alias_method :ok?, :ok
+
+  def ok_nodes
+    result = {}
+    @result_hash.each_pair { |k, v| result[k] = v unless v.is_a?(Error) }
+    self.class.new(result, true)
+  end
+
+  def [](node_uri)
+    @result_hash[node_uri]
+  end
+
+  def value(node_uri)
+    self[node_uri]
+  end
+
+  def values
+    @result_hash.values
+  end
+
+  def _pcore_init_hash
+    @result_hash
+  end
+
+  def eql?(o)
+    self.class == o.class && self.result_hash == o.result_hash
+  end
+
+  def ==(o)
+    eql?(o)
+  end
+
+  private
+
+  def convert_errors(result_hash)
+    converted = {}
+    result_hash.each_pair { |k, v| converted[k] = convert_error(v) }
+    converted
+  end
+
+  def convert_error(value_or_error)
+    error = value_or_error['error']
+    value = value_or_error['value']
+    error.nil? ? value : Puppet::DataTypes::Error.new(error['msg'], error['kind'], error['issue_code'], value, error['details'])
+  end
+
+  EMPTY_RESULT = new({})
+end
+end

--- a/lib/bolt/execution_result.rb
+++ b/lib/bolt/execution_result.rb
@@ -1,109 +1,109 @@
 module Bolt
-class ExecutionResult
+  class ExecutionResult
+    if Object.const_defined?(:Puppet) && Puppet.const_defined?(:Pops)
+      include Puppet::Pops::Types::Iterable
+      include Puppet::Pops::Types::IteratorProducer
 
-  if Object.const_defined?(:Puppet) && Puppet.const_defined?(:Pops)
-    include Puppet::Pops::Types::Iterable
-    include Puppet::Pops::Types::IteratorProducer
+      def iterator
+        tc = Puppet::Pops::Types::TypeFactory
+        Puppet::Pops::Types::Iterable.on(
+          @result_hash,
+          tc.tuple([tc.string, tc.data], Puppet::Pops::Types::PHashType::KEY_PAIR_TUPLE_SIZE)
+        )
+      end
 
-    def iterator
-      tc = Puppet::Pops::Types::TypeFactory
-      Puppet::Pops::Types::Iterable.on(
-        @result_hash,
-        tc.tuple([tc.string, tc.data], Puppet::Pops::Types::PHashType::KEY_PAIR_TUPLE_SIZE))
+      def to_s
+        Puppet::Pops::Types::StringConverter.singleton.convert(self)
+      end
+    else
+      def iterator
+        @result_hash.each
+      end
     end
 
-    def to_s
-      Puppet::Pops::Types::StringConverter.singleton.convert(self)
+    # Creates a pure Data hash from a result hash returned from the Bolt::Executor
+    # @return [Hash{String => Data}] The data hash
+    def self.from_bolt(result_hash)
+      data_result = {}
+      result_hash.each_pair { |k, v| data_result[k.uri] = v.to_h }
+      new(data_result)
     end
-  else
-    def iterator
-      @result_hash.each
+
+    attr_reader :result_hash
+
+    def initialize(result_hash, final = false)
+      result_hash = convert_errors(result_hash) unless final
+      @result_hash = result_hash
     end
+
+    def count
+      @result_hash.size
+    end
+
+    def empty
+      @result_hash.empty?
+    end
+    alias empty? empty
+
+    def error_nodes
+      result = {}
+      @result_hash.each_pair { |k, v| result[k] = v if v.is_a?(Error) }
+      self.class.new(result, true)
+    end
+
+    def names
+      @result_hash.keys
+    end
+
+    def ok
+      @result_hash.values.none? { |v| v.is_a?(Error) }
+    end
+    alias ok? ok
+
+    def ok_nodes
+      result = {}
+      @result_hash.each_pair { |k, v| result[k] = v unless v.is_a?(Error) }
+      self.class.new(result, true)
+    end
+
+    def [](node_uri)
+      @result_hash[node_uri]
+    end
+
+    def value(node_uri)
+      self[node_uri]
+    end
+
+    def values
+      @result_hash.values
+    end
+
+    def _pcore_init_hash
+      @result_hash
+    end
+
+    def eql?(other)
+      self.class == other.class && @result_hash == other.result_hash
+    end
+
+    def ==(other)
+      eql?(other)
+    end
+
+    private
+
+    def convert_errors(result_hash)
+      converted = {}
+      result_hash.each_pair { |k, v| converted[k] = convert_error(v) }
+      converted
+    end
+
+    def convert_error(value_or_error)
+      e = value_or_error['error']
+      v = value_or_error['value']
+      e.nil? ? v : Puppet::DataTypes::Error.new(e['msg'], e['kind'], e['issue_code'], v, e['details'])
+    end
+
+    EMPTY_RESULT = new({})
   end
-
-  # Creates a pure Data hash from a result hash returned from the Bolt::Executor
-  # @return [Hash{String => Data}] The data hash
-  def self.from_bolt(result_hash)
-    data_result = {}
-    result_hash.each_pair { |k, v| data_result[k.uri] = v.to_h }
-    self.new(data_result)
-  end
-
-  attr_reader :result_hash
-
-  def initialize(result_hash, final=false)
-    result_hash = convert_errors(result_hash) unless final
-    @result_hash = result_hash
-  end
-
-  def count
-    @result_hash.size
-  end
-
-  def empty
-    @result_hash.empty?
-  end
-  alias_method :empty?, :empty
-
-  def error_nodes
-    result = {}
-    @result_hash.each_pair { |k, v| result[k] = v if v.is_a?(Error) }
-    self.class.new(result, true)
-  end
-
-  def names
-    @result_hash.keys
-  end
-
-  def ok
-    !@result_hash.values.any? { |v| v.is_a?(Error) }
-  end
-  alias_method :ok?, :ok
-
-  def ok_nodes
-    result = {}
-    @result_hash.each_pair { |k, v| result[k] = v unless v.is_a?(Error) }
-    self.class.new(result, true)
-  end
-
-  def [](node_uri)
-    @result_hash[node_uri]
-  end
-
-  def value(node_uri)
-    self[node_uri]
-  end
-
-  def values
-    @result_hash.values
-  end
-
-  def _pcore_init_hash
-    @result_hash
-  end
-
-  def eql?(o)
-    self.class == o.class && self.result_hash == o.result_hash
-  end
-
-  def ==(o)
-    eql?(o)
-  end
-
-  private
-
-  def convert_errors(result_hash)
-    converted = {}
-    result_hash.each_pair { |k, v| converted[k] = convert_error(v) }
-    converted
-  end
-
-  def convert_error(value_or_error)
-    error = value_or_error['error']
-    value = value_or_error['value']
-    error.nil? ? value : Puppet::DataTypes::Error.new(error['msg'], error['kind'], error['issue_code'], value, error['details'])
-  end
-
-  EMPTY_RESULT = new({})
-end
 end

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -3,6 +3,7 @@ require 'bolt/node_uri'
 require 'bolt/formatter'
 require 'bolt/result'
 require 'bolt/config'
+require 'bolt/target'
 
 module Bolt
   class Node

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -1,0 +1,33 @@
+module Bolt
+class Target
+  attr_reader :host, :options
+
+  def self.from_asserted_hash(hash)
+    new(hash['host'], hash['options'])
+  end
+
+  def initialize(host, options = {})
+    @host = host
+    @options = options
+  end
+
+  def eql?(o)
+    self.class.equal?(o.class) && @host == o.host && @options == o.options
+  end
+  alias == eql?
+
+  def hash
+    @host.hash ^ @options.hash
+  end
+
+  def to_s
+    # Use Puppet::Pops::Types::StringConverter if it is available
+    if Object.const_defined?(:Puppet) && Puppet.const_defined?(:Pops)
+      Puppet::Pops::Types::StringConverter.singleton.convert(self)
+    else
+      "Target('#{@host}', #{@options})"
+    end
+  end
+end
+end
+

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -1,33 +1,32 @@
 module Bolt
-class Target
-  attr_reader :host, :options
+  class Target
+    attr_reader :host, :options
 
-  def self.from_asserted_hash(hash)
-    new(hash['host'], hash['options'])
-  end
+    def self.from_asserted_hash(hash)
+      new(hash['host'], hash['options'])
+    end
 
-  def initialize(host, options = {})
-    @host = host
-    @options = options
-  end
+    def initialize(host, options = {})
+      @host = host
+      @options = options
+    end
 
-  def eql?(o)
-    self.class.equal?(o.class) && @host == o.host && @options == o.options
-  end
-  alias == eql?
+    def eql?(other)
+      self.class.equal?(other.class) && @host == other.host && @options == other.options
+    end
+    alias == eql?
 
-  def hash
-    @host.hash ^ @options.hash
-  end
+    def hash
+      @host.hash ^ @options.hash
+    end
 
-  def to_s
-    # Use Puppet::Pops::Types::StringConverter if it is available
-    if Object.const_defined?(:Puppet) && Puppet.const_defined?(:Pops)
-      Puppet::Pops::Types::StringConverter.singleton.convert(self)
-    else
-      "Target('#{@host}', #{@options})"
+    def to_s
+      # Use Puppet::Pops::Types::StringConverter if it is available
+      if Object.const_defined?(:Puppet) && Puppet.const_defined?(:Pops)
+        Puppet::Pops::Types::StringConverter.singleton.convert(self)
+      else
+        "Target('#{@host}', #{@options})"
+      end
     end
   end
 end
-end
-

--- a/modules/boltlib/lib/puppet/datatypes/executionresult.rb
+++ b/modules/boltlib/lib/puppet/datatypes/executionresult.rb
@@ -1,0 +1,28 @@
+Puppet::DataTypes.create_type('ExecutionResult') do
+  interface <<-PUPPET
+    attributes => {
+      'result_hash' => Hash[
+        String[1],
+        Struct[
+          Optional[value] => Data,
+          Optional[error] => Struct[
+            msg => String[1],
+            Optional[kind] => String[1],
+            Optional[issue_code] => String[1],
+            Optional[details] => Hash[String[1], Data]]]]
+    },
+    functions => {
+      count => Callable[[], Integer],
+      empty => Callable[[], Boolean],
+      error_nodes => Callable[[], ExecutionResult],
+      names => Callable[[], Array[String[1]]],
+      ok => Callable[[], Boolean],
+      ok_nodes => Callable[[], ExecutionResult],
+      value => Callable[[String[1]], Variant[Error, Data]],
+      values => Callable[[], Array[Variant[Error,Data]]],
+      '[]' => Callable[[String[1]], Variant[Error, Data]]
+    }
+  PUPPET
+
+  implementation_class Bolt::ExecutionResult
+end

--- a/modules/boltlib/lib/puppet/datatypes/executionresult.rb
+++ b/modules/boltlib/lib/puppet/datatypes/executionresult.rb
@@ -24,5 +24,7 @@ Puppet::DataTypes.create_type('ExecutionResult') do
     }
   PUPPET
 
+  load_file('bolt/executionresult')
+
   implementation_class Bolt::ExecutionResult
 end

--- a/modules/boltlib/lib/puppet/datatypes/target.rb
+++ b/modules/boltlib/lib/puppet/datatypes/target.rb
@@ -6,5 +6,7 @@ Puppet::DataTypes.create_type('Target') do
     }
     PUPPET
 
+  load_file('bolt/target')
+
   implementation_class Bolt::Target
 end

--- a/modules/boltlib/lib/puppet/datatypes/target.rb
+++ b/modules/boltlib/lib/puppet/datatypes/target.rb
@@ -1,0 +1,10 @@
+Puppet::DataTypes.create_type('Target') do
+  interface <<-PUPPET
+    attributes => {
+      host => String[1],
+      options => { type => Hash[String[1], Data], value => {} }
+    }
+    PUPPET
+
+  implementation_class Bolt::Target
+end

--- a/modules/boltlib/lib/puppet/functions/file_upload.rb
+++ b/modules/boltlib/lib/puppet/functions/file_upload.rb
@@ -39,15 +39,15 @@ Puppet::Functions.create_function(:file_upload, Puppet::Functions::InternalFunct
     end
 
     # Ensure that that given targets are all Target instances
-    targets = targets.flatten.map { |t| t.is_a?(String) ? Puppet::Pops::Types::TypeFactory.target.create(t) : t }
+    targets = targets.flatten.map { |t| t.is_a?(String) ? Bolt::Target.new(t) : t }
     if targets.empty?
       call_function('debug', "Simulating file upload of '#{found}' - no targets given - no action taken")
-      Puppet::Pops::Types::ExecutionResult::EMPTY_RESULT
+      Bolt::ExecutionResult::EMPTY_RESULT
     else
       # Awaits change in the executor, enabling it receive Target instances
       hosts = targets.map(&:host)
 
-      Puppet::Pops::Types::ExecutionResult.from_bolt(
+      Bolt::ExecutionResult.from_bolt(
         executor.file_upload(executor.from_uris(hosts), found, destination)
       )
     end

--- a/modules/boltlib/lib/puppet/functions/run_command.rb
+++ b/modules/boltlib/lib/puppet/functions/run_command.rb
@@ -30,16 +30,16 @@ Puppet::Functions.create_function(:run_command) do
     end
 
     # Ensure that that given targets are all Target instances
-    targets = targets.flatten.map { |t| t.is_a?(String) ? Puppet::Pops::Types::TypeFactory.target.create(t) : t }
+    targets = targets.flatten.map { |t| t.is_a?(String) ? Bolt::Target.new(t) : t }
 
     if targets.empty?
       call_function('debug', "Simulating run_command('#{command}') - no targets given - no action taken")
-      Puppet::Pops::Types::ExecutionResult::EMPTY_RESULT
+      Bolt::ExecutionResult::EMPTY_RESULT
     else
       # Awaits change in the executor, enabling it receive Target instances
       hosts = targets.map(&:host)
 
-      Puppet::Pops::Types::ExecutionResult.from_bolt(executor.run_command(executor.from_uris(hosts), command))
+      Bolt::ExecutionResult.from_bolt(executor.run_command(executor.from_uris(hosts), command))
     end
   end
 end

--- a/modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/modules/boltlib/lib/puppet/functions/run_script.rb
@@ -54,15 +54,15 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
     end
 
     # Ensure that that given targets are all Target instances)
-    targets = [targets].flatten.map { |t| t.is_a?(String) ? Puppet::Pops::Types::TypeFactory.target.create(t) : t }
+    targets = [targets].flatten.map { |t| t.is_a?(String) ? Bolt::Target.new(t) : t }
     if targets.empty?
       call_function('debug', "Simulating run_script of '#{found}' - no targets given - no action taken")
-      Puppet::Pops::Types::ExecutionResult::EMPTY_RESULT
+      Bolt::ExecutionResult::EMPTY_RESULT
     else
       # Awaits change in the executor, enabling it receive Target instances
       hosts = targets.map(&:host)
 
-      Puppet::Pops::Types::ExecutionResult.from_bolt(
+      Bolt::ExecutionResult.from_bolt(
         executor.run_script(executor.from_uris(hosts), found, args_hash['arguments'])
       )
     end

--- a/modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/modules/boltlib/lib/puppet/functions/run_task.rb
@@ -25,7 +25,7 @@ Puppet::Functions.create_function(:run_task) do
   end
 
   def run_task(task_name, targets, task_args = nil)
-    Puppet::Pops::Types::ExecutionResult.from_bolt(
+    Bolt::ExecutionResult.from_bolt(
       run_task_raw(task_name, targets, task_args)
     )
   end
@@ -68,7 +68,7 @@ Puppet::Functions.create_function(:run_task) do
 
     # Ensure that that given targets are all Target instances
     targets = [targets] unless targets.is_a?(Array)
-    targets = targets.flatten.map { |t| t.is_a?(String) ? Puppet::Pops::Types::TypeFactory.target.create(t) : t }
+    targets = targets.flatten.map { |t| t.is_a?(String) ? Bolt::Target.new(t) : t }
     if targets.empty?
       call_function('debug', "Simulating run of task #{task.name} - no targets given - no action taken")
       Puppet::Pops::EMPTY_HASH

--- a/modules/boltlib/spec/functions/file_upload_spec.rb
+++ b/modules/boltlib/spec/functions/file_upload_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'puppet/pops/types/execution_result'
+require 'bolt/execution_result'
 
 describe 'file_upload' do
   include PuppetlabsSpec::Fixtures

--- a/modules/boltlib/spec/functions/file_upload_spec.rb
+++ b/modules/boltlib/spec/functions/file_upload_spec.rb
@@ -19,7 +19,7 @@ describe 'file_upload' do
     let(:host) { stub(uri: hostname) }
     let(:message) { 'uploaded' }
     let(:result) { { value: message } }
-    let(:exec_result) { Puppet::Pops::Types::ExecutionResult.from_bolt(host => result) }
+    let(:exec_result) { Bolt::ExecutionResult.from_bolt(host => result) }
     let(:module_root) { File.expand_path(fixtures('modules', 'test')) }
     let(:full_path) { File.join(module_root, 'files/uploads/index.html') }
     let(:full_dir_path) { File.dirname(full_path) }
@@ -46,7 +46,7 @@ describe 'file_upload' do
       executor.expects(:from_uris).with(hosts).returns([host])
       executor.expects(:file_upload).with([host], full_dir_path, destination).returns(host => result)
 
-      target = Puppet::Pops::Types::TypeFactory.target.create(hostname)
+      target = Bolt::Target.new(hostname)
       is_expected.to run.with_params('test/uploads', destination, target).and_return(exec_result)
     end
 
@@ -56,7 +56,7 @@ describe 'file_upload' do
       let(:host2) { stub(uri: hostname2) }
       let(:message2) { 'received' }
       let(:result2) { { value: message2 } }
-      let(:exec_result) { Puppet::Pops::Types::ExecutionResult.from_bolt(host => result, host2 => result2) }
+      let(:exec_result) { Bolt::ExecutionResult.from_bolt(host => result, host2 => result2) }
 
       it 'propagates multiple hosts and returns multiple results' do
         executor.expects(:from_uris).with(hosts).returns([host, host2])
@@ -73,7 +73,7 @@ describe 'file_upload' do
       executor.expects(:file_upload).never
 
       is_expected.to run.with_params('test/uploads/index.html', destination)
-                        .and_return(Puppet::Pops::Types::ExecutionResult::EMPTY_RESULT)
+                        .and_return(Bolt::ExecutionResult::EMPTY_RESULT)
     end
 
     it 'errors when file is not found' do

--- a/modules/boltlib/spec/functions/run_command_spec.rb
+++ b/modules/boltlib/spec/functions/run_command_spec.rb
@@ -18,7 +18,7 @@ describe 'run_command' do
     let(:host) { stub(uri: hostname) }
     let(:command) { 'hostname' }
     let(:result) { { value: hostname } }
-    let(:exec_result) { Puppet::Pops::Types::ExecutionResult.from_bolt(host => result) }
+    let(:exec_result) { Bolt::ExecutionResult.from_bolt(host => result) }
     before(:each) do
       Puppet.features.stubs(:bolt?).returns(true)
     end
@@ -34,7 +34,7 @@ describe 'run_command' do
       executor.expects(:from_uris).with(hosts).returns([host])
       executor.expects(:run_command).with([host], command).returns(host => result)
 
-      target = Puppet::Pops::Types::TypeFactory.target.create(hostname)
+      target = Bolt::Target.new(hostname)
       is_expected.to run.with_params(command, target).and_return(exec_result)
     end
 
@@ -43,7 +43,7 @@ describe 'run_command' do
       let(:hosts) { [hostname, hostname2] }
       let(:host2) { stub(uri: hostname2) }
       let(:result2) { { value: hostname2 } }
-      let(:exec_result) { Puppet::Pops::Types::ExecutionResult.from_bolt(host => result, host2 => result2) }
+      let(:exec_result) { Bolt::ExecutionResult.from_bolt(host => result, host2 => result2) }
 
       it 'with propagates multiple hosts and returns multiple results' do
         executor.expects(:from_uris).with(hosts).returns([host, host2])
@@ -56,8 +56,8 @@ describe 'run_command' do
         executor.expects(:from_uris).with(hosts).returns([host, host2])
         executor.expects(:run_command).with([host, host2], command).returns(host => result, host2 => result2)
 
-        target = Puppet::Pops::Types::TypeFactory.target.create(hostname)
-        target2 = Puppet::Pops::Types::TypeFactory.target.create(hostname2)
+        target = Bolt::Target.new(hostname)
+        target2 = Bolt::Target.new(hostname2)
         is_expected.to run.with_params(command, target, target2).and_return(exec_result)
       end
     end
@@ -66,7 +66,7 @@ describe 'run_command' do
       executor.expects(:from_uris).never
       executor.expects(:run_command).never
 
-      is_expected.to run.with_params(command).and_return(Puppet::Pops::Types::ExecutionResult::EMPTY_RESULT)
+      is_expected.to run.with_params(command).and_return(Bolt::ExecutionResult::EMPTY_RESULT)
     end
   end
 

--- a/modules/boltlib/spec/functions/run_command_spec.rb
+++ b/modules/boltlib/spec/functions/run_command_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'puppet/pops/types/execution_result'
+require 'bolt/execution_result'
 
 describe 'run_command' do
   let(:executor) { mock('bolt_executor') }

--- a/modules/boltlib/spec/functions/run_script_spec.rb
+++ b/modules/boltlib/spec/functions/run_script_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'puppet/pops/types/execution_result'
+require 'bolt/execution_result'
 
 describe 'run_script' do
   include PuppetlabsSpec::Fixtures

--- a/modules/boltlib/spec/functions/run_script_spec.rb
+++ b/modules/boltlib/spec/functions/run_script_spec.rb
@@ -18,7 +18,7 @@ describe 'run_script' do
     let(:hosts) { [hostname] }
     let(:host) { stub(uri: hostname) }
     let(:result) { { value: hostname } }
-    let(:exec_result) { Puppet::Pops::Types::ExecutionResult.from_bolt(host => result) }
+    let(:exec_result) { Bolt::ExecutionResult.from_bolt(host => result) }
     let(:module_root) { File.expand_path(fixtures('modules', 'test')) }
     let(:full_path) { File.join(module_root, 'files/uploads/hostname.sh') }
     before(:each) do
@@ -36,7 +36,7 @@ describe 'run_script' do
       executor.expects(:from_uris).with(hosts).returns([host])
       executor.expects(:run_script).with([host], full_path, []).returns(host => result)
 
-      target = Puppet::Pops::Types::TypeFactory.target.create(hostname)
+      target = Bolt::Target.new(hostname)
       is_expected.to run.with_params('test/uploads/hostname.sh', target).and_return(exec_result)
     end
 
@@ -53,7 +53,7 @@ describe 'run_script' do
       executor.expects(:from_uris).with(hosts).returns([host])
       executor.expects(:run_script).with([host], full_path, []).returns(host => result)
 
-      target = Puppet::Pops::Types::TypeFactory.target.create(hostname)
+      target = Bolt::Target.new(hostname)
       is_expected.to run.with_params('test/uploads/hostname.sh', target, 'arguments' => []).and_return(exec_result)
     end
 
@@ -62,7 +62,7 @@ describe 'run_script' do
       let(:hosts) { [hostname, hostname2] }
       let(:host2) { stub(uri: hostname2) }
       let(:result2) { { value: hostname2 } }
-      let(:exec_result) { Puppet::Pops::Types::ExecutionResult.from_bolt(host => result, host2 => result2) }
+      let(:exec_result) { Bolt::ExecutionResult.from_bolt(host => result, host2 => result2) }
       let(:nodes) { [mock(hostname), mock(hostname2)] }
 
       it 'with propagated multiple hosts and returns multiple results' do
@@ -78,7 +78,7 @@ describe 'run_script' do
       executor.expects(:run_script).never
 
       is_expected.to run
-        .with_params('test/uploads/hostname.sh').and_return(Puppet::Pops::Types::ExecutionResult::EMPTY_RESULT)
+        .with_params('test/uploads/hostname.sh').and_return(Bolt::ExecutionResult::EMPTY_RESULT)
     end
 
     it 'errors when script is not found' do

--- a/modules/boltlib/spec/functions/run_task_spec.rb
+++ b/modules/boltlib/spec/functions/run_task_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'puppet/pops/types/execution_result'
+require 'bolt/execution_result'
 
 describe 'run_task' do
   include PuppetlabsSpec::Fixtures

--- a/modules/boltlib/spec/functions/run_task_spec.rb
+++ b/modules/boltlib/spec/functions/run_task_spec.rb
@@ -23,7 +23,7 @@ describe 'run_task' do
     let(:host) { stub(uri: hostname) }
     let(:host2) { stub(uri: hostname2) }
     let(:result) { { value: message } }
-    let(:exec_result) { Puppet::Pops::Types::ExecutionResult.from_bolt(host => result) }
+    let(:exec_result) { Bolt::ExecutionResult.from_bolt(host => result) }
     let(:tasks_root) { File.expand_path(fixtures('modules', 'test', 'tasks')) }
 
     it 'when running a task without metadata the input method is "both"' do
@@ -57,11 +57,11 @@ describe 'run_task' do
       executor.expects(:from_uris).never
       executor.expects(:run_task).never
 
-      is_expected.to run.with_params('Test::Yes', []).and_return(Puppet::Pops::Types::ExecutionResult::EMPTY_RESULT)
+      is_expected.to run.with_params('Test::Yes', []).and_return(Bolt::ExecutionResult::EMPTY_RESULT)
     end
 
     context 'with multiple destinations' do
-      let(:exec_result) { Puppet::Pops::Types::ExecutionResult.from_bolt(host => result, host2 => result) }
+      let(:exec_result) { Bolt::ExecutionResult.from_bolt(host => result, host2 => result) }
 
       it 'nodes can be specified as repeated nested arrays and strings and combine into one list of nodes' do
         executable = File.join(tasks_root, 'meta.sh')
@@ -81,8 +81,8 @@ describe 'run_task' do
         executor.expects(:run_task).with([host, host2], executable, 'environment', 'message' => message)
                 .returns(host => result, host2 => result)
 
-        target = Puppet::Pops::Types::TypeFactory.target.create(hostname)
-        target2 = Puppet::Pops::Types::TypeFactory.target.create(hostname2)
+        target = Bolt::Target.new(hostname)
+        target2 = Bolt::Target.new(hostname2)
         is_expected.to run.with_params('Test::Meta', [target, [[target2]], []], 'message' => message)
                           .and_return(exec_result)
       end


### PR DESCRIPTION
This commit adds the `ExecutionResult` and `Target` data types to `Bolt`
and makes them available to Puppet using the new
`Puppet::DataTypes#create_type` introduced by PUP-8195.

Note! The data types were previously present in Puppet core and this
commit must be synchronized with an upgrade to use a puppet version
where PUP-8265 (covering the removal) has been merged.