### PR TITLE
(BOLT-283) Assert that run_task arguments are Data compatible

### DIFF
--- a/modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/modules/boltlib/lib/puppet/functions/run_task.rb
@@ -56,6 +56,11 @@ Puppet::Functions.create_function(:run_task) do
     task_signature.runnable_with?(use_args) do |mismatch|
       raise Puppet::ParseError, mismatch
     end || (raise Puppet::ParseError, 'Task parameters did not match')
+
+    unless Puppet::Pops::Types::TypeFactory.data.instance?(use_args)
+      raise Puppet::ParseError, 'Task parameters is not of type Data'
+    end
+
     task = task_signature.task
 
     if executor.noop

--- a/modules/boltlib/spec/fixtures/modules/test/tasks/params.json
+++ b/modules/boltlib/spec/fixtures/modules/test/tasks/params.json
@@ -21,6 +21,10 @@
     "optional_integer": {
       "description": "Optional integer parameter",
       "type": "Optional[Integer[-5,5]]"
+    },
+    "optional_hash": {
+      "description": "Optional hash parameter",
+      "type": "Optional[Hash]"
     }
   }
 }

--- a/modules/boltlib/spec/functions/run_task_spec.rb
+++ b/modules/boltlib/spec/functions/run_task_spec.rb
@@ -176,5 +176,18 @@ describe 'run_task' do
                                          \ got\ Integer\[10,\ 10\]/x
       )
     end
+
+    it "errors when a specified parameter value is not Data" do
+      task_params.merge!(
+        'mandatory_string'  => 'str',
+        'mandatory_integer' => 10,
+        'mandatory_boolean' => true,
+        'optional_hash'     => { now: Time.now }
+      )
+
+      is_expected.to run.with_params(task_name, hostname, task_params).and_raise_error(
+        Puppet::ParseError, /Task parameters is not of type Data/
+      )
+    end
   end
 end


### PR DESCRIPTION
This commit adds add check that the user defined argument hash passed to
the `run_task` function is an instance of the `Data` data type.