### PR TITLE
(PUP-8441) Monkey Patch to_json onto Puppet::DataTypes::Error

### DIFF
--- a/spec/fixtures/modules/error/plans/nested.pp
+++ b/spec/fixtures/modules/error/plans/nested.pp
@@ -1,0 +1,4 @@
+plan error::nested {
+  $err = run_plan('error::err', '_catch_errors' => true);
+  { 'error' => [ $err ] }
+}

--- a/spec/integration/fail_plan_spec.rb
+++ b/spec/integration/fail_plan_spec.rb
@@ -71,4 +71,15 @@ describe "When a plan fails" do
       expect(result['msg']).to match(/error::fail/)
     end
   end
+
+  it 'outputs nested errors' do
+    if error_support
+      result = run_cli_json(['plan', 'run', 'error::nested'] + config_flags)
+      expect(result).to eq('error' => [{
+                             'msg' => 'oops',
+                             'kind' => 'test/oops',
+                             'details' => { 'some' => 'info' }
+                           }])
+    end
+  end
 end


### PR DESCRIPTION
This is a temporary hack until we have a better way to generate a JSON
object for Error objects returned from plans. Since our output is based
on to_json now we need Error to support to_json to handle nested
objects.