### PR TITLE
(BOLT-482) Bump puppetlabs-service to 0.3.1

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -5,7 +5,7 @@ forge "http://forge.puppetlabs.com"
 moduledir File.join(File.dirname(__FILE__), 'modules')
 
 mod 'puppetlabs-package', '0.2.0'
-mod 'puppetlabs-service', '0.2.0'
+mod 'puppetlabs-service', '0.3.1'
 mod 'puppetlabs-puppet_conf', '0.2.0'
 
 # If we don't list these modules explicitly, r10k will purge them


### PR DESCRIPTION
Brings in agentless tasks for Windows and Linux.