### PR TITLE
(BOLT-81) implement disable_ssh_agent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ ssh:
 
 `insecure`: If true, host key validation will be skipped when connecting over SSH. (default: false)
 
+`disable-ssh-agent`: If true, ssh-agent will be skipped when connecting over SSH. (default: false)
+
 `private-key`: The path to the private key file to use for SSH authentication.
 
 `connect-timeout`: Maximum amount of time to allow for an SSH connection to be established, in seconds.

--- a/acceptance/lib/acceptance/bolt_command_helper.rb
+++ b/acceptance/lib/acceptance/bolt_command_helper.rb
@@ -8,6 +8,7 @@ module Acceptance
     # @option flags [String] '--user' the user to run the command as
     # @option flags [String] '--password' the password for the user
     # @option flags [nil] '--insecure' specify nil to use
+    # @option flags [nil] '--disable-ssh-agent' specify nil to use
     # @param [Hash] opts the options hash for this method
     def bolt_command_on(host, command, flags = {}, opts = {})
       platform = host['platform']

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -184,6 +184,10 @@ HELP
                 "Whether to connect insecurely ") do |insecure|
           results[:insecure] = insecure
         end
+        opts.on('--disable-ssh-agent',
+                "Whether to disable ssh-agent ") do |disable_ssh_agent|
+          results[:disable_ssh_agent] = disable_ssh_agent
+        end
         opts.on('--transport TRANSPORT', TRANSPORTS,
                 "Specify a default transport: #{TRANSPORTS.join(', ')}") do |t|
           results[:transport] = t

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -18,14 +18,15 @@ module Bolt
       format: 'human'
     }.freeze
 
-    TRANSPORT_OPTIONS = %i[insecure password run_as sudo_password extensions
-                           key tty tmpdir user connect_timeout cacert
+    TRANSPORT_OPTIONS = %i[insecure disable_ssh_agent password run_as sudo_password
+                           extensions key tty tmpdir user connect_timeout cacert
                            token_file orch_task_environment service_url].freeze
 
     TRANSPORT_DEFAULTS = {
       connect_timeout: 10,
       orch_task_environment: 'production',
       insecure: false,
+      disable_ssh_agent: false,
       tty: false
     }.freeze
 
@@ -102,6 +103,9 @@ module Bolt
         end
         if data['ssh']['insecure']
           self[:transports][:ssh][:insecure] = data['ssh']['insecure']
+        end
+        if data['ssh']['disable-ssh-agent']
+          self[:transports][:ssh][:disable_ssh_agent] = data['ssh']['disable-ssh-agent']
         end
         if data['ssh']['connect-timeout']
           self[:transports][:ssh][:connect_timeout] = data['ssh']['connect-timeout']

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -31,6 +31,7 @@ module Bolt
       @user = @target.user || transport_conf[:user]
       @password = @target.password || transport_conf[:password]
       @key = transport_conf[:key]
+      @disable_ssh_agent = transport_conf[:disable_ssh_agent]
       @cacert = transport_conf[:cacert]
       @tty = transport_conf[:tty]
       @insecure = transport_conf[:insecure]

--- a/lib/bolt/node/ssh.rb
+++ b/lib/bolt/node/ssh.rb
@@ -35,6 +35,7 @@ module Bolt
                                   else
                                     Net::SSH::Verifiers::Secure.new
                                   end
+      options[:use_agent] = !@disable_ssh_agent
       options[:timeout] = @connect_timeout if @connect_timeout
 
       @session = Net::SSH.start(@target.host, @user, options)


### PR DESCRIPTION
Prior to this commit, bolt reported an error when Net-SSH
attempted to use an unconfigured ssh-agent.

Net-SSH offers a use_agent option which can be used to skip ssh-agent.

With this commit, bolt offers a disable-ssh-agent option
which can be used to used to specifiy the Net-SSH use_agent option.