### PR TITLE
(BOLT-194) Gracefully handle Ctrl-C

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,16 +11,21 @@ SCRIPT
 Vagrant.configure("2") do |config|
   config.vm.define :windows do |windows|
     windows.vm.box = "mwrock/WindowsNano"
-    windows.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh"
     windows.vm.guest = :windows
+    windows.vm.communicator = "winrm"
+    windows.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", disabled: true
+    windows.vm.network :forwarded_port, guest: 5985, host: 25985, host_ip: "127.0.0.1", id: "winrm"
+    windows.vm.network :forwarded_port, guest: 5986, host: 25986, host_ip: "127.0.0.1", id: "winrm-ssl"
     windows.vm.provision "file", source: "resources/cert.pfx", destination: 'C:\cert.pfx'
     windows.vm.provision "shell", privileged: true, inline: windows_enable_winrm_ssl
-    windows.vm.communicator = "winrm"
+    windows.vm.provider "virtualbox" do |vb|
+      vb.gui = false
+    end
   end
 
   config.vm.define :linux do |linux|
     linux.vm.box = "bento/centos-6.7"
-    linux.vm.network :forwarded_port, guest: 22, host: 2224, id: "ssh"
+    linux.vm.network :forwarded_port, guest: 22, host: 20022, host_ip: "127.0.0.1", id: "ssh"
     linux.vm.provision "shell", inline: linux_provision
   end
 end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -168,10 +168,10 @@ describe "Bolt::CLI" do
       end
 
       it "reads from stdin when --nodes is '-'" do
-        nodes = <<NODES
+        nodes = <<-'NODES'
 foo
 bar
-NODES
+        NODES
         cli = Bolt::CLI.new(%w[command run --nodes -])
         allow(STDIN).to receive(:read).and_return(nodes)
         result = cli.parse
@@ -179,10 +179,10 @@ NODES
       end
 
       it "reads from a file when --nodes starts with @" do
-        nodes = <<NODES
+        nodes = <<-'NODES'
 foo
 bar
-NODES
+        NODES
         with_tempfile_containing('nodes-args', nodes) do |file|
           cli = Bolt::CLI.new(%W[command run --nodes @#{file.path}])
           result = cli.parse
@@ -581,18 +581,21 @@ NODES
       end
 
       context 'when running a command' do
+        let(:options) {
+          {
+            nodes: targets,
+            mode: 'command',
+            action: 'run',
+            object: 'whoami'
+          }
+        }
+
         it "executes the 'whoami' command" do
           expect(executor)
             .to receive(:run_command)
             .with(targets, 'whoami')
             .and_return(Bolt::ResultSet.new([]))
 
-          options = {
-            nodes: targets,
-            mode: 'command',
-            action: 'run',
-            object: 'whoami'
-          }
           expect(cli.execute(options)).to eq(0)
           expect(JSON.parse(output.string)).to be
         end
@@ -603,12 +606,6 @@ NODES
             .with(targets, 'whoami')
             .and_return(fail_set)
 
-          options = {
-            nodes: targets,
-            mode: 'command',
-            action: 'run',
-            object: 'whoami'
-          }
           expect(cli.execute(options)).to eq(2)
         end
       end
@@ -669,7 +666,7 @@ NODES
         end
       end
 
-      context "when showing available tasks", reset_puppet_settings: true do
+      context "when showing available tasks", :reset_puppet_settings do
         before :each do
           cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
         end
@@ -744,7 +741,7 @@ NODES
         end
       end
 
-      context "when available tasks include an error", reset_puppet_settings: true do
+      context "when available tasks include an error", :reset_puppet_settings do
         before :each do
           cli.config.modulepath = [File.join(__FILE__, '../../fixtures/invalid_mods')]
         end
@@ -762,7 +759,7 @@ NODES
         end
       end
 
-      context "when the task is not in the modulepath", reset_puppet_settings: true do
+      context "when the task is not in the modulepath", :reset_puppet_settings do
         before :each do
           cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
         end
@@ -778,7 +775,7 @@ NODES
         end
       end
 
-      context "when showing available plans", reset_puppet_settings: true do
+      context "when showing available plans", :reset_puppet_settings do
         before :each do
           cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
         end
@@ -830,7 +827,7 @@ NODES
         end
       end
 
-      context "when available plans include an error", reset_puppet_settings: true do
+      context "when available plans include an error", :reset_puppet_settings do
         before :each do
           cli.config.modulepath = [File.join(__FILE__, '../../fixtures/invalid_mods')]
         end
@@ -862,7 +859,7 @@ NODES
         end
       end
 
-      context "when the plan is not in the modulepath", reset_puppet_settings: true do
+      context "when the plan is not in the modulepath", :reset_puppet_settings do
         before :each do
           cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
         end
@@ -878,16 +875,25 @@ NODES
         end
       end
 
-      context "when running a task", reset_puppet_settings: true do
+      context "when running a task", :reset_puppet_settings do
+        let(:task_name) { 'sample::echo' }
+        let(:task_params) { { 'message' => 'hi' } }
+        let(:options) {
+          {
+            nodes: targets,
+            mode: 'task',
+            action: 'run',
+            object: task_name,
+            task_options: task_params
+          }
+        }
+        let(:input_method) { 'both' }
+
         before :each do
           cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
         end
 
         it "runs a task given a name" do
-          task_name = 'sample::echo'
-          task_params = { 'message' => 'hi' }
-          input_method = 'both'
-
           expect(executor)
             .to receive(:run_task)
             .with(
@@ -895,22 +901,11 @@ NODES
               %r{modules/sample/tasks/echo.sh$}, input_method, task_params, {}
             ).and_return(Bolt::ResultSet.new([]))
 
-          options = {
-            nodes: targets,
-            mode: 'task',
-            action: 'run',
-            object: task_name,
-            task_options: task_params
-          }
           expect(cli.execute(options)).to eq(0)
           expect(JSON.parse(output.string)).to be
         end
 
         it "returns 2 if any node fails" do
-          task_name = 'sample::echo'
-          task_params = { 'message' => 'hi' }
-          input_method = 'both'
-
           expect(executor)
             .to receive(:run_task)
             .with(
@@ -918,27 +913,12 @@ NODES
               %r{modules/sample/tasks/echo.sh$}, input_method, task_params, {}
             ).and_return(fail_set)
 
-          options = {
-            nodes: targets,
-            mode: 'task',
-            action: 'run',
-            object: task_name,
-            task_options: task_params
-          }
           expect(cli.execute(options)).to eq(2)
         end
 
         it "errors for non-existent modules" do
-          task_name = 'dne::task1'
-          task_params = { 'message' => 'hi' }
+          task_name.replace 'dne::task1'
 
-          options = {
-            nodes: targets,
-            mode: 'task',
-            action: 'run',
-            object: task_name,
-            task_options: task_params
-          }
           expect { cli.execute(options) }.to raise_error(
             Bolt::CLIError, /Task not found: dne::task1/
           )
@@ -946,16 +926,8 @@ NODES
         end
 
         it "errors for non-existent tasks" do
-          task_name = 'sample::dne'
-          task_params = { 'message' => 'hi' }
+          task_name.replace 'sample::dne'
 
-          options = {
-            nodes: targets,
-            mode: 'task',
-            action: 'run',
-            object: task_name,
-            task_options: task_params
-          }
           expect { cli.execute(options) }.to raise_error(
             Bolt::CLIError, /Task not found: sample::dne/
           )
@@ -963,8 +935,7 @@ NODES
         end
 
         it "raises errors from the executor" do
-          task_name = 'sample::echo'
-          input_method = 'both'
+          task_params.clear
 
           expect(executor)
             .to receive(:run_task)
@@ -973,20 +944,11 @@ NODES
               %r{modules/sample/tasks/echo.sh$}, input_method, {}, {}
             ).and_raise("Could not connect to target")
 
-          options = {
-            nodes: targets,
-            mode: 'task',
-            action: 'run',
-            object: task_name,
-            task_options: {}
-          }
           expect { cli.execute(options) }.to raise_error(/Could not connect to target/)
         end
 
         it "runs an init task given a module name" do
-          task_name = 'sample'
-          task_params = { 'message' => 'hi' }
-          input_method = 'both'
+          task_name.replace 'sample'
 
           expect(executor)
             .to receive(:run_task)
@@ -995,20 +957,12 @@ NODES
               %r{modules/sample/tasks/init.sh$}, input_method, task_params, {}
             ).and_return(Bolt::ResultSet.new([]))
 
-          options = {
-            nodes: targets,
-            mode: 'task',
-            action: 'run',
-            object: task_name,
-            task_options: task_params
-          }
           cli.execute(options)
           expect(JSON.parse(output.string)).to be
         end
 
         it "runs a task passing input on stdin" do
-          task_name = 'sample::stdin'
-          task_params = { 'message' => 'hi' }
+          task_name.replace 'sample::stdin'
           input_method = 'stdin'
 
           expect(executor)
@@ -1017,20 +971,12 @@ NODES
                   %r{modules/sample/tasks/stdin.sh$}, input_method, task_params, {})
             .and_return(Bolt::ResultSet.new([]))
 
-          options = {
-            nodes: targets,
-            mode: 'task',
-            action: 'run',
-            object: task_name,
-            task_options: task_params
-          }
           cli.execute(options)
           expect(JSON.parse(output.string)).to be
         end
 
         it "runs a powershell task passing input on stdin" do
-          task_name = 'sample::winstdin'
-          task_params = { 'message' => 'hi' }
+          task_name.replace 'sample::winstdin'
           input_method = 'stdin'
 
           expect(executor)
@@ -1039,13 +985,6 @@ NODES
                   %r{modules/sample/tasks/winstdin.ps1$}, input_method, task_params, {})
             .and_return(Bolt::ResultSet.new([]))
 
-          options = {
-            nodes: targets,
-            mode: 'task',
-            action: 'run',
-            object: task_name,
-            task_options: task_params
-          }
           cli.execute(options)
           expect(JSON.parse(output.string)).to be
         end
@@ -1054,15 +993,6 @@ NODES
           let(:task_name) { 'sample::params' }
           let(:task_params) { {} }
           let(:input_method) { 'stdin' }
-          let(:options) {
-            {
-              nodes: targets,
-              mode: 'task',
-              action: 'run',
-              object: task_name,
-              task_options: task_params
-            }
-          }
 
           it "errors when unknown parameters are specified" do
             task_params.merge!(
@@ -1148,16 +1078,25 @@ NODES
         end
       end
 
-      context "when running a plan", reset_puppet_settings: true do
+      context "when running a plan", :reset_puppet_settings do
+        let(:plan_name) { 'sample::single_task' }
+        let(:plan_params) { { 'nodes' => targets.map(&:host).join(',') } }
+        let(:options) {
+          {
+            nodes: targets,
+            mode: 'plan',
+            action: 'run',
+            object: plan_name,
+            task_options: plan_params
+          }
+        }
+        let(:input_method) { 'both' }
+
         before :each do
           cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
         end
 
         it "formats results of a passing task" do
-          plan_name = 'sample::single_task'
-          plan_params = { 'nodes' => targets.map(&:host).join(',') }
-          input_method = 'both'
-
           expect(executor)
             .to receive(:run_task)
             .with(
@@ -1165,13 +1104,6 @@ NODES
               %r{modules/sample/tasks/echo.sh$}, input_method, { 'message' => 'hi there' }, {}
             ).and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'yes', '', 0)]))
 
-          options = {
-            nodes: targets,
-            mode: 'plan',
-            action: 'run',
-            object: plan_name,
-            task_options: plan_params
-          }
           cli.execute(options)
           expect(JSON.parse(output.string)).to eq(
             [{ 'node' => 'foo', 'status' => 'success', 'result' => { '_output' => 'yes' } }]
@@ -1179,10 +1111,6 @@ NODES
         end
 
         it "raises errors from the executor" do
-          plan_name = 'sample::single_task'
-          plan_params = { 'nodes' => targets.map(&:host).join(',') }
-          input_method = 'both'
-
           expect(executor)
             .to receive(:run_task)
             .with(
@@ -1190,21 +1118,10 @@ NODES
               %r{modules/sample/tasks/echo.sh$}, input_method, { 'message' => 'hi there' }, {}
             ).and_raise("Could not connect to target")
 
-          options = {
-            nodes: targets,
-            mode: 'plan',
-            action: 'run',
-            object: plan_name,
-            task_options: plan_params
-          }
           expect { cli.execute(options) }.to raise_error(/Could not connect to target/)
         end
 
         it "formats results of a failing task" do
-          plan_name = 'sample::single_task'
-          plan_params = { 'nodes' => targets.map(&:host).join(',') }
-          input_method = 'both'
-
           expect(executor)
             .to receive(:run_task)
             .with(
@@ -1212,13 +1129,6 @@ NODES
               %r{modules/sample/tasks/echo.sh$}, input_method, { 'message' => 'hi there' }, {}
             ).and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'no', '', 1)]))
 
-          options = {
-            nodes: targets,
-            mode: 'plan',
-            action: 'run',
-            object: plan_name,
-            task_options: plan_params
-          }
           cli.execute(options)
           expect(JSON.parse(output.string)).to eq(
             [
@@ -1319,65 +1229,49 @@ NODES
         allow(cli).to receive(:outputter).and_return(outputter)
       end
 
-      context "when running a task", reset_puppet_settings: true do
+      context "when running a task", :reset_puppet_settings do
+        let(:task_name) { 'sample::noop' }
+        let(:task_params) { { 'message' => 'hi' } }
+        let(:options) {
+          {
+            nodes: targets,
+            mode: 'task',
+            action: 'run',
+            object: task_name,
+            task_options: task_params,
+            noop: true
+          }
+        }
+        let(:input_method) { 'both' }
+
         before :each do
           cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
         end
 
         it "runs a task that supports noop" do
-          task_name = 'sample::noop'
-          task_params = { 'message' => 'hi' }
-          input_method = 'both'
-
           expect(executor)
             .to receive(:run_task)
             .with(targets,
                   %r{modules/sample/tasks/noop.sh$}, input_method, task_params.merge('_noop' => true), {})
             .and_return(Bolt::ResultSet.new([]))
 
-          options = {
-            nodes: targets,
-            mode: 'task',
-            action: 'run',
-            object: task_name,
-            task_options: task_params,
-            noop: true
-          }
           cli.execute(options)
           expect(JSON.parse(output.string)).to be
         end
 
         it "errors on a task that doesn't support noop" do
-          task_name = 'sample::no_noop'
-          task_params = { 'message' => 'hi' }
+          task_name.replace 'sample::no_noop'
 
           expect(executor).not_to receive(:run_task)
 
-          options = {
-            nodes: targets,
-            mode: 'task',
-            action: 'run',
-            object: task_name,
-            task_options: task_params,
-            noop: true
-          }
           expect { cli.execute(options) }.to raise_error('Task does not support noop')
         end
 
         it "errors on a task without metadata" do
-          task_name = 'sample::echo'
-          task_params = { 'message' => 'hi' }
+          task_name.replace 'sample::echo'
 
           expect(executor).not_to receive(:run_task)
 
-          options = {
-            nodes: targets,
-            mode: 'task',
-            action: 'run',
-            object: task_name,
-            task_options: task_params,
-            noop: true
-          }
           expect { cli.execute(options) }.to raise_error('Task does not support noop')
         end
       end

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -34,7 +34,7 @@ describe "Bolt::Executor" do
   let(:node_results) { mock_node_results }
 
   before(:each) do
-    allow(executor).to receive(:from_targets).with(targets).and_return(node_results.map(&:first))
+    allow(executor).to receive(:from_targets).with(targets).and_return(node_results.keys)
   end
 
   context 'running a command' do

--- a/spec/bolt/node/ssh_spec.rb
+++ b/spec/bolt/node/ssh_spec.rb
@@ -16,7 +16,7 @@ describe Bolt::SSH do
   let(:hostname) { ENV['BOLT_SSH_HOST'] || "localhost" }
   let(:user) { ENV['BOLT_SSH_USER'] || "vagrant" }
   let(:password) { ENV['BOLT_SSH_PASSWORD'] || "vagrant" }
-  let(:port) { ENV['BOLT_SSH_PORT'] || 2224 }
+  let(:port) { ENV['BOLT_SSH_PORT'] || 20022 }
   let(:key) { ENV['BOLT_SSH_KEY'] || Dir[".vagrant/**/private_key"] }
   let(:command) { "pwd" }
   let(:config) { mk_config(user: user, password: password) }

--- a/spec/bolt/node/winrm_spec.rb
+++ b/spec/bolt/node/winrm_spec.rb
@@ -14,8 +14,8 @@ describe Bolt::WinRM do
   end
 
   let(:host) { ENV['BOLT_WINRM_HOST'] || 'localhost' }
-  let(:port) { ENV['BOLT_WINRM_PORT'] || 55985 }
-  let(:ssl_port) { ENV['BOLT_WINRM_SSL_PORT'] || 55986 }
+  let(:port) { ENV['BOLT_WINRM_PORT'] || 25985 }
+  let(:ssl_port) { ENV['BOLT_WINRM_SSL_PORT'] || 25986 }
   let(:user) { ENV['BOLT_WINRM_USER'] || "vagrant" }
   let(:password) { ENV['BOLT_WINRM_PASSWORD'] || "vagrant" }
   let(:command) { "echo $env:UserName" }

--- a/spec/integration/ssh_spec.rb
+++ b/spec/integration/ssh_spec.rb
@@ -36,23 +36,23 @@ describe "when runnning over the ssh transport", ssh: true do
       expect(result['_error']['msg']).to eq('The command failed with exit code 127')
     end
 
-    it 'runs a task', reset_puppet_settings: true do
+    it 'runs a task', :reset_puppet_settings do
       result = run_one_node(%W[task run #{stdin_task} message=somemessage] + config_flags)
       expect(result['message'].strip).to eq("somemessage")
     end
 
-    it 'reports errors when task fails', reset_puppet_settings: true do
+    it 'reports errors when task fails', :reset_puppet_settings do
       result = run_failed_node(%w[task run results fail=true] + config_flags)
       expect(result['_error']['kind']).to eq('puppetlabs.tasks/task-error')
       expect(result['_error']['msg']).to eq('The task failed with exit code 1')
     end
 
-    it 'passes noop to a task that supports noop', reset_puppet_settings: true do
+    it 'passes noop to a task that supports noop', :reset_puppet_settings do
       result = run_one_node(%w[task run sample::noop message=somemessage --noop] + config_flags)
       expect(result['_output'].strip).to eq("somemessage with noop true")
     end
 
-    it 'does not pass noop to a task by default', reset_puppet_settings: true do
+    it 'does not pass noop to a task by default', :reset_puppet_settings do
       result = run_one_node(%w[task run sample::noop message=somemessage] + config_flags)
       expect(result['_output'].strip).to eq("somemessage with noop")
     end
@@ -83,14 +83,14 @@ describe "when runnning over the ssh transport", ssh: true do
       end
     end
 
-    it 'runs a task', reset_puppet_settings: true do
+    it 'runs a task', :reset_puppet_settings do
       with_tempfile_containing('conf', YAML.dump(config)) do |conf|
         result = run_one_node(%W[task run #{stdin_task} message=somemessage --configfile #{conf.path}] + config_flags)
         expect(result['message'].strip).to eq("somemessage")
       end
     end
 
-    it 'runs a task as a specified user', reset_puppet_settings: true do
+    it 'runs a task as a specified user', :reset_puppet_settings do
       config['ssh']['run-as'] = user
 
       with_tempfile_containing('conf', YAML.dump(config)) do |conf|

--- a/spec/integration/winrm_spec.rb
+++ b/spec/integration/winrm_spec.rb
@@ -29,23 +29,23 @@ describe "when runnning over the winrm transport", winrm: true do
       expect(result['_error']['msg']).to eq('The command failed with exit code 1')
     end
 
-    it 'runs a task', reset_puppet_settings: true do
+    it 'runs a task', :reset_puppet_settings do
       result = run_one_node(%W[task run #{stdin_task} message=somemessage] + config_flags)
       expect(result['_output'].strip).to match(/STDIN: {"messa/)
     end
 
-    it 'reports errors when task fails', reset_puppet_settings: true do
+    it 'reports errors when task fails', :reset_puppet_settings do
       result = run_failed_node(%w[task run results::win] + config_flags)
       expect(result['_error']['kind']).to eq('puppetlabs.tasks/task-error')
       expect(result['_error']['msg']).to eq("The task failed with exit code 1:\n")
     end
 
-    it 'passes noop to a task that supports noop', reset_puppet_settings: true do
+    it 'passes noop to a task that supports noop', :reset_puppet_settings do
       result = run_one_node(%w[task run sample::ps_noop message=somemessage --noop] + config_flags)
       expect(result['_output'].strip).to eq("somemessage with noop true")
     end
 
-    it 'does not pass noop to a task by default', reset_puppet_settings: true do
+    it 'does not pass noop to a task by default', :reset_puppet_settings do
       result = run_one_node(%w[task run sample::ps_noop message=somemessage] + config_flags)
       expect(result['_output'].strip).to eq("somemessage with noop")
     end
@@ -62,7 +62,7 @@ describe "when runnning over the winrm transport", winrm: true do
       end
     end
 
-    it 'runs a task', reset_puppet_settings: true do
+    it 'runs a task', :reset_puppet_settings do
       with_tempfile_containing('conf', YAML.dump(config)) do |conf|
         result = run_one_node(%W[task run #{stdin_task} message=somemessage --configfile #{conf.path}] + config_flags)
         expect(result['_output'].strip).to match(/STDIN: {"messa/)

--- a/spec/lib/bolt_spec/conn.rb
+++ b/spec/lib/bolt_spec/conn.rb
@@ -4,9 +4,9 @@ module BoltSpec
       tu = transport.upcase
       default_port = case transport
                      when 'ssh'
-                       2224
+                       20022
                      when 'winrm'
-                       55985
+                       25985
                      end
 
       {

--- a/spec/signal_helper.rb
+++ b/spec/signal_helper.rb
@@ -1,0 +1,35 @@
+RSpec.shared_context 'synchronization thread' do
+  let(:sync_thread) { Thread.new { Thread.stop } }
+
+  before :each do
+    # make sure the thread is started
+    sync_thread
+  end
+
+  after :each do
+    # cleanup the thread
+    sync_thread.kill
+  end
+end
+
+RSpec.configure do |config|
+  # Start a thread used for synchronization between the test code and
+  # signal handlers for tests which specify the `:signals_self`
+  # metadata.
+  config.include_context 'synchronization thread', :signals_self
+
+  # Tests which specify the `:signals_self` metadata send signals to the
+  # process executing the tests which causes problems on Windows where the
+  # signals are delivered not only to that particular process but rather
+  # to the entire process group the process is a member of (i.e. typically
+  # to all processes sharing the same Windows console). This may include
+  # batch scripts (commonly used to invoke bundler and/or rspec) which
+  # handle at least some of the signals by printing:
+  #   Terminate batch job (Y/N)?
+  # message and waiting for user input. I.e. they effectively hang.
+  # To prevent such hangs we skip these tests on Windows unless explicitly
+  # enabled by specifying `--tag ~~signals_self` on the rspec command
+  # line. Note the double tilde.
+  config.filter_run_excluding :signals_self \
+    if Gem.win_platform? && !config.exclusion_filter[:'~signals_self']
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,6 +60,6 @@ RSpec.configure do |config|
 
   # Make it possible to include the 'reset puppet settings' shared context
   # in a group (or even an individual test) by specifying
-  # `reset_puppet_settings: true' metadata on the group/test
-  config.include_context 'reset puppet settings', reset_puppet_settings: true
+  # `:reset_puppet_settings' metadata on the group/test
+  config.include_context 'reset puppet settings', :reset_puppet_settings
 end


### PR DESCRIPTION
Adds code which installs a SIGINT handler just before any command/script/task/plan is executed and removes it afterwards.
When invoked, the handler logs an appropriate message at the info level and then makes bolt exit promptly possibly leaving behind processes running on nodes.

Note that this does not prevent bolt from printing a stacktrace when it receives SIGINT while not executing any command/script/task/plan.