### PR TITLE
(BOLT-518) Fact task incorrect OS Family

### DIFF
--- a/modules/facts/tasks/bash.sh
+++ b/modules/facts/tasks/bash.sh
@@ -38,6 +38,13 @@ if [ -z "${name}" ]; then
         name=$(grep "^NAME" /usr/lib/os-release | cut -d'=' -f2 | sed "s/\"//g")
         release=$(grep "^VERSION_ID" /usr/lib/os-release | cut -d'=' -f2 | sed "s/\"//g")
     fi
+    if [ -n "${name}" ]; then
+        if echo "${name}" | egrep -iq "(.*red)(.*hat)"; then
+            name="RedHat"
+        elif echo "${name}" | egrep -iq "debian"; then
+            name="Debian"
+        fi
+    fi
 fi
 
 if [ -z "${name}" ]; then

--- a/modules/facts/tasks/bash.sh
+++ b/modules/facts/tasks/bash.sh
@@ -29,6 +29,17 @@ if [ -z "${name}" ]; then
     fi
 fi
 
+# if lsb not available try os-release
+if [ -z "${name}" ]; then
+    if [ -e /etc/os-release ]; then
+        name=$(grep "^NAME" /etc/os-release | cut -d'=' -f2 | sed "s/\"//g")
+        release=$(grep "^VERSION_ID" /etc/os-release | cut -d'=' -f2 | sed "s/\"//g")
+    elif [-e /usr/lib/os-release ]; then
+        name=$(grep "^NAME" /usr/lib/os-release | cut -d'=' -f2 | sed "s/\"//g")
+        release=$(grep "^VERSION_ID" /usr/lib/os-release | cut -d'=' -f2 | sed "s/\"//g")
+    fi
+fi
+
 if [ -z "${name}" ]; then
     name=$(uname)
     release=$(uname -r)

--- a/spec/integration/modules/facts_spec.rb
+++ b/spec/integration/modules/facts_spec.rb
@@ -28,8 +28,7 @@ describe "running the facts plan" do
       expect(data['status']).to eq('success')
       expect(data['result'].size).to eq(1)
       expect(data['result']['os']['name']).to be
-      # temporarily add Linux to matcher while BOLT-518 is investigated
-      expect(data['result']['os']['family']).to match(/RedHat|Debian|Linux/)
+      expect(data['result']['os']['family']).to match(/RedHat|Debian/)
       expect(data['result']['os']['release']).to be
     end
   end


### PR DESCRIPTION
Rastasheep/ubuntu-sshd no long comes with lsb_release. Use /etc/os-release to parse ubuntu facts.