### PR TITLE
(BOLT-377) Accept inventory in environment variable

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -212,6 +212,9 @@ Available options are:
         end
         define('--inventoryfile INVENTORY_PATH',
                'Specify where to load the inventory file from') do |path|
+          if ENV.include?(Bolt::Inventory::ENVIRONMENT_VAR)
+            raise Bolt::CLIError, "Cannot pass inventory file when #{Bolt::Inventory::ENVIRONMENT_VAR} is set"
+          end
           @options[:inventoryfile] = path
         end
         define_tail('--[no-]tty',

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1711,5 +1711,17 @@ bar
         cli.parse
       }.to raise_error(Bolt::Error, /Could not parse/)
     end
+
+    context 'with BOLT_INVENTORY set' do
+      before(:each) { ENV['BOLT_INVENTORY'] = '---' }
+      after(:each) { ENV.delete('BOLT_INVENTORY') }
+
+      it 'errors when BOLT_INVENTORY is set' do
+        cli = Bolt::CLI.new(%W[command run --inventoryfile #{File.join(inventorydir, 'invalid.yml')} --nodes foo])
+        expect {
+          cli.parse
+        }.to raise_error(Bolt::Error, /BOLT_INVENTORY is set/)
+      end
+    end
   end
 end

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -159,6 +159,26 @@ describe Bolt::Inventory do
     end
   end
 
+  context 'with BOLT_INVENTORY set' do
+    let(:inventory) { Bolt::Inventory.from_config(config) }
+    let(:target) { inventory.get_targets('node1')[0] }
+
+    before(:each) do
+      ENV['BOLT_INVENTORY'] = {
+        'nodes' => ['node1'],
+        'config' => {
+          'transport' => 'winrm'
+        }
+      }.to_yaml
+    end
+
+    after(:each) { ENV.delete('BOLT_INVENTORY') }
+
+    it 'should have the default protocol' do
+      expect(target.protocol).to eq('winrm')
+    end
+  end
+
   context 'with config' do
     let(:inventory) {
       Bolt::Inventory.from_config(config(transport: 'winrm',


### PR DESCRIPTION
This adds the ability for bolt to accept inventory data from an
environment variable instead of a file. This can be useful when running
bolt programatically.