### PR TITLE
(BOLT-328) Pass Puppet Task type to transports

### DIFF
--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -123,17 +123,18 @@ module Bolt
       results
     end
 
-    def run_task(targets, task, input_method, arguments, options = {}, &callback)
-      @logger.info("Starting task #{task} on #{targets.map(&:uri)}")
-      @logger.debug("Arguments: #{arguments} Input method: #{input_method}")
+    def run_task(targets, task, arguments, options = {}, &callback)
+      task_name = task.name
+      @logger.info("Starting task #{task_name} on #{targets.map(&:uri)}")
+      @logger.debug("Arguments: #{arguments} Input method: #{task.input_method}")
       notify = proc { |event| @notifier.notify(callback, event) if callback }
       options = { '_run_as' => run_as }.merge(options) if run_as
 
       results = batch_execute(targets) do |transport, batch|
-        transport.batch_task(batch, task, input_method, arguments, options, &notify)
+        transport.batch_task(batch, task, arguments, options, &notify)
       end
 
-      @logger.info(summary('task', task, results))
+      @logger.info(summary('task', task_name, results))
       @notifier.shutdown
       results
     end

--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -75,12 +75,12 @@ module Bolt
       # The default implementation only supports batches of size 1 and will fail otherwise.
       #
       # Transports may override this method to implement their own batch processing.
-      def batch_task(targets, task, input_method, arguments, options = {}, &callback)
+      def batch_task(targets, task, arguments, options = {}, &callback)
         assert_batch_size_one("batch_task()", targets)
         target = targets.first
         with_events(target, callback) do
           @logger.debug { "Running task run '#{task}' on #{target.uri}" }
-          run_task(target, task, input_method, arguments, filter_options(target, options))
+          run_task(target, task, arguments, filter_options(target, options))
         end
       end
 

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -77,7 +77,8 @@ module Bolt
         end
       end
 
-      def run_task(target, task, input_method, arguments, options = {})
+      def run_task(target, task, arguments, options = {})
+        input_method = task.input_method
         with_connection(target) do |conn|
           conn.running_as(options['_run_as']) do
             export_args = {}
@@ -98,7 +99,7 @@ module Bolt
             execute_options = {}
 
             conn.with_remote_tempdir do |dir|
-              remote_task_path = conn.write_remote_executable(dir, task)
+              remote_task_path = conn.write_remote_executable(dir, task.executable)
               if conn.run_as && stdin
                 wrapper = make_wrapper_stringio(remote_task_path, stdin)
                 remote_wrapper_path = conn.write_remote_executable(dir, wrapper, 'wrapper.sh')

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -75,7 +75,8 @@ catch
         end
       end
 
-      def run_task(target, task, input_method, arguments, _options = {})
+      def run_task(target, task, arguments, _options = {})
+        input_method = task.input_method
         with_connection(target) do |conn|
           if STDIN_METHODS.include?(input_method)
             stdin = JSON.dump(arguments)
@@ -91,7 +92,7 @@ catch
             end
           end
 
-          conn.with_remote_file(task) do |remote_path|
+          conn.with_remote_file(task.executable) do |remote_path|
             output =
               if powershell_file?(remote_path) && stdin.nil?
                 # NOTE: cannot redirect STDIN to a .ps1 script inside of PowerShell

--- a/modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/modules/boltlib/lib/puppet/functions/run_task.rb
@@ -84,9 +84,8 @@ Puppet::Functions.create_function(:run_task) do
     if targets.empty?
       Bolt::ResultSet.new([])
     else
-      # TODO: pass entire task to executor
       options = task_args.select { |k, _| k == '_run_as' }
-      executor.run_task(targets, task.executable, task.input_method, use_args, options, &block)
+      executor.run_task(targets, task, use_args, options, &block)
     end
   end
 

--- a/modules/boltlib/spec/functions/run_command_spec.rb
+++ b/modules/boltlib/spec/functions/run_command_spec.rb
@@ -1,4 +1,6 @@
 require 'spec_helper'
+require 'bolt/result'
+require 'bolt/result_set'
 require 'bolt/target'
 
 describe 'run_command' do

--- a/modules/boltlib/spec/functions/run_task_spec.rb
+++ b/modules/boltlib/spec/functions/run_task_spec.rb
@@ -1,4 +1,6 @@
 require 'spec_helper'
+require 'bolt/result'
+require 'bolt/result_set'
 require 'bolt/target'
 
 describe 'run_task' do

--- a/modules/boltlib/spec/functions/run_task_spec.rb
+++ b/modules/boltlib/spec/functions/run_task_spec.rb
@@ -18,6 +18,10 @@ describe 'run_task' do
     end
   end
 
+  def mock_task(executable, input_method)
+    responds_with(:executable, executable) & responds_with(:input_method, input_method)
+  end
+
   context 'it calls bolt executor run_task' do
     let(:hostname) { 'a.b.com' }
     let(:hostname2) { 'x.y.com' }
@@ -33,7 +37,7 @@ describe 'run_task' do
     it 'when running a task without metadata the input method is "both"' do
       executable = File.join(tasks_root, 'echo.sh')
 
-      executor.expects(:run_task).with([target], executable, 'both', default_args, {}).returns(result_set)
+      executor.expects(:run_task).with([target], mock_task(executable, 'both'), default_args, {}).returns(result_set)
       inventory.expects(:get_targets).with(hostname).returns([target])
 
       is_expected.to run.with_params('Test::Echo', hostname, default_args).and_return(result_set)
@@ -42,7 +46,7 @@ describe 'run_task' do
     it 'when running a task with metadata - the input method is specified by the metadata' do
       executable = File.join(tasks_root, 'meta.sh')
 
-      executor.expects(:run_task).with([target], executable, 'environment', default_args, {})
+      executor.expects(:run_task).with([target], mock_task(executable, 'environment'), default_args, {})
               .returns(result_set)
       inventory.expects(:get_targets).with(hostname).returns([target])
 
@@ -52,7 +56,8 @@ describe 'run_task' do
     it 'when called with _run_as - _run_as is passed to the executor' do
       executable = File.join(tasks_root, 'meta.sh')
 
-      executor.expects(:run_task).with([target], executable, 'environment', default_args, '_run_as' => 'root')
+      executor.expects(:run_task)
+              .with([target], mock_task(executable, 'environment'), default_args, '_run_as' => 'root')
               .returns(result_set)
       inventory.expects(:get_targets).with(hostname).returns([target])
 
@@ -63,7 +68,7 @@ describe 'run_task' do
     it 'when called without without args hash (for a task where this is allowed)' do
       executable = File.join(tasks_root, 'yes.sh')
 
-      executor.expects(:run_task).with([target], executable, 'both', {}, {}).returns(result_set)
+      executor.expects(:run_task).with([target], mock_task(executable, 'both'), {}, {}).returns(result_set)
       inventory.expects(:get_targets).with(hostname).returns([target])
 
       is_expected.to run.with_params('test::yes', hostname).and_return(result_set)
@@ -82,7 +87,7 @@ describe 'run_task' do
       it 'nodes can be specified as repeated nested arrays and strings and combine into one list of nodes' do
         executable = File.join(tasks_root, 'meta.sh')
 
-        executor.expects(:run_task).with([target, target2], executable, 'environment', default_args, {})
+        executor.expects(:run_task).with([target, target2], mock_task(executable, 'environment'), default_args, {})
                 .returns(result_set)
         inventory.expects(:get_targets).with([hostname, [[hostname2]], []]).returns([target, target2])
 
@@ -93,7 +98,7 @@ describe 'run_task' do
       it 'nodes can be specified as repeated nested arrays and Targets and combine into one list of nodes' do
         executable = File.join(tasks_root, 'meta.sh')
 
-        executor.expects(:run_task).with([target, target2], executable, 'environment', default_args, {})
+        executor.expects(:run_task).with([target, target2], mock_task(executable, 'environment'), default_args, {})
                 .returns(result_set)
         inventory.expects(:get_targets).with([target, [[target2]], []]).returns([target, target2])
 
@@ -108,7 +113,7 @@ describe 'run_task' do
         it 'errors by default' do
           executable = File.join(tasks_root, 'meta.sh')
 
-          executor.expects(:run_task).with([target, target2], executable, 'environment', default_args, {})
+          executor.expects(:run_task).with([target, target2], mock_task(executable, 'environment'), default_args, {})
                   .returns(result_set)
           inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 
@@ -119,7 +124,7 @@ describe 'run_task' do
         it 'does not error with _catch_errors' do
           executable = File.join(tasks_root, 'meta.sh')
 
-          executor.expects(:run_task).with([target, target2], executable, 'environment', default_args, {})
+          executor.expects(:run_task).with([target, target2], mock_task(executable, 'environment'), default_args, {})
                   .returns(result_set)
           inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 
@@ -142,7 +147,7 @@ describe 'run_task' do
       it 'finds task named after the module' do
         executable = File.join(tasks_root, 'init.sh')
 
-        executor.expects(:run_task).with([target], executable, 'both', {}, {}).returns(result_set)
+        executor.expects(:run_task).with([target], mock_task(executable, 'both'), {}, {}).returns(result_set)
         inventory.expects(:get_targets).with(hostname).returns([target])
 
         is_expected.to run.with_params('test', hostname).and_return(result_set)

--- a/spec/lib/bolt_spec/task.rb
+++ b/spec/lib/bolt_spec/task.rb
@@ -1,0 +1,36 @@
+require 'bolt_spec/files'
+
+module BoltSpec
+  module Task
+    class TaskTypeMatcher
+      def initialize(name, executable, input_method)
+        @name = name
+        @executable = Regexp.new(executable)
+        @input_method = input_method
+      end
+
+      def ===(other)
+        @name == other.name && @executable =~ other.executable && @input_method == other.input_method
+      end
+
+      def description
+        "task_type(#{name}, #{executable}, #{input_method})"
+      end
+    end
+
+    def mock_task(name, executable = nil, input_method = 'both')
+      double('task', name: name, executable: executable || name, input_method: input_method)
+    end
+
+    def task_type(name, executable = nil, input_method = 'both')
+      TaskTypeMatcher.new(name, executable || name, input_method)
+    end
+
+    include BoltSpec::Files
+    def with_task_containing(name, contents, input_method, extension = nil)
+      with_tempfile_containing(name, contents, extension) do |file|
+        yield mock_task(name, file.path, input_method)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Passes the Puppet Task type to transports rather than executable path
and input method. This allows transports to introspect tasks more
directly.

The Puppet Task type is an object that corresponds to the description at
https://github.com/puppetlabs/puppet/blob/5.4.0/lib/puppet/pops/pcore.rb#L43-L84.