### PR TITLE
(BOLT-293) Add return_type to run_xxx and file_upload functions

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -602,10 +602,6 @@ HELP
           cli << "--#{setting}" << dir
         end
         in_bolt_compiler(cli) do |compiler|
-          # Make sure the Datatypes we expose to plans are loaded
-          compiler.type('ExecutionResult')
-          compiler.type('Target')
-
           result = compiler.call_function('run_plan', plan, args)
           # Querying ExecutionResult for failures currently requires a script compiler.
           # Convert from an ExecutionResult to structured output that we can print.

--- a/modules/boltlib/lib/puppet/functions/file_upload.rb
+++ b/modules/boltlib/lib/puppet/functions/file_upload.rb
@@ -15,6 +15,7 @@ Puppet::Functions.create_function(:file_upload, Puppet::Functions::InternalFunct
     param 'String[1]', :source
     param 'String[1]', :destination
     repeated_param 'TargetOrTargets', :targets
+    return_type 'ExecutionResult'
   end
 
   def file_upload(scope, source, destination, *targets)

--- a/modules/boltlib/lib/puppet/functions/run_command.rb
+++ b/modules/boltlib/lib/puppet/functions/run_command.rb
@@ -13,6 +13,7 @@ Puppet::Functions.create_function(:run_command) do
   dispatch :run_command do
     param 'String[1]', :command
     repeated_param 'TargetOrTargets', :targets
+    return_type 'ExecutionResult'
   end
 
   def run_command(command, *targets)

--- a/modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/modules/boltlib/lib/puppet/functions/run_script.rb
@@ -15,12 +15,14 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
     param 'String[1]', :script
     param 'TargetOrTargets', :targets
     param 'Struct[arguments => Array[String]]', :arguments
+    return_type 'ExecutionResult'
   end
 
   dispatch :run_script do
     scope_param
     param 'String[1]', :script
     repeated_param 'TargetOrTargets', :targets
+    return_type 'ExecutionResult'
   end
 
   def run_script(scope, script, *targets)

--- a/modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/modules/boltlib/lib/puppet/functions/run_task.rb
@@ -14,6 +14,7 @@ Puppet::Functions.create_function(:run_task) do
     param 'String[1]', :task_name
     param 'TargetOrTargets', :targets
     optional_param 'Hash[String[1], Any]', :task_args
+    return_type 'ExecutionResult'
   end
 
   # this is used from 'bolt task run'


### PR DESCRIPTION
This commit adds `return_type ExecutionResult` to the `run_xxx` and
`file_upload` functions to ensure that the `ExecutionResult` data type
is loaded before an attempt is made to access it in Puppet.

This removes the need for pre-loading the data type.