### PR TITLE
(PUP-8441) Serialize pcore values in plans

### DIFF
--- a/lib/bolt/error.rb
+++ b/lib/bolt/error.rb
@@ -28,6 +28,10 @@ module Bolt
       to_h.to_json(opts)
     end
 
+    def update_details(&block)
+      @details = yield(@details)
+    end
+
     def to_puppet_error
       Puppet::DataTypes::Error.from_asserted_hash(to_h)
     end
@@ -65,12 +69,8 @@ module Bolt
   end
 
   class PuppetError < Error
-    def self.convert_puppet_errors(result)
-      Bolt::Util.walk_vals(result) { |v| v.is_a?(Puppet::DataTypes::Error) ? from_error(v) : v }
-    end
-
-    def self.from_error(err)
-      new(err.msg, err.kind, err.details, err.issue_code)
+    def self.from_asserted_hash(error_hash)
+      new(error_hash['msg'], error_hash['kind'], error_hash['details'], error_hash['issue_code'])
     end
   end
 end

--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -7,6 +7,15 @@ module Bolt
   class Result
     attr_reader :target, :value
 
+    def self.from_asserted_args(target, value)
+      new(target, value: value)
+    end
+
+    def self.from_asserted_hash(hash)
+      new(hash['target'], value: hash['value'])
+    end
+
+
     def self.from_exception(target, exception)
       @exception = exception
       if @exception.is_a?(Bolt::Error)

--- a/lib/bolt/result_set.rb
+++ b/lib/bolt/result_set.rb
@@ -12,6 +12,10 @@ module Bolt
       include(Puppet::Pops::Types::IteratorProducer)
     end
 
+    def self.from_asserted_hash(hash)
+      new(hash['results'])
+    end
+
     def iterator
       if Object.const_defined?(:Puppet) && Puppet.const_defined?(:Pops) &&
          self.class.included_modules.include?(Puppet::Pops::Types::Iterable)

--- a/spec/fixtures/modules/error/plans/catch_plan.pp
+++ b/spec/fixtures/modules/error/plans/catch_plan.pp
@@ -1,3 +1,4 @@
 plan error::catch_plan {
+  $foo = Error['oops']
  run_plan('error::err', '_catch_errors' => true)
 }

--- a/spec/fixtures/modules/results/plans/result_set.pp
+++ b/spec/fixtures/modules/results/plans/result_set.pp
@@ -1,0 +1,5 @@
+plan results::result_set (
+  String $target
+) {
+  run_task('results', [$target], 'fail' => 'true', '_catch_errors' => true)
+}

--- a/spec/integration/result_set_spec.rb
+++ b/spec/integration/result_set_spec.rb
@@ -40,5 +40,11 @@ describe "when running a plan that manipulates an execution result", ssh: true d
       output = run_cli(['plan', 'run', 'results::test_error', "--params", params] + config_flags)
       expect(output.strip).to eq('"The task failed with exit code 1"')
     end
+
+    it 'can be returned with errors' do
+      params = { target: uri }.to_json
+      output = run_cli_json(['plan', 'run', 'results::result_set', "--params", params] + config_flags)
+      expect(output).to eq({})
+    end
   end
 end


### PR DESCRIPTION
Currently plans are allowed to return arbitrary objects which may not
support to_json and therefore will error when we try to serialize them.
Worse, pcore objects tend to blow up when to_s is called on them outside
a compiler.

We should choose between supporting arbitrary pcore objects as the
return value for plans and handling serialization of them or limiting
the return to datatypes we expect. Currentlty I think the valid types
are Data, Error, Result, ResultSet, Target, and combinations thereof.

If we do decide on serializing pcore we need to choose between
displaying it as raw json like we do with the expected types of using
the rich data format.

I personally lean towards restricting the return types of plans. I think
it's adaquate for now and it's easier to expand the spec to support more
return types than restrict it in the future.

Notes about this implementation:

I'm recreating the ruby objects we care about so that we can handle them
more cleanly outside of pal. An alternate implementation would be to
keep the compiler arround for duration of a bolt execution and serialize
pcore more later as needed.