### PR TITLE
(BOLT-484) Allow transport to be set in the config file

### DIFF
--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -131,7 +131,7 @@ module Bolt
         self[:modulepath] = data['modulepath'].split(File::PATH_SEPARATOR)
       end
 
-      %w[inventoryfile concurrency format puppetdb color].each do |key|
+      %w[inventoryfile concurrency format puppetdb color transport].each do |key|
         if data.key?(key)
           self[key.to_sym] = data[key]
         end


### PR DESCRIPTION
Previously, setting `transport` in the config file did nothing. Now it
can be used to set the default transport, which is useful in
environments which primarily use winrm or pcp.