### PR TITLE
(BOLT-397) Add helpers for testing plans and mocking run_task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,12 +4,16 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 gemspec
 
+# Required to pick up plan specs in the rake spec task
+gem "puppetlabs_spec_helper", git: 'https://github.com/puppetlabs/puppetlabs_spec_helper.git', ref: 'master'
+
 group(:test) do
   gem "beaker-hostgenerator"
   gem "gettext-setup", '~> 0.28', require: false
   gem "rubocop", '~> 0.50', require: false
 end
 
-if File.exist? "Gemfile.local"
-  eval_gemfile "Gemfile.local"
+local_gemfile = File.join(__dir__, 'Gemfile.local')
+if File.exist? local_gemfile
+  eval_gemfile local_gemfile
 end

--- a/modules/aggregate/spec/fixtures/modules/test_task/tasks/init.sh
+++ b/modules/aggregate/spec/fixtures/modules/test_task/tasks/init.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+# empty task for plan

--- a/modules/aggregate/spec/plans/count_spec.rb
+++ b/modules/aggregate/spec/plans/count_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/plans'
+
+describe 'aggregate::count' do
+  include BoltSpec::Plans
+
+  it 'counts the same value' do
+    expect_task('test_task').always_return('key1' => 'val', 'key2' => 'val')
+    result = run_plan('aggregate::count', 'nodes' => "foo,bar", "task" => "test_task")
+    expect(result).to eq('key1' => { 'val' => 2 }, 'key2' => { 'val' => 2 })
+  end
+
+  it 'passes params' do
+    params = { "param1" => 'pv' }
+    expect_task('test_task').always_return({}).with_params(params)
+    result = run_plan('aggregate::count', 'nodes' => "foo",
+                                          "task" => "test_task",
+                                          'params' => params)
+    expect(result).to eq({})
+  end
+end

--- a/modules/aggregate/spec/plans/node_spec.rb
+++ b/modules/aggregate/spec/plans/node_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/plans'
+
+describe 'aggregate::nodes' do
+  include BoltSpec::Plans
+
+  it 'collects nodes with the same value' do
+    expect_task('test_task').return_for_targets('node1' => { 'key1' => 'val', 'key2' => 'val' },
+                                                'node2' => { 'key1' => 'val1', 'key2' => 'val' })
+    result = run_plan('aggregate::nodes', 'nodes' => "node1,node2", "task" => "test_task")
+    expect(result).to eq('key1' => { 'val' => ['node1'], 'val1' => ['node2'] }, 'key2' => { 'val' => %w[node1 node2] })
+  end
+
+  it 'passes params' do
+    params = { "param1" => 'pv', '_run_as' => 'me' }
+    expect_task('test_task').always_return({}).with_params(params)
+    result = run_plan('aggregate::nodes', 'nodes' => "foo",
+                                          "task" => "test_task",
+                                          'params' => params)
+    expect(result).to eq({})
+  end
+end

--- a/modules/aggregate/spec/spec_helper.rb
+++ b/modules/aggregate/spec/spec_helper.rb
@@ -2,6 +2,10 @@
 
 require_relative '../../../vendored/require_vendored.rb'
 
+# Add bolt spec helpers
+bolt_dir = Gem::Specification.find_by_name('bolt').gem_dir
+$LOAD_PATH.unshift(File.join(bolt_dir, 'spec', 'lib'))
+
 # Ensure tasks are enabled when rspec-puppet sets up an environment
 # so we get task loaders.
 Puppet[:tasks] = true

--- a/modules/canary/spec/fixtures/modules/test_task/tasks/init.pp
+++ b/modules/canary/spec/fixtures/modules/test_task/tasks/init.pp
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+#empty task file

--- a/modules/canary/spec/plans/init_spec.rb
+++ b/modules/canary/spec/plans/init_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/plans'
+
+describe 'canary' do
+  include BoltSpec::Plans
+
+  it 'runs targets in two groups' do
+    expect_task('test_task').be_called_times(2).always_return({})
+    run_plan('canary', 'nodes' => 'foo,bar,baz', 'task' => 'test_task')
+  end
+
+  it 'skips targets after a failure' do
+    allow_task('test_task').be_called_times(1).error_with('kind' => 'task-failed', 'msg' => 'oops')
+    result = run_plan('canary', 'nodes' => 'foo,bar,baz', 'task' => 'test_task')
+    kinds = result.map { |r| r.error_hash['kind'] }.sort
+    expect(kinds).to eq(["canary/skipped-node", "canary/skipped-node", "task-failed"])
+  end
+end

--- a/modules/canary/spec/spec_helper.rb
+++ b/modules/canary/spec/spec_helper.rb
@@ -2,6 +2,10 @@
 
 require_relative '../../../vendored/require_vendored.rb'
 
+# Add bolt spec helpers
+bolt_dir = Gem::Specification.find_by_name('bolt').gem_dir
+$LOAD_PATH.unshift(File.join(bolt_dir, 'spec', 'lib'))
+
 # Ensure tasks are enabled when rspec-puppet sets up an environment
 # so we get task loaders.
 Puppet[:tasks] = true

--- a/spec/lib/bolt_spec/plans.rb
+++ b/spec/lib/bolt_spec/plans.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require 'bolt_spec/plans/mock_executor'
+require 'bolt/config'
+
+# These helpers are intended to be used for plan unit testing without calling
+# out to target nodes. It accomplishes this by replacing bolt's executor with a
+# mock executor. The mock executor allows calls to run_* functions to be
+# stubbed out for testing. By default this executor will fail on any run_*
+# call but stubs can be set up with allow_* and expect_* functions.
+#
+# Stub matching
+#
+# Stubs match invocations of run_* functions by default matching any call but
+# with_targets and with_params helpers can further restrict the stub to match
+# more exact invocations. It's possible a call to run_* could match multiple
+# stubs. In this case the mock executor will first check for stubs specifically
+# matching the task being run after which it will use the last stub that
+# matched
+#
+#
+# allow vs expect
+#
+# Stubs have two general modes bases on whether the test is making assertions
+# on whether function was called. Allow stubs allow the run_* invocation  to
+# be called any number of times while expect stubs will fail if no run_*
+# invocation matches them. The be_called_times(n) stub method can be used to
+# ensure an allow stub is not called more than n times or that an expect stub
+# is called exactly n times.
+#
+# Configuration
+#
+#  By default the plan helpers use the modulepath set up for rspec-puppet and
+#  an otherwise empty bolt config and inventory. To create your own values for
+#  these override the modulepath, config, or inventory methods.
+#
+#
+#  TODO:
+#  - allow stubbing for commands, scripts and file uploads
+#  - Allow description based stub matching
+#  - Better testing of plan errors
+#  - Better error collection around call counts. Show what stubs exists and more than a single failure
+#  - Allow stubbing with a block(at the double level? As a matched stub?)
+#  - package code so that it can be used for testing modules outside of this repo
+#  - set subject from describe and provide matchers similar to rspec puppets function tests
+#
+#  MAYBE TODO?:
+#  - allow stubbing for subplans
+#  - validate call expectations at the end of the example instead of in run_plan
+#  - resultset matchers to help testing canary like plans?
+#  - inventory matchers to help testing plans that change inventory
+#
+# Example:
+#   describe "my_plan" do
+#     it 'should return' do
+#       allow_task('my_task').always_return({'result_key' => 10})
+#       expect(run_plan('my_plan', { 'param1' => 10 })).to be
+#     end
+#
+#     it 'should call task with param1' do
+#       expect_task('my_task').with_params('param1' => 10).always_return({'result_key' => 10})
+#       expect(run_plan('my_plan', { 'param1' => 10 })).to eq(10)
+#     end
+#
+#     it 'should call task with param1 once' do
+#       expect_task('my_task').with_params('param1' => 10).always_return({'result_key' => 10}).be_called_times(1)
+#       expect(run_plan('my_plan', { 'param1' => 10 })).to eq(10)
+#     end
+#
+#     it 'should not_call task with 100' do
+#       allow_task('my_task').always_return({'result_key' => 10})
+#       # Any call with param1 => 100 will match this since it's added second
+#       expect_task('my_task').with_params('param1' => 100).not_be_called
+#       expect(run_plan('my_plan', { 'param1' => 10 })).to eq(10)
+#     end
+#
+#     it 'should be called on both node1 and node2' do
+#       expect_task('my_task').with_targets(['node1', 'node2']).always_return({'result_key' => 10})
+#       expect(run_plan('my_plan', { 'param1' => 10 })).to eq(10)
+#     end
+#
+#     it 'should average results from targets' do
+#       expect_task('my_task').return_for_targets({
+#         'node1' => {'result_key' => 20},
+#         'node2' => {'result_key' => 6} })
+#       expect(run_plan('my_plan', { 'param1' => 10 })).to eq(13)
+#     end
+#   end
+#
+module BoltSpec
+  module Plans
+    # Override in your tests if needed
+    def modulepath
+      [RSpec.configuration.module_path]
+    rescue NoMethodError
+      raise "RSpec.configuration.module_path not defined set up rspec puppet or define modulepath for this test"
+    end
+
+    # Override in your tests
+    def config
+      Bolt::Config.new(modulepath: modulepath)
+    end
+
+    # Override in your tests
+    def inventory
+      @inventory ||= Bolt::Inventory.new({})
+    end
+
+    # TODO: handle expected plan failures
+    def run_plan(name, params)
+      pal = Bolt::PAL.new(config)
+      begin
+        result = pal.run_plan(name, params, executor, inventory)
+      rescue Bolt::CLIError => e
+        if executor.error_message
+          raise executor.error_message
+        else
+          raise e
+        end
+      end
+
+      executor.assert_call_expectations
+      result
+    end
+
+    # Allowed task stubs can be called up to be_called_times number
+    # of times
+    def allow_task(task_name)
+      executor.stub_task(task_name).add_stub
+    end
+
+    # Expected task stubs must be called exactly the expected number of times
+    # or at least once without be_called_times
+    def expect_task(task_name)
+      allow_task(task_name).expect_call
+    end
+
+    # This stub will catch any task call if there are no stubs specifically for that task
+    def allow_any_task
+      executor.stub_task(:default).add_stub
+    end
+
+    # Example helpers to mock other run functions
+    # The with_targets method  makes sense for all stubs
+    # with_params could be reused for options
+    # They probably need special stub methods for other arguments through
+
+    # Scripts can be mocked like tasks by their name
+    # arguments is an array instead of a hash though
+    # so it probably should be set separately
+    # def allow_script(script_name)
+    #
+    # file uploads have a single destination and no arguments
+    # def allow_file_upload(source_name)
+    #
+    # Most of the information in commands is in the command string itself
+    # we may need more flexible allows than just the name/command string
+    # Only option params exist on a command.
+    # def allow_command(command)
+    # def allow_command_matching(command_regex)
+    # def allow_command(&block)
+    #
+    # Plan execution does not flow through the executor mocking may make sense but
+    # will be a separate effort.
+    # def allow_plan(plan_name)
+
+    # intended to be private below here
+    def executor
+      @executor ||= BoltSpec::Plans::MockExecutor.new
+    end
+  end
+end

--- a/spec/lib/bolt_spec/plans/mock_executor.rb
+++ b/spec/lib/bolt_spec/plans/mock_executor.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require 'bolt/error'
+require 'bolt/result_set'
+require 'bolt/result'
+require 'set'
+
+module BoltSpec
+  module Plans
+    class UnexpectedInvocation < ArgumentError; end
+
+    # Nothing in the TaskDouble is 'public'
+    class TaskDouble
+      def initialize
+        @stubs = []
+      end
+
+      def process(targets, task, arguments, options)
+        # TODO: should we bother matching at all? or just call each
+        # stub until one works?
+        matches = @stubs.select { |s| s.matches(targets, task, arguments, options) }
+        unless matches.empty?
+          matches[0].call(targets, task, arguments, options)
+        end
+      end
+
+      def assert_called(taskname)
+        @stubs.each { |s| s.assert_called(taskname) }
+      end
+
+      def add_stub
+        stub = TaskStub.new
+        @stubs.unshift stub
+        stub
+      end
+    end
+
+    class TaskStub
+      attr_reader :invocation
+
+      def initialize(expect = false)
+        @calls = 0
+        @expect = expect
+        @expected_calls = 1
+        # invocation spec
+        @invocation = {}
+        # return value
+        @data = { default: {} }
+      end
+
+      def matches(targets, _task, arguments, options)
+        if @invocation[:targets] && Set.new(@invocation[:targets]) != Set.new(targets.map(&:name))
+          return false
+        end
+
+        if @invocation[:arguments] && arguments != @invocation[:arguments]
+          return false
+        end
+
+        if @invocation[:options] && options != @invocation[:options]
+          return false
+        end
+
+        true
+      end
+
+      def call(targets, _task, _arguments, _options)
+        @calls += 1
+        Bolt::ResultSet.new(targets.map do |target|
+          val = @data[target.name] || @data[:default]
+          Bolt::Result.new(target, value: val)
+        end)
+      end
+
+      def assert_called(taskname)
+        satisfied = if @expect
+                      (@expected_calls.nil? && @calls > 0) || @calls == @expected_calls
+                    else
+                      @expected_calls.nil? || @calls <= @expected_calls
+                    end
+        unless satisfied
+          unless (times = @expected_calls)
+            times = @expect ? "at least one" : "any number of"
+          end
+          message = "Expected #{taskname} to be called #{times} times"
+          message += " with targets #{@invocation[:targets]}" if @invocation[:targets]
+          message += " with parameters #{@invocations[:parameters]}" if @invocation[:parameters]
+          raise message
+        end
+      end
+
+      # This changes the stub from an allow to an expect which will validate
+      # that it has been called.
+      def expect_call
+        @expect = true
+        self
+      end
+
+      # Below here are the intended 'public' methods of the stub
+
+      # Restricts the stub to only match invocations with
+      # the correct targets
+      def with_targets(targets)
+        targets = [targets] unless targets.is_a? Array
+        @invocation[:targets] = targets.map do |target|
+          if target.is_a? String
+            target
+          else
+            target.name
+          end
+        end
+        self
+      end
+
+      # Restricts the stub to only match invocations with certain parameters
+      # All parameters must match exactly and since arguments and options are
+      # treated differently at the executor this won't work with some '_*' options
+      # TODO: Fix handling of '_*' options probably by breaking them into other helpers
+      def with_params(params)
+        @invocation[:parameters] = params
+        @invocation[:arguments] = params.reject { |k, _v| k.start_with?('_') }
+        @invocation[:options] = params.select { |k, _v| k.start_with?('_') }
+        self
+      end
+
+      # limit the maximum number of times an allow stub may be called or
+      # specify how many times an expect stub must be called.
+      def be_called_times(times)
+        @expected_calls = times
+        self
+      end
+
+      # error if the stub is called at all.
+      def not_be_called
+        @expected_calls = 0
+        self
+      end
+
+      # Set different result values for each target
+      def return_for_targets(data)
+        data.each do |target, result|
+          raise "Mocked results must be hashes: #{target}: #{result}" unless result.is_a? Hash
+        end
+        @data = data
+        self
+      end
+
+      # Set a default return value for all targets, specific targets may be overridden with return_for_targets
+      def always_return(default_data)
+        return_for_targets(default: default_data)
+      end
+
+      # Set a default error result for all targets.
+      def error_with(error_data)
+        always_return("_error" => error_data)
+      end
+    end
+
+    # Nothing on the executor is 'public'
+    class MockExecutor
+      attr_reader :noop, :error_message
+
+      def initialize
+        @noop = false
+        @task_doubles = {}
+        @allow_any_task = true
+        @error_message = nil
+      end
+
+      def run_task(targets, task, arguments, options)
+        result = nil
+        if (doub = @task_doubles[task.name] || @task_doubles[:default])
+          result = doub.process(targets, task.name, arguments, options)
+        end
+        unless result
+          targets = targets.map(&:name)
+          params = arguments.merge(options)
+          @error_message = "Unexpected call to 'run_task(#{task.name}, #{targets}, #{params})'"
+          raise UnexpectedInvocation, @error_message
+        end
+        result
+      end
+
+      def assert_call_expectations
+        @task_doubles.map do |taskname, doub|
+          doub.assert_called(taskname)
+        end
+      end
+
+      def stub_task(task_name)
+        @task_doubles[task_name] ||= TaskDouble.new
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a plan test helper with a mock executor capable of stubbing
out task calls. This is a prototype for how plan testing unit testing in
the large puppet ecosystem. Eventually this functionality should be
moved into rspec-puppet but that is probably blocked in bolt
unvendoring puppet

Questions:
- Is this too similar to rspec-mock
- Does the general workflow make sense