### PR TITLE
(BOLT-316) Batch tasks, etc when using the orch transport

### DIFF
--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -101,17 +101,19 @@ module Bolt
       results
     end
 
-    def run_script(targets, script, arguments, options = {})
+    def run_script(targets, script, arguments, options = {}, &callback)
       @logger.info("Starting script run #{script} on #{targets.map(&:uri)}")
       @logger.debug("Arguments: #{arguments}")
-      callback = block_given? ? Proc.new : nil
+      notify = proc { |event| @notifier.notify(callback, event) if callback }
+      options = { '_run_as' => run_as }.merge(options) if run_as
 
-      r = on(targets, callback) do |transport, target|
-        @logger.debug { "Running script '#{script}' on #{target.uri}" }
-        transport.run_script(target, script, arguments, get_run_as(target, options))
+      result_futures = targets.group_by(&:protocol).flat_map do |protocol, batch|
+        transport(protocol).batch_script(batch, script, arguments, options, &notify)
       end
-      @logger.info(summary('script', script, r))
-      r
+      results = ResultSet.new(result_futures.map(&:value))
+      @logger.info(summary('script', script, results))
+      @notifier.shutdown
+      results
     end
 
     def run_task(targets, task, input_method, arguments, options = {}, &callback)

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -54,6 +54,7 @@ module Bolt
             rescue StandardError => ex
               Bolt::Result.from_exception(target, ex)
             end
+          @logger.debug("Result on #{target.uri}: #{JSON.dump(result.value)}")
           results.concat([result])
           @notifier.notify(callback, type: :node_result, result: result) if callback
         end
@@ -97,11 +98,7 @@ module Bolt
 
       r = on(targets, callback) do |transport, target|
         @logger.debug("Running command '#{command}' on #{target.uri}")
-        target_result = with_exception_handling(target) do
-          transport.run_command(target, command, get_run_as(target, options))
-        end
-        @logger.debug("Result on #{target.uri}: #{JSON.dump(target_result.value)}")
-        target_result
+        transport.run_command(target, command, get_run_as(target, options))
       end
       @logger.info(summary('command', command, r))
       r
@@ -114,11 +111,7 @@ module Bolt
 
       r = on(targets, callback) do |transport, target|
         @logger.debug { "Running script '#{script}' on #{target.uri}" }
-        target_result = with_exception_handling(target) do
-          transport.run_script(target, script, arguments, get_run_as(target, options))
-        end
-        @logger.debug("Result on #{target.uri}: #{JSON.dump(target_result.value)}")
-        target_result
+        transport.run_script(target, script, arguments, get_run_as(target, options))
       end
       @logger.info(summary('script', script, r))
       r
@@ -131,11 +124,7 @@ module Bolt
 
       r = on(targets, callback) do |transport, target|
         @logger.debug { "Running task run '#{task}' on #{target.uri}" }
-        target_result = with_exception_handling(target) do
-          transport.run_task(target, task, input_method, arguments, get_run_as(target, options))
-        end
-        @logger.debug("Result on #{target.uri}: #{JSON.dump(target_result.value)}")
-        target_result
+        transport.run_task(target, task, input_method, arguments, get_run_as(target, options))
       end
       @logger.info(summary('task', task, r))
       r
@@ -147,11 +136,7 @@ module Bolt
 
       r = on(targets, callback) do |transport, target|
         @logger.debug { "Uploading: '#{source}' to #{destination} on #{target.uri}" }
-        target_result = with_exception_handling(target) do
-          transport.upload(target, source, destination, options)
-        end
-        @logger.debug("Result on #{target.uri}: #{JSON.dump(target_result.value)}")
-        target_result
+        transport.upload(target, source, destination, options)
       end
       @logger.info(summary('upload', source, r))
       r

--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -1,30 +1,53 @@
-require 'concurrent'
 require 'logging'
 
 module Bolt
   module Transport
+    # This class provides the default behavior for Transports. A Transport is
+    # responsible for uploading files and running commands, scripts, and tasks
+    # on Targets.
+    #
+    # Bolt executes work on the Transport in "batches". To do that, it calls
+    # the batches() method, which is responsible for dividing the list of
+    # Targets into batches according to how it wants to handle them. It will
+    # then call Transport#batch_task, or the corresponding method for another
+    # operation, passing a list of Targets. The Transport returns a list of
+    # Bolt::Result objects, one per Target. Each batch is executed on a
+    # separate thread, controlled by the `concurrency` setting, so many batches
+    # may be running in parallel.
+    #
+    # The default batch implementation splits the list of Targets into batches
+    # of 1. It then calls run_task(), or a corresponding method for other
+    # operations, passing in the single Target.
+    #
+    # Most Transport implementations, like the SSH and WinRM transports, don't
+    # need to do their own batching, since they only operate on a single Target
+    # at a time. Those Transports can implement the run_task() and related
+    # methods, which will automatically handle running many Targets in
+    # parallel, and will handle publishing start and finish events for each
+    # Target.
+    #
+    # Transports that need their own batching, like the Orch transport, can
+    # instead override the batches() method to split Targets into sets that can
+    # be executed together, and override the batch_task() and related methods
+    # to execute a batch of nodes. In that case, those Transports should accept
+    # a block argument and call it with a :node_start event for each Target
+    # before executing, and a :node_result event for each Target after
+    # execution.
     class Base
       attr_reader :logger
 
-      def initialize(_config, executor = Concurrent.global_immediate_executor)
+      def initialize(_config)
         @logger = Logging.logger[self]
-        @executor = executor
       end
 
-      def on(targets, callback)
-        targets.map do |target|
-          Concurrent::Future.execute(executor: @executor) do
-            begin
-              callback.call(type: :node_start, target: target) if callback
-              result = yield target
-              @logger.debug("Result on #{target.uri}: #{JSON.dump(result.value)}")
-              callback.call(type: :node_result, result: result) if callback
-              result
-            rescue StandardError => ex
-              Bolt::Result.from_exception(target, ex)
-            end
-          end
-        end
+      def with_events(target, callback)
+        callback.call(type: :node_start, target: target) if callback
+        result = yield
+        @logger.debug("Result on #{target.uri}: #{JSON.dump(result.value)}")
+        callback.call(type: :node_result, result: result) if callback
+        result
+      rescue StandardError => ex
+        Bolt::Result.from_exception(target, ex)
       end
 
       def filter_options(target, options)
@@ -35,51 +58,99 @@ module Bolt
         end
       end
 
-      def batch_task(targets, task, input_method, arguments, options = {})
-        callback = Proc.new if block_given?
-        on(targets, callback) do |target|
-          @logger.debug { "Running task run '#{task}' on #{target.uri}" }
-          target_options = filter_options(target, options)
-          run_task(target, task, input_method, arguments, target_options)
+      # Raises an error if more than one target was given in the batch.
+      #
+      # The default implementations of batch_* strictly assume the transport is
+      # using the default batch size of 1. This method ensures that is the
+      # case and raises an error if it's not.
+      def assert_batch_size_one(method, targets)
+        if targets.length > 1
+          message = "#{self.class.name} must implement #{method} to support batches (got #{targets.length} nodes)"
+          raise NotImplementedError, message
         end
       end
 
-      def batch_command(targets, command, options = {})
-        callback = Proc.new if block_given?
-        on(targets, callback) do |target|
+      # Runs the given task on a batch of nodes.
+      #
+      # The default implementation only supports batches of size 1 and will fail otherwise.
+      #
+      # Transports may override this method to implement their own batch processing.
+      def batch_task(targets, task, input_method, arguments, options = {}, &callback)
+        assert_batch_size_one("batch_task()", targets)
+        target = targets.first
+        with_events(target, callback) do
+          @logger.debug { "Running task run '#{task}' on #{target.uri}" }
+          run_task(target, task, input_method, arguments, filter_options(target, options))
+        end
+      end
+
+      # Runs the given command on a batch of nodes.
+      #
+      # The default implementation only supports batches of size 1 and will fail otherwise.
+      #
+      # Transports may override this method to implement their own batch processing.
+      def batch_command(targets, command, options = {}, &callback)
+        assert_batch_size_one("batch_command()", targets)
+        target = targets.first
+        with_events(target, callback) do
           @logger.debug("Running command '#{command}' on #{target.uri}")
           run_command(target, command, filter_options(target, options))
         end
       end
 
-      def batch_script(targets, script, arguments, options = {})
-        callback = Proc.new if block_given?
-        on(targets, callback) do |target|
+      # Runs the given script on a batch of nodes.
+      #
+      # The default implementation only supports batches of size 1 and will fail otherwise.
+      #
+      # Transports may override this method to implement their own batch processing.
+      def batch_script(targets, script, arguments, options = {}, &callback)
+        assert_batch_size_one("batch_script()", targets)
+        target = targets.first
+        with_events(target, callback) do
           @logger.debug { "Running script '#{script}' on #{target.uri}" }
           run_script(target, script, arguments, filter_options(target, options))
         end
       end
 
-      def batch_upload(targets, source, destination, options = {})
-        callback = Proc.new if block_given?
-        on(targets, callback) do |target|
+      # Uploads the given source file to the destination location on a batch of nodes.
+      #
+      # The default implementation only supports batches of size 1 and will fail otherwise.
+      #
+      # Transports may override this method to implement their own batch processing.
+      def batch_upload(targets, source, destination, options = {}, &callback)
+        assert_batch_size_one("batch_upload()", targets)
+        target = targets.first
+        with_events(target, callback) do
           @logger.debug { "Uploading: '#{source}' to #{destination} on #{target.uri}" }
           upload(target, source, destination, filter_options(target, options))
         end
       end
 
+      # Split the given list of targets into a list of batches. The default
+      # implementation returns single-node batches.
+      #
+      # Transports may override this method, and the corresponding batch_*
+      # methods, to implement their own batch processing.
+      def batches(targets)
+        targets.map { |target| [target] }
+      end
+
+      # Transports should override this method with their own implementation of running a command.
       def run_command(*_args)
         raise NotImplementedError, "run_command() must be implemented by the transport class"
       end
 
+      # Transports should override this method with their own implementation of running a script.
       def run_script(*_args)
         raise NotImplementedError, "run_script() must be implemented by the transport class"
       end
 
+      # Transports should override this method with their own implementation of running a task.
       def run_task(*_args)
         raise NotImplementedError, "run_task() must be implemented by the transport class"
       end
 
+      # Transports should override this method with their own implementation of file upload.
       def upload(*_args)
         raise NotImplementedError, "upload() must be implemented by the transport class"
       end

--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -44,6 +44,14 @@ module Bolt
         end
       end
 
+      def batch_command(targets, command, options = {})
+        callback = Proc.new if block_given?
+        on(targets, callback) do |target|
+          @logger.debug("Running command '#{command}' on #{target.uri}")
+          run_command(target, command, filter_options(target, options))
+        end
+      end
+
       def run_command(*_args)
         raise NotImplementedError, "run_command() must be implemented by the transport class"
       end

--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -1,0 +1,64 @@
+require 'concurrent'
+require 'logging'
+
+module Bolt
+  module Transport
+    class Base
+      attr_reader :logger
+
+      def initialize(_config, executor = Concurrent.global_immediate_executor)
+        @logger = Logging.logger[self]
+        @executor = executor
+      end
+
+      def on(targets, callback)
+        targets.map do |target|
+          Concurrent::Future.execute(executor: @executor) do
+            begin
+              callback.call(type: :node_start, target: target) if callback
+              result = yield target
+              @logger.debug("Result on #{target.uri}: #{JSON.dump(result.value)}")
+              callback.call(type: :node_result, result: result) if callback
+              result
+            rescue StandardError => ex
+              Bolt::Result.from_exception(target, ex)
+            end
+          end
+        end
+      end
+
+      def filter_options(target, options)
+        if target.options[:run_as]
+          options.reject { |k, _v| k == '_run_as' }
+        else
+          options
+        end
+      end
+
+      def batch_task(targets, task, input_method, arguments, options = {})
+        callback = Proc.new if block_given?
+        on(targets, callback) do |target|
+          @logger.debug { "Running task run '#{task}' on #{target.uri}" }
+          target_options = filter_options(target, options)
+          run_task(target, task, input_method, arguments, target_options)
+        end
+      end
+
+      def run_command(*_args)
+        raise NotImplementedError, "run_command() must be implemented by the transport class"
+      end
+
+      def run_script(*_args)
+        raise NotImplementedError, "run_script() must be implemented by the transport class"
+      end
+
+      def run_task(*_args)
+        raise NotImplementedError, "run_task() must be implemented by the transport class"
+      end
+
+      def upload(*_args)
+        raise NotImplementedError, "upload() must be implemented by the transport class"
+      end
+    end
+  end
+end

--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -52,6 +52,14 @@ module Bolt
         end
       end
 
+      def batch_script(targets, script, arguments, options = {})
+        callback = Proc.new if block_given?
+        on(targets, callback) do |target|
+          @logger.debug { "Running script '#{script}' on #{target.uri}" }
+          run_script(target, script, arguments, filter_options(target, options))
+        end
+      end
+
       def run_command(*_args)
         raise NotImplementedError, "run_command() must be implemented by the transport class"
       end

--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -60,6 +60,14 @@ module Bolt
         end
       end
 
+      def batch_upload(targets, source, destination, options = {})
+        callback = Proc.new if block_given?
+        on(targets, callback) do |target|
+          @logger.debug { "Uploading: '#{source}' to #{destination} on #{target.uri}" }
+          upload(target, source, destination, filter_options(target, options))
+        end
+      end
+
       def run_command(*_args)
         raise NotImplementedError, "run_command() must be implemented by the transport class"
       end

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -69,7 +69,7 @@ module Bolt
       end
 
       def process_run_results(targets, results)
-        targets_by_name = Hash[targets.map(&:name).zip(targets)]
+        targets_by_name = Hash[targets.map(&:host).zip(targets)]
         results.map do |node_result|
           target = targets_by_name[node_result['name']]
           state = node_result['state']

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -101,6 +101,16 @@ module Bolt
         end
       end
 
+      def batch_command(targets, command, _options = {})
+        promises = batch_task(targets,
+                              BOLT_MOCK_FILE,
+                              'stdin',
+                              action: 'command',
+                              command: command,
+                              options: {})
+        promises.map { |promise| promise.then { |result| unwrap_bolt_result(result.target, result) } }
+      end
+
       def batch_task(targets, task, _inputmethod, arguments, _options = {})
         callback = block_given? ? Proc.new : proc {}
         body = build_request(targets, task, arguments)

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -111,6 +111,18 @@ module Bolt
         promises.map { |promise| promise.then { |result| unwrap_bolt_result(result.target, result) } }
       end
 
+      def batch_script(targets, script, arguments, _options = {})
+        content = File.open(script, &:read)
+        content = Base64.encode64(content)
+        params = {
+          action: 'script',
+          content: content,
+          arguments: arguments
+        }
+        promises = batch_task(targets, BOLT_MOCK_FILE, 'stdin', params)
+        promises.map { |promise| promise.then { |result| unwrap_bolt_result(result.target, result) } }
+      end
+
       def batch_task(targets, task, _inputmethod, arguments, _options = {})
         callback = block_given? ? Proc.new : proc {}
         body = build_request(targets, task, arguments)

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -1,19 +1,16 @@
 require 'bolt/node/errors'
-require 'bolt/transport/ssh/connection'
+require 'bolt/transport/base'
 require 'json'
-require 'logging'
 require 'shellwords'
 
 module Bolt
   module Transport
-    class SSH
-      attr_reader :logger
-
+    class SSH < Base
       STDIN_METHODS       = %w[both stdin].freeze
       ENVIRONMENT_METHODS = %w[both environment].freeze
 
-      def initialize(_config)
-        @logger = Logging.logger[self]
+      def initialize(_config, _executor = Concurrent.global_immediate_executor)
+        super
 
         require 'net/ssh'
         require 'net/scp'
@@ -34,7 +31,7 @@ module Bolt
         begin
           conn.disconnect if conn
         rescue StandardError => ex
-          @logger.info("Failed to close connection to #{target.uri} : #{ex.message}")
+          logger.info("Failed to close connection to #{target.uri} : #{ex.message}")
         end
       end
 
@@ -133,3 +130,5 @@ SCRIPT
     end
   end
 end
+
+require 'bolt/transport/ssh/connection'

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -9,7 +9,7 @@ module Bolt
       STDIN_METHODS       = %w[both stdin].freeze
       ENVIRONMENT_METHODS = %w[both environment].freeze
 
-      def initialize(_config, _executor = Concurrent.global_immediate_executor)
+      def initialize(_config)
         super
 
         require 'net/ssh'

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -4,7 +4,7 @@ require 'bolt/node/output'
 
 module Bolt
   module Transport
-    class SSH
+    class SSH < Base
       class Connection
         class RemoteTempdir
           def initialize(node, path)

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -1,11 +1,8 @@
-require 'bolt/transport/winrm/connection'
-require 'logging'
+require 'bolt/transport/base'
 
 module Bolt
   module Transport
-    class WinRM
-      attr_reader :logger
-
+    class WinRM < Base
       STDIN_METHODS       = %w[both stdin].freeze
       ENVIRONMENT_METHODS = %w[both environment].freeze
 
@@ -13,9 +10,8 @@ module Bolt
         -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass
       ].freeze
 
-      def initialize(_config)
-        @logger = Logging.logger[self]
-
+      def initialize(_config, _executor = Concurrent.global_immediate_executor)
+        super
         require 'winrm'
         require 'winrm-fs'
       end
@@ -28,7 +24,7 @@ module Bolt
         begin
           conn.disconnect if conn
         rescue StandardError => ex
-          @logger.info("Failed to close connection to #{target.uri} : #{ex.message}")
+          logger.info("Failed to close connection to #{target.uri} : #{ex.message}")
         end
       end
 
@@ -164,3 +160,5 @@ try { & "#{remote_path}" @taskArgs } catch { exit 1 }
     end
   end
 end
+
+require 'bolt/transport/winrm/connection'

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -10,7 +10,7 @@ module Bolt
         -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass
       ].freeze
 
-      def initialize(_config, _executor = Concurrent.global_immediate_executor)
+      def initialize(_config)
         super
         require 'winrm'
         require 'winrm-fs'

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -3,7 +3,7 @@ require 'bolt/node/output'
 
 module Bolt
   module Transport
-    class WinRM
+    class WinRM < Base
       class Connection
         attr_reader :logger, :target
 
@@ -87,283 +87,283 @@ module Bolt
           return nil if @shell_initialized
           result = execute(<<-PS)
 $ENV:PATH += ";${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\bin\\;" +
-  "${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\sys\\ruby\\bin\\"
+"${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\sys\\ruby\\bin\\"
 $ENV:RUBYLIB = "${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\puppet\\lib;" +
-  "${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\facter\\lib;" +
-  "${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\hiera\\lib;" +
-  $ENV:RUBYLIB
+"${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\facter\\lib;" +
+"${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\hiera\\lib;" +
+$ENV:RUBYLIB
 
 Add-Type -AssemblyName System.ServiceModel.Web, System.Runtime.Serialization
 $utf8 = [System.Text.Encoding]::UTF8
 
 function Invoke-Interpreter
 {
-  [CmdletBinding()]
-  Param (
-    [Parameter()]
-    [String]
-    $Path,
+[CmdletBinding()]
+Param (
+  [Parameter()]
+  [String]
+  $Path,
 
-    [Parameter()]
-    [String]
-    $Arguments,
+  [Parameter()]
+  [String]
+  $Arguments,
 
-    [Parameter()]
-    [Int32]
-    $Timeout,
+  [Parameter()]
+  [Int32]
+  $Timeout,
 
-    [Parameter()]
-    [String]
-    $StdinInput = $Null
-  )
+  [Parameter()]
+  [String]
+  $StdinInput = $Null
+)
 
-  try
+try
+{
+  if (-not (Get-Command $Path -ErrorAction SilentlyContinue))
   {
-    if (-not (Get-Command $Path -ErrorAction SilentlyContinue))
-    {
-      throw "Could not find executable '$Path' in ${ENV:PATH} on target node"
-    }
-
-    $startInfo = New-Object System.Diagnostics.ProcessStartInfo($Path, $Arguments)
-    $startInfo.UseShellExecute = $false
-    $startInfo.WorkingDirectory = Split-Path -Parent (Get-Command $Path).Path
-    $startInfo.CreateNoWindow = $true
-    if ($StdinInput) { $startInfo.RedirectStandardInput = $true }
-    $startInfo.RedirectStandardOutput = $true
-    $startInfo.RedirectStandardError = $true
-
-    $stdoutHandler = { if (-not ([String]::IsNullOrEmpty($EventArgs.Data))) { $Host.UI.WriteLine($EventArgs.Data) } }
-    $stderrHandler = { if (-not ([String]::IsNullOrEmpty($EventArgs.Data))) { $Host.UI.WriteErrorLine($EventArgs.Data) } }
-    $invocationId = [Guid]::NewGuid().ToString()
-
-    $process = New-Object System.Diagnostics.Process
-    $process.StartInfo = $startInfo
-    $process.EnableRaisingEvents = $true
-
-    # https://msdn.microsoft.com/en-us/library/system.diagnostics.process.standarderror(v=vs.110).aspx#Anchor_2
-    $stdoutEvent = Register-ObjectEvent -InputObject $process -EventName 'OutputDataReceived' -Action $stdoutHandler
-    $stderrEvent = Register-ObjectEvent -InputObject $process -EventName 'ErrorDataReceived' -Action $stderrHandler
-    $exitedEvent = Register-ObjectEvent -InputObject $process -EventName 'Exited' -SourceIdentifier $invocationId
-
-    $process.Start() | Out-Null
-
-    $process.BeginOutputReadLine()
-    $process.BeginErrorReadLine()
-
-    if ($StdinInput)
-    {
-      $process.StandardInput.WriteLine($StdinInput)
-      $process.StandardInput.Close()
-    }
-
-    # park current thread until the PS event is signaled upon process exit
-    # OR the timeout has elapsed
-    $waitResult = Wait-Event -SourceIdentifier $invocationId -Timeout $Timeout
-    if (! $process.HasExited)
-    {
-      $Host.UI.WriteErrorLine("Process $Path did not complete in $Timeout seconds")
-      return 1
-    }
-
-    return $process.ExitCode
+    throw "Could not find executable '$Path' in ${ENV:PATH} on target node"
   }
-  catch
+
+  $startInfo = New-Object System.Diagnostics.ProcessStartInfo($Path, $Arguments)
+  $startInfo.UseShellExecute = $false
+  $startInfo.WorkingDirectory = Split-Path -Parent (Get-Command $Path).Path
+  $startInfo.CreateNoWindow = $true
+  if ($StdinInput) { $startInfo.RedirectStandardInput = $true }
+  $startInfo.RedirectStandardOutput = $true
+  $startInfo.RedirectStandardError = $true
+
+  $stdoutHandler = { if (-not ([String]::IsNullOrEmpty($EventArgs.Data))) { $Host.UI.WriteLine($EventArgs.Data) } }
+  $stderrHandler = { if (-not ([String]::IsNullOrEmpty($EventArgs.Data))) { $Host.UI.WriteErrorLine($EventArgs.Data) } }
+  $invocationId = [Guid]::NewGuid().ToString()
+
+  $process = New-Object System.Diagnostics.Process
+  $process.StartInfo = $startInfo
+  $process.EnableRaisingEvents = $true
+
+  # https://msdn.microsoft.com/en-us/library/system.diagnostics.process.standarderror(v=vs.110).aspx#Anchor_2
+  $stdoutEvent = Register-ObjectEvent -InputObject $process -EventName 'OutputDataReceived' -Action $stdoutHandler
+  $stderrEvent = Register-ObjectEvent -InputObject $process -EventName 'ErrorDataReceived' -Action $stderrHandler
+  $exitedEvent = Register-ObjectEvent -InputObject $process -EventName 'Exited' -SourceIdentifier $invocationId
+
+  $process.Start() | Out-Null
+
+  $process.BeginOutputReadLine()
+  $process.BeginErrorReadLine()
+
+  if ($StdinInput)
   {
-    $Host.UI.WriteErrorLine($_)
+    $process.StandardInput.WriteLine($StdinInput)
+    $process.StandardInput.Close()
+  }
+
+  # park current thread until the PS event is signaled upon process exit
+  # OR the timeout has elapsed
+  $waitResult = Wait-Event -SourceIdentifier $invocationId -Timeout $Timeout
+  if (! $process.HasExited)
+  {
+    $Host.UI.WriteErrorLine("Process $Path did not complete in $Timeout seconds")
     return 1
   }
-  finally
-  {
-    @($stdoutEvent, $stderrEvent, $exitedEvent) |
-      ? { $_ -ne $Null } |
-      % { Unregister-Event -SourceIdentifier $_.Name }
 
-    if ($process -ne $Null)
+  return $process.ExitCode
+}
+catch
+{
+  $Host.UI.WriteErrorLine($_)
+  return 1
+}
+finally
+{
+  @($stdoutEvent, $stderrEvent, $exitedEvent) |
+    ? { $_ -ne $Null } |
+    % { Unregister-Event -SourceIdentifier $_.Name }
+
+  if ($process -ne $Null)
+  {
+    if (($process.Handle -ne $Null) -and (! $process.HasExited))
     {
-      if (($process.Handle -ne $Null) -and (! $process.HasExited))
-      {
-        try { $process.Kill() } catch { $Host.UI.WriteErrorLine("Failed To Kill Process $Path") }
-      }
-      $process.Dispose()
+      try { $process.Kill() } catch { $Host.UI.WriteErrorLine("Failed To Kill Process $Path") }
     }
+    $process.Dispose()
   }
+}
 }
 
 function Write-Stream {
-  PARAM(
-    [Parameter(Position=0)] $stream,
-    [Parameter(ValueFromPipeline=$true)] $string
-  )
-  PROCESS {
-    $bytes = $utf8.GetBytes($string)
-    $stream.Write( $bytes, 0, $bytes.Length )
-  }
+PARAM(
+  [Parameter(Position=0)] $stream,
+  [Parameter(ValueFromPipeline=$true)] $string
+)
+PROCESS {
+  $bytes = $utf8.GetBytes($string)
+  $stream.Write( $bytes, 0, $bytes.Length )
+}
 }
 
 function Convert-JsonToXml {
-  PARAM([Parameter(ValueFromPipeline=$true)] [string[]] $json)
-  BEGIN {
-    $mStream = New-Object System.IO.MemoryStream
+PARAM([Parameter(ValueFromPipeline=$true)] [string[]] $json)
+BEGIN {
+  $mStream = New-Object System.IO.MemoryStream
+}
+PROCESS {
+  $json | Write-Stream -Stream $mStream
+}
+END {
+  $mStream.Position = 0
+  try {
+    $jsonReader = [System.Runtime.Serialization.Json.JsonReaderWriterFactory]::CreateJsonReader($mStream,[System.Xml.XmlDictionaryReaderQuotas]::Max)
+    $xml = New-Object Xml.XmlDocument
+    $xml.Load($jsonReader)
+    $xml
+  } finally {
+    $jsonReader.Close()
+    $mStream.Dispose()
   }
-  PROCESS {
-    $json | Write-Stream -Stream $mStream
-  }
-  END {
-    $mStream.Position = 0
-    try {
-      $jsonReader = [System.Runtime.Serialization.Json.JsonReaderWriterFactory]::CreateJsonReader($mStream,[System.Xml.XmlDictionaryReaderQuotas]::Max)
-      $xml = New-Object Xml.XmlDocument
-      $xml.Load($jsonReader)
-      $xml
-    } finally {
-      $jsonReader.Close()
-      $mStream.Dispose()
-    }
-  }
+}
 }
 
 Function ConvertFrom-Xml {
-  [CmdletBinding(DefaultParameterSetName="AutoType")]
-  PARAM(
-    [Parameter(ValueFromPipeline=$true,Mandatory=$true,Position=1)] [Xml.XmlNode] $xml,
-    [Parameter(Mandatory=$true,ParameterSetName="ManualType")] [Type] $Type,
-    [Switch] $ForceType
-  )
-  PROCESS{
-    if (Get-Member -InputObject $xml -Name root) {
-      return $xml.root.Objects | ConvertFrom-Xml
-    } elseif (Get-Member -InputObject $xml -Name Objects) {
-      return $xml.Objects | ConvertFrom-Xml
-    }
-    $propbag = @{}
-    foreach ($name in Get-Member -InputObject $xml -MemberType Properties | Where-Object{$_.Name -notmatch "^__|type"} | Select-Object -ExpandProperty name) {
-      Write-Debug "$Name Type: $($xml.$Name.type)" -Debug:$false
-      $propbag."$Name" = Convert-Properties $xml."$name"
-    }
-    if (!$Type -and $xml.HasAttribute("__type")) { $Type = $xml.__Type }
-    if ($ForceType -and $Type) {
-      try {
-        $output = New-Object $Type -Property $propbag
-      } catch {
-        $output = New-Object PSObject -Property $propbag
-        $output.PsTypeNames.Insert(0, $xml.__type)
-      }
-    } elseif ($propbag.Count -ne 0) {
-      $output = New-Object PSObject -Property $propbag
-      if ($Type) {
-        $output.PsTypeNames.Insert(0, $Type)
-      }
-    }
-    return $output
+[CmdletBinding(DefaultParameterSetName="AutoType")]
+PARAM(
+  [Parameter(ValueFromPipeline=$true,Mandatory=$true,Position=1)] [Xml.XmlNode] $xml,
+  [Parameter(Mandatory=$true,ParameterSetName="ManualType")] [Type] $Type,
+  [Switch] $ForceType
+)
+PROCESS{
+  if (Get-Member -InputObject $xml -Name root) {
+    return $xml.root.Objects | ConvertFrom-Xml
+  } elseif (Get-Member -InputObject $xml -Name Objects) {
+    return $xml.Objects | ConvertFrom-Xml
   }
+  $propbag = @{}
+  foreach ($name in Get-Member -InputObject $xml -MemberType Properties | Where-Object{$_.Name -notmatch "^__|type"} | Select-Object -ExpandProperty name) {
+    Write-Debug "$Name Type: $($xml.$Name.type)" -Debug:$false
+    $propbag."$Name" = Convert-Properties $xml."$name"
+  }
+  if (!$Type -and $xml.HasAttribute("__type")) { $Type = $xml.__Type }
+  if ($ForceType -and $Type) {
+    try {
+      $output = New-Object $Type -Property $propbag
+    } catch {
+      $output = New-Object PSObject -Property $propbag
+      $output.PsTypeNames.Insert(0, $xml.__type)
+    }
+  } elseif ($propbag.Count -ne 0) {
+    $output = New-Object PSObject -Property $propbag
+    if ($Type) {
+      $output.PsTypeNames.Insert(0, $Type)
+    }
+  }
+  return $output
+}
 }
 
 Function Convert-Properties {
-  PARAM($InputObject)
-  switch ($InputObject.type) {
-    "object" {
-      return (ConvertFrom-Xml -Xml $InputObject)
-    }
-    "string" {
-      $MightBeADate = $InputObject.get_InnerText() -as [DateTime]
-      ## Strings that are actually dates (*grumble* JSON is crap)
-      if ($MightBeADate -and $propbag."$Name" -eq $MightBeADate.ToString("G")) {
-        return $MightBeADate
-      } else {
-        return $InputObject.get_InnerText()
-      }
-    }
-    "number" {
-      $number = $InputObject.get_InnerText()
-      if ($number -eq ($number -as [int])) {
-        return $number -as [int]
-      } elseif ($number -eq ($number -as [double])) {
-        return $number -as [double]
-      } else {
-        return $number -as [decimal]
-      }
-    }
-    "boolean" {
-      return [bool]::parse($InputObject.get_InnerText())
-    }
-    "null" {
-      return $null
-    }
-    "array" {
-      [object[]]$Items = $(foreach( $item in $InputObject.GetEnumerator() ) {
-        Convert-Properties $item
-      })
-      return $Items
-    }
-    default {
-      return $InputObject
+PARAM($InputObject)
+switch ($InputObject.type) {
+  "object" {
+    return (ConvertFrom-Xml -Xml $InputObject)
+  }
+  "string" {
+    $MightBeADate = $InputObject.get_InnerText() -as [DateTime]
+    ## Strings that are actually dates (*grumble* JSON is crap)
+    if ($MightBeADate -and $propbag."$Name" -eq $MightBeADate.ToString("G")) {
+      return $MightBeADate
+    } else {
+      return $InputObject.get_InnerText()
     }
   }
+  "number" {
+    $number = $InputObject.get_InnerText()
+    if ($number -eq ($number -as [int])) {
+      return $number -as [int]
+    } elseif ($number -eq ($number -as [double])) {
+      return $number -as [double]
+    } else {
+      return $number -as [decimal]
+    }
+  }
+  "boolean" {
+    return [bool]::parse($InputObject.get_InnerText())
+  }
+  "null" {
+    return $null
+  }
+  "array" {
+    [object[]]$Items = $(foreach( $item in $InputObject.GetEnumerator() ) {
+      Convert-Properties $item
+    })
+    return $Items
+  }
+  default {
+    return $InputObject
+  }
+}
 }
 
 Function ConvertFrom-Json2 {
-  [CmdletBinding()]
-  PARAM(
-    [Parameter(ValueFromPipeline=$true,Mandatory=$true,Position=1)] [string] $InputObject,
-    [Parameter(Mandatory=$true)] [Type] $Type,
-    [Switch] $ForceType
-  )
-  PROCESS {
-    $null = $PSBoundParameters.Remove("InputObject")
-    [Xml.XmlElement]$xml = (Convert-JsonToXml $InputObject).Root
-    if ($xml) {
-      if ($xml.Objects) {
-        $xml.Objects.Item.GetEnumerator() | ConvertFrom-Xml @PSBoundParameters
-      } elseif ($xml.Item -and $xml.Item -isnot [System.Management.Automation.PSParameterizedProperty]) {
-        $xml.Item | ConvertFrom-Xml @PSBoundParameters
-      } else {
-        $xml | ConvertFrom-Xml @PSBoundParameters
-      }
+[CmdletBinding()]
+PARAM(
+  [Parameter(ValueFromPipeline=$true,Mandatory=$true,Position=1)] [string] $InputObject,
+  [Parameter(Mandatory=$true)] [Type] $Type,
+  [Switch] $ForceType
+)
+PROCESS {
+  $null = $PSBoundParameters.Remove("InputObject")
+  [Xml.XmlElement]$xml = (Convert-JsonToXml $InputObject).Root
+  if ($xml) {
+    if ($xml.Objects) {
+      $xml.Objects.Item.GetEnumerator() | ConvertFrom-Xml @PSBoundParameters
+    } elseif ($xml.Item -and $xml.Item -isnot [System.Management.Automation.PSParameterizedProperty]) {
+      $xml.Item | ConvertFrom-Xml @PSBoundParameters
     } else {
-      Write-Error "Failed to parse JSON with JsonReader" -Debug:$false
+      $xml | ConvertFrom-Xml @PSBoundParameters
     }
+  } else {
+    Write-Error "Failed to parse JSON with JsonReader" -Debug:$false
   }
+}
 }
 
 function ConvertFrom-PSCustomObject
 {
-  PARAM([Parameter(ValueFromPipeline = $true)] $InputObject)
-  PROCESS {
-    if ($null -eq $InputObject) { return $null }
+PARAM([Parameter(ValueFromPipeline = $true)] $InputObject)
+PROCESS {
+  if ($null -eq $InputObject) { return $null }
 
-    if ($InputObject -is [System.Collections.IEnumerable] -and $InputObject -isnot [string]) {
-      $collection = @(
-        foreach ($object in $InputObject) { ConvertFrom-PSCustomObject $object }
-      )
+  if ($InputObject -is [System.Collections.IEnumerable] -and $InputObject -isnot [string]) {
+    $collection = @(
+      foreach ($object in $InputObject) { ConvertFrom-PSCustomObject $object }
+    )
 
-      $collection
-    } elseif ($InputObject -is [System.Management.Automation.PSCustomObject]) {
-      $hash = @{}
-      foreach ($property in $InputObject.PSObject.Properties) {
-        $hash[$property.Name] = ConvertFrom-PSCustomObject $property.Value
-      }
-
-      $hash
-    } else {
-      $InputObject
+    $collection
+  } elseif ($InputObject -is [System.Management.Automation.PSCustomObject]) {
+    $hash = @{}
+    foreach ($property in $InputObject.PSObject.Properties) {
+      $hash[$property.Name] = ConvertFrom-PSCustomObject $property.Value
     }
+
+    $hash
+  } else {
+    $InputObject
   }
+}
 }
 
 function Get-ContentAsJson
 {
-  [CmdletBinding()]
-  PARAM(
-    [Parameter(Mandatory = $true)] $Text,
-    [Parameter(Mandatory = $false)] [Text.Encoding] $Encoding = [Text.Encoding]::UTF8
-  )
+[CmdletBinding()]
+PARAM(
+  [Parameter(Mandatory = $true)] $Text,
+  [Parameter(Mandatory = $false)] [Text.Encoding] $Encoding = [Text.Encoding]::UTF8
+)
 
-  # using polyfill cmdlet on PS2, so pass type info
-  if ($PSVersionTable.PSVersion -lt [Version]'3.0') {
-    $Text | ConvertFrom-Json2 -Type PSObject | ConvertFrom-PSCustomObject
-  } else {
-    $Text | ConvertFrom-Json | ConvertFrom-PSCustomObject
-  }
+# using polyfill cmdlet on PS2, so pass type info
+if ($PSVersionTable.PSVersion -lt [Version]'3.0') {
+  $Text | ConvertFrom-Json2 -Type PSObject | ConvertFrom-PSCustomObject
+} else {
+  $Text | ConvertFrom-Json | ConvertFrom-PSCustomObject
+}
 }
 PS
           if result.exit_code != 0
@@ -402,21 +402,21 @@ PS
           end.join(',')
 
           execute(<<-PS)
-    $quoted_array = @(
-      #{quoted_args}
-    )
+$quoted_array = @(
+  #{quoted_args}
+)
 
-    $invokeArgs = @{
-      Path = "#{path}"
-      Arguments = $quoted_array -Join ' '
-      Timeout = #{timeout}
-      #{stdin.nil? ? '' : "StdinInput = @'\n" + stdin + "\n'@"}
-    }
+$invokeArgs = @{
+  Path = "#{path}"
+  Arguments = $quoted_array -Join ' '
+  Timeout = #{timeout}
+  #{stdin.nil? ? '' : "StdinInput = @'\n" + stdin + "\n'@"}
+}
 
-    # winrm gem checks $? prior to using $LASTEXITCODE
-    # making it necessary to exit with the desired code to propagate status properly
-    exit $(Invoke-Interpreter @invokeArgs)
-    PS
+# winrm gem checks $? prior to using $LASTEXITCODE
+# making it necessary to exit with the desired code to propagate status properly
+exit $(Invoke-Interpreter @invokeArgs)
+PS
         end
 
         DEFAULT_EXTENSIONS = ['.ps1', '.rb', '.pp'].freeze

--- a/spec/bolt/transport/orch_spec.rb
+++ b/spec/bolt/transport/orch_spec.rb
@@ -271,7 +271,7 @@ describe Bolt::Transport::Orch, orchestrator: true do
       end
     end
 
-    describe :upload do
+    describe 'uploading files' do
       let(:source_path) { File.join(base_path, 'spec', 'fixtures', 'scripts', 'success.sh') }
       let(:dest_path) { 'success.sh' } # to be prepended with a temp dir in the 'around(:each)' block
       let(:params) {
@@ -294,18 +294,30 @@ describe Bolt::Transport::Orch, orchestrator: true do
         end
       end
 
-      it 'should write the file' do
-        expect(orch.upload(target, source_path, dest_path).value).to eq(
-          '_output' => "Uploaded '#{source_path}' to '#{hostname}:#{dest_path}'"
-        )
+      describe :batch_upload do
+        it 'should write the file' do
+          results = orch.batch_upload(targets, source_path, dest_path).map(&:value)
+          expect(results[0]).to be_success
+          expect(results[1]).to be_success
+          expect(results[0].message).to match(/Uploaded '#{source_path}' to '#{targets[0].host}:#{dest_path}/)
+          expect(results[1].message).to match(/Uploaded '#{source_path}' to '#{targets[1].host}:#{dest_path}/)
+        end
+      end
 
-        source_mode = File.stat(source_path).mode
-        dest_mode = File.stat(dest_path).mode
-        expect(dest_mode).to eq(source_mode)
+      describe :upload do
+        it 'should write the file' do
+          expect(orch.upload(target, source_path, dest_path).value).to eq(
+            '_output' => "Uploaded '#{source_path}' to '#{hostname}:#{dest_path}'"
+          )
 
-        source_content = File.read(source_path)
-        dest_content = File.read(dest_path)
-        expect(dest_content).to eq(source_content)
+          source_mode = File.stat(source_path).mode
+          dest_mode = File.stat(dest_path).mode
+          expect(dest_mode).to eq(source_mode)
+
+          source_content = File.read(source_path)
+          dest_content = File.read(dest_path)
+          expect(dest_content).to eq(source_content)
+        end
       end
     end
 

--- a/spec/bolt/transport/orch_spec.rb
+++ b/spec/bolt/transport/orch_spec.rb
@@ -12,50 +12,29 @@ describe Bolt::Transport::Orch, orchestrator: true do
     Bolt::Target.new(hostname).update_conf(Bolt::Config.new.transport_conf)
   end
 
-  let(:orch) { Bolt::Transport::Orch.new({}) }
+  let(:targets) do
+    [Bolt::Target.new('node1').update_conf(Bolt::Config.new.transport_conf),
+     Bolt::Target.new('node2').update_conf(Bolt::Config.new.transport_conf)]
+  end
 
-  let(:task) { "foo" }
-  let(:task_environment) { 'production' }
+  let(:orch) do
+    client = instance_double("OrchestratorClient", run_task: results)
+    orch = Bolt::Transport::Orch.new({})
+    allow(orch).to receive(:client).and_return(client)
+    orch
+  end
+
+  let(:results) do
+    [{ 'name' => 'localhost', 'state' => result_state, 'result' => result }]
+  end
+
   let(:taskpath) { "foo/tasks/init" }
   let(:params) { { param: 'val' } }
-  let(:scope) { { nodes: [hostname] } }
 
-  let(:noop) { nil }
   let(:result_state) { 'finished' }
   let(:result) { { '_output' => 'ok' } }
 
   let(:base_path) { File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..')) }
-
-  def mock_client
-    orch_client = instance_double("OrchestratorClient")
-
-    body = { task: task, environment: task_environment, noop: noop, params: params, scope: scope }
-    results = [{ 'state' => result_state, 'result' => result }]
-
-    expect(orch_client).to(receive(:run_task).with(body).and_return(results))
-
-    allow(orch).to receive(:client).and_return(orch_client)
-  end
-
-  def bolt_task_client
-    bolt_task = File.expand_path(File.join(base_path, 'tasks', 'init.rb'))
-    body = { task: 'bolt', environment: task_environment, noop: noop, params: params, scope: scope }
-
-    orch_client = instance_double("OrchestratorClient")
-    allow(orch).to receive(:client).and_return(orch_client)
-    allow(orch_client).to(receive(:run_task).with(body) do
-      Open3.popen3("ruby #{bolt_task};") do |stdin, stdout, stderr, wt|
-        stdin.write(params.to_json)
-        stdin.close
-        output = stdout.read
-        err = stderr.read
-        exit_code = wt.value.exitstatus
-        expect(err).to be_empty
-        expect(exit_code).to eq(0)
-        [{ 'state' => 'finished', 'result' => JSON.parse(output) }]
-      end
-    end)
-  end
 
   describe :task_name_from_path do
     it 'finds a namespaced task' do
@@ -76,228 +55,296 @@ describe Bolt::Transport::Orch, orchestrator: true do
     end
   end
 
-  describe :run_task do
-    before(:each) do
-      mock_client
+  describe :build_request do
+    it "gets the task name from the path" do
+      body = orch.build_request(targets, 'foo/tasks/bar', {})
+      expect(body[:task]).to eq('foo::bar')
     end
 
-    it "executes a task on a host" do
-      expect(orch.run_task(target, taskpath, 'stdin', params).value)
-        .to eq(result)
+    it "gets the task name if it's init" do
+      body = orch.build_request(targets, 'foo/tasks/init', {})
+      expect(body[:task]).to eq('foo')
     end
 
-    it "returns a success" do
-      expect(orch.run_task(target, taskpath, 'stdin', params)).to be_success
+    it "sets environment" do
+      targets.first.options[:orch_task_environment] = 'development'
+      body = orch.build_request(targets, taskpath, {})
+      expect(body[:environment]).to eq('development')
     end
 
-    it 'ignores _run_as' do
-      expect(orch.run_task(target, taskpath, 'stdin', params, '_run_as' => 'root')).to be_success
+    it "omits noop if unspecified" do
+      body = orch.build_request(targets, taskpath, {})
+      expect(body[:noop]).to be_nil
     end
 
-    context "when running noop" do
-      let(:noop) { true }
+    it "sets noop to true if specified noop" do
+      body = orch.build_request(targets, taskpath, '_noop' => true)
+      expect(body[:noop]).to eq(true)
+    end
 
-      it "handles the _noop param" do
-        expect(orch.run_task(target, taskpath, 'stdin', params.merge('_noop' => true))).to be_success
+    it "sets the parameters" do
+      params = { 'foo' => 1, 'bar' => 'baz' }
+      body = orch.build_request(targets, taskpath, params)
+      expect(body[:params]).to eq(params)
+    end
+
+    it "doesn't pass noop as a parameter" do
+      params = { 'foo' => 1, 'bar' => 'baz' }
+      body = orch.build_request(targets, taskpath, params.merge('_noop' => true))
+      expect(body[:params]).to eq(params)
+    end
+
+    it "sets the scope to the list of hosts" do
+      body = orch.build_request(targets, taskpath, params.merge('_noop' => true))
+      expect(body[:scope]).to eq(nodes: %w[node1 node2])
+    end
+  end
+
+  describe :process_run_results do
+    it "returns a result for every successful node" do
+      results = [{ 'name' => 'node1', 'state' => 'finished', 'result' => { '_output' => 'hello' } },
+                 { 'name' => 'node2', 'state' => 'finished', 'result' => { '_output' => 'goodbye' } }]
+      node_results = orch.process_run_results(targets, results)
+
+      expect(node_results[0]).to be_success
+      expect(node_results[1]).to be_success
+      expect(node_results[0].target).to eq(targets[0])
+      expect(node_results[1].target).to eq(targets[1])
+      expect(node_results[0].value).to eq('_output' => 'hello')
+      expect(node_results[1].value).to eq('_output' => 'goodbye')
+    end
+
+    context 'when a node fails' do
+      it "returns failure for only the failed node" do
+        results = [{ 'name' => 'node1', 'state' => 'finished', 'result' => { '_output' => 'hello' } },
+                   { 'name' => 'node2', 'state' => 'failed', 'result' => { '_output' => 'goodbye' } }]
+        node_results = orch.process_run_results(targets, results)
+
+        expect(node_results[0]).to be_success
+        expect(node_results[1]).not_to be_success
+
+        error = node_results[1].error_hash
+        expect(error['kind']).to eq('puppetlabs.tasks/task-error')
+        expect(error['msg']).to match(/The task failed with exit code/)
       end
-    end
 
-    context "when the task target node was skipped" do
-      let(:result_state) { 'skipped' }
+      it "returns the error specified by the node" do
+        error_result = { '_error' => { 'kind' => 'puppetlabs.orchestrator/arbitrary-failure',
+                                       'msg' => 'something went wrong',
+                                       'details' => {} } }
+        results = [{ 'name' => 'node1', 'state' => 'finished', 'result' => { '_output' => 'hello' } },
+                   { 'name' => 'node2', 'state' => 'failed', 'result' => error_result }]
+        node_results = orch.process_run_results(targets, results)
 
-      it 'returns a failure' do
-        expect(orch.run_task(target, taskpath, 'stdin', params)).not_to be_success
+        expect(node_results[0]).to be_success
+        expect(node_results[1]).not_to be_success
+
+        expect(node_results[1].error_hash).to eq(error_result['_error'])
       end
 
-      it 'includes an appropriate error in the returned result' do
-        expect(orch.run_task(target, taskpath, 'stdin', params).error_hash).to eq(
+      it "returns an error for skipped nodes" do
+        results = [{ 'name' => 'node1', 'state' => 'finished', 'result' => { '_output' => 'hello' } },
+                   # XXX double-check that this is the correct result for a skipped node
+                   { 'name' => 'node2', 'state' => 'skipped', 'result' => nil }]
+        node_results = orch.process_run_results(targets, results)
+
+        expect(node_results[0]).to be_success
+        expect(node_results[1]).not_to be_success
+
+        expect(node_results[1].error_hash).to eq(
           'kind' => 'puppetlabs.tasks/skipped-node',
-          'msg' => "Node #{hostname} was skipped",
+          'msg' => "Node node2 was skipped",
           'details' => {}
         )
       end
     end
+  end
 
-    context "when the task failed" do
-      let(:result_state) { 'failed' }
+  describe :batch_task do
+    it "executes a task on a host" do
+      results = [{ 'name' => 'node1', 'state' => 'finished', 'result' => { '_output' => 'hello' } },
+                 { 'name' => 'node2', 'state' => 'finished', 'result' => { '_output' => 'goodbye' } }]
+      allow(orch.client).to receive(:run_task).and_return(results)
 
-      it "returns a failure" do
-        expect(orch.run_task(target, taskpath, 'stdin', params)).not_to be_success
-      end
+      node_results = orch.batch_task(targets, taskpath, 'stdin', params).map(&:value)
+      expect(node_results[0].value).to eq('_output' => 'hello')
+      expect(node_results[1].value).to eq('_output' => 'goodbye')
+      expect(node_results[0]).to be_success
+      expect(node_results[1]).to be_success
+    end
+  end
 
-      context "when there is an error and no exitcode" do
-        it "does not report success" do
-          expect(orch.run_task(target, taskpath, 'stdin', params)).not_to be_success
+  describe :run_task do
+    it "executes a task on a host" do
+      node_result = orch.run_task(target, taskpath, 'stdin', params)
+      expect(node_result.value).to eq(result)
+      expect(node_result).to be_success
+    end
+  end
+
+  context 'using the bolt task wrapper' do
+    before(:each) do
+      bolt_task = File.expand_path(File.join(base_path, 'tasks', 'init.rb'))
+      allow(orch.client).to(receive(:run_task) do
+        Open3.popen3("ruby #{bolt_task};") do |stdin, stdout, stderr, wt|
+          stdin.write(params.to_json)
+          stdin.close
+          output = stdout.read
+          err = stderr.read
+          exit_code = wt.value.exitstatus
+          expect(err).to be_empty
+          expect(exit_code).to eq(0)
+          [{ 'state' => 'finished', 'result' => JSON.parse(output) }]
+        end
+      end)
+    end
+
+    describe :run_command do
+      let(:options) { {} }
+      let(:params) {
+        {
+          action: 'command',
+          command: command,
+          options: options
+        }
+      }
+
+      context 'when it succeeds' do
+        let(:command) { 'echo hi!; echo bye >&2' }
+
+        it 'returns a success' do
+          expect(orch.run_command(target, command)).to be_success
+        end
+
+        it 'captures stdout' do
+          expect(orch.run_command(target, command)['stdout']).to eq("hi!\n")
+        end
+
+        it 'captures stderr' do
+          expect(orch.run_command(target, command)['stderr']).to eq("bye\n")
+        end
+
+        it 'ignores _run_as' do
+          expect(orch.run_command(target, command, '_run_as' => 'root')).to be_success
         end
       end
 
-      context "when there is an exit_code" do
-        let(:result) { { '_error' => { 'details' => { 'exit_code' => '3' } } } }
+      context 'when it fails' do
+        let(:command) { 'echo hi!; echo bye >&2; exit 23' }
 
-        it "does not report success" do
-          expect(orch.run_task(target, taskpath, 'stdin', params)).not_to be_success
+        it 'returns a failure' do
+          expect(orch.run_command(target, command)).not_to be_success
+        end
+
+        it 'captures exit_code' do
+          expect(orch.run_command(target, command)['exit_code']).to eq(23)
+        end
+
+        it 'captures stdout' do
+          expect(orch.run_command(target, command)['stdout']).to eq("hi!\n")
+        end
+
+        it 'captures stderr' do
+          expect(orch.run_command(target, command)['stderr']).to eq("bye\n")
         end
       end
     end
-  end
 
-  describe :run_command do
-    let(:options) { {} }
-    let(:params) {
-      {
-        action: 'command',
-        command: command,
-        options: options
+    describe :upload do
+      let(:source_path) { File.join(base_path, 'spec', 'fixtures', 'scripts', 'success.sh') }
+      let(:dest_path) { 'success.sh' } # to be prepended with a temp dir in the 'around(:each)' block
+      let(:params) {
+        content = Base64.encode64(File.read(source_path))
+        mode = File.stat(source_path).mode
+
+        {
+          action: 'upload',
+          path: dest_path,
+          content: content,
+          mode: mode
+        }
       }
-    }
 
-    before(:each) do
-      bolt_task_client
-    end
+      around(:each) do |example|
+        Dir.mktmpdir(nil, '/tmp') do |dir|
+          dest_path.replace(File.join(dir, dest_path)) # prepend the temp dir to the dest_path
 
-    context 'when it succeeds' do
-      let(:command) { 'echo hi!; echo bye >&2' }
-
-      it 'returns a success' do
-        expect(orch.run_command(target, command)).to be_success
+          example.run
+        end
       end
 
-      it 'captures stdout' do
-        expect(orch.run_command(target, command)['stdout']).to eq("hi!\n")
-      end
+      it 'should write the file' do
+        expect(orch.upload(target, source_path, dest_path).value).to eq(
+          '_output' => "Uploaded '#{source_path}' to '#{hostname}:#{dest_path}'"
+        )
 
-      it 'captures stderr' do
-        expect(orch.run_command(target, command)['stderr']).to eq("bye\n")
-      end
+        source_mode = File.stat(source_path).mode
+        dest_mode = File.stat(dest_path).mode
+        expect(dest_mode).to eq(source_mode)
 
-      it 'ignores _run_as' do
-        expect(orch.run_command(target, command, '_run_as' => 'root')).to be_success
+        source_content = File.read(source_path)
+        dest_content = File.read(dest_path)
+        expect(dest_content).to eq(source_content)
       end
     end
 
-    context 'when it fails' do
-      let(:command) { 'echo hi!; echo bye >&2; exit 23' }
+    describe :run_script do
+      let(:args) { ['with spaces', 'nospaces', 'echo $HOME; cat /etc/passwd'] }
+      let(:params) {
+        content = Base64.encode64(File.read(script_path))
 
-      it 'returns a failure' do
-        expect(orch.run_command(target, command)).not_to be_success
-      end
-
-      it 'captures exit_code' do
-        expect(orch.run_command(target, command)['exit_code']).to eq(23)
-      end
-
-      it 'captures stdout' do
-        expect(orch.run_command(target, command)['stdout']).to eq("hi!\n")
-      end
-
-      it 'captures stderr' do
-        expect(orch.run_command(target, command)['stderr']).to eq("bye\n")
-      end
-    end
-  end
-
-  describe :upload do
-    let(:source_path) { File.join(base_path, 'spec', 'fixtures', 'scripts', 'success.sh') }
-    let(:dest_path) { 'success.sh' } # to be prepended with a temp dir in the 'around(:each)' block
-    let(:params) {
-      content = Base64.encode64(File.read(source_path))
-      mode = File.stat(source_path).mode
-
-      {
-        action: 'upload',
-        path: dest_path,
-        content: content,
-        mode: mode
+        {
+          action: 'script',
+          content: content,
+          arguments: args
+        }
       }
-    }
 
-    around(:each) do |example|
-      Dir.mktmpdir(nil, '/tmp') do |dir|
-        dest_path.replace(File.join(dir, dest_path)) # prepend the temp dir to the dest_path
+      context "when the script succeeds" do
+        let(:script_path) { File.join(base_path, 'spec', 'fixtures', 'scripts', 'success.sh') }
 
-        example.run
-      end
-    end
+        it 'returns a success' do
+          expect(orch.run_script(target, script_path, args)).to be_success
+        end
 
-    before(:each) do
-      bolt_task_client
-    end
-
-    it 'should write the file' do
-      expect(orch.upload(target, source_path, dest_path).value).to eq(
-        '_output' => "Uploaded '#{source_path}' to '#{hostname}:#{dest_path}'"
-      )
-
-      source_mode = File.stat(source_path).mode
-      dest_mode = File.stat(dest_path).mode
-      expect(dest_mode).to eq(source_mode)
-
-      source_content = File.read(source_path)
-      dest_content = File.read(dest_path)
-      expect(dest_content).to eq(source_content)
-    end
-  end
-
-  describe :run_script do
-    let(:args) { ['with spaces', 'nospaces', 'echo $HOME; cat /etc/passwd'] }
-    let(:params) {
-      content = Base64.encode64(File.read(script_path))
-
-      {
-        action: 'script',
-        content: content,
-        arguments: args
-      }
-    }
-
-    before(:each) do
-      bolt_task_client
-    end
-
-    context "when the script succeeds" do
-      let(:script_path) { File.join(base_path, 'spec', 'fixtures', 'scripts', 'success.sh') }
-
-      it 'returns a success' do
-        expect(orch.run_script(target, script_path, args)).to be_success
-      end
-
-      it 'captures stdout' do
-        expect(
-          orch.run_script(target, script_path, args)['stdout']
-        ).to eq(<<-OUT)
+        it 'captures stdout' do
+          expect(
+            orch.run_script(target, script_path, args)['stdout']
+          ).to eq(<<-OUT)
 arg: with spaces
 arg: nospaces
 arg: echo $HOME; cat /etc/passwd
 standard out
-        OUT
+          OUT
+        end
+
+        it 'captures stderr' do
+          expect(orch.run_script(target, script_path, args)['stderr']).to eq("standard error\n")
+        end
+
+        it 'ignores _run_as' do
+          expect(orch.run_script(target, script_path, args, '_run_as' => 'root')).to be_success
+        end
       end
 
-      it 'captures stderr' do
-        expect(orch.run_script(target, script_path, args)['stderr']).to eq("standard error\n")
-      end
+      context "when the script fails" do
+        let(:script_path) { File.join(base_path, 'spec', 'fixtures', 'scripts', 'failure.sh') }
 
-      it 'ignores _run_as' do
-        expect(orch.run_script(target, script_path, args, '_run_as' => 'root')).to be_success
-      end
-    end
+        it 'returns a failure' do
+          expect(orch.run_script(target, script_path, args)).not_to be_success
+        end
 
-    context "when the script fails" do
-      let(:script_path) { File.join(base_path, 'spec', 'fixtures', 'scripts', 'failure.sh') }
+        it 'captures exit_code' do
+          expect(orch.run_script(target, script_path, args)['exit_code']).to eq(34)
+        end
 
-      it 'returns a failure' do
-        expect(orch.run_script(target, script_path, args)).not_to be_success
-      end
+        it 'captures stdout' do
+          expect(orch.run_script(target, script_path, args)['stdout']).to eq("standard out\n")
+        end
 
-      it 'captures exit_code' do
-        expect(orch.run_script(target, script_path, args)['exit_code']).to eq(34)
-      end
-
-      it 'captures stdout' do
-        expect(orch.run_script(target, script_path, args)['stdout']).to eq("standard out\n")
-      end
-
-      it 'captures stderr' do
-        expect(orch.run_script(target, script_path, args)['stderr']).to eq("standard error\n")
+        it 'captures stderr' do
+          expect(orch.run_script(target, script_path, args)['stderr']).to eq("standard error\n")
+        end
       end
     end
   end

--- a/spec/bolt/transport/orch_spec.rb
+++ b/spec/bolt/transport/orch_spec.rb
@@ -13,7 +13,7 @@ describe Bolt::Transport::Orch, orchestrator: true do
   end
 
   let(:targets) do
-    [Bolt::Target.new('node1').update_conf(Bolt::Config.new.transport_conf),
+    [Bolt::Target.new('pcp://node1').update_conf(Bolt::Config.new.transport_conf),
      Bolt::Target.new('node2').update_conf(Bolt::Config.new.transport_conf)]
   end
 

--- a/spec/bolt/transport/orch_spec.rb
+++ b/spec/bolt/transport/orch_spec.rb
@@ -309,6 +309,26 @@ describe Bolt::Transport::Orch, orchestrator: true do
       end
     end
 
+    describe :batch_script do
+      let(:args) { ['with spaces', 'nospaces', 'echo $HOME; cat /etc/passwd'] }
+      let(:script_path) { File.join(base_path, 'spec', 'fixtures', 'scripts', 'success.sh') }
+      let(:params) {
+        content = Base64.encode64(File.read(script_path))
+
+        {
+          action: 'script',
+          content: content,
+          arguments: args
+        }
+      }
+
+      it 'returns a success' do
+        results = orch.batch_script(targets, script_path, args).map(&:value)
+        expect(results[0]).to be_success
+        expect(results[1]).to be_success
+      end
+    end
+
     describe :run_script do
       let(:args) { ['with spaces', 'nospaces', 'echo $HOME; cat /etc/passwd'] }
       let(:params) {


### PR DESCRIPTION
This pull request adds new methods batch_task, batch_script, batch_command and
batch_upload to transports. These methods are used to indicate to a transport
that it should perform an operation on multiple nodes as part of a single
batch. This is specifically useful for the orch transport, which can run many
nodes as part of a single orchestrator job. Previously, it would create one
orchestrator job for each node.

This PR adds a batches() method to the transport, which is called by
the executor to determine how to batch runs. This allows all the
concurrency constructs to be moved entirely into the executor, so that
transports don't have to care about concurrency at all, other than the
requirement that they be thread-safe.

The executor now has a batch_execute() method that takes a list of
targets, splits them by transport, batches them according to the
transport's batching implementation, and then calls batch_task, etc
on each batch in a thread, collecting the results into a single
ResultSet.

The default implementation of the batches() method will split the list
of targets into batches of 1 target. The corresponding batch_* methods
handle sending start and finish events, and defer to the run_* methods.
This means that transport authors who don't want batching still only
need to implement run_task, etc.

Transports which do have their own batching need to implement a custom
batches() method to decide how batches should be constructed, and need
to implement batch_task, etc appropriately, including sending start and
finish events, but don't need to worry about managing concurrency.

We now use a CachedThreadPool for the executor rather than a FixedThreadPool,
and keep it alive between invocations. The previous behavior was to queue up
all the work on the threadpool and then stop it and wait for everything to
finish. We now create promises for every expected result and block until those
have been delivered.