### PR TITLE
(BOLT-505) pass -E to sudo when using environment variable params

### DIFF
--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -188,7 +188,9 @@ module Bolt
 
           command_str = command.is_a?(String) ? command : Shellwords.shelljoin(command)
           if use_sudo
-            sudo_str = Shellwords.shelljoin(["sudo", "-S", "-u", run_as, "-p", sudo_prompt])
+            sudo_flags = ["sudo", "-S", "-u", run_as, "-p", sudo_prompt]
+            sudo_flags += ["-E"] if options[:environment]
+            sudo_str = Shellwords.shelljoin(sudo_flags)
             command_str = "#{sudo_str} #{command_str}"
           end
 

--- a/pre-docs/writing_tasks.md
+++ b/pre-docs/writing_tasks.md
@@ -410,6 +410,9 @@ end
 exit exitcode
 ```
 
+If your task accepts input on stdin it should specify `"input_method": "stdin"`
+in its metadata.json or it may not work with sudo for some users.
+
 ### Returning structured output
 
 To return structured data from your task, print only a single JSON object to

--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -423,6 +423,15 @@ SHELL
       end
     end
 
+    it "can run a task passing input with environment vars", ssh: true do
+      contents = "#!/bin/sh\necho -n ${PT_message_one} then ${PT_message_two}"
+      arguments = { message_one: 'Hello from task', message_two: 'Goodbye' }
+      with_task_containing('tasks_test', contents, 'environment') do |task|
+        expect(ssh.run_task(target, task, arguments).message)
+          .to eq('Hello from task then Goodbye')
+      end
+    end
+
     it "can upload a file as root", ssh: true do
       contents = "upload file test as root content"
       dest = '/tmp/root-file-upload-test'


### PR DESCRIPTION
This may result in tasks that do not specify input method and accept
stdin not causing a permission error when run with sudo if the user
does not have the appropriate permissions. That is preferable to running
with no environment variables set.
1. Users who don't specify input method are more likely to use
environment variables
2. Running with unset environment variables may be dangerous if the task
author was relying on parameter validation.