### PR TITLE
(maint) Remove use of System.ServiceModel.Web

### DIFF
--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -75,7 +75,7 @@ $ENV:RUBYLIB = "${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\puppet\\lib;" +
   "${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\hiera\\lib;" +
   $ENV:RUBYLIB
 
-Add-Type -AssemblyName System.ServiceModel.Web, System.Runtime.Serialization
+Add-Type -AssemblyName System.Runtime.Serialization
 $utf8 = [System.Text.Encoding]::UTF8
 
 function Invoke-Interpreter


### PR DESCRIPTION
System.ServiceModel.Web was included as a relic of a previous iteration
of the powershell shim. It requires .NET Framework 3.5, which is newer
than we intended to support. Drop inclusion of that assembly, as it's
not used.