### PR TITLE
(BOLT-218) Upload files as the run-as user

### DIFF
--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -150,7 +150,7 @@ module Bolt
       r
     end
 
-    def file_upload(targets, source, destination)
+    def file_upload(targets, source, destination, options = {})
       nodes = from_targets(targets)
       @logger.info("Starting file upload from #{source} to #{destination} on #{nodes.map(&:uri)}")
       callback = block_given? ? Proc.new : nil
@@ -158,7 +158,7 @@ module Bolt
       r = on(nodes, callback) do |node|
         @logger.debug { "Uploading: '#{source}' to #{destination} on #{node.uri}" }
         node_result = with_exception_handling(node) do
-          node.upload(source, destination)
+          node.upload(source, destination, options)
         end
         @logger.debug("Result on #{node.uri}: #{JSON.dump(node_result.value)}")
         node_result

--- a/lib/bolt/node.rb
+++ b/lib/bolt/node.rb
@@ -52,8 +52,8 @@ module Bolt
       @target.uri
     end
 
-    def upload(_source, _destination)
-      raise NotImplementedError, 'transports must implement upload(source, destination)'
+    def upload(_source, _destination, _options = nil)
+      raise NotImplementedError, 'transports must implement upload(source, destination, options = nil)'
     end
 
     def run_command(_command, _options = nil)

--- a/lib/bolt/node/ssh.rb
+++ b/lib/bolt/node/ssh.rb
@@ -15,6 +15,11 @@ module Bolt
       }
     end
 
+    def initialize(target)
+      super(target)
+      @user = @user || Net::SSH::Config.for(target.host)[:user] || Etc.getlogin
+    end
+
     def protocol
       'ssh'
     end

--- a/lib/bolt/node/ssh.rb
+++ b/lib/bolt/node/ssh.rb
@@ -133,14 +133,10 @@ module Bolt
 
     def execute(command, sudoable: false, **options)
       result_output = Bolt::Node::Output.new
-      use_sudo = sudoable && @run_as
+      run_as = options[:run_as] || @run_as
+      use_sudo = sudoable && run_as && @user != run_as
       if use_sudo
-        user_clause = if @run_as
-                        "-u #{@run_as}"
-                      else
-                        ''
-                      end
-        command = "sudo -S #{user_clause} -p '#{sudo_prompt}' #{command}"
+        command = "sudo -S -u #{run_as} -p '#{sudo_prompt}' #{command}"
       end
 
       @logger.debug { "Executing: #{command}" }

--- a/lib/bolt/node/ssh.rb
+++ b/lib/bolt/node/ssh.rb
@@ -187,7 +187,8 @@ module Bolt
       result_output
     end
 
-    def upload(source, destination)
+    def upload(source, destination, options = {})
+      @run_as = options['_run_as'] || @conf_run_as
       with_remote_tempdir do |dir|
         basename = File.basename(destination)
         tmpfile = "#{dir}/#{basename}"
@@ -207,6 +208,8 @@ module Bolt
         end
       end
       Bolt::Result.for_upload(@target, source, destination)
+    ensure
+      @run_as = @conf_run_as
     end
 
     def write_remote_file(source, destination)

--- a/lib/bolt/node/winrm.rb
+++ b/lib/bolt/node/winrm.rb
@@ -461,7 +461,7 @@ PS
       end
     end
 
-    def upload(source, destination)
+    def upload(source, destination, _options = nil)
       write_remote_file(source, destination)
       Bolt::Result.for_upload(@target, source, destination)
     end

--- a/modules/boltlib/lib/puppet/functions/file_upload.rb
+++ b/modules/boltlib/lib/puppet/functions/file_upload.rb
@@ -50,7 +50,7 @@ Puppet::Functions.create_function(:file_upload, Puppet::Functions::InternalFunct
       call_function('debug', "Simulating file upload of '#{found}' - no targets given - no action taken")
       r = Bolt::ResultSet.new([])
     else
-      r = executor.file_upload(targets, found, destination)
+      r = executor.file_upload(targets, found, destination, options.select { |k, _| k == '_run_as' })
     end
 
     if !r.ok && !options['_catch_errors']

--- a/modules/boltlib/spec/functions/file_upload_spec.rb
+++ b/modules/boltlib/spec/functions/file_upload_spec.rb
@@ -32,24 +32,33 @@ describe 'file_upload' do
     end
 
     it 'with fully resolved path of file and destination' do
-      executor.expects(:file_upload).with([target], full_path, destination).returns(result_set)
+      executor.expects(:file_upload).with([target], full_path, destination, {}).returns(result_set)
       inventory.stubs(:get_targets).with(hostname).returns([target])
 
       is_expected.to run.with_params('test/uploads/index.html', destination, hostname).and_return(result_set)
     end
 
     it 'with fully resolved path of directory and destination' do
-      executor.expects(:file_upload).with([target], full_dir_path, destination).returns(result_set)
+      executor.expects(:file_upload).with([target], full_dir_path, destination, {}).returns(result_set)
       inventory.stubs(:get_targets).with(hostname).returns([target])
 
       is_expected.to run.with_params('test/uploads', destination, hostname).and_return(result_set)
     end
 
     it 'with target specified as a Target' do
-      executor.expects(:file_upload).with([target], full_dir_path, destination).returns(result_set)
+      executor.expects(:file_upload).with([target], full_dir_path, destination, {}).returns(result_set)
       inventory.stubs(:get_targets).with(target).returns([target])
 
       is_expected.to run.with_params('test/uploads', destination, target).and_return(result_set)
+    end
+
+    it 'runs as another user' do
+      executor.expects(:file_upload)
+              .with([target], full_dir_path, destination, '_run_as' => 'soandso')
+              .returns(result_set)
+      inventory.stubs(:get_targets).with(target).returns([target])
+
+      is_expected.to run.with_params('test/uploads', destination, target, '_run_as' => 'soandso').and_return(result_set)
     end
 
     context 'with multiple destinations' do
@@ -61,7 +70,7 @@ describe 'file_upload' do
 
       it 'propagates multiple hosts and returns multiple results' do
         executor
-          .expects(:file_upload).with([target, target2], full_path, destination)
+          .expects(:file_upload).with([target, target2], full_path, destination, {})
           .returns(result_set)
         inventory.stubs(:get_targets).with([hostname, hostname2]).returns([target, target2])
 
@@ -73,7 +82,7 @@ describe 'file_upload' do
         let(:result2) { Bolt::Result.new(target2, error: { 'msg' => 'oops' }) }
 
         it 'errors by default' do
-          executor.expects(:file_upload).with([target, target2], full_path, destination)
+          executor.expects(:file_upload).with([target, target2], full_path, destination, {})
                   .returns(result_set)
           inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 
@@ -82,7 +91,7 @@ describe 'file_upload' do
         end
 
         it 'does not error with _catch_errors' do
-          executor.expects(:file_upload).with([target, target2], full_path, destination)
+          executor.expects(:file_upload).with([target, target2], full_path, destination, {})
                   .returns(result_set)
           inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -251,7 +251,7 @@ describe "Bolt::Executor" do
       node_results.each do |node, result|
         expect(node)
           .to receive(:upload)
-          .with(script, dest)
+          .with(script, dest, {})
           .and_return(result)
       end
 
@@ -265,7 +265,7 @@ describe "Bolt::Executor" do
       node_results.each do |node, result|
         expect(node)
           .to receive(:upload)
-          .with(script, dest)
+          .with(script, dest, {})
           .and_return(result)
       end
 
@@ -283,7 +283,7 @@ describe "Bolt::Executor" do
       node_results.each_key do |node|
         expect(node)
           .to receive(:upload)
-          .with(script, dest)
+          .with(script, dest, {})
           .and_raise(Bolt::Error, 'failed', 'my-exception')
       end
 
@@ -372,7 +372,7 @@ describe "Bolt::Executor" do
       node_results.each do |node, result|
         expect(node)
           .to receive(:upload)
-          .with(script, dest)
+          .with(script, dest, {})
           .and_return(result)
       end
 

--- a/spec/bolt/node/ssh_spec.rb
+++ b/spec/bolt/node/ssh_spec.rb
@@ -406,6 +406,18 @@ SHELL
       end
     end
 
+    it "can upload a file as root", ssh: true do
+      contents = "upload file test as root content"
+      dest = '/tmp/root-file-upload-test'
+      with_tempfile_containing('tasks test upload as root', contents) do |file|
+        expect(ssh.upload(file.path, dest).message).to match(/Uploaded/)
+        expect(ssh.run_command("cat #{dest}")['stdout']).to eq(contents)
+        expect(ssh.run_command("stat -c %U #{dest}")['stdout'].chomp).to eq('root')
+      end
+
+      ssh.execute("rm #{dest}", sudoable: true, run_as: 'root')
+    end
+
     context "requesting a pty" do
       let(:config) {
         mk_config(host_key_check: false, sudo_password: password, run_as: 'root',

--- a/spec/bolt/node/ssh_spec.rb
+++ b/spec/bolt/node/ssh_spec.rb
@@ -257,11 +257,11 @@ SHELLWORDS
       end
     end
 
-    it "doesn't call with_task_wrapper", ssh: true do
+    it "doesn't generate a task wrapper when not needed", ssh: true do
       contents = "#!/bin/sh\necho -n ${PT_message_one} ${PT_message_two}"
       arguments = { message_one: 'Hello from task', message_two: 'Goodbye' }
       with_tempfile_containing('tasks test', contents) do |file|
-        expect(ssh).not_to receive(:with_task_wrapper)
+        expect(ssh).not_to receive(:make_wrapper_stringio)
         ssh.run_task(file.path, 'environment', arguments)
       end
     end

--- a/spec/bolt/node/ssh_spec.rb
+++ b/spec/bolt/node/ssh_spec.rb
@@ -451,6 +451,18 @@ SHELL
           expect(ssh.run_task(file.path, 'environment', {}, '_run_as' => 'root').message).to eq("root\n")
         end
       end
+
+      it "can override run_as for file upload via an option", ssh: true do
+        contents = "upload file test as root content"
+        dest = '/tmp/root-file-upload-test'
+        with_tempfile_containing('tasks test upload as root', contents) do |file|
+          expect(ssh.upload(file.path, dest, '_run_as' => 'root').message).to match(/Uploaded/)
+          expect(ssh.run_command("cat #{dest}", '_run_as' => 'root')['stdout']).to eq(contents)
+          expect(ssh.run_command("stat -c %U #{dest}", '_run_as' => 'root')['stdout'].chomp).to eq('root')
+        end
+
+        ssh.execute("rm #{dest}", sudoable: true, run_as: 'root')
+      end
     end
 
     context "with an incorrect password" do


### PR DESCRIPTION
Previously, uploaded files would be owned by the user making the SSH
connection. For `file upload`, that was plainly incorrect. For tasks and
scripts, that caused an issue where the uploaded file might or might not be
executable by the user in question, depending on how the tempdir was created
and what the original file permissions were.

We now always chown the file to the run-as user, to ensure that the user can
actually execute the file.

We also now support the `_run_as` argument to the `file_upload()` plan
function, which has the same semantics as passing `--run-as` to `bolt file
upload` on the CLI.