### PR TITLE
(BOLT-307) Add _catch_error option to run_plan

### DIFF
--- a/lib/bolt/error.rb
+++ b/lib/bolt/error.rb
@@ -25,20 +25,24 @@ module Bolt
     def to_json(opts = nil)
       to_h.to_json(opts)
     end
+
+    def to_puppet_error
+      Puppet::DataTypes::Error.from_asserted_hash(to_h)
+    end
   end
 
   class RunFailure < Error
-    attr_reader :resultset
+    attr_reader :result_set
 
-    def initialize(resultset, action, object)
+    def initialize(result_set, action, object)
       details = {
-        action: action,
-        object: object,
-        failed_targets: resultset.error_set.names
+        'action' => action,
+        'object' =>  object,
+        'result_set' => result_set
       }
-      message = "Plan aborted: #{action} '#{object}' failed on #{details[:failed_targets].length} nodes"
+      message = "Plan aborted: #{action} '#{object}' failed on #{result_set.error_set.length} nodes"
       super(message, 'bolt/run-failure', details)
-      @resultset = resultset
+      @result_set = result_set
       @error_code = 2
     end
   end

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -170,7 +170,7 @@ module Bolt
       def fatal_error(e)
         @stream.puts(colorize(:red, e.message))
         if e.is_a? Bolt::RunFailure
-          @stream.puts ::JSON.pretty_generate(e.resultset)
+          @stream.puts ::JSON.pretty_generate(e.result_set)
         end
       end
     end

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -47,7 +47,13 @@ module Bolt
       r = Puppet::Pal.in_tmp_environment('bolt', modulepath: [BOLTLIB_PATH] + @config[:modulepath], facts: {}) do |pal|
         pal.with_script_compiler do |compiler|
           begin
-            yield compiler
+            result = yield compiler
+            # TODO: remove after PUP-8441 adds to_json to Errors
+            # This hack won't handle nested errors
+            if result.is_a? Puppet::DataTypes::Error
+              result = result._pcore_init_hash
+            end
+            result
           rescue Puppet::PreformattedError => err
             # Puppet sometimes rescues exceptions notes the location and reraises
             # For now return the original error. Exception cause support was added in Ruby 2.1

--- a/spec/fixtures/modules/error/plans/catch_plan.pp
+++ b/spec/fixtures/modules/error/plans/catch_plan.pp
@@ -1,0 +1,3 @@
+plan error::catch_plan {
+ run_plan('error::err', '_catch_errors' => true)
+}

--- a/spec/fixtures/modules/error/plans/catch_plan_run.pp
+++ b/spec/fixtures/modules/error/plans/catch_plan_run.pp
@@ -1,0 +1,7 @@
+# This plan catches a RunFailure from a subplan
+plan error::catch_plan_run(
+  String $target
+) {
+ $r = run_plan('error::run_fail', 'target' => $target, '_catch_errors' => true)
+ $r.details['result_set'].first.error
+}

--- a/spec/fixtures/modules/error/plans/run_fail.pp
+++ b/spec/fixtures/modules/error/plans/run_fail.pp
@@ -1,0 +1,5 @@
+plan error::run_fail(
+  String $target
+) {
+ run_task('error::fail', $target)
+}

--- a/spec/fixtures/modules/error/tasks/fail.sh
+++ b/spec/fixtures/modules/error/tasks/fail.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "failing"
+exit 1

--- a/spec/integration/fail_plan_spec.rb
+++ b/spec/integration/fail_plan_spec.rb
@@ -2,12 +2,14 @@ require 'spec_helper'
 require 'bolt_spec/conn'
 require 'bolt_spec/files'
 require 'bolt_spec/config'
+require 'bolt_spec/conn'
 require 'bolt_spec/integration'
 require 'bolt/cli'
 
 describe "When a plan fails" do
   include BoltSpec::Integration
   include BoltSpec::Config
+  include BoltSpec::Conn
 
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
@@ -15,8 +17,10 @@ describe "When a plan fails" do
   let(:config_flags) {
     ['--format', 'json',
      '--configfile', fixture_path('configs', 'empty.yml'),
-     '--modulepath', modulepath]
+     '--modulepath', modulepath,
+     '--no-host-key-check']
   }
+  let(:target) { conn_uri('ssh', true) }
 
   it 'returns the error object' do
     result = run_cli_json(['plan', 'run', 'error::args'] + config_flags, rescue_exec: true)
@@ -39,6 +43,32 @@ describe "When a plan fails" do
     else
       expect(result['msg']).to match(/oops/)
       expect(result['kind']).to eq('bolt/cli-error')
+    end
+  end
+
+  it 'catches plan failures' do
+    if error_support
+      result = run_cli_json(['plan', 'run', 'error::catch_plan'] + config_flags)
+      expect(result).to eq('msg' => 'oops',
+                           'kind' => 'test/oops',
+                           'details' => { 'some' => 'info' })
+    else
+      result = run_cli_json(['plan', 'run', 'error::catch_plan'] + config_flags, rescue_exec: true)
+      expect(result['msg']).to match(/oops/)
+    end
+  end
+
+  it 'catches run failures', ssh: true do
+    if error_support
+      result = run_cli_json(['plan', 'run', 'error::catch_plan_run', "target=#{target}"] + config_flags)
+      expect(result).to eq("kind" => "puppetlabs.tasks/task-error",
+                           "issue_code" => "TASK_ERROR",
+                           "msg" => "The task failed with exit code 1",
+                           "details" => { "exit_code" => 1 })
+    else
+      result = run_cli_json(['plan', 'run', 'error::catch_plan_run', "target=#{target}"] + config_flags,
+                            rescue_exec: true)
+      expect(result['msg']).to match(/error::fail/)
     end
   end
 end

--- a/spec/lib/bolt_spec/integration.rb
+++ b/spec/lib/bolt_spec/integration.rb
@@ -29,7 +29,7 @@ module BoltSpec
       output = run_cli(arguments, **opts)
 
       begin
-        result = JSON.parse(output)
+        result = JSON.parse(output, quirks_mode: true)
       rescue JSON::ParserError
         expect(output.string).to eq("Output should be JSON")
       end


### PR DESCRIPTION
In order to add module unit tests I'll have to spread the "handles errors" ruby 2.0 logic there. I think it's better to just wait until we drop ruby 2.0 support to test at that level.