### PR TITLE
(BOLT-286) Results and ResultSets should be displayed in json from plans

### DIFF
--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -123,13 +123,15 @@ module Bolt
       end
 
       def print_plan(result)
-        # If a hash or array, pretty-print as JSON
-        if result.is_a?(Hash) || result.is_a?(Array)
-          if result.empty?
-            # Avoids extra lines for an empty result
+        # If the object has a json representation display it
+        if result.respond_to?(:to_json)
+          # Guard against to_json methods that don't accept options
+          # and don't print empty results on multiple lines
+          if result.method(:to_json).arity == 0 ||
+             (result.respond_to?(:empty?) && result.empty?)
             @stream.puts(result.to_json)
           else
-            @stream.puts(::JSON.pretty_generate(result))
+            @stream.puts(::JSON.pretty_generate(result, quirks_mode: true))
           end
         else
           @stream.puts result.to_s

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -112,7 +112,7 @@ TASK_OUTPUT
   it "prints simple output from a plan" do
     result = "some data"
     outputter.print_plan(result)
-    expect(output.string.strip).to eq(result)
+    expect(output.string.strip).to eq("\"#{result}\"")
   end
 
   it "handles fatal errors" do


### PR DESCRIPTION
This favors to_json over to_s when displaying the result of a plan. As a
side effect this will cause strings to be quoted which we may want to
reconsider later.