### PR TITLE
(BOLT-359) Add minifact module to modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ script:
 - pushd modules/aggregate
 - bundle exec rake spec
 - popd
+- pushd modules/minifact
+- bundle exec rake spec
+- popd
 notifications:
   email: false
   hipchat:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,3 +45,5 @@ test_script:
   - bundle exec rake spec
   - cd ../../modules/aggregate
   - bundle exec rake spec
+  - cd ../../modules/minifact
+  - bundle exec rake spec

--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -68,6 +68,11 @@ module Bolt
       new(target, message: "Uploaded '#{source}' to '#{target.host}:#{destination}'")
     end
 
+    # Satisfies the Puppet datatypes API
+    def self.from_asserted_args(target, value)
+      new(target, value: value)
+    end
+
     def initialize(target, error: nil, message: nil, value: nil)
       @target = target
       @value = value || {}

--- a/modules/aggregate/plans/count.pp
+++ b/modules/aggregate/plans/count.pp
@@ -16,11 +16,11 @@ plan aggregate::count(
   }
 
   if ($type_count == 0) {
-    fail_plan("Must specify a command, script, or task to run", 'canary/invalid-params')
+    fail_plan("Must specify a command, script, or task to run", 'aggregate/invalid-params')
   }
 
   if ($type_count > 1) {
-    fail_plan("Must specify only one command, script, or task to run", 'canary/invalid-params')
+    fail_plan("Must specify only one command, script, or task to run", 'aggregate/invalid-params')
   }
 
   $res = if ($task) {

--- a/modules/aggregate/plans/nodes.pp
+++ b/modules/aggregate/plans/nodes.pp
@@ -16,11 +16,11 @@ plan aggregate::nodes(
   }
 
   if ($type_count == 0) {
-    fail_plan("Must specify a command, script, or task to run", 'canary/invalid-params')
+    fail_plan("Must specify a command, script, or task to run", 'aggregate/invalid-params')
   }
 
   if ($type_count > 1) {
-    fail_plan("Must specify only one command, script, or task to run", 'canary/invalid-params')
+    fail_plan("Must specify only one command, script, or task to run", 'aggregate/invalid-params')
   }
 
   $res = if ($task) {

--- a/modules/minifact/.fixtures.yml
+++ b/modules/minifact/.fixtures.yml
@@ -1,0 +1,5 @@
+---
+fixtures:
+  symlinks:
+    minifact: "#{source_dir}"
+    boltlib: "#{File.absolute_path(File.join(source_dir, '..', '..', 'bolt-modules', 'boltlib'))}"

--- a/modules/minifact/README.md
+++ b/modules/minifact/README.md
@@ -1,0 +1,37 @@
+# minifact
+
+#### Table of Contents
+
+1. [Description](#description)
+2. [Requirements](#requirements)
+3. [Usage](#usage)
+4. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
+
+## Description
+
+This module provides a collection of minifact plans all of which retrieve facts from the specified nodes but each of them processes the retrieved facts differently (if at all). The provided plans are:
+* `minifact` - retrieves the facts and then stores them in the inventory, returns a result set wrapping result objects for each specified node which in turn wrap the retrieved facts
+* `minifact::info` - retrieves the facts and returns information about each node's OS compiled from the `os` fact value retrieved from that node
+* `minifact::retrieve` - retrieves the facts and without further processing returns a result set wrapping result objects for each specified node which in turn wrap the retrieved facts (this plan is internally used by the other two)
+
+## Requirements
+
+This module is compatible with the version of Puppet Bolt it ships with.
+
+## Usage
+
+To run the minifact plan run
+
+```
+bolt plan run minifact --nodes node1.example.com,node2.example.com
+```
+
+### Parameters
+
+All plans have only one parameter:
+
+* **nodes** - The nodes to retrieve the facts from.
+
+## Reference
+
+The core functionality is implemented in the `minifact::retrieve` plan, which runs the `minifact::bash` task for `ssh://` (and possibly `local://` if the bash shell is available on the local host) targets, the `minifact::powershell` task for `winrm://` targets and `minifact::ruby` for `pcp://` targets. Other targets are currently not supported. The tasks either run `facter --json` command if facter is available on the target and return its output or - as a fallback - compile and return information mimicking that provided by the facter's `os` fact. The plan then collects the results of the task runs on the individual nodes (and adds synthesized fail results for the unsupported nodes) and returns them wrapped in a ResultSet object.

--- a/modules/minifact/Rakefile
+++ b/modules/minifact/Rakefile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require_relative '../../vendored/require_vendored.rb'
+require 'puppetlabs_spec_helper/rake_tasks'

--- a/modules/minifact/lib/puppet/functions/minifact/group_by.rb
+++ b/modules/minifact/lib/puppet/functions/minifact/group_by.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# A simple wrapper of the ruby's group_by function.
+Puppet::Functions.create_function(:'minifact::group_by') do
+  dispatch :native_group_by do
+    param 'Iterable', :collection
+    block_param
+    return_type 'Hash'
+  end
+
+  def native_group_by(collection, &block)
+    collection.group_by(&block)
+  end
+end

--- a/modules/minifact/lib/puppet/functions/minifact/is_command_available.rb
+++ b/modules/minifact/lib/puppet/functions/minifact/is_command_available.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Checks whether the given command is available on the local host. Calls
+# the Puppet::Util.which function, returns true if that function returns
+# a non-nil value, false otherwise.
+Puppet::Functions.create_function(:'minifact::is_command_available') do
+  dispatch :check_command do
+    param 'String[1]', :command
+    return_type 'Boolean'
+  end
+
+  def check_command(command)
+    !Puppet::Util.which(command).nil?
+  end
+end

--- a/modules/minifact/plans/info.pp
+++ b/modules/minifact/plans/info.pp
@@ -1,0 +1,16 @@
+# A plan that simply prints basic OS information for the specified nodes.
+# It first runs the minifact::retrieve plan to retrieve facts from the nodes,
+# then compiles the desired OS information from the os fact value of each
+# node.
+#
+# The $nodes parameter is a list of the nodes for which to print the OS
+# information.
+plan minifact::info(TargetSpec $nodes) {
+  run_plan(minifact::retrieve, nodes => $nodes).reduce([]) |$info, $r| {
+    if ($r.ok) {
+      $info + "${r.target.name}: ${r[os][name]} ${r[os][release][full]} (${r[os][family]})"
+    } else {
+      $info # don't include any info for nodes which failed
+    }
+  }
+}

--- a/modules/minifact/plans/init.pp
+++ b/modules/minifact/plans/init.pp
@@ -1,0 +1,16 @@
+# A plan that stores facts retrieved by the minifact::retrieve plan
+# from the specified nodes into the inventory.
+#
+# The $nodes parameter is a list of nodes to retrieve the facts for.
+plan minifact(TargetSpec $nodes) {
+  $result_set = run_plan(minifact::retrieve, nodes => $nodes)
+
+  $result_set.each |$result| {
+    # Store facts for nodes from which they were succefully retrieved
+    if ($result.ok) {
+      add_facts($result.target, $result.value)
+    }
+  }
+
+  $result_set
+}

--- a/modules/minifact/plans/retrieve.pp
+++ b/modules/minifact/plans/retrieve.pp
@@ -1,0 +1,46 @@
+# A plan that retrieves facts from the specified nodes by running
+# an apropriate minifact::* task on each. Care is taken to run a
+# minifact::* task corresponding to the node's platfrom on each
+# node. If there is no variant of the task appropriate for some
+# node's platform the node is treated as if the task had failed.
+#
+# The $nodes parameter is a list of the nodes to retrieve the facts
+# from.
+plan minifact::retrieve(TargetSpec $nodes) {
+  $targets = get_targets($nodes)
+
+  # Build a mapping from the names of the tasks to run to the lists of
+  # targets to run the tasks on
+  $task_targets = $targets.minifact::group_by |$target| {
+    $target.protocol ? {
+      'ssh'   => 'minifact::bash',
+      'winrm' => 'minifact::powershell',
+      'pcp'   => 'minifact::ruby',
+      'local' => if (minifact::is_command_available('bash')) { 'minifact::bash' } else { undef },
+      default => undef,
+    }
+  }
+
+  # Return a single result set composed of results from the result sets
+  # returned by the individual task runs (and a result set synthesized
+  # for the unsupported targets)
+  ResultSet(
+    $task_targets.map |$task, $targets| {
+      if ($task == undef) {
+        # Synthesize a result set for the unsupported targets
+        ResultSet($targets.map |$target| {
+          Result($target, '_error' => {
+            'kind' => 'minifact/unsupported',
+            'msg'  => 'Target not supported by minifact.',
+          })
+        })
+      } else {
+        # Run the task on the targets
+        run_task($task, $targets, '_catch_errors' => true)
+      }
+    }.reduce([]) |$results, $result_set| {
+      # Collect the results from the individual result sets
+      $results + $result_set.results
+    }
+  )
+}

--- a/modules/minifact/spec/functions/group_by_spec.rb
+++ b/modules/minifact/spec/functions/group_by_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'minifact::group_by' do
+  it 'delegates to the native group_by function' do
+    collection = mock('Puppet::Pops::Types::Iterable').extend(Puppet::Pops::Types::Iterable)
+    return_value = {}
+
+    verifier = mock('verifier')
+    token = mock('token')
+
+    collection.expects(:group_by).with.yields(token).returns(return_value)
+    # this is to verify that the block passed to the 'minifact::group_by' function
+    # is yielded to from the stubbed group_by method
+    verifier.expects(:verify).with(token)
+
+    is_expected.to run.with_params(collection).with_lambda(&(proc do |t|
+      verifier.verify(t)
+    end)).and_return(return_value)
+  end
+end

--- a/modules/minifact/spec/functions/is_command_available_spec.rb
+++ b/modules/minifact/spec/functions/is_command_available_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'minifact::is_command_available' do
+  let(:command) { 'command' }
+
+  it 'returns true if the specified command is available' do
+    Puppet::Util.expects(:which).with(command).returns('/path/to/command')
+
+    is_expected.to run.with_params(command).and_return(true)
+  end
+
+  it 'returns false if the specified command is not available' do
+    Puppet::Util.expects(:which).with(command).returns(nil)
+
+    is_expected.to run.with_params(command).and_return(false)
+  end
+end

--- a/modules/minifact/spec/plan_helper.rb
+++ b/modules/minifact/spec/plan_helper.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/config'
+require 'bolt/result_set'
+
+Bolt::ResultSet.include_iterable
+
+RSpec.shared_context 'plan helper' do
+  include RSpec::Puppet::FunctionExampleGroup # to be able to call find_function
+
+  class MockInventory
+    attr_reader :nodes, :targets
+
+    def initialize
+      @nodes = nil
+      @targets = []
+    end
+
+    def populate(config, nodes)
+      @nodes = nodes
+      @targets = nodes.split(/[[:space:],]+/).reject(&:empty?).map { |node|
+        target = Bolt::Target.new(node)
+        protocol = target.protocol
+        if protocol.nil? || config.transport_conf.key?(protocol)
+          target.update_conf(config.transport_conf)
+        end
+        target
+      }
+    end
+
+    def get_targets(targetspec)
+      return @targets if targetspec == @nodes
+      return targetspec if targetspec.is_a?(Array) && (targetspec - @targets).empty?
+      raise "Unexpected invocation of Bolt::Inventory#get_targets with arguments: #{targetspec.inspect}"
+    end
+
+    def protocol_targets(*protocols, inverse: false)
+      protocols = protocols.to_set
+      @targets.select { |target| protocols.include?(target.protocol) ^ inverse }
+    end
+  end
+
+  let(:run_plan_function) {
+    # inject a global type alias for the 'Boltlib::TargetSpec'
+    scope.compiler.context_overrides[:loaders].instance_exec do
+      instantiate_definitions(
+        Puppet::Pops::Parser::EvaluatingParser.singleton.parse_string(
+          'type TargetSpec = Boltlib::TargetSpec'
+        ),
+        public_environment_loader
+      )
+    end
+
+    find_function(:run_plan)
+  }
+
+  def run_plan(name, params)
+    run_plan_function.execute(name, params)
+  end
+
+  def run_subject_plan(params)
+    run_plan(self.class.top_level_description, params)
+  end
+
+  let(:executor) {
+    mock('Bolt::Executor').tap do |executor|
+      executor.stubs(:noop).returns(false)
+    end
+  }
+  let(:inventory) { MockInventory.new }
+
+  around(:each) do |example|
+    Puppet[:tasks] = true
+    Puppet.features.stubs(:bolt?).returns(true)
+
+    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
+      example.run
+    end
+  end
+
+  let(:config) { Bolt::Config.new }
+
+  def populate_mock_inventory(nodes)
+    inventory.populate(config, nodes)
+  end
+
+  def generate_results(targets, error: nil)
+    targets.map.with_index { |target, index|
+      if block_given?
+        Bolt::Result.new(target, value: yield(target, index))
+      elsif error.nil?
+        Bolt::Result.new(target, message: "Ran on #{target.name}")
+      else
+        Bolt::Result.new(target, error: error)
+      end
+    }
+  end
+end

--- a/modules/minifact/spec/plans/info_spec.rb
+++ b/modules/minifact/spec/plans/info_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'plan_helper'
+
+describe 'minifact::info' do
+  include_context 'plan helper'
+
+  describe "plan's return value" do
+    it 'contains OS information for every target for which facts were retrieved successfully' do
+      populate_mock_inventory(
+        'ssh-host-1,winrm://winrm-host-1,local://host,ssh://ssh-host-2,pcp://pcp-host,winrm://winrm-host-2'
+      )
+      results = generate_results(inventory.protocol_targets('ssh', 'local', 'winrm', 'pcp')) { |target, index|
+        if index % 2 == 0 # fail every other target # rubocop:disable Style/EvenOdd
+          {
+            '_error' => {
+              'msg' => "Failed on #{target.name}"
+            }
+          }
+        else
+          family = target.protocol == 'winrm' ? 'windows' : 'unix'
+          {
+            'os' => {
+              'name'    => family,
+              'family'  => family,
+              'release' => {}
+            }
+          }
+        end
+      }
+      bash_results = results.select { |result| case result.target.protocol when 'ssh', 'local' then true; end }
+      powershell_results = results.select { |result| case result.target.protocol when 'winrm' then true; end }
+      ruby_results = results.select { |result| case result.target.protocol when 'pcp' then true; end }
+
+      Puppet::Util.stubs(:which).with('bash').returns('/bin/bash')
+
+      executor.expects(:run_task).with(
+        inventory.protocol_targets('ssh', 'local'),
+        responds_with(:name, 'minifact::bash'),
+        {},
+        {}
+      ).returns(Bolt::ResultSet.new(bash_results))
+
+      executor.expects(:run_task).with(
+        inventory.protocol_targets('winrm'),
+        responds_with(:name, 'minifact::powershell'),
+        {},
+        {}
+      ).returns(Bolt::ResultSet.new(powershell_results))
+
+      executor.expects(:run_task).with(
+        inventory.protocol_targets('pcp'),
+        responds_with(:name, 'minifact::ruby'),
+        {},
+        {}
+      ).returns(Bolt::ResultSet.new(ruby_results))
+
+      expected_result = results.each_with_object([]) do |result, accumulator|
+        if result.ok
+          accumulator << "#{result.target.name}: " \
+            "#{result['os']['name']} #{result['os']['release']['full']} (#{result['os']['family']})"
+        end
+      end
+
+      expect(run_subject_plan('nodes' => inventory.nodes).to_set).to eq(expected_result.to_set)
+    end
+  end
+end

--- a/modules/minifact/spec/plans/minifact_spec.rb
+++ b/modules/minifact/spec/plans/minifact_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'plan_helper'
+
+describe 'minifact' do
+  include_context 'plan helper'
+
+  describe 'retrieved facts processing' do
+    it 'stores the retrieved facts for every target for which they were retrieved successfully' do
+      populate_mock_inventory(
+        'ssh-host-1,winrm://winrm-host,local://host,ssh://ssh-host-2,pcp://pcp-host,unsupported://'
+      )
+
+      results = generate_results(inventory.protocol_targets('ssh', 'winrm', 'pcp')) { |target, index|
+        if index % 3 == 0 # fail every third target
+          {
+            '_error' => {
+              'msg' => "Failed on #{target.name}"
+            }
+          }
+        else
+          {
+            '_output' => "Ran on #{target.name}"
+          }
+        end
+      }
+
+      results.each do |result|
+        inventory.expects(:add_facts).with(result.target, result.value) if result.ok
+      end
+
+      Puppet::Util.stubs(:which).with('bash').returns(nil)
+
+      executor.expects(:run_task).with(
+        inventory.protocol_targets('ssh'),
+        responds_with(:name, 'minifact::bash'),
+        {},
+        {}
+      ).returns(Bolt::ResultSet.new(results.select { |result| result.target.protocol == 'ssh' }))
+
+      executor.expects(:run_task).with(
+        inventory.protocol_targets('winrm'),
+        responds_with(:name, 'minifact::powershell'),
+        {},
+        {}
+      ).returns(Bolt::ResultSet.new(results.select { |result| result.target.protocol == 'winrm' }))
+
+      executor.expects(:run_task).with(
+        inventory.protocol_targets('pcp'),
+        responds_with(:name, 'minifact::ruby'),
+        {},
+        {}
+      ).returns(Bolt::ResultSet.new(results.select { |result| result.target.protocol == 'pcp' }))
+
+      run_subject_plan('nodes' => inventory.nodes)
+    end
+  end
+
+  describe "plan's return value" do
+    it 'contains a result for each target' do
+      populate_mock_inventory(
+        'ssh-host-1,winrm://winrm-host,local://host,ssh://ssh-host-2,pcp://pcp-host,unsupported://'
+      )
+
+      bash_results = generate_results(inventory.protocol_targets('ssh', 'local')) { |target|
+        {
+          '_error' => {
+            'msg' => "Failed on #{target.name}"
+          }
+        }
+      }
+      powershell_results = generate_results(inventory.protocol_targets('winrm'))
+      ruby_results = generate_results(inventory.protocol_targets('pcp'))
+      unsupported_results = generate_results(
+        inventory.protocol_targets('ssh', 'local', 'winrm', 'pcp', inverse: true),
+        error: {
+          'kind' => 'minifact/unsupported',
+          'msg'  => 'Target not supported by minifact.'
+        }
+      )
+
+      Puppet::Util.stubs(:which).with('bash').returns('/bin/bash')
+      inventory.stubs(:add_facts)
+
+      executor.expects(:run_task).with(
+        inventory.protocol_targets('ssh', 'local'),
+        responds_with(:name, 'minifact::bash'),
+        {},
+        {}
+      ).returns(Bolt::ResultSet.new(bash_results))
+
+      executor.expects(:run_task).with(
+        inventory.protocol_targets('winrm'),
+        responds_with(:name, 'minifact::powershell'),
+        {},
+        {}
+      ).returns(Bolt::ResultSet.new(powershell_results))
+
+      executor.expects(:run_task).with(
+        inventory.protocol_targets('pcp'),
+        responds_with(:name, 'minifact::ruby'),
+        {},
+        {}
+      ).returns(Bolt::ResultSet.new(ruby_results))
+
+      result = run_subject_plan('nodes' => inventory.nodes)
+
+      expect(result.result_hash).to eq(
+        Bolt::ResultSet.new(bash_results + powershell_results + ruby_results + unsupported_results).result_hash
+      )
+    end
+  end
+end

--- a/modules/minifact/spec/plans/retrieve_spec.rb
+++ b/modules/minifact/spec/plans/retrieve_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require 'plan_helper'
+
+describe 'minifact::retrieve' do
+  include_context 'plan helper'
+
+  describe 'tasks run by the plan' do
+    it 'runs the minifact::bash task on ssh:// targets' do
+      populate_mock_inventory('host-1,ssh://host-2')
+
+      executor.expects(:run_task).with(
+        inventory.protocol_targets('ssh'),
+        responds_with(:name, 'minifact::bash'),
+        {},
+        {}
+      ).returns(Bolt::ResultSet.new([]))
+
+      run_subject_plan('nodes' => inventory.nodes)
+    end
+
+    it 'runs the minifact::bash task on the local:// target if bash is available' do
+      populate_mock_inventory('local://host')
+
+      Puppet::Util.expects(:which).with('bash').returns('/bin/bash')
+
+      executor.expects(:run_task).with(
+        inventory.protocol_targets('local'),
+        responds_with(:name, 'minifact::bash'),
+        {},
+        {}
+      ).returns(Bolt::ResultSet.new([]))
+
+      run_subject_plan('nodes' => inventory.nodes)
+    end
+
+    it 'runs the minifact::powershell task on winrm:// targets' do
+      populate_mock_inventory('winrm://host-1,winrm://host-2')
+
+      executor.expects(:run_task).with(
+        inventory.protocol_targets('winrm'),
+        responds_with(:name, 'minifact::powershell'),
+        {},
+        {}
+      ).returns(Bolt::ResultSet.new([]))
+
+      run_subject_plan('nodes' => inventory.nodes)
+    end
+
+    it 'runs the minifact::ruby task on pcp:// targets' do
+      populate_mock_inventory('pcp://host-1,pcp://host-2')
+
+      executor.expects(:run_task).with(
+        inventory.protocol_targets('pcp'),
+        responds_with(:name, 'minifact::ruby'),
+        {},
+        {}
+      ).returns(Bolt::ResultSet.new([]))
+
+      run_subject_plan('nodes' => inventory.nodes)
+    end
+
+    it "doesn't run any task on unsupported targets" do
+      populate_mock_inventory('unsupported://host,local://host')
+
+      Puppet::Util.expects(:which).with('bash').returns(nil)
+
+      executor.expects(:run_task).never
+
+      run_subject_plan('nodes' => inventory.nodes)
+    end
+
+    it 'runs multiple tasks as appropriate for the specified targets' do
+      populate_mock_inventory(
+        'ssh-host-1,winrm://winrm-host,pcp://pcp-host,local://host,ssh://ssh-host-2,unsupported://'
+      )
+
+      Puppet::Util.stubs(:which).with('bash').returns('/bin/bash')
+
+      executor.expects(:run_task).with(
+        inventory.protocol_targets('ssh', 'local'),
+        responds_with(:name, 'minifact::bash'),
+        {},
+        {}
+      ).returns(Bolt::ResultSet.new([]))
+
+      executor.expects(:run_task).with(
+        inventory.protocol_targets('winrm'),
+        responds_with(:name, 'minifact::powershell'),
+        {},
+        {}
+      ).returns(Bolt::ResultSet.new([]))
+
+      executor.expects(:run_task).with(
+        inventory.protocol_targets('pcp'),
+        responds_with(:name, 'minifact::ruby'),
+        {},
+        {}
+      ).returns(Bolt::ResultSet.new([]))
+
+      run_subject_plan('nodes' => inventory.nodes)
+    end
+  end
+
+  describe "plan's return value" do
+    it 'contains a result for each target' do
+      populate_mock_inventory('ssh-host-1,winrm://winrm-host,local://host,ssh://ssh-host-2')
+      bash_results = generate_results(inventory.protocol_targets('ssh', 'local'))
+      powershell_results = generate_results(inventory.protocol_targets('winrm'))
+
+      Puppet::Util.stubs(:which).with('bash').returns('/bin/bash')
+
+      executor.expects(:run_task).with(
+        inventory.protocol_targets('ssh', 'local'),
+        responds_with(:name, 'minifact::bash'),
+        {},
+        {}
+      ).returns(Bolt::ResultSet.new(bash_results))
+
+      executor.expects(:run_task).with(
+        inventory.protocol_targets('winrm'),
+        responds_with(:name, 'minifact::powershell'),
+        {},
+        {}
+      ).returns(Bolt::ResultSet.new(powershell_results))
+
+      result = run_subject_plan('nodes' => inventory.nodes)
+
+      expect(result.result_hash).to eq(Bolt::ResultSet.new(bash_results + powershell_results).result_hash)
+    end
+
+    it 'contains a synthesized error result for each unsupported target' do
+      populate_mock_inventory(
+        'ssh-host-1,winrm://winrm-host,local://host,ssh://ssh-host-2,pcp://pcp-host,unsupported://'
+      )
+
+      unsupported_results = generate_results(
+        inventory.protocol_targets('ssh', 'winrm', 'pcp', inverse: true),
+        error: {
+          'kind' => 'minifact/unsupported',
+          'msg'  => 'Target not supported by minifact.'
+        }
+      )
+
+      Puppet::Util.stubs(:which).with('bash').returns(nil)
+
+      executor.expects(:run_task).with(
+        inventory.protocol_targets('ssh'),
+        responds_with(:name, 'minifact::bash'),
+        {},
+        {}
+      ).returns(Bolt::ResultSet.new([]))
+
+      executor.expects(:run_task).with(
+        inventory.protocol_targets('winrm'),
+        responds_with(:name, 'minifact::powershell'),
+        {},
+        {}
+      ).returns(Bolt::ResultSet.new([]))
+
+      executor.expects(:run_task).with(
+        inventory.protocol_targets('pcp'),
+        responds_with(:name, 'minifact::ruby'),
+        {},
+        {}
+      ).returns(Bolt::ResultSet.new([]))
+
+      result = run_subject_plan('nodes' => inventory.nodes)
+
+      expect(result.results).to eq(unsupported_results)
+    end
+  end
+end

--- a/modules/minifact/spec/spec_helper.rb
+++ b/modules/minifact/spec/spec_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require_relative '../../../vendored/require_vendored.rb'
+
+# Ensure tasks are enabled when rspec-puppet sets up an environment
+# so we get task loaders.
+Puppet[:tasks] = true
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/modules/minifact/tasks/bash.sh
+++ b/modules/minifact/tasks/bash.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Delegate to facter if available
+command -v facter > /dev/null 2>&1 && exec facter --json
+
+minor () {
+    minor="${*#*.}"
+    [ "$minor" == "$*" ] || echo "${minor%%.*}"
+}
+
+# Determine the OS name
+if [ -f /etc/redhat-release ]; then
+    if egrep -iq centos /etc/redhat-release; then
+        name=CentOS
+    elif egrep -iq 'Fedora release' /etc/redhat-release; then
+        name=Fedora
+    fi
+    release=$(sed -r -e 's/^.* release ([0-9]+(\.[0-9]+)?).*$/\1/' \
+                  /etc/redhat-release)
+fi
+
+if [ -z "${name}" ]; then
+    LSB_RELEASE=$(command -v lsb_release)
+    if [ -n "$LSB_RELEASE" ]; then
+        if [ -z "$name" ]; then
+            name=$($LSB_RELEASE -i | sed -re 's/^.*:[ \t]*//')
+        fi
+        release=$($LSB_RELEASE -r | sed -re 's/^.*:[ \t]*//')
+    fi
+fi
+
+case $name in
+    RedHat|Fedora|CentOS|Scientific|SLC|Ascendos|CloudLinux)
+        family=RedHat;;
+    HuaweiOS|LinuxMint|Ubuntu|Debian)
+        family=Debian;;
+    *)
+        family=Other;;
+esac
+
+# Print it all out
+if [ -z "$name" ]; then
+    cat <<JSON
+{
+  "_error": {
+    "kind": "minfact/noname",
+    "msg": "Could not determine OS name"
+  }
+}
+JSON
+else
+    cat <<JSON
+{
+  "os": {
+    "name": "${name}",
+JSON
+    [ -n "$release" ] && cat <<JSON
+    "release": {
+      "full": "${release}",
+      "major": "${release%%.*}",
+      "minor": "`minor "${release}"`"
+    },
+JSON
+    cat <<JSON
+    "family": "${family}"
+  }
+}
+JSON
+fi

--- a/modules/minifact/tasks/powershell.ps1
+++ b/modules/minifact/tasks/powershell.ps1
@@ -1,0 +1,53 @@
+#!powershell.exe
+
+# Delegate to facter if available
+if (Get-Command facter -ErrorAction SilentlyContinue) {
+    facter --json
+} else {
+    if ([System.Environment]::OSVersion.Platform -gt 2) { # [System.PlatformID]::Win32NT
+@'
+{
+  "_error": {
+    "kind": "minfact/noname",
+    "msg": "Could not determine OS name"
+  }
+}
+'@
+    } else {
+        $release = [System.Environment]::OSVersion.Version.ToString() -replace '\.[^.]*\z'
+        $version = $release -replace '\.[^.]*\z'
+
+        # This fails for regular users unless explicitly enabled
+        $os = Get-CimInstance Win32_OperatingSystem -ErrorAction SilentlyContinue
+        $consumerrel = $os.ProductType -eq '1'
+
+        if ($version -eq '10.0') {
+            $release = if ($consumerrel) { '10' } else { '2016' }
+        } elseif ($version -eq '6.3') {
+            $release = if ($consumerrel) { '8.1' } else { '2012 R2' }
+        } elseif ($version -eq '6.2') {
+            $release = if ($consumerrel) { '8' } else { '2012' }
+        } elseif ($version -eq '6.1') {
+            $release = if ($consumerrel) { '7' } else { '2008 R2' }
+        } elseif ($version -eq '6.0') {
+            $release = if ($consumerrel) { 'Vista' } else { '2008' }
+        } elseif ($version -eq '5.2') {
+            $release = if ($consumerrel) { 'XP' } else {
+                if ($os.OtherTypeDescription -eq 'R2') { '2003 R2' } else { '2003' }
+            }
+        }
+
+@"
+{
+  "os": {
+    "name": "windows",
+    "release": {
+      "full": "$release",
+      "major": "$release"
+    },
+    "family": "windows"
+  }
+}
+"@
+    }
+}

--- a/modules/minifact/tasks/ruby.rb
+++ b/modules/minifact/tasks/ruby.rb
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+def facter_executable
+  if ENV.key? 'Path'
+    ENV['Path'].split(';').each do |p|
+      if p =~ /Puppet\\bin\\?$/
+        return File.join(p, 'facter')
+      end
+    end
+    'C:\Program Files\Puppet Labs\Puppet\bin\facter'
+  else
+    '/opt/puppetlabs/puppet/bin/facter'
+  end
+end
+
+# Delegate to facter
+exec(facter_executable, '--json')

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -848,7 +848,10 @@ bar
           }
           cli.execute(options)
           json = JSON.parse(output.string)
-          expect(json).to eq([['sample::ok', nil]])
+          expect(json).to eq([["minifact::bash", nil],
+                              ["minifact::powershell", nil],
+                              ["minifact::ruby", nil],
+                              ['sample::ok', nil]])
 
           expect(@puppet_logs.first.message).to match(/unexpected token.*params\.json/m)
         end
@@ -939,6 +942,9 @@ bar
           expect(json).to eq([["aggregate::count"],
                               ["aggregate::nodes"],
                               ["canary"],
+                              ["minifact"],
+                              ["minifact::info"],
+                              ["minifact::retrieve"],
                               ["puppetdb_fact"],
                               ["sample::ok"]])
 


### PR DESCRIPTION
Adds the `minifact` module which provides several plans (and supporting tasks) for retrieving facts from nodes.