### PR TITLE
(BOLT-439) Support inventory groups defined within other groups

### DIFF
--- a/lib/bolt/inventory/group.rb
+++ b/lib/bolt/inventory/group.rb
@@ -52,7 +52,6 @@ module Bolt
         if node_names.include?(@name)
           raise ValidationError.new("Group #{@name} conflicts with node of the same name", @name)
         end
-        raise ValidationError.new("Group #{@name} is too deeply nested", @name) if depth > 1
 
         check_deprecated_config('Group', @name, @config)
 
@@ -129,7 +128,7 @@ module Bolt
           # Shallow merge instead of deep merge so that vars with a hash value
           # are assigned a new hash, rather than merging the existing value
           # with the value meant to replace it
-          'vars'   => data2['vars'].merge(data1['vars']),
+          'vars'   => data1['vars'].merge(data2['vars']),
           'facts'  => Bolt::Util.deep_merge(data1['facts'], data2['facts']),
           'groups' => data2['groups'] + data1['groups']
         }

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -63,6 +63,12 @@ describe Bolt::Inventory do
               } },
             'node7', 'ssh://node8'
           ],
+          'groups' => [
+            { 'name' => 'group3',
+              'nodes' => [
+                'node9'
+              ] }
+          ],
           'config' => {
             'ssh' => {
               'host-key-check' => false,
@@ -137,14 +143,14 @@ describe Bolt::Inventory do
       inventory = Bolt::Inventory.new(data)
       inventory.collect_groups
       targets = inventory.get_targets('all')
-      expect(targets.size).to eq(8)
+      expect(targets.size).to eq(9)
     end
 
     it 'finds nodes in a subgroup' do
       inventory = Bolt::Inventory.new(data)
       inventory.collect_groups
       targets = inventory.get_targets('group2')
-      expect(targets).to eq(targets(%w[node6 node7 ssh://node8]))
+      expect(targets).to eq(targets(%w[node6 node7 ssh://node8 node9]))
     end
   end
 
@@ -259,7 +265,7 @@ describe Bolt::Inventory do
 
       it 'should match wildcard selectors' do
         targets = inventory.get_targets('node*')
-        expect(targets).to eq(targets(%w[node1 node2 node3 node4 node5 node6 node7]))
+        expect(targets).to eq(targets(%w[node1 node2 node3 node4 node5 node6 node7 node9]))
       end
 
       it 'should fail if wildcard selector matches nothing' do


### PR DESCRIPTION
Previously, the code needed to support nested inventory groups was
present, but with an explicit check to disable it. This commit removes
that check and fixes a bug where variables were merged in reverse order
compared to other values.

Groups can now be defined within other groups. Variables/config prefer the
first "branch" (top-level group) that the node matches, and use the most
deeply nested (most specific) group within that branch. In other words,
we use depth-first lookup, and merge across branches.

A group is not allowed to be defined as a child of multiple parent
groups. This triggers the same error as redefining a group did
previously.