### PR TITLE
(BOLT-388) Avoid adding 'localhost' to inventory

### DIFF
--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -154,6 +154,10 @@ describe Bolt::Inventory do
       expect(inventory).to be
     end
 
+    it 'the all group should be empty' do
+      expect(inventory.get_targets('all')).to eq([])
+    end
+
     it 'should have the default protocol' do
       expect(target.protocol).to eq('ssh')
     end


### PR DESCRIPTION
When added to inventory implicitly, it becomes part of the `all` group.
Instead default `transport` to `local` only if the name `localhost`
isn't found in inventory when creating the Target.