### PR TITLE
(BOLT-346) Support different inventory orchestrator config

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "net-scp", "~> 1.2"
   spec.add_dependency "net-ssh", "~> 4.2"
-  spec.add_dependency "orchestrator_client", "~> 0.2.1"
+  spec.add_dependency "orchestrator_client", "~> 0.2.3"
   spec.add_dependency "terminal-table", "~> 1.8.0"
   spec.add_dependency "winrm", "~> 2.0"
   spec.add_dependency "winrm-fs", "~> 1.1.0"

--- a/spec/bolt/transport/orch_spec.rb
+++ b/spec/bolt/transport/orch_spec.rb
@@ -140,14 +140,33 @@ describe Bolt::Transport::Orch, orchestrator: true do
   end
 
   describe :batches do
-    let(:targets) do
-      [Bolt::Target.new('a', orch_task_environment: 'production'),
-       Bolt::Target.new('b', orch_task_environment: 'development'),
-       Bolt::Target.new('c', orch_task_environment: 'test'),
-       Bolt::Target.new('d', orch_task_environment: 'development')]
+    it "splits targets in different environments into separate batches" do
+      targets = [Bolt::Target.new('a', orch_task_environment: 'production'),
+                 Bolt::Target.new('b', orch_task_environment: 'development'),
+                 Bolt::Target.new('c', orch_task_environment: 'test'),
+                 Bolt::Target.new('d', orch_task_environment: 'development')]
+      batches = Set.new([[targets[0]],
+                         [targets[1], targets[3]],
+                         [targets[2]]])
+      expect(Set.new(orch.batches(targets))).to eq(batches)
     end
 
-    it "splits targets in different environments into separate batches" do
+    it "splits targets with different urls into separate batches" do
+      targets = [Bolt::Target.new('a'),
+                 Bolt::Target.new('b', :'service-url' => 'master2'),
+                 Bolt::Target.new('c', :'service-url' => 'master3'),
+                 Bolt::Target.new('d', :'service-url' => 'master2')]
+      batches = Set.new([[targets[0]],
+                         [targets[1], targets[3]],
+                         [targets[2]]])
+      expect(Set.new(orch.batches(targets))).to eq(batches)
+    end
+
+    it "splits targets with different tokens into separate batches" do
+      targets = [Bolt::Target.new('a'),
+                 Bolt::Target.new('b', :'token-file' => 'token2'),
+                 Bolt::Target.new('c', :'token-file' => 'token3'),
+                 Bolt::Target.new('d', :'token-file' => 'token2')]
       batches = Set.new([[targets[0]],
                          [targets[1], targets[3]],
                          [targets[2]]])


### PR DESCRIPTION
The orchestrator transport will now batch based on service-url,
token-file in addition to task-environment. Instead of reading config on
initialization is used the config for the first target of each batch to
create a client.