### PR TITLE
(BOLT-330) Allow wildcard matching node names in inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,20 @@ $ bolt task run package name=puppet action=status --nodes sshnode1.example.com,w
 
 The global transport option and any transport specific config option can be set in the inventory file. You can also set `user` and `password` for specific transports.
 
+When an inventory is present, node selection can also be done by specifying group names:
+
+```
+$ bolt command run hostname --nodes ssh_nodes
+```
+
+or using wildcard matching against node names enumerated in the inventory:
+
+```
+$ bolt command run hostname --nodes 'sshnode*.example.com'
+```
+
+Note that - in place of wildcard matching - shell-specific expansions (such as `sshnode{1,2}.example.com`) can also be useful ways to specify a pattern of nodes to run.
+
 
 ## Usage examples
 

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -18,7 +18,6 @@ module Bolt
   class CLIError < Bolt::Error
     def initialize(msg)
       super(msg, "bolt/cli-error")
-      @error_code = error_code if error_code
     end
   end
 
@@ -318,7 +317,7 @@ HELP
       options[:targets] = inventory.get_targets(options[:nodes]) if options[:nodes]
 
       options
-    rescue Bolt::CLIError => e
+    rescue Bolt::Error => e
       warn e.message
       raise e
     end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1382,6 +1382,7 @@ bar
     let(:configdir) { File.join(__dir__, '..', 'fixtures', 'configs') }
     let(:complete_config) do
       { 'modulepath' => "/foo/bar#{File::PATH_SEPARATOR}/baz/qux",
+        'inventoryfile' => File.join(__dir__, '..', 'fixtures', 'inventory', 'empty.yml'),
         'concurrency' => 14,
         'format' => 'json',
         'ssh' => {
@@ -1533,6 +1534,17 @@ bar
       expect {
         cli.parse
       }.to raise_error(Bolt::CLIError, /Could not parse/)
+    end
+  end
+
+  describe 'inventoryfile' do
+    let(:inventorydir) { File.join(__dir__, '..', 'fixtures', 'configs') }
+
+    it 'raises an error if a inventory file is specified and invalid' do
+      cli = Bolt::CLI.new(%W[command run --inventoryfile #{File.join(inventorydir, 'invalid.yml')} --nodes foo])
+      expect {
+        cli.parse
+      }.to raise_error(Bolt::Error, /Could not parse/)
     end
   end
 end

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -293,6 +293,17 @@ describe Bolt::Inventory do
         targets = inventory.get_targets('group1,a')
         expect(targets).to eq(targets(%w[node4 node5 node6 node7 a]))
       end
+
+      it 'should match wildcard selectors' do
+        targets = inventory.get_targets('node*')
+        expect(targets).to eq(targets(%w[node1 node2 node3 node4 node5 node6 node7 node8]))
+      end
+
+      it 'should fail if wildcard selector matches nothing' do
+        expect {
+          inventory.get_targets('*node')
+        }.to raise_error(Bolt::Inventory::WildcardError, /Found 0 nodes matching wildcard pattern \*node/)
+      end
     end
   end
 end

--- a/spec/fixtures/inventory/invalid.yml
+++ b/spec/fixtures/inventory/invalid.yml
@@ -1,0 +1,1 @@
+this : isn't a : yaml file is it"?


### PR DESCRIPTION
Supports using wildcard `(*)` when passing nodes to `get_targets` to match multiple nodes if present in inventory.

Also fix some things.