### PR TITLE
(BOLT-451) Fix naming for `without_default_logging`

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/without_default_logging.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/without_default_logging.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-Puppet::Functions.create_function(:without_plan_logging) do
-  dispatch :without_plan_logging do
+Puppet::Functions.create_function(:without_default_logging) do
+  dispatch :without_default_logging do
     block_param 'Callable[0, 0]', :block
   end
 
-  def without_plan_logging(&block)
+  def without_default_logging(&block)
     executor = Puppet.lookup(:bolt_executor) { nil }
     old_log = executor.plan_logging
     executor.plan_logging = false

--- a/spec/fixtures/modules/logging/plans/without_default.pp
+++ b/spec/fixtures/modules/logging/plans/without_default.pp
@@ -2,7 +2,7 @@ plan logging::without_default(
   TargetSpec       $nodes,
   Optional[String] $description = undef,
 ) {
-  without_plan_logging() || {
+  without_default_logging() || {
     run_task("logging::echo", $nodes, message => "hi there", _catch_errors => true)
   }
 }


### PR DESCRIPTION
The functionality was implemented as `without_plan_logging`, but
original plan was to use `without_default_logging`. Update names to
`without_default_logging`.