### PR TITLE
(maint) Update ruby on targets for acceptance tests

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -99,6 +99,8 @@ will default to `root`.
 tests as the user for connecting to all hosts using the `winrm` role.
 This user must already be present on the system.
 
+**RUBY_URL** (Default `https://artifactory.delivery.puppetlabs.net/artifactory/generic__buildsources/buildsources/ruby-2.4.4.tar.gz`): The url to download and install ruby from.
+
 ### For Gem Testing
 
 **GEM_VERSION** (Default `> 0.1.0`): When testing via gem install,

--- a/acceptance/lib/acceptance/install_ruby.rb
+++ b/acceptance/lib/acceptance/install_ruby.rb
@@ -1,0 +1,7 @@
+def install_ruby_from_source(host)
+  ENV['RUBY_URL'] ||= "https://artifactory.delivery.puppetlabs.net/artifactory/generic__buildsources/buildsources/ruby-2.4.4.tar.gz"
+  on(host, "mkdir ruby")
+  on(host, "curl -o ruby.tar.gz #{ENV['RUBY_URL']}")
+  on(host, "tar -xvf ruby.tar.gz")
+  on(host, "cd $(ls | grep 'ruby-') && ./configure && make && make install")
+end

--- a/acceptance/setup/common/pre-suite/010_install_ruby.rb
+++ b/acceptance/setup/common/pre-suite/010_install_ruby.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'install_ruby'
+
 test_name "Install Ruby" do
   step "Ensure Ruby is installed on Bolt controller" do
     result = nil
@@ -22,16 +24,13 @@ PS
       result = on(bolt, powershell('ruby --version'))
     when /debian|ubuntu/
       # install system ruby packages
-      install_package(bolt, 'ruby')
-      install_package(bolt, 'ruby-ffi')
+      install_package(bolt, "zlib1g zlib1g-dev openssl libssl-dev")
+      install_ruby_from_source(bolt)
       result = on(bolt, 'ruby --version')
     when /el-|centos|fedora/
       # install system ruby packages
-      install_package(bolt, 'ruby')
-      install_package(bolt, 'rubygem-json')
-      install_package(bolt, 'rubygem-ffi')
-      install_package(bolt, 'rubygem-bigdecimal')
-      install_package(bolt, 'rubygem-io-console')
+      install_package(bolt, "zlib zlib-devel openssl-devel libssl-devel")
+      install_ruby_from_source(bolt)
       result = on(bolt, 'ruby --version')
     when /osx/
       # ruby dev tools should be already installed


### PR DESCRIPTION
This ensures that either ruby 2.4 or a specified version are installed on the SUTs before running the acceptance tests.