### PR TITLE
(maint) Fix info-level logging for plans

### DIFF
--- a/lib/bolt/logger.rb
+++ b/lib/bolt/logger.rb
@@ -18,11 +18,11 @@ module Bolt
       root_logger.add_appenders Logging.appenders.stderr(
         'console',
         layout: default_layout,
-        level: default_level
+        level: :all
       )
       # We set the root logger's level so that it logs everything but we do
       # limit what's actually logged in every appender individually.
-      root_logger.level = :all
+      root_logger.level = default_level
     end
 
     def self.configure(config)


### PR DESCRIPTION
By default, bolt logs at :notice level. However, when running a plan,
we bump up the default log level for the executor to :info, so that
the intermediate operations of the plan are logged.

This was failing to actually log those info messages to the console,
because we had the console appender explicitly configured to only log at
:notice level. The intent was that the root logger would accept any
message and the console appender would ensure that they were only logged
at :notice level.

The actual behavior is that the logger decides which messages to pass
to the appender, and the appender decides which messages to log. This
meant that no matter what the child logger decided to pass to the
console appender, the console appender would refuse to log it if it was
more verbose than :notice.

The proper behavior here is for the root logger (which sets the
*default* log level) to be configured for :notice, and for the console
appender to accept :all. This way, child loggers can choose to be more
open in which messages are passed to the console appender, while still
defaulting to the root log level.