### PR TITLE
(maint) Use Bolt::PAL for interactions with puppet

### DIFF
--- a/spec/bolt/pal_spec.rb
+++ b/spec/bolt/pal_spec.rb
@@ -1,0 +1,2 @@
+# Currently PAL is tested through the CLI execute method. New tests should be
+# added here as we add features or fix bugs.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require 'bolt'
 require 'bolt/logger'
 require 'logging'
 require 'rspec/logging_helper'
+# Make sure puppet is required for the 'reset puppet settings' context
+require_relative '../vendored/require_vendored'
 
 $LOAD_PATH.unshift File.join(__dir__, 'lib')
 


### PR DESCRIPTION
Previously the PAL class was only used for tests and was duplicated in
CLI. This converts CLI to interact with Puppet through the PAL clas
instead.