### PR TITLE
(BOLT-285) Overhaul error handling around Puppet code evaluation

### DIFF
--- a/exe/bolt
+++ b/exe/bolt
@@ -10,6 +10,5 @@ begin
 rescue Bolt::CLIExit
   exit
 rescue Bolt::CLIError => e
-  warn e.message
   exit e.error_code
 end

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -272,6 +272,9 @@ HELP
       validate(options)
 
       options
+    rescue Bolt::CLIError => e
+      warn e.message
+      raise e
     end
 
     def print_help(mode)

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -136,7 +136,9 @@ module Bolt
         end
       end
 
-      def fatal_error(e); end
+      def fatal_error(e)
+        @stream.puts(colorize(:red, e.message))
+      end
     end
 
     def print_message(message)

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -629,8 +629,7 @@ NODES
             mode: 'task',
             action: 'show'
           }
-          expect(Puppet).to receive(:err).with(/unexpected token at/)
-          expect { cli.execute(options) }.to raise_error "Failure while reading task metadata"
+          expect { cli.execute(options) }.to raise_error(/unexpected token at/)
         end
       end
 
@@ -683,8 +682,21 @@ NODES
             mode: 'plan',
             action: 'show'
           }
-          expect(Puppet).to receive(:log_exception)
-          expect { cli.execute(options) }.to raise_error "Failure while reading plans"
+          expect { cli.execute(options) }.to raise_error(/^Syntax error at/)
+        end
+
+        it "plan run displays an error" do
+          plan_name = 'sample::single_task'
+          plan_params = { 'nodes' => nodes.join(',') }
+
+          options = {
+            nodes: node_names,
+            mode: 'plan',
+            action: 'run',
+            object: plan_name,
+            task_options: plan_params
+          }
+          expect { cli.execute(options) }.to raise_error(/^Syntax error at/)
         end
       end
 

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -5,6 +5,14 @@ require 'bolt/cli'
 describe "Bolt::CLI" do
   include BoltSpec::Files
 
+  before(:each) do
+    @output = StringIO.new
+    outputter = Bolt::Outputter::Human.new(@output)
+
+    allow_any_instance_of(Bolt::CLI).to receive(:outputter).and_return(outputter)
+    allow_any_instance_of(Bolt::CLI).to receive(:warn)
+  end
+
   def stub_file(path)
     stat = double('stat', readable?: true, file?: true)
 

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -120,6 +120,6 @@ TASK_OUTPUT
 
   it "handles fatal errors" do
     outputter.fatal_error(Bolt::CLIError.new("oops"))
-    expect(output.string).to eq('')
+    expect(output.string).to eq("oops\n")
   end
 end


### PR DESCRIPTION
Overhauls error handling when calling Puppet functions to catch exceptions before they're passed to the PAL compiler and rethrow them outside the PAL API. This allows us to work with undecorated exceptions and provide simpler error messages. It also prevents Puppet from logging when we would rather display the message directly.

For errors running Bolt subcommands:
- When using human-format output, print errors to stdout and color them
red rather than printing to stderr.
- When using json-format output, errors will no longer be reprinted on
stderr.

Errors parsing Bolt configuration will continue to be output on stderr.