### PR TITLE
(BOLT-454) Return undef from plans without explicit return

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -47,7 +47,12 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
       end
 
       begin
-        result = func.class.dispatcher.dispatchers[0].call_by_name_with_scope(scope, params, true)
+        func.class.dispatcher.dispatchers[0].call_by_name_with_scope(scope, params, true)
+        # If the plan returns using a return statement then we never get here.
+        # We only get here if the plan finishes without executing any return
+        # statement and since we don't want to leak any implicit return value
+        # from the plan we simply set the result to nil here.
+        result = nil
       rescue Puppet::PreformattedError => err
         if named_args['_catch_errors'] && err.cause.is_a?(Bolt::Error)
           result = err.cause.to_puppet_error

--- a/bolt-modules/boltlib/spec/fixtures/modules/test/plans/init.pp
+++ b/bolt-modules/boltlib/spec/fixtures/modules/test/plans/init.pp
@@ -1,1 +1,1 @@
-plan test() { "worked4" }
+plan test() { return "worked4" }

--- a/bolt-modules/boltlib/spec/fixtures/modules/test/plans/no_return.pp
+++ b/bolt-modules/boltlib/spec/fixtures/modules/test/plans/no_return.pp
@@ -1,0 +1,1 @@
+plan test::no_return() { "this is not returned" }

--- a/bolt-modules/boltlib/spec/fixtures/modules/test/plans/run_me.pp
+++ b/bolt-modules/boltlib/spec/fixtures/modules/test/plans/run_me.pp
@@ -1,1 +1,1 @@
-plan test::run_me() { "worked2" }
+plan test::run_me() { return "worked2" }

--- a/bolt-modules/boltlib/spec/fixtures/modules/test/plans/run_me_int.pp
+++ b/bolt-modules/boltlib/spec/fixtures/modules/test/plans/run_me_int.pp
@@ -1,1 +1,1 @@
-plan test::run_me_int(Integer $x) { $x }
+plan test::run_me_int(Integer $x) { return $x }

--- a/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
@@ -24,7 +24,7 @@ describe 'run_plan' do
         result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: env.modulepath) do |pal|
           pal.with_script_compiler do |compiler|
             compiler.evaluate_string(<<-CODE)
-            plan run_me() { "worked1" }
+            plan run_me() { return "worked1" }
             run_plan('run_me')
             CODE
           end
@@ -66,6 +66,10 @@ describe 'run_plan' do
         is_expected.to run.with_params('test::run_me_int', 'x' => 'should not work')
                           .and_raise_error(/expects an Integer value/)
       end
+    end
+
+    it 'returns undef for plans without explicit return' do
+      is_expected.to run.with_params('test::no_return').and_return(nil)
     end
   end
 end

--- a/modules/aggregate/plans/count.pp
+++ b/modules/aggregate/plans/count.pp
@@ -31,5 +31,5 @@ plan aggregate::count(
     run_script($script, $nodes, $params)
   }
 
-  aggregate::count($res)
+  return aggregate::count($res)
 }

--- a/modules/aggregate/plans/nodes.pp
+++ b/modules/aggregate/plans/nodes.pp
@@ -31,5 +31,5 @@ plan aggregate::nodes(
     run_script($script, $nodes, $params)
   }
 
-  aggregate::nodes($res)
+  return aggregate::nodes($res)
 }

--- a/modules/canary/plans/init.pp
+++ b/modules/canary/plans/init.pp
@@ -48,5 +48,5 @@ plan canary(
     $restr = canary::skip($rest)
   }
 
-  canary::merge($canr, $restr)
+  return canary::merge($canr, $restr)
 }

--- a/modules/facts/plans/info.pp
+++ b/modules/facts/plans/info.pp
@@ -5,7 +5,7 @@
 # The $nodes parameter is a list of the nodes for which to print the OS
 # information.
 plan facts::info(TargetSpec $nodes) {
-  run_plan(facts::retrieve, nodes => $nodes).reduce([]) |$info, $r| {
+  return run_plan(facts::retrieve, nodes => $nodes).reduce([]) |$info, $r| {
     if ($r.ok) {
       $info + "${r.target.name}: ${r[os][name]} ${r[os][release][full]} (${r[os][family]})"
     } else {

--- a/modules/facts/plans/init.pp
+++ b/modules/facts/plans/init.pp
@@ -12,5 +12,5 @@ plan facts(TargetSpec $nodes) {
     }
   }
 
-  $result_set
+  return $result_set
 }

--- a/modules/facts/plans/retrieve.pp
+++ b/modules/facts/plans/retrieve.pp
@@ -21,7 +21,7 @@ plan facts::retrieve(TargetSpec $nodes) {
 
   # Return a single result set composed of results from the result sets
   # returned by the individual task runs.
-  ResultSet(
+  return ResultSet(
     $task_targets.map |$task, $targets| {
       run_task($task, $targets, '_catch_errors' => true)
     }.reduce([]) |$results, $result_set| {

--- a/spec/fixtures/modules/error/plans/catch_plan.pp
+++ b/spec/fixtures/modules/error/plans/catch_plan.pp
@@ -1,3 +1,3 @@
 plan error::catch_plan {
- run_plan('error::err', '_catch_errors' => true)
+ return run_plan('error::err', '_catch_errors' => true)
 }

--- a/spec/fixtures/modules/error/plans/catch_plan_run.pp
+++ b/spec/fixtures/modules/error/plans/catch_plan_run.pp
@@ -3,5 +3,5 @@ plan error::catch_plan_run(
   String $target
 ) {
  $r = run_plan('error::run_fail', 'target' => $target, '_catch_errors' => true)
- $r.details['result_set'].first.error
+ return $r.details['result_set'].first.error
 }

--- a/spec/fixtures/modules/error/plans/nested.pp
+++ b/spec/fixtures/modules/error/plans/nested.pp
@@ -1,4 +1,4 @@
 plan error::nested {
   $err = run_plan('error::err', '_catch_errors' => true);
-  { 'error' => [ $err ] }
+  return({ 'error' => [ $err ] })
 }

--- a/spec/fixtures/modules/inventory/plans/init.pp
+++ b/spec/fixtures/modules/inventory/plans/init.pp
@@ -2,5 +2,5 @@ plan inventory(
   String $command,
   String $host,
 ) {
-  run_command($command, $host)
+  return run_command($command, $host)
 }

--- a/spec/fixtures/modules/results/plans/test_error.pp
+++ b/spec/fixtures/modules/results/plans/test_error.pp
@@ -2,5 +2,5 @@ plan results::test_error (
   String $target
 ) {
     $result = run_task('results', [$target], 'fail' => 'true', '_catch_errors' => true)
-    $result.first.error.message
+    return $result.first.error.message
 }

--- a/spec/fixtures/modules/results/plans/test_methods.pp
+++ b/spec/fixtures/modules/results/plans/test_methods.pp
@@ -11,5 +11,5 @@ plan results::test_methods(
   # Test to_s works
   $str = "result ${result}"
   # return ok
-  $result.ok
+  return $result.ok
 }

--- a/spec/fixtures/modules/results/plans/test_target.pp
+++ b/spec/fixtures/modules/results/plans/test_target.pp
@@ -3,5 +3,5 @@ plan results::test_target(
 ) {
   $target = Target($node)
   $target2 = Target($target.uri, $target.options)
-  run_task('results', $target2)
+  return run_task('results', $target2)
 }

--- a/spec/fixtures/modules/sample/plans/single_task.pp
+++ b/spec/fixtures/modules/sample/plans/single_task.pp
@@ -3,7 +3,7 @@ plan sample::single_task(
   TargetSpec       $nodes,
   Optional[String] $description = undef,
 ) {
-  if $description {
+  return if $description {
     run_task("sample::echo", $nodes, $description, message => "hi there", _catch_errors => true)
   } else {
     run_task("sample::echo", $nodes, message => "hi there", _catch_errors => true)

--- a/spec/fixtures/run_as/test/plans/except.pp
+++ b/spec/fixtures/run_as/test/plans/except.pp
@@ -1,5 +1,5 @@
 plan test::except(
   String $target
 ) {
-  run_plan(test::id, target => $target, _run_as => 'root')
+  return run_plan(test::id, target => $target, _run_as => 'root')
 }

--- a/spec/fixtures/run_as/test/plans/id.pp
+++ b/spec/fixtures/run_as/test/plans/id.pp
@@ -1,7 +1,7 @@
 plan test::id(
   String $target
 ) {
-  [
+  return [
     run_task(test::id, [$target]),
     run_task(test::id, [$target], '_run_as' => 'root'),
 

--- a/spec/fixtures/run_as/test/plans/incept.pp
+++ b/spec/fixtures/run_as/test/plans/incept.pp
@@ -1,5 +1,5 @@
 plan test::incept(
   String $target
 ) {
-  run_plan(test::id, target => $target)
+  return run_plan(test::id, target => $target)
 }

--- a/spec/fixtures/run_as/test/plans/run_as_user.pp
+++ b/spec/fixtures/run_as/test/plans/run_as_user.pp
@@ -2,5 +2,5 @@ plan test::run_as_user(String $target, String $user) {
   run_command('whoami', $target, _run_as => $user)
   file_upload('test/id.sh', "/home/${user}/id.sh", $target, _run_as => $user)
   run_script("test/id.sh", $target, _run_as => $user)
-  run_plan(test::whoami, target => $target, _run_as => $user)
+  return run_plan(test::whoami, target => $target, _run_as => $user)
 }

--- a/spec/fixtures/run_as/test/plans/whoami.pp
+++ b/spec/fixtures/run_as/test/plans/whoami.pp
@@ -1,3 +1,3 @@
 plan test::whoami(String $target) {
-  run_command('whoami', $target)
+  return run_command('whoami', $target)
 }


### PR DESCRIPTION
This disables implicit return values from plans. More precisely: Any plan which finishes without executing a `return` statement returns `undef`.
If a different return value is desired it must be returned using the `return` statement.