### PR TITLE
(BOLT-356) Add pcp/local-validation setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ ssh:
 
 `task-environment`: The environment from which Orchestrator will serve task implementations. (default: `production`)
 
+`local-validation`: Whether or not to perform validation of task parameters against the locally installed copy of a task when the task is run exclusively on targets which use the `pcp` transport. If set to false (and the task is run exclusively on targets which use the `pcp` transport) no validation of the task parameters is performed by bolt and the task doesn't even need to be installed locally. If a task is run on targets which use different transports (which may or may not include `pcp`) the validation of the task parameters is performed irrespective of this setting. (default: true)
+
 ### `local` transport configuration options
 
 `tmpdir`: The directory to store temporary files and use as the working directory for local execution. (default: `Dir.mktmpdir`)

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -240,9 +240,14 @@ Available options are:
       end
 
       def update
+        # show the --nodes and --query switches by default
+        @nodes.hide = @query.hide = false
+
         # Update the banner according to the mode
         self.banner = case @options[:mode]
                       when 'plan'
+                        # don't show the --nodes and --query switches in the plan help
+                        @nodes.hide = @query.hide = true
                         PLAN_HELP
                       when 'command'
                         COMMAND_HELP
@@ -255,13 +260,6 @@ Available options are:
                       else
                         BANNER
                       end
-
-        # Only show the --nodes and --query switches in the help message
-        # produced by the #help method when not dealing with plans
-        if @options[:mode] == 'plan'
-          @nodes.hide = true
-          @query.hide = true
-        end
       end
 
       def parse_params(params)

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -179,5 +179,27 @@ describe Bolt::Config do
         Bolt::Config.new(config).validate
       }.to raise_error(Bolt::CLIError)
     end
+
+    it "accepts a boolean for local-validation" do
+      config = {
+        transports: {
+          pcp: { :'local-validation' => false }
+        }
+      }
+      expect {
+        Bolt::Config.new(config).validate
+      }.not_to raise_error
+    end
+
+    it "does not accept local-validation that is not a boolean" do
+      config = {
+        transports: {
+          pcp: { :'local-validation' => 'false' }
+        }
+      }
+      expect {
+        Bolt::Config.new(config).validate
+      }.to raise_error(Bolt::CLIError)
+    end
   end
 end

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -407,7 +407,8 @@ describe Bolt::Inventory do
           'service-url' => 'https://master',
           'cacert' => transport + '.pem',
           'token-file' => 'token',
-          'task-environment' => 'prod'
+          'task-environment' => 'prod',
+          'local-validation' => false
         }
       end
 
@@ -484,7 +485,8 @@ describe Bolt::Inventory do
           tty: false,
           :"service-url" => "https://master",
           cacert: "pcp.pem",
-          :"token-file" => "token"
+          :"token-file" => "token",
+          :"local-validation" => false
         )
       end
     end


### PR DESCRIPTION
Adds support for the `pcp/local-validation` configuration setting.
When set to `false` then, under the condition that a task is run on targets exclusively using the `pcp` transport, no validation of the specified task parameters against the local task definition is performed (the definition is not even loaded so the task doesn't even need to be installed locally).
The validation still takes place if the task is run on targets which use different transports (which may or may not include the `pcp` transport).