### PR TITLE
(maint) Pin FFI to 1.9.18

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -44,6 +44,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "win32-security", "= 0.2.5"
   spec.add_dependency "win32-service", "= 0.8.8"
 
+  # Pin FFI until its releases are fixed up
+  spec.add_dependency "ffi", "<= 1.9.18"
+
   # there is a bug in puppetlabs_spec_helper for modules without fixtures
   spec.add_development_dependency "puppetlabs_spec_helper", "~> 2.6"
   spec.add_development_dependency "bundler", "~> 1.14"


### PR DESCRIPTION
FFI releases since 1.9.18 seem to be messed up. On Centos 7 they now try
to build libffi and require autoconf. Pin to 1.9.18 until that mess
settles.