### PR TITLE
(BOLT-270) Update ca-cert to cacert

### DIFF
--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -21,7 +21,7 @@ module Bolt
     }.freeze
 
     TRANSPORT_OPTIONS = %i[insecure password run_as sudo sudo_password
-                           key tty tmpdir user connect_timeout ca_cert
+                           key tty tmpdir user connect_timeout cacert
                            token_file orch_task_environment service_url].freeze
 
     TRANSPORT_DEFAULTS = {
@@ -115,8 +115,8 @@ module Bolt
         if data['winrm']['tmpdir']
           self[:transports][:winrm][:tmpdir] = data['winrm']['tmpdir']
         end
-        if data['winrm']['ca-cert']
-          self[:transports][:winrm][:ca_cert] = data['winrm']['ca-cert']
+        if data['winrm']['cacert']
+          self[:transports][:winrm][:cacert] = data['winrm']['cacert']
         end
       end
 
@@ -124,8 +124,8 @@ module Bolt
         if data['pcp']['service-url']
           self[:transports][:pcp][:service_url] = data['pcp']['service-url']
         end
-        if data['pcp']['ca-cert']
-          self[:transports][:pcp][:ca_cert] = data['pcp']['ca-cert']
+        if data['pcp']['cacert']
+          self[:transports][:pcp][:cacert] = data['pcp']['cacert']
         end
         if data['pcp']['token-file']
           self[:transports][:pcp][:token_file] = data['pcp']['token-file']

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -41,7 +41,7 @@ module Bolt
       @user = user || transport_conf[:user]
       @password = password || transport_conf[:password]
       @key = transport_conf[:key]
-      @ca_cert = transport_conf[:ca_cert]
+      @cacert = transport_conf[:cacert]
       @tty = transport_conf[:tty]
       @insecure = transport_conf[:insecure]
       @connect_timeout = transport_conf[:connect_timeout]

--- a/lib/bolt/node/orch.rb
+++ b/lib/bolt/node/orch.rb
@@ -19,7 +19,7 @@ module Bolt
       opts = {}
       opts["service-url"] = @service_url if @service_url
       opts["token-file"] = @token_file if @token_file
-      opts["cacert"] = @ca_cert if @ca_cert
+      opts["cacert"] = @cacert if @cacert
       OrchestratorClient.new(opts, true)
     end
 

--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -32,7 +32,7 @@ module Bolt
                   password: @password,
                   retry_limit: 1,
                   transport: transport,
-                  ca_trust_path: @ca_cert }
+                  ca_trust_path: @cacert }
 
       Timeout.timeout(@connect_timeout) do
         @connection = ::WinRM::Connection.new(options)

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1042,13 +1042,14 @@ NODES
           'connect-timeout' => 4
         },
         'winrm' => {
-          'connect-timeout' => 7
+          'connect-timeout' => 7,
+          'cacert' => '/path/to/winrm-cacert'
         },
         'pcp' => {
           'task-environment' => 'testenv',
           'service-url' => 'http://foo.org',
           'token-file' => '/path/to/token',
-          'ca-cert' => '/path/to/cacert'
+          'cacert' => '/path/to/cacert'
         } }
     end
 
@@ -1125,11 +1126,12 @@ NODES
       end
     end
 
-    it 'reads ca cert file for pcp' do
+    it 'reads separate cacert file for pcp and winrm' do
       with_tempfile_containing('conf', YAML.dump(complete_config)) do |conf|
         cli = Bolt::CLI.new(%W[command run --configfile #{conf.path} --nodes foo --insecure])
         cli.parse
-        expect(cli.config[:transports][:pcp][:ca_cert]).to eql('/path/to/cacert')
+        expect(cli.config[:transports][:pcp][:cacert]).to eql('/path/to/cacert')
+        expect(cli.config[:transports][:winrm][:cacert]).to eql('/path/to/winrm-cacert')
       end
     end
 

--- a/spec/bolt/node/winrm_spec.rb
+++ b/spec/bolt/node/winrm_spec.rb
@@ -16,7 +16,7 @@ describe Bolt::WinRM do
   let(:password) { ENV['BOLT_WINRM_PASSWORD'] || "vagrant" }
   let(:command) { "echo $env:UserName" }
   let(:config) { Bolt::Config.new(transports: { winrm: { insecure: true } }) }
-  let(:ssl_config) { Bolt::Config.new(transports: { winrm: { ca_cert: 'resources/cert.pem' } }) }
+  let(:ssl_config) { Bolt::Config.new(transports: { winrm: { cacert: 'resources/cert.pem' } }) }
   let(:winrm) { Bolt::WinRM.new(host, port, user, password, config: config) }
   let(:winrm_ssl) { Bolt::WinRM.new(host, ssl_port, user, password, config: ssl_config) }
   let(:echo_script) { <<PS }


### PR DESCRIPTION
Switch PCP and WinRM transport config options from `ca-cert` to `cacert`
to be shorter and consistent with CURL and other Puppet tools.