### PR TITLE
(BOLT-333) Fix packaging, some rename cleanup

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
                        Dir['lib/**/*.rb'] +
                        Dir['vendored/*.rb'] +
                        Dir['vendored/*/lib/**/*.rb'] +
-                       Dir['modules/boltlib/lib/**/*.rb'] +
-                       Dir['modules/boltlib/types/**/*.pp']
+                       Dir['bolt-modules/boltlib/lib/**/*.rb'] +
+                       Dir['bolt-modules/boltlib/types/**/*.pp']
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -100,7 +100,6 @@ HELP
                  'plan'    => %w[show run],
                  'file'    => %w[upload] }.freeze
     TRANSPORTS = %w[ssh winrm pcp].freeze
-    BOLTLIB_PATH = File.join(__FILE__, '../../../modules')
 
     attr_reader :parser, :config
     attr_accessor :options


### PR DESCRIPTION
Fixes gem packaging to include `bolt-modules`. Also remove an unused variable.