### PR TITLE
(MAINT) Corrections based on Rubocop 0.56.0

### DIFF
--- a/lib/bolt/puppetdb/client.rb
+++ b/lib/bolt/puppetdb/client.rb
@@ -42,7 +42,7 @@ module Bolt
           fields = results.first&.keys
           raise Bolt::PuppetDBError, "Query results did not contain a 'certname' field: got #{fields.join(', ')}"
         end
-        results&.map { |result| result['certname'] }.uniq
+        results&.map { |result| result['certname'] }&.uniq
       end
 
       # This method expects an array of certnames to get facts for

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -140,7 +140,7 @@ module Bolt
               dir.chown(conn.run_as)
 
               execute_options[:sudoable] = true if conn.run_as
-              output = conn.execute(command, **execute_options)
+              output = conn.execute(command, execute_options)
             end
             Bolt::Result.for_task(target, output.stdout.string,
                                   output.stderr.string,

--- a/lib/bolt/util/on_access.rb
+++ b/lib/bolt/util/on_access.rb
@@ -10,7 +10,8 @@ module Bolt
 
       # If a method is called and we haven't constructed the object,
       # construct it. Then pass the call to the object.
-      # rubocop:disable Style/MethodMissing
+      # rubocop:disable Style/MethodMissingSuper
+      # rubocop:disable Style/MissingRespondToMissing
       def method_missing(method, *args, &block)
         if @obj.nil?
           @obj = @constructor.call
@@ -18,7 +19,8 @@ module Bolt
 
         @obj.send(method, *args, &block)
       end
-      # rubocop:enable Style/MethodMissing
+      # rubocop:enable Style/MethodMissingSuper
+      # rubocop:enable Style/MissingRespondToMissing
     end
   end
 end

--- a/spec/lib/bolt_spec/integration.rb
+++ b/spec/lib/bolt_spec/integration.rb
@@ -29,7 +29,7 @@ module BoltSpec
     end
 
     def run_cli_json(arguments, **opts)
-      output = run_cli(arguments, **opts)
+      output = run_cli(arguments, opts)
 
       begin
         result = JSON.parse(output, quirks_mode: true)


### PR DESCRIPTION
- passing splat keyword args as single hash
- Style/MethodMissing was split into two separate cops
- save navigation on map