### PR TITLE
(BOLT-435) Return empty hash rather than nil when not in inventory

### DIFF
--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -93,7 +93,7 @@ module Bolt
     end
 
     def vars(target)
-      @target_vars[target.name]
+      @target_vars[target.name] || {}
     end
 
     def add_facts(target, new_facts = {})
@@ -102,7 +102,7 @@ module Bolt
     end
 
     def facts(target)
-      @target_facts[target.name]
+      @target_facts[target.name] || {}
     end
 
     #### PRIVATE ####

--- a/spec/fixtures/modules/facts/plans/emit.pp
+++ b/spec/fixtures/modules/facts/plans/emit.pp
@@ -1,0 +1,4 @@
+plan facts::emit(String $host) {
+  $target = get_targets($host)[0]
+  return "Facts for ${host}: ${facts($target)}"
+}

--- a/spec/fixtures/modules/facts/plans/init.pp
+++ b/spec/fixtures/modules/facts/plans/init.pp
@@ -1,5 +1,5 @@
 plan facts(String $host) {
   $target = get_targets($host)[0]
   add_facts($target, { 'kernel' => 'Linux', 'cloud' => { 'provider' => 'AWS' } })
-  run_command("echo 'Facts for ${host}: ${facts($target)}'", $host)
+  return "Facts for ${host}: ${facts($target)}"
 }

--- a/spec/fixtures/modules/vars/plans/emit.pp
+++ b/spec/fixtures/modules/vars/plans/emit.pp
@@ -1,5 +1,4 @@
-plan vars(String $host) {
+plan vars::emit(String $host) {
   $target = get_targets($host)[0]
-  $target.set_var('bugs', 'bunny')
   return "Vars for ${host}: ${$target.vars}"
 }


### PR DESCRIPTION
When a node is not in inventory or doesn't have facts/vars set, return
an empty hash rather than nil so that the plan doesn't error.