### PR TITLE
(BOLT-372) Send information to orchestrator when running a plan

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -39,43 +39,44 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
     # The perspective of the environment is wanted here (for now) to not have to
     # require modules to have dependencies defined in meta data.
     loader = loaders.private_environment_loader
-    if loader && (func = loader.load(:plan, plan_name))
-      # TODO: Add profiling around this
-      if (run_as = named_args['_run_as'])
-        old_run_as = executor.run_as
-        executor.run_as = run_as
-      end
 
-      begin
-        # If the plan does not throw :return by calling the return function it's result is
-        # undef/nil
-        result = catch(:return) do
-          func.class.dispatcher.dispatchers[0].call_by_name_with_scope(scope, params, true)
-          nil
-        end&.value
-        # Validate the result is a PlanResult
-        unless Puppet::Pops::Types::TypeParser.singleton.parse('Boltlib::PlanResult').instance?(result)
-          raise Bolt::InvalidPlanResult.new(plan_name, result.to_s)
-        end
-        result
-      rescue Puppet::PreformattedError => err
-        if named_args['_catch_errors'] && err.cause.is_a?(Bolt::Error)
-          result = err.cause.to_puppet_error
-        else
-          raise err
-        end
-      ensure
-        if run_as
-          executor.run_as = old_run_as
-        end
-      end
-
-      return result
+    # TODO: Why would we not have a private_environment_loader?
+    unless loader && (func = loader.load(:plan, plan_name))
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Puppet::Pops::Issues.issue(:UNKNOWN_PLAN) { Bolt::Error.unknown_plan(plan_name) }
+      )
     end
 
-    # Could not find plan
-    raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-      Puppet::Pops::Issues.issue(:UNKNOWN_PLAN) { Bolt::Error.unknown_plan(plan_name) }
-    )
+    # TODO: Add profiling around this
+    if (run_as = named_args['_run_as'])
+      old_run_as = executor.run_as
+      executor.run_as = run_as
+    end
+    result = nil
+    begin
+      # If the plan does not throw :return by calling the return function it's result is
+      # undef/nil
+      result = catch(:return) do
+        func.class.dispatcher.dispatchers[0].call_by_name_with_scope(scope, params, true)
+        nil
+      end&.value
+      # Validate the result is a PlanResult
+      unless Puppet::Pops::Types::TypeParser.singleton.parse('Boltlib::PlanResult').instance?(result)
+        raise Bolt::InvalidPlanResult.new(plan_name, result.to_s)
+      end
+      result
+    rescue Puppet::PreformattedError => err
+      if named_args['_catch_errors'] && err.cause.is_a?(Bolt::Error)
+        result = err.cause.to_puppet_error
+      else
+        raise err
+      end
+    ensure
+      if run_as
+        executor.run_as = old_run_as
+      end
+    end
+
+    result
   end
 end

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "logging", "~> 2.2"
   spec.add_dependency "net-scp", "~> 1.2"
   spec.add_dependency "net-ssh", "~> 4.2"
-  spec.add_dependency "orchestrator_client", "~> 0.2"
+  spec.add_dependency "orchestrator_client", "~> 0.2.4"
   spec.add_dependency "terminal-table", "~> 1.8"
   spec.add_dependency "winrm", "~> 2.0"
   spec.add_dependency "winrm-fs", "~> 1.1"

--- a/lib/bolt/error.rb
+++ b/lib/bolt/error.rb
@@ -65,10 +65,6 @@ module Bolt
   end
 
   class PuppetError < Error
-    def self.convert_puppet_errors(result)
-      Bolt::Util.walk_vals(result) { |v| v.is_a?(Puppet::DataTypes::Error) ? from_error(v) : v }
-    end
-
     def self.from_error(err)
       new(err.msg, err.kind, err.details, err.issue_code)
     end

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -2,6 +2,7 @@
 
 require 'bolt/executor'
 require 'bolt/error'
+require 'bolt/plan_result'
 
 module Bolt
   class PAL
@@ -235,8 +236,10 @@ module Bolt
     def run_plan(plan_name, params, executor = nil, inventory = nil, pdb_client = nil)
       in_plan_compiler(executor, inventory, pdb_client) do |compiler|
         r = compiler.call_function('run_plan', plan_name, params)
-        Bolt::PuppetError.convert_puppet_errors(r)
+        Bolt::PlanResult.from_pcore(r, 'success')
       end
+    rescue Bolt::Error => e
+      Bolt::PlanResult.new(e, 'failure')
     end
   end
 end

--- a/lib/bolt/plan_result.rb
+++ b/lib/bolt/plan_result.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'bolt/error'
+require 'bolt/util'
+
+module Bolt
+  class PlanResult
+    attr_accessor :value, :status
+
+    # This must be called from inside a compiler
+    def self.from_pcore(result, status)
+      result = Bolt::Util.walk_vals(result) do |v|
+        if v.is_a?(Puppet::DataTypes::Error)
+          Bolt::PuppetError.from_error(v)
+        else
+          v
+        end
+      end
+      new(result, status)
+    end
+
+    def initialize(value, status)
+      @value = value
+      @status = status
+    end
+
+    def ok?
+      @status == 'success'
+    end
+
+    def ==(other)
+      value == other.value && status == other.status
+    end
+
+    def to_json(*args)
+      @value.to_json(*args)
+    end
+  end
+end

--- a/lib/bolt/transport/orch/connection.rb
+++ b/lib/bolt/transport/orch/connection.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Bolt
+  module Transport
+    class Orch < Base
+      class Connection
+        attr_reader :logger, :key
+
+        CONTEXT_KEYS = Set.new(%i[plan_name description params]).freeze
+
+        def self.get_key(opts)
+          [
+            opts['service-url'],
+            opts['task-environment'],
+            opts['token-file']
+          ].join('-')
+        end
+
+        def initialize(opts, plan_context, logger)
+          @logger = logger
+          @key = self.class.get_key(opts)
+          client_keys = %w[service-url token-file cacert]
+          client_opts = client_keys.each_with_object({}) do |k, acc|
+            acc[k] = opts[k] if opts.include?(k)
+          end
+          logger.debug("Creating orchestrator client for #{client_opts}")
+
+          @client = OrchestratorClient.new(client_opts, true)
+          @plan_job = start_plan(plan_context)
+
+          @environment = opts["task-environment"]
+        end
+
+        def start_plan(plan_context)
+          if plan_context
+            begin
+              opts = plan_context.select { |k, _| CONTEXT_KEYS.include? k }
+              @client.command.plan_start(opts)['name']
+            rescue OrchestratorClient::ApiError => e
+              if e.code == '404'
+                @logger.debug("Orchestrator #{key} does not support plans")
+              else
+                @logger.error("Failed to start a plan with orchestrator #{key}: #{e.message}")
+              end
+              nil
+            end
+          end
+        end
+
+        def finish_plan(plan_result)
+          if @plan_job
+            @client.command.plan_finish(
+              plan_job: @plan_job,
+              result: plan_result.value,
+              status: plan_result.status
+            )
+          end
+        end
+
+        def build_request(targets, task, arguments, description = nil)
+          body = { task: task.name,
+                   environment: @environment,
+                   noop: arguments['_noop'],
+                   params: arguments.reject { |k, _| k == '_noop' },
+                   scope: {
+                     nodes: targets.map(&:host)
+                   } }
+          body[:description] = description if description
+          body[:plan_job] = @plan_job if @plan_job
+          body
+        end
+
+        def run_task(targets, task, arguments, options)
+          body = build_request(targets, task, arguments, options['_description'])
+          @client.run_task(body)
+        end
+      end
+    end
+  end
+end

--- a/modules/aggregate/spec/plans/count_spec.rb
+++ b/modules/aggregate/spec/plans/count_spec.rb
@@ -9,7 +9,7 @@ describe 'aggregate::count' do
   it 'counts the same value' do
     expect_task('test_task').always_return('key1' => 'val', 'key2' => 'val')
     result = run_plan('aggregate::count', 'nodes' => "foo,bar", "task" => "test_task")
-    expect(result).to eq('key1' => { 'val' => 2 }, 'key2' => { 'val' => 2 })
+    expect(result.value).to eq('key1' => { 'val' => 2 }, 'key2' => { 'val' => 2 })
   end
 
   it 'passes params' do
@@ -18,6 +18,6 @@ describe 'aggregate::count' do
     result = run_plan('aggregate::count', 'nodes' => "foo",
                                           "task" => "test_task",
                                           'params' => params)
-    expect(result).to eq({})
+    expect(result.value).to eq({})
   end
 end

--- a/modules/aggregate/spec/plans/node_spec.rb
+++ b/modules/aggregate/spec/plans/node_spec.rb
@@ -10,7 +10,8 @@ describe 'aggregate::nodes' do
     expect_task('test_task').return_for_targets('node1' => { 'key1' => 'val', 'key2' => 'val' },
                                                 'node2' => { 'key1' => 'val1', 'key2' => 'val' })
     result = run_plan('aggregate::nodes', 'nodes' => "node1,node2", "task" => "test_task")
-    expect(result).to eq('key1' => { 'val' => ['node1'], 'val1' => ['node2'] }, 'key2' => { 'val' => %w[node1 node2] })
+    expect(result.value).to eq('key1' => { 'val' => ['node1'], 'val1' => ['node2'] },
+                               'key2' => { 'val' => %w[node1 node2] })
   end
 
   it 'passes params' do
@@ -19,6 +20,6 @@ describe 'aggregate::nodes' do
     result = run_plan('aggregate::nodes', 'nodes' => "foo",
                                           "task" => "test_task",
                                           'params' => params)
-    expect(result).to eq({})
+    expect(result.value).to eq({})
   end
 end

--- a/modules/canary/spec/plans/init_spec.rb
+++ b/modules/canary/spec/plans/init_spec.rb
@@ -14,7 +14,7 @@ describe 'canary' do
   it 'skips targets after a failure' do
     allow_task('test_task').be_called_times(1).error_with('kind' => 'task-failed', 'msg' => 'oops')
     result = run_plan('canary', 'nodes' => 'foo,bar,baz', 'task' => 'test_task')
-    kinds = result.map { |r| r.error_hash['kind'] }.sort
+    kinds = result.value.map { |r| r.error_hash['kind'] }.sort
     expect(kinds).to eq(["canary/skipped-node", "canary/skipped-node", "task-failed"])
   end
 end

--- a/modules/facts/spec/plans/info_spec.rb
+++ b/modules/facts/spec/plans/info_spec.rb
@@ -12,13 +12,13 @@ describe 'facts::info' do
     it 'contains OS information for target' do
       expect_task('facts::bash').always_return('os' => { 'name' => 'unix', 'family' => 'unix', 'release' => {} })
 
-      expect(run_plan('facts::info', 'nodes' => [node])).to eq(["#{node}: unix  (unix)"])
+      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq(["#{node}: unix  (unix)"])
     end
 
     it 'omits failed targets' do
       expect_task('facts::bash').always_return('_error' => { 'msg' => "Failed on #{node}" })
 
-      expect(run_plan('facts::info', 'nodes' => [node])).to eq([])
+      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq([])
     end
   end
 
@@ -28,13 +28,13 @@ describe 'facts::info' do
     it 'contains OS information for target' do
       expect_task('facts::powershell').always_return('os' => { 'name' => 'win', 'family' => 'win', 'release' => {} })
 
-      expect(run_plan('facts::info', 'nodes' => [node])).to eq(["#{node}: win  (win)"])
+      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq(["#{node}: win  (win)"])
     end
 
     it 'omits failed targets' do
       expect_task('facts::powershell').always_return('_error' => { 'msg' => "Failed on #{node}" })
 
-      expect(run_plan('facts::info', 'nodes' => [node])).to eq([])
+      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq([])
     end
   end
 
@@ -44,13 +44,13 @@ describe 'facts::info' do
     it 'contains OS information for target' do
       expect_task('facts::ruby').always_return('os' => { 'name' => 'any', 'family' => 'any', 'release' => {} })
 
-      expect(run_plan('facts::info', 'nodes' => [node])).to eq(["#{node}: any  (any)"])
+      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq(["#{node}: any  (any)"])
     end
 
     it 'omits failed targets' do
       expect_task('facts::ruby').always_return('_error' => { 'msg' => "Failed on #{node}" })
 
-      expect(run_plan('facts::info', 'nodes' => [node])).to eq([])
+      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq([])
     end
   end
 
@@ -60,13 +60,13 @@ describe 'facts::info' do
     it 'contains OS information for target' do
       expect_task('facts::bash').always_return('os' => { 'name' => 'any', 'family' => 'any', 'release' => {} })
 
-      expect(run_plan('facts::info', 'nodes' => [node])).to eq(["#{node}: any  (any)"])
+      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq(["#{node}: any  (any)"])
     end
 
     it 'omits failed targets' do
       expect_task('facts::bash').always_return('_error' => { 'msg' => "Failed on #{node}" })
 
-      expect(run_plan('facts::info', 'nodes' => [node])).to eq([])
+      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq([])
     end
   end
 
@@ -82,7 +82,7 @@ describe 'facts::info' do
         expect_task(task).return_for_targets(node => result)
       end
 
-      expect(run_plan('facts::info', 'nodes' => nodes)).to eq(
+      expect(run_plan('facts::info', 'nodes' => nodes).value).to eq(
         ["#{nodes[0]}: unix  (unix)", "#{nodes[1]}: win  (win)", "#{nodes[2]}: any  (any)"]
       )
     end
@@ -92,7 +92,7 @@ describe 'facts::info' do
         expect_task(fact).return_for_targets(node => { '_error' => { 'msg' => "Failed on #{node}" } })
       end
 
-      expect(run_plan('facts::info', 'nodes' => nodes)).to eq([])
+      expect(run_plan('facts::info', 'nodes' => nodes).value).to eq([])
     end
   end
 end

--- a/modules/facts/spec/plans/init_spec.rb
+++ b/modules/facts/spec/plans/init_spec.rb
@@ -28,14 +28,14 @@ describe 'facts' do
       expect_task('facts::bash').always_return(fact_output)
       inventory.expects(:add_facts).with(target, fact_output)
 
-      expect(run_plan('facts', 'nodes' => [node])).to eq(results(fact_output))
+      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(fact_output))
     end
 
     it 'omits failed targets' do
       expect_task('facts::bash').always_return(err_output)
       inventory.expects(:add_facts).never
 
-      expect(run_plan('facts', 'nodes' => [node])).to eq(results(err_output))
+      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(err_output))
     end
   end
 
@@ -46,14 +46,14 @@ describe 'facts' do
       expect_task('facts::powershell').always_return(fact_output)
       inventory.expects(:add_facts).with(target, fact_output)
 
-      expect(run_plan('facts', 'nodes' => [node])).to eq(results(fact_output))
+      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(fact_output))
     end
 
     it 'omits failed targets' do
       expect_task('facts::powershell').always_return(err_output)
       inventory.expects(:add_facts).never
 
-      expect(run_plan('facts', 'nodes' => [node])).to eq(results(err_output))
+      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(err_output))
     end
   end
 
@@ -64,14 +64,14 @@ describe 'facts' do
       expect_task('facts::ruby').always_return(fact_output)
       inventory.expects(:add_facts).with(target, fact_output)
 
-      expect(run_plan('facts', 'nodes' => [node])).to eq(results(fact_output))
+      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(fact_output))
     end
 
     it 'omits failed targets' do
       expect_task('facts::ruby').always_return(err_output)
       inventory.expects(:add_facts).never
 
-      expect(run_plan('facts', 'nodes' => [node])).to eq(results(err_output))
+      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(err_output))
     end
   end
 
@@ -82,14 +82,14 @@ describe 'facts' do
       expect_task('facts::bash').always_return(fact_output)
       inventory.expects(:add_facts).with(target, fact_output)
 
-      expect(run_plan('facts', 'nodes' => [node])).to eq(results(fact_output))
+      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(fact_output))
     end
 
     it 'omits failed targets' do
       expect_task('facts::bash').always_return(err_output)
       inventory.expects(:add_facts).never
 
-      expect(run_plan('facts', 'nodes' => [node])).to eq(results(err_output))
+      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(err_output))
     end
   end
 
@@ -105,7 +105,7 @@ describe 'facts' do
       result_set = Bolt::ResultSet.new(
         nodes.map { |node| Bolt::Result.new(Bolt::Target.new(node), value: fact_output(node)) }
       )
-      expect(run_plan('facts', 'nodes' => nodes)).to eq(result_set)
+      expect(run_plan('facts', 'nodes' => nodes).value).to eq(result_set)
     end
 
     it 'omits failed targets' do
@@ -117,7 +117,7 @@ describe 'facts' do
       result_set = Bolt::ResultSet.new(
         nodes.map { |node| Bolt::Result.new(Bolt::Target.new(node), value: err_output(node)) }
       )
-      expect(run_plan('facts', 'nodes' => nodes)).to eq(result_set)
+      expect(run_plan('facts', 'nodes' => nodes).value).to eq(result_set)
     end
   end
 end

--- a/modules/facts/spec/plans/retrieve_spec.rb
+++ b/modules/facts/spec/plans/retrieve_spec.rb
@@ -27,13 +27,13 @@ describe 'facts::retrieve' do
     it 'retrieves facts' do
       expect_task('facts::bash').always_return(fact_output)
 
-      expect(run_plan('facts::retrieve', 'nodes' => [node])).to eq(results(fact_output))
+      expect(run_plan('facts::retrieve', 'nodes' => [node]).value).to eq(results(fact_output))
     end
 
     it 'omits failed targets' do
       expect_task('facts::bash').always_return(err_output)
 
-      expect(run_plan('facts', 'nodes' => [node])).to eq(results(err_output))
+      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(err_output))
     end
   end
 
@@ -43,13 +43,13 @@ describe 'facts::retrieve' do
     it 'retrieves facts' do
       expect_task('facts::powershell').always_return(fact_output)
 
-      expect(run_plan('facts::retrieve', 'nodes' => [node])).to eq(results(fact_output))
+      expect(run_plan('facts::retrieve', 'nodes' => [node]).value).to eq(results(fact_output))
     end
 
     it 'omits failed targets' do
       expect_task('facts::powershell').always_return(err_output)
 
-      expect(run_plan('facts', 'nodes' => [node])).to eq(results(err_output))
+      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(err_output))
     end
   end
 
@@ -59,13 +59,13 @@ describe 'facts::retrieve' do
     it 'retrieves facts' do
       expect_task('facts::ruby').always_return(fact_output)
 
-      expect(run_plan('facts::retrieve', 'nodes' => [node])).to eq(results(fact_output))
+      expect(run_plan('facts::retrieve', 'nodes' => [node]).value).to eq(results(fact_output))
     end
 
     it 'omits failed targets' do
       expect_task('facts::ruby').always_return(err_output)
 
-      expect(run_plan('facts', 'nodes' => [node])).to eq(results(err_output))
+      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(err_output))
     end
   end
 
@@ -75,13 +75,13 @@ describe 'facts::retrieve' do
     it 'retrieves facts' do
       expect_task('facts::bash').always_return(fact_output)
 
-      expect(run_plan('facts::retrieve', 'nodes' => [node])).to eq(results(fact_output))
+      expect(run_plan('facts::retrieve', 'nodes' => [node]).value).to eq(results(fact_output))
     end
 
     it 'omits failed targets' do
       expect_task('facts::bash').always_return(err_output)
 
-      expect(run_plan('facts::retrieve', 'nodes' => [node])).to eq(results(err_output))
+      expect(run_plan('facts::retrieve', 'nodes' => [node]).value).to eq(results(err_output))
     end
   end
 
@@ -96,7 +96,7 @@ describe 'facts::retrieve' do
       result_set = Bolt::ResultSet.new(
         nodes.map { |node| Bolt::Result.new(Bolt::Target.new(node), value: fact_output(node)) }
       )
-      expect(run_plan('facts::retrieve', 'nodes' => nodes)).to eq(result_set)
+      expect(run_plan('facts::retrieve', 'nodes' => nodes).value).to eq(result_set)
     end
 
     it 'omits failed targets' do
@@ -107,7 +107,7 @@ describe 'facts::retrieve' do
       result_set = Bolt::ResultSet.new(
         nodes.map { |node| Bolt::Result.new(Bolt::Target.new(node), value: err_output(node)) }
       )
-      expect(run_plan('facts::retrieve', 'nodes' => nodes)).to eq(result_set)
+      expect(run_plan('facts::retrieve', 'nodes' => nodes).value).to eq(result_set)
     end
   end
 end

--- a/modules/puppetdb_fact/spec/plans/init_spec.rb
+++ b/modules/puppetdb_fact/spec/plans/init_spec.rb
@@ -18,7 +18,7 @@ describe 'puppetdb_fact' do
   it 'returns facts from PuppetDB' do
     puppetdb_client.expects(:facts_for_node).with(facts.keys).returns(facts)
     result = run_plan('puppetdb_fact', 'nodes' => facts.keys)
-    expect(result).to eq(facts)
+    expect(result).to eq(Bolt::PlanResult.new(facts, 'success'))
   end
 
   it 'adds facts to Targets' do
@@ -32,6 +32,6 @@ describe 'puppetdb_fact' do
   it 'returns an empty hash for an empty list' do
     puppetdb_client.expects(:facts_for_node).with([]).returns({})
     result = run_plan('puppetdb_fact', 'nodes' => [])
-    expect(result).to eq({})
+    expect(result).to eq(Bolt::PlanResult.new({}, 'success'))
   end
 end

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -354,8 +354,9 @@ describe "Bolt::Executor" do
   end
 
   context "When running a plan" do
-    let(:executor) { Bolt::Executor.new(config, nil, true) }
+    let(:executor) { Bolt::Executor.new(config, nil) }
     let(:nodes_string) { results.map(&:first).map(&:uri) }
+    let(:plan_context) { { name: 'foo' } }
 
     before :all do
       @log_output.level = :notice
@@ -372,6 +373,7 @@ describe "Bolt::Executor" do
           .and_return(result)
       end
 
+      executor.start_plan(plan_context)
       executor.run_command(targets, command)
 
       expect(@log_output.readline).to match(/NOTICE.*Starting: command '.*' on .*/)
@@ -386,6 +388,7 @@ describe "Bolt::Executor" do
           .and_return(result)
       end
 
+      executor.start_plan(plan_context)
       executor.run_script(targets, script, [])
 
       expect(@log_output.readline).to match(/NOTICE.*Starting: script .* on .*/)
@@ -400,6 +403,7 @@ describe "Bolt::Executor" do
           .and_return(result)
       end
 
+      executor.start_plan(plan_context)
       executor.run_task(targets, mock_task(task), task_arguments)
 
       expect(@log_output.readline).to match(/NOTICE.*Starting: task service::restart on .*/)
@@ -414,6 +418,7 @@ describe "Bolt::Executor" do
           .and_return(result)
       end
 
+      executor.start_plan(plan_context)
       executor.file_upload(targets, script, dest)
 
       expect(@log_output.readline).to match(/NOTICE.*Starting: file upload from .* to .* on .*/)

--- a/spec/lib/bolt_spec/plans.rb
+++ b/spec/lib/bolt_spec/plans.rb
@@ -110,20 +110,16 @@ module BoltSpec
       @puppetdb_client ||= mock('puppetdb_client')
     end
 
-    # TODO: handle expected plan failures
     def run_plan(name, params)
       pal = Bolt::PAL.new(config)
-      begin
-        result = pal.run_plan(name, params, executor, inventory, puppetdb_client)
-      rescue Bolt::CLIError => e
-        if executor.error_message
-          raise executor.error_message
-        else
-          raise e
-        end
+      result = pal.run_plan(name, params, executor, inventory, puppetdb_client)
+
+      if executor.error_message
+        raise executor.error_message
       end
 
       executor.assert_call_expectations
+
       result
     end
 


### PR DESCRIPTION
When a plan is run the orchestrator transport will send the plan_start
command the first time a task runs on a node through that orchestrator.
Every task will be run with the plan_task command instead of the task
command and before exiting bolt will send a plan_finish command with the
result to each orchestrator that was used during the plan.