### PR TITLE
(MAINT) remove ci namespace from acceptance rakefile

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -99,7 +99,7 @@ BOLT_CONTROLLER=centos7-64                  \
 BOLT_NODES=ubuntu1604-64,windows10ent-64    \
 SSH_PASSWORD='S3@ret3'                      \
 WINRM_PASSWORD='S3@ret3'                    \
-bundle exec rake ci:test:gem
+bundle exec rake test:gem
 ```
 
 Example to test specific gem version from https://rubygems.mymirror.example.org
@@ -110,7 +110,7 @@ BOLT_CONTROLLER=centos7-64                  \
 BOLT_NODES=ubuntu1604-64,windows10ent-64    \
 SSH_PASSWORD='S3@ret3'                      \
 WINRM_PASSWORD='S3@ret3'                    \
-bundle exec rake ci:test:gem
+bundle exec rake test:gem
 ```
 
 #### Git
@@ -120,7 +120,7 @@ BOLT_CONTROLLER=centos7-64                  \
 BOLT_NODES=ubuntu1604-64,windows10ent-64    \
 SSH_PASSWORD='S3@ret3'                      \
 WINRM_PASSWORD='S3@ret3'                    \
-bundle exec rake ci:test:git
+bundle exec rake test:git
 ```
 
 Example to test specific SHA on https://github.com/puppetlabs/bolt
@@ -130,7 +130,7 @@ BOLT_CONTROLLER=centos7-64                  \
 BOLT_NODES=ubuntu1604-64,windows10ent-64    \
 SSH_PASSWORD='S3@ret3'                      \
 WINRM_PASSWORD='S3@ret3'                    \
-bundle exec rake ci:test:git
+bundle exec rake test:git
 ```
 
 Example to test topic branch on fork of bolt on GitHub
@@ -141,7 +141,7 @@ BOLT_CONTROLLER=centos7-64                  \
 BOLT_NODES=ubuntu1604-64,windows10ent-64    \
 SSH_PASSWORD='S3@ret3'                      \
 WINRM_PASSWORD='S3@ret3'                    \
-bundle exec rake ci:test:git
+bundle exec rake test:git
 ```
 
 ### Beaker

--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -27,87 +27,85 @@ rototiller_task :host_config do |task|
   sh "cat hosts.yaml"
 end
 
-namespace :ci do
-  beaker_options = [
-    { name: '--log-level',
-      add_argument: {
-        name: 'debug',
-        add_env: {
-          name: 'BEAKER_LOG_LEVEL',
-          message: 'Beaker log level'
-        }
-      } },
-    { name: '--hosts',
-      add_argument: {
-        name: 'hosts.yaml',
-        add_env: {
-          name: 'BEAKER_HOSTS_FILE',
-          message: 'Beaker hosts file'
-        }
-      } },
-    { name: '--tests',
-      add_argument: {
-        name: 'tests',
-        add_env: {
-          name: 'BEAKER_TESTS',
-          message: 'Beaker test path(s)'
-        }
-      } },
-    { name: '--preserve-hosts',
-      add_argument: {
-        name: 'never',
-        add_env: {
-          name: 'BEAKER_PRESERVE_HOSTS',
-          message: 'When should beaker keep hosts alive'
-        }
-      } },
-    { name: '--keyfile',
-      add_argument: {
-        add_env: {
-          name: 'BEAKER_KEYFILE',
-          message: 'The private SSH key beaker will use to connect to SUTs'
-        }
-      } }
-  ]
-  namespace :test do
-    desc "Run bolt acceptance tests against a published gem"
-    task gem: :host_config
-    rototiller_task :gem do |task|
-      beaker_options << {
-        name: '--options',
-        add_argument: { name: 'config/gem/options.rb' }
+beaker_options = [
+  { name: '--log-level',
+    add_argument: {
+      name: 'debug',
+      add_env: {
+        name: 'BEAKER_LOG_LEVEL',
+        message: 'Beaker log level'
       }
-      task.add_env(name: 'GEM_VERSION', default: '> 0.1.0')
-      task.add_env(name: 'GEM_SOURCE',  default: 'https://rubygems.org')
-      task.add_env(name: 'SSH_USER',    default: 'root')
-      task.add_env(name: 'SSH_PASSWORD')
-      task.add_env(name: 'WINRM_USER', default: 'Administrator')
-      task.add_env(name: 'WINRM_PASSWORD')
-      task.add_command do |cmd|
-        cmd.name = 'beaker'
-        cmd.add_option(*beaker_options)
-      end
+    } },
+  { name: '--hosts',
+    add_argument: {
+      name: 'hosts.yaml',
+      add_env: {
+        name: 'BEAKER_HOSTS_FILE',
+        message: 'Beaker hosts file'
+      }
+    } },
+  { name: '--tests',
+    add_argument: {
+      name: 'tests',
+      add_env: {
+        name: 'BEAKER_TESTS',
+        message: 'Beaker test path(s)'
+      }
+    } },
+  { name: '--preserve-hosts',
+    add_argument: {
+      name: 'never',
+      add_env: {
+        name: 'BEAKER_PRESERVE_HOSTS',
+        message: 'When should beaker keep hosts alive'
+      }
+    } },
+  { name: '--keyfile',
+    add_argument: {
+      add_env: {
+        name: 'BEAKER_KEYFILE',
+        message: 'The private SSH key beaker will use to connect to SUTs'
+      }
+    } }
+]
+namespace :test do
+  desc "Run bolt acceptance tests against a published gem"
+  task gem: :host_config
+  rototiller_task :gem do |task|
+    beaker_options << {
+      name: '--options',
+      add_argument: { name: 'config/gem/options.rb' }
+    }
+    task.add_env(name: 'GEM_VERSION', default: '> 0.1.0')
+    task.add_env(name: 'GEM_SOURCE',  default: 'https://rubygems.org')
+    task.add_env(name: 'SSH_USER',    default: 'root')
+    task.add_env(name: 'SSH_PASSWORD')
+    task.add_env(name: 'WINRM_USER', default: 'Administrator')
+    task.add_env(name: 'WINRM_PASSWORD')
+    task.add_command do |cmd|
+      cmd.name = 'beaker'
+      cmd.add_option(*beaker_options)
     end
+  end
 
-    desc "Run bolt acceptance tests against a git repo"
-    task git: :host_config
-    rototiller_task :git do |task|
-      beaker_options << {
-        name: '--options',
-        add_argument: { name: 'config/git/options.rb' }
-      }
-      task.add_env(name: 'GIT_SERVER', default: 'https://github.com')
-      task.add_env(name: 'GIT_FORK',   default: 'puppetlabs/bolt.git')
-      task.add_env(name: 'GIT_BRANCH', default: 'master')
-      task.add_env(name: 'GIT_SHA',    default: '')
-      task.add_env(name: 'SSH_USER',   default: 'root')
-      task.add_env(name: 'SSH_PASSWORD')
-      task.add_env(name: 'WINRM_USER', default: 'Administrator')
-      task.add_env(name: 'WINRM_PASSWORD')
-      task.add_command do |cmd|
-        cmd.name = 'beaker'
-        cmd.add_option(*beaker_options)
-      end
+  desc "Run bolt acceptance tests against a git repo"
+  task git: :host_config
+  rototiller_task :git do |task|
+    beaker_options << {
+      name: '--options',
+      add_argument: { name: 'config/git/options.rb' }
+    }
+    task.add_env(name: 'GIT_SERVER', default: 'https://github.com')
+    task.add_env(name: 'GIT_FORK',   default: 'puppetlabs/bolt.git')
+    task.add_env(name: 'GIT_BRANCH', default: 'master')
+    task.add_env(name: 'GIT_SHA',    default: '')
+    task.add_env(name: 'SSH_USER',   default: 'root')
+    task.add_env(name: 'SSH_PASSWORD')
+    task.add_env(name: 'WINRM_USER', default: 'Administrator')
+    task.add_env(name: 'WINRM_PASSWORD')
+    task.add_command do |cmd|
+      cmd.name = 'beaker'
+      cmd.add_option(*beaker_options)
     end
   end
 end


### PR DESCRIPTION
Since CI doesn't actually use the CI namespace I removed it from the Rakefile.  