### PR TITLE
(BOLT-311) Provide Ruby 2.0 fallback for exception causes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Bolt is a Ruby command-line tool for executing commands, scripts, and tasks on r
 
 > For complete usage and installation details, see the [Puppet Bolt docs](https://puppet.com/docs/bolt). For contribution information, including alternate installation methods and running from source, see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
+> Note that details of some exceptions generated within plans will be lost when using Ruby 2.0.
+
 ## Installation
 
 ### On *nix

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -538,8 +538,9 @@ HELP
             yield compiler
           rescue Puppet::PreformattedError => err
             # Puppet sometimes rescues exceptions notes the location and reraises
-            # For now return the original error.
-            if err.cause
+            # For now return the original error. Exception cause support was added in Ruby 2.1
+            # so we fall back to reporting the error we got for Ruby 2.0.
+            if err.respond_to?(:cause) && err.cause
               if err.cause.is_a? Bolt::Error
                 err.cause
               else

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -892,6 +892,27 @@ NODES
           expect(JSON.parse(@output.string)).to be
         end
 
+        it "raises errors from the executor" do
+          task_name = 'sample::echo'
+          input_method = 'both'
+
+          expect(executor)
+            .to receive(:run_task)
+            .with(
+              targets,
+              %r{modules/sample/tasks/echo.sh$}, input_method, {}
+            ).and_raise("Could not connect to target")
+
+          options = {
+            nodes: targets,
+            mode: 'task',
+            action: 'run',
+            object: task_name,
+            task_options: {}
+          }
+          expect { cli.execute(options) }.to raise_error(/Could not connect to target/)
+        end
+
         it "runs an init task given a module name" do
           task_name = 'sample'
           task_params = { 'message' => 'hi' }
@@ -1085,6 +1106,28 @@ NODES
           expect(JSON.parse(@output.string)).to eq(
             [{ 'node' => 'foo', 'status' => 'finished', 'result' => { '_output' => 'yes' } }]
           )
+        end
+
+        it "raises errors from the executor" do
+          plan_name = 'sample::single_task'
+          plan_params = { 'nodes' => targets.map(&:host).join(',') }
+          input_method = 'both'
+
+          expect(executor)
+            .to receive(:run_task)
+            .with(
+              targets,
+              %r{modules/sample/tasks/echo.sh$}, input_method, 'message' => 'hi there'
+            ).and_raise("Could not connect to target")
+
+          options = {
+            nodes: targets,
+            mode: 'plan',
+            action: 'run',
+            object: plan_name,
+            task_options: plan_params
+          }
+          expect { cli.execute(options) }.to raise_error(/Could not connect to target/)
         end
 
         it "formats results of a failing task" do


### PR DESCRIPTION
Exception causes were added in Ruby 2.1. We want to continue using them.
Provide a fallback to inferior error handling for Ruby 2.0.