### PR TITLE
(perf) Improve performance when searching a large inventory.

### DIFF
--- a/lib/bolt/inventory/group.rb
+++ b/lib/bolt/inventory/group.rb
@@ -9,18 +9,18 @@ module Bolt
         @logger = Logging.logger[self]
         @name = data['name']
 
-        @nodes = if data['nodes']
-                   data['nodes'].inject({}) do |acc,n|
-                     if n.is_a? String
-                       acc[n] = {'name' => n}
-                     else
-                       acc[n['name']] = n
-                     end
-                     acc
-                   end
-                 else
-                   {}
-                 end
+        @nodes = {}
+        if data['nodes']
+          data['nodes'].each do |n|
+            n = { 'name' => n } if n.is_a? String
+            if @nodes.include? n['name']
+              @logger.warn("Ignoring duplicate node in #{@name}: #{n}")
+            else
+              @nodes[n['name']] = n
+            end
+          end
+        end
+
         @config = data['config'] || {}
         @groups = if data['groups']
                     data['groups'].map { |g| Group.new(g) }
@@ -126,7 +126,7 @@ module Bolt
       end
 
       def local_node_names
-        @_node_names ||= Set.new(nodes.keys { |n| n['name'] })
+        Set.new(@nodes.keys)
       end
       private :local_node_names
 
@@ -152,7 +152,7 @@ module Bolt
 
         if data
           data_merge(group_data, data)
-        elsif local_node_names.include?(node_name)
+        elsif @nodes.include?(node_name)
           group_data
         end
       end

--- a/lib/bolt/inventory/group.rb
+++ b/lib/bolt/inventory/group.rb
@@ -10,15 +10,16 @@ module Bolt
         @name = data['name']
 
         @nodes = if data['nodes']
-                   data['nodes'].map do |n|
+                   data['nodes'].inject({}) do |acc,n|
                      if n.is_a? String
-                       { 'name' => n }
+                       acc[n] = {'name' => n}
                      else
-                       n
+                       acc[n['name']] = n
                      end
+                     acc
                    end
                  else
-                   []
+                   {}
                  end
         @config = data['config'] || {}
         @groups = if data['groups']
@@ -45,7 +46,7 @@ module Bolt
 
         used_names << @name
 
-        @nodes.each do |n|
+        @nodes.each_value do |n|
           # Require nodes to be parseable as a Target.
           begin
             Target.new(n['name'])
@@ -82,7 +83,7 @@ module Bolt
       end
 
       def node_data(node_name)
-        if (data = @nodes.find { |n| n['name'] == node_name })
+        if (data = @nodes[node_name])
           { 'config' => data['config'] || {},
             # groups come from group_data
             'groups' => [] }
@@ -125,7 +126,7 @@ module Bolt
       end
 
       def local_node_names
-        @_node_names ||= Set.new(nodes.map { |n| n['name'] })
+        @_node_names ||= Set.new(nodes.keys { |n| n['name'] })
       end
       private :local_node_names
 

--- a/spec/bolt/inventory/group_spec.rb
+++ b/spec/bolt/inventory/group_spec.rb
@@ -335,6 +335,24 @@ describe Bolt::Inventory::Group do
     end
   end
 
+  context 'with a duplicate node' do
+    let(:data) do
+      {
+        'name' => 'group1',
+        'nodes' => [
+          { 'name' => 'node1',
+            'val' => 'a' },
+          { 'name' => 'node1',
+            'val' => 'b' }
+        ]
+      }
+    end
+
+    it 'uses the first value' do
+      expect(group.nodes['node1']['val']).to eq('a')
+    end
+  end
+
   context 'where a node uses an invalid name' do
     let(:data) do
       {


### PR DESCRIPTION
This converts @nodes in an inventory group to a Hash so it can be more
quickly searched and prevented descending into a group when searching if
it does not contain the node. In practice this reduces the time of a
    get_targets call for 18k targets from ~1min ~1s