### PR TITLE
(BOLT-352, BOLT-358) Fix config file and inventory file config bugs

### DIFF
--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -22,7 +22,7 @@ module Bolt
 
     TRANSPORT_OPTIONS = %i[host_key_check password run_as sudo_password extensions
                            ssl key tty tmpdir user connect_timeout cacert
-                           token-file task_environment service-url].freeze
+                           token-file task-environment service-url].freeze
 
     TRANSPORT_DEFAULTS = {
       connect_timeout: 10,
@@ -37,7 +37,7 @@ module Bolt
         ssl: true
       },
       pcp: {
-        task_environment: 'production'
+        :"task-environment" => 'production'
       }
     }.freeze
 
@@ -168,7 +168,7 @@ module Bolt
           self[:transports][:pcp][:"token-file"] = data['pcp']['token-file']
         end
         if data['pcp']['task-environment']
-          self[:transports][:pcp][:task_environment] = data['pcp']['task-environment']
+          self[:transports][:pcp][:"task-environment"] = data['pcp']['task-environment']
         end
       end
     end
@@ -192,7 +192,7 @@ module Bolt
 
       TRANSPORT_OPTIONS.each do |key|
         TRANSPORTS.each do |transport|
-          unless %i[ssl host_key_check task_environment].any? { |k| k == key }
+          unless %i[ssl host_key_check task-environment].any? { |k| k == key }
             self[:transports][transport][key] = options[key] if options[key]
             next
           end

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -232,6 +232,16 @@ module Bolt
                      "user to escalate to with --run-as")
       end
 
+      host_key = self[:transports][:ssh][:host_key_check]
+      unless !!host_key == host_key
+        raise Bolt::CLIError, 'host-key-check option must be a Boolean true or false'
+      end
+
+      ssl_flag = self[:transports][:winrm][:ssl]
+      unless !!ssl_flag == ssl_flag
+        raise Bolt::CLIError, 'ssl option must be a Boolean true or false'
+      end
+
       self[:transports].each_value do |v|
         timeout_value = v[:connect_timeout]
         unless timeout_value.is_a?(Integer) || timeout_value.nil?

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -22,11 +22,10 @@ module Bolt
 
     TRANSPORT_OPTIONS = %i[host_key_check password run_as sudo_password extensions
                            ssl key tty tmpdir user connect_timeout cacert
-                           token_file orch_task_environment service_url].freeze
+                           token-file task_environment service-url].freeze
 
     TRANSPORT_DEFAULTS = {
       connect_timeout: 10,
-      orch_task_environment: 'production',
       tty: false
     }.freeze
 
@@ -37,7 +36,9 @@ module Bolt
       winrm: {
         ssl: true
       },
-      pcp: {}
+      pcp: {
+        task_environment: 'production'
+      }
     }.freeze
 
     TRANSPORTS = %i[ssh winrm pcp].freeze
@@ -154,16 +155,16 @@ module Bolt
 
       if data['pcp']
         if data['pcp']['service-url']
-          self[:transports][:pcp][:service_url] = data['pcp']['service-url']
+          self[:transports][:pcp][:"service-url"] = data['pcp']['service-url']
         end
         if data['pcp']['cacert']
           self[:transports][:pcp][:cacert] = data['pcp']['cacert']
         end
         if data['pcp']['token-file']
-          self[:transports][:pcp][:token_file] = data['pcp']['token-file']
+          self[:transports][:pcp][:"token-file"] = data['pcp']['token-file']
         end
         if data['pcp']['task-environment']
-          self[:transports][:pcp][:orch_task_environment] = data['pcp']['task-environment']
+          self[:transports][:pcp][:task_environment] = data['pcp']['task-environment']
         end
       end
     end
@@ -186,7 +187,7 @@ module Bolt
 
       TRANSPORT_OPTIONS.each do |key|
         TRANSPORTS.each do |transport|
-          unless %i[ssl host_key_check].any? { |k| k == key }
+          unless %i[ssl host_key_check task_environment].any? { |k| k == key }
             self[:transports][transport][key] = options[key] if options[key]
             next
           end

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -72,12 +72,7 @@ module Bolt
     end
 
     def deep_clone
-      copy = clone
-      copy[:transports] = self[:transports].clone
-      TRANSPORTS.each do |transport|
-        copy[:transports][transport] = self[:transports][transport].clone
-      end
-      copy
+      Bolt::Util.deep_clone(self)
     end
 
     def default_paths

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -27,7 +27,7 @@ module Bolt
 
       def build_request(targets, task, arguments)
         { task: task.name,
-          environment: targets.first.options[:orch_task_environment],
+          environment: targets.first.options[:task_environment],
           noop: arguments['_noop'],
           params: arguments.reject { |k, _| k == '_noop' },
           scope: {
@@ -117,7 +117,7 @@ module Bolt
 
       def batches(targets)
         targets.group_by do |target|
-          [target.options[:orch_task_environment],
+          [target.options[:task_environment],
            target.options[:"service-url"],
            target.options[:"token-file"]]
         end.values

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -27,7 +27,7 @@ module Bolt
 
       def build_request(targets, task, arguments)
         { task: task.name,
-          environment: targets.first.options[:task_environment],
+          environment: targets.first.options[:"task-environment"],
           noop: arguments['_noop'],
           params: arguments.reject { |k, _| k == '_noop' },
           scope: {
@@ -117,7 +117,7 @@ module Bolt
 
       def batches(targets)
         targets.group_by do |target|
-          [target.options[:task_environment],
+          [target.options[:"task-environment"],
            target.options[:"service-url"],
            target.options[:"token-file"]]
         end.values

--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -42,6 +42,40 @@ module Bolt
         end
         hash1.merge(hash2, &recursive_merge)
       end
+
+      # Performs a deep_clone, using an identical copy if the cloned structure contains multiple
+      # references to the same object and prevents endless recursion.
+      # Credit to Jan Molic via https://github.com/rubyworks/facets/blob/master/LICENSE.txt
+      def deep_clone(obj, cloned = {})
+        cloned[obj.object_id] if cloned.include?(obj.object_id)
+
+        begin
+          cl = obj.clone
+        rescue TypeError
+          # unclonable (TrueClass, Fixnum, ...)
+          cloned[obj.object_id] = obj
+          return obj
+        else
+          cloned[obj.object_id] = cl
+          cloned[cl.object_id] = cl
+
+          if cl.is_a? Hash
+            obj.each { |k, v| cl[k] = deep_clone(v, cloned) }
+          elsif cl.is_a? Array
+            cl.collect! { |v| deep_clone(v, cloned) }
+          elsif cl.is_a? Struct
+            obj.each_pair { |k, v| cl[k] = deep_clone(v, cloned) }
+          end
+
+          cl.instance_variables.each do |var|
+            v = cl.instance_eval { var }
+            v_cl = deep_clone(v, cloned)
+            cl.instance_eval { @var = v_cl }
+          end
+
+          return cl
+        end
+      end
     end
   end
 end

--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -42,13 +42,6 @@ module Bolt
         end
         hash1.merge(hash2, &recursive_merge)
       end
-
-      def symbolize_keys(hash)
-        hash.each_with_object({}) do |(k, v), acc|
-          k = k.to_sym
-          acc[k] = v.is_a?(Hash) ? symbolize_keys(v) : v
-        end
-      end
     end
   end
 end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1517,7 +1517,7 @@ bar
       with_tempfile_containing('conf', YAML.dump(complete_config)) do |conf|
         cli = Bolt::CLI.new(%W[command run --configfile #{conf.path} --nodes foo])
         cli.parse
-        expect(cli.config[:transports][:pcp][:task_environment]).to eq('testenv')
+        expect(cli.config[:transports][:pcp][:"task-environment"]).to eq('testenv')
       end
     end
 

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1517,7 +1517,7 @@ bar
       with_tempfile_containing('conf', YAML.dump(complete_config)) do |conf|
         cli = Bolt::CLI.new(%W[command run --configfile #{conf.path} --nodes foo])
         cli.parse
-        expect(cli.config[:transports][:pcp][:orch_task_environment]).to eq('testenv')
+        expect(cli.config[:transports][:pcp][:task_environment]).to eq('testenv')
       end
     end
 
@@ -1525,7 +1525,7 @@ bar
       with_tempfile_containing('conf', YAML.dump(complete_config)) do |conf|
         cli = Bolt::CLI.new(%W[command run --configfile #{conf.path} --nodes foo])
         cli.parse
-        expect(cli.config[:transports][:pcp][:service_url]).to eql('http://foo.org')
+        expect(cli.config[:transports][:pcp][:"service-url"]).to eql('http://foo.org')
       end
     end
 
@@ -1533,7 +1533,7 @@ bar
       with_tempfile_containing('conf', YAML.dump(complete_config)) do |conf|
         cli = Bolt::CLI.new(%W[command run --configfile #{conf.path} --nodes foo])
         cli.parse
-        expect(cli.config[:transports][:pcp][:token_file]).to eql('/path/to/token')
+        expect(cli.config[:transports][:pcp][:"token-file"]).to eql('/path/to/token')
       end
     end
 

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -106,5 +106,49 @@ describe Bolt::Config do
       )
       expect { config.validate }.to raise_error(Bolt::CLIError)
     end
+
+    it "accepts a boolean for host-key-check" do
+      config = {
+        transports: {
+          ssh: { host_key_check: false }
+        }
+      }
+      expect {
+        Bolt::Config.new(config).validate
+      }.not_to raise_error
+    end
+
+    it "does not accept host-key-check that is not a boolean" do
+      config = {
+        transports: {
+          ssh: { host_key_check: 'false' }
+        }
+      }
+      expect {
+        Bolt::Config.new(config).validate
+      }.to raise_error(Bolt::CLIError)
+    end
+
+    it "accepts a boolean for ssl" do
+      config = {
+        transports: {
+          winrm: { ssl: false }
+        }
+      }
+      expect {
+        Bolt::Config.new(config).validate
+      }.not_to raise_error
+    end
+
+    it "does not accept ssl that is not a boolean" do
+      config = {
+        transports: {
+          winrm: { ssl: 'false' }
+        }
+      }
+      expect {
+        Bolt::Config.new(config).validate
+      }.to raise_error(Bolt::CLIError)
+    end
   end
 end

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -27,6 +27,35 @@ describe Bolt::Config do
     end
   end
 
+  describe "deep_clone" do
+    let(:conf) { config.deep_clone }
+
+    {
+      concurrency: -1,
+      modulepath: '/foo',
+      transport: 'anything',
+      format: 'other'
+    }.each do |k, v|
+      it "updates #{k} in the copy to #{v}" do
+        conf[k] = v
+        expect(conf[k]).to eq(v)
+        expect(config[k]).not_to eq(v)
+      end
+    end
+
+    {
+      ssh: :host_key_check,
+      winrm: :ssl,
+      pcp: :foo
+    }.each do |transport, key|
+      it "updates #{transport} #{key} in the copy to false" do
+        conf[:transports][transport][key] = false
+        expect(conf[:transports][transport][key]).to eq(false)
+        expect(config[:transports][transport][key]).not_to eq(false)
+      end
+    end
+  end
+
   describe "load_file" do
     let(:default_path) { File.expand_path(File.join('~', '.puppetlabs', 'bolt.yaml')) }
     let(:alt_path) { File.expand_path(File.join('~', '.puppetlabs', 'bolt.yml')) }

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -480,7 +480,7 @@ describe Bolt::Inventory do
         expect(target.port).to be nil
         expect(target.options).to eq(
           connect_timeout: 10,
-          task_environment: "prod",
+          :"task-environment" => "prod",
           tty: false,
           :"service-url" => "https://master",
           cacert: "pcp.pem",

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -101,6 +101,27 @@ describe Bolt::Inventory do
         Bolt::Inventory.new(data).validate
       }.to raise_error(Bolt::Inventory::ValidationError, /Tried to redefine group group1/)
     end
+
+    it 'fails with deprecated property transport in global config' do
+      data = { 'config' => { 'transports' => {} } }
+      expect {
+        Bolt::Inventory.new(data).validate
+      }.to raise_error(Bolt::Inventory::ValidationError, /Group all contains invalid config/)
+    end
+
+    it 'fails with deprecated property transport in group config' do
+      data = { 'groups' => [{ 'name' => 'group1', 'config' => { 'transports' => {} } }] }
+      expect {
+        Bolt::Inventory.new(data).validate
+      }.to raise_error(Bolt::Inventory::ValidationError, /Group group1 contains invalid config/)
+    end
+
+    it 'fails with deprecated property transport in node config' do
+      data = { 'nodes' => [{ 'name' => 'node1', 'config' => { 'transports' => {} } }] }
+      expect {
+        Bolt::Inventory.new(data).validate
+      }.to raise_error(Bolt::Inventory::ValidationError, /Node node1 contains invalid config/)
+    end
   end
 
   describe :collect_groups do

--- a/spec/bolt/transport/orch_spec.rb
+++ b/spec/bolt/transport/orch_spec.rb
@@ -46,7 +46,7 @@ describe Bolt::Transport::Orch, orchestrator: true do
     end
 
     it "sets environment" do
-      targets.first.options[:orch_task_environment] = 'development'
+      targets.first.options[:task_environment] = 'development'
       body = orch.build_request(targets, mtask, {})
       expect(body[:environment]).to eq('development')
     end
@@ -141,10 +141,10 @@ describe Bolt::Transport::Orch, orchestrator: true do
 
   describe :batches do
     it "splits targets in different environments into separate batches" do
-      targets = [Bolt::Target.new('a', orch_task_environment: 'production'),
-                 Bolt::Target.new('b', orch_task_environment: 'development'),
-                 Bolt::Target.new('c', orch_task_environment: 'test'),
-                 Bolt::Target.new('d', orch_task_environment: 'development')]
+      targets = [Bolt::Target.new('a', task_environment: 'production'),
+                 Bolt::Target.new('b', task_environment: 'development'),
+                 Bolt::Target.new('c', task_environment: 'test'),
+                 Bolt::Target.new('d', task_environment: 'development')]
       batches = Set.new([[targets[0]],
                          [targets[1], targets[3]],
                          [targets[2]]])

--- a/spec/bolt/transport/orch_spec.rb
+++ b/spec/bolt/transport/orch_spec.rb
@@ -46,7 +46,7 @@ describe Bolt::Transport::Orch, orchestrator: true do
     end
 
     it "sets environment" do
-      targets.first.options[:task_environment] = 'development'
+      targets.first.options[:"task-environment"] = 'development'
       body = orch.build_request(targets, mtask, {})
       expect(body[:environment]).to eq('development')
     end
@@ -141,10 +141,10 @@ describe Bolt::Transport::Orch, orchestrator: true do
 
   describe :batches do
     it "splits targets in different environments into separate batches" do
-      targets = [Bolt::Target.new('a', task_environment: 'production'),
-                 Bolt::Target.new('b', task_environment: 'development'),
-                 Bolt::Target.new('c', task_environment: 'test'),
-                 Bolt::Target.new('d', task_environment: 'development')]
+      targets = [Bolt::Target.new('a', :'task-environment' => 'production'),
+                 Bolt::Target.new('b', :'task-environment' => 'development'),
+                 Bolt::Target.new('c', :'task-environment' => 'test'),
+                 Bolt::Target.new('d', :'task-environment' => 'development')]
       batches = Set.new([[targets[0]],
                          [targets[1], targets[3]],
                          [targets[2]]])

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -16,19 +16,15 @@ describe 'running with an inventory file', reset_puppet_settings: true do
       { name: conn[:host],
         config: {
           transport: conn[:protocol],
-          transports: {
-            conn[:protocol] => {
-              user: conn[:user],
-              port: conn[:port]
-            }
+          conn[:protocol] => {
+            user: conn[:user],
+            port: conn[:port]
           }
         } }
     ],
       config: {
-        transports: {
-          ssh: { host_key_check: false },
-          winrm: { ssl: false }
-        }
+        ssh: { 'host-key-check' => false },
+        winrm: { ssl: false }
       },
       vars: {
         daffy: "duck"


### PR DESCRIPTION
Moves task_environment to be specific to the pcp transport, and fixes specifying token-file and service-url in the Bolt config file (it worked correctly in the inventory file).

Fixes the inventory file config section so it uses structure and keys
that are consistent with the config file format. Previously it required
them to match the internal structure of the Bolt::Config object, which
led to a lot of inconsistency between inventory and config file formats.

So
```
config:
  transports:
    ssh:
      host_key_check: false
```
is now
```
config:
  ssh:
    host-key-check: false
```