### PR TITLE
(BOLT-348) Add package-based install method to acceptance tests

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -92,6 +92,11 @@ GIT_SHA
     pre-suites to determine what git ref should be checked out for testing.
     This variable supercedes `GIT_BRANCH` if provided.
 
+SHA
+    :  When testing via package install, this value will be used by the test
+    pre-suites to determine what package version should be installed for
+    testing.
+
 ## Running Tests on the vcloud
 
 ### Rake tasks
@@ -150,6 +155,18 @@ BOLT_NODES=ubuntu1604-64,windows10ent-64    \
 SSH_PASSWORD='S3@ret3'                      \
 WINRM_PASSWORD='S3@ret3'                    \
 bundle exec rake test:git
+```
+
+#### Package
+Example to test a specific package version from Puppet's internal package repos
+```
+SHA=261d55b5cc1e8a6d00f4ff4573e17048bea08c10 \
+BEAKER_KEYFILE=~/.ssh/id_rsa-mykey           \
+BOLT_CONTROLLER=centos7-64                   \
+BOLT_NODES=ubuntu1604-64,windows10ent-64     \
+SSH_PASSWORD='S3@ret3'                       \
+WINRM_PASSWORD='S3@ret3'                     \
+bundle exec rake test:package
 ```
 
 ### Beaker

--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -16,7 +16,7 @@ rototiller_task :host_config do |task|
              else
                'ssh'
              end
-    node = node + roles.join(',') + '.'
+    node = node + roles.join(',') + '.{type=aio}'
     n_new << node
   end
   nodes_final = n_new.join('-')
@@ -103,6 +103,24 @@ namespace :test do
     task.add_env(name: 'SSH_PASSWORD')
     task.add_env(name: 'WINRM_USER', default: 'Administrator')
     task.add_env(name: 'WINRM_PASSWORD')
+    task.add_command do |cmd|
+      cmd.name = 'beaker'
+      cmd.add_option(*beaker_options)
+    end
+  end
+
+  desc "Run bolt acceptance tests against a package"
+  task package: :host_config
+  rototiller_task :package do |task|
+    beaker_options << {
+      name: '--options',
+      add_argument: { name: 'config/package/options.rb' }
+    }
+    task.add_env(name: 'SSH_USER', default: 'root')
+    task.add_env(name: 'SSH_PASSWORD')
+    task.add_env(name: 'WINRM_USER', default: 'Administrator')
+    task.add_env(name: 'WINRM_PASSWORD')
+    task.add_env(name: 'SHA')
     task.add_command do |cmd|
       cmd.name = 'beaker'
       cmd.add_option(*beaker_options)

--- a/acceptance/config/package/options.rb
+++ b/acceptance/config/package/options.rb
@@ -1,0 +1,7 @@
+{
+  pre_suite: [
+    'setup/package/pre-suite/015_install_puppet_agent_repo.rb',
+    'setup/package/pre-suite/020_install.rb'
+  ],
+  load_path: './lib/acceptance'
+}

--- a/acceptance/setup/package/pre-suite/015_install_puppet_agent_repo.rb
+++ b/acceptance/setup/package/pre-suite/015_install_puppet_agent_repo.rb
@@ -1,0 +1,14 @@
+step 'Install puppet-agent package' do
+  case bolt.platform
+  when /((?:sles|el)-\d+)/
+    platform = Regexp.last_match(1)
+    bolt.install_package_with_rpm("http://yum.puppetlabs.com/puppet5/puppet5-release-#{platform}.noarch.rpm")
+  when /ubuntu|deb/
+    codename = Platform.new(bolt.platform).codename
+    release_package = "puppet5-release-#{codename}.deb"
+    on bolt, "curl -L http://apt.puppetlabs.com/#{release_package} -O"
+    bolt.install_local_package(release_package)
+  else
+    fail_test "Can't install puppet-agent on #{host.platform}"
+  end
+end

--- a/acceptance/setup/package/pre-suite/020_install.rb
+++ b/acceptance/setup/package/pre-suite/020_install.rb
@@ -1,0 +1,7 @@
+step 'Install Bolt package' do
+  bolt_sha = ENV['SHA']
+
+  install_puppetlabs_dev_repo(bolt, 'bolt', bolt_sha, 'repo-configs')
+  bolt.install_package('bolt')
+  add_puppet_paths_on(bolt)
+end


### PR DESCRIPTION
This adds the `test:package` rake task, which runs the bolt acceptance
tests against a dev package.