### PR TITLE
(BOLT-334) Bundle the package, service, puppet_conf modules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,12 @@ To use `rubocop`, perform the bundle install with no exclusions
     bundle install --path .bundle --with test
     bundle exec rake rubocop
 
+### Contributing to bundled modules
+
+Some module content is included with the Bolt gem for out-of-the-box use. Some of those modules are included in this repository and others are managed with the Puppetfile included in this repository. All the bundled modules are installed in the `modules` directory.
+
+To change external modules (to add a new module or bump the version), update the Puppetfile and then run `bundle exec r10k puppetfile install`.
+
 ## Testing
 
 Some tests require a Windows VMs or Linux containers. For Linux tests (recommended, if you're not sure) `docker-compose up -d --build` to bring these up with the `docker-compose.yaml` included with the `bolt` gem. For windows tests, execute `vagrant up` to bring these up with the provided Vagrantfile. Any tests that require this are tagged with `:winrm` or `:ssh` in rspec.

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,10 @@ group(:test) do
   gem "rubocop", '~> 0.50', require: false
 end
 
+group(:development) do
+  gem "r10k", "~> 2.6"
+end
+
 local_gemfile = File.join(__dir__, 'Gemfile.local')
 if File.exist? local_gemfile
   eval_gemfile local_gemfile

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+forge "http://forge.puppetlabs.com"
+
+moduledir File.join(File.dirname(__FILE__), 'modules')
+
+# If we don't list these modules explicitly, r10k will purge them
+mod 'canary', local: true
+mod 'facts', local: true
+mod 'aggregate', local: true
+mod 'puppetdb_fact', local: true

--- a/Puppetfile
+++ b/Puppetfile
@@ -4,6 +4,10 @@ forge "http://forge.puppetlabs.com"
 
 moduledir File.join(File.dirname(__FILE__), 'modules')
 
+mod 'puppetlabs-package', '0.2.0'
+mod 'puppetlabs-service', '0.2.0'
+mod 'puppetlabs-puppet_conf', '0.2.0'
+
 # If we don't list these modules explicitly, r10k will purge them
 mod 'canary', local: true
 mod 'facts', local: true


### PR DESCRIPTION
This allows users to manage packages, services, and puppet.conf settings in
an out-of-the-box bolt install.

This adds a Puppetfile to manage the set of modules we bundle with bolt. It
also adds a development dependency on r10k to apply the Puppetfile.