### PR TITLE
(BOLT-123) Add fail_plan function to boltlib

### DIFF
--- a/lib/bolt/error.rb
+++ b/lib/bolt/error.rb
@@ -42,4 +42,11 @@ module Bolt
       @error_code = 2
     end
   end
+
+  class PlanFailure < Error
+    def initialize(*args)
+      super(*args)
+      @error_code = 2
+    end
+  end
 end

--- a/modules/boltlib/lib/puppet/functions/fail_plan.rb
+++ b/modules/boltlib/lib/puppet/functions/fail_plan.rb
@@ -1,0 +1,27 @@
+# Raises a Bolt::PlanFailure exception to signal to callers that the plan failed
+#
+# Plan authors should call this function when their plan is not successful. The
+# error may then be caught by another plans run_plan function or in bolt itself
+
+require 'bolt/error'
+
+Puppet::Functions.create_function(:fail_plan, Puppet::Functions::InternalFunction) do
+  dispatch :from_args do
+    param 'String[1]', :msg
+    optional_param 'String[1]', :kind
+    optional_param 'Hash[String[1], Any]', :details
+    optional_param 'String[1]', :issue_code
+  end
+
+  dispatch :from_error do
+    param 'Error', :error
+  end
+
+  def from_args(msg, kind = nil, details = nil, issue_code = nil)
+    raise Bolt::PlanFailure.new(msg, kind || 'bolt/plan-failure', details, issue_code)
+  end
+
+  def from_error(e)
+    from_args(e.message, e.kind, e.details, e.issue_code)
+  end
+end

--- a/modules/boltlib/spec/functions/fail_plan_spec.rb
+++ b/modules/boltlib/spec/functions/fail_plan_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+require 'bolt/error'
+
+describe 'fail_plan' do
+  include PuppetlabsSpec::Fixtures
+
+  it 'raises an error from arguments' do
+    is_expected.to run.with_params('oops').and_raise_error(Bolt::PlanFailure)
+  end
+
+  it 'raises an error from an Error object' do
+    error = Puppet::DataTypes::Error.new('oops')
+    is_expected.to run.with_params(error).and_raise_error(Bolt::PlanFailure)
+  end
+end

--- a/spec/fixtures/modules/error/plans/args.pp
+++ b/spec/fixtures/modules/error/plans/args.pp
@@ -1,0 +1,3 @@
+plan error::args {
+  fail_plan('oops', 'test/oops', { 'some' => 'info' })
+}

--- a/spec/fixtures/modules/error/plans/err.pp
+++ b/spec/fixtures/modules/error/plans/err.pp
@@ -1,0 +1,3 @@
+plan error::err {
+  fail_plan(Error('oops', 'test/oops', undef, undef, {'some' => 'info'}))
+}

--- a/spec/integration/fail_plan_spec.rb
+++ b/spec/integration/fail_plan_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require 'bolt_spec/conn'
+require 'bolt_spec/files'
+require 'bolt_spec/config'
+require 'bolt_spec/integration'
+require 'bolt/cli'
+
+describe "When a plan fails" do
+  include BoltSpec::Integration
+  include BoltSpec::Config
+
+  after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
+
+  let(:modulepath) { fixture_path('modules') }
+  let(:config_flags) {
+    ['--format', 'json',
+     '--configfile', fixture_path('configs', 'empty.yml'),
+     '--modulepath', modulepath]
+  }
+
+  it 'returns the error object' do
+    result = run_cli_json(['plan', 'run', 'error::args'] + config_flags, rescue_exec: true)
+    if error_support
+      expect(result).to eq('msg' => 'oops',
+                           'kind' => 'test/oops',
+                           'details' => { 'some' => 'info' })
+    else
+      expect(result['msg']).to match(/oops/)
+      expect(result['kind']).to eq('bolt/cli-error')
+    end
+  end
+
+  it 'returns the error object' do
+    result = run_cli_json(['plan', 'run', 'error::err'] + config_flags, rescue_exec: true)
+    if error_support
+      expect(result).to eq('msg' => 'oops',
+                           'kind' => 'test/oops',
+                           'details' => { 'some' => 'info' })
+    else
+      expect(result['msg']).to match(/oops/)
+      expect(result['kind']).to eq('bolt/cli-error')
+    end
+  end
+end


### PR DESCRIPTION
This adds a fail_plan function to the boltlib module. This function
should be used to raise an error if a plan fails.