### PR TITLE
(BOLT-344) Restore displaying errors for failed connection on the CLI

### DIFF
--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -42,13 +42,13 @@ module Bolt
 
       def with_events(target, callback)
         callback.call(type: :node_start, target: target) if callback
-        result = yield
-        @logger.debug("Result on #{target.uri}: #{JSON.dump(result.value)}")
-        callback.call(type: :node_result, result: result) if callback
-        result
-      rescue StandardError => ex
-        result = Bolt::Result.from_exception(target, ex)
-        @logger.debug("Failure on #{target.uri}: #{JSON.dump(result.value)}")
+
+        result = begin
+          yield
+        rescue StandardError => ex
+          Bolt::Result.from_exception(target, ex)
+        end
+
         callback.call(type: :node_result, result: result) if callback
         result
       end

--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -47,7 +47,10 @@ module Bolt
         callback.call(type: :node_result, result: result) if callback
         result
       rescue StandardError => ex
-        Bolt::Result.from_exception(target, ex)
+        result = Bolt::Result.from_exception(target, ex)
+        @logger.debug("Failure on #{target.uri}: #{JSON.dump(result.value)}")
+        callback.call(type: :node_result, result: result) if callback
+        result
       end
 
       def filter_options(target, options)

--- a/spec/integration/fail_plan_spec.rb
+++ b/spec/integration/fail_plan_spec.rb
@@ -20,7 +20,7 @@ describe "When a plan fails" do
      '--modulepath', modulepath,
      '--no-host-key-check']
   }
-  let(:target) { conn_uri('ssh', true) }
+  let(:target) { conn_uri('ssh', include_password: true) }
 
   it 'returns the error object' do
     result = run_cli_json(['plan', 'run', 'error::args'] + config_flags, rescue_exec: true)

--- a/spec/integration/result_set_spec.rb
+++ b/spec/integration/result_set_spec.rb
@@ -9,7 +9,7 @@ describe "when running a plan that manipulates an execution result", ssh: true d
   include BoltSpec::Integration
 
   let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
-  let(:uri) { conn_uri('ssh', true) }
+  let(:uri) { conn_uri('ssh', include_password: true) }
   let(:config_flags) { %W[--no-host-key-check --format json --modulepath #{modulepath}] }
 
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }

--- a/spec/integration/run_as_spec.rb
+++ b/spec/integration/run_as_spec.rb
@@ -9,7 +9,7 @@ describe "when running a plan using run_as", ssh: true do
   include BoltSpec::Integration
 
   let(:modulepath) { File.join(__dir__, '../fixtures/run_as') }
-  let(:uri) { conn_uri('ssh', true) }
+  let(:uri) { conn_uri('ssh', include_password: true) }
   let(:user) { conn_info('ssh')[:user] }
   let(:password) { conn_info('ssh')[:password] }
   let(:config_flags) { %W[--no-host-key-check --format json --modulepath #{modulepath}] }

--- a/spec/integration/ssh_spec.rb
+++ b/spec/integration/ssh_spec.rb
@@ -36,6 +36,18 @@ describe "when runnning over the ssh transport", ssh: true do
       expect(result['_error']['msg']).to eq('The command failed with exit code 127')
     end
 
+    context 'wrong port' do
+      let(:uri) { conn_uri('ssh', override_port: 62223) }
+
+      it 'reports errors when node is unreachable' do
+        result = run_failed_node(%W[command run #{whoami}] + config_flags)
+        expect(result['_error']['kind']).to eq('puppetlabs.tasks/connect-error')
+        expect(result['_error']['msg']).to match(
+          %r{Failed to connect to ssh:\/\/bolt@localhost:62223: Connection refused}
+        )
+      end
+    end
+
     it 'runs a task', :reset_puppet_settings do
       result = run_one_node(%W[task run #{stdin_task} message=somemessage] + config_flags)
       expect(result['message'].strip).to eq("somemessage")

--- a/spec/integration/target_spec.rb
+++ b/spec/integration/target_spec.rb
@@ -9,7 +9,7 @@ describe "when running a plan that manipulates an execution result", ssh: true d
   include BoltSpec::Integration
 
   let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
-  let(:uri) { conn_uri('ssh', true) }
+  let(:uri) { conn_uri('ssh', include_password: true) }
 
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 

--- a/spec/lib/bolt_spec/conn.rb
+++ b/spec/lib/bolt_spec/conn.rb
@@ -27,10 +27,11 @@ module BoltSpec
       }
     end
 
-    def conn_uri(transport, include_password = false)
+    def conn_uri(transport, include_password: false, override_port: nil)
       conn = conn_info(transport)
       passwd = include_password ? ":#{conn[:password]}" : ''
-      "#{conn[:protocol]}://#{conn[:user]}#{passwd}@#{conn[:host]}:#{conn[:port]}"
+      port = override_port ? override_port : conn[:port]
+      "#{conn[:protocol]}://#{conn[:user]}#{passwd}@#{conn[:host]}:#{port}"
     end
   end
 end


### PR DESCRIPTION
Work on batching execution introduced a regression where errors would be
caught but not yielded to the event block passed to the executor.
Therefore the CLI would no longer report connection failures.

Restore yielding transport exceptions as error results if a block is
passed.