### PR TITLE
(BOLT-363) Fix batching by protocol

### DIFF
--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -58,9 +58,9 @@ module Bolt
     # transport, is yielded to the block in turn and the results all collected
     # into a single ResultSet.
     def batch_execute(targets)
-      promises = targets.group_by(&:protocol).flat_map do |protocol, _protocol_targets|
+      promises = targets.group_by(&:protocol).flat_map do |protocol, protocol_targets|
         transport = transport(protocol)
-        transport.batches(targets).flat_map do |batch|
+        transport.batches(protocol_targets).flat_map do |batch|
           batch_promises = Hash[Array(batch).map { |target| [target, Concurrent::Promise.new(executor: :immediate)] }]
           # Pass this argument through to avoid retaining a reference to a
           # local variable that will change on the next iteration of the loop.

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -61,7 +61,9 @@ module Bolt
       promises = targets.group_by(&:protocol).flat_map do |protocol, protocol_targets|
         transport = transport(protocol)
         transport.batches(protocol_targets).flat_map do |batch|
-          batch_promises = Hash[Array(batch).map { |target| [target, Concurrent::Promise.new(executor: :immediate)] }]
+          batch_promises = Array(batch).each_with_object({}) do |target, h|
+            h[target] = Concurrent::Promise.new(executor: :immediate)
+          end
           # Pass this argument through to avoid retaining a reference to a
           # local variable that will change on the next iteration of the loop.
           @pool.post(batch_promises) do |result_promises|

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -321,16 +321,22 @@ describe "Bolt::Executor" do
     end
   end
 
-  it "returns ensures that every target has a result, no matter what" do
-    result_set = executor.batch_execute(targets) do
-      # Intentionally *don't* return a result
-      []
-    end
+  context "targets with different protocols" do
+    let(:targets) {
+      [Bolt::Target.new('ssh://node1'), Bolt::Target.new('winrm://node2'), Bolt::Target.new('pcp://node3')]
+    }
 
-    expect(result_set.names).to eq([targets[0].name, targets[1].name])
-    result_set.each do |result|
-      expect(result).not_to be_success
-      expect(result.error_hash['msg']).to match(/No result was returned/)
+    it "returns ensures that every target has a result, no matter what" do
+      result_set = executor.batch_execute(targets) do
+        # Intentionally *don't* return a result
+        []
+      end
+
+      expect(result_set.names).to eq(targets.map(&:name))
+      result_set.each do |result|
+        expect(result).not_to be_success
+        expect(result.error_hash['msg']).to match(/No result was returned/)
+      end
     end
   end
 


### PR DESCRIPTION
Previously, running a command across targets with different protocols
would try to reach the target on each protocol. Now correctly group by
protocols and only try to reach a particular target by its specified
protocol.