### PR TITLE
(BOLT-410) Add test that description is used in logging

### DIFF
--- a/spec/fixtures/modules/sample/plans/single_task.pp
+++ b/spec/fixtures/modules/sample/plans/single_task.pp
@@ -1,9 +1,11 @@
 # one line plan to show we can run a task by name
-plan sample::single_task(String $nodes) {
-  $node_array = split($nodes, ',')
-  run_task (
-    "sample::echo", $node_array,
-    message => "hi there",
-    '_catch_errors' => true,
-  )
+plan sample::single_task(
+  TargetSpec       $nodes,
+  Optional[String] $description = undef,
+) {
+  if $description {
+    run_task("sample::echo", $nodes, $description, message => "hi there", _catch_errors => true)
+  } else {
+    run_task("sample::echo", $nodes, message => "hi there", _catch_errors => true)
+  }
 }

--- a/spec/integration/logging_spec.rb
+++ b/spec/integration/logging_spec.rb
@@ -50,6 +50,13 @@ describe "when logging executor activity", ssh: true do
     expect(result[0]['result']['_output'].strip).to match(/hi there/)
   end
 
+  it 'logs description when included' do
+    result = run_cli_json(%W[plan run #{echo_plan} description=somemessage] + config_flags)
+    expect(@log_output.readline).to match(/Starting: somemessage on/)
+    expect(@log_output.readline).to match(/Finished: somemessage on/)
+    expect(result[0]['result']['_output'].strip).to match(/hi there/)
+  end
+
   context 'with verbose logging' do
     let(:log_level) { :info }
 


### PR DESCRIPTION
Add a test that description, when passed as an argument to a run action,
is included in logging.