### PR TITLE
(BOLT-303) Speed up tasks/plans when using winrm from Windows host

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -390,6 +390,14 @@ HELP
     def execute(options)
       if options[:mode] == 'plan' || options[:mode] == 'task'
         begin
+          if Gem.win_platform?
+            # Windows 'fix' for openssl behaving strangely. Prevents very slow operation
+            # of random_bytes later when establishing winrm connections from a Windows host.
+            # See https://github.com/rails/rails/issues/25805 for background.
+            require 'openssl'
+            OpenSSL::Random.random_bytes(1)
+          end
+
           require_relative '../../vendored/require_vendored'
         rescue LoadError
           raise Bolt::CLIError, "Puppet must be installed to execute tasks"


### PR DESCRIPTION
An issue with OpenSSL on Windows results in a very slow call to
`random_bytes` unless done very early in the program. Make sure we
initialize early to avoid this issue if we're doing anything complicated
on Windows (like using Puppet).