### PR TITLE
(BOLT-357 Fix bolt-inventory-pdb help message

### DIFF
--- a/lib/bolt_ext/puppetdb_inventory.rb
+++ b/lib/bolt_ext/puppetdb_inventory.rb
@@ -197,7 +197,7 @@ query results.
 
         inventory_file = positional_args.shift
         unless inventory_file
-          raise "--inventory is a required option"
+          raise "Please specify an input file (see --help for details)"
         end
 
         if positional_args.any?


### PR DESCRIPTION
The error message when no input file is given is confusing, as it refers
to an argument that doesn't exist. Update the message to be accurate.