### PR TITLE
(BOLT-209) Return exitcode 2 when some nodes fail an operation

### DIFF
--- a/exe/bolt
+++ b/exe/bolt
@@ -6,7 +6,8 @@ require 'bolt/cli'
 cli = Bolt::CLI.new(ARGV)
 begin
   opts = cli.parse
-  cli.execute(opts)
+  exitcode = cli.execute(opts)
+  exit exitcode
 rescue Bolt::CLIExit
   exit
 rescue Bolt::Error => e

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -430,6 +430,7 @@ HELP
       if options[:mode] == 'plan'
         executor = Bolt::Executor.new(@config, options[:noop], true)
         execute_plan(executor, options)
+        code = 0
       else
         executor = Bolt::Executor.new(@config, options[:noop])
         targets = options[:nodes]
@@ -471,7 +472,10 @@ HELP
         end
 
         outputter.print_summary(results, elapsed_time)
+        successful = results.values.all?(&:success?)
+        code = successful ? 0 : 2
       end
+      code
     rescue Bolt::Error => e
       outputter.fatal_error(e)
       raise e


### PR DESCRIPTION
Previously, as long as an operation was started successfully, bolt would
always exit 0, regardless of whether it actually completed successfully.
This meant that it was impossible to tell whether a task or command had
actually run on the nodes in question, only whether the task exists
or whether the command was properly interpreted by bolt.

For tasks, scripts, comamnds and file uploads, we now exit 2 if any node
fails. The behavior for plans is unchanged, as we still don't have a
solid definition of a plan "result". It can now be assumed that if bolt
exits 0, the operation completed successfully on every node.