### PR TITLE
(BOLT-410) Allow descriptions for run_* functions and CLI

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/file_upload.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/file_upload.rb
@@ -19,8 +19,24 @@ Puppet::Functions.create_function(:file_upload, Puppet::Functions::InternalFunct
     return_type 'ResultSet'
   end
 
+  dispatch :file_upload_with_description do
+    scope_param
+    param 'String[1]', :source
+    param 'String[1]', :destination
+    param 'Boltlib::TargetSpec', :targets
+    param 'String', :description
+    optional_param 'Hash[String[1], Any]', :options
+    return_type 'ResultSet'
+  end
+
   def file_upload(scope, source, destination, targets, options = nil)
+    file_upload_with_description(scope, source, destination, targets, nil, options)
+  end
+
+  def file_upload_with_description(scope, source, destination, targets, description = nil, options = nil)
     options ||= {}
+    options = options.merge('_description' => description) if description
+
     unless Puppet[:tasks]
       raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
         Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, operation: 'file_upload'

--- a/bolt-modules/boltlib/lib/puppet/functions/file_upload.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/file_upload.rb
@@ -48,7 +48,7 @@ Puppet::Functions.create_function(:file_upload, Puppet::Functions::InternalFunct
       call_function('debug', "Simulating file upload of '#{found}' - no targets given - no action taken")
       r = Bolt::ResultSet.new([])
     else
-      r = executor.file_upload(targets, found, destination, options.select { |k, _| k == '_run_as' })
+      r = executor.file_upload(targets, found, destination, options)
     end
 
     if !r.ok && !options['_catch_errors']

--- a/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
@@ -40,7 +40,7 @@ Puppet::Functions.create_function(:run_command) do
       call_function('debug', "Simulating run_command('#{command}') - no targets given - no action taken")
       r = Bolt::ResultSet.new([])
     else
-      r = executor.run_command(targets, command, options.select { |k, _| k == '_run_as' })
+      r = executor.run_command(targets, command, options)
     end
 
     if !r.ok && !options['_catch_errors']

--- a/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
@@ -17,8 +17,22 @@ Puppet::Functions.create_function(:run_command) do
     return_type 'ResultSet'
   end
 
+  dispatch :run_command_with_description do
+    param 'String[1]', :command
+    param 'Boltlib::TargetSpec', :targets
+    param 'String', :description
+    optional_param 'Hash[String[1], Any]', :options
+    return_type 'ResultSet'
+  end
+
   def run_command(command, targets, options = nil)
+    run_command_with_description(command, targets, nil, options)
+  end
+
+  def run_command_with_description(command, targets, description = nil, options = nil)
     options ||= {}
+    options = options.merge('_description' => description) if description
+
     unless Puppet[:tasks]
       raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
         Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, operation: 'run_command'

--- a/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
@@ -50,7 +50,7 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
     r = if targets.empty?
           Bolt::ResultSet.new([])
         else
-          executor.run_script(targets, found, options['arguments'] || [], options.select { |k, _| k == '_run_as' })
+          executor.run_script(targets, found, options['arguments'] || [], options.reject { |k, _| k == 'arguments' })
         end
 
     if !r.ok && !options['_catch_errors']

--- a/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
@@ -16,8 +16,23 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
     return_type 'ResultSet'
   end
 
+  dispatch :run_script_with_description do
+    scope_param
+    param 'String[1]', :script
+    param 'Boltlib::TargetSpec', :targets
+    param 'String', :description
+    optional_param 'Hash[String[1], Any]', :options
+    return_type 'ResultSet'
+  end
+
   def run_script(scope, script, targets, options = nil)
+    run_script_with_description(scope, script, targets, nil, options)
+  end
+
+  def run_script_with_description(scope, script, targets, description = nil, options = nil)
     options ||= {}
+    options = options.merge('_description' => description) if description
+
     unless Puppet[:tasks]
       raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
         Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, operation: 'run_script'

--- a/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
@@ -54,7 +54,7 @@ Puppet::Functions.create_function(:run_task) do
     # Ensure that given targets are all Target instances
     targets = inventory.get_targets(targets)
 
-    use_args = task_args.reject { |k, _| k.start_with?('_') }
+    options, use_args = task_args.partition { |k, _| k.start_with?('_') }.map(&:to_h)
 
     # Don't bother loading the local task definition if all targets use the 'pcp' transport
     # and the local-validation option is set to false for all of them
@@ -94,7 +94,6 @@ Puppet::Functions.create_function(:run_task) do
     if targets.empty?
       Bolt::ResultSet.new([])
     else
-      options = task_args.select { |k, _| k == '_run_as' }
       executor.run_task(targets, task, use_args, options, &block)
     end
   end

--- a/bolt-modules/boltlib/spec/functions/file_upload_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/file_upload_spec.rb
@@ -63,6 +63,44 @@ describe 'file_upload' do
       is_expected.to run.with_params('test/uploads', destination, target, '_run_as' => 'soandso').and_return(result_set)
     end
 
+    context 'with description' do
+      let(:message) { 'test message' }
+
+      it 'passes the description through if parameters are passed' do
+        executor.expects(:file_upload)
+                .with([target], full_dir_path, destination, '_description' => message)
+                .returns(result_set)
+        inventory.stubs(:get_targets).with(target).returns([target])
+
+        is_expected.to run.with_params('test/uploads', destination, target, message, {}).and_return(result_set)
+      end
+
+      it 'passes the description through if no parameters are passed' do
+        executor.expects(:file_upload)
+                .with([target], full_dir_path, destination, '_description' => message)
+                .returns(result_set)
+        inventory.stubs(:get_targets).with(target).returns([target])
+
+        is_expected.to run.with_params('test/uploads', destination, target, message).and_return(result_set)
+      end
+    end
+
+    context 'without description' do
+      it 'ignores description if parameters are passed' do
+        executor.expects(:file_upload).with([target], full_dir_path, destination, {}).returns(result_set)
+        inventory.stubs(:get_targets).with(target).returns([target])
+
+        is_expected.to run.with_params('test/uploads', destination, target, {}).and_return(result_set)
+      end
+
+      it 'ignores description if no parameters are passed' do
+        executor.expects(:file_upload).with([target], full_dir_path, destination, {}).returns(result_set)
+        inventory.stubs(:get_targets).with(target).returns([target])
+
+        is_expected.to run.with_params('test/uploads', destination, target).and_return(result_set)
+      end
+    end
+
     context 'with multiple destinations' do
       let(:hostname2) { 'test.testing.com' }
       let(:target2) { Bolt::Target.new(hostname2) }

--- a/bolt-modules/boltlib/spec/functions/file_upload_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/file_upload_spec.rb
@@ -93,7 +93,7 @@ describe 'file_upload' do
         end
 
         it 'does not error with _catch_errors' do
-          executor.expects(:file_upload).with([target, target2], full_path, destination, {})
+          executor.expects(:file_upload).with([target, target2], full_path, destination, '_catch_errors' => true)
                   .returns(result_set)
           inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 

--- a/bolt-modules/boltlib/spec/functions/run_command_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_command_spec.rb
@@ -81,7 +81,7 @@ describe 'run_command' do
         end
 
         it 'does not error with _catch_errors' do
-          executor.expects(:run_command).with([target, target2], command, {})
+          executor.expects(:run_command).with([target, target2], command, '_catch_errors' => true)
                   .returns(result_set)
           inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 

--- a/bolt-modules/boltlib/spec/functions/run_command_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_command_spec.rb
@@ -48,6 +48,40 @@ describe 'run_command' do
       is_expected.to run.with_params(command, target, '_run_as' => 'root').and_return(result_set)
     end
 
+    context 'with description' do
+      let(:message) { 'test message' }
+
+      it 'passes the description through if parameters are passed' do
+        executor.expects(:run_command).with([target], command, '_description' => message).returns(result_set)
+        inventory.expects(:get_targets).with(target).returns([target])
+
+        is_expected.to run.with_params(command, target, message, {}).and_return(result_set)
+      end
+
+      it 'passes the description through if no parameters are passed' do
+        executor.expects(:run_command).with([target], command, '_description' => message).returns(result_set)
+        inventory.expects(:get_targets).with(target).returns([target])
+
+        is_expected.to run.with_params(command, target, message).and_return(result_set)
+      end
+    end
+
+    context 'without description' do
+      it 'ignores description if parameters are passed' do
+        executor.expects(:run_command).with([target], command, {}).returns(result_set)
+        inventory.expects(:get_targets).with(target).returns([target])
+
+        is_expected.to run.with_params(command, target, {}).and_return(result_set)
+      end
+
+      it 'ignores description if no parameters are passed' do
+        executor.expects(:run_command).with([target], command, {}).returns(result_set)
+        inventory.expects(:get_targets).with(target).returns([target])
+
+        is_expected.to run.with_params(command, target).and_return(result_set)
+      end
+    end
+
     context 'with multiple hosts' do
       let(:hostname2) { 'test.testing.com' }
       let(:target2) { Bolt::Target.new(hostname2) }

--- a/bolt-modules/boltlib/spec/functions/run_script_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_script_spec.rb
@@ -93,7 +93,7 @@ describe 'run_script' do
         end
 
         it 'does not error with _catch_errors' do
-          executor.expects(:run_script).with([target, target2], full_path, [], {})
+          executor.expects(:run_script).with([target, target2], full_path, [], '_catch_errors' => true)
                   .returns(result_set)
           inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 

--- a/bolt-modules/boltlib/spec/functions/run_script_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_script_spec.rb
@@ -66,6 +66,40 @@ describe 'run_script' do
       is_expected.to run.with_params('test/uploads/hostname.sh', target, '_run_as' => 'root').and_return(result_set)
     end
 
+    context 'with description' do
+      let(:message) { 'test message' }
+
+      it 'passes the description through if parameters are passed' do
+        executor.expects(:run_script).with([target], full_path, [], '_description' => message).returns(result_set)
+        inventory.expects(:get_targets).with(target).returns([target])
+
+        is_expected.to run.with_params('test/uploads/hostname.sh', target, message, {})
+      end
+
+      it 'passes the description through if no parameters are passed' do
+        executor.expects(:run_script).with([target], full_path, [], '_description' => message).returns(result_set)
+        inventory.expects(:get_targets).with(target).returns([target])
+
+        is_expected.to run.with_params('test/uploads/hostname.sh', target, message)
+      end
+    end
+
+    context 'without description' do
+      it 'ignores description if parameters are passed' do
+        executor.expects(:run_script).with([target], full_path, [], {}).returns(result_set)
+        inventory.expects(:get_targets).with(target).returns([target])
+
+        is_expected.to run.with_params('test/uploads/hostname.sh', target, {})
+      end
+
+      it 'ignores description if no parameters are passed' do
+        executor.expects(:run_script).with([target], full_path, [], {}).returns(result_set)
+        inventory.expects(:get_targets).with(target).returns([target])
+
+        is_expected.to run.with_params('test/uploads/hostname.sh', target)
+      end
+    end
+
     context 'with multiple destinations' do
       let(:hostname2) { 'test.testing.com' }
       let(:target2) { Bolt::Target.new(hostname2) }

--- a/bolt-modules/boltlib/spec/functions/run_task_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_spec.rb
@@ -86,6 +86,40 @@ describe 'run_task' do
       is_expected.to run.with_params('Test::Yes', []).and_return(Bolt::ResultSet.new([]))
     end
 
+    context 'with description' do
+      let(:message) { 'test message' }
+
+      it 'passes the description through if parameters are passed' do
+        executor.expects(:run_task).with([target], anything, {}, '_description' => message).returns(result_set)
+        inventory.expects(:get_targets).with(hostname).returns([target])
+
+        is_expected.to run.with_params('test::yes', hostname, message, {})
+      end
+
+      it 'passes the description through if no parameters are passed' do
+        executor.expects(:run_task).with([target], anything, {}, '_description' => message).returns(result_set)
+        inventory.expects(:get_targets).with(hostname).returns([target])
+
+        is_expected.to run.with_params('test::yes', hostname, message)
+      end
+    end
+
+    context 'without description' do
+      it 'ignores description if parameters are passed' do
+        executor.expects(:run_task).with([target], anything, {}, {}).returns(result_set)
+        inventory.expects(:get_targets).with(hostname).returns([target])
+
+        is_expected.to run.with_params('test::yes', hostname, {})
+      end
+
+      it 'ignores description if no parameters are passed' do
+        executor.expects(:run_task).with([target], anything, {}, {}).returns(result_set)
+        inventory.expects(:get_targets).with(hostname).returns([target])
+
+        is_expected.to run.with_params('test::yes', hostname)
+      end
+    end
+
     context 'with multiple destinations' do
       let(:result_set) { Bolt::ResultSet.new([result, result2]) }
 

--- a/bolt-modules/boltlib/spec/functions/run_task_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_spec.rb
@@ -129,7 +129,10 @@ describe 'run_task' do
         it 'does not error with _catch_errors' do
           executable = File.join(tasks_root, 'meta.sh')
 
-          executor.expects(:run_task).with([target, target2], mock_task(executable, 'environment'), default_args, {})
+          executor.expects(:run_task).with([target, target2],
+                                           mock_task(executable, 'environment'),
+                                           default_args,
+                                           '_catch_errors' => true)
                   .returns(result_set)
           inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -135,6 +135,10 @@ Available options are:
                'User to authenticate as') do |user|
           @options[:user] = user
         end
+        define('--description DESCRIPTION',
+               'Description to use for the job') do |description|
+          @options[:description] = description
+        end
         define('-p', '--password [PASSWORD]',
                'Password to authenticate with.',
                'Omit the value to prompt for the password.') do |password|
@@ -523,17 +527,19 @@ Available options are:
         outputter.print_head
 
         elapsed_time = Benchmark.realtime do
+          executor_opts = {}
+          executor_opts['_description'] = options[:description] if options.key?(:description)
           results =
             case options[:mode]
             when 'command'
-              executor.run_command(targets, options[:object]) do |event|
+              executor.run_command(targets, options[:object], executor_opts) do |event|
                 outputter.print_event(event)
               end
             when 'script'
               script = options[:object]
               validate_file('script', script)
               executor.run_script(
-                targets, script, options[:leftovers]
+                targets, script, options[:leftovers], executor_opts
               ) do |event|
                 outputter.print_event(event)
               end
@@ -542,7 +548,8 @@ Available options are:
                            targets,
                            options[:task_options],
                            executor,
-                           inventory) do |event|
+                           inventory,
+                           options[:description]) do |event|
                 outputter.print_event(event)
               end
             when 'file'
@@ -553,7 +560,7 @@ Available options are:
                 raise Bolt::CLIError, "A destination path must be specified"
               end
               validate_file('source file', src)
-              executor.file_upload(targets, src, dest) do |event|
+              executor.file_upload(targets, src, dest, executor_opts) do |event|
                 outputter.print_event(event)
               end
             end

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -98,6 +98,7 @@ module Bolt
     end
 
     def run_command(targets, command, options = {}, &callback)
+      @logger.notice(options['_description']) if options.key?('_description')
       @logger.info("Starting command run '#{command}' on #{targets.map(&:uri)}")
       notify = proc { |event| @notifier.notify(callback, event) if callback }
       options = { '_run_as' => run_as }.merge(options) if run_as
@@ -112,6 +113,7 @@ module Bolt
     end
 
     def run_script(targets, script, arguments, options = {}, &callback)
+      @logger.notice(options['_description']) if options.key?('_description')
       @logger.info("Starting script run #{script} on #{targets.map(&:uri)}")
       @logger.debug("Arguments: #{arguments}")
       notify = proc { |event| @notifier.notify(callback, event) if callback }
@@ -127,8 +129,8 @@ module Bolt
     end
 
     def run_task(targets, task, arguments, options = {}, &callback)
-      task_name = task.name
-      @logger.info("Starting task #{task_name} on #{targets.map(&:uri)}")
+      @logger.notice(options['_description']) if options.key?('_description')
+      @logger.info("Starting task #{task.name} on #{targets.map(&:uri)}")
       @logger.debug("Arguments: #{arguments} Input method: #{task.input_method}")
       notify = proc { |event| @notifier.notify(callback, event) if callback }
       options = { '_run_as' => run_as }.merge(options) if run_as
@@ -137,12 +139,13 @@ module Bolt
         transport.batch_task(batch, task, arguments, options, &notify)
       end
 
-      @logger.info(summary('task', task_name, results))
+      @logger.info(summary('task', task.name, results))
       @notifier.shutdown
       results
     end
 
     def file_upload(targets, source, destination, options = {}, &callback)
+      @logger.notice(options['_description']) if options.key?('_description')
       @logger.info("Starting file upload from #{source} to #{destination} on #{targets.map(&:uri)}")
       notify = proc { |event| @notifier.notify(callback, event) if callback }
       options = { '_run_as' => run_as }.merge(options) if run_as

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -43,11 +43,11 @@ module Bolt
       impl.value
     end
 
-    def summary(action, object, result)
+    def summary(description, result)
       fc = result.error_set.length
       npl = result.length == 1 ? '' : 's'
       fpl = fc == 1 ? '' : 's'
-      "Ran #{action} '#{object}' on #{result.length} node#{npl} with #{fc} failure#{fpl}"
+      "Finished: #{description} on #{result.length} node#{npl} with #{fc} failure#{fpl}"
     end
     private :summary
 
@@ -98,8 +98,9 @@ module Bolt
     end
 
     def run_command(targets, command, options = {}, &callback)
-      @logger.notice(options['_description']) if options.key?('_description')
-      @logger.info("Starting command run '#{command}' on #{targets.map(&:uri)}")
+      description = options.fetch('_description', "command '#{command}'")
+      @logger.info("Starting: #{description} on #{targets.map(&:uri)}")
+      @logger.debug("Running command '#{command}' on #{targets.map(&:uri)}")
       notify = proc { |event| @notifier.notify(callback, event) if callback }
       options = { '_run_as' => run_as }.merge(options) if run_as
 
@@ -107,15 +108,16 @@ module Bolt
         transport.batch_command(batch, command, options, &notify)
       end
 
-      @logger.info(summary('command', command, results))
+      @logger.info(summary(description, results))
       @notifier.shutdown
       results
     end
 
     def run_script(targets, script, arguments, options = {}, &callback)
-      @logger.notice(options['_description']) if options.key?('_description')
-      @logger.info("Starting script run #{script} on #{targets.map(&:uri)}")
-      @logger.debug("Arguments: #{arguments}")
+      description = options.fetch('_description', "script #{script}")
+      @logger.info("Starting: #{description} on #{targets.map(&:uri)}")
+      @logger.debug("Running script #{script} with '#{arguments}' on #{targets.map(&:uri)}")
+
       notify = proc { |event| @notifier.notify(callback, event) if callback }
       options = { '_run_as' => run_as }.merge(options) if run_as
 
@@ -123,15 +125,16 @@ module Bolt
         transport.batch_script(batch, script, arguments, options, &notify)
       end
 
-      @logger.info(summary('script', script, results))
+      @logger.info(summary(description, results))
       @notifier.shutdown
       results
     end
 
     def run_task(targets, task, arguments, options = {}, &callback)
-      @logger.notice(options['_description']) if options.key?('_description')
-      @logger.info("Starting task #{task.name} on #{targets.map(&:uri)}")
-      @logger.debug("Arguments: #{arguments} Input method: #{task.input_method}")
+      description = options.fetch('_description', "task #{task.name}")
+      @logger.info("Starting: #{description} on #{targets.map(&:uri)}")
+      @logger.debug("Running task #{task.name} with '#{arguments}' via #{task.input_method} on #{targets.map(&:uri)}")
+
       notify = proc { |event| @notifier.notify(callback, event) if callback }
       options = { '_run_as' => run_as }.merge(options) if run_as
 
@@ -139,14 +142,14 @@ module Bolt
         transport.batch_task(batch, task, arguments, options, &notify)
       end
 
-      @logger.info(summary('task', task.name, results))
+      @logger.info(summary(description, results))
       @notifier.shutdown
       results
     end
 
     def file_upload(targets, source, destination, options = {}, &callback)
-      @logger.notice(options['_description']) if options.key?('_description')
-      @logger.info("Starting file upload from #{source} to #{destination} on #{targets.map(&:uri)}")
+      description = options.fetch('_description', "file upload from #{source} to #{destination}")
+      @logger.info("Starting: #{description} on #{targets.map(&:uri)}")
       notify = proc { |event| @notifier.notify(callback, event) if callback }
       options = { '_run_as' => run_as }.merge(options) if run_as
 
@@ -154,7 +157,7 @@ module Bolt
         transport.batch_upload(batch, source, destination, options, &notify)
       end
 
-      @logger.info(summary('upload', source, results))
+      @logger.info(summary(description, results))
       @notifier.shutdown
       results
     end

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -222,7 +222,7 @@ module Bolt
 
     def run_task(task_name, targets, params, executor, inventory, &eventblock)
       in_task_compiler(executor, inventory) do |compiler|
-        compiler.call_function('run_task', task_name, targets, params, &eventblock)
+        compiler.call_function('run_task', task_name, targets, nil, params, &eventblock)
       end
     end
 

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -220,9 +220,9 @@ module Bolt
       plan_info
     end
 
-    def run_task(task_name, targets, params, executor, inventory, &eventblock)
+    def run_task(task_name, targets, params, executor, inventory, description = nil, &eventblock)
       in_task_compiler(executor, inventory) do |compiler|
-        compiler.call_function('run_task', task_name, targets, nil, params, &eventblock)
+        compiler.call_function('run_task', task_name, targets, description, params, &eventblock)
       end
     end
 

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1318,7 +1318,7 @@ bar
 
           expect(executor)
             .to receive(:run_task)
-            .with(targets, task_t, { 'message' => 'hi there' }, {})
+            .with(targets, task_t, { 'message' => 'hi there' }, kind_of(Hash))
             .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'yes', '', 0)]))
 
           cli.execute(options)
@@ -1340,7 +1340,7 @@ bar
         it "formats results of a passing task" do
           expect(executor)
             .to receive(:run_task)
-            .with(targets, task_t, { 'message' => 'hi there' }, {})
+            .with(targets, task_t, { 'message' => 'hi there' }, kind_of(Hash))
             .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'yes', '', 0)]))
 
           cli.execute(options)
@@ -1352,7 +1352,7 @@ bar
         it "raises errors from the executor" do
           expect(executor)
             .to receive(:run_task)
-            .with(targets, task_t, { 'message' => 'hi there' }, {})
+            .with(targets, task_t, { 'message' => 'hi there' }, kind_of(Hash))
             .and_raise("Could not connect to target")
 
           expect { cli.execute(options) }.to raise_error(/Could not connect to target/)
@@ -1361,7 +1361,7 @@ bar
         it "formats results of a failing task" do
           expect(executor)
             .to receive(:run_task)
-            .with(targets, task_t, { 'message' => 'hi there' }, {})
+            .with(targets, task_t, { 'message' => 'hi there' }, kind_of(Hash))
             .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'no', '', 1)]))
 
           cli.execute(options)
@@ -1396,7 +1396,7 @@ bar
         it "traps SIGINT", :signals_self do
           expect(executor)
             .to receive(:run_task)
-            .with(targets, task_t, { 'message' => 'hi there' }, {}) do
+            .with(targets, task_t, { 'message' => 'hi there' }, kind_of(Hash)) do
               Process.kill :INT, Process.pid
               sync_thread.join(1) # give ruby some time to handle the signal
               Bolt::ResultSet.new([])

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -650,7 +650,7 @@ bar
         it "executes the 'whoami' command" do
           expect(executor)
             .to receive(:run_command)
-            .with(targets, 'whoami')
+            .with(targets, 'whoami', kind_of(Hash))
             .and_return(Bolt::ResultSet.new([]))
 
           expect(cli.execute(options)).to eq(0)
@@ -660,14 +660,14 @@ bar
         it "returns 2 if any node fails" do
           expect(executor)
             .to receive(:run_command)
-            .with(targets, 'whoami')
+            .with(targets, 'whoami', kind_of(Hash))
             .and_return(fail_set)
 
           expect(cli.execute(options)).to eq(2)
         end
 
         it "traps SIGINT", :signals_self do
-          expect(executor).to receive(:run_command).with(targets, 'whoami') do
+          expect(executor).to receive(:run_command).with(targets, 'whoami', kind_of(Hash)) do
             Process.kill :INT, Process.pid
             sync_thread.join(1) # give ruby some time to handle the signal
             Bolt::ResultSet.new([])
@@ -697,7 +697,7 @@ bar
 
           expect(executor)
             .to receive(:run_script)
-            .with(targets, script, [])
+            .with(targets, script, [], kind_of(Hash))
             .and_return(Bolt::ResultSet.new([]))
 
           expect(cli.execute(options)).to eq(0)
@@ -734,7 +734,7 @@ bar
         it "returns 2 if any node fails" do
           stub_file(script)
           expect(executor).to receive(:run_script)
-            .with(targets, script, [])
+            .with(targets, script, [], kind_of(Hash))
             .and_return(fail_set)
 
           expect(cli.execute(options)).to eq(2)
@@ -743,7 +743,7 @@ bar
         it "traps SIGINT", :signals_self do
           stub_file(script)
 
-          expect(executor).to receive(:run_script).with(targets, script, []) do
+          expect(executor).to receive(:run_script).with(targets, script, [], kind_of(Hash)) do
             Process.kill :INT, Process.pid
             sync_thread.join(1) # give ruby some time to handle the signal
             Bolt::ResultSet.new([])
@@ -1432,7 +1432,7 @@ bar
 
           expect(executor)
             .to receive(:file_upload)
-            .with(targets, source, dest)
+            .with(targets, source, dest, kind_of(Hash))
             .and_return(Bolt::ResultSet.new([]))
 
           cli.execute(options)
@@ -1444,7 +1444,7 @@ bar
 
           expect(executor)
             .to receive(:file_upload)
-            .with(targets, source, dest)
+            .with(targets, source, dest, kind_of(Hash))
             .and_return(fail_set)
 
           expect(cli.execute(options)).to eq(2)

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -374,8 +374,8 @@ describe "Bolt::Executor" do
 
       executor.run_command(targets, command)
 
-      expect(@log_output.readline).to match(/INFO.*Starting command run .* on .*/)
-      expect(@log_output.readline).to match(/INFO.*Ran command .* on 2 nodes with 0 failures/)
+      expect(@log_output.readline).to match(/INFO.*Starting: command '.*' on .*/)
+      expect(@log_output.readline).to match(/INFO.*Finished: command '.*' on 2 nodes with 0 failures/)
     end
 
     it "logs scripts" do
@@ -388,8 +388,8 @@ describe "Bolt::Executor" do
 
       executor.run_script(targets, script, [])
 
-      expect(@log_output.readline).to match(/INFO.*Starting script run .* on .*/)
-      expect(@log_output.readline).to match(/INFO.*Ran script .* on 2 nodes with 0 failures/)
+      expect(@log_output.readline).to match(/INFO.*Starting: script .* on .*/)
+      expect(@log_output.readline).to match(/INFO.*Finished: script .* on 2 nodes with 0 failures/)
     end
 
     it "logs tasks" do
@@ -402,8 +402,8 @@ describe "Bolt::Executor" do
 
       executor.run_task(targets, mock_task(task), task_arguments)
 
-      expect(@log_output.readline).to match(/INFO.*Starting task service::restart on .*/)
-      expect(@log_output.readline).to match(/INFO.*Ran task 'service::restart' on 2 nodes with 0 failures/)
+      expect(@log_output.readline).to match(/INFO.*Starting: task service::restart on .*/)
+      expect(@log_output.readline).to match(/INFO.*Finished: task service::restart on 2 nodes with 0 failures/)
     end
 
     it "logs uploads" do
@@ -416,8 +416,8 @@ describe "Bolt::Executor" do
 
       executor.file_upload(targets, script, dest)
 
-      expect(@log_output.readline).to match(/INFO.*Starting file upload from .* to .* on .*/)
-      expect(@log_output.readline).to match(/INFO.*Ran upload .* on 2 nodes with 0 failures/)
+      expect(@log_output.readline).to match(/INFO.*Starting: file upload from .* to .* on .*/)
+      expect(@log_output.readline).to match(/INFO.*Finished: file upload from .* to .* on 2 nodes with 0 failures/)
     end
   end
 end

--- a/spec/bolt/transport/orch_spec.rb
+++ b/spec/bolt/transport/orch_spec.rb
@@ -79,6 +79,16 @@ describe Bolt::Transport::Orch, orchestrator: true do
       body = orch.build_request(targets, mtask, params.merge('_noop' => true))
       expect(body[:scope]).to eq(nodes: %w[node1 node2])
     end
+
+    it "sets description if passed" do
+      body = orch.build_request(targets, mtask, params, 'test description')
+      expect(body[:description]).to eq('test description')
+    end
+
+    it "omits description if not passed" do
+      body = orch.build_request(targets, mtask, params, nil)
+      expect(body).not_to include(:description)
+    end
   end
 
   describe :process_run_results do
@@ -204,6 +214,12 @@ describe Bolt::Transport::Orch, orchestrator: true do
         expect(events).to include(type: :node_start, target: result.target)
         expect(events).to include(type: :node_result, result: result)
       end
+    end
+
+    it 'passes description through if supplied' do
+      expect(mock_client).to receive(:run_task).with(include(description: 'test message')).and_return(results)
+
+      orch.batch_task(targets, mtask, params, '_description' => 'test message')
     end
   end
 

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -211,7 +211,12 @@ describe 'running with an inventory file', reset_puppet_settings: true do
       end
 
       context 'with localhost in inventory' do
-        let(:inventory) { { nodes: ['localhost'] } }
+        let(:inventory) do
+          # Ensure that we try to connect to a *closed* port, to avoid spurious "success"
+          port = TCPServer.open(0) { |socket| socket.addr[1] }
+          config = { transport: 'ssh', ssh: { port: port } }
+          { nodes: ['localhost'], config: config }
+        end
 
         it 'fails to connect' do
           result = run_failed_node(run_command)


### PR DESCRIPTION
The `run_task()`, `run_script()`, `run_command()`, and `file_upload()`
functions can now take a positional "description" argument after the target. If
supplied, the description will be logged at notice level when running that
step, and will also be set as the job description in orchestrator.

There is also now a `--description` argument which can be used to specify the
description for a one-off job from the CLI. That description will similarly be
logged and sent to orchestrator.