### PR TITLE
(BOLT-277) Provide pointers for common WinRM connection error cases

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -424,7 +424,7 @@ HELP
         elsif options[:mode] == 'plan'
           outputter.print_table(list_plans)
         end
-        return
+        return 0
       end
 
       if options[:mode] == 'plan'

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -121,7 +121,7 @@ HELP
       parser = OptionParser.new('') do |opts|
         unless results[:mode] == 'plan'
           opts.on('-n', '--nodes NODES',
-                  'Node(s) to connect to in URI format [protocol://]host[:port]',
+                  'Node(s) to connect to in URI format [protocol://]host[:port] (Optional)',
                   'Eg. --nodes bolt.puppet.com',
                   'Eg. --nodes localhost,ssh://nix.com:2222,winrm://windows.puppet.com',
                   "\n",
@@ -129,7 +129,8 @@ HELP
                   '* nodes from a file, or \'-\' to read from stdin',
                   '* Windows nodes must specify protocol with winrm://',
                   '* protocol is `ssh` by default, may be `ssh` or `winrm`',
-                  '* port is `22` by default for SSH, `5985` for winrm (Optional)') do |nodes|
+                  '* port defaults to `22` for SSH',
+                  '* port defaults to `5985` or `5986` for WinRM, based on the --insecure setting') do |nodes|
             results[:nodes] += parse_nodes(nodes)
             results[:nodes].uniq!
           end
@@ -154,7 +155,7 @@ HELP
           results[:key] = key
         end
         opts.on('--tmpdir DIR',
-                "The directory to upload and execute temporary files on the target(Optional)") do |tmpdir|
+                "The directory to upload and execute temporary files on the target (Optional)") do |tmpdir|
           results[:tmpdir] = tmpdir
         end
         opts.on('-c', '--concurrency CONCURRENCY', Integer,


### PR DESCRIPTION
Bolt defaults to using SSL for WinRM unless explicitly instructed
otherwise, but the default configuration for Windows hosts is to not accept
SSL connections for WinRM. Because of that, a common failure scenario is to
try to run bolt against a node and have it fail to connect because the SSL
port isn't open. Since we want to maintain a secure default, this commit
adds logic to detect that case and mention what the problem might be,
pointing users to try --insecure.

Another potential error case is trying to use SSL to connect to the non-SSL
port, which result in an extremely arcane OpenSSL error:

    SSL_connect returned=1 errno=0 state=SSLv2/v3 read server hello A:
unknown protocol

We now also detect this scenario and mention the likely cause.

Also corrected the description of the default port behavior for WinRM.

And fixed an issue with `bolt task show`/`bolt plan show` lacking exit codes.