### PR TITLE
(BOLT-379) Accept key-data in addition to the path of a key file

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -151,7 +151,7 @@ Available options are:
         end
         define('--private-key KEY',
                'Private ssh key to authenticate with (Optional)') do |key|
-          @options[:key] = key
+          @options[:'private-key'] = key
         end
         define('--tmpdir DIR',
                'The directory to upload and execute temporary files on the target (Optional)') do |tmpdir|

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -7,7 +7,7 @@ module Bolt
   module Transport
     class SSH < Base
       def self.options
-        %w[port user password sudo-password key host-key-check connect-timeout tmpdir run-as]
+        %w[port user password sudo-password private-key host-key-check connect-timeout tmpdir run-as]
       end
 
       def initialize

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -68,9 +68,16 @@ module Bolt
             non_interactive: true
           }
 
+          if (key = target.options['private-key'])
+            if key.instance_of?(String)
+              options[:keys] = key
+            else
+              options[:key_data] = [key['key-data']]
+            end
+          end
+
           options[:port] = target.port if target.port
           options[:password] = target.password if target.password
-          options[:keys] = target.options['key'] if target.options['key']
           options[:verify_host_key] = if target.options['host-key-check']
                                         Net::SSH::Verifiers::Secure.new
                                       else

--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -43,6 +43,21 @@ module Bolt
         hash1.merge(hash2, &recursive_merge)
       end
 
+      # Accepts a Data object and returns a copy with all hash keys
+      # modifed by block. use &:to_s to stringify keys or :to_sym to symbolize them
+      def walk_keys(data, &block)
+        if data.is_a? Hash
+          data.each_with_object({}) do |(k, v), acc|
+            v = walk_keys(v, &block)
+            acc[yield(k)] = v
+          end
+        elsif data.is_a? Array
+          data.map { |v| walk_keys(v, &block) }
+        else
+          data
+        end
+      end
+
       # Performs a deep_clone, using an identical copy if the cloned structure contains multiple
       # references to the same object and prevents endless recursion.
       # Credit to Jan Molic via https://github.com/rubyworks/facets/blob/master/LICENSE.txt

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -3,6 +3,7 @@ require 'signal_helper'
 require 'bolt_spec/files'
 require 'bolt_spec/task'
 require 'bolt/cli'
+require 'bolt/util'
 
 describe "Bolt::CLI" do
   include BoltSpec::Files
@@ -307,8 +308,8 @@ bar
         cli = Bolt::CLI.new(%w[  command run
                                  --private-key ~/.ssh/google_compute_engine
                                  --nodes foo])
-        expect(cli.parse).to include(key: '~/.ssh/google_compute_engine')
-        expect(cli.config[:transports][:ssh]['key']).to eq('~/.ssh/google_compute_engine')
+        expect(cli.parse).to include(:'private-key' => '~/.ssh/google_compute_engine')
+        expect(cli.config[:transports][:ssh]['private-key']).to eq('~/.ssh/google_compute_engine')
       end
 
       it "generates an error message if no key value is given" do
@@ -1542,7 +1543,7 @@ bar
         'concurrency' => 14,
         'format' => 'json',
         'ssh' => {
-          'key' => '/bar/foo',
+          'private-key' => '/bar/foo',
           'host-key-check' => false,
           'connect-timeout' => 4,
           'run-as' => 'Fakey McFakerson'
@@ -1590,7 +1591,7 @@ bar
       with_tempfile_containing('conf', YAML.dump(complete_config)) do |conf|
         cli = Bolt::CLI.new(%W[command run --configfile #{conf.path} --nodes foo --no-host-key-check])
         cli.parse
-        expect(cli.config[:transports][:ssh]['key']).to eq('/bar/foo')
+        expect(cli.config[:transports][:ssh]['private-key']).to eq('/bar/foo')
       end
     end
 

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -158,6 +158,28 @@ describe Bolt::Config do
       }.to raise_error(Bolt::CLIError)
     end
 
+    it "accepts a private-key hash" do
+      config = {
+        transports: {
+          ssh: { 'private-key' => { 'key-data' => "foo" } }
+        }
+      }
+      expect {
+        Bolt::Config.new(config).validate
+      }.not_to raise_error
+    end
+
+    it "does not accept a private-key hash without data" do
+      config = {
+        transports: {
+          ssh: { 'private-key' => { 'not-data' => "foo" } }
+        }
+      }
+      expect {
+        Bolt::Config.new(config).validate
+      }.to raise_error(Bolt::CLIError)
+    end
+
     it "accepts a boolean for ssl" do
       config = {
         transports: {

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -396,7 +396,7 @@ describe Bolt::Inventory do
           'user' => 'me' + transport,
           'password' => 'you' + transport,
           'port' => '12345' + transport,
-          'key' => 'anything',
+          'private-key' => 'anything',
           'ssl' => false,
           'host-key-check' => false,
           'connect-timeout' => transport.size,
@@ -450,7 +450,7 @@ describe Bolt::Inventory do
           'connect-timeout' => 3,
           'tty' => false,
           'host-key-check' => false,
-          'key' => "anything",
+          'private-key' => "anything",
           'tmpdir' => "/ssh",
           'run-as' => "root",
           'sudo-password' => "nothing"


### PR DESCRIPTION
This allows private key data to be stored directly in config in addition
to the path to private key files.