### PR TITLE
(maint) Move tmpdir to Transports section

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -200,9 +200,6 @@ Available options are:
         end
 
         separator 'Run context:'
-        define('--tmpdir DIR', 'The directory to upload and execute temporary files on the target') do |tmpdir|
-          @options[:tmpdir] = tmpdir
-        end
         define('-c', '--concurrency CONCURRENCY', Integer,
                'Maximum number of simultaneous connections (default: 100)') do |concurrency|
           @options[:concurrency] = concurrency
@@ -233,6 +230,9 @@ Available options are:
         end
         define('--[no-]tty', 'Request a pseudo TTY on nodes that support it') do |tty|
           @options[:tty] = tty
+        end
+        define('--tmpdir DIR', 'The directory to upload and execute temporary files on the target') do |tmpdir|
+          @options[:tmpdir] = tmpdir
         end
 
         separator 'Display:'


### PR DESCRIPTION
The tmpdir is a property of the transport/target, not part of the local
run context. Move it to the Transports section of help output.