### PR TITLE
(maint) Refactor logic out of Node class

### DIFF
--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -132,7 +132,7 @@ module Bolt
       callback = block_given? ? Proc.new : nil
 
       r = on(nodes, callback) do |node|
-        @logger.debug { "Uploading: '#{source}' to #{node.uri}" }
+        @logger.debug { "Uploading: '#{source}' to #{destination} on #{node.uri}" }
         node_result = node.upload(source, destination)
         @logger.debug("Result on #{node.uri}: #{JSON.dump(node_result.value)}")
         node_result

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -49,28 +49,6 @@ module Bolt
     def uri
       @target.uri
     end
-
-    def upload(source, destination)
-      @logger.debug { "Uploading #{source} to #{destination}" }
-      result = _upload(source, destination)
-      if result.success?
-        Bolt::Result.new(@target, message: "Uploaded '#{source}' to '#{@target.host}:#{destination}'")
-      else
-        result
-      end
-    end
-
-    def run_command(command)
-      _run_command(command)
-    end
-
-    def run_script(script, arguments)
-      _run_script(script, arguments)
-    end
-
-    def run_task(task, input_method, arguments)
-      _run_task(task, input_method, arguments)
-    end
   end
 end
 

--- a/lib/bolt/node/orch.rb
+++ b/lib/bolt/node/orch.rb
@@ -43,7 +43,7 @@ module Bolt
       end
     end
 
-    def _run_task(task, _input_method, arguments)
+    def run_task(task, _input_method, arguments)
       body = { task: task_name_from_path(task),
                environment: @orch_task_environment,
                noop: arguments['_noop'],
@@ -88,16 +88,16 @@ module Bolt
       Bolt::Result.for_command(@target, result.value['stdout'], result.value['stderr'], result.value['exit_code'])
     end
 
-    def _run_command(command, options = {})
-      result = _run_task(BOLT_MOCK_FILE,
-                         'stdin',
-                         action: 'command',
-                         command: command,
-                         options: options)
+    def run_command(command, options = {})
+      result = run_task(BOLT_MOCK_FILE,
+                        'stdin',
+                        action: 'command',
+                        command: command,
+                        options: options)
       unwrap_bolt_result(result)
     end
 
-    def _upload(source, destination)
+    def upload(source, destination)
       content = File.open(source, &:read)
       content = Base64.encode64(content)
       mode = File.stat(source).mode
@@ -107,12 +107,12 @@ module Bolt
         content: content,
         mode: mode
       }
-      result = _run_task(BOLT_MOCK_FILE, 'stdin', params)
-      result = Bolt::Result.new(@target) unless result.error_hash
+      result = run_task(BOLT_MOCK_FILE, 'stdin', params)
+      result = Bolt::Result.for_upload(@target, source, destination) unless result.error_hash
       result
     end
 
-    def _run_script(script, arguments)
+    def run_script(script, arguments)
       content = File.open(script, &:read)
       content = Base64.encode64(content)
       params = {
@@ -120,7 +120,7 @@ module Bolt
         content: content,
         arguments: arguments
       }
-      unwrap_bolt_result(_run_task(BOLT_MOCK_FILE, 'stdin', params))
+      unwrap_bolt_result(run_task(BOLT_MOCK_FILE, 'stdin', params))
     end
   end
 end

--- a/lib/bolt/node/ssh.rb
+++ b/lib/bolt/node/ssh.rb
@@ -160,9 +160,9 @@ module Bolt
       result_output
     end
 
-    def _upload(source, destination)
+    def upload(source, destination)
       write_remote_file(source, destination)
-      Bolt::Result.new(@target)
+      Bolt::Result.for_upload(@target, source, destination)
     rescue StandardError => e
       Bolt::Result.from_exception(@target, e)
     end
@@ -253,7 +253,7 @@ SCRIPT
       end
     end
 
-    def _run_command(command)
+    def run_command(command)
       output = execute(command, sudoable: true)
       Bolt::Result.for_command(@target, output.stdout.string, output.stderr.string, output.exit_code)
     # TODO: We should be able to rely on the excutor for this but it will mean
@@ -262,7 +262,7 @@ SCRIPT
       Bolt::Result.from_exception(@target, e)
     end
 
-    def _run_script(script, arguments)
+    def run_script(script, arguments)
       with_remote_file(script) do |remote_path|
         output = execute("'#{remote_path}' #{Shellwords.join(arguments)}",
                          sudoable: true)
@@ -274,7 +274,7 @@ SCRIPT
       Bolt::Result.from_exception(@target, e)
     end
 
-    def _run_task(task, input_method, arguments)
+    def run_task(task, input_method, arguments)
       export_args = {}
       stdin, output = nil
 

--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -460,9 +460,9 @@ PS
       end
     end
 
-    def _upload(source, destination)
+    def upload(source, destination)
       write_remote_file(source, destination)
-      Bolt::Result.new(@target)
+      Bolt::Result.for_upload(@target, source, destination)
     # TODO: we should rely on the executor for this
     rescue StandardError => ex
       Bolt::Result.from_exception(@target, ex)
@@ -510,7 +510,7 @@ PS
       end
     end
 
-    def _run_command(command)
+    def run_command(command)
       output = execute(command)
       Bolt::Result.for_command(@target, output.stdout.string, output.stderr.string, output.exit_code)
     # TODO: we should rely on the executor for this
@@ -518,7 +518,7 @@ PS
       Bolt::Result.from_exception(@target, e)
     end
 
-    def _run_script(script, arguments)
+    def run_script(script, arguments)
       with_remote_file(script) do |remote_path|
         if powershell_file?(remote_path)
           mapped_args = arguments.map do |a|
@@ -552,7 +552,7 @@ catch
       Bolt::Result.from_exception(@target, e)
     end
 
-    def _run_task(task, input_method, arguments)
+    def run_task(task, input_method, arguments)
       if STDIN_METHODS.include?(input_method)
         stdin = JSON.dump(arguments)
       end

--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -62,6 +62,10 @@ module Bolt
       new(target, value: value)
     end
 
+    def self.for_upload(target, source, destination)
+      new(target, message: "Uploaded '#{source}' to '#{target.host}:#{destination}'")
+    end
+
     def initialize(target, error: nil, message: nil, value: nil)
       @target = target
       @value = value || {}

--- a/spec/bolt/node_spec.rb
+++ b/spec/bolt/node_spec.rb
@@ -34,17 +34,4 @@ describe Bolt::Node do
       expect(node.password).to eq('better')
     end
   end
-
-  describe "returning results from upload" do
-    let(:node) { Bolt::SSH.new(Bolt::Target.from_uri('localhost')) }
-
-    it "on success returns a result with value nil" do
-      result = Bolt::Result.new(node.target)
-      expect(node).to receive(:_upload).and_return(result)
-
-      expect(node.upload('here', 'there').value).to eq(
-        '_output' => "Uploaded 'here' to 'localhost:there'"
-      )
-    end
-  end
 end


### PR DESCRIPTION
Removes the dumb wrappers around run_* from node. Moves logic around upload to a new UploadResult type.

Note that the deleted Node tests were mostly redundant with the Result tests.