### PR TITLE
(BOLT-455) Use bolt logger from puppet

### DIFF
--- a/lib/bolt/pal/logging.rb
+++ b/lib/bolt/pal/logging.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+Puppet::Util::Log.newdesttype :logging do
+  match "Logging::Logger"
+
+  # Bolt log levels don't match exactly with Puppet log levels, so we use
+  # an explicit mapping.
+  def initialize(logger)
+    @external_logger = logger
+
+    @log_level_map = {
+      debug: :debug,
+      info: :info,
+      notice: :notice,
+      warning: :warn,
+      err: :error,
+      # Nothing in Puppet actually uses alert, emerg or crit, so it's hard to say
+      # what they indicate, but they sound pretty bad.
+      alert: :error,
+      emerg: :fatal,
+      crit: :fatal
+    }
+  end
+
+  def handle(log)
+    @external_logger.send(@log_level_map[log.level], log.to_s)
+  end
+end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -18,8 +18,7 @@ describe "Bolt::CLI" do
     allow_any_instance_of(Bolt::CLI).to receive(:outputter).and_return(outputter)
     allow_any_instance_of(Bolt::CLI).to receive(:warn)
 
-    # This will turn on logging to the console by default... not ideal for tests
-    allow(Bolt::PAL).to receive(:configure_logging)
+    Logging.logger[:root].level = :info
   end
 
   def stub_file(path)
@@ -853,7 +852,8 @@ bar
                               ["facts::ruby", nil],
                               ['sample::ok', nil]])
 
-          expect(@puppet_logs.first.message).to match(/unexpected token.*params\.json/m)
+          output = @log_output.readlines.join
+          expect(output).to match(/unexpected token.*params\.json/m)
         end
       end
 
@@ -948,7 +948,7 @@ bar
                               ["puppetdb_fact"],
                               ["sample::ok"]])
 
-          expect(@puppet_logs.first.message).to match(/^Syntax error at.*single_task.pp/m)
+          expect(@log_output.readlines.join).to match(/Syntax error at.*single_task.pp/m)
         end
 
         it "plan run displays an error" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,16 +41,6 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
-  config.before :each do
-    @puppet_logs = []
-    Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(@puppet_logs))
-  end
-
-  config.after :each do
-    @puppet_logs.clear
-    Puppet::Util::Log.close_all
-  end
-
   # This will be default in future rspec, leave it on
   config.shared_context_metadata_behavior = :apply_to_host_groups
 


### PR DESCRIPTION
This adds a stub 'logging' logdestination type to Puppet that passes log
messages through to the Logging logger used by bolt. This causes
Puppet's logs to be logged alongside bolt logs, with the same format.
This also means that Puppet logs properly get logged to files in
addition to the console.

This also fixes a bug where we weren't actually logging in Puppet,
because `with_puppet_settings` was resetting the log destinations to
empty. We now reconfigure logging every time we re-initialize settings,
so that we always log.

We now use the 'debug' log level for Puppet, causing it to "log"
*everything* (which really means pass it through to the Logging logger),
allowing the Logging logger to decide which messages to actually log.