### PR TITLE
(BOLT-342) Add TargetSpec type alias to replace TargetOrTargets

### DIFF
--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -47,6 +47,14 @@ module Bolt
       end
     end
 
+    # Create a top-level alias for TargetSpec so that users don't have to
+    # namespace it with Boltlib, which is just an implementation detail. This
+    # allows TargetSpec to feel like a built-in type in bolt, rather than
+    # something has been, no pun intended, "bolted on".
+    def add_target_spec(compiler)
+      compiler.evaluate_string('type TargetSpec = Boltlib::TargetSpec')
+    end
+
     # Runs a block in a PAL script compiler configured for Bolt.  Catches
     # exceptions thrown by the block and re-raises them ensuring they are
     # Bolt::Errors since the script compiler block will squash all exceptions.
@@ -54,6 +62,7 @@ module Bolt
       Puppet.initialize_settings(opts)
       r = Puppet::Pal.in_tmp_environment('bolt', modulepath: [BOLTLIB_PATH] + @config[:modulepath], facts: {}) do |pal|
         pal.with_script_compiler do |compiler|
+          add_target_spec(compiler)
           begin
             yield compiler
           rescue Puppet::PreformattedError => err

--- a/modules/boltlib/lib/puppet/functions/file_upload.rb
+++ b/modules/boltlib/lib/puppet/functions/file_upload.rb
@@ -8,15 +8,11 @@
 require 'bolt/error'
 
 Puppet::Functions.create_function(:file_upload, Puppet::Functions::InternalFunction) do
-  local_types do
-    type 'TargetOrTargets = Variant[String[1], Target, Array[TargetOrTargets]]'
-  end
-
   dispatch :file_upload do
     scope_param
     param 'String[1]', :source
     param 'String[1]', :destination
-    param 'TargetOrTargets', :targets
+    param 'Boltlib::TargetSpec', :targets
     optional_param 'Hash[String[1], Any]', :options
     return_type 'ResultSet'
   end

--- a/modules/boltlib/lib/puppet/functions/get_targets.rb
+++ b/modules/boltlib/lib/puppet/functions/get_targets.rb
@@ -16,12 +16,8 @@
 require 'bolt/error'
 
 Puppet::Functions.create_function(:get_targets) do
-  local_types do
-    type 'TargetOrTargets = Variant[String[1], Target, Array[TargetOrTargets]]'
-  end
-
   dispatch :get_targets do
-    param 'TargetOrTargets', :names
+    param 'Boltlib::TargetSpec', :names
     return_type 'Array[Target]'
   end
 

--- a/modules/boltlib/lib/puppet/functions/run_command.rb
+++ b/modules/boltlib/lib/puppet/functions/run_command.rb
@@ -8,13 +8,9 @@
 require 'bolt/error'
 
 Puppet::Functions.create_function(:run_command) do
-  local_types do
-    type 'TargetOrTargets = Variant[String[1], Target, Array[TargetOrTargets]]'
-  end
-
   dispatch :run_command do
     param 'String[1]', :command
-    param 'TargetOrTargets', :targets
+    param 'Boltlib::TargetSpec', :targets
     optional_param 'Hash[String[1], Any]', :options
     return_type 'ResultSet'
   end

--- a/modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/modules/boltlib/lib/puppet/functions/run_script.rb
@@ -6,14 +6,10 @@
 # * The returned value contains information about the result per target.
 #
 Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFunction) do
-  local_types do
-    type 'TargetOrTargets = Variant[String[1], Target, Array[TargetOrTargets]]'
-  end
-
   dispatch :run_script do
     scope_param
     param 'String[1]', :script
-    param 'TargetOrTargets', :targets
+    param 'Boltlib::TargetSpec', :targets
     optional_param 'Hash[String[1], Any]', :options
     return_type 'ResultSet'
   end

--- a/modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/modules/boltlib/lib/puppet/functions/run_task.rb
@@ -8,13 +8,9 @@
 require 'bolt/error'
 
 Puppet::Functions.create_function(:run_task) do
-  local_types do
-    type 'TargetOrTargets = Variant[String[1], Target, Array[TargetOrTargets]]'
-  end
-
   dispatch :run_task do
     param 'String[1]', :task_name
-    param 'TargetOrTargets', :targets
+    param 'Boltlib::TargetSpec', :targets
     optional_param 'Hash[String[1], Any]', :task_args
     return_type 'ResultSet'
   end
@@ -22,7 +18,7 @@ Puppet::Functions.create_function(:run_task) do
   # this is used from 'bolt task run'
   dispatch :run_task_raw do
     param 'String[1]', :task_name
-    param 'TargetOrTargets', :targets
+    param 'Boltlib::TargetSpec', :targets
     optional_param 'Hash[String[1], Any]', :task_args
     # return_type 'ResultSet'
     block_param

--- a/modules/boltlib/types/targetspec.pp
+++ b/modules/boltlib/types/targetspec.pp
@@ -1,0 +1,7 @@
+# A TargetSpec represents any String, Target or combination thereof that can be
+# passed to get_targets() to return an Array[Target]. Generally, users
+# shouldn't need to worry about the distinction between TargetSpec and
+# Target/Array[Target], since the run_* functions will all handle them both
+# automatically. But for use cases that need to deal with the exact list of
+# Targets that will be used, get_targets() will return that.
+type Boltlib::TargetSpec = Variant[String[1], Target, Array[Boltlib::TargetSpec]]


### PR DESCRIPTION
(BOLT-342) Add TargetSpec type alias to replace TargetOrTargets

This moves the TargetOrTargets type alias out of the boltlib functions
and directly into the types/ directory of boltlib, as the new
Boltlib::TargetSpec alias. We also create a top-level TargetSpec alias
that refers to Boltlib::TargetSpec, so that users who wish to specify
that type in their plans can do it without having to namespace it under
Boltlib, which is purely an implementation detail.

The TargetSpec type accepts a String, a Target, or any set of Arrays of
those two types.

Specifically, TargetSpec represents the set of types that can be passed
to get_targets() and result in an Array[Target]. For the most part,
this type should be transparent to users, since it can be passed through
to other plans and to run_task, etc. In the case where users need to do
some sort of logic based on the *actual* Target objects, get_targets()
can be used to "resolve" the TargetSpec to a list.