### PR TITLE
(maint) Add gettext:update_pot Rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 group(:test) do
   gem "beaker-hostgenerator"
+  gem "gettext-setup", '~> 0.28', require: false
   gem "rubocop", '0.50.0', require: false
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -54,3 +54,7 @@ namespace :integration do
     sh 'git submodule update --init'
   end
 end
+
+spec = Gem::Specification.find_by_name 'gettext-setup'
+load "#{spec.gem_dir}/lib/tasks/gettext.rake"
+GettextSetup.initialize(File.absolute_path('locales', File.dirname(__FILE__)))

--- a/locales/bolt.pot
+++ b/locales/bolt.pot
@@ -1,0 +1,20 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2018 Puppet, Inc.
+# This file is distributed under the same license as the Bolt: task execution made easy package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Bolt: task execution made easy 0.17.2-4-ga822444\n"
+"\n"
+"Report-Msgid-Bugs-To: docs@puppet.com\n"
+"POT-Creation-Date: 2018-03-15 09:29-0700\n"
+"PO-Revision-Date: 2018-03-15 09:29-0700\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"

--- a/locales/config.yaml
+++ b/locales/config.yaml
@@ -1,0 +1,26 @@
+---
+# This is the project-specific configuration file for setting up
+# fast_gettext for your project.
+gettext:
+  # This is used for the name of the .pot and .po files; they will be
+  # called <project_name>.pot?
+  project_name: 'bolt'
+  # This is used in comments in the .pot and .po files to indicate what
+  # project the files belong to and should bea little more descriptive than
+  # <project_name>
+  package_name: 'Bolt: task execution made easy'
+  # The locale that the default messages in the .pot file are in
+  default_locale: en
+  # The email used for sending bug reports.
+  bugs_address: docs@puppet.com
+  # The holder of the copyright.
+  copyright_holder: Puppet, Inc.
+  # This determines which comments in code should be eligible for translation.
+  # Any comments that start with this string will be externalized. (Leave
+  # empty to include all.)
+  comments_tag: TRANSLATORS
+  # Patterns for +Dir.glob+ used to find all files that might contain
+  # translatable content, relative to the project root directory
+  source_files:
+    - 'exe/*.rb'
+    - 'lib/**/*.rb'


### PR DESCRIPTION
Adds some basic gettext setup to ensure CI jobs for updating the pot
file don't break. This is also necessary preparation for localization.