### PR TITLE
(maint) Add test that we can list plans with an init plan

### DIFF
--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -659,6 +659,7 @@ NODES
           cli.execute(options)
           expect(JSON.parse(@output.string)).to eq(
             [
+              ['sample'],
               ['sample::single_task'],
               ['sample::three_tasks'],
               ['sample::two_tasks']

--- a/spec/fixtures/modules/sample/plans/init.pp
+++ b/spec/fixtures/modules/sample/plans/init.pp
@@ -1,0 +1,3 @@
+plan sample() {
+  notice 'I am the init plan'
+}


### PR DESCRIPTION
Tests the fix for PUP-8271 when included in Bolt.