### PR TITLE
(maint) Add printable format for Result

### DIFF
--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -109,6 +109,14 @@ module Bolt
       eql?(other)
     end
 
+    def to_json(opts = nil)
+      status_hash.to_json(opts)
+    end
+
+    def to_s
+      to_json
+    end
+
     # TODO: remove in favor of ok?
     def success?
       ok?


### PR DESCRIPTION
Previously attempting to print a Result data type would not display
anything other than the type name. Now it prints the contents as a hash.

Output now is
> Notice: Scope(<module>/foo/plans/init.pp, 11): Everything's fine, we're all fine here in {"node":"vagrant:vagrant@localhost:20022","status":"failure","result":{"_output":"","_error":{"kind":"puppetlabs.tasks/task-error","issue_code":"TASK_ERROR","msg":"The task failed with exit code 1:\n","details":{"exit_code":1}}}}

This is consistent with ResultSet's formatting of an array of Results.