### PR TITLE
(maint) Improve facter powershell task syntax

### DIFF
--- a/modules/facts/tasks/powershell.ps1
+++ b/modules/facts/tasks/powershell.ps1
@@ -27,24 +27,16 @@ else {
         $os = Get-CimInstance Win32_OperatingSystem -ErrorAction SilentlyContinue
         $consumerrel = $os.ProductType -eq '1'
 
-        if ($version -eq '10.0') {
-            $release = if ($consumerrel) { '10' } else { '2016' }
-        }
-        elseif ($version -eq '6.3') {
-            $release = if ($consumerrel) { '8.1' } else { '2012 R2' }
-        }
-        elseif ($version -eq '6.2') {
-            $release = if ($consumerrel) { '8' } else { '2012' }
-        }
-        elseif ($version -eq '6.1') {
-            $release = if ($consumerrel) { '7' } else { '2008 R2' }
-        }
-        elseif ($version -eq '6.0') {
-            $release = if ($consumerrel) { 'Vista' } else { '2008' }
-        }
-        elseif ($version -eq '5.2') {
-            $release = if ($consumerrel) { 'XP' } else {
-                if ($os.OtherTypeDescription -eq 'R2') { '2003 R2' } else { '2003' }
+        $release = switch($version){
+            '10.0'{ if ($consumerrel) { '10' } else { '2016' } }
+            '6.3' { if ($consumerrel) { '8.1' } else { '2012 R2' } }
+            '6.2' { if ($consumerrel) { '8' } else { '2012' } }
+            '6.1' { if ($consumerrel) { '7' } else { '2008 R2' } }
+            '6.0' { if ($consumerrel) { 'Vista' } else { '2008' } }
+            '5.2' { 
+                if ($consumerrel) { 'XP' } else {
+                    if ($os.OtherTypeDescription -eq 'R2') { '2003 R2' } else { '2003' }
+                }
             }
         }
 


### PR DESCRIPTION
This commit improves the OS version detection if/else block by
converting it to a switch statement. This reduces line count and is
easier to read, which also brings it into following PowerShell coding
style guidelines.