### PR TITLE
(TBD) Include rbnacl and bcrypt_pbkdf by default

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -34,6 +34,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "winrm", "~> 2.0"
   spec.add_dependency "winrm-fs", "~> 1.1.0"
   spec.add_dependency "logging", "~> 2.2"
+  spec.add_dependency 'rbnacl'
+  spec.add_dependency 'rbnacl-libsodium'
+  spec.add_dependency 'bcrypt_pbkdf'
 
   # Dependencies of our vendored puppet, etc
   spec.add_dependency "CFPropertyList", "~> 2.2"


### PR DESCRIPTION
net-ssh requires several extra libraries for ed25519 support. Include
them in the gem dependencies to smooth setup, so users don't see
```
2018-02-26T13:59:32.131096 WARN   Net::SSH: ignoring unimplemented key:unsupported key type `ssh-ed25519'
net-ssh requires the following gems for ed25519 support:
 * rbnacl (>= 3.2, < 5.0)
 * rbnacl-libsodium, if your system doesn't have libsodium installed.
 * bcrypt_pbkdf (>= 1.0, < 2.0)
See https://github.com/net-ssh/net-ssh/issues/478 for more information
Gem::MissingSpecError : "Could not find 'rbnacl' (< 5.0, >= 3.2.0) among 86 total gem(s)
```