### PR TITLE
(BOLT-486) Plans accept targets via puppetdb

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -392,7 +392,7 @@ Available options are:
       validate(options)
 
       # After validation, initialize inventory and targets. Errors here are better to catch early.
-      unless options[:action] == 'show' || options[:mode] == 'plan'
+      unless options[:action] == 'show'
         if options[:query]
           nodes = query_puppetdb_nodes(options[:query])
           options[:targets] = inventory.get_targets(nodes)

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -589,6 +589,16 @@ bar
           cli.parse
         }.to raise_error(Bolt::CLIError, /Invalid plan/)
       end
+
+      it "accepts targets resulting from --query from puppetdb" do
+        cli = Bolt::CLI.new(%w[plan run foo --query nodes{}])
+        allow(cli).to receive(:query_puppetdb_nodes).and_return(%w[foo bar])
+
+        targets = [Bolt::Target.new('foo'), Bolt::Target.new('bar')]
+
+        result = cli.parse
+        expect(result[:targets]).to eq(targets)
+      end
     end
 
     describe "execute" do


### PR DESCRIPTION
When executing a plan, allow targets to be built from PDB query.