### PR TITLE
(maint) Properly construct error result of last resort

### DIFF
--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -84,7 +84,7 @@ module Bolt
                 next if promise.fulfilled?
                 error = $ERROR_INFO || Bolt::Error.new("No result was returned for #{target.uri}",
                                                        "puppetlabs.bolt/missing-result-error")
-                promise.set(Bolt::Result.from_exception(error))
+                promise.set(Bolt::Result.from_exception(target, error))
               end
             end
           end

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -321,6 +321,19 @@ describe "Bolt::Executor" do
     end
   end
 
+  it "returns ensures that every target has a result, no matter what" do
+    result_set = executor.batch_execute(targets) do
+      # Intentionally *don't* return a result
+      []
+    end
+
+    expect(result_set.names).to eq([targets[0].name, targets[1].name])
+    result_set.each do |result|
+      expect(result).not_to be_success
+      expect(result.error_hash['msg']).to match(/No result was returned/)
+    end
+  end
+
   it "returns an exception result if the connect raises an unhandled error" do
     node_results.each_key do |_target|
       expect(ssh).to receive(:with_connection).and_raise("reset")


### PR DESCRIPTION
This code tries to ensure that every Promise we construct will get a
value, no matter what happens during execution, in order to avoid a
deadlock. However, the call to create the error result itself had a bug,
causing... a deadlock. We now properly pass the target when creating the
error result, avoiding aforementioned deadlock.