### PR TITLE
Revert "(maint) Pin FFI to 1.9.18"

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -45,9 +45,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "win32-security", "= 0.2.5"
   spec.add_dependency "win32-service", "= 0.8.8"
 
-  # Pin FFI until its releases are fixed up
-  spec.add_dependency "ffi", "<= 1.9.18"
-
   # there is a bug in puppetlabs_spec_helper for modules without fixtures
   spec.add_development_dependency "puppetlabs_spec_helper", "~> 2.6"
   spec.add_development_dependency "bundler", "~> 1.14"


### PR DESCRIPTION
This reverts commit 36e45eb7d5f8cc6bf7431281a5eb01fc428b21f9.
https://github.com/ffi/ffi/issues/607 has been resolved.