### PR TITLE
(maint) Update test defaults to work for test:git

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -5,9 +5,9 @@ require 'rototiller'
 desc "Generate Beaker Host config"
 rototiller_task :host_config do |task|
   unless ENV['BEAKER_HOSTS']
-    task.add_env(name: 'BOLT_CONTROLLER', default: 'centos7-64')
+    task.add_env(name: 'BOLT_CONTROLLER', default: 'debian9-64')
     task.add_env(name: 'BOLT_NODES',
-                 default: 'ubuntu1604-64,osx1012-64,windows10ent-64')
+                 default: 'centos7-64,osx1012-64,windows10ent-64')
     ns = [ENV['BOLT_CONTROLLER'], ENV['BOLT_NODES']].join(',')
     n  = ns.split(',')
     n_new = []


### PR DESCRIPTION
Use default test platforms that work with `test:git` and `test:gem`.
CentOS 7's Ruby is too old to be the default controller.