### PR TITLE
(TBD) Support `puppetdb_query`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 	path = vendored/facter
 	url = https://github.com/puppetlabs/facter
 	branch = 2.x
+[submodule "vendored/puppetdb"]
+	path = vendored/puppetdb
+	url = https://github.com/puppetlabs/puppetdb

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |spec|
                        Dir['lib/**/*.rb'] +
                        Dir['vendored/*.rb'] +
                        Dir['vendored/*/lib/**/*.rb'] +
-                       Dir['modules/boltlib/lib/**/*.rb']
+                       Dir['modules/boltlib/lib/**/*.rb'] +
+                       Dir['modules/puppetdb/lib/**/*.rb']
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -104,7 +104,7 @@ module Bolt
     def with_puppet_settings
       Dir.mktmpdir('bolt') do |dir|
         cli = []
-        Puppet::Settings::REQUIRED_APP_SETTINGS.each do |setting|
+        Puppet::Settings::REQUIRED_APP_SETTINGS.reject { |k| k == :confdir }.each do |setting|
           cli << "--#{setting}" << dir
         end
         yield cli

--- a/modules/puppetdb
+++ b/modules/puppetdb
@@ -1,0 +1,1 @@
+../vendored/puppetdb/puppet


### PR DESCRIPTION
Not sure if this is a good idea yet. We might want to pin to a release of puppetdb. Also needs tests.

What we should probably do instead is write a gem for querying PuppetDB using certs or auth token, and ship that in Bolt and PuppetDB independently.