### PR TITLE
(BOLT-268) Switch from built-in Logger to Logging gem

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "terminal-table", "~> 1.8.0"
   spec.add_dependency "winrm", "~> 2.0"
   spec.add_dependency "winrm-fs", "~> 1.0"
+  spec.add_dependency "logging", "~> 2.2"
 
   # Dependencies of our vendored puppet, etc
   spec.add_dependency "CFPropertyList", "~> 2.2"

--- a/lib/bolt/formatter.rb
+++ b/lib/bolt/formatter.rb
@@ -1,9 +1,0 @@
-require 'logger'
-
-module Bolt
-  class Formatter < Logger::Formatter
-    def call(severity, time, progname, msg)
-      "#{format_datetime(time)} #{severity} #{progname}: #{msg2str(msg)}\n"
-    end
-  end
-end

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -1,8 +1,8 @@
-require 'bolt/logger'
 require 'bolt/node_uri'
 require 'bolt/result'
 require 'bolt/config'
 require 'bolt/target'
+require 'logging'
 
 module Bolt
   class Node
@@ -53,8 +53,7 @@ module Bolt
       @orch_task_environment = transport_conf[:orch_task_environment]
       @extensions = transport_conf[:extensions]
 
-      @logger = Logger.get_logger(progname: @host)
-      @transport_logger = Logger.get_logger(progname: @host, log_level: Logger::WARN)
+      @logger = Logging.logger[@host]
     end
 
     def upload(source, destination)

--- a/lib/bolt/node/ssh.rb
+++ b/lib/bolt/node/ssh.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'shellwords'
+require 'logging'
 require 'net/ssh'
 require 'net/scp'
 require 'bolt/node/output'
@@ -19,8 +20,10 @@ module Bolt
     end
 
     def connect
+      transport_logger = Logging.logger[Net::SSH]
+      transport_logger.level = :warn
       options = {
-        logger: @transport_logger,
+        logger: transport_logger,
         non_interactive: true
       }
 

--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -1,5 +1,6 @@
 require 'winrm'
 require 'winrm-fs'
+require 'logging'
 require 'bolt/result'
 require 'base64'
 require 'set'
@@ -39,7 +40,9 @@ module Bolt
 
       Timeout.timeout(@connect_timeout) do
         @connection = ::WinRM::Connection.new(options)
-        @connection.logger = @transport_logger
+        transport_logger = Logging.logger[::WinRM]
+        transport_logger.level = :warn
+        @connection.logger = transport_logger
 
         @session = @connection.shell(:powershell)
         @session.run('$PSVersionTable.PSVersion')

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -236,11 +236,12 @@ NODES
     end
 
     describe "log level" do
-      after(:each) { Logger.configure(log_level: Logger::NOTICE) }
+      let(:root_logger) { Logging.logger[:root] }
+      after(:each) { root_logger.level = :notice }
       it "is not sensitive to ordering of debug and verbose" do
         cli = Bolt::CLI.new(%w[command run --nodes foo --debug --verbose])
         cli.parse
-        expect(cli.config[:log_level]).to eq(Logger::DEBUG)
+        expect(root_logger.level).to eq(Logging.level_num(:debug))
       end
     end
 

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -46,15 +46,13 @@ describe Bolt::Config do
     end
 
     it "warns if both defaults exist, and uses the new default" do
-      logger = double('logger')
-      expect(logger).to receive(:warn).with("Config files found at #{default_path}, #{alt_path}, using the first")
-      expect(Logger).to receive(:get_logger).and_return(logger)
-
       expect(File).to receive(:exist?).with(default_path).and_return(true)
       expect(File).to receive(:exist?).with(alt_path).and_return(true)
       expect(File).to receive(:open).with(default_path, 'r:UTF-8').and_raise(Errno::ENOENT)
 
       config.load_file(nil)
+
+      expect(@log_output.readline).to match(/WARN.*Config files found at #{default_path}, #{alt_path}, using the first/)
     end
 
     it "loads from the specified file" do

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -164,13 +164,10 @@ describe "Bolt::Executor" do
           .and_return(success)
       end
 
-      logger = double('logger')
-      allow(logger).to receive(:debug)
-      expect(logger).to receive(:log).with(Logger::NOTICE, "Starting command run '#{command}' on #{nodes_string}")
-      expect(logger).to receive(:log).with(Logger::NOTICE, "Ran command '#{command}' on 2 nodes with 0 failures")
-      allow(Logger).to receive(:get_logger).and_return(logger)
-
       executor.run_command(nodes, command)
+
+      expect(@log_output.readline).to match(/INFO.*Starting command run .* on .*/)
+      expect(@log_output.readline).to match(/INFO.*Ran command .* on 2 nodes with 0 failures/)
     end
 
     it "logs scripts" do
@@ -181,13 +178,10 @@ describe "Bolt::Executor" do
           .and_return(success)
       end
 
-      logger = double('logger')
-      allow(logger).to receive(:debug)
-      expect(logger).to receive(:log).with(Logger::NOTICE, "Starting script run #{script} on #{nodes_string}")
-      expect(logger).to receive(:log).with(Logger::NOTICE, "Ran script '#{script}' on 2 nodes with 0 failures")
-      allow(Logger).to receive(:get_logger).and_return(logger)
-
       executor.run_script(nodes, script, [])
+
+      expect(@log_output.readline).to match(/INFO.*Starting script run .* on .*/)
+      expect(@log_output.readline).to match(/INFO.*Ran script .* on 2 nodes with 0 failures/)
     end
 
     it "logs tasks" do
@@ -198,13 +192,10 @@ describe "Bolt::Executor" do
           .and_return(success)
       end
 
-      logger = double('logger')
-      allow(logger).to receive(:debug)
-      expect(logger).to receive(:log).with(Logger::NOTICE, 'Starting task service::restart on ["node1", "node2"]')
-      expect(logger).to receive(:log).with(Logger::NOTICE, "Ran task 'service::restart' on 2 nodes with 0 failures")
-      allow(Logger).to receive(:get_logger).and_return(logger)
-
       executor.run_task(nodes, task, 'both', task_arguments)
+
+      expect(@log_output.readline).to match(/INFO.*Starting task service::restart on .*/)
+      expect(@log_output.readline).to match(/INFO.*Ran task 'service::restart' on 2 nodes with 0 failures/)
     end
 
     it "logs uploads" do
@@ -215,14 +206,10 @@ describe "Bolt::Executor" do
           .and_return(success)
       end
 
-      logger = double('logger')
-      allow(logger).to receive(:debug)
-      expect(logger).to receive(:log).with(Logger::NOTICE,
-                                           "Starting file upload from #{script} to #{dest} on #{nodes_string}")
-      expect(logger).to receive(:log).with(Logger::NOTICE, "Ran upload '#{script}' on 2 nodes with 0 failures")
-      allow(Logger).to receive(:get_logger).and_return(logger)
-
       executor.file_upload(nodes, script, dest)
+
+      expect(@log_output.readline).to match(/INFO.*Starting file upload from .* to .* on .*/)
+      expect(@log_output.readline).to match(/INFO.*Ran upload .* on 2 nodes with 0 failures/)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 require 'bolt'
+require 'bolt/logger'
+require 'logging'
+require 'rspec/logging_helper'
 
 $LOAD_PATH.unshift File.join(__dir__, 'lib')
 
@@ -14,6 +17,10 @@ RSpec.shared_context 'reset puppet settings' do
 end
 
 RSpec.configure do |config|
+  Bolt::Logger.initialize_logging
+  include RSpec::LoggingHelper
+  config.capture_log_messages
+
   # rspec-expectations config
   config.expect_with :rspec do |expectations|
     #     be_bigger_than(2).and_smaller_than(4).description


### PR DESCRIPTION
This commit swaps out the built-in Ruby Logger class for the Logging
gem, modeled after log4j.

This allows us much better control over which components log at which
levels, as well as allowing multiple log destinations (ie. both STDERR
and a file). It also includes built-in support for problems like
colorization that we would otherwise need to roll on our own.