### PR TITLE
(maint) Add license_finder to Bolt.

### DIFF
--- a/.dependency_decisions.yml
+++ b/.dependency_decisions.yml
@@ -1,0 +1,61 @@
+---
+- - :approve
+  - CFPropertyList
+  - :who: bradejr
+    :why: 
+    :versions: []
+    :when: 2018-02-26 23:47:22.727579000 Z
+- - :whitelist
+  - MIT
+  - :who: bradejr
+    :why: 
+    :versions: []
+    :when: 2018-02-26 23:48:16.400477000 Z
+- - :whitelist
+  - Apache 2.0
+  - :who: bradejr
+    :why: 
+    :versions: []
+    :when: 2018-02-26 23:48:48.021244000 Z
+- - :whitelist
+  - ruby
+  - :who: bradejr
+    :why: 
+    :versions: []
+    :when: 2018-02-26 23:49:17.135760000 Z
+- - :whitelist
+  - Ruby
+  - :who: bradejr
+    :why: 
+    :versions: []
+    :when: 2018-02-26 23:49:33.016564000 Z
+- - :approve
+  - gettext
+  - :who: bradejr
+    :why: 
+    :versions: []
+    :when: 2018-02-26 23:50:00.597890000 Z
+- - :whitelist
+  - Simplified BSD
+  - :who: bradejr
+    :why: 
+    :versions: []
+    :when: 2018-02-26 23:50:22.302791000 Z
+- - :approve
+  - ffi
+  - :who: bradejr
+    :why: 
+    :versions: []
+    :when: 2018-02-26 23:50:46.376092000 Z
+- - :whitelist
+  - Artistic 2.0
+  - :who: bradejr
+    :why: 
+    :versions: []
+    :when: 2018-02-26 23:51:39.013184000 Z
+- - :approve
+  - puppetlabs_spec_helper
+  - :who: bradejr
+    :why: 
+    :versions: []
+    :when: 2018-02-26 23:56:53.530952000 Z

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ cache: bundler
 rvm:
 - 2.4
 - 2.0
+env:
+  - CHECK = spec
+  - CHECK = license_manager
 before_script:
 - eval `ssh-agent`
 - cat Gemfile.lock
@@ -12,7 +15,7 @@ before_script:
 script:
 - bundle exec rake travisci rubocop
 - cd bolt-modules/boltlib
-- bundle exec rake spec
+- bundle exec rake $CHECK
 notifications:
   email: false
   hipchat:

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 group(:test) do
   gem "beaker-hostgenerator"
   gem "rubocop", '0.50.0', require: false
+  gem 'license_finder', '~> 3.0.4'
 end
 
 if File.exist? "Gemfile.local"

--- a/Rakefile
+++ b/Rakefile
@@ -32,6 +32,11 @@ end
 desc "Run tests and style checker"
 task test: %w[spec rubocop]
 
+desc 'Check for unapproved licenses in dependencies'
+task(:license_finder) do
+  system('license_finder --decisions-file=.dependency_decisions.yml') || raise(StandardError, 'Unapproved license(s) found on dependencies')
+end
+
 task :default do
   system "rake --tasks"
 end


### PR DESCRIPTION
Using PDK project as a model, this adds the license_finder
gem and a task to the test gemset. Also adds all current
dependencies to the "approved" list, and adds a travis check
to validate dependency licenses.