### PR TITLE
(BOLT-264) add run-as to ssh config

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -109,6 +109,7 @@ HELP
       }
       @config = Bolt::Config.new
       @parser = create_option_parser(@options)
+      @logger = Logger.new(STDERR)
     end
 
     def create_option_parser(results)
@@ -186,13 +187,13 @@ HELP
                 "User to run as using privilege escalation") do |user|
           results[:run_as] = user
         end
-        opts.on('--sudo [PROGRAM]',
-                "Program to execute for privilege escalation. " \
-                "Currently only sudo is supported.") do |program|
-          results[:sudo] = program || 'sudo'
-        end
         opts.on('--sudo-password [PASSWORD]',
                 'Password for privilege escalation') do |password|
+          if results[:run_as].nil?
+            @logger.warn("--sudo-password only provides privilege escalation
+                        for a user specified by --run-as. Please include the
+                        --run-as flag")
+          end
           if password.nil?
             STDOUT.print "Please enter your privilege escalation password: "
             results[:sudo_password] = STDIN.noecho(&:gets).chomp

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -21,7 +21,7 @@ module Bolt
       log_destination: STDERR
     }.freeze
 
-    TRANSPORT_OPTIONS = %i[insecure password run_as sudo sudo_password
+    TRANSPORT_OPTIONS = %i[insecure password run_as sudo_password
                            key tty tmpdir user connect_timeout cacert
                            token_file orch_task_environment service_url].freeze
 
@@ -112,6 +112,9 @@ module Bolt
         if data['ssh']['tmpdir']
           self[:transports][:ssh][:tmpdir] = data['ssh']['tmpdir']
         end
+        if data['ssh']['run-as']
+          self[:transports][:ssh][:run_as] = data['ssh']['run-as']
+        end
       end
 
       if data['winrm']
@@ -151,7 +154,7 @@ module Bolt
     end
 
     def update_from_cli(options)
-      %i[concurrency transport format modulepath].each do |key|
+      %i[concurrency transport format modulepath ssh['run_as']].each do |key|
         self[key] = options[key] if options[key]
       end
 
@@ -171,10 +174,7 @@ module Bolt
 
     def validate
       TRANSPORTS.each do |transport|
-        tconf = self[:transports][transport]
-        if tconf[:sudo] && tconf[:sudo] != 'sudo'
-          raise Bolt::CLIError, "Only 'sudo' is supported for privilege escalation."
-        end
+        self[:transports][transport]
       end
 
       unless %w[human json].include? self[:format]

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -46,7 +46,6 @@ module Bolt
       @tty = transport_conf[:tty]
       @insecure = transport_conf[:insecure]
       @connect_timeout = transport_conf[:connect_timeout]
-      @sudo = transport_conf[:sudo]
       @sudo_password = transport_conf[:sudo_password]
       @run_as = transport_conf[:run_as]
       @tmpdir = transport_conf[:tmpdir]

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -286,17 +286,6 @@ NODES
     end
 
     describe "sudo" do
-      it "defaults method to sudo" do
-        cli = Bolt::CLI.new(%w[command run --nodes foo whoami --sudo])
-        cli.parse
-        expect(cli.config[:transports][:ssh][:sudo]).to eq('sudo')
-      end
-
-      it "rejects unsupported methods" do
-        cli = Bolt::CLI.new(%w[command run --nodes foo whoami --sudo rm])
-        expect { cli.parse }.to raise_error(Bolt::CLIError)
-      end
-
       it "supports running as a user" do
         cli = Bolt::CLI.new(%w[command run --nodes foo whoami --run-as root])
         expect(cli.parse[:run_as]).to eq('root')
@@ -1131,7 +1120,8 @@ NODES
         'ssh' => {
           'private-key' => '/bar/foo',
           'insecure' => true,
-          'connect-timeout' => 4
+          'connect-timeout' => 4,
+          'run-as' => 'Fakey McFakerson'
         },
         'winrm' => {
           'connect-timeout' => 7,
@@ -1182,6 +1172,14 @@ NODES
         cli = Bolt::CLI.new(%W[command run --configfile #{conf.path} --nodes foo --insecure])
         cli.parse
         expect(cli.config[:transports][:ssh][:insecure]).to eq(true)
+      end
+    end
+
+    it 'reads run-as for ssh' do
+      with_tempfile_containing('conf', YAML.dump(complete_config)) do |conf|
+        cli = Bolt::CLI.new(%W[command run --configfile #{conf.path} --nodes foo --password bar --insecure])
+        cli.parse
+        expect(cli.config[:transports][:ssh][:run_as]).to eq('Fakey McFakerson')
       end
     end
 


### PR DESCRIPTION
Only note: if I do pass `--sudo`, it still asks for a password. It doesn't seem to actually do anything, but the prompt is misleading and annoying. It seems to be coming from https://github.com/puppetlabs/bolt/blob/master/lib/bolt/cli.rb#L197

```
$ bb task run exec command=whoami -n fgyhjd78bkyzjtv.delivery.puppetlabs.net -u lucy -p puppetlabs --sudo --tty
Please enter your privilege escalation password: 
Started on fgyhjd78bkyzjtv.delivery.puppetlabs.net...
Finished on fgyhjd78bkyzjtv.delivery.puppetlabs.net:
  lucy
  {
  }
Ran on 1 node in 2.32 seconds
```