### PR TITLE
(BOLT-426) Add pre-docs for installing

### DIFF
--- a/pre-docs/bolt_installing.md
+++ b/pre-docs/bolt_installing.md
@@ -1,67 +1,21 @@
 
 # Installing Bolt
 
-Install Bolt and any dependencies for your operating system, such as Ruby, a
-GNU Compiler Collection (GCC) compiler and the Bolt gem.
-
-Packaged versions of Bolt are available for select Linux distributions and
-versions: Debian 8 and 9, Enterprise Linux 6 and 7, SUSE Linux Enterprise
-Server 12 and Ubuntu 14.04 and 16.04.
-
-
-## Install Bolt on *nix
-
-Install Bolt and its dependencies on *nix platforms.
-
-1. To install dependencies required to install Bolt, run the command that
-  corresponds to your operating system.
-
-  -  For Fedora 25
-     ```
-     dnf install -y make gcc redhat-rpm-config ruby-devel rubygem-rdoc
-     ```
-  - For Debian 9 or Ubuntu 16.04
-    ```
-    apt-get install -y make gcc ruby-dev
-    ```
-
-2. To install Bolt,
-    ```
-    run gem install bolt
-    ```
-3. Run a Bolt command to verify it has installed correctly.
-    ```
-    bolt --help
-    ```
-
-## Install Bolt on Mac OS X
-Install Bolt and its dependencies on Mac OS X systems.
-
-1. If you do not already have them, install the command line tools for Mac OS X.
-   ```
-   xcode-select --install
-   ```
-
-2. To install Bolt, run `gem install bolt`
-3. Run a Bolt command to verify it has installed correctly.
-```
-bolt --help
-```
-
+Packaged versions of Bolt are available for many modern Linux distributions,
+as well as macOS and Windows.
 
 ## Install Bolt on Windows
 
-Install Bolt and its dependencies on Windows systems.
+Download from https://downloads.puppet.com/windows/puppet5/bolt-x64-latest.msi and install.
 
-1. If you do not already have it, install Ruby.
+## Install Bolt on Mac OS X
 
-  You can download Ruby from https://rubyinstaller.org/ or the Chocolatey Windows package manager.
-2. Start a Windows PowerShell session and refresh your environment refreshenv.
-3. To install Bolt, run `gem install bolt`
-4. Run a Bolt command to verify it has installed correctly.
-  ```
-  bolt --help
-  ```
+Go to  > About This Mac to determine which version you're running.
+
+Download and install using the following links:
+* __10.11 (El Capitan)__ - https://downloads.puppet.com/mac/puppet5/10.11/x86_64/bolt-latest.dmg
+* __10.12 (Sierra)__ - https://downloads.puppet.com/mac/puppet5/10.12/x86_64/bolt-latest.dmg
+* __10.13 (High Sierra)__ - https://downloads.puppet.com/mac/puppet5/10.13/x86_64/bolt-latest.dmg
 
 ## Install Bolt from apt repositories on Debian or Ubuntu
 
@@ -73,46 +27,39 @@ https://apt.puppet.com. Packages are named using the convention
 <PLATFORM_VERSION>-release-<VERSION CODE NAME>.deb. For example, the release
 package for Puppet 5 Platform on 8 “Jessie” is puppet5-release-jessie.deb.
 
-> Note: These packages require you to download the Puppet 5 Platform and include
-> puppet-agent as a dependency. If you use an earlier puppet agent you'll have
-> to upgrade it. Download and install the software and its
-> dependencies. Use the commands appropriate to your system.
+> Note: These repositories include the Puppet 5 Platform. If you wish to install
+> only the Bolt package you can install the packages directly as well.
 
-1. -  Debian 8
-      ```
-      wget https://apt.puppet.com/puppet5-release-jessie.deb
-      sudo dpkg -i puppet5-release-jessie.deb
-      sudo apt-get update
-      sudo apt-get install bolt
-      ```
-   -  Debian 9
+- Debian 8
+  ```
+  wget https://apt.puppet.com/puppet5-release-jessie.deb
+  sudo dpkg -i puppet5-release-jessie.deb
+  sudo apt-get update
+  sudo apt-get install bolt
+  ```
+- Debian 9
+  ```
+  wget https://apt.puppet.com/puppet5-release-stretch.deb
+  sudo dpkg -i puppet5-release-stretch.deb
+  sudo apt-get update
+  sudo apt-get install bolt
+  ```
+- Ubuntu 14.04
+  ```
+  wget https://apt.puppet.com/puppet5-release-trusty.deb
+  sudo dpkg -i puppet5-release-trusty.deb
+  sudo apt-get update
+  sudo apt-get install bolt
+  ```
+- Ubuntu 16.04
+  ```
+  wget https://apt.puppet.com/puppet5-release-xenial.deb
+  sudo dpkg -i puppet5-release-xenial.deb
+  sudo apt-get update
+  sudo apt-get install bolt
+  ```
 
-      ```
-      wget https://apt.puppet.com/puppet5-release-stretch.deb
-      sudo dpkg -i puppet5-release-stretch.deb
-      sudo apt-get update
-      sudo apt-get install bolt
-      ```
-   -  Ubuntu 14.04
-
-      ```
-      wget https://apt.puppet.com/puppet5-release-trusty.deb
-      sudo dpkg -i puppet5-release-trusty.deb
-      sudo apt-get update
-      sudo apt-get install bolt
-      ```
-   -  Ubuntu 16.04
-      ```
-      wget https://apt.puppet.com/puppet5-release-xenial.deb
-      sudo dpkg -i puppet5-release-xenial.deb
-      sudo apt-get update
-      sudo apt-get install bolt
-      ```
-2. Run a Bolt command to verify it has installed correctly.
-   ```
-   bolt --help
-   ```
-
+Get started with `bolt --help`.
 
 ## Install Bolt from yum reposities on RHEL or SLES
 
@@ -125,27 +72,49 @@ http://yum.puppet.com/puppet5/ Packages are named using the convention
 the release package for Puppet 5 Platform on Linux 7 is
 puppet5-release-el-7.noarch.rpm.
 
-> Note: These packages require you to download the Puppet 5 Platform and include
-> puppet-agent as a dependency. If you use an earlier puppet agent you'll have
-> to upgrade it.  Download and install the software and its
-> dependencies. Use the commands appropriate to your system.
+> Note: These repositories include the Puppet 5 Platform. If you wish to install
+> only the Bolt package you can install the packages directly as well.
 
-1. -  Enterprise Linux 6
-      ```
-      sudo rpm -Uvh https://yum.puppet.com/puppet5/puppet5-release-el-6.noarch.rpm
-      sudo yum install bolt
-      ```
-   -  Enterprise Linux 7
-      ```
-      sudo rpm -Uvh https://yum.puppet.com/puppet5/puppet5-release-el-7.noarch.rpm
-      sudo yum install bolt
-      ```
-   -  SUSE Linux Enterprise Server 12
-      ```
-      sudo rpm -Uvh https://yum.puppet.com/puppet5/puppet5-release-sles-12.noarch.rpm
-      sudo yum install bolt
-      ```
-2. Run a Bolt command to verify it has installed correctly.
-   ```
-   bolt --help
-   ```
+- Enterprise Linux 6
+  ```
+  sudo rpm -Uvh  https://yum.puppet.com/puppet5/puppet5-release-el-6.noarch.rpm
+  sudo yum install bolt
+  ```
+- Enterprise Linux 7
+  ```
+  sudo rpm -Uvh https://yum.puppet.com/puppet5/puppet5-release-el-7.noarch.rpm
+  sudo yum install bolt
+  ```
+- SUSE Linux Enterprise Server 12
+  ```
+  sudo rpm -Uvh https://yum.puppet.com/puppet5/puppet5-release-sles-12.noarch.rpm
+  sudo zypper install bolt
+  ```
+
+Get started with `bolt --help`.
+
+## Install Bolt as a gem
+
+Install Ruby 2.3+ and Bolt. Note that only very modern operating systems include a
+supported version of Ruby.
+
+### Install Bolt dependencies
+
+- For Fedora 27
+  ```
+  dnf install -y ruby rubygem-json rubygem-ffi rubygem-bigdecimal rubygem-io-console
+  ```
+- For Debian 9 or Ubuntu 16.04
+  ```
+  apt-get install -y ruby ruby-ffi
+  ```
+- For Mac OS X 10.13 (High Sierra)
+  ```
+  xcode-select --install
+  ```
+- For Windows, you can download Ruby from https://rubyinstaller.org/ or the Chocolatey
+  Windows package manager. Run subsequent commands in a Windows PowerShell session.
+
+### Install Bolt
+
+Run `gem install bolt`. Then get started with `bolt --help`.


### PR DESCRIPTION
Highlight packages as the primary install method, with installing from
gem available as a last option.