### PR TITLE
(maint) Speed up gem installation during tests

### DIFF
--- a/acceptance/setup/common/pre-suite/010_install_ruby.rb
+++ b/acceptance/setup/common/pre-suite/010_install_ruby.rb
@@ -23,24 +23,14 @@ PS
     when /debian|ubuntu/
       # install system ruby packages
       install_package(bolt, 'ruby')
-      install_package(bolt, 'ruby-dev')
-      # install dev tools
-      install_package(bolt, 'make')
-      install_package(bolt, 'gcc')
+      install_package(bolt, 'ruby-ffi')
       result = on(bolt, 'ruby --version')
     when /el-|centos|fedora/
       # install system ruby packages
       install_package(bolt, 'ruby')
-      install_package(bolt, 'ruby-devel')
-      # install dev tools
-      install_package(bolt, 'make')
-      install_package(bolt, 'gcc')
-      if bolt['platform'] =~ /fedora/
-        install_package(bolt, 'redhat-rpm-config')
-        install_package(bolt, 'rubygem-bigdecimal')
-        install_package(bolt, 'rubygem-json')
-        install_package(bolt, 'rubygem-rdoc')
-      end
+      install_package(bolt, 'rubygem-json')
+      install_package(bolt, 'rubygem-ffi')
+      install_package(bolt, 'rubygem-bigdecimal')
       result = on(bolt, 'ruby --version')
     when /osx/
       # ruby dev tools should be already installed

--- a/acceptance/setup/gem/pre-suite/020_install.rb
+++ b/acceptance/setup/gem/pre-suite/020_install.rb
@@ -5,7 +5,7 @@ gem_version = ENV['BOLT_GEM'] || ""
 
 test_name "Install Bolt gem" do
   step "Install Bolt gem" do
-    install_command = "gem install bolt --source #{gem_source}"
+    install_command = "gem install bolt --source #{gem_source} --no-ri --no-rdoc"
     install_command += " -v '#{gem_version}'" unless gem_version.empty?
     case bolt['platform']
     when /windows/

--- a/acceptance/setup/git/pre-suite/020_install.rb
+++ b/acceptance/setup/git/pre-suite/020_install.rb
@@ -28,20 +28,21 @@ test_name "Install Bolt via git" do
     VERS
   end
   step "Build gem" do
+    build_command = "cd bolt; gem build bolt.gemspec"
     case bolt['platform']
     when /windows/
-      execute_powershell_script_on(bolt, 'cd bolt; gem build bolt.gemspec')
+      execute_powershell_script_on(bolt, build_command)
     else
-      on(bolt, "cd bolt && gem build bolt.gemspec")
+      on(bolt, build_command)
     end
   end
   step "Install custom gem" do
+    install_command = "cd bolt; gem install bolt-#{version}.gem --no-ri --no-rdoc"
     case bolt['platform']
     when /windows/
-      execute_powershell_script_on(bolt,
-                                   "cd bolt; gem install bolt-#{version}.gem")
+      execute_powershell_script_on(bolt, install_command)
     else
-      on(bolt, "cd bolt && gem install bolt-#{version}.gem")
+      on(bolt, install_command)
     end
   end
   step "Ensure install succeeded" do

--- a/acceptance/tests/plan_ssh.rb
+++ b/acceptance/tests/plan_ssh.rb
@@ -102,9 +102,9 @@ plan test::ssh_retry_plan($nodes) {
     }
 
     result = bolt_command_on(bolt, bolt_command, flags)
-    assert_match(/Bolt::Executor: Starting task/, result.output,
+    assert_match(/Bolt::Executor: Starting: task/, result.output,
                  "The starting task message was not in the output")
-    assert_match(/Bolt::Executor: Ran task/, result.output,
+    assert_match(/Bolt::Executor: Finished: task/, result.output,
                  "The ran task message was not in the output")
     assert_match(/on #{ssh_nodes.length} node[s]? with 1 failure/, result.output,
                  "Task run failure was not logged correctly")

--- a/acceptance/tests/plan_winrm.rb
+++ b/acceptance/tests/plan_winrm.rb
@@ -110,9 +110,9 @@ plan test::winrm_retry_plan($nodes) {
 
     result = bolt_command_on(bolt, bolt_command, flags)
 
-    assert_match(/Bolt::Executor: Starting task/, result.output,
+    assert_match(/Bolt::Executor: Starting: task/, result.output,
                  "The starting task message was not in the output")
-    assert_match(/Bolt::Executor: Ran task/, result.output,
+    assert_match(/Bolt::Executor: Finished: task/, result.output,
                  "The ran task message was not in the output")
     assert_match(/on #{winrm_nodes.length} node[s]? with 1 failure/, result.output,
                  "Node failure was not logged correctly")


### PR DESCRIPTION
This also includes improvements to speed up gem installation during tests.
Previously, we were installing build tools and building native extensions for
gem dependencies. Now we install the OS packages for those dependencies
instead. We also now install with --no-ri and --no-rdoc, which cuts the install
time by half.