### PR TITLE
(BOLT-340) Properly escape strings when constructing commands

### DIFF
--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -84,7 +84,7 @@ catch
 
           if ENVIRONMENT_METHODS.include?(input_method)
             arguments.each do |(arg, val)|
-              cmd = "[Environment]::SetEnvironmentVariable('PT_#{arg}', '#{val}')"
+              cmd = "[Environment]::SetEnvironmentVariable('PT_#{arg}', @'\n#{val}\n'@)"
               result = conn.execute(cmd)
               if result.exit_code != 0
                 raise EnvironmentVarError(var, value)

--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -175,6 +175,10 @@ BASH
       expect(ssh.run_command(target, "ssh -V").value['stderr']).to match(/OpenSSH/)
     end
 
+    it "can execute a command containing quotes", ssh: true do
+      expect(ssh.run_command(target, "echo 'hello \" world'").value).to eq(result_value("hello \" world\n"))
+    end
+
     it "can upload a file to a host", ssh: true do
       contents = "kljhdfg"
       with_tempfile_containing('upload-test', contents) do |file|
@@ -278,6 +282,18 @@ SHELL
 Hello from task Goodbye{\"message_one\":\
 \"Hello from task\",\"message_two\":\"Goodbye\"}
 SHELL
+      end
+    end
+
+    it "can run a task with params containing quotes", ssh: true do
+      contents = <<SHELL
+#!/bin/sh
+echo -n ${PT_message}
+SHELL
+
+      arguments = { message: "foo ' bar ' baz" }
+      with_task_containing('tasks_test_quotes', contents, 'both') do |task|
+        expect(ssh.run_task(target, task, arguments).message).to eq "foo ' bar ' baz"
       end
     end
 

--- a/spec/bolt/transport/winrm_spec.rb
+++ b/spec/bolt/transport/winrm_spec.rb
@@ -347,6 +347,15 @@ SHELLWORDS
       end
     end
 
+    it "can run a task with arguments containing quotes", winrm: true do
+      contents = 'Write-Host "$env:PT_message"'
+      arguments = { message: "it's a hello world" }
+      with_task_containing('task-test-winrm', contents, 'environment', '.ps1') do |task|
+        expect(winrm.run_task(target, task, arguments).message)
+          .to eq("it's a hello world\r\n")
+      end
+    end
+
     it "ignores _run_as", winrm: true do
       contents = 'Write-Host "$env:PT_message_one ${env:PT_message two}"'
       arguments = { :message_one => 'task is running',


### PR DESCRIPTION
Previously, we weren't always safely interpolating filenames and variables
into SSH commands. We now construct commands as arrays, using Shellquote to
properly escape them.

When interpolating task parameters to set powershell environment variables,
we were naively using just single quotes to escape the values. That doesn't
work if the value itself contains single quotes. We now use a single-quoted
here string to ensure that we get the literal value as intended.