### PR TITLE
(BOLT-293) Load Datatypes before running plans.

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -602,6 +602,10 @@ HELP
           cli << "--#{setting}" << dir
         end
         in_bolt_compiler(cli) do |compiler|
+          # Make sure the Datatypes we expose to plans are loaded
+          compiler.type('ExecutionResult')
+          compiler.type('Target')
+
           result = compiler.call_function('run_plan', plan, args)
           # Querying ExecutionResult for failures currently requires a script compiler.
           # Convert from an ExecutionResult to structured output that we can print.

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -559,19 +559,20 @@ NODES
             action: 'show'
           }
           cli.execute(options)
-          expect(JSON.parse(@output.string)).to eq(
-            [
-              ['sample', nil],
-              ['sample::echo', nil],
-              ['sample::no_noop', 'Task with no noop'],
-              ['sample::noop', 'Task with noop'],
-              ['sample::notice', nil],
-              ['sample::params', 'Task with parameters'],
-              ['sample::ps_noop', 'Powershell task with noop'],
-              ['sample::stdin', nil],
-              ['sample::winstdin', nil]
-            ]
-          )
+          tasks = JSON.parse(@output.string)
+          [
+            ['sample', nil],
+            ['sample::echo', nil],
+            ['sample::no_noop', 'Task with no noop'],
+            ['sample::noop', 'Task with noop'],
+            ['sample::notice', nil],
+            ['sample::params', 'Task with parameters'],
+            ['sample::ps_noop', 'Powershell task with noop'],
+            ['sample::stdin', nil],
+            ['sample::winstdin', nil]
+          ].each do |taskdoc|
+            expect(tasks).to include(taskdoc)
+          end
         end
 
         it "shows an individual task data in json" do
@@ -660,14 +661,15 @@ NODES
             action: 'show'
           }
           cli.execute(options)
-          expect(JSON.parse(@output.string)).to eq(
-            [
-              ['sample'],
-              ['sample::single_task'],
-              ['sample::three_tasks'],
-              ['sample::two_tasks']
-            ]
-          )
+          plan_list = JSON.parse(@output.string)
+          [
+            ['sample'],
+            ['sample::single_task'],
+            ['sample::three_tasks'],
+            ['sample::two_tasks']
+          ].each do |plan|
+            expect(plan_list).to include(plan)
+          end
         end
       end
 

--- a/spec/fixtures/modules/results/plans/test_methods.pp
+++ b/spec/fixtures/modules/results/plans/test_methods.pp
@@ -1,0 +1,15 @@
+plan results::test_methods(
+  String $target,
+  Optional[String] $fail = 'false'
+) {
+  if($fail) {
+    $result = run_task('results', [$target], 'fail' => 'true')
+  } else {
+    $result = run_task('results', [$target])
+  }
+
+  # Test to_s works
+  $str = "result ${result}"
+  # return ok
+  $result.ok
+}

--- a/spec/fixtures/modules/results/tasks/init.sh
+++ b/spec/fixtures/modules/results/tasks/init.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env/bash
+
+echo "hi"
+
+if [ -v $PT_fail ]; then
+  exit 1
+fi

--- a/spec/integration/execution_result.rb
+++ b/spec/integration/execution_result.rb
@@ -1,0 +1,24 @@
+require 'bolt_spec/conn'
+require 'bolt_spec/files'
+require 'bolt_spec/integration'
+require 'bolt/cli'
+
+describe "when runnning over the ssh transport", ssh: true do
+  include BoltSpec::Conn
+  include BoltSpec::Files
+  include BoltSpec::Integration
+
+  let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
+  let(:uri) { conn_uri('ssh') }
+  let(:user) { conn_info('ssh')[:user] }
+  let(:password) { conn_info('ssh')[:password] }
+
+  context 'when using CLI options' do
+    let(:config_flags) { %W[--insecure --format json --modulepath #{modulepath}] }
+
+    it 'returns true on success' do
+      output = run_cli(['plan', 'run', 'results::test_methods', "target=#{uri}"] + config_flags)
+      expect(output.strip).to eq('true')
+    end
+  end
+end


### PR DESCRIPTION
This ensures the datatypes we expose to plans are loaded before plans
are run. Otherwise there is a chance one will be returned by run_* but
it's methods will not be available.