### PR TITLE
(BOLT-377) Use safe_load instead of load

### DIFF
--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -41,8 +41,11 @@ module Bolt
     def self.from_config(config)
       if ENV.include?(ENVIRONMENT_VAR)
         begin
-          # rubocop:disable YAMLLoad
-          data = YAML.load(ENV[ENVIRONMENT_VAR])
+          if YAML.respond_to?(:safe_load)
+            data = YAML.safe_load(ENV[ENVIRONMENT_VAR])
+          else
+            data = YAML.load(ENV[ENVIRONMENT_VAR])
+          end
         # In older releases of psych SyntaxError is not a subclass of Exception
         rescue Psych::SyntaxError
           raise Bolt::CLIError, "Could not parse inventory from $#{ENVIRONMENT_VAR}"


### PR DESCRIPTION
Use `safe_load` to avoid any possible concerns around loading arbitrary YAML.