### PR TITLE
(BOLT-486) Plans accept targets via puppetdb

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -394,8 +394,12 @@ Available options are:
       # After validation, initialize inventory and targets. Errors here are better to catch early.
       unless options[:action] == 'show'
         if options[:query]
+          if options[:nodes].any?
+            raise Bolt::CLIError, "Only one of '--nodes' or '--query' may be specified"
+          end
           nodes = query_puppetdb_nodes(options[:query])
           options[:targets] = inventory.get_targets(nodes)
+          options[:nodes] = nodes if options[:mode] == 'plan'
         else
           options[:targets] = inventory.get_targets(options[:nodes])
         end
@@ -532,6 +536,7 @@ Available options are:
           end
           options[:task_options]['nodes'] = options[:nodes].join(',')
         end
+
         params = options[:noop] ? options[:task_options].merge("_noop" => true) : options[:task_options]
         plan_context = { plan_name: options[:object],
                          params: params }

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -592,12 +592,20 @@ bar
 
       it "accepts targets resulting from --query from puppetdb" do
         cli = Bolt::CLI.new(%w[plan run foo --query nodes{}])
-        allow(cli).to receive(:query_puppetdb_nodes).and_return(%w[foo bar])
-
+        allow(cli).to receive(:query_puppetdb_nodes).once.and_return(%w[foo bar])
         targets = [Bolt::Target.new('foo'), Bolt::Target.new('bar')]
-
         result = cli.parse
+        cli.validate(result)
+        cli.execute(result)
         expect(result[:targets]).to eq(targets)
+        expect(result[:nodes]).to eq(%w[foo bar])
+      end
+
+      it "fails when --nodes AND --query provided" do
+        expect {
+          cli = Bolt::CLI.new(%w[plan run foo --query nodes{} --nodes bar])
+          cli.parse
+        }.to raise_error(Bolt::CLIError, /'--nodes' or '--query'/)
       end
     end
 


### PR DESCRIPTION
When executing a plan, allow targets to be build from PDB query. Also ensure EITHER --nodes OR --query.