### PR TITLE
(BOLT-433) Fix requires for bolt-inventory-pdb

### DIFF
--- a/lib/bolt_ext/puppetdb_inventory.rb
+++ b/lib/bolt_ext/puppetdb_inventory.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'bolt/puppetdb/config'
+require 'bolt/puppetdb'
 require 'json'
 require 'httpclient'
 require 'optparse'


### PR DESCRIPTION
Fixes `bolt-inventory-pdb` so it works again by requiring all necessary
components after code refactor.