### PR TITLE
(BOLT-331) Add helper to generate an inventory from PuppetDB

### DIFF
--- a/exe/bolt-inventory-pdb
+++ b/exe/bolt-inventory-pdb
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require 'bolt_ext/puppetdb_inventory'
+
+exitcode = Bolt::PuppetDBInventory::CLI.new(ARGV).run
+exit exitcode

--- a/lib/bolt_ext/puppetdb_inventory.rb
+++ b/lib/bolt_ext/puppetdb_inventory.rb
@@ -1,0 +1,243 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'httpclient'
+require 'optparse'
+require 'yaml'
+
+module Bolt
+  class PuppetDBInventory
+    class Client
+      def self.from_config(config)
+        uri = URI.parse(config['server_urls'].first)
+        uri.port ||= 8081
+
+        cacert = File.expand_path(config['cacert'])
+        token = config.token
+
+        cert = config['cert']
+        key = config['key']
+
+        new(uri, cacert, token: token, cert: cert, key: key)
+      end
+
+      def initialize(uri, cacert, token: nil, cert: nil, key: nil)
+        @uri = uri
+        @cacert = cacert
+        @token = token
+        @cert = cert
+        @key = key
+      end
+
+      def query_certnames(query)
+        return [] unless query
+
+        body = JSON.generate(query: query)
+
+        response = http_client.post("#{@uri}/pdb/query/v4", body: body, header: headers)
+        if response.code != 200
+          raise "Failed to query PuppetDB: #{response.body}"
+        else
+          results = JSON.parse(response.body)
+          if results.first && !results.first.key?('certname')
+            raise "Query results did not contain a 'certname' field: got #{results.first.keys.join(', ')}"
+          end
+          results.map { |result| result['certname'] }.uniq
+        end
+      end
+
+      def http_client
+        return @http if @http
+        @http = HTTPClient.new
+        @http.ssl_config.set_client_cert_file(@cert, @key)
+        @http.ssl_config.add_trust_ca(@cacert)
+
+        @http
+      end
+
+      def headers
+        headers = { 'Content-Type' => 'application/json' }
+        headers['X-Authentication'] = @token if @token
+        headers
+      end
+    end
+
+    class Config
+      DEFAULT_TOKEN = File.expand_path('~/.puppetlabs/token')
+      DEFAULT_CONFIG = File.expand_path('~/.puppetlabs/client-tools/puppetdb.conf')
+
+      def initialize(config_file, options)
+        @settings = load_config(config_file)
+        @settings.merge!(options)
+
+        expand_paths
+        validate
+      end
+
+      def load_config(filename)
+        if filename
+          if File.exist?(filename)
+            config = JSON.parse(File.read(filename))
+          else
+            raise "config file #{filename} does not exist"
+          end
+        elsif File.exist?(DEFAULT_CONFIG)
+          config = JSON.parse(File.read(DEFAULT_CONFIG))
+        end
+        config.fetch('puppetdb', {})
+      end
+
+      def token
+        return @token if @token
+        if @settings['token']
+          File.read(@settings['token'])
+        elsif File.exist?(DEFAULT_TOKEN)
+          File.read(DEFAULT_TOKEN)
+        end
+      end
+
+      def [](key)
+        @settings[key]
+      end
+
+      def expand_paths
+        %w[cacert cert key token].each do |file|
+          @settings[file] = File.expand_path(@settings[file]) if @settings[file]
+        end
+      end
+
+      def validate_file_exists(file)
+        if @settings[file] && !File.exist?(@settings[file])
+          raise "#{file} file #{@settings[file]} does not exist"
+        end
+      end
+
+      def validate
+        unless @settings['server_urls']
+          raise "server_urls must be specified in the config file or with --url"
+        end
+        unless @settings['cacert']
+          raise "cacert must be specified in the config file or with --cacert"
+        end
+
+        if (@settings['cert'] && !@settings['key']) ||
+           (!@settings['cert'] && @settings['key'])
+          raise "cert and key must be specified together"
+        end
+
+        validate_file_exists('cacert')
+        validate_file_exists('cert')
+        validate_file_exists('key')
+      end
+    end
+
+    class CLI
+      def initialize(args)
+        @args = args
+        @cli_opts = {}
+        @parser = build_parser
+      end
+
+      def build_parser
+        parser = OptionParser.new('') do |opts|
+          opts.on('--cacert CACERT', "Path to the CA certificate") do |cacert|
+            @cli_opts['cacert'] = cacert
+          end
+          opts.on('--cert CERT', "Path to the certificate") do |cert|
+            @cli_opts['cert'] = cert
+          end
+          opts.on('--key KEY', "Path to the private key") do |key|
+            @cli_opts['key'] = key
+          end
+          opts.on('--token-file TOKEN',
+                  "Path to the token file",
+                  "Default: #{Config::DEFAULT_TOKEN} if present") do |token|
+            @cli_opts['token'] = token
+          end
+          opts.on('--url URL', "The URL of the PuppetDB server to connect to") do |url|
+            @cli_opts['server_urls'] = [url]
+          end
+          opts.on('--config CONFIG',
+                  "The puppetdb.conf file to read configuration from",
+                  "Default: #{Config::DEFAULT_CONFIG} if present") do |file|
+            @config_file = File.expand_path(file)
+          end
+          opts.on('--output FILE', '-o FILE',
+                  "Where to write the generated inventory file, defaults to stdout") do |file|
+            @output_file = file
+          end
+          opts.on('--trace', "Show stacktraces for exceptions") do |trace|
+            @trace = trace
+          end
+          opts.on('-h', '--help', "Display help") do |_|
+            @show_help = true
+          end
+        end
+        parser.banner = <<-BANNER
+Usage: bolt-inventory-pdb <input-file> [--output <output-file>] [--url <url>] [auth-options]
+
+Populate the nodes in an inventory file based on PuppetDB queries.
+
+The input file should be a Bolt inventory file, where each 'nodes' entry is
+replaced with a 'query' entry to be executed against PuppetDB. The output will
+be the input file, with the 'nodes' entry for each group populated with the
+query results.
+
+        BANNER
+        parser
+      end
+
+      def run
+        positional_args = @parser.permute(@args)
+
+        if @show_help
+          puts @parser.help
+          return 0
+        end
+
+        inventory_file = positional_args.shift
+        unless inventory_file
+          raise "--inventory is a required option"
+        end
+
+        if positional_args.any?
+          raise "Unknown argument(s) #{positional_args.join(', ')}"
+        end
+
+        config = Config.new(@config_file, @cli_opts)
+        @puppetdb_client = Client.from_config(config)
+
+        unless File.readable?(inventory_file)
+          raise "Can't read the inventory file #{inventory_file}"
+        end
+
+        inventory = YAML.load_file(inventory_file)
+        resolve_group(inventory)
+
+        result = inventory.to_yaml
+
+        if @output_file
+          File.write(@output_file, result)
+        else
+          puts result
+        end
+
+        return 0
+      rescue StandardError => e
+        puts "Error: #{e}"
+        puts e.backtrace if @trace
+        return 1
+      end
+
+      def resolve_group(group)
+        group['nodes'] = @puppetdb_client.query_certnames(group['query'])
+
+        group.fetch('groups', []).each do |child|
+          resolve_group(child)
+        end
+
+        group
+      end
+    end
+  end
+end

--- a/spec/bolt_ext/puppetdb_inventory_spec.rb
+++ b/spec/bolt_ext/puppetdb_inventory_spec.rb
@@ -1,0 +1,120 @@
+require 'spec_helper'
+require 'bolt_ext/puppetdb_inventory'
+
+describe "PuppetDBInventory" do
+  describe Bolt::PuppetDBInventory::Client do
+    let(:uri) { 'https://puppetdb:8081' }
+    let(:cacert) { '/path/to/cacert' }
+    let(:options) { {} }
+    let(:client) { Bolt::PuppetDBInventory::Client.new(uri, cacert, options) }
+
+    describe "#headers" do
+      it 'sets content-type' do
+        expect(client.headers['Content-Type']).to eq('application/json')
+      end
+
+      it 'includes the token if specified' do
+        token = 'footokentest'
+        options[:token] = token
+
+        expect(client.headers['X-Authentication']).to eq(token)
+      end
+
+      it 'omits token if not specified' do
+        expect(client.headers).not_to include('X-Authentication')
+      end
+    end
+
+    describe "#query_certnames" do
+      let(:response) { double('response', code: 200, body: '[]') }
+      let(:http_client) { double('http_client', post: response) }
+
+      before :each do
+        allow(client).to receive(:http_client).and_return(http_client)
+      end
+
+      it 'returns unique certnames' do
+        body = [{ 'certname' => 'foo' }, { 'certname' => 'bar' }, { 'certname' => 'foo' }]
+        allow(response).to receive(:body).and_return(body.to_json)
+
+        expect(client.query_certnames('query')).to eq(%w[foo bar])
+      end
+
+      it 'returns an empty list if the query result is empty' do
+        expect(client.query_certnames('query')).to eq([])
+      end
+
+      it 'fails if the result has no certname field' do
+        body = [{ 'environment' => 'production' }, { 'environment' => 'development' }]
+        allow(response).to receive(:body).and_return(body.to_json)
+
+        expect { client.query_certnames('query') }.to raise_error(/Query results did not contain a 'certname' field/)
+      end
+
+      it 'fails if the response from PuppetDB is an error' do
+        allow(response).to receive(:code).and_return(400)
+        allow(response).to receive(:body).and_return("something went wrong")
+
+        expect { client.query_certnames('query') }.to raise_error(/Failed to query PuppetDB: something went wrong/)
+      end
+    end
+  end
+
+  describe Bolt::PuppetDBInventory::Config do
+    let(:config_file) { nil }
+    let(:config) { Bolt::PuppetDBInventory::Config.new(config_file, @options) }
+    let(:options) do
+      {
+        'server_urls' => ['https://puppetdb:8081'],
+        'cacert' => '/path/to/cacert',
+        'token' => '/path/to/token',
+        'cert' => '/path/to/cert',
+        'key' => '/path/to/key'
+      }
+    end
+
+    before :each do
+      allow_any_instance_of(Bolt::PuppetDBInventory::Config).to receive(:load_config).and_return({})
+      allow_any_instance_of(Bolt::PuppetDBInventory::Config).to receive(:validate_file_exists)
+    end
+
+    describe "#validate" do
+      it "fails if no url is set" do
+        options.delete('server_urls')
+
+        expect { described_class.new(config_file, options) }.to raise_error(/server_urls must be specified/)
+      end
+
+      it "fails if no cacert is set" do
+        options.delete('cacert')
+
+        expect { described_class.new(config_file, options) }.to raise_error(/cacert must be specified/)
+      end
+
+      it "accepts only a token with cert/key" do
+        options.delete('cert')
+        options.delete('key')
+
+        expect { described_class.new(config_file, options) }.not_to raise_error
+      end
+
+      it "accepts a cert and key without a token" do
+        options.delete('token')
+
+        expect { described_class.new(config_file, options) }.not_to raise_error
+      end
+
+      it "fails if only cert and no key is specified" do
+        options.delete('key')
+
+        expect { described_class.new(config_file, options) }.to raise_error(/cert and key must be specified together/)
+      end
+
+      it "fails if only key and no cert is specified" do
+        options.delete('cert')
+
+        expect { described_class.new(config_file, options) }.to raise_error(/cert and key must be specified together/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds the bolt-inventory-pdb command which can be used to populate a
"template" inventory file with nodes based on PuppetDB queries.

The input to the command is basically an inventory file, except groups
should have a "query" field instead of a "nodes" field. The command will
read the input, execute each of the queries against PuppetDB, and print
a complete inventory with the "nodes" field populated for each group.

This command supports both token and cert auth to PuppetDB, and will
read the puppetdb.conf from the `puppet query` command if it's present.