### PR TITLE
(BOLT-292) Add support for _run_as option to run functions

### DIFF
--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -10,6 +10,7 @@ require 'bolt/result_set'
 module Bolt
   class Executor
     attr_reader :noop
+    attr_accessor :run_as
 
     def initialize(config = Bolt::Config.new, noop = nil, plan_logging = false)
       @config = config
@@ -21,6 +22,7 @@ module Bolt
       default_log_level = plan_logging ? :info : :notice
       @logger.level = @config[:log_level] || default_log_level
       @noop = noop
+      @run_as = nil
       @notifier = Bolt::Notifier.new
     end
 
@@ -79,6 +81,15 @@ module Bolt
     end
     private :summary
 
+    def get_run_as(node, options)
+      if node.run_as.nil? && run_as
+        { '_run_as' => run_as }.merge(options)
+      else
+        options
+      end
+    end
+    private :get_run_as
+
     def run_command(targets, command, options = {})
       nodes = from_targets(targets)
       @logger.info("Starting command run '#{command}' on #{nodes.map(&:uri)}")
@@ -86,7 +97,7 @@ module Bolt
 
       r = on(nodes, callback) do |node|
         @logger.debug("Running command '#{command}' on #{node.uri}")
-        node_result = node.run_command(command, options)
+        node_result = node.run_command(command, get_run_as(node, options))
         @logger.debug("Result on #{node.uri}: #{JSON.dump(node_result.value)}")
         node_result
       end
@@ -102,7 +113,7 @@ module Bolt
 
       r = on(nodes, callback) do |node|
         @logger.debug { "Running script '#{script}' on #{node.uri}" }
-        node_result = node.run_script(script, arguments, options)
+        node_result = node.run_script(script, arguments, get_run_as(node, options))
         @logger.debug("Result on #{node.uri}: #{JSON.dump(node_result.value)}")
         node_result
       end
@@ -118,7 +129,7 @@ module Bolt
 
       r = on(nodes, callback) do |node|
         @logger.debug { "Running task run '#{task}' on #{node.uri}" }
-        node_result = node.run_task(task, input_method, arguments, options)
+        node_result = node.run_task(task, input_method, arguments, get_run_as(node, options))
         @logger.debug("Result on #{node.uri}: #{JSON.dump(node_result.value)}")
         node_result
       end

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -79,14 +79,14 @@ module Bolt
     end
     private :summary
 
-    def run_command(targets, command)
+    def run_command(targets, command, options = {})
       nodes = from_targets(targets)
       @logger.info("Starting command run '#{command}' on #{nodes.map(&:uri)}")
       callback = block_given? ? Proc.new : nil
 
       r = on(nodes, callback) do |node|
         @logger.debug("Running command '#{command}' on #{node.uri}")
-        node_result = node.run_command(command)
+        node_result = node.run_command(command, options)
         @logger.debug("Result on #{node.uri}: #{JSON.dump(node_result.value)}")
         node_result
       end
@@ -94,7 +94,7 @@ module Bolt
       r
     end
 
-    def run_script(targets, script, arguments)
+    def run_script(targets, script, arguments, options = {})
       nodes = from_targets(targets)
       @logger.info("Starting script run #{script} on #{nodes.map(&:uri)}")
       @logger.debug("Arguments: #{arguments}")
@@ -102,7 +102,7 @@ module Bolt
 
       r = on(nodes, callback) do |node|
         @logger.debug { "Running script '#{script}' on #{node.uri}" }
-        node_result = node.run_script(script, arguments)
+        node_result = node.run_script(script, arguments, options)
         @logger.debug("Result on #{node.uri}: #{JSON.dump(node_result.value)}")
         node_result
       end
@@ -110,7 +110,7 @@ module Bolt
       r
     end
 
-    def run_task(targets, task, input_method, arguments)
+    def run_task(targets, task, input_method, arguments, options = {})
       nodes = from_targets(targets)
       @logger.info("Starting task #{task} on #{nodes.map(&:uri)}")
       @logger.debug("Arguments: #{arguments} Input method: #{input_method}")
@@ -118,7 +118,7 @@ module Bolt
 
       r = on(nodes, callback) do |node|
         @logger.debug { "Running task run '#{task}' on #{node.uri}" }
-        node_result = node.run_task(task, input_method, arguments)
+        node_result = node.run_task(task, input_method, arguments, options)
         @logger.debug("Result on #{node.uri}: #{JSON.dump(node_result.value)}")
         node_result
       end

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -49,6 +49,22 @@ module Bolt
     def uri
       @target.uri
     end
+
+    def upload(_source, _destination)
+      raise NotImplementedError, 'transports must implement upload(source, destination)'
+    end
+
+    def run_command(_command, _options = nil)
+      raise NotImplementedError, 'transports must implement run_command(command, options = nil)'
+    end
+
+    def run_script(_script, _arguments, _options = nil)
+      raise NotImplementedError, 'transports must implement run_script(script, arguments, options = nil)'
+    end
+
+    def run_task(_task, _input_method, _arguments, _options = nil)
+      raise NotImplementedError, 'transports must implement run_task(task, input_method, arguments, options = nil)'
+    end
   end
 end
 

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -22,7 +22,7 @@ module Bolt
 
     def self.initialize_transport(_logger); end
 
-    attr_reader :logger, :user, :password, :connect_timeout, :target
+    attr_reader :logger, :user, :password, :connect_timeout, :target, :run_as
 
     def initialize(target, config: Bolt::Config.new)
       @target = target

--- a/lib/bolt/node/orch.rb
+++ b/lib/bolt/node/orch.rb
@@ -43,7 +43,7 @@ module Bolt
       end
     end
 
-    def run_task(task, _input_method, arguments)
+    def run_task(task, _input_method, arguments, _options = nil)
       body = { task: task_name_from_path(task),
                environment: @orch_task_environment,
                noop: arguments['_noop'],
@@ -88,12 +88,12 @@ module Bolt
       Bolt::Result.for_command(@target, result.value['stdout'], result.value['stderr'], result.value['exit_code'])
     end
 
-    def run_command(command, options = {})
+    def run_command(command, _options = nil)
       result = run_task(BOLT_MOCK_FILE,
                         'stdin',
                         action: 'command',
                         command: command,
-                        options: options)
+                        options: {})
       unwrap_bolt_result(result)
     end
 
@@ -112,7 +112,7 @@ module Bolt
       result
     end
 
-    def run_script(script, arguments)
+    def run_script(script, arguments, _options = nil)
       content = File.open(script, &:read)
       content = Base64.encode64(content)
       params = {

--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -396,6 +396,7 @@ PS
       end
       result_output
     end
+    private :execute
 
     # 10 minutes in seconds
     DEFAULT_EXECUTION_TIMEOUT = 10 * 60

--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -511,7 +511,7 @@ PS
       end
     end
 
-    def run_command(command)
+    def run_command(command, _options = nil)
       output = execute(command)
       Bolt::Result.for_command(@target, output.stdout.string, output.stderr.string, output.exit_code)
     # TODO: we should rely on the executor for this
@@ -519,7 +519,7 @@ PS
       Bolt::Result.from_exception(@target, e)
     end
 
-    def run_script(script, arguments)
+    def run_script(script, arguments, _options = nil)
       with_remote_file(script) do |remote_path|
         if powershell_file?(remote_path)
           mapped_args = arguments.map do |a|
@@ -553,7 +553,7 @@ catch
       Bolt::Result.from_exception(@target, e)
     end
 
-    def run_task(task, input_method, arguments)
+    def run_task(task, input_method, arguments, _options = nil)
       if STDIN_METHODS.include?(input_method)
         stdin = JSON.dump(arguments)
       end

--- a/modules/boltlib/lib/puppet/functions/run_command.rb
+++ b/modules/boltlib/lib/puppet/functions/run_command.rb
@@ -42,7 +42,7 @@ Puppet::Functions.create_function(:run_command) do
       call_function('debug', "Simulating run_command('#{command}') - no targets given - no action taken")
       r = Bolt::ResultSet.new([])
     else
-      r = executor.run_command(targets, command)
+      r = executor.run_command(targets, command, options.select { |k, _| k == '_run_as' })
     end
 
     if !r.ok && !options['_catch_errors']

--- a/modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/modules/boltlib/lib/puppet/functions/run_script.rb
@@ -50,7 +50,7 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
     r = if targets.empty?
           Bolt::ResultSet.new([])
         else
-          executor.run_script(targets, found, options['arguments'] || [])
+          executor.run_script(targets, found, options['arguments'] || [], options.select { |k, _| k == '_run_as' })
         end
 
     if !r.ok && !options['_catch_errors']

--- a/modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/modules/boltlib/lib/puppet/functions/run_task.rb
@@ -87,7 +87,8 @@ Puppet::Functions.create_function(:run_task) do
       Bolt::ResultSet.new([])
     else
       # TODO: pass entire task to executor
-      executor.run_task(targets, task.executable, task.input_method, use_args, &block)
+      options = task_args.select { |k, _| k == '_run_as' }
+      executor.run_task(targets, task.executable, task.input_method, use_args, options, &block)
     end
   end
 end

--- a/modules/boltlib/spec/functions/run_command_spec.rb
+++ b/modules/boltlib/spec/functions/run_command_spec.rb
@@ -23,15 +23,21 @@ describe 'run_command' do
     end
 
     it 'with given command and host' do
-      executor.expects(:run_command).with([target], command).returns(result_set)
+      executor.expects(:run_command).with([target], command, {}).returns(result_set)
 
       is_expected.to run.with_params(command, hostname).and_return(result_set)
     end
 
     it 'with given command and Target' do
-      executor.expects(:run_command).with([target], command).returns(result_set)
+      executor.expects(:run_command).with([target], command, {}).returns(result_set)
 
       is_expected.to run.with_params(command, target).and_return(result_set)
+    end
+
+    it 'with _run_as' do
+      executor.expects(:run_command).with([target], command, '_run_as' => 'root').returns(result_set)
+
+      is_expected.to run.with_params(command, target, '_run_as' => 'root').and_return(result_set)
     end
 
     context 'with multiple hosts' do
@@ -41,13 +47,13 @@ describe 'run_command' do
       let(:result_set) { Bolt::ResultSet.new([result, result2]) }
 
       it 'with propagates multiple hosts and returns multiple results' do
-        executor.expects(:run_command).with([target, target2], command).returns(result_set)
+        executor.expects(:run_command).with([target, target2], command, {}).returns(result_set)
 
         is_expected.to run.with_params(command, [hostname, hostname2]).and_return(result_set)
       end
 
       it 'with propagates multiple Targets and returns multiple results' do
-        executor.expects(:run_command).with([target, target2], command).returns(result_set)
+        executor.expects(:run_command).with([target, target2], command, {}).returns(result_set)
 
         is_expected.to run.with_params(command, [target, target2]).and_return(result_set)
       end
@@ -56,14 +62,14 @@ describe 'run_command' do
         let(:result2) { Bolt::Result.new(target2, error: { 'message' => hostname2 }) }
 
         it 'errors by default' do
-          executor.expects(:run_command).with([target, target2], command)
+          executor.expects(:run_command).with([target, target2], command, {})
                   .returns(result_set)
 
           is_expected.to run.with_params(command, [target, target2]).and_raise_error(Bolt::RunFailure)
         end
 
         it 'does not error with _catch_errors' do
-          executor.expects(:run_command).with([target, target2], command)
+          executor.expects(:run_command).with([target, target2], command, {})
                   .returns(result_set)
 
           is_expected.to run.with_params(command, [hostname, hostname2], '_catch_errors' => true)

--- a/modules/boltlib/spec/functions/run_script_spec.rb
+++ b/modules/boltlib/spec/functions/run_script_spec.rb
@@ -27,19 +27,19 @@ describe 'run_script' do
     end
 
     it 'with fully resolved path of file' do
-      executor.expects(:run_script).with([target], full_path, []).returns(result_set)
+      executor.expects(:run_script).with([target], full_path, [], {}).returns(result_set)
 
       is_expected.to run.with_params('test/uploads/hostname.sh', hostname).and_return(result_set)
     end
 
     it 'with host given as Target' do
-      executor.expects(:run_script).with([target], full_path, []).returns(result_set)
+      executor.expects(:run_script).with([target], full_path, [], {}).returns(result_set)
 
       is_expected.to run.with_params('test/uploads/hostname.sh', target).and_return(result_set)
     end
 
     it 'with given arguments as a hash of {arguments => [value]}' do
-      executor.expects(:run_script).with([target], full_path, %w[hello world]).returns(result_set)
+      executor.expects(:run_script).with([target], full_path, %w[hello world], {}).returns(result_set)
 
       is_expected.to run.with_params('test/uploads/hostname.sh',
                                      hostname,
@@ -47,9 +47,15 @@ describe 'run_script' do
     end
 
     it 'with given arguments as a hash of {arguments => []}' do
-      executor.expects(:run_script).with([target], full_path, []).returns(result_set)
+      executor.expects(:run_script).with([target], full_path, [], {}).returns(result_set)
 
       is_expected.to run.with_params('test/uploads/hostname.sh', target, 'arguments' => []).and_return(result_set)
+    end
+
+    it 'with _run_as' do
+      executor.expects(:run_script).with([target], full_path, [], '_run_as' => 'root').returns(result_set)
+
+      is_expected.to run.with_params('test/uploads/hostname.sh', target, '_run_as' => 'root').and_return(result_set)
     end
 
     context 'with multiple destinations' do
@@ -59,7 +65,7 @@ describe 'run_script' do
       let(:result_set) { Bolt::ResultSet.new([result, result2]) }
 
       it 'with propagated multiple hosts and returns multiple results' do
-        executor.expects(:run_script).with([target, target2], full_path, [])
+        executor.expects(:run_script).with([target, target2], full_path, [], {})
                 .returns(result_set)
 
         is_expected.to run.with_params('test/uploads/hostname.sh', [hostname, hostname2]).and_return(result_set)
@@ -69,7 +75,7 @@ describe 'run_script' do
         let(:result2) { Bolt::Result.new(target2, error: { 'message' => hostname2 }) }
 
         it 'errors by default' do
-          executor.expects(:run_script).with([target, target2], full_path, [])
+          executor.expects(:run_script).with([target, target2], full_path, [], {})
                   .returns(result_set)
 
           is_expected.to run.with_params('test/uploads/hostname.sh', [hostname, hostname2])
@@ -77,7 +83,7 @@ describe 'run_script' do
         end
 
         it 'does not error with _catch_errors' do
-          executor.expects(:run_script).with([target, target2], full_path, [])
+          executor.expects(:run_script).with([target, target2], full_path, [], {})
                   .returns(result_set)
 
           is_expected.to run.with_params('test/uploads/hostname.sh', [hostname, hostname2], '_catch_errors' => true)

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -837,7 +837,7 @@ NODES
             .to receive(:run_task)
             .with(
               targets,
-              %r{modules/sample/tasks/echo.sh$}, input_method, task_params
+              %r{modules/sample/tasks/echo.sh$}, input_method, task_params, {}
             ).and_return(Bolt::ResultSet.new([]))
 
           options = {
@@ -860,7 +860,7 @@ NODES
             .to receive(:run_task)
             .with(
               targets,
-              %r{modules/sample/tasks/echo.sh$}, input_method, task_params
+              %r{modules/sample/tasks/echo.sh$}, input_method, task_params, {}
             ).and_return(fail_set)
 
           options = {
@@ -915,7 +915,7 @@ NODES
             .to receive(:run_task)
             .with(
               targets,
-              %r{modules/sample/tasks/echo.sh$}, input_method, {}
+              %r{modules/sample/tasks/echo.sh$}, input_method, {}, {}
             ).and_raise("Could not connect to target")
 
           options = {
@@ -937,7 +937,7 @@ NODES
             .to receive(:run_task)
             .with(
               targets,
-              %r{modules/sample/tasks/init.sh$}, input_method, task_params
+              %r{modules/sample/tasks/init.sh$}, input_method, task_params, {}
             ).and_return(Bolt::ResultSet.new([]))
 
           options = {
@@ -959,7 +959,7 @@ NODES
           expect(executor)
             .to receive(:run_task)
             .with(targets,
-                  %r{modules/sample/tasks/stdin.sh$}, input_method, task_params)
+                  %r{modules/sample/tasks/stdin.sh$}, input_method, task_params, {})
             .and_return(Bolt::ResultSet.new([]))
 
           options = {
@@ -981,7 +981,7 @@ NODES
           expect(executor)
             .to receive(:run_task)
             .with(targets,
-                  %r{modules/sample/tasks/winstdin.ps1$}, input_method, task_params)
+                  %r{modules/sample/tasks/winstdin.ps1$}, input_method, task_params, {})
             .and_return(Bolt::ResultSet.new([]))
 
           options = {
@@ -1078,7 +1078,7 @@ NODES
             expect(executor)
               .to receive(:run_task)
               .with(targets,
-                    %r{modules/sample/tasks/params.sh$}, input_method, task_params)
+                    %r{modules/sample/tasks/params.sh$}, input_method, task_params, {})
               .and_return(Bolt::ResultSet.new([]))
             task_params.merge!(
               'mandatory_string'  => ' ',
@@ -1107,7 +1107,7 @@ NODES
             .to receive(:run_task)
             .with(
               targets,
-              %r{modules/sample/tasks/echo.sh$}, input_method, 'message' => 'hi there'
+              %r{modules/sample/tasks/echo.sh$}, input_method, { 'message' => 'hi there' }, {}
             ).and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'yes', '', 0)]))
 
           options = {
@@ -1132,7 +1132,7 @@ NODES
             .to receive(:run_task)
             .with(
               targets,
-              %r{modules/sample/tasks/echo.sh$}, input_method, 'message' => 'hi there'
+              %r{modules/sample/tasks/echo.sh$}, input_method, { 'message' => 'hi there' }, {}
             ).and_raise("Could not connect to target")
 
           options = {
@@ -1154,7 +1154,7 @@ NODES
             .to receive(:run_task)
             .with(
               targets,
-              %r{modules/sample/tasks/echo.sh$}, input_method, 'message' => 'hi there'
+              %r{modules/sample/tasks/echo.sh$}, input_method, { 'message' => 'hi there' }, {}
             ).and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'no', '', 1)]))
 
           options = {
@@ -1277,7 +1277,7 @@ NODES
           expect(executor)
             .to receive(:run_task)
             .with(targets,
-                  %r{modules/sample/tasks/noop.sh$}, input_method, task_params.merge('_noop' => true))
+                  %r{modules/sample/tasks/noop.sh$}, input_method, task_params.merge('_noop' => true), {})
             .and_return(Bolt::ResultSet.new([]))
 
           options = {

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -37,15 +37,15 @@ describe "Bolt::Executor" do
 
   it "executes a command on all nodes" do
     node_results.each do |node, result|
-      expect(node).to receive(:run_command).with(command).and_return(result)
+      expect(node).to receive(:run_command).with(command, {}).and_return(result)
     end
 
-    executor.run_command(targets, command)
+    executor.run_command(targets, command, {})
   end
 
   it "yields each command result" do
     node_results.each do |node, result|
-      expect(node).to receive(:run_command).with(command).and_return(result)
+      expect(node).to receive(:run_command).with(command, {}).and_return(result)
     end
 
     results = []
@@ -61,10 +61,10 @@ describe "Bolt::Executor" do
 
   it "runs a script on all nodes" do
     node_results.each do |node, result|
-      expect(node).to receive(:run_script).with(script, []).and_return(result)
+      expect(node).to receive(:run_script).with(script, [], {}).and_return(result)
     end
 
-    results = executor.run_script(targets, script, [])
+    results = executor.run_script(targets, script, [], {})
     results.each do |result|
       expect(result).to be_instance_of(Bolt::Result)
     end
@@ -72,7 +72,7 @@ describe "Bolt::Executor" do
 
   it "yields each script result" do
     node_results.each do |node, result|
-      expect(node).to receive(:run_script).with(script, []).and_return(result)
+      expect(node).to receive(:run_script).with(script, [], {}).and_return(result)
     end
 
     results = []
@@ -90,11 +90,11 @@ describe "Bolt::Executor" do
     node_results.each do |node, result|
       expect(node)
         .to receive(:run_task)
-        .with(task, 'both', task_arguments)
+        .with(task, 'both', task_arguments, {})
         .and_return(result)
     end
 
-    results = executor.run_task(targets, task, 'both', task_arguments)
+    results = executor.run_task(targets, task, 'both', task_arguments, {})
     results.each do |result|
       expect(result).to be_instance_of(Bolt::Result)
     end
@@ -104,7 +104,7 @@ describe "Bolt::Executor" do
     node_results.each do |node, result|
       expect(node)
         .to receive(:run_task)
-        .with(task, 'both', task_arguments)
+        .with(task, 'both', task_arguments, {})
         .and_return(result)
     end
 
@@ -186,7 +186,7 @@ describe "Bolt::Executor" do
       node_results.each do |node, result|
         expect(node)
           .to receive(:run_command)
-          .with(command)
+          .with(command, {})
           .and_return(result)
       end
 
@@ -200,7 +200,7 @@ describe "Bolt::Executor" do
       node_results.each do |node, result|
         expect(node)
           .to receive(:run_script)
-          .with(script, [])
+          .with(script, [], {})
           .and_return(result)
       end
 
@@ -214,7 +214,7 @@ describe "Bolt::Executor" do
       node_results.each do |node, result|
         expect(node)
           .to receive(:run_task)
-          .with(task, 'both', task_arguments)
+          .with(task, 'both', task_arguments, {})
           .and_return(result)
       end
 

--- a/spec/bolt/node/orch_spec.rb
+++ b/spec/bolt/node/orch_spec.rb
@@ -87,6 +87,10 @@ describe Bolt::Orch, orchestrator: true do
       expect(orch.run_task(taskpath, 'stdin', params)).to be_success
     end
 
+    it 'ignores _run_as' do
+      expect(orch.run_task(taskpath, 'stdin', params, '_run_as' => 'root')).to be_success
+    end
+
     context "when running noop" do
       let(:noop) { true }
 
@@ -161,6 +165,10 @@ describe Bolt::Orch, orchestrator: true do
 
       it 'captures stderr' do
         expect(orch.run_command(command)['stderr']).to eq("bye\n")
+      end
+
+      it 'ignores _run_as' do
+        expect(orch.run_command(command, '_run_as' => 'root')).to be_success
       end
     end
 
@@ -263,6 +271,10 @@ standard out
 
       it 'captures stderr' do
         expect(orch.run_script(script_path, args)['stderr']).to eq("standard error\n")
+      end
+
+      it 'ignores _run_as' do
+        expect(orch.run_script(script_path, args, '_run_as' => 'root')).to be_success
       end
     end
 

--- a/spec/bolt/node/ssh_spec.rb
+++ b/spec/bolt/node/ssh_spec.rb
@@ -409,6 +409,28 @@ SHELL
       end
     end
 
+    context "as non-root" do
+      let(:config) { mk_config(insecure: true, sudo_password: password, run_as: user, user: user, password: password) }
+
+      it "can override run_as for command via an option", ssh: true do
+        expect(ssh.run_command('whoami', '_run_as' => 'root')['stdout']).to eq("root\n")
+      end
+
+      it "can override run_as for script via an option", ssh: true do
+        contents = "#!/bin/sh\nwhoami"
+        with_tempfile_containing('script test', contents) do |file|
+          expect(ssh.run_script(file.path, [], '_run_as' => 'root')['stdout']).to eq("root\n")
+        end
+      end
+
+      it "can override run_as for task via an option", ssh: true do
+        contents = "#!/bin/sh\nwhoami"
+        with_tempfile_containing('tasks test', contents) do |file|
+          expect(ssh.run_task(file.path, 'environment', {}, '_run_as' => 'root').message).to eq("root\n")
+        end
+      end
+    end
+
     context "with an incorrect password" do
       let(:config) {
         mk_config(insecure: true, sudo_password: 'nonsense', run_as: 'root',

--- a/spec/bolt/node/winrm_spec.rb
+++ b/spec/bolt/node/winrm_spec.rb
@@ -132,7 +132,7 @@ PS
     after(:each) { winrm_ssl.disconnect }
 
     it "executes a command on a host" do
-      expect(winrm_ssl.execute(command).stdout.string).to eq("#{user}\r\n")
+      expect(winrm_ssl.run_command(command)['stdout']).to eq("#{user}\r\n")
     end
 
     it "can upload a file to a host" do
@@ -146,10 +146,10 @@ PS
         )
 
         expect(
-          winrm_ssl.execute("type #{remote_path}").stdout.string
+          winrm_ssl.run_command("type #{remote_path}")['stdout']
         ).to eq("#{contents}\r\n")
 
-        winrm_ssl.execute("del #{remote_path}")
+        winrm_ssl.run_command("del #{remote_path}")
       end
     end
   end
@@ -159,7 +159,7 @@ PS
     after(:each) { winrm.disconnect }
 
     it "executes a command on a host", winrm: true do
-      expect(winrm.execute(command).stdout.string).to eq("#{user}\r\n")
+      expect(winrm.run_command(command)['stdout']).to eq("#{user}\r\n")
     end
 
     it "reuses a PowerShell host / runspace for multiple commands", winrm: true do
@@ -175,11 +175,11 @@ PS
         "$ENV:A, $B, $script:C, $local:D, $global:E"
       ].join('; ')
 
-      result = winrm.execute(contents)
-      instance, runspace, *outputs = result.stdout.string.split("\r\n")
+      result = winrm.run_command(contents)
+      instance, runspace, *outputs = result['stdout'].split("\r\n")
 
-      result2 = winrm.execute(contents)
-      instance2, runspace2, *outputs2 = result2.stdout.string.split("\r\n")
+      result2 = winrm.run_command(contents)
+      instance2, runspace2, *outputs2 = result2['stdout'].split("\r\n")
 
       # Host should be identical (uniquely identified by Guid)
       expect(instance).to eq(instance2)
@@ -205,10 +205,10 @@ PS
         )
 
         expect(
-          winrm.execute("type #{remote_path}").stdout.string
+          winrm.run_command("type #{remote_path}")['stdout']
         ).to eq("#{contents}\r\n")
 
-        winrm.execute("del #{remote_path}")
+        winrm.run_command("del #{remote_path}")
       end
     end
 

--- a/spec/fixtures/run_as/test/files/id.sh
+++ b/spec/fixtures/run_as/test/files/id.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+id -un

--- a/spec/fixtures/run_as/test/plans/except.pp
+++ b/spec/fixtures/run_as/test/plans/except.pp
@@ -1,0 +1,5 @@
+plan test::except(
+  String $target
+) {
+  run_plan(test::id, target => $target, _run_as => 'root')
+}

--- a/spec/fixtures/run_as/test/plans/id.pp
+++ b/spec/fixtures/run_as/test/plans/id.pp
@@ -1,0 +1,24 @@
+plan test::id(
+  String $target
+) {
+  [
+    run_task(test::id, [$target]),
+    run_task(test::id, [$target], '_run_as' => 'root'),
+
+    run_command('id -un', [$target]),
+    run_command('id -un', [$target], '_run_as' => 'root'),
+
+    run_script('test/id.sh', [$target]),
+    run_script('test/id.sh', [$target], '_run_as' => 'root'),
+  ].map |$rset| {
+    $rset.map |$r| {
+      if $r["stdout"] {
+        $r["stdout"]
+      } else {
+        $r["_output"]
+      }
+    }
+  }.reduce |$arr, $output| {
+    $arr + $output
+  }
+}

--- a/spec/fixtures/run_as/test/plans/incept.pp
+++ b/spec/fixtures/run_as/test/plans/incept.pp
@@ -1,0 +1,5 @@
+plan test::incept(
+  String $target
+) {
+  run_plan(test::id, target => $target)
+}

--- a/spec/fixtures/run_as/test/tasks/id.sh
+++ b/spec/fixtures/run_as/test/tasks/id.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+id -un

--- a/spec/integration/run_as_spec.rb
+++ b/spec/integration/run_as_spec.rb
@@ -1,0 +1,44 @@
+require 'bolt_spec/conn'
+require 'bolt_spec/files'
+require 'bolt_spec/integration'
+require 'bolt/cli'
+
+describe "when running a plan using run_as", ssh: true do
+  include BoltSpec::Conn
+  include BoltSpec::Files
+  include BoltSpec::Integration
+
+  let(:modulepath) { File.join(__dir__, '../fixtures/run_as') }
+  let(:uri) { conn_uri('ssh', true) }
+  let(:user) { conn_info('ssh')[:user] }
+  let(:password) { conn_info('ssh')[:password] }
+  let(:config_flags) { %W[--insecure --format json --modulepath #{modulepath}] }
+
+  after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
+
+  def run_plan(plan, params)
+    run_cli(['plan', 'run', plan, "--params", params.to_json] + config_flags)
+  end
+
+  context 'when using CLI options' do
+    let(:config_flags) { %W[--insecure --format json --sudo-password #{password} --modulepath #{modulepath}] }
+
+    it 'runs sudo when specified' do
+      params = { target: uri }.to_json
+      output = run_cli(['plan', 'run', 'test::id', "--params", params] + config_flags)
+      expect(JSON.parse(output)).to eq(%W[#{user}\n root\n #{user}\n root\n #{user}\n root\n])
+    end
+
+    it 'runs sudo within a plan when specified' do
+      params = { target: uri }.to_json
+      output = run_cli(['plan', 'run', 'test::incept', "--params", params] + config_flags)
+      expect(JSON.parse(output)).to eq(%W[#{user}\n root\n #{user}\n root\n #{user}\n root\n])
+    end
+
+    it 'runs sudo within a plan when specified' do
+      params = { target: uri }.to_json
+      output = run_cli(['plan', 'run', 'test::except', "--params", params] + config_flags)
+      expect(JSON.parse(output)).to eq(%W[root\n root\n root\n root\n root\n root\n])
+    end
+  end
+end


### PR DESCRIPTION
Adds support for passing `_run_as => 'foo'` to `run_command`, `run_task`, `run_script`, and `run_plan` as part of a plan to tell them to run as a different user. Only applies to the SSH transport.

When specified on `run_plan`, it overrides any config settings for the duration of that plan and applies to all run function calls during that plan.

When specified on other run functions, overrides any config setting and prior plan setting when running that command/script/task on the targets.