### PR TITLE
make travis fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,18 @@ before_script:
 - docker-compose build && docker-compose up -d
 
 script:
-- bundle exec rake travisci rubocop
+- bundle exec rake travisci
+- bundle exec rubocop
 - |
+  status=0
   pushd bolt-modules/boltlib
   if ! bundle exec rake spec; then
-    exit 1
+    status=1
   fi
   popd
+  if [ $status -eq 1 ]; then
+    false
+  fi
 - |
   status=0
   for i in $( ls modules ); do
@@ -26,7 +31,10 @@ script:
     fi
     popd
   done
-  exit $status
+  # fail this step if there were any failures
+  if [ $status -eq 1 ]; then
+    false
+  fi
 notifications:
   email: false
   hipchat:

--- a/bolt-modules/boltlib/lib/puppet/functions/without_default_logging.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/without_default_logging.rb
@@ -5,12 +5,12 @@ Puppet::Functions.create_function(:without_default_logging) do
     block_param 'Callable[0, 0]', :block
   end
 
-  def without_default_logging(&block)
+  def without_default_logging
     executor = Puppet.lookup(:bolt_executor) { nil }
     old_log = executor.plan_logging
     executor.plan_logging = false
     begin
-      block.call
+      yield
     ensure
       executor.plan_logging = old_log
     end

--- a/spec/integration/logging_spec.rb
+++ b/spec/integration/logging_spec.rb
@@ -102,6 +102,5 @@ describe "when logging executor activity", ssh: true do
       expect(@log_output.readline).to match(/hi there/)
       expect(@log_output.readline).to match(/Finished: task logging::echo/)
     end
-
   end
 end


### PR DESCRIPTION
Steps in the script section of .travis.yml are not executed as scripts themselves so calling exit in them halts the entire "script" section and masks any other failures.