### PR TITLE
(BOLT-135) Support multiple task implementations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "vendored/puppet"]
 	path = vendored/puppet
-	url = https://github.com/puppetlabs/puppet
-	branch = master
+	url = https://github.com/nicklewis/puppet
+  branch = PUP-8588-multiple-task-implementations
 [submodule "vendored/hiera"]
 	path = vendored/hiera
 	url = https://github.com/puppetlabs/hiera

--- a/acceptance/config/gem/options.rb
+++ b/acceptance/config/gem/options.rb
@@ -3,7 +3,8 @@
 {
   pre_suite: [
     'setup/common/pre-suite/010_install_ruby.rb',
-    'setup/gem/pre-suite/020_install.rb'
+    'setup/gem/pre-suite/020_install.rb',
+    'setup/common/pre-suite/050_build_bolt_inventory.rb'
   ],
   load_path: './lib/acceptance'
 }

--- a/acceptance/config/git/options.rb
+++ b/acceptance/config/git/options.rb
@@ -4,7 +4,8 @@
   pre_suite: [
     'setup/common/pre-suite/010_install_ruby.rb',
     'setup/git/pre-suite/010_install_git.rb',
-    'setup/git/pre-suite/020_install.rb'
+    'setup/git/pre-suite/020_install.rb',
+    'setup/common/pre-suite/050_build_bolt_inventory.rb'
   ],
   load_path: './lib/acceptance',
   ssh: { forward_agent: false }

--- a/acceptance/config/package/options.rb
+++ b/acceptance/config/package/options.rb
@@ -3,7 +3,8 @@
 {
   pre_suite: [
     'setup/package/pre-suite/015_install_puppet_agent_repo.rb',
-    'setup/package/pre-suite/020_install.rb'
+    'setup/package/pre-suite/020_install.rb',
+    'setup/common/pre-suite/050_build_bolt_inventory.rb'
   ],
   load_path: './lib/acceptance'
 }

--- a/acceptance/setup/common/pre-suite/050_build_bolt_inventory.rb
+++ b/acceptance/setup/common/pre-suite/050_build_bolt_inventory.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+test_name "build bolt inventory file" do
+  ssh_nodes = select_hosts(roles: ['ssh'])
+  winrm_nodes = select_hosts(roles: ['winrm'])
+
+  ssh_config = {
+    'transport' => 'ssh',
+    'ssh' => {
+      'user' => ENV['SSH_USER'],
+      'password' => ENV['SSH_PASSWORD'],
+      'host-key-check' => false,
+    }
+  }
+  winrm_config = {
+    'transport' => 'winrm',
+    'winrm' => {
+      'user' => ENV['WINRM_USER'],
+      'password' => ENV['WINRM_PASSWORD'],
+      'ssl' => false,
+    }
+  }
+
+  inventory = {
+    'groups' => [
+      {'name' => 'ssh_nodes', 'nodes' => ssh_nodes.map(&:hostname), 'config' => ssh_config},
+      {'name' => 'winrm_nodes', 'nodes' => winrm_nodes.map(&:hostname), 'config' => winrm_config}
+    ]
+  }
+
+  on bolt, 'mkdir -p ~/.puppetlabs/bolt'
+  create_remote_file(bolt, "/root/.puppetlabs/bolt/inventory.yaml", inventory.to_yaml)
+end

--- a/acceptance/tests/command_ssh.rb
+++ b/acceptance/tests/command_ssh.rb
@@ -10,18 +10,9 @@ test_name "C100546: \
   skip_test('no applicable nodes to test on') if ssh_nodes.empty?
 
   step "execute `bolt command run` via SSH" do
-    user = ENV['SSH_USER']
-    password = ENV['SSH_PASSWORD']
-    nodes_csv = ssh_nodes.map(&:hostname).join(',')
-
     command = 'echo """hello from $(hostname)"""'
     bolt_command = "bolt command run '#{command}'"
-    flags = {
-      '--nodes'              => nodes_csv,
-      '-u'                   => user,
-      '-p'                   => password,
-      '--no-host-key-check'  => nil
-    }
+    flags = { '--nodes' => 'ssh_nodes' }
 
     result = bolt_command_on(bolt, bolt_command, flags)
 

--- a/acceptance/tests/command_winrm.rb
+++ b/acceptance/tests/command_winrm.rb
@@ -10,17 +10,9 @@ test_name "C100547: \
   skip_test('no applicable nodes to test on') if winrm_nodes.empty?
 
   step "execute `bolt command run` via WinRM" do
-    user = ENV['WINRM_USER']
-    password = ENV['WINRM_PASSWORD']
-    nodes_csv = winrm_nodes.map { |host| "winrm://#{host.hostname}" }.join(',')
     command = '[System.Net.Dns]::GetHostByName(($env:computerName))'
     bolt_command = "bolt command run '#{command}'"
-    flags = {
-      '--nodes'     => nodes_csv,
-      '-u'          => user,
-      '-p'          => password,
-      '--no-ssl'    => nil
-    }
+    flags = { '--nodes'     => 'winrm_nodes' }
 
     result = bolt_command_on(bolt, bolt_command, flags)
 

--- a/acceptance/tests/cross_platform_task.rb
+++ b/acceptance/tests/cross_platform_task.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'bolt_command_helper'
+
+test_name "cross-platform tasks run on multiple kinds of nodes" do
+  extend Acceptance::BoltCommandHelper
+
+  dir = bolt.tmpdir('cross_platform_task')
+  task_dir = "#{dir}/modules/test/tasks"
+
+  step "create a cross-platform task" do
+    on bolt, "mkdir -p #{task_dir}"
+    create_remote_file(bolt, "#{task_dir}/hostname.sh", <<-FILE)
+    echo "hello from $(hostname)"
+    FILE
+    create_remote_file(bolt, "#{task_dir}/hostname.ps1", <<-FILE)
+    [System.Net.Dns]::GetHostByName(($env:computerName))
+    FILE
+    create_remote_file(bolt, "#{task_dir}/hostname.json", <<-FILE)
+    {
+      "implementations": [
+        {"name": "hostname.sh", "requirements": ["shell"]},
+        {"name": "hostname.ps1", "requirements": ["powershell"]}
+      ]
+    }
+    FILE
+  end
+
+  step "execute `bolt task run` via both SSH and WinRM" do
+    command = 'echo """hello from $(hostname)"""'
+    bolt_command = "bolt task run test::hostname"
+    flags = {
+      '--nodes' => 'all',
+      '--modulepath' => "#{dir}/modules"
+    }
+
+    result = bolt_command_on(bolt, bolt_command, flags)
+
+    ssh_nodes = select_hosts(roles: ['ssh'])
+    winrm_nodes = select_hosts(roles: ['winrm'])
+
+    ssh_nodes.each do |node|
+      message = "Unexpected output from the command:\n#{result.cmd}"
+      regex = /hello from #{node.hostname.split('.')[0]}/
+      assert_match(regex, result.stdout, message)
+    end
+
+    winrm_nodes.each do |node|
+      message = "Unexpected output from the command:\n#{result.cmd}"
+      assert_match(/#{node.hostname.split('.')[0]}/, result.stdout, message)
+      assert_match(/{#{node.ip}}/, result.stdout, message)
+    end
+  end
+end

--- a/acceptance/tests/file_ssh.rb
+++ b/acceptance/tests/file_ssh.rb
@@ -19,17 +19,8 @@ test_name "C1005xx: \
 
   step "execute `bolt file upload` via SSH" do
     source = dest = 'C1005xx_file.txt'
-    user = ENV['SSH_USER']
-    password = ENV['SSH_PASSWORD']
-    nodes_csv = ssh_nodes.map(&:hostname).join(',')
     bolt_command = "bolt file upload #{dir}/#{source} /tmp/#{dest}"
-    flags = {
-      '--nodes'              => nodes_csv,
-      '--user'               => user,
-      '--password'           => password,
-      '--no-host-key-check'  => nil
-    }
-
+    flags = { '--nodes' => 'ssh_nodes' }
     result = bolt_command_on(bolt, bolt_command, flags)
 
     message = "Unexpected output from the command:\n#{result.cmd}"

--- a/acceptance/tests/file_winrm.rb
+++ b/acceptance/tests/file_winrm.rb
@@ -26,17 +26,10 @@ test_name "C1005xx: \
 
   step "execute `bolt file upload` via WinRM" do
     source = dest = 'C1005xx_file.txt'
-    user = ENV['WINRM_USER']
-    password = ENV['WINRM_PASSWORD']
     nodes_csv = winrm_nodes.map { |host| "winrm://#{host.hostname}" }.join(',')
     bolt_command = "bolt file upload '#{dir}/#{source}' '#{testdir}/#{dest}'"
 
-    flags = {
-      '--nodes'     => nodes_csv,
-      '-u'          => user,
-      '-p'          => password,
-      '--no-ssl'    => nil
-    }
+    flags = { '--nodes' => 'winrm_nodes' }
 
     result = bolt_command_on(bolt, bolt_command, flags)
     message = "Unexpected output from the command:\n#{result.cmd}"

--- a/acceptance/tests/plan_ssh.rb
+++ b/acceptance/tests/plan_ssh.rb
@@ -11,9 +11,6 @@ test_name "C100553: \
   skip_test('no applicable nodes to test on') if ssh_nodes.empty?
 
   first_node = ssh_nodes[0].hostname.split('.')[0]
-  user = ENV['SSH_USER']
-  password = ENV['SSH_PASSWORD']
-  nodes_csv = ssh_nodes.map(&:hostname).join(',')
 
   dir = bolt.tmpdir('C100553')
 
@@ -44,13 +41,10 @@ plan test::ssh_retry_plan($nodes) {
   end
 
   step "execute `bolt plan run` via SSH with json output" do
-    bolt_command = "bolt plan run test::ssh_retry_plan nodes=#{nodes_csv}"
+    bolt_command = "bolt plan run test::ssh_retry_plan nodes=ssh_nodes"
     flags = {
-      '-u'                     => user,
-      '--modulepath'           => "#{dir}/modules",
-      '-p'                     => password,
-      '--format'               => 'json',
-      '--no-host-key-check'    => nil
+      '--modulepath' => "#{dir}/modules",
+      '--format'     => 'json',
     }
 
     result = bolt_command_on(bolt, bolt_command, flags)
@@ -92,13 +86,10 @@ plan test::ssh_retry_plan($nodes) {
   end
 
   step "execute `bolt plan run` via SSH with verbose, human readable output" do
-    bolt_command = "bolt plan run test::ssh_retry_plan nodes=#{nodes_csv}"
+    bolt_command = "bolt plan run test::ssh_retry_plan nodes=ssh_nodes"
     flags = {
-      '-u'                     => user,
-      '--modulepath'           => "#{dir}/modules",
-      '-p'                     => password,
-      '--no-host-key-check'    => nil,
-      '--verbose'              => nil
+      '--modulepath' => "#{dir}/modules",
+      '--verbose'    => nil
     }
 
     result = bolt_command_on(bolt, bolt_command, flags)

--- a/acceptance/tests/plan_winrm.rb
+++ b/acceptance/tests/plan_winrm.rb
@@ -10,9 +10,6 @@ test_name "C100554: \
   skip_test('no applicable nodes to test on') if winrm_nodes.empty?
 
   first_node = winrm_nodes[0].hostname.split('.')[0].upcase
-  user = ENV['WINRM_USER']
-  password = ENV['WINRM_PASSWORD']
-  nodes_csv = winrm_nodes.map { |host| "winrm://#{host.hostname}" }.join(',')
 
   dir = bolt.tmpdir('C100554')
 
@@ -51,13 +48,10 @@ plan test::winrm_retry_plan($nodes) {
   end
 
   step "execute `bolt plan run` via WinRM with json output" do
-    bolt_command = "bolt plan run test::winrm_retry_plan nodes=#{nodes_csv}"
+    bolt_command = "bolt plan run test::winrm_retry_plan nodes=winrm_nodes"
     flags = {
-      '--modulepath'  => "#{dir}/modules",
-      '-u'            => user,
-      '-p'            => password,
-      '--format'      => 'json',
-      '--no-ssl'      => nil
+      '--modulepath' => "#{dir}/modules",
+      '--format'     => 'json',
     }
 
     result = bolt_command_on(bolt, bolt_command, flags)
@@ -75,14 +69,14 @@ plan test::winrm_retry_plan($nodes) {
     failed_node = json['result'].select { |n| n['status'] == 'failure' }
     assert(!failed_node.empty?, "No nodes failed on the first task run")
     assert(failed_node.length < 2, "More than 1 node failed the first task run")
-    assert_equal("winrm://#{winrm_nodes[0].hostname}", failed_node[0]['node'],
+    assert_equal(winrm_nodes[0].hostname, failed_node[0]['node'],
                  "The hostname #{winrm_nodes[0].hostname} is not correct")
 
     # Verify that the second node succeeded on the first run
     if winrm_nodes.length > 1
       winrm_nodes[1..-1].each do |node|
         host = node.hostname
-        result = json['result'].select { |n| n['node'] == "winrm://#{host}" }
+        result = json['result'].select { |n| n['node'] == host }
         assert_equal('success', result[0]['status'],
                      "The task did not succeed on #{node.hostname}")
       end
@@ -92,20 +86,17 @@ plan test::winrm_retry_plan($nodes) {
 
     # Verify that the retry run succeeded with expected nodes
     assert_equal(1, json['retry'].length, "More than 1 node was retried")
-    assert_equal("winrm://#{winrm_nodes[0].hostname}", json['retry'][0]['node'],
+    assert_equal(winrm_nodes[0].hostname, json['retry'][0]['node'],
                  "The retry run did not run on #{winrm_nodes[0].hostname}")
     assert_equal('success', json['retry'][0]['status'],
                  "The retry run did not succeed")
   end
 
   step "execute `bolt plan run` via WinRM with verbose, human readable output" do
-    bolt_command = "bolt plan run test::winrm_retry_plan nodes=#{nodes_csv}"
+    bolt_command = "bolt plan run test::winrm_retry_plan nodes=winrm_nodes"
     flags = {
-      '--modulepath'  => "#{dir}/modules",
-      '-u'            => user,
-      '-p'            => password,
-      '--no-ssl'      => nil,
-      '--verbose'     => nil
+      '--modulepath' => "#{dir}/modules",
+      '--verbose'    => nil
     }
 
     result = bolt_command_on(bolt, bolt_command, flags)

--- a/acceptance/tests/script_ssh.rb
+++ b/acceptance/tests/script_ssh.rb
@@ -19,17 +19,9 @@ test_name "C100548: \
   end
 
   step "execute `bolt script run` via SSH" do
-    user = ENV['SSH_USER']
-    password = ENV['SSH_PASSWORD']
-    nodes_csv = ssh_nodes.map(&:hostname).join(',')
     bolt_command = "bolt script run #{script}"
 
-    flags = {
-      '--nodes'              => nodes_csv,
-      '-u'                   => user,
-      '-p'                   => password,
-      '--no-host-key-check'  => nil
-    }
+    flags = { '--nodes' => 'ssh_nodes' }
 
     result = bolt_command_on(bolt, bolt_command, flags)
     ssh_nodes.each do |node|

--- a/acceptance/tests/script_winrm.rb
+++ b/acceptance/tests/script_winrm.rb
@@ -18,16 +18,8 @@ test_name "C100549: \
   end
 
   step "execute `bolt script run` via WinRM" do
-    user = ENV['WINRM_USER']
-    password = ENV['WINRM_PASSWORD']
-    nodes_csv = winrm_nodes.map { |host| "winrm://#{host.hostname}" }.join(',')
     bolt_command = "bolt script run #{script}"
-    flags = {
-      '--nodes'     => nodes_csv,
-      '-u'          => user,
-      '-p'          => password,
-      '--no-ssl'    => nil
-    }
+    flags = { '--nodes' => 'winrm_nodes' }
 
     result = bolt_command_on(bolt, bolt_command, flags)
     winrm_nodes.each do |node|

--- a/acceptance/tests/task_ssh.rb
+++ b/acceptance/tests/task_ssh.rb
@@ -19,16 +19,10 @@ test_name "C100550: \
   end
 
   step "execute `bolt task run` via SSH" do
-    user = ENV['SSH_USER']
-    password = ENV['SSH_PASSWORD']
-    nodes_csv = ssh_nodes.map(&:hostname).join(',')
     bolt_command = "bolt task run test::hostname_nix"
     flags = {
-      '--nodes'                => nodes_csv,
-      '--modulepath'           => "#{dir}/modules",
-      '-u'                     => user,
-      '-p'                     => password,
-      '--no-host-key-check'    => nil
+      '--nodes'      => 'ssh_nodes',
+      '--modulepath' => "#{dir}/modules",
     }
 
     result = bolt_command_on(bolt, bolt_command, flags)

--- a/acceptance/tests/task_winrm.rb
+++ b/acceptance/tests/task_winrm.rb
@@ -19,17 +19,11 @@ test_name "C100551: \
   end
 
   step "execute `bolt task run` via WinRM" do
-    user = ENV['WINRM_USER']
-    password = ENV['WINRM_PASSWORD']
-    nodes_csv = winrm_nodes.map { |host| "winrm://#{host.hostname}" }.join(',')
     bolt_command = "bolt task run test::hostname_win"
 
     flags = {
-      '--nodes'       => nodes_csv,
-      '--modulepath'  => "#{dir}/modules",
-      '-u'            => user,
-      '-p'            => password,
-      '--no-ssl'      => nil
+      '--nodes'      => 'winrm_nodes',
+      '--modulepath' => "#{dir}/modules",
     }
 
     result = bolt_command_on(bolt, bolt_command, flags)

--- a/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
@@ -61,9 +61,9 @@ Puppet::Functions.create_function(:run_task) do
     if !targets.empty? && targets.all? { |t| t.protocol == 'pcp' && t.options['local-validation'] == false }
       # create a fake task
       task = Puppet::Pops::Types::TypeFactory.task.from_hash(
-        'name'          => task_name,
-        'executable'    => '',
-        'supports_noop' => true
+        'name'            => task_name,
+        'implementations' => [{ 'name' => '', 'path' => '' }],
+        'supports_noop'   => true
       )
     else
       # TODO: use the compiler injection once PUP-8237 lands

--- a/bolt-modules/boltlib/lib/puppet/functions/set_feature.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_feature.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'bolt/error'
+
+# Sets a particular feature to present on a target.
+
+Puppet::Functions.create_function(:set_feature) do
+  dispatch :set_feature do
+    param 'Target', :target
+    param 'String', :feature
+    optional_param 'Boolean', :value
+  end
+
+  def set_feature(target, feature, value = true)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, operation: 'set_feature'
+      )
+    end
+
+    inventory = Puppet.lookup(:bolt_inventory) { nil }
+
+    unless inventory
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('set feature')
+      )
+    end
+
+    inventory.set_feature(target, feature, value)
+
+    target
+  end
+end

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -66,6 +66,7 @@ module Bolt
       @group_lookup = {}
       @target_vars = {}
       @target_facts = {}
+      @target_features = {}
     end
 
     def validate
@@ -103,6 +104,19 @@ module Bolt
 
     def facts(target)
       @target_facts[target.name]
+    end
+
+    def set_feature(target, feature, value = true)
+      @target_features[target.name] ||= Set.new
+      if value
+        @target_features[target.name] << feature
+      else
+        @target_features[target.name].delete(feature)
+      end
+    end
+
+    def features(target)
+      @target_features[target.name] || Set.new
     end
 
     #### PRIVATE ####
@@ -177,7 +191,11 @@ module Bolt
         # Expand a comma-separated list
         targets.split(/[[:space:],]+/).reject(&:empty?).map do |name|
           ts = resolve_name(name)
-          ts.map { |t| Bolt::Target.new(t) }
+          ts.map do |t|
+            target = Target.new(t)
+            target.inventory = self
+            target
+          end
         end
       end
     end

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -6,6 +6,7 @@ require 'bolt/error'
 module Bolt
   class Target
     attr_reader :uri, :options
+    attr_writer :inventory
 
     # Satisfies the Puppet datatypes API
     def self.from_asserted_hash(hash)
@@ -43,6 +44,14 @@ module Bolt
       end
     end
     private :parse
+
+    def features
+      if @inventory
+        @inventory.features(self)
+      else
+        Set.new
+      end
+    end
 
     def eql?(other)
       self.class.equal?(other.class) && @uri == other.uri

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -45,6 +45,12 @@ module Bolt
     end
     private :parse
 
+    def select_impl(task, additional_features = [])
+      available_features = features + additional_features
+      suitable_impl = task.implementations.find { |impl| Set.new(impl['requirements']).subset?(available_features) }
+      return suitable_impl['path'] if suitable_impl
+    end
+
     def features
       if @inventory
         @inventory.features(self)

--- a/lib/bolt/transport/local.rb
+++ b/lib/bolt/transport/local.rb
@@ -13,6 +13,8 @@ module Bolt
         %w[tmpdir]
       end
 
+      PROVIDED_FEATURES = ['shell'].freeze
+
       def self.validate(_options); end
 
       def initialize
@@ -80,11 +82,14 @@ module Bolt
       end
 
       def run_task(target, task, arguments, _options = {})
+        executable = target.select_impl(task, PROVIDED_FEATURES)
+        raise "No suitable implementation of #{task.name} for #{target.name}" unless executable
+
         input_method = task.input_method
         stdin = STDIN_METHODS.include?(input_method) ? JSON.dump(arguments) : nil
         env = ENVIRONMENT_METHODS.include?(input_method) ? arguments : nil
 
-        with_tmpscript(task.executable, target.options['tmpdir']) do |script|
+        with_tmpscript(executable, target.options['tmpdir']) do |script|
           logger.debug("Running '#{script}' with #{arguments}")
 
           output = @conn.execute(script, stdin: stdin, env: env)

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -17,6 +17,8 @@ module Bolt
         %w[service-url cacert token-file task-environment local-validation]
       end
 
+      PROVIDED_FEATURES = ['puppet-agent'].freeze
+
       def self.validate(options)
         validation_flag = options['local-validation']
         unless !!validation_flag == validation_flag

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -11,7 +11,7 @@ module Bolt
   module Transport
     class Orch < Base
       CONF_FILE = File.expand_path('~/.puppetlabs/client-tools/orchestrator.conf')
-      BOLT_MOCK_TASK = Struct.new(:name, :executable).new('bolt', 'bolt/tasks/init').freeze
+      BOLT_MOCK_TASK = Struct.new(:name).new('bolt').freeze
 
       def self.options
         %w[service-url cacert token-file task-environment local-validation]

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -797,7 +797,7 @@ bar
           }
           cli.execute(options)
           json = JSON.parse(output.string)
-          json.delete('executable')
+          json.delete('implementations')
           expect(json).to eq(
             "name" => "sample::params",
             "description" => "Task with parameters",

--- a/spec/bolt/target_spec.rb
+++ b/spec/bolt/target_spec.rb
@@ -153,4 +153,52 @@ describe Bolt::Target do
     uri2 = Bolt::Target.new(uri1.uri)
     expect(uri1).to eq(uri2)
   end
+
+  describe "#select_impl" do
+    let(:target) { Bolt::Target.new('example') }
+
+    before :each do
+      allow(target).to receive(:features).and_return(Set.new(['powershell']))
+    end
+
+    it "returns the first implementation if there are no requirements" do
+      impls = [{ 'name' => 'foo.sh', 'path' => '/path/to/foo.sh', 'requirements' => [] },
+               { 'name' => 'foo.ps1', 'path' => '/path/to/foo.ps1', 'requirements' => [] }]
+      task = double('task', implementations: impls)
+
+      expect(target.select_impl(task)).to eq('/path/to/foo.sh')
+    end
+
+    it "returns the first implementation that matches its features" do
+      impls = [{ 'name' => 'foo.sh', 'path' => '/path/to/foo.sh', 'requirements' => ['shell'] },
+               { 'name' => 'foo.ps1', 'path' => '/path/to/foo.ps1', 'requirements' => ['powershell'] }]
+      task = double('task', implementations: impls)
+
+      expect(target.select_impl(task)).to eq('/path/to/foo.ps1')
+    end
+
+    it "only matches if all required features are present" do
+      impls = [{ 'name' => 'foo.rb', 'path' => '/path/to/foo.rb', 'requirements' => ['powershell', 'puppet-agent'] },
+               { 'name' => 'foo.ps1', 'path' => '/path/to/foo.ps1', 'requirements' => ['powershell'] }]
+      task = double('task', implementations: impls)
+
+      expect(target.select_impl(task)).to eq('/path/to/foo.ps1')
+    end
+
+    it "uses additional features passed in when deciding which implementation to use" do
+      impls = [{ 'name' => 'foo.rb', 'path' => '/path/to/foo.rb', 'requirements' => ['powershell', 'puppet-agent'] },
+               { 'name' => 'foo.ps1', 'path' => '/path/to/foo.ps1', 'requirements' => ['powershell'] }]
+      task = double('task', implementations: impls)
+
+      expect(target.select_impl(task, ['puppet-agent'])).to eq('/path/to/foo.rb')
+    end
+
+    it "returns nil if no implementation is suitable" do
+      impls = [{ 'name' => 'foo.rb', 'path' => '/path/to/foo.rb', 'requirements' => ['powershell', 'puppet-agent'] },
+               { 'name' => 'foo.ps1', 'path' => '/path/to/foo.ps1', 'requirements' => %w[powershell foobar] }]
+      task = double('task', implementations: impls)
+
+      expect(target.select_impl(task)).to be_nil
+    end
+  end
 end

--- a/spec/lib/bolt_spec/task.rb
+++ b/spec/lib/bolt_spec/task.rb
@@ -12,7 +12,7 @@ module BoltSpec
       end
 
       def ===(other)
-        @name == other.name && @executable =~ other.executable && @input_method == other.input_method
+        @name == other.name && @executable =~ other.implementations.first['path'] && @input_method == other.input_method
       end
 
       def description
@@ -20,8 +20,9 @@ module BoltSpec
       end
     end
 
-    def mock_task(name, executable = nil, input_method = 'both')
-      double('task', name: name, executable: executable || name, input_method: input_method)
+    def mock_task(name, executable = name, input_method = 'both')
+      impls = [{ 'name' => executable, 'path' => executable }]
+      double('task', name: name, implementations: impls, input_method: input_method)
     end
 
     def task_type(name, executable = nil, input_method = 'both')

--- a/spec/pal/features_spec.rb
+++ b/spec/pal/features_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/files'
+require 'bolt_spec/pal'
+require 'bolt/pal'
+require 'bolt/inventory'
+
+describe 'set_features function' do
+  include BoltSpec::Files
+  include BoltSpec::PAL
+
+  before(:all) { Bolt::PAL.load_puppet }
+  after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
+
+  let(:data) {
+    {
+      'nodes' => %w[example],
+      'vars' => { 'pb' => 'jelly', 'mac' => 'cheese' }
+    }
+  }
+  let(:inventory) { Bolt::Inventory.new(data) }
+  let(:pal) { Bolt::PAL.new(config) }
+  let(:target) { inventory.get_targets('example')[0] }
+
+  it 'adds the feature to the target' do
+    peval(<<-CODE, pal, nil, inventory)
+    $t = get_targets('example')[0]
+    $t.set_feature('shell')
+    CODE
+    expect(inventory.features(target).to_a).to eq(['shell'])
+  end
+
+  it 'only adds the feature once' do
+    peval(<<-CODE, pal, nil, inventory)
+    $t = get_targets('example')[0]
+    $t.set_feature('shell').set_feature('shell')
+    CODE
+    expect(inventory.features(target).to_a).to eq(['shell'])
+  end
+
+  it 'deletes the feature if false is passed' do
+    peval(<<-CODE, pal, nil, inventory)
+    $t = get_targets('example')[0]
+    $t.set_feature('shell')
+    CODE
+
+    expect(inventory.features(target).to_a).to eq(['shell'])
+
+    peval(<<-CODE, pal, nil, inventory)
+    $t = get_targets('example')[0]
+    $t.set_feature('shell', false)
+    CODE
+
+    expect(inventory.features(target).to_a).to be_empty
+  end
+
+  it "does nothing if false is passed for a feature that isn't present" do
+    peval(<<-CODE, pal, nil, inventory)
+    $t = get_targets('example')[0]
+    $t.set_feature('shell', false)
+    CODE
+
+    expect(inventory.features(target).to_a).to be_empty
+  end
+
+  it 'sets separate features for different nodes' do
+    peval(<<-CODE, pal, nil, inventory)
+    $targets = get_targets('example1,example2')
+    $targets[0].set_feature('shell')
+    $targets[1].set_feature('powershell')
+    CODE
+
+    example1, example2 = inventory.get_targets('example1,example2')
+    expect(inventory.features(example1).to_a).to eq(['shell'])
+    expect(inventory.features(example2).to_a).to eq(['powershell'])
+  end
+end


### PR DESCRIPTION
This change adds logic to the existing transports to dynamically select the
appropriate task implementation based on the available features of a
target. Target now has a select_impl() method which, given a task and an
optional list of "additional" features, will return the path to the first
suitable executable. The "additional" features are passed by the transport
and account for any features which are directly *implied* to be present
based on the transport (ie. 'shell' for ssh and 'powershell' for winrm).

This allows a single task to have multiple implementations for different
platforms and for Bolt to choose the appropriate one for each target at
runtime.

A new set_feature() function in puppet language can be used to add and
remove features on a target.