### PR TITLE
(BOLT-259) Update config file to default to `bolt.yaml`

### DIFF
--- a/spec/lib/bolt_spec/integration.rb
+++ b/spec/lib/bolt_spec/integration.rb
@@ -4,7 +4,7 @@ module BoltSpec
       cli = Bolt::CLI.new(arguments)
 
       # prevent tests from reading users config
-      allow(cli.config).to receive(:default_path).and_return(File.join('.', 'path', 'does not exist'))
+      allow(cli.config).to receive(:default_paths).and_return([File.join('.', 'path', 'does not exist')])
       output =  StringIO.new
       outputter = Bolt::Outputter::JSON.new(output)
       allow(cli).to receive(:outputter).and_return(outputter)


### PR DESCRIPTION
Changes the default config file to `bolt.yaml`; continues to fall back
to `bolt.yml` if `bolt.yaml` not found. Issues a warning if both
`bolt.yml` and `bolt.yaml` exist.