### PR TITLE
(BOLT-453) Improve logging to the console

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -243,6 +243,9 @@ Available options are:
         define('--format FORMAT', 'Output format to use: human or json') do |format|
           @options[:format] = format
         end
+        define('--[no-]color', 'Whether to show output in color') do |color|
+          @options[:color] = color
+        end
         define('-h', '--help', 'Display help') do |_|
           @options[:help] = true
         end

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -30,6 +30,7 @@ module Bolt
     :log,
     :modulepath,
     :puppetdb,
+    :color,
     :transport,
     :transports
   ) do
@@ -39,7 +40,8 @@ module Bolt
       transport: 'ssh',
       format: 'human',
       modulepath: [],
-      puppetdb: {}
+      puppetdb: {},
+      color: true
     }.freeze
 
     TRANSPORT_OPTIONS = %i[password run-as sudo-password extensions
@@ -129,8 +131,8 @@ module Bolt
         self[:modulepath] = data['modulepath'].split(File::PATH_SEPARATOR)
       end
 
-      %w[inventoryfile concurrency format puppetdb].each do |key|
-        if data[key]
+      %w[inventoryfile concurrency format puppetdb color].each do |key|
+        if data.key?(key)
           self[key.to_sym] = data[key]
         end
       end
@@ -150,8 +152,8 @@ module Bolt
     end
 
     def update_from_cli(options)
-      %i[concurrency transport format modulepath inventoryfile].each do |key|
-        self[key] = options[key] if options[key]
+      %i[concurrency transport format modulepath inventoryfile color].each do |key|
+        self[key] = options[key] if options.key?(key)
       end
 
       if options[:debug]

--- a/lib/bolt/logger.rb
+++ b/lib/bolt/logger.rb
@@ -16,10 +16,20 @@ module Bolt
 
       Logging.init :debug, :info, :notice, :warn, :error, :fatal, :any
 
+      Logging.color_scheme(
+        'bolt',
+        lines: {
+          notice: :green,
+          warn: :yellow,
+          error: :red,
+          fatal: %i[white on_red]
+        }
+      )
+
       root_logger = Logging.logger[:root]
       root_logger.add_appenders Logging.appenders.stderr(
         'console',
-        layout: default_layout,
+        layout: console_layout,
         level: default_level
       )
       # We set the root logger's level so that it logs everything but we do
@@ -56,8 +66,15 @@ module Bolt
       end
     end
 
+    def self.console_layout
+      Logging.layouts.pattern(
+        pattern: '%m\n',
+        color_scheme: :bolt
+      )
+    end
+
     def self.default_layout
-      @default_layout ||= Logging.layouts.pattern(
+      Logging.layouts.pattern(
         pattern: '%d %-6l %c: %m\n',
         date_pattern: '%Y-%m-%dT%H:%M:%S.%6N'
       )

--- a/lib/bolt/logger.rb
+++ b/lib/bolt/logger.rb
@@ -25,20 +25,20 @@ module Bolt
           fatal: %i[white on_red]
         }
       )
-
-      root_logger = Logging.logger[:root]
-      root_logger.add_appenders Logging.appenders.stderr(
-        'console',
-        layout: console_layout,
-        level: default_level
-      )
-      # We set the root logger's level so that it logs everything but we do
-      # limit what's actually logged in every appender individually.
-      root_logger.level = :all
     end
 
     def self.configure(config)
       root_logger = Logging.logger[:root]
+
+      root_logger.add_appenders Logging.appenders.stderr(
+        'console',
+        layout: console_layout(config[:color]),
+        level: default_level
+      )
+
+      # We set the root logger's level so that it logs everything but we do
+      # limit what's actually logged in every appender individually.
+      root_logger.level = :all
 
       config[:log].each_pair do |name, params|
         appender = Logging.appenders[name]
@@ -66,10 +66,11 @@ module Bolt
       end
     end
 
-    def self.console_layout
+    def self.console_layout(color)
+      color_scheme = :bolt if color
       Logging.layouts.pattern(
         pattern: '%m\n',
-        color_scheme: :bolt
+        color_scheme: color_scheme
       )
     end
 

--- a/pre-docs/bolt_configuration_options.md
+++ b/pre-docs/bolt_configuration_options.md
@@ -29,6 +29,7 @@ directories seperated by the OS specific file path seperator.
 `inventoryfile`: The path to a structured data inventory file used to refer to
 groups of nodes on the commandline and from plans.
 
+`color`: Whether to use colored output when printing messages to the console.
 
 ## SSH transport configuration options
 

--- a/pre-docs/bolt_options.md
+++ b/pre-docs/bolt_options.md
@@ -234,6 +234,7 @@ Options are optional unless marked as required.
 ||
 | Display |
 | `--format` | Output format to use: human or json |
+| `--[no-]color` | Whether to show output in color |
 | `--help, -h` | Displays help for the bolt command. |
 | `--verbose` | Display verbose logging |
 | `--debug` | Display debug logging |

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -18,6 +18,9 @@ describe "Bolt::CLI" do
     allow_any_instance_of(Bolt::CLI).to receive(:outputter).and_return(outputter)
     allow_any_instance_of(Bolt::CLI).to receive(:warn)
 
+    # Don't allow tests to override the captured log config
+    allow(Bolt::Logger).to receive(:configure)
+
     Logging.logger[:root].level = :info
   end
 
@@ -344,12 +347,11 @@ bar
     end
 
     describe "console log level" do
-      let(:console_log) { Logging.appenders['console'] }
-      after(:each) { console_log.level = :notice }
       it "is not sensitive to ordering of debug and verbose" do
+        expect(Bolt::Logger).to receive(:configure).with(have_attributes(log: { 'console' => { level: :debug } }))
+
         cli = Bolt::CLI.new(%w[command run --nodes foo --debug --verbose])
         cli.parse
-        expect(console_log.level).to eq(Logging.level_num(:debug))
       end
     end
 

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -375,7 +375,7 @@ describe "Bolt::Executor" do
       executor.run_command(targets, command)
 
       expect(@log_output.readline).to match(/NOTICE.*Starting: command '.*' on .*/)
-      expect(@log_output.readline).to match(/NOTICE.*Finished: command '.*' on 2 nodes with 0 failures/)
+      expect(@log_output.readline).to match(/NOTICE.*Finished: command '.*' with 0 failures/)
     end
 
     it "logs scripts" do
@@ -389,7 +389,7 @@ describe "Bolt::Executor" do
       executor.run_script(targets, script, [])
 
       expect(@log_output.readline).to match(/NOTICE.*Starting: script .* on .*/)
-      expect(@log_output.readline).to match(/NOTICE.*Finished: script .* on 2 nodes with 0 failures/)
+      expect(@log_output.readline).to match(/NOTICE.*Finished: script .* with 0 failures/)
     end
 
     it "logs tasks" do
@@ -403,7 +403,7 @@ describe "Bolt::Executor" do
       executor.run_task(targets, mock_task(task), task_arguments)
 
       expect(@log_output.readline).to match(/NOTICE.*Starting: task service::restart on .*/)
-      expect(@log_output.readline).to match(/NOTICE.*Finished: task service::restart on 2 nodes with 0 failures/)
+      expect(@log_output.readline).to match(/NOTICE.*Finished: task service::restart with 0 failures/)
     end
 
     it "logs uploads" do
@@ -417,7 +417,7 @@ describe "Bolt::Executor" do
       executor.file_upload(targets, script, dest)
 
       expect(@log_output.readline).to match(/NOTICE.*Starting: file upload from .* to .* on .*/)
-      expect(@log_output.readline).to match(/NOTICE.*Finished: file upload from .* to .* on 2 nodes with 0 failures/)
+      expect(@log_output.readline).to match(/NOTICE.*Finished: file upload from .* to .* with 0 failures/)
     end
   end
 end

--- a/spec/integration/logging_spec.rb
+++ b/spec/integration/logging_spec.rb
@@ -46,7 +46,7 @@ describe "when logging executor activity", ssh: true do
   it 'logs with a plan that includes a description' do
     result = run_cli_json(%W[plan run #{echo_plan} description=somemessage] + config_flags)
     expect(@log_output.readline).to match(/Starting: somemessage on/)
-    expect(@log_output.readline).to match(/Finished: somemessage on/)
+    expect(@log_output.readline).to match(/Finished: somemessage/)
     expect(result[0]['result']['_output'].strip).to match(/hi there/)
   end
 

--- a/spec/lib/bolt_spec/integration.rb
+++ b/spec/lib/bolt_spec/integration.rb
@@ -11,6 +11,7 @@ module BoltSpec
       output =  StringIO.new
       outputter = Bolt::Outputter::JSON.new(output)
       allow(cli).to receive(:outputter).and_return(outputter)
+      allow(Bolt::Logger).to receive(:configure)
 
       opts = cli.parse
 


### PR DESCRIPTION
Previously, we used a fairly overbearing log format for the console,
including the complete ISO-8601 date time with microsecond-precision, the
name of the class doing the logging, and the log level. We now print only
the message itself, excluding the timestamp, logger name and the log level.

We now use colors to indicate the log level on the console, with red
representing errors, yellow for warnings, green for notices and the rest
uncolored.

Because the context can sometimes be useful, we continue to include it in
the log format we use for log files. We also exclude colors for log files.

To make up for the lack of timestamps, we now include a duration in the
"finished" message for every step.

We also now only list the nodes targeted by an action if there are 5 or
fewer; otherwise we just show a count. Because start and finish messages
are directly correlated, we also no longer repeat the node count in the
finished message.

This adds a `color` option to the config file to toggle color on and off as
well as a `--[no-]color` command line flag.