### PR TITLE
(BOLT-432) Correctly retrieve types for plan parameters

### DIFF
--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -153,7 +153,7 @@ module Bolt
     def parse_params(type, object_name, params)
       in_bolt_compiler do |compiler|
         if type == 'task'
-          param_spec = compiler.task_signature(object_name)&.task_hash&.dig('parameters')
+          param_spec = compiler.task_signature(object_name)&.task_hash
         elsif type == 'plan'
           plan = compiler.plan_signature(object_name)
           param_spec = plan_hash(object_name, plan) if plan
@@ -161,7 +161,7 @@ module Bolt
         param_spec ||= {}
 
         params.each_with_object({}) do |(name, str), acc|
-          type = param_spec.dig(name, 'type')
+          type = param_spec.dig('parameters', name, 'type')
           begin
             parsed = JSON.parse(str, quirks_mode: true)
             # The type may not exist if the module is remote on orch or if a task

--- a/spec/integration/parsing_spec.rb
+++ b/spec/integration/parsing_spec.rb
@@ -57,7 +57,23 @@ describe "CLI parses input" do
               'array=13',
               'hash={"this": "that"}']
     result = run_cli_json(%w[plan run parsing] + params + config_flags, rescue_exec: true)
-    expect(result["msg"]).to eq("parsing: parameter 'array' expects a value of type Undef or Array, got Integer")
+    expect(result["msg"]).to eq("parsing: parameter 'array' expects a value of type Undef or Array, got String")
+  end
+
+  it 'parses plan parameters' do
+    params = ['string=false',
+              'string_bool=true',
+              '--nodes', 'foo,bar',
+              'array=[13]',
+              'hash={"this": "that"}']
+    result = run_cli_json(%w[plan run parsing] + params + config_flags, rescue_exec: true)
+    expect(result).to eq(
+      'array' => [13],
+      'hash' => { 'this' => 'that' },
+      'nodes' => %w[foo bar],
+      'string' => 'false',
+      'string_bool' => true
+    )
   end
 
   it 'parses task parameters', ssh: true do


### PR DESCRIPTION
When checking whether plan parameter types matched the JSON-parsed
input, we failed to actually retrieve the parameter types so we always
used the parsed result. Fix so we retrieve the parameter types
correctly.