### PR TITLE
(BOLT-295) Support running arbitrary scripts on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,15 +73,31 @@ ssh:
 
 `private-key`: The path to the private key file to use for SSH authentication.
 
-`connect-timeout`: Maximum amount of time to allow for an SSH connection to be established, in seconds
+`connect-timeout`: Maximum amount of time to allow for an SSH connection to be established, in seconds.
+
+`tmpdir`: The directory to store temporary files on the target node. (default: location used by `mktemp -d`, usually `/tmp`)
+
+`run-as`: Triggers privilege escalation for commands on the target node as the specified user. Currently only works via `sudo`.
 
 ### `winrm` transport configuration options
 
-`connect-timeout`: Maximum amount of time to allow for a WinRM connection to be established, in seconds
+`connect-timeout`: Maximum amount of time to allow for a WinRM connection to be established, in seconds.
+
+`insecure`: Whether to skip requiring SSL for connections. (default: false)
+
+`cacert`: The CA certificate used to authenticate SSL connections. (default: uses system CA certificates)
+
+`tmpdir`: The directory to store temporary files on the target node. (default: `[System.IO.Path]::GetTempPath()`)
 
 ### `pcp` transport configuration options
 
-There are currently no options for the PCP orchestrator transport
+`service-url`: The URL of the Orchestrator service, usually of the form `https://puppet:8143`. If not specified, will attempt to read local PE Client Tools configuration for the same setting from `orchestrator.conf`.
+
+`cacert`: The CA certificate used to authenticate the `service-url`. If not specified, will attempt to read local PE Client Tools configuration for the same setting from `orchestrator.conf`.
+
+`token-file`: The token certificate used to authorize requests to the `service-url`. If not specified, will attempt to read local PE Client Tools configuration for the same setting from `orchestrator.conf`. (default: `~/.puppetlabs/token`)
+
+`task-environment`: The environment from which Orchestrator will serve task implementations. (default: `production`)
 
 
 ## Usage examples

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ ssh:
 
 `tmpdir`: The directory to store temporary files on the target node. (default: `[System.IO.Path]::GetTempPath()`)
 
+`extensions`: List of file extensions that will be accepted for scripts or tasks. Scripts with these file extensions will rely on the target node's file type association to run. For example, if Python is installed on the system, a `.py` script should run with `python.exe`. `.ps1`, `.rb`, and `.pp` are always allowed and run via hard-coded executables.
+
 ### `pcp` transport configuration options
 
 `service-url`: The URL of the Orchestrator service, usually of the form `https://puppet:8143`. If not specified, will attempt to read local PE Client Tools configuration for the same setting from `orchestrator.conf`.

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -18,7 +18,7 @@ module Bolt
       format: 'human'
     }.freeze
 
-    TRANSPORT_OPTIONS = %i[insecure password run_as sudo_password
+    TRANSPORT_OPTIONS = %i[insecure password run_as sudo_password extensions
                            key tty tmpdir user connect_timeout cacert
                            token_file orch_task_environment service_url].freeze
 
@@ -126,6 +126,11 @@ module Bolt
         end
         if data['winrm']['cacert']
           self[:transports][:winrm][:cacert] = data['winrm']['cacert']
+        end
+        if data['winrm']['extensions']
+          # Accept a single entry or a list, ensure each is prefixed with '.'
+          self[:transports][:winrm][:extensions] =
+            [data['winrm']['extensions']].flatten.map { |ext| ext[0] != '.' ? '.' + ext : ext }
         end
       end
 

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -51,6 +51,7 @@ module Bolt
       @service_url = transport_conf[:service_url]
       @token_file = transport_conf[:token_file]
       @orch_task_environment = transport_conf[:orch_task_environment]
+      @extensions = transport_conf[:extensions]
 
       @logger = Logger.get_logger(progname: @host)
       @transport_logger = Logger.get_logger(progname: @host, log_level: Logger::WARN)

--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -466,8 +466,6 @@ PS
 
     def with_remote_file(file)
       file_base = File.basename(file)
-      # Default to powershell if no extension present
-      file_base += '.ps1' if File.extname(file).empty?
       dir = make_tempdir
       dest = "#{dir}\\#{file_base}"
       begin

--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -401,8 +401,6 @@ exit $(Invoke-Interpreter @invokeArgs)
 PS
     end
 
-    VALID_EXTENSIONS = ['.ps1', '.rb', '.pp'].freeze
-
     PS_ARGS = %w[
       -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass
     ].freeze
@@ -427,6 +425,12 @@ PS
         [
           'puppet.bat',
           ['apply', "\"#{path}\""]
+        ]
+      else
+        # Run the script via cmd, letting Windows extension handling determine how
+        [
+          'cmd.exe',
+          ['/c', "\"#{path}\""]
         ]
       end
     end
@@ -461,11 +465,11 @@ PS
     end
 
     def with_remote_file(file)
-      ext = File.extname(file)
-      ext = VALID_EXTENSIONS.include?(ext) ? ext : '.ps1'
-      file_base = File.basename(file, '.*')
+      file_base = File.basename(file)
+      # Default to powershell if no extension present
+      file_base += '.ps1' if File.extname(file).empty?
       dir = make_tempdir
-      dest = "#{dir}\\#{file_base}#{ext}"
+      dest = "#{dir}\\#{file_base}"
       begin
         write_remote_file(file, dest)
         shell_init

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1135,7 +1135,8 @@ NODES
         },
         'winrm' => {
           'connect-timeout' => 7,
-          'cacert' => '/path/to/winrm-cacert'
+          'cacert' => '/path/to/winrm-cacert',
+          'extensions' => ['.py', '.bat']
         },
         'pcp' => {
           'task-environment' => 'testenv',
@@ -1199,6 +1200,24 @@ NODES
         cli.parse
         expect(cli.config[:transports][:ssh][:connect_timeout]).to eq(4)
         expect(cli.config[:transports][:winrm][:connect_timeout]).to eq(7)
+      end
+    end
+
+    it 'reads extensions for winrm' do
+      with_tempfile_containing('conf', YAML.dump(complete_config)) do |conf|
+        cli = Bolt::CLI.new(%W[command run --configfile #{conf.path} --nodes foo --insecure])
+        cli.parse
+        expect(cli.config[:transports][:winrm][:extensions]).to eq(['.py', '.bat'])
+      end
+    end
+
+    it 'transforms extensions for winrm' do
+      new_config = complete_config.clone
+      new_config['winrm'] = { 'extensions' => 'py' }
+      with_tempfile_containing('conf', YAML.dump(new_config)) do |conf|
+        cli = Bolt::CLI.new(%W[command run --configfile #{conf.path} --nodes foo --insecure])
+        cli.parse
+        expect(cli.config[:transports][:winrm][:extensions]).to eq(['.py'])
       end
     end
 

--- a/spec/bolt/node/winrm_spec.rb
+++ b/spec/bolt/node/winrm_spec.rb
@@ -125,7 +125,7 @@ PS
     it "can upload a file to a host" do
       contents = "kadejtw89894"
       remote_path = 'C:\Windows\Temp\upload-test-winrm-ssl'
-      with_tempfile_containing('upload-test-winrm-ssl', contents) do |file|
+      with_tempfile_containing('upload-test-winrm-ssl', contents, '.ps1') do |file|
         winrm_ssl.upload(file.path, remote_path)
 
         expect(
@@ -180,7 +180,7 @@ PS
     it "can upload a file to a host", winrm: true do
       contents = "934jklnvf"
       remote_path = 'C:\Windows\Temp\upload-test-winrm'
-      with_tempfile_containing('upload-test-winrm', contents) do |file|
+      with_tempfile_containing('upload-test-winrm', contents, '.ps1') do |file|
         winrm.upload(file.path, remote_path)
 
         expect(
@@ -193,7 +193,7 @@ PS
 
     it "can run a PowerShell script remotely", winrm: true do
       contents = "Write-Output \"hellote\""
-      with_tempfile_containing('script-test-winrm', contents) do |file|
+      with_tempfile_containing('script-test-winrm', contents, '.ps1') do |file|
         expect(
           winrm._run_script(file.path, []).stdout
         ).to eq("hellote\r\n")
@@ -216,7 +216,7 @@ PS
         $ENV:A, $B, $script:C, $local:D, $global:E
       PS
 
-      with_tempfile_containing('script-test-winrm', contents) do |file|
+      with_tempfile_containing('script-test-winrm', contents, '.ps1') do |file|
         result = winrm._run_script(file.path, [])
         instance, runspace, *outputs = result.stdout.split("\r\n")
 
@@ -240,7 +240,7 @@ PS
     end
 
     it "can run a PowerShell script remotely with quoted args", winrm: true do
-      with_tempfile_containing('script-test-winrm-quotes', echo_script) do |file|
+      with_tempfile_containing('script-test-winrm-quotes', echo_script, '.ps1') do |file|
         expect(
           winrm._run_script(
             file.path,
@@ -263,7 +263,7 @@ QUOTED
     end
 
     it "correctly passes embedded double quotes to PowerShell", winrm: true do
-      with_tempfile_containing('script-test-winrm-psquote', echo_script) do |file|
+      with_tempfile_containing('script-test-winrm-psquote', echo_script, '.ps1') do |file|
         expect(
           winrm._run_script(
             file.path,
@@ -282,7 +282,7 @@ QUOTED
     end
 
     it "escapes unsafe shellwords", winrm: true do
-      with_tempfile_containing('script-test-winrm-escape', echo_script) do |file|
+      with_tempfile_containing('script-test-winrm-escape', echo_script, '.ps1') do |file|
         expect(
           winrm._run_script(
             file.path,
@@ -300,7 +300,7 @@ SHELLWORDS
       $Host.UI.WriteErrorLine([Text.Encoding]::UTF8.GetString((New-Object Byte[] ($bytes_in_k))))
       PS
 
-      with_tempfile_containing('script-test-winrm', contents) do |file|
+      with_tempfile_containing('script-test-winrm', contents, '.ps1') do |file|
         result = winrm._run_script(file.path, [])
         expect(result).to be_success
         expected_nulls = ("\0" * (1024 * 4 + 1)) + "\r\n"
@@ -312,7 +312,7 @@ SHELLWORDS
       contents = 'Write-Host "$env:PT_message_one ${env:PT_message two}"'
       arguments = { :message_one => 'task is running',
                     :"message two" => 'task has run' }
-      with_tempfile_containing('task-test-winrm', contents) do |file|
+      with_tempfile_containing('task-test-winrm', contents, '.ps1') do |file|
         expect(winrm._run_task(file.path, 'environment', arguments).message)
           .to eq("task is running task has run\r\n")
       end
@@ -333,7 +333,7 @@ Height: $Height ($(if ($Height -ne $null) { $Height.GetType().Name } else { 'nul
       arguments = { Age: 30,
                     Height: 5.75,
                     Name: 'John Doe' }
-      with_tempfile_containing('task-params-test-winrm', contents) do |file|
+      with_tempfile_containing('task-params-test-winrm', contents, '.ps1') do |file|
         expect(winrm._run_task(file.path, 'powershell', arguments).message)
           .to match(/\AName: John Doe \(String\).*^Age: 30 \(Int\d+\).*^Height: 5.75 \((Double|Decimal)\).*\Z/m)
       end
@@ -352,7 +352,7 @@ Height: $Height ($(if ($Height -ne $null) { $Height.GetType().Name } else { 'nul
           "bar: $bar ($(if ($bar -ne $null) { $bar.GetType().Name } else { 'null' }))"
       PS
       arguments = { bar: 30 } # note that the script doesn't recognize the 'bar' parameter
-      with_tempfile_containing('task-params-test-winrm', contents) do |file|
+      with_tempfile_containing('task-params-test-winrm', contents, '.ps1') do |file|
         expect(winrm._run_task(file.path, 'powershell', arguments).error)
           .to_not be_nil
       end
@@ -372,7 +372,7 @@ bar: $bar ($(if ($bar -ne $null) { $bar.GetType().Name } else { 'null' }))
 "@
       PS
       arguments = { bar: 30 } # note that the script doesn't recognize the 'bar' parameter
-      with_tempfile_containing('task-params-test-winrm', contents) do |file|
+      with_tempfile_containing('task-params-test-winrm', contents, '.ps1') do |file|
         expect(winrm._run_task(file.path, 'environment', arguments).message)
           .to match(/\Afoo:  \(String\).*^bar: 30 \(String\).*\Z/m) # note that $foo is an empty string and not null
       end
@@ -398,7 +398,7 @@ bar: $bar ($(if ($bar -ne $null) { $bar.GetType().Name } else { 'null' }))
       else { Write-Host "message 6" }
       PS
 
-      with_tempfile_containing('stdout-test-winrm', contents) do |file|
+      with_tempfile_containing('stdout-test-winrm', contents, '.ps1') do |file|
         expect(
           winrm._run_script(file.path, []).stdout
         ).to eq([
@@ -417,7 +417,7 @@ $line = [Console]::In.ReadLine()
 Write-Host $line
 PS
       arguments = { message_one: 'Hello from task', message_two: 'Goodbye' }
-      with_tempfile_containing('tasks-test-stdin-winrm', contents) do |file|
+      with_tempfile_containing('tasks-test-stdin-winrm', contents, '.ps1') do |file|
         expect(winrm._run_task(file.path, 'stdin', arguments).value)
           .to eq("message_one" => "Hello from task", "message_two" => "Goodbye")
       end
@@ -430,7 +430,7 @@ $line = [Console]::In.ReadLine()
 Write-Host $line
 PS
       arguments = { message_one: 'Hello from task', message_two: 'Goodbye' }
-      with_tempfile_containing('tasks-test-both-winrm', contents) do |file|
+      with_tempfile_containing('tasks-test-both-winrm', contents, '.ps1') do |file|
         expect(
           winrm._run_task(file.path, 'both', arguments).message
         ).to eq([
@@ -453,7 +453,7 @@ PS
         exit 42
         PS
 
-        with_tempfile_containing('script-test-winrm', contents) do |file|
+        with_tempfile_containing('script-test-winrm', contents, '.ps1') do |file|
           result = winrm._run_script(file.path, [])
           expect(result).to_not be_success
           expect(result.exit_code).to eq(42)
@@ -466,7 +466,7 @@ PS
           throw "My Error"
           PS
 
-          with_tempfile_containing('script-test-winrm', contents) do |file|
+          with_tempfile_containing('script-test-winrm', contents, '.ps1') do |file|
             result = winrm._run_script(file.path, [])
             expect(result).to_not be_success
             expect(result.exit_code).to eq(1)
@@ -479,7 +479,7 @@ PS
           Write-Error "error stream addition"
           PS
 
-          with_tempfile_containing('script-test-winrm', contents) do |file|
+          with_tempfile_containing('script-test-winrm', contents, '.ps1') do |file|
             result = winrm._run_script(file.path, [])
             expect(result).to_not be_success
           end
@@ -488,7 +488,7 @@ PS
         it "ParserError Code (IncompleteParseException)", winrm: true do
           contents = '{'
 
-          with_tempfile_containing('script-test-winrm', contents) do |file|
+          with_tempfile_containing('script-test-winrm', contents, '.ps1') do |file|
             result = winrm._run_script(file.path, [])
             expect(result).to_not be_success
           end
@@ -499,7 +499,7 @@ PS
           if (1 -badop 2) { Write-Out 'hi' }
           PS
 
-          with_tempfile_containing('script-test-winrm', contents) do |file|
+          with_tempfile_containing('script-test-winrm', contents, '.ps1') do |file|
             result = winrm._run_script(file.path, [])
             expect(result).to_not be_success
           end
@@ -510,7 +510,7 @@ PS
           Foo-Bar
           PS
 
-          with_tempfile_containing('script-test-winrm', contents) do |file|
+          with_tempfile_containing('script-test-winrm', contents, '.ps1') do |file|
             result = winrm._run_script(file.path, [])
             expect(result).to_not be_success
           end
@@ -523,7 +523,7 @@ PS
           Write-Error "error stream addition"
           PS
 
-          with_tempfile_containing('script-test-winrm', contents) do |file|
+          with_tempfile_containing('script-test-winrm', contents, '.ps1') do |file|
             result = winrm._run_script(file.path, [])
             expect(result).to be_success
           end
@@ -537,7 +537,7 @@ PS
           # exit $LASTEXITCODE
           PS
 
-          with_tempfile_containing('script-test-winrm', contents) do |file|
+          with_tempfile_containing('script-test-winrm', contents, '.ps1') do |file|
             result = winrm._run_script(file.path, [])
             expect(result).to be_success
           end
@@ -552,7 +552,7 @@ PS
 
       it 'uploads scripts to the specified tmpdir' do
         contents = "Write-Host $PSScriptRoot"
-        with_tempfile_containing('script-test-winrm', contents) do |file|
+        with_tempfile_containing('script-test-winrm', contents, '.ps1') do |file|
           expect(winrm._run_script(file.path, []).stdout).to match(/#{Regexp.escape(tmpdir)}/)
         end
       end


### PR DESCRIPTION
Support running arbitrary scripts on Windows as long as an extension
handler is registered and its extension added to PATHEXT.

Preserves support for running scripts without an extension as powershell
scripts, but will only do it if they have no extension (rather than when
they have an extension that doesn't match one of the built-in defaults:
.rb, .ps1, .pp).