### PR TITLE
(BOLT-295) Update acceptance tests to use .ps1 explicitly

### DIFF
--- a/acceptance/tests/plan_winrm.rb
+++ b/acceptance/tests/plan_winrm.rb
@@ -18,10 +18,10 @@ test_name "C100554: \
 
   step "create plan on bolt controller" do
     on(bolt, "mkdir -p #{dir}/modules/test/{tasks,plans}")
-    create_remote_file(bolt, "#{dir}/modules/test/tasks/a_win", <<-FILE)
+    create_remote_file(bolt, "#{dir}/modules/test/tasks/a_win.ps1", <<-FILE)
     (echo "Line one from task a") > #{testdir}/C100554_plan_artifact.txt
     FILE
-    create_remote_file(bolt, "#{dir}/modules/test/tasks/b_win", <<-FILE)
+    create_remote_file(bolt, "#{dir}/modules/test/tasks/b_win.ps1", <<-FILE)
     (echo "Line two from task b") >> #{testdir}/C100554_plan_artifact.txt
     FILE
     create_remote_file(bolt,

--- a/acceptance/tests/task_winrm.rb
+++ b/acceptance/tests/task_winrm.rb
@@ -11,7 +11,7 @@ test_name "C100551: \
 
   step "create task on bolt controller" do
     on(bolt, "mkdir -p #{dir}/modules/test/tasks")
-    create_remote_file(bolt, "#{dir}/modules/test/tasks/hostname_win", <<-FILE)
+    create_remote_file(bolt, "#{dir}/modules/test/tasks/hostname_win.ps1", <<-FILE)
     [System.Net.Dns]::GetHostByName(($env:computerName))
     FILE
   end


### PR DESCRIPTION
Updates acceptance tests to create powershell scripts with a .ps1
extension, rather than relying on previous undocumented behavior of Bolt
appending .ps1 to scripts without an extension.