### PR TITLE
(BOLT-294) Create local to_s method for ExecutionResults

### DIFF
--- a/lib/bolt/execution_result.rb
+++ b/lib/bolt/execution_result.rb
@@ -13,7 +13,7 @@ module Bolt
       end
 
       def to_s
-        Puppet::Pops::Types::StringConverter.singleton.convert(self)
+        @result_hash.to_s
       end
     else
       def iterator


### PR DESCRIPTION
We're going to be refactoring this soon anyway at which point were
should design the to_s output better. We can't rely on Pops anyway if we
want to use this directly in bolt and this at least prevents infinite
recursion.