### PR TITLE
(BOLT-264) Don't show warning when run-as is configured in file

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -189,11 +189,6 @@ HELP
         end
         opts.on('--sudo-password [PASSWORD]',
                 'Password for privilege escalation') do |password|
-          if results[:run_as].nil?
-            @logger.warn("--sudo-password only provides privilege escalation
-                        for a user specified by --run-as. Please include the
-                        --run-as flag")
-          end
           if password.nil?
             STDOUT.print "Please enter your privilege escalation password: "
             results[:sudo_password] = STDIN.noecho(&:gets).chomp

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -154,7 +154,7 @@ module Bolt
     end
 
     def update_from_cli(options)
-      %i[concurrency transport format modulepath ssh['run_as']].each do |key|
+      %i[concurrency transport format modulepath].each do |key|
         self[key] = options[key] if options[key]
       end
 
@@ -169,6 +169,12 @@ module Bolt
         TRANSPORTS.each do |transport|
           self[:transports][transport][key] = options[key] if options[key]
         end
+      end
+
+      if options[:sudo_password] && self[:transports][:ssh][:run_as].nil?
+        logger = Logger.new(self[:log_destination])
+        logger.warn("'--sudo-password will not be used without specifying a" \
+                    "user to escalate to with --run-as")
       end
     end
 

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -294,7 +294,7 @@ NODES
 
     describe "sudo-password" do
       it "accepts a password" do
-        cli = Bolt::CLI.new(%w[command run --sudo-password opensez --nodes foo])
+        cli = Bolt::CLI.new(%w[command run --sudo-password opensez --run-as alibaba --nodes foo])
         expect(cli.parse).to include(sudo_password: 'opensez')
       end
 
@@ -303,7 +303,7 @@ NODES
         pw_prompt = 'Please enter your privilege escalation password: '
         allow(STDOUT).to receive(:print).with(pw_prompt)
         allow(STDOUT).to receive(:puts)
-        cli = Bolt::CLI.new(%w[command run --nodes foo --sudo-password])
+        cli = Bolt::CLI.new(%w[command run --nodes foo --run-as alibaba --sudo-password])
         expect(cli.parse).to include(sudo_password: 'opensez')
       end
     end


### PR DESCRIPTION
I realized for the warning message around having `--sudo-password` without `--run-as` I left out the case where run-as is configured in a file. This fixes that issue, and gets rid of warnings in the spec tests.