### PR TITLE
(BOLT-520) Enforce concurrency limit

### DIFF
--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -27,7 +27,7 @@ module Bolt
 
       @noop = noop
       @run_as = nil
-      @pool = Concurrent::CachedThreadPool.new(max_threads: @config[:concurrency])
+      @pool = Concurrent::ThreadPoolExecutor.new(max_threads: @config[:concurrency])
       @logger.debug { "Started with #{@config[:concurrency]} max thread(s)" }
       @notifier = Bolt::Notifier.new
     end


### PR DESCRIPTION
Initializing CachedThreadPool with max_threads does not cap concurrency as expected. Use ThreadPoolExecutor instead.