### PR TITLE
(docs) Provide a link to the tasks-hands-on-lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Bolt is a Ruby command-line tool for executing commands, scripts, and tasks on r
 * Scales to more than 1000 concurrent connections.
 * Supports industry standard protocols (SSH/SCP, WinRM/PSRP) and authentication methods (password, publickey).
 
+> For a step-by-step introduction to Bolt, see our [hands-on-lab](https://github.com/puppetlabs/tasks-hands-on-lab).
+
 ## Supported platforms
 
 * Linux, OSX, Windows


### PR DESCRIPTION
The tasks-hands-on-lab is a step-by-step introduction to Bolt. Provide a
prominent link for visitors new to Bolt to help them get started.

Fixes #318.