### PR TITLE
(PUP-8441) Handle serializing Puppet Error Datatype better

### DIFF
--- a/lib/bolt/error.rb
+++ b/lib/bolt/error.rb
@@ -63,4 +63,14 @@ module Bolt
       @error_code = 2
     end
   end
+
+  class PuppetError < Error
+    def self.convert_puppet_errors(result)
+      Bolt::Util.walk_vals(result) { |v| v.is_a?(Puppet::DataTypes::Error) ? from_error(v) : v }
+    end
+
+    def self.from_error(err)
+      new(err.msg, err.kind, err.details, err.issue_code)
+    end
+  end
 end

--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -46,7 +46,7 @@ module Bolt
       end
 
       # Accepts a Data object and returns a copy with all hash keys
-      # modifed by block. use &:to_s to stringify keys or :to_sym to symbolize them
+      # modified by block. use &:to_s to stringify keys or &:to_sym to symbolize them
       def walk_keys(data, &block)
         if data.is_a? Hash
           data.each_with_object({}) do |(k, v), acc|
@@ -55,6 +55,20 @@ module Bolt
           end
         elsif data.is_a? Array
           data.map { |v| walk_keys(v, &block) }
+        else
+          data
+        end
+      end
+
+      # Accepts a Data object and returns a copy with all hash and array values
+      # Arrays and hashes including the initial object are modified before
+      # their descendants are.
+      def walk_vals(data, &block)
+        data = yield(data)
+        if data.is_a? Hash
+          map_vals(data) { |v| walk_vals(v, &block) }
+        elsif data.is_a? Array
+          data.map { |v| walk_vals(v, &block) }
         else
           data
         end

--- a/spec/integration/fail_plan_spec.rb
+++ b/spec/integration/fail_plan_spec.rb
@@ -26,64 +26,39 @@ describe "When a plan fails" do
 
   it 'returns the error object' do
     result = run_cli_json(['plan', 'run', 'error::args'] + config_flags, rescue_exec: true)
-    # TODO: remove now that ruby 2.0 is dropped
-    if error_support
-      expect(result).to eq('msg' => 'oops',
-                           'kind' => 'test/oops',
-                           'details' => { 'some' => 'info' })
-    else
-      expect(result['msg']).to match(/oops/)
-      expect(result['kind']).to eq('bolt/cli-error')
-    end
+    expect(result).to eq('msg' => 'oops',
+                         'kind' => 'test/oops',
+                         'details' => { 'some' => 'info' })
   end
 
   it 'returns the error object' do
     result = run_cli_json(['plan', 'run', 'error::err'] + config_flags, rescue_exec: true)
-    # TODO: remove now that ruby 2.0 is dropped
-    if error_support
-      expect(result).to eq('msg' => 'oops',
-                           'kind' => 'test/oops',
-                           'details' => { 'some' => 'info' })
-    else
-      expect(result['msg']).to match(/oops/)
-      expect(result['kind']).to eq('bolt/cli-error')
-    end
+    expect(result).to eq('msg' => 'oops',
+                         'kind' => 'test/oops',
+                         'details' => { 'some' => 'info' })
   end
 
   it 'catches plan failures' do
-    if error_support
-      result = run_cli_json(['plan', 'run', 'error::catch_plan'] + config_flags)
-      expect(result).to eq('msg' => 'oops',
-                           'kind' => 'test/oops',
-                           'details' => { 'some' => 'info' })
-    else
-      result = run_cli_json(['plan', 'run', 'error::catch_plan'] + config_flags, rescue_exec: true)
-      expect(result['msg']).to match(/oops/)
-    end
+    result = run_cli_json(['plan', 'run', 'error::catch_plan'] + config_flags)
+    expect(result).to eq('msg' => 'oops',
+                         'kind' => 'test/oops',
+                         'details' => { 'some' => 'info' })
   end
 
   it 'catches run failures', ssh: true do
-    if error_support
-      result = run_cli_json(['plan', 'run', 'error::catch_plan_run', "target=#{target}"] + config_flags)
-      expect(result).to eq("kind" => "puppetlabs.tasks/task-error",
-                           "issue_code" => "TASK_ERROR",
-                           "msg" => "The task failed with exit code 1",
-                           "details" => { "exit_code" => 1 })
-    else
-      result = run_cli_json(['plan', 'run', 'error::catch_plan_run', "target=#{target}"] + config_flags,
-                            rescue_exec: true)
-      expect(result['msg']).to match(/error::fail/)
-    end
+    result = run_cli_json(['plan', 'run', 'error::catch_plan_run', "target=#{target}"] + config_flags)
+    expect(result).to eq("kind" => "puppetlabs.tasks/task-error",
+                         "issue_code" => "TASK_ERROR",
+                         "msg" => "The task failed with exit code 1",
+                         "details" => { "exit_code" => 1 })
   end
 
   it 'outputs nested errors' do
-    if error_support
-      result = run_cli_json(['plan', 'run', 'error::nested'] + config_flags)
-      expect(result).to eq('error' => [{
-                             'msg' => 'oops',
-                             'kind' => 'test/oops',
-                             'details' => { 'some' => 'info' }
-                           }])
-    end
+    result = run_cli_json(['plan', 'run', 'error::nested'] + config_flags)
+    expect(result).to eq('error' => [{
+                           'msg' => 'oops',
+                           'kind' => 'test/oops',
+                           'details' => { 'some' => 'info' }
+                         }])
   end
 end

--- a/spec/lib/bolt_spec/integration.rb
+++ b/spec/lib/bolt_spec/integration.rb
@@ -15,11 +15,10 @@ module BoltSpec
       opts = cli.parse
 
       if rescue_exec
-        err_kls = error_support ? Bolt::Error : StandardError
         begin
           cli.execute(opts)
         # rubocop:disable HandleExceptions
-        rescue err_kls
+        rescue Bolt::Error
         end
         # rubocop:enable HandleExceptions
       else
@@ -51,11 +50,6 @@ module BoltSpec
       result = run_cli_json(arguments)
       expect(result['_error'] || (result['items'] && result['items'][0] && result['items'][0]['status'] != 'success'))
       result['items'][0]['result']
-    end
-
-    def error_support
-      minor = RUBY_VERSION.split('.')[1].to_i
-      minor >= 1
     end
   end
 end


### PR DESCRIPTION
Currently none of the Datatypes we expect to support can contain
non-data attributes. Therefore to handle the Error Datatype we only have
to walk a single top level data object so we can do that and drop the
monkey patch. We don't restrict plans to returning only expected data
types. Essentially we previously supported PlanReturn as defined below
and we should either make that official or handle pcore transformation
explicitly.

type PlanReturn = Variant[Data, Error, Result, ResultSet, Target,
Array[PlanReturn], Hash[String, PlanReturn]]