### PR TITLE
(maint) Add spec tests for the puppetdb_fact plan

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/puppetdb_fact.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/puppetdb_fact.rb
@@ -12,6 +12,7 @@ require 'bolt/error'
 Puppet::Functions.create_function(:puppetdb_fact) do
   dispatch :puppetdb_fact do
     param 'Array[String]', :targets
+    return_type 'Hash[String, Data]'
   end
 
   def puppetdb_fact(targets)

--- a/bolt-modules/boltlib/spec/functions/puppetdb_fact.rb
+++ b/bolt-modules/boltlib/spec/functions/puppetdb_fact.rb
@@ -5,25 +5,24 @@ require 'spec_helper'
 describe 'puppetdb_fact' do
   include PuppetlabsSpec::Fixtures
 
-  let(:executor) { mock('bolt_executor') }
-  let(:inventory) { mock('inventory') }
+  let(:pdb_client) { mock('pdb_client') }
 
   around(:each) do |example|
     Puppet[:tasks] = true
     Puppet.features.stubs(:bolt?).returns(true)
 
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
+    Puppet.override(bolt_pdb_client: pdb_client) do
       example.run
     end
   end
 
   context 'it calls puppetdb_facts' do
-    let(:targets) { %w[a.com b.com] }
-    let(:pdb_facts) { { 'a.com' => {}, 'b.com' => {} } }
-    it 'with list of nodes' do
-      executor.expects(:puppetdb_facts).with(targets).returns(pdb_facts)
+    let(:facts) { { 'a.com' => {}, 'b.com' => {} } }
 
-      is_expected.to run.with_params(targets).and_return(pdb_facts)
+    it 'with list of nodes' do
+      pdb_client.expects(:facts_for_node).with(facts.keys).returns(facts)
+
+      is_expected.to run.with_params(facts.keys).and_return(facts)
     end
   end
 end

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -155,17 +155,5 @@ module Bolt
       @notifier.shutdown
       results
     end
-
-    def puppetdb_client
-      return @puppetdb_client if @puppetdb_client
-      puppetdb_config = Bolt::PuppetDB::Config.new(nil, @config.puppetdb)
-      @puppetdb_client = Bolt::PuppetDB::Client.from_config(puppetdb_config)
-    end
-
-    def puppetdb_fact(certnames)
-      puppetdb_client.facts_for_node(certnames)
-    rescue StandardError => e
-      raise Bolt::CLIError, "Could not retrieve targets from PuppetDB: #{e}"
-    end
   end
 end

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -96,12 +96,12 @@ module Bolt
       r
     end
 
-    def with_bolt_executor(executor, inventory, &block)
-      Puppet.override({ bolt_executor: executor, bolt_inventory: inventory }, &block)
+    def with_bolt_executor(executor, inventory, pdb_client = nil, &block)
+      Puppet.override({ bolt_executor: executor, bolt_inventory: inventory, bolt_pdb_client: pdb_client }, &block)
     end
 
-    def in_plan_compiler(executor, inventory)
-      with_bolt_executor(executor, inventory) do
+    def in_plan_compiler(executor, inventory, pdb_client)
+      with_bolt_executor(executor, inventory, pdb_client) do
         # TODO: remove this call and see if anything breaks when
         # settings dirs don't actually exist. Plans shouldn't
         # actually be using them.
@@ -226,8 +226,8 @@ module Bolt
       end
     end
 
-    def run_plan(plan_name, params, executor = nil, inventory = nil)
-      in_plan_compiler(executor, inventory) do |compiler|
+    def run_plan(plan_name, params, executor = nil, inventory = nil, pdb_client = nil)
+      in_plan_compiler(executor, inventory, pdb_client) do |compiler|
         r = compiler.call_function('run_plan', plan_name, params)
         Bolt::PuppetError.convert_puppet_errors(r)
       end

--- a/lib/bolt/util/on_access.rb
+++ b/lib/bolt/util/on_access.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Bolt
+  module Util
+    class OnAccess
+      def initialize(&block)
+        @constructor = block
+        @obj = nil
+      end
+
+      # If a method is called and we haven't constructed the object,
+      # construct it. Then pass the call to the object.
+      # rubocop:disable Style/MethodMissing
+      def method_missing(method, *args, &block)
+        if @obj.nil?
+          @obj = @constructor.call
+        end
+
+        @obj.send(method, *args, &block)
+      end
+      # rubocop:enable Style/MethodMissing
+    end
+  end
+end

--- a/modules/puppetdb_fact/spec/plans/init_spec.rb
+++ b/modules/puppetdb_fact/spec/plans/init_spec.rb
@@ -16,13 +16,13 @@ describe 'puppetdb_fact' do
   }
 
   it 'returns facts from PuppetDB' do
-    executor.expects(:puppetdb_fact).with(facts.keys).returns(facts)
+    puppetdb_client.expects(:facts_for_node).with(facts.keys).returns(facts)
     result = run_plan('puppetdb_fact', 'nodes' => facts.keys)
     expect(result).to eq(facts)
   end
 
   it 'adds facts to Targets' do
-    executor.expects(:puppetdb_fact).with(facts.keys).returns(facts)
+    puppetdb_client.expects(:facts_for_node).with(facts.keys).returns(facts)
     run_plan('puppetdb_fact', 'nodes' => facts.keys)
     facts.each do |k, v|
       expect(inventory.facts(Bolt::Target.new(k))).to eq(v)
@@ -30,7 +30,7 @@ describe 'puppetdb_fact' do
   end
 
   it 'returns an empty hash for an empty list' do
-    executor.expects(:puppetdb_fact).with([]).returns({})
+    puppetdb_client.expects(:facts_for_node).with([]).returns({})
     result = run_plan('puppetdb_fact', 'nodes' => [])
     expect(result).to eq({})
   end

--- a/modules/puppetdb_fact/spec/plans/init_spec.rb
+++ b/modules/puppetdb_fact/spec/plans/init_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/plans'
+require 'bolt/target'
+
+describe 'puppetdb_fact' do
+  include BoltSpec::Plans
+
+  let(:facts) {
+    {
+      'foo' => { 'fqdn' => 'foo', 'osfamily' => 'RedHat' },
+      'bar' => { 'fqdn' => 'bar', 'osfamily' => 'windows' },
+      'baz' => { 'fqdn' => 'baz', 'osfamily' => 'Darwin' }
+    }
+  }
+
+  it 'returns facts from PuppetDB' do
+    executor.expects(:puppetdb_fact).with(facts.keys).returns(facts)
+    result = run_plan('puppetdb_fact', 'nodes' => facts.keys)
+    expect(result).to eq(facts)
+  end
+
+  it 'adds facts to Targets' do
+    executor.expects(:puppetdb_fact).with(facts.keys).returns(facts)
+    run_plan('puppetdb_fact', 'nodes' => facts.keys)
+    facts.each do |k, v|
+      expect(inventory.facts(Bolt::Target.new(k))).to eq(v)
+    end
+  end
+
+  it 'returns an empty hash for an empty list' do
+    executor.expects(:puppetdb_fact).with([]).returns({})
+    result = run_plan('puppetdb_fact', 'nodes' => [])
+    expect(result).to eq({})
+  end
+end

--- a/modules/puppetdb_fact/spec/spec_helper.rb
+++ b/modules/puppetdb_fact/spec/spec_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative '../../../vendored/require_vendored.rb'
+
+# Add bolt spec helpers
+bolt_dir = Gem::Specification.find_by_name('bolt').gem_dir
+$LOAD_PATH.unshift(File.join(bolt_dir, 'spec', 'lib'))
+
+# Ensure tasks are enabled when rspec-puppet sets up an environment
+# so we get task loaders.
+Puppet[:tasks] = true
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/spec/bolt/util/on_access_spec.rb
+++ b/spec/bolt/util/on_access_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/util/on_access'
+
+describe Bolt::Util::OnAccess do
+  it 'delays initialization' do
+    obj = Bolt::Util::OnAccess.new do
+      raise 'failed init'
+    end
+
+    expect {
+      obj.length
+    }.to raise_error('failed init')
+  end
+
+  it 'constructs an object and passes calls through' do
+    obj = Bolt::Util::OnAccess.new do
+      [1, 2, 3]
+    end
+
+    expect(obj.length).to eq(3)
+    expect(obj[0]).to eq(1)
+  end
+end

--- a/spec/lib/bolt_spec/pal.rb
+++ b/spec/lib/bolt_spec/pal.rb
@@ -17,8 +17,8 @@ module BoltSpec
       conf
     end
 
-    def peval(code, pal, executor = nil, inventory = nil)
-      pal.in_plan_compiler(executor, inventory) do |c|
+    def peval(code, pal, executor = nil, inventory = nil, pdb_client = nil)
+      pal.in_plan_compiler(executor, inventory, pdb_client) do |c|
         c.evaluate_string(code)
       end
     end

--- a/spec/lib/bolt_spec/plans.rb
+++ b/spec/lib/bolt_spec/plans.rb
@@ -106,11 +106,15 @@ module BoltSpec
       @inventory ||= Bolt::Inventory.new({})
     end
 
+    def puppetdb_client
+      @puppetdb_client ||= mock('puppetdb_client')
+    end
+
     # TODO: handle expected plan failures
     def run_plan(name, params)
       pal = Bolt::PAL.new(config)
       begin
-        result = pal.run_plan(name, params, executor, inventory)
+        result = pal.run_plan(name, params, executor, inventory, puppetdb_client)
       rescue Bolt::CLIError => e
         if executor.error_message
           raise executor.error_message


### PR DESCRIPTION
Note that it places expectations on the executor directly. The
`puppetdb_fact` method may move out of the executor directly, so we
don't add an explicit helper to BoltSpec::Plans.