### PR TITLE
(BOLT-318) Add support for targeting nodes by group

### DIFF
--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -94,7 +94,8 @@ module Bolt
       elsif targets.is_a? Array
         targets.map { |tish| expand_targets(tish) }
       elsif targets.is_a? String
-        Bolt::Target.new(targets)
+        # Expand a comma-separated list
+        targets.split(/[[:space:],]+/).reject(&:empty?).map { |t| Bolt::Target.new(t) }
       end
     end
   end

--- a/lib/bolt/inventory/group.rb
+++ b/lib/bolt/inventory/group.rb
@@ -101,9 +101,24 @@ module Bolt
         }
       end
 
+      # Returns all nodes contained within the group, which includes nodes from subgroups.
       def node_names
+        @groups.inject(local_node_names) do |acc, g|
+          acc.merge(g.node_names)
+        end
+      end
+
+      # Return a mapping of group names to group.
+      def collect_groups
+        @groups.inject(name => self) do |acc, g|
+          acc.merge(g.collect_groups)
+        end
+      end
+
+      def local_node_names
         @_node_names ||= Set.new(nodes.map { |n| n['name'] })
       end
+      private :local_node_names
 
       def node_collect(node_name)
         data = @groups.inject(nil) do |acc, g|
@@ -127,7 +142,7 @@ module Bolt
 
         if data
           data_merge(group_data, data)
-        elsif node_names.include?(node_name)
+        elsif local_node_names.include?(node_name)
           group_data
         end
       end

--- a/lib/bolt/inventory/group.rb
+++ b/lib/bolt/inventory/group.rb
@@ -45,7 +45,14 @@ module Bolt
         used_names << @name
 
         @nodes.each do |n|
-          raise ValidationError.new("node #{n['name']} does not have a name", n['name']) unless n['name']
+          # Require nodes to be referenced only by their host name
+          host = Addressable::URI.parse('//' + n['name']).host
+          ipv6host = Addressable::URI.parse('//[' + n['name'] + ']').host
+          if n['name'] != host && n['name'] != ipv6host
+            raise ValidationError.new("Invalid node name #{n['name']}", n['name'])
+          end
+
+          raise ValidationError.new("Node #{n['name']} does not have a name", n['name']) unless n['name']
           if used_names.include?(n['name'])
             raise ValidationError.new("Group #{n['name']} conflicts with node of the same name", n['name'])
           end

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -10,10 +10,6 @@ module Bolt
       new(hash['uri'], hash['options'])
     end
 
-    def self.parse_urls(urls)
-      urls.split(/[[:space:],]+/).reject(&:empty?).uniq.map { |url| new(url) }
-    end
-
     def initialize(uri, options = nil)
       @uri = uri
       @uri_obj = parse(uri)

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -10,12 +10,8 @@ module Bolt
       new(hash['uri'], hash['options'])
     end
 
-    def self.from_uri(uri)
-      new(uri)
-    end
-
     def self.parse_urls(urls)
-      urls.split(/[[:space:],]+/).reject(&:empty?).uniq.map { |url| from_uri(url) }
+      urls.split(/[[:space:],]+/).reject(&:empty?).uniq.map { |url| new(url) }
     end
 
     def initialize(uri, options = nil)

--- a/modules/boltlib/lib/puppet/functions/fail_plan.rb
+++ b/modules/boltlib/lib/puppet/functions/fail_plan.rb
@@ -5,7 +5,7 @@
 
 require 'bolt/error'
 
-Puppet::Functions.create_function(:fail_plan, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:fail_plan) do
   dispatch :from_args do
     param 'String[1]', :msg
     optional_param 'String[1]', :kind

--- a/modules/boltlib/lib/puppet/functions/get_targets.rb
+++ b/modules/boltlib/lib/puppet/functions/get_targets.rb
@@ -1,0 +1,45 @@
+# Parses common ways of referring to targets and returns an array of Targets.
+#
+# Accepts input consisting of
+# - a group
+# - a target URI
+# - an array of groups and/or target URIs
+# - a string that consists of a comma-separated list of groups and/or target URIs
+#
+# Examples of the above would be
+# - 'group1'
+# - 'host1,group1,winrm://host2:54321'
+# - ['host1', 'group1', 'winrm://host2:54321']
+#
+# Returns an array of unique Targets resolved from any target URIs and groups.
+
+require 'bolt/error'
+
+Puppet::Functions.create_function(:get_targets) do
+  local_types do
+    type 'TargetOrTargets = Variant[String[1], Target, Array[TargetOrTargets]]'
+  end
+
+  dispatch :get_targets do
+    param 'TargetOrTargets', :names
+    return_type 'Array[Target]'
+  end
+
+  def get_targets(names)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, operation: 'get_targets'
+      )
+    end
+
+    inventory = Puppet.lookup(:bolt_inventory) { nil }
+
+    unless inventory && Puppet.features.bolt?
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('process targets through inventory')
+      )
+    end
+
+    inventory.get_targets(names)
+  end
+end

--- a/modules/boltlib/lib/puppet/functions/run_command.rb
+++ b/modules/boltlib/lib/puppet/functions/run_command.rb
@@ -35,7 +35,7 @@ Puppet::Functions.create_function(:run_command) do
       )
     end
 
-    # Ensure that that given targets are all Target instances
+    # Ensure that given targets are all Target instances
     targets = inventory.get_targets(targets)
 
     if targets.empty?

--- a/modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/modules/boltlib/lib/puppet/functions/run_script.rb
@@ -46,7 +46,7 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
       )
     end
 
-    # Ensure that that given targets are all Target instances)
+    # Ensure that given targets are all Target instances)
     targets = inventory.get_targets(targets)
 
     #

--- a/modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/modules/boltlib/lib/puppet/functions/run_task.rb
@@ -81,7 +81,7 @@ Puppet::Functions.create_function(:run_task) do
       end
     end
 
-    # Ensure that that given targets are all Target instances
+    # Ensure that given targets are all Target instances
     targets = inventory.get_targets(targets)
     if targets.empty?
       Bolt::ResultSet.new([])

--- a/modules/boltlib/spec/functions/file_upload_spec.rb
+++ b/modules/boltlib/spec/functions/file_upload_spec.rb
@@ -18,7 +18,7 @@ describe 'file_upload' do
 
   context 'it calls bolt executor file_upload' do
     let(:hostname) { 'test.example.com' }
-    let(:target) { Bolt::Target.from_uri(hostname) }
+    let(:target) { Bolt::Target.new(hostname) }
 
     let(:message) { 'uploaded' }
     let(:result) { Bolt::Result.new(target, message: message) }
@@ -63,7 +63,7 @@ describe 'file_upload' do
 
     context 'with multiple destinations' do
       let(:hostname2) { 'test.testing.com' }
-      let(:target2) { Bolt::Target.from_uri(hostname2) }
+      let(:target2) { Bolt::Target.new(hostname2) }
       let(:message2) { 'received' }
       let(:result2) { Bolt::Result.new(target2, message: message2) }
       let(:result_set) { Bolt::ResultSet.new([result, result2]) }

--- a/modules/boltlib/spec/functions/get_targets_spec.rb
+++ b/modules/boltlib/spec/functions/get_targets_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+require 'bolt/target'
+
+describe 'get_targets' do
+  let(:inventory) { mock('inventory') }
+  let(:tasks_enabled) { true }
+
+  around(:each) do |example|
+    Puppet[:tasks] = tasks_enabled
+    Puppet.override(bolt_inventory: inventory) do
+      example.run
+    end
+  end
+
+  context 'it calls inventory get_targets' do
+    let(:hostname) { 'test.example.com' }
+    let(:target) { Bolt::Target.new(hostname) }
+    before(:each) do
+      Puppet.features.stubs(:bolt?).returns(true)
+    end
+
+    it 'with given host' do
+      inventory.expects(:get_targets).with(hostname).returns([target])
+
+      is_expected.to run.with_params(hostname).and_return([target])
+    end
+
+    it 'with given Target' do
+      inventory.expects(:get_targets).with(target).returns([target])
+
+      is_expected.to run.with_params(target).and_return([target])
+    end
+
+    it 'with array of hosts' do
+      inventory.expects(:get_targets).with([hostname]).returns([target])
+
+      is_expected.to run.with_params([hostname]).and_return([target])
+    end
+
+    it 'with array of Targets' do
+      inventory.expects(:get_targets).with([target]).returns([target])
+
+      is_expected.to run.with_params([target]).and_return([target])
+    end
+
+    it 'with comma-separated hosts' do
+      inventory.expects(:get_targets).with("#{hostname},group").returns([target])
+
+      is_expected.to run.with_params("#{hostname},group").and_return([target])
+    end
+
+    it 'errors on unknown types' do
+      is_expected.to run.with_params(mock('anything')).and_raise_error(ArgumentError)
+    end
+  end
+
+  context 'without bolt feature present' do
+    it 'fails and reports that bolt library is required' do
+      Puppet.features.stubs(:bolt?).returns(false)
+      is_expected.to run.with_params('echo hello')
+                        .and_raise_error(/The 'bolt' library is required to process targets through inventory/)
+    end
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+
+    it 'fails and reports that run_command is not available' do
+      is_expected.to run.with_params('echo hello')
+                        .and_raise_error(/The task operation 'get_targets' is not available/)
+    end
+  end
+end

--- a/modules/boltlib/spec/functions/run_command_spec.rb
+++ b/modules/boltlib/spec/functions/run_command_spec.rb
@@ -15,7 +15,7 @@ describe 'run_command' do
 
   context 'it calls bolt executor run_command' do
     let(:hostname) { 'test.example.com' }
-    let(:target) { Bolt::Target.from_uri(hostname) }
+    let(:target) { Bolt::Target.new(hostname) }
     let(:command) { 'hostname' }
     let(:result) { Bolt::Result.new(target, value: { 'stdout' => hostname }) }
     let(:result_set) { Bolt::ResultSet.new([result]) }
@@ -46,7 +46,7 @@ describe 'run_command' do
 
     context 'with multiple hosts' do
       let(:hostname2) { 'test.testing.com' }
-      let(:target2) { Bolt::Target.from_uri(hostname2) }
+      let(:target2) { Bolt::Target.new(hostname2) }
       let(:result2) { Bolt::Result.new(target2, value: { 'stdout' => hostname2 }) }
       let(:result_set) { Bolt::ResultSet.new([result, result2]) }
 

--- a/modules/boltlib/spec/functions/run_script_spec.rb
+++ b/modules/boltlib/spec/functions/run_script_spec.rb
@@ -18,7 +18,7 @@ describe 'run_script' do
 
   context 'it calls bolt executor run_script' do
     let(:hostname) { 'test.example.com' }
-    let(:target) { Bolt::Target.from_uri(hostname) }
+    let(:target) { Bolt::Target.new(hostname) }
     let(:result) { Bolt::Result.new(target, value: { 'stdout' => hostname }) }
     let(:result_set) { Bolt::ResultSet.new([result]) }
     let(:module_root) { File.expand_path(fixtures('modules', 'test')) }
@@ -66,7 +66,7 @@ describe 'run_script' do
 
     context 'with multiple destinations' do
       let(:hostname2) { 'test.testing.com' }
-      let(:target2) { Bolt::Target.from_uri(hostname2) }
+      let(:target2) { Bolt::Target.new(hostname2) }
       let(:result2) { Bolt::Result.new(target2, value: { 'stdout' => hostname2 }) }
       let(:result_set) { Bolt::ResultSet.new([result, result2]) }
 

--- a/modules/boltlib/spec/functions/run_task_spec.rb
+++ b/modules/boltlib/spec/functions/run_task_spec.rb
@@ -20,8 +20,8 @@ describe 'run_task' do
     let(:hostname) { 'a.b.com' }
     let(:hostname2) { 'x.y.com' }
     let(:message) { 'the message' }
-    let(:target) { Bolt::Target.from_uri(hostname) }
-    let(:target2) { Bolt::Target.from_uri(hostname2) }
+    let(:target) { Bolt::Target.new(hostname) }
+    let(:target2) { Bolt::Target.new(hostname2) }
     let(:result) { Bolt::Result.new(target, value: { '_output' => message }) }
     let(:result2) { Bolt::Result.new(target2, value: { '_output' => message }) }
     let(:result_set) { Bolt::ResultSet.new([result]) }

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -5,7 +5,7 @@ require 'bolt/cli'
 
 describe "Bolt::CLI" do
   include BoltSpec::Files
-  let(:target) { Bolt::Target.from_uri('foo') }
+  let(:target) { Bolt::Target.new('foo') }
 
   before(:each) do
     outputter = Bolt::Outputter::Human.new(StringIO.new)
@@ -151,7 +151,7 @@ describe "Bolt::CLI" do
     end
 
     describe "nodes" do
-      let(:targets) { [target, Bolt::Target.from_uri('bar')] }
+      let(:targets) { [target, Bolt::Target.new('bar')] }
 
       it "accepts a single node" do
         cli = Bolt::CLI.new(%w[command run --nodes foo])

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -155,17 +155,18 @@ describe "Bolt::CLI" do
 
       it "accepts a single node" do
         cli = Bolt::CLI.new(%w[command run --nodes foo])
-        expect(cli.parse).to include(nodes: [['foo']])
+        expect(cli.parse).to include(targets: [target])
       end
 
       it "accepts multiple nodes" do
         cli = Bolt::CLI.new(%w[command run --nodes foo,bar])
-        expect(cli.parse).to include(nodes: [%w[foo bar]])
+        expect(cli.parse).to include(targets: targets)
       end
 
       it "accepts multiple nodes across multiple declarations" do
         cli = Bolt::CLI.new(%w[command run --nodes foo,bar --nodes bar,more,bars])
-        expect(cli.parse).to include(nodes: [%w[foo bar], %w[bar more bars]])
+        extra_targets = [Bolt::Target.new('more'), Bolt::Target.new('bars')]
+        expect(cli.parse).to include(targets: targets + extra_targets)
       end
 
       it "reads from stdin when --nodes is '-'" do
@@ -176,7 +177,7 @@ bar
         cli = Bolt::CLI.new(%w[command run --nodes -])
         allow(STDIN).to receive(:read).and_return(nodes)
         result = cli.parse
-        expect(result[:nodes]).to eq([%w[foo bar]])
+        expect(result[:targets]).to eq(targets)
       end
 
       it "reads from a file when --nodes starts with @" do
@@ -187,7 +188,7 @@ bar
         with_tempfile_containing('nodes-args', nodes) do |file|
           cli = Bolt::CLI.new(%W[command run --nodes @#{file.path}])
           result = cli.parse
-          expect(result[:nodes]).to eq([%w[foo bar]])
+          expect(result[:targets]).to eq(targets)
         end
       end
 
@@ -196,7 +197,8 @@ bar
         with_tempfile_containing('nodes-args', nodes) do |file|
           cli = Bolt::CLI.new(%W[command run --nodes @#{file.path}])
           result = cli.parse
-          expect(result[:nodes]).to eq([%w[foo bar baz qux]])
+          extra_targets = [Bolt::Target.new('baz'), Bolt::Target.new('qux')]
+          expect(result[:targets]).to eq(targets + extra_targets)
         end
       end
 
@@ -603,7 +605,7 @@ bar
       context 'when running a command' do
         let(:options) {
           {
-            nodes: targets,
+            targets: targets,
             mode: 'command',
             action: 'run',
             object: 'whoami'
@@ -651,7 +653,7 @@ bar
       context "when running a script" do
         let(:script) { 'bar.sh' }
         let(:options) {
-          { nodes: targets, mode: 'script', action: 'run', object: script,
+          { targets: targets, mode: 'script', action: 'run', object: script,
             leftovers: [] }
         }
 
@@ -938,7 +940,7 @@ bar
         let(:task_params) { { 'message' => 'hi' } }
         let(:options) {
           {
-            nodes: targets,
+            targets: targets,
             mode: 'task',
             action: 'run',
             object: task_name,
@@ -1161,7 +1163,7 @@ bar
         let(:plan_params) { { 'nodes' => targets.map(&:host).join(',') } }
         let(:options) {
           {
-            nodes: targets,
+            targets: targets,
             mode: 'plan',
             action: 'run',
             object: plan_name,
@@ -1253,7 +1255,7 @@ bar
         let(:dest) { '/path/to/remote' }
         let(:options) {
           {
-            nodes: targets,
+            targets: targets,
             mode: 'file',
             action: 'upload',
             object: source,
@@ -1332,7 +1334,7 @@ bar
         let(:task_params) { { 'message' => 'hi' } }
         let(:options) {
           {
-            nodes: targets,
+            targets: targets,
             mode: 'task',
             action: 'run',
             object: task_name,

--- a/spec/bolt/inventory/group_spec.rb
+++ b/spec/bolt/inventory/group_spec.rb
@@ -288,22 +288,22 @@ describe Bolt::Inventory::Group do
     end
   end
 
-  context 'with nodes in multiple group levels' do
+  context 'with IP-based nodes in multiple group levels' do
     let(:data) do
       {
         'name' => 'group0',
-        'nodes' => [{ 'name' => 'node1' }],
+        'nodes' => [{ 'name' => '127.0.0.1' }],
         'groups' => [
           {
             'name' => 'group1',
-            'nodes' => [{ 'name' => 'node2' }]
+            'nodes' => [{ 'name' => '2001:db8:0:1' }]
           }
         ]
       }
     end
 
     it 'should find two nodes' do
-      expect(group.node_names.to_a).to eq(%w[node1 node2])
+      expect(group.node_names.to_a).to eq(%w[127.0.0.1 2001:db8:0:1])
     end
 
     it 'should collect 2 groups' do
@@ -315,7 +315,20 @@ describe Bolt::Inventory::Group do
 
     it 'should find one node in the subgroup' do
       groups = group.collect_groups
-      expect(groups['group1'].node_names.to_a).to eq(%w[node2])
+      expect(groups['group1'].node_names.to_a).to eq(%w[2001:db8:0:1])
+    end
+  end
+
+  context 'where a node uses an invalid name' do
+    let(:data) do
+      {
+        'name' => 'group1',
+        'nodes' => [{ 'name' => 'foo1:22' }]
+      }
+    end
+
+    it 'raises an error' do
+      expect { group.validate }.to raise_error(Bolt::Inventory::ValidationError, /Invalid node name/)
     end
   end
 

--- a/spec/bolt/inventory/group_spec.rb
+++ b/spec/bolt/inventory/group_spec.rb
@@ -39,8 +39,14 @@ describe Bolt::Inventory::Group do
       expect(group.node_data('node1')).to eq('config' => {}, 'groups' => [])
     end
 
-    it 'should include node1' do
-      expect(group.node_names).to include('node1')
+    it 'should find three nodes' do
+      expect(group.node_names.to_a).to eq(%w[node1 node2 node3])
+    end
+
+    it 'should collect one group' do
+      groups = group.collect_groups
+      expect(groups.size).to eq(1)
+      expect(groups['group1']).to eq(group)
     end
 
     it 'should return a hash for a string node' do
@@ -59,6 +65,7 @@ describe Bolt::Inventory::Group do
   context 'with data at all levels' do
     let(:data) do
       {
+        'name' => 'group0',
         'nodes' => [{
           'name' => 'node1',
           'config' => { 'ssh' => { 'user' => 'parent_node' } }
@@ -77,6 +84,22 @@ describe Bolt::Inventory::Group do
 
     it 'uses the childs node definition' do
       expect(group.data_for('node1')['config']['ssh']['user']).to eq('child_node')
+    end
+
+    it 'should find one node' do
+      expect(group.node_names.to_a).to eq(%w[node1])
+    end
+
+    it 'should collect 2 groups' do
+      groups = group.collect_groups
+      expect(groups.size).to eq(2)
+      expect(groups['group0']).to eq(group)
+      expect(groups['group1'].name).to eq('group1')
+    end
+
+    it 'should find one node in the subgroup' do
+      groups = group.collect_groups
+      expect(groups['group1'].node_names.to_a).to eq(%w[node1])
     end
   end
 
@@ -262,6 +285,37 @@ describe Bolt::Inventory::Group do
 
     it 'uses the second childs group definition' do
       expect(node1_ssh).to eq('child2_group')
+    end
+  end
+
+  context 'with nodes in multiple group levels' do
+    let(:data) do
+      {
+        'name' => 'group0',
+        'nodes' => [{ 'name' => 'node1' }],
+        'groups' => [
+          {
+            'name' => 'group1',
+            'nodes' => [{ 'name' => 'node2' }]
+          }
+        ]
+      }
+    end
+
+    it 'should find two nodes' do
+      expect(group.node_names.to_a).to eq(%w[node1 node2])
+    end
+
+    it 'should collect 2 groups' do
+      groups = group.collect_groups
+      expect(groups.size).to eq(2)
+      expect(groups['group0']).to eq(group)
+      expect(groups['group1'].name).to eq('group1')
+    end
+
+    it 'should find one node in the subgroup' do
+      groups = group.collect_groups
+      expect(groups['group1'].node_names.to_a).to eq(%w[node2])
     end
   end
 

--- a/spec/bolt/inventory/group_spec.rb
+++ b/spec/bolt/inventory/group_spec.rb
@@ -75,7 +75,7 @@ describe Bolt::Inventory::Group do
       }
     end
 
-    it 'uses the childs node defintion' do
+    it 'uses the childs node definition' do
       expect(group.data_for('node1')['config']['ssh']['user']).to eq('child_node')
     end
   end
@@ -98,7 +98,7 @@ describe Bolt::Inventory::Group do
       }
     end
 
-    it 'uses the parents node defintion' do
+    it 'uses the parents node definition' do
       expect(group.data_for('node1')['config']['ssh']['user']).to eq('parent_node')
     end
   end
@@ -120,7 +120,7 @@ describe Bolt::Inventory::Group do
       }
     end
 
-    it 'uses the childs group defintion' do
+    it 'uses the childs group definition' do
       expect(group.data_for('node1')['config']['ssh']['user']).to eq('child_group')
     end
   end
@@ -155,7 +155,7 @@ describe Bolt::Inventory::Group do
       }
     end
 
-    it 'uses the first childs node defintion' do
+    it 'uses the first childs node definition' do
       expect(node1_ssh).to eq('child1_node')
     end
   end
@@ -190,7 +190,7 @@ describe Bolt::Inventory::Group do
       }
     end
 
-    it 'uses the first childs node defintion' do
+    it 'uses the first childs node definition' do
       expect(node1_ssh).to eq('child2_node')
     end
   end
@@ -225,7 +225,7 @@ describe Bolt::Inventory::Group do
       }
     end
 
-    it 'uses the first childs group defintion' do
+    it 'uses the first childs group definition' do
       expect(node1_ssh).to eq('child1_group')
     end
   end
@@ -260,8 +260,59 @@ describe Bolt::Inventory::Group do
       }
     end
 
-    it 'uses the second childs group defintion' do
+    it 'uses the second childs group definition' do
       expect(node1_ssh).to eq('child2_group')
+    end
+  end
+
+  context 'where a group name conflicts with a prior node name' do
+    let(:data) do
+      {
+        'name' => 'group1',
+        'nodes' => [{ 'name' => 'foo1' }],
+        'groups' => [{ 'name' => 'foo1' }]
+      }
+    end
+
+    it 'raises an error' do
+      expect { group.validate }.to raise_error(Bolt::Inventory::ValidationError, /conflicts with node/)
+    end
+  end
+
+  context 'where a group name conflicts with a child node name' do
+    let(:data) do
+      {
+        'name' => 'group1',
+        'groups' => [
+          {
+            'name' => 'foo1',
+            'nodes' => [{ 'name' => 'foo1' }]
+          }
+        ]
+      }
+    end
+
+    it 'raises an error' do
+      expect { group.validate }.to raise_error(Bolt::Inventory::ValidationError, /conflicts with node/)
+    end
+  end
+
+  context 'where a group name conflicts with a child node of another group' do
+    let(:data) do
+      {
+        'name' => 'group1',
+        'groups' => [
+          { 'name' => 'foo1' },
+          {
+            'name' => 'foo2',
+            'nodes' => [{ 'name' => 'foo1' }]
+          }
+        ]
+      }
+    end
+
+    it 'raises an error' do
+      expect { group.validate }.to raise_error(Bolt::Inventory::ValidationError, /conflicts with node/)
     end
   end
 end

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -5,6 +5,10 @@ require 'bolt/inventory'
 describe Bolt::Inventory do
   include BoltSpec::Config
 
+  def targets(names)
+    names.map { |n| Bolt::Target.new(n) }
+  end
+
   let(:data) {
     {
       'nodes' => [
@@ -195,6 +199,28 @@ describe Bolt::Inventory do
     end
   end
 
+  describe :collect_groups do
+    it 'finds the all group with an empty inventory' do
+      inventory = Bolt::Inventory.new({})
+      inventory.collect_groups
+      expect(inventory.get_targets('all')).to eq([])
+    end
+
+    it 'finds the all group with a non-empty inventory' do
+      inventory = Bolt::Inventory.new(data)
+      inventory.collect_groups
+      targets = inventory.get_targets('all')
+      expect(targets.size).to eq(8)
+    end
+
+    it 'finds nodes in a subgroup' do
+      inventory = Bolt::Inventory.new(data)
+      inventory.collect_groups
+      targets = inventory.get_targets('group2')
+      expect(targets).to eq(targets(%w[node6 node7 node8]))
+    end
+  end
+
   context 'with an empty config' do
     let(:inventory) { Bolt::Inventory.from_config(config) }
     let(:target) { inventory.get_targets('nonode')[0] }
@@ -226,31 +252,47 @@ describe Bolt::Inventory do
     end
   end
 
-  def targets(names)
-    names.map { |n| Bolt::Target.new(n) }
-  end
-
   describe 'get_targets' do
-    let(:inventory) { Bolt::Inventory.from_config(config) }
+    context 'empty inventory' do
+      let(:inventory) { Bolt::Inventory.from_config(config) }
 
-    it 'should parse a single target URI' do
-      name = 'nonode'
-      expect(inventory.get_targets(name)).to eq(targets([name]))
+      it 'should parse a single target URI' do
+        name = 'nonode'
+        expect(inventory.get_targets(name)).to eq(targets([name]))
+      end
+
+      it 'should parse an array of target URIs' do
+        names = ['pcp://a', 'winrm://b', 'c']
+        expect(inventory.get_targets(names)).to eq(targets(names))
+      end
+
+      it 'should parse a nested array of target URIs and Targets' do
+        names = [['a'], Bolt::Target.new('b'), ['c', 'ssh://d']]
+        expect(inventory.get_targets(names)).to eq(targets(['a', 'b', 'c', 'ssh://d']))
+      end
+
+      it 'should split a comma-separated list of target URIs' do
+        ts = targets(['ssh://a', 'winrm://b:5000', 'u:p@c'])
+        expect(inventory.get_targets('ssh://a, winrm://b:5000, u:p@c')).to eq(ts)
+      end
     end
 
-    it 'should parse an array of target URIs' do
-      names = ['pcp://a', 'winrm://b', 'c']
-      expect(inventory.get_targets(names)).to eq(targets(names))
-    end
+    context 'non-empty inventory' do
+      let(:inventory) {
+        inv = Bolt::Inventory.new(data)
+        inv.collect_groups
+        inv
+      }
 
-    it 'should parse a nested array of target URIs and Targets' do
-      names = [['a'], Bolt::Target.new('b'), ['c', 'ssh://d']]
-      expect(inventory.get_targets(names)).to eq(targets(['a', 'b', 'c', 'ssh://d']))
-    end
+      it 'should parse an array of target URI and group name' do
+        targets = inventory.get_targets(%w[a group1])
+        expect(targets).to eq(targets(%w[a node4 node5 node6 node7]))
+      end
 
-    it 'should split a comma-separated list of target URIs' do
-      ts = targets(['ssh://a', 'winrm://b:5000', 'u:p@c'])
-      expect(inventory.get_targets('ssh://a, winrm://b:5000, u:p@c')).to eq(ts)
+      it 'should split a comma-separated list of target URI and group name' do
+        targets = inventory.get_targets('group1,a')
+        expect(targets).to eq(targets(%w[node4 node5 node6 node7 a]))
+      end
     end
   end
 end

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -224,8 +224,33 @@ describe Bolt::Inventory do
     it 'should not use ssl' do
       expect(target.options[:ssl]).to eq(false)
     end
+  end
 
-    context 'with inventory' do
+  def targets(names)
+    names.map { |n| Bolt::Target.new(n) }
+  end
+
+  describe 'get_targets' do
+    let(:inventory) { Bolt::Inventory.from_config(config) }
+
+    it 'should parse a single target URI' do
+      name = 'nonode'
+      expect(inventory.get_targets(name)).to eq(targets([name]))
+    end
+
+    it 'should parse an array of target URIs' do
+      names = ['pcp://a', 'winrm://b', 'c']
+      expect(inventory.get_targets(names)).to eq(targets(names))
+    end
+
+    it 'should parse a nested array of target URIs and Targets' do
+      names = [['a'], Bolt::Target.new('b'), ['c', 'ssh://d']]
+      expect(inventory.get_targets(names)).to eq(targets(['a', 'b', 'c', 'ssh://d']))
+    end
+
+    it 'should split a comma-separated list of target URIs' do
+      ts = targets(['ssh://a', 'winrm://b:5000', 'u:p@c'])
+      expect(inventory.get_targets('ssh://a, winrm://b:5000, u:p@c')).to eq(ts)
     end
   end
 end

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -174,7 +174,7 @@ describe Bolt::Inventory do
       expect(Bolt::Inventory.new({}).validate).to be_nil
     end
 
-    it 'accepts empty inventory' do
+    it 'accepts non-empty inventory' do
       data = {
         'nodes' => [
           'node1',

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -180,14 +180,18 @@ describe Bolt::Inventory do
       expect(Bolt::Inventory.new(data).validate).to be_nil
     end
 
-    it 'fails with unamed groups' do
+    it 'fails with unnamed groups' do
       data = { 'groups' => [{}] }
-      expect { Bolt::Inventory.new(data).validate }.to raise_error(Bolt::Inventory::ValidationError)
+      expect {
+        Bolt::Inventory.new(data).validate
+      }.to raise_error(Bolt::Inventory::ValidationError, /Group does not have a name/)
     end
 
     it 'fails with duplicate groups' do
       data = { 'groups' => [{ 'name' => 'group1' }, { 'name' => 'group1' }] }
-      expect { Bolt::Inventory.new(data).validate }.to raise_error(Bolt::Inventory::ValidationError)
+      expect {
+        Bolt::Inventory.new(data).validate
+      }.to raise_error(Bolt::Inventory::ValidationError, /Tried to redefine group group1/)
     end
   end
 

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -5,6 +5,58 @@ require 'bolt/inventory'
 describe Bolt::Inventory do
   include BoltSpec::Config
 
+  let(:data) {
+    {
+      'nodes' => [
+        'node1',
+        { 'name' =>  'node2' },
+        { 'name' =>  'node3',
+          'config' => {
+            'ssh' => {
+              'user' => 'me'
+            }
+          } }
+      ],
+      'config' => {
+        'ssh' => {
+          'user' => 'you',
+          'insecure' => 'true',
+          'port' => '2222'
+        }
+      },
+      'groups' => [
+        { 'name' => 'group1',
+          'nodes' => [
+            { 'name' => 'node4',
+              'config' => {
+                'ssh' => {
+                  'user' => 'me'
+                }
+              } },
+            'node5',
+            'node6',
+            'node7'
+          ],
+          'config' => {
+            'ssh' => {
+              'insecure' => false
+            }
+          } },
+        { 'name' => 'group2',
+          'nodes' => [
+            { 'name' => 'node6',
+              'config' => {
+                'ssh' => { 'user' => 'someone' }
+              } },
+            'node7', 'node8'
+          ],
+          'config' => { 'ssh' => {
+            'insecure' => 'maybe'
+          } } }
+      ]
+    }
+  }
+
   describe :config_for do
     context 'with nodes at the top level' do
       let(:data) {
@@ -87,56 +139,6 @@ describe Bolt::Inventory do
     end
 
     context 'with data in the group' do
-      let(:data) {
-        {
-          'nodes' => [
-            'node1',
-            { 'name' =>  'node2' },
-            { 'name' =>  'node3',
-              'config' => {
-                'ssh' => {
-                  'user' => 'me'
-                }
-              } }
-          ],
-          'config' => {
-            'ssh' => {
-              'user' => 'you',
-              'insecure' => 'true',
-              'port' => '2222'
-            }
-          },
-          'groups' => [
-            { 'name' => 'group1',
-              'nodes' => [
-                { 'name' => 'node4',
-                  'config' => {
-                    'ssh' => {
-                      'user' => 'me'
-                    }
-                  } },
-                'node5',
-                'node6',
-                'node7'
-              ],
-              'config' => {
-                'ssh' => {
-                  'insecure' => false
-                }
-              } },
-            { 'name' => 'group2',
-              'nodes' => [
-                { 'name' => 'node6',
-                  'config' => {
-                    'ssh' => { 'user' => 'someone' }
-                  } },
-                'node7', 'node8'
-              ],
-              'config' => { 'ssh' => {
-                'insecure' => 'maybe'
-              } } }
-          ]
-        } }
       let(:inventory) { Bolt::Inventory.new(data) }
 
       it 'should use value from lowest node definition' do
@@ -175,55 +177,6 @@ describe Bolt::Inventory do
     end
 
     it 'accepts non-empty inventory' do
-      data = {
-        'nodes' => [
-          'node1',
-          { 'name' =>  'node2' },
-          { 'name' =>  'node3',
-            'config' => {
-              'ssh' => {
-                'user' => 'me'
-              }
-            } }
-        ],
-        'config' => {
-          'ssh' => {
-            'user' => 'you',
-            'insecure' => 'true',
-            'port' => '2222'
-          }
-        },
-        'groups' => [
-          { 'name' => 'group1',
-            'nodes' => [
-              { 'name' => 'node4',
-                'config' => {
-                  'ssh' => {
-                    'user' => 'me'
-                  }
-                } },
-              'node5',
-              'node6',
-              'node7'
-            ],
-            'config' => {
-              'ssh' => {
-                'insecure' => false
-              }
-            } },
-          { 'name' => 'group2',
-            'nodes' => [
-              { 'name' => 'node6',
-                'config' => {
-                  'ssh' => { 'user' => 'someone' }
-                } },
-              'node7', 'node8'
-            ],
-            'config' => { 'ssh' => {
-              'insecure' => 'maybe'
-            } } }
-        ]
-      }
       expect(Bolt::Inventory.new(data).validate).to be_nil
     end
 

--- a/spec/bolt/node/orch_spec.rb
+++ b/spec/bolt/node/orch_spec.rb
@@ -10,7 +10,7 @@ describe Bolt::Orch, orchestrator: true do
 
   let(:hostname) { "localhost" }
   let(:target) do
-    Bolt::Target.from_uri(hostname).update_conf(Bolt::Config.new.transport_conf)
+    Bolt::Target.new(hostname).update_conf(Bolt::Config.new.transport_conf)
   end
 
   let(:orch) { Bolt::Orch.new(target) }

--- a/spec/bolt/node/ssh_spec.rb
+++ b/spec/bolt/node/ssh_spec.rb
@@ -30,7 +30,7 @@ done
 BASH
 
   def target(h: hostname, p: port, conf: config)
-    Bolt::Target.from_uri("#{h}:#{p}").update_conf(conf.transport_conf)
+    Bolt::Target.new("#{h}:#{p}").update_conf(conf.transport_conf)
   end
 
   def result_value(stdout = nil, stderr = nil, exit_code = 0)

--- a/spec/bolt/node/winrm_spec.rb
+++ b/spec/bolt/node/winrm_spec.rb
@@ -31,7 +31,7 @@ foreach ($i in $args)
 PS
 
   def target(h: host, p: port, conf: config)
-    Bolt::Target.from_uri("#{h}:#{p}").update_conf(conf)
+    Bolt::Target.new("#{h}:#{p}").update_conf(conf)
   end
 
   def stub_winrm_to_raise(klass, message)

--- a/spec/bolt/node_spec.rb
+++ b/spec/bolt/node_spec.rb
@@ -5,7 +5,7 @@ require 'bolt/target'
 require 'bolt/node'
 
 def from_uri(uri, config)
-  Bolt::Node.from_target(Bolt::Target.from_uri(uri).update_conf(config))
+  Bolt::Node.from_target(Bolt::Target.new(uri).update_conf(config))
 end
 
 describe Bolt::Node do

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -6,7 +6,7 @@ describe "Bolt::Outputter::Human" do
   let(:output) { StringIO.new }
   let(:outputter) { Bolt::Outputter::Human.new(output) }
   let(:config) { Bolt::Config.new }
-  let(:target) { Bolt::Target.from_uri('node1') }
+  let(:target) { Bolt::Target.new('node1') }
   let(:results) { { node1: Bolt::Result.new(target, message: "ok") } }
 
   it "starts items in head" do
@@ -23,7 +23,7 @@ describe "Bolt::Outputter::Human" do
   it "prints status" do
     outputter.print_head
     outputter.print_result(Bolt::Result.new(target))
-    outputter.print_result(Bolt::Result.new(Bolt::Target.from_uri('node2'), error: { 'msg' => 'oops' }))
+    outputter.print_result(Bolt::Result.new(Bolt::Target.new('node2'), error: { 'msg' => 'oops' }))
     outputter.print_summary(results, 10.0)
     lines = output.string
     expect(lines).to match(/Finished on node1/)

--- a/spec/bolt/target_spec.rb
+++ b/spec/bolt/target_spec.rb
@@ -7,26 +7,26 @@ describe Bolt::Target do
     let(:password) { 'foobar' }
 
     it "accepts userinfo when a port is specified" do
-      uri = Bolt::Target.from_uri("ssh://#{user}:#{password}@neptune:2222")
+      uri = Bolt::Target.new("ssh://#{user}:#{password}@neptune:2222")
       expect(uri.user).to eq(user)
       expect(uri.password).to eq(password)
     end
 
     it "accepts userinfo without a port" do
-      uri = Bolt::Target.from_uri("ssh://#{user}:#{password}@neptune")
+      uri = Bolt::Target.new("ssh://#{user}:#{password}@neptune")
       expect(uri.user).to eq(user)
       expect(uri.password).to eq(password)
     end
 
     it "accepts userinfo when using the default protocol" do
-      uri = Bolt::Target.from_uri("#{user}:#{password}@neptune")
+      uri = Bolt::Target.new("#{user}:#{password}@neptune")
       expect(uri.user).to eq(user)
       expect(uri.password).to eq(password)
     end
 
     it "rejects unescaped special characters" do
       expect {
-        Bolt::Target.from_uri("#{user}:a/b@neptune")
+        Bolt::Target.new("#{user}:a/b@neptune")
       }.to raise_error(Addressable::URI::InvalidURIError,
                        /Invalid port number/)
     end
@@ -72,21 +72,21 @@ describe Bolt::Target do
         encoded.concat(v)
       end
 
-      uri = Bolt::Target.from_uri("#{encoded}:#{encoded}@neptune")
+      uri = Bolt::Target.new("#{encoded}:#{encoded}@neptune")
       expect(uri.user).to eq(unencoded)
       expect(uri.password).to eq(unencoded)
     end
   end
 
   it "does not default the port without a protocol" do
-    uri = Bolt::Target.from_uri('pluto')
+    uri = Bolt::Target.new('pluto')
     expect(uri.host).to eq('pluto')
     expect(uri.port).to be_nil
   end
 
   describe "with winrm" do
     it "accepts 'winrm://host:port'" do
-      uri = Bolt::Target.from_uri('winrm://neptune:55985')
+      uri = Bolt::Target.new('winrm://neptune:55985')
       expect(uri.protocol).to eq('winrm')
       expect(uri.host).to eq('neptune')
       expect(uri.port).to eq(55985)
@@ -95,21 +95,21 @@ describe Bolt::Target do
 
   describe "with ssh" do
     it "accepts 'ssh://host:port'" do
-      uri = Bolt::Target.from_uri('ssh://pluto:2224')
+      uri = Bolt::Target.new('ssh://pluto:2224')
       expect(uri.protocol).to eq('ssh')
       expect(uri.host).to eq('pluto')
       expect(uri.port).to eq(2224)
     end
 
     it "does not default the ssh port" do
-      uri = Bolt::Target.from_uri('ssh://pluto')
+      uri = Bolt::Target.new('ssh://pluto')
       expect(uri.protocol).to eq('ssh')
       expect(uri.host).to eq('pluto')
       expect(uri.port).to be_nil
     end
 
     it "accepts 'host:port' without a protocol" do
-      uri = Bolt::Target.from_uri('pluto:2224')
+      uri = Bolt::Target.new('pluto:2224')
       expect(uri.protocol).to eq(nil)
       expect(uri.host).to eq('pluto')
       expect(uri.port).to eq(2224)
@@ -118,14 +118,14 @@ describe Bolt::Target do
 
   describe "with pcp" do
     it "accepts 'pcp://pluto:666'" do
-      uri = Bolt::Target.from_uri('pcp://pluto:666')
+      uri = Bolt::Target.new('pcp://pluto:666')
       expect(uri.protocol).to eq('pcp')
       expect(uri.host).to eq('pluto')
       expect(uri.port).to eq(666)
     end
 
     it "accepts 'pcp://pluto' without a port" do
-      uri = Bolt::Target.from_uri('pcp://pluto')
+      uri = Bolt::Target.new('pcp://pluto')
       expect(uri.protocol).to eq('pcp')
       expect(uri.host).to eq('pluto')
       expect(uri.port).to be_nil
@@ -134,7 +134,7 @@ describe Bolt::Target do
 
   describe "with unsupported http protocol" do
     it "accepts 'http://pluto:666'" do
-      uri = Bolt::Target.from_uri('http://pluto:666')
+      uri = Bolt::Target.new('http://pluto:666')
       expect(uri.protocol).to eq('http')
       expect(uri.host).to eq('pluto')
       expect(uri.port).to eq(666)
@@ -142,12 +142,12 @@ describe Bolt::Target do
   end
 
   it "strips brackets from ipv6 addresses in a uri" do
-    uri = Bolt::Target.from_uri('ssh://[::1]:22')
+    uri = Bolt::Target.new('ssh://[::1]:22')
     expect(uri.host).to eq('::1')
   end
 
   it "can be copied" do
-    uri1 = Bolt::Target.from_uri('http://pluto:666')
+    uri1 = Bolt::Target.new('http://pluto:666')
     uri2 = Bolt::Target.new(uri1.uri)
     expect(uri1).to eq(uri2)
   end

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -31,6 +31,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
         }
       } }
   end
+  let(:target) { conn[:host] }
 
   let(:modulepath) { fixture_path('modules') }
   let(:config_flags) {
@@ -41,9 +42,9 @@ describe 'running with an inventory file', reset_puppet_settings: true do
      '--password', conn[:password]]
   }
 
-  let(:run_command) { ['command', 'run', whoami, '--nodes', conn[:host]] + config_flags }
+  let(:run_command) { ['command', 'run', whoami, '--nodes', target] + config_flags }
 
-  let(:run_plan) { ['plan', 'run', 'inventory', "command=#{whoami}", "host=#{conn[:host]}"] + config_flags }
+  let(:run_plan) { ['plan', 'run', 'inventory', "command=#{whoami}", "host=#{target}"] + config_flags }
 
   around(:each) do |example|
     with_tempfile_containing('inventory', inventory.to_json, '.yml') do |f|
@@ -61,8 +62,19 @@ describe 'running with an inventory file', reset_puppet_settings: true do
     end
 
     it 'connects to run a plan' do
-      # result = run_cli(run_plan)
       expect(run_cli_json(run_plan)[0]['status']).to eq('success')
+    end
+
+    context 'with a group' do
+      let(:target) { 'all' }
+
+      it 'runs a command' do
+        expect(run_one_node(run_command)).to be
+      end
+
+      it 'runs a plan using a group' do
+        expect(run_cli_json(run_plan)[0]['status']).to eq('success')
+      end
     end
   end
 
@@ -76,6 +88,18 @@ describe 'running with an inventory file', reset_puppet_settings: true do
 
     it 'connects to run a plan' do
       expect(run_cli_json(run_plan)[0]['status']).to eq('success')
+    end
+
+    context 'with a group' do
+      let(:target) { 'all' }
+
+      it 'connects to run a command' do
+        expect(run_one_node(run_command)).to be
+      end
+
+      it 'connects to run a plan' do
+        expect(run_cli_json(run_plan)[0]['status']).to eq('success')
+      end
     end
   end
 end


### PR DESCRIPTION
Adds support for targeting nodes by group. A group name can be used in-place of a target URI on the CLI
```
bolt command run 'hostname' --nodes ssh://host1,group_name
```
or in commands that accept a list of targets
```
run_command('hostname', ['ssh://host1', 'group_name'])
```

Note that the top-level group in inventory is named `all` unless otherwise specified.

Bolt plan run functions will now also split comma-separated list of target URIs, allowing the following to work via a CLI argument similar to `--nodes`
```
plan targets(String $targets) { run_command('hostname', $targets) }
```

A new function has been added to help resolve target input to a list of Targets, `get_targets`. It backs the Bolt plan run functions, so it will split on comma/space and translate groups to targets in that group.