### PR TITLE
(BOLT-389) Initial implementation of WinRM --[no-]ssl-verify

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ To run Bolt from source:
 
 To use `rubocop`, perform the bundle install with no exclusions
 
-    bundle install --path .bundle
+    bundle install --path .bundle --with test
     bundle exec rake rubocop
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ ssh:
 
 `ssl`: If false, skip requiring SSL for connections. (default: true)
 
+`ssl-verify`: If false, skip remote host SSL certificate verification (for self-signed certs). (default: true)
+
 `cacert`: The CA certificate used to authenticate SSL connections. (default: uses system CA certificates)
 
 `tmpdir`: The directory to store temporary files on the target node. (default: `[System.IO.Path]::GetTempPath()`)

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -188,6 +188,10 @@ Available options are:
                'Use SSL with WinRM') do |ssl|
           @options[:ssl] = ssl
         end
+        define('--[no-]ssl-verify',
+               'Verify remote host SSL certificate with WinRM') do |ssl_verify|
+          @options[:'ssl-verify'] = ssl_verify
+        end
         define('--transport TRANSPORT', TRANSPORTS.keys.map(&:to_s),
                'Specify a default transport: ' << TRANSPORTS.keys.join(', ')) do |t|
           @options[:transport] = t

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -48,7 +48,8 @@ module Bolt
         'host-key-check' => true
       },
       winrm: {
-        'ssl' => true
+        'ssl' => true,
+        'ssl-verify' => true
       },
       pcp: {
         'task-environment' => 'production',
@@ -162,6 +163,10 @@ module Bolt
 
       if options.key?(:ssl) # this defaults to true so we need to check the presence of the key
         self[:transports][:winrm]['ssl'] = options[:ssl]
+      end
+
+      if options.key?(:'ssl-verify') # this defaults to true so we need to check the presence of the key
+        self[:transports][:winrm]['ssl-verify'] = options[:'ssl-verify']
       end
 
       if options.key?(:'host-key-check') # this defaults to true so we need to check the presence of the key

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -16,7 +16,7 @@ module Bolt
         unless !!ssl_flag == ssl_flag
           raise Bolt::CLIError, 'ssl option must be a Boolean true or false'
         end
-        
+
         ssl_verify_flag = options['ssl-verify']
         unless !!ssl_verify_flag == ssl_verify_flag
           raise Bolt::CLIError, 'ssl-verify option must be a Boolean true or false'

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -8,13 +8,18 @@ module Bolt
       ].freeze
 
       def self.options
-        %w[port user password connect-timeout ssl tmpdir cacert extensions]
+        %w[port user password connect-timeout ssl ssl-verify tmpdir cacert extensions]
       end
 
       def self.validate(options)
         ssl_flag = options['ssl']
         unless !!ssl_flag == ssl_flag
           raise Bolt::CLIError, 'ssl option must be a Boolean true or false'
+        end
+        
+        ssl_verify_flag = options['ssl-verify']
+        unless !!ssl_verify_flag == ssl_verify_flag
+          raise Bolt::CLIError, 'ssl-verify option must be a Boolean true or false'
         end
 
         timeout_value = options['connect-timeout']

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -74,7 +74,9 @@ module Bolt
             theres_your_problem = "\nAre you using SSL to connect to a non-SSL port?"
           end
           if target.options['ssl-verify'] && e.message.include?('certificate verify failed')
-            theres_your_problem = "\nIs the remote host using a self-signed SSL certificate? Use --no-ssl-verify to disable remote host SSL verification."
+            theres_your_problem = "\nIs the remote host using a self-signed SSL"\
+                                  "certificate? Use --no-ssl-verify to disable "\
+                                  "remote host SSL verification."
           end
           raise Bolt::Node::ConnectError.new(
             "Failed to connect to #{endpoint}: #{e.message}#{theres_your_problem}",

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1552,7 +1552,8 @@ bar
           'connect-timeout' => 7,
           'cacert' => '/path/to/winrm-cacert',
           'extensions' => ['.py', '.bat'],
-          'ssl' => false
+          'ssl' => false,
+          'ssl-verify' => false
         },
         'pcp' => {
           'task-environment' => 'testenv',
@@ -1625,6 +1626,14 @@ bar
         cli = Bolt::CLI.new(%W[command run --configfile #{conf.path} --nodes foo])
         cli.parse
         expect(cli.config[:transports][:winrm]['ssl']).to eq(false)
+      end
+    end
+
+    it 'reads ssl-verify for winrm' do
+      with_tempfile_containing('conf', YAML.dump(complete_config)) do |conf|
+        cli = Bolt::CLI.new(%W[command run --configfile #{conf.path} --nodes foo])
+        cli.parse
+        expect(cli.config[:transports][:winrm]['ssl-verify']).to eq(false)
       end
     end
 

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -46,6 +46,7 @@ describe Bolt::Config do
     {
       ssh: 'host-key-check',
       winrm: 'ssl',
+      winrm: 'ssl-verify',
       pcp: 'foo'
     }.each do |transport, key|
       it "updates #{transport} #{key} in the copy to false" do
@@ -195,6 +196,28 @@ describe Bolt::Config do
       config = {
         transports: {
           winrm: { 'ssl' => 'false' }
+        }
+      }
+      expect {
+        Bolt::Config.new(config).validate
+      }.to raise_error(Bolt::CLIError)
+    end
+
+    it "accepts a boolean for ssl-verify" do
+      config = {
+        transports: {
+          winrm: { 'ssl-verify' => false }
+        }
+      }
+      expect {
+        Bolt::Config.new(config).validate
+      }.not_to raise_error
+    end
+
+    it "does not accept ssl-verify that is not a boolean" do
+      config = {
+        transports: {
+          winrm: { 'ssl-verify' => 'false' }
         }
       }
       expect {

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -43,16 +43,17 @@ describe Bolt::Config do
       end
     end
 
-    {
-      ssh: 'host-key-check',
-      winrm: 'ssl',
-      winrm: 'ssl-verify',
-      pcp: 'foo'
-    }.each do |transport, key|
-      it "updates #{transport} #{key} in the copy to false" do
-        conf[:transports][transport][key] = false
-        expect(conf[:transports][transport][key]).to eq(false)
-        expect(config[:transports][transport][key]).not_to eq(false)
+    [{ssh: 'host-key-check'},
+     {winrm: 'ssl'},
+     {winrm: 'ssl-verify'},
+     {pcp: 'foo'}
+    ].each do |hash|
+      hash.each do |transport, key|
+        it "updates #{transport} #{key} in the copy to false" do
+          conf[:transports][transport][key] = false
+          expect(conf[:transports][transport][key]).to eq(false)
+          expect(config[:transports][transport][key]).not_to eq(false)
+        end
       end
     end
   end

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -43,10 +43,11 @@ describe Bolt::Config do
       end
     end
 
-    [{ssh: 'host-key-check'},
-     {winrm: 'ssl'},
-     {winrm: 'ssl-verify'},
-     {pcp: 'foo'}
+    [
+      { ssh: 'host-key-check' },
+      { winrm: 'ssl' },
+      { winrm: 'ssl-verify' },
+      { pcp: 'foo' }
     ].each do |hash|
       hash.each do |transport, key|
         it "updates #{transport} #{key} in the copy to false" do

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -183,7 +183,8 @@ describe Bolt::Inventory do
     let(:inventory) {
       Bolt::Inventory.from_config(config(transport: 'winrm',
                                          transports: { winrm: {
-                                           'ssl' => false
+                                           'ssl' => false,
+                                           'ssl-verify' => false
                                          } }))
     }
     let(:target) { inventory.get_targets('nonode')[0] }
@@ -194,6 +195,10 @@ describe Bolt::Inventory do
 
     it 'should not use ssl' do
       expect(target.options['ssl']).to eq(false)
+    end
+    
+    it 'should not use ssl-verify' do
+      expect(target.options['ssl-verify']).to eq(false)
     end
   end
 
@@ -408,6 +413,19 @@ describe Bolt::Inventory do
           expect { inventory.get_targets('node') }.to raise_error(Bolt::CLIError)
         end
       end
+      
+      context 'ssl-verify' do
+        let(:data) {
+          {
+            'nodes' => ['node'],
+            'config' => { 'winrm' => { 'ssl-verify' => 'true' } }
+          }
+        }
+
+        it 'fails validation' do
+          expect { inventory.get_targets('node') }.to raise_error(Bolt::CLIError)
+        end
+      end
     end
 
     context 'with all options in the config' do
@@ -418,6 +436,7 @@ describe Bolt::Inventory do
           'port' => '12345' + transport,
           'private-key' => 'anything',
           'ssl' => false,
+          'ssl-verify' => false,
           'host-key-check' => false,
           'connect-timeout' => transport.size,
           'tmpdir' => '/' + transport,
@@ -453,6 +472,7 @@ describe Bolt::Inventory do
         expect(conf[:transport]).to eq('ssh')
         expect(conf[:transports][:ssh]['host-key-check']).to be true
         expect(conf[:transports][:winrm]['ssl']).to be true
+        expect(conf[:transports][:winrm]['ssl-verify']).to be true
       end
 
       it 'uses the configured transport' do
@@ -487,6 +507,7 @@ describe Bolt::Inventory do
           'connect-timeout' => 5,
           'tty' => false,
           'ssl' => false,
+          'ssl-verify' => false,
           'tmpdir' => "/winrm",
           'cacert' => "winrm.pem",
           'extensions' => ".py"

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -196,7 +196,7 @@ describe Bolt::Inventory do
     it 'should not use ssl' do
       expect(target.options['ssl']).to eq(false)
     end
-    
+
     it 'should not use ssl-verify' do
       expect(target.options['ssl-verify']).to eq(false)
     end
@@ -413,7 +413,7 @@ describe Bolt::Inventory do
           expect { inventory.get_targets('node') }.to raise_error(Bolt::CLIError)
         end
       end
-      
+
       context 'ssl-verify' do
         let(:data) {
           {

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -24,7 +24,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
     ],
       config: {
         ssh: { 'host-key-check' => false },
-        winrm: { ssl: false }
+        winrm: { ssl: false, 'ssl-verify' => false }
       },
       vars: {
         daffy: "duck"

--- a/spec/integration/winrm_spec.rb
+++ b/spec/integration/winrm_spec.rb
@@ -16,8 +16,10 @@ describe "when runnning over the winrm transport", winrm: true do
   let(:user) { conn_info('winrm')[:user] }
 
   context 'when using CLI options' do
-    let(:config_flags) { %W[--nodes #{uri} --no-ssl --no-ssl-verify --format json
-                          --modulepath #{modulepath} --password #{password}] }
+    let(:config_flags) {
+      %W[--nodes #{uri} --no-ssl --no-ssl-verify --format json --modulepath #{modulepath}
+         --password #{password}]
+    }
 
     it 'runs a command' do
       result = run_one_node(%W[command run #{whoami}] + config_flags)
@@ -53,9 +55,14 @@ describe "when runnning over the winrm transport", winrm: true do
   end
 
   context 'when using a configfile' do
-    let(:config) { { 'format' => 'json',
-                     'modulepath' => modulepath,
-                     'winrm' => { 'ssl' => false, 'ssl-verify' => false } } }
+    let(:config) {
+      {
+        'format' => 'json',
+        'modulepath' => modulepath,
+        'winrm' => { 'ssl' => false,
+                     'ssl-verify' => false }
+      }
+    }
     let(:config_flags) { %W[--nodes #{uri} --password #{password}] }
 
     it 'runs a command' do

--- a/spec/integration/winrm_spec.rb
+++ b/spec/integration/winrm_spec.rb
@@ -16,7 +16,8 @@ describe "when runnning over the winrm transport", winrm: true do
   let(:user) { conn_info('winrm')[:user] }
 
   context 'when using CLI options' do
-    let(:config_flags) { %W[--nodes #{uri} --no-ssl --no-ssl-verify --format json --modulepath #{modulepath} --password #{password}] }
+    let(:config_flags) { %W[--nodes #{uri} --no-ssl --no-ssl-verify --format json
+                          --modulepath #{modulepath} --password #{password}] }
 
     it 'runs a command' do
       result = run_one_node(%W[command run #{whoami}] + config_flags)
@@ -52,7 +53,9 @@ describe "when runnning over the winrm transport", winrm: true do
   end
 
   context 'when using a configfile' do
-    let(:config) { { 'format' => 'json', 'modulepath' => modulepath, 'winrm' => { 'ssl' => false, 'ssl-verify' => false } } }
+    let(:config) { { 'format' => 'json',
+                     'modulepath' => modulepath,
+                     'winrm' => { 'ssl' => false, 'ssl-verify' => false } } }
     let(:config_flags) { %W[--nodes #{uri} --password #{password}] }
 
     it 'runs a command' do

--- a/spec/integration/winrm_spec.rb
+++ b/spec/integration/winrm_spec.rb
@@ -16,7 +16,7 @@ describe "when runnning over the winrm transport", winrm: true do
   let(:user) { conn_info('winrm')[:user] }
 
   context 'when using CLI options' do
-    let(:config_flags) { %W[--nodes #{uri} --no-ssl --format json --modulepath #{modulepath} --password #{password}] }
+    let(:config_flags) { %W[--nodes #{uri} --no-ssl --no-ssl-verify --format json --modulepath #{modulepath} --password #{password}] }
 
     it 'runs a command' do
       result = run_one_node(%W[command run #{whoami}] + config_flags)
@@ -52,7 +52,7 @@ describe "when runnning over the winrm transport", winrm: true do
   end
 
   context 'when using a configfile' do
-    let(:config) { { 'format' => 'json', 'modulepath' => modulepath, 'winrm' => { 'ssl' => false } } }
+    let(:config) { { 'format' => 'json', 'modulepath' => modulepath, 'winrm' => { 'ssl' => false, 'ssl-verify' => false } } }
     let(:config_flags) { %W[--nodes #{uri} --password #{password}] }
 
     it 'runs a command' do


### PR DESCRIPTION
Currently Bolt doesn't support ignoring SSL verification for use with self-signed certificats.

To support this i've introduced a new command line switch and config option under the WinRM transport called `ssl-verify` that can be used from the CLI with the `--[no-]ssl-verify` option.

In the interest of security i've continued to use the "secure by default" paradigm and make the default value of `--ssl-verify` be `true`