### PR TITLE
(BOLT-222) run_* functions will raise an exception when they fail

### DIFF
--- a/exe/bolt
+++ b/exe/bolt
@@ -9,6 +9,6 @@ begin
   cli.execute(opts)
 rescue Bolt::CLIExit
   exit
-rescue Bolt::CLIError => e
+rescue Bolt::Error => e
   exit e.error_code
 end

--- a/lib/bolt/execution_result.rb
+++ b/lib/bolt/execution_result.rb
@@ -78,6 +78,23 @@ module Bolt
       @result_hash.values
     end
 
+    # Expects to be called with a configured Puppet compiler or error.instance? will fail
+    def unwrap
+      iterator.map do |node, output|
+        if output.is_a?(Puppet::DataTypes::Error)
+          # Get the original error hash used to initialize the Error type object.
+          result = output.partial_result || {}
+          result[:_error] = { msg: output.message,
+                              kind: output.kind,
+                              details: output.details,
+                              issue_code: output.issue_code }
+          { node: node, status: 'failed', result: result }
+        else
+          { node: node, status: 'finished', result: output }
+        end
+      end
+    end
+
     def _pcore_init_hash
       @result_hash
     end

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -138,6 +138,9 @@ module Bolt
 
       def fatal_error(e)
         @stream.puts(colorize(:red, e.message))
+        if e.is_a? Bolt::RunFailure
+          @stream.puts ::JSON.pretty_generate(e.resultset)
+        end
       end
     end
 

--- a/modules/boltlib/lib/puppet/functions/run_command.rb
+++ b/modules/boltlib/lib/puppet/functions/run_command.rb
@@ -5,6 +5,8 @@
 # * A target is a String with a targets's hostname or a Target.
 # * The returned value contains information about the result per target.
 #
+require 'bolt/error'
+
 Puppet::Functions.create_function(:run_command) do
   local_types do
     type 'TargetOrTargets = Variant[String[1], Target, Array[TargetOrTargets]]'
@@ -12,11 +14,13 @@ Puppet::Functions.create_function(:run_command) do
 
   dispatch :run_command do
     param 'String[1]', :command
-    repeated_param 'TargetOrTargets', :targets
+    param 'TargetOrTargets', :targets
+    optional_param 'Hash[String[1], Any]', :options
     return_type 'ExecutionResult'
   end
 
-  def run_command(command, *targets)
+  def run_command(command, targets, options = nil)
+    options ||= {}
     unless Puppet[:tasks]
       raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
         Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, operation: 'run_command'
@@ -31,16 +35,22 @@ Puppet::Functions.create_function(:run_command) do
     end
 
     # Ensure that that given targets are all Target instances
+    targets = [targets] unless targets.is_a?(Array)
     targets = targets.flatten.map { |t| t.is_a?(String) ? Bolt::Target.new(t) : t }
 
     if targets.empty?
       call_function('debug', "Simulating run_command('#{command}') - no targets given - no action taken")
-      Bolt::ExecutionResult::EMPTY_RESULT
+      r = Bolt::ExecutionResult::EMPTY_RESULT
     else
       # Awaits change in the executor, enabling it receive Target instances
       hosts = targets.map(&:host)
 
-      Bolt::ExecutionResult.from_bolt(executor.run_command(executor.from_uris(hosts), command))
+      r = Bolt::ExecutionResult.from_bolt(executor.run_command(executor.from_uris(hosts), command))
     end
+
+    if !r.ok && options['_abort'] != false
+      raise Bolt::RunFailure.new(r, 'run_command', command)
+    end
+    r
   end
 end

--- a/modules/boltlib/spec/functions/file_upload_spec.rb
+++ b/modules/boltlib/spec/functions/file_upload_spec.rb
@@ -18,7 +18,7 @@ describe 'file_upload' do
     let(:hosts) { [hostname] }
     let(:host) { stub(uri: hostname) }
     let(:message) { 'uploaded' }
-    let(:result) { { value: message } }
+    let(:result) { { 'value' => message } }
     let(:exec_result) { Bolt::ExecutionResult.from_bolt(host => result) }
     let(:module_root) { File.expand_path(fixtures('modules', 'test')) }
     let(:full_path) { File.join(module_root, 'files/uploads/index.html') }
@@ -55,7 +55,7 @@ describe 'file_upload' do
       let(:hosts) { [hostname, hostname2] }
       let(:host2) { stub(uri: hostname2) }
       let(:message2) { 'received' }
-      let(:result2) { { value: message2 } }
+      let(:result2) { { 'value' => message2 } }
       let(:exec_result) { Bolt::ExecutionResult.from_bolt(host => result, host2 => result2) }
 
       it 'propagates multiple hosts and returns multiple results' do
@@ -63,8 +63,31 @@ describe 'file_upload' do
         executor.expects(:file_upload).with([host, host2], full_path, destination).returns(host => result,
                                                                                            host2 => result2)
 
-        is_expected.to run.with_params('test/uploads/index.html', destination, hostname, hostname2)
+        is_expected.to run.with_params('test/uploads/index.html', destination, [hostname, hostname2])
                           .and_return(exec_result)
+      end
+
+      context 'when upload fails on one node' do
+        let(:failresult) { { 'error' => {} } }
+        let(:exec_fail) { Bolt::ExecutionResult.from_bolt(host => result, host2 => failresult) }
+
+        it 'errors by default' do
+          executor.expects(:from_uris).with(hosts).returns([host, host2])
+          executor.expects(:file_upload).with([host, host2], full_path, destination).returns(host => result,
+                                                                                             host2 => failresult)
+
+          is_expected.to run.with_params('test/uploads/index.html', destination, [hostname, hostname2])
+                            .and_raise_error(Bolt::RunFailure)
+        end
+
+        it 'does not error with _abort false' do
+          executor.expects(:from_uris).with(hosts).returns([host, host2])
+          executor.expects(:file_upload).with([host, host2], full_path, destination).returns(host => result,
+                                                                                             host2 => failresult)
+
+          is_expected.to run.with_params('test/uploads/index.html', destination, [hostname, hostname2],
+                                         '_abort' => false)
+        end
       end
     end
 
@@ -72,7 +95,7 @@ describe 'file_upload' do
       executor.expects(:from_uris).never
       executor.expects(:file_upload).never
 
-      is_expected.to run.with_params('test/uploads/index.html', destination)
+      is_expected.to run.with_params('test/uploads/index.html', destination, [])
                         .and_return(Bolt::ExecutionResult::EMPTY_RESULT)
     end
 
@@ -80,7 +103,7 @@ describe 'file_upload' do
       executor.expects(:from_uris).never
       executor.expects(:file_upload).never
 
-      is_expected.to run.with_params('test/uploads/nonesuch.html', destination)
+      is_expected.to run.with_params('test/uploads/nonesuch.html', destination, [])
                         .and_raise_error(/No such file or directory: .*nonesuch\.html/)
     end
   end
@@ -88,7 +111,7 @@ describe 'file_upload' do
   context 'without bolt feature present' do
     it 'fails and reports that bolt library is required' do
       Puppet.features.stubs(:bolt?).returns(false)
-      is_expected.to run.with_params('test/uploads/nonesuch.html', '/some/place')
+      is_expected.to run.with_params('test/uploads/nonesuch.html', '/some/place', [])
                         .and_raise_error(/The 'bolt' library is required to do file uploads/)
     end
   end
@@ -97,7 +120,7 @@ describe 'file_upload' do
     let(:tasks_enabled) { false }
 
     it 'fails and reports that file_upload is not available' do
-      is_expected.to run.with_params('test/uploads/nonesuch.html', '/some/place')
+      is_expected.to run.with_params('test/uploads/nonesuch.html', '/some/place', [])
                         .and_raise_error(/The task operation 'file_upload' is not available/)
     end
   end

--- a/modules/boltlib/spec/functions/run_command_spec.rb
+++ b/modules/boltlib/spec/functions/run_command_spec.rb
@@ -49,7 +49,7 @@ describe 'run_command' do
         executor.expects(:from_uris).with(hosts).returns([host, host2])
         executor.expects(:run_command).with([host, host2], command).returns(host => result, host2 => result2)
 
-        is_expected.to run.with_params(command, hostname, hostname2).and_return(exec_result)
+        is_expected.to run.with_params(command, [hostname, hostname2]).and_return(exec_result)
       end
 
       it 'with propagates multiple Targets and returns multiple results' do
@@ -58,7 +58,26 @@ describe 'run_command' do
 
         target = Bolt::Target.new(hostname)
         target2 = Bolt::Target.new(hostname2)
-        is_expected.to run.with_params(command, target, target2).and_return(exec_result)
+        is_expected.to run.with_params(command, [target, target2]).and_return(exec_result)
+      end
+
+      context 'when a command fails on one node' do
+        let(:failresult) { { 'error' => {} } }
+        let(:exec_fail) { Bolt::ExecutionResult.from_bolt(host => result, host2 => failresult) }
+
+        it 'errors by default' do
+          executor.expects(:from_uris).with(hosts).returns([host, host2])
+          executor.expects(:run_command).with([host, host2], command).returns(host => result, host2 => failresult)
+
+          is_expected.to run.with_params(command, [hostname, hostname2]).and_raise_error(Bolt::RunFailure)
+        end
+
+        it 'does not error with _abort false' do
+          executor.expects(:from_uris).with(hosts).returns([host, host2])
+          executor.expects(:run_command).with([host, host2], command).returns(host => result, host2 => failresult)
+
+          is_expected.to run.with_params(command, [hostname, hostname2], '_abort' => false)
+        end
       end
     end
 
@@ -66,14 +85,15 @@ describe 'run_command' do
       executor.expects(:from_uris).never
       executor.expects(:run_command).never
 
-      is_expected.to run.with_params(command).and_return(Bolt::ExecutionResult::EMPTY_RESULT)
+      is_expected.to run.with_params(command, []).and_return(Bolt::ExecutionResult::EMPTY_RESULT)
     end
   end
 
   context 'without bolt feature present' do
     it 'fails and reports that bolt library is required' do
       Puppet.features.stubs(:bolt?).returns(false)
-      is_expected.to run.with_params('echo hello').and_raise_error(/The 'bolt' library is required to run a command/)
+      is_expected.to run.with_params('echo hello', [])
+                        .and_raise_error(/The 'bolt' library is required to run a command/)
     end
   end
 
@@ -81,7 +101,8 @@ describe 'run_command' do
     let(:tasks_enabled) { false }
 
     it 'fails and reports that run_command is not available' do
-      is_expected.to run.with_params('echo hello').and_raise_error(/The task operation 'run_command' is not available/)
+      is_expected.to run.with_params('echo hello', [])
+                        .and_raise_error(/The task operation 'run_command' is not available/)
     end
   end
 end

--- a/spec/fixtures/modules/results/plans/test_methods.pp
+++ b/spec/fixtures/modules/results/plans/test_methods.pp
@@ -3,7 +3,7 @@ plan results::test_methods(
   Boolean $fail = false
 ) {
   if($fail) {
-    $result = run_task('results', [$target], 'fail' => 'true')
+    $result = run_task('results', [$target], 'fail' => 'true', '_abort' => false)
   } else {
     $result = run_task('results', [$target])
   }

--- a/spec/fixtures/modules/sample/plans/single_task.pp
+++ b/spec/fixtures/modules/sample/plans/single_task.pp
@@ -3,6 +3,7 @@ plan sample::single_task(String $nodes) {
   $node_array = split($nodes, ',')
   run_task (
     "sample::echo", $node_array,
-    message => "hi there"
+    message => "hi there",
+    '_abort' => false,
   )
 }


### PR DESCRIPTION
Previously the run_* functions would return ExecutionResults containing
failures by default leaving it up to the plan author to check `ok`
before continting. Now run_* functions will check the ExecutionResult
and raise a RunFailure exception unless they are successful. The
'_abort' option can be passed to allow failing results to be returned