### PR TITLE
(BOLT-460) Include Puppet facts in facts module

### DIFF
--- a/modules/facts/tasks/bash.sh
+++ b/modules/facts/tasks/bash.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Delegate to facter if available
-command -v facter > /dev/null 2>&1 && exec facter --json
+command -v facter > /dev/null 2>&1 && exec facter -p --json
 
 minor () {
     minor="${*#*.}"

--- a/modules/facts/tasks/powershell.ps1
+++ b/modules/facts/tasks/powershell.ps1
@@ -2,7 +2,7 @@
 
 # Delegate to facter if available
 if (Get-Command facter -ErrorAction SilentlyContinue) {
-    facter --json
+    facter -p --json
 }
 else {
     # The number 2 in the condition below is the value of

--- a/modules/facts/tasks/ruby.rb
+++ b/modules/facts/tasks/ruby.rb
@@ -15,4 +15,4 @@ def facter_executable
 end
 
 # Delegate to facter
-exec(facter_executable, '--json')
+exec(facter_executable, '-p', '--json')


### PR DESCRIPTION
The facter_task module does this, and is a frequent request whenever we
do something that doesn't include Puppet facts.