### PR TITLE
(BOLT-508) Stop using CLIError outside of Bolt::CLI

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/puppetdb_fact.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/puppetdb_fact.rb
@@ -29,10 +29,6 @@ Puppet::Functions.create_function(:puppetdb_fact) do
       )
     end
 
-    begin
-      puppetdb_client.facts_for_node(certnames)
-    rescue StandardError => e
-      raise Bolt::CLIError, "Could not retrieve targets from PuppetDB: #{e}"
-    end
+    puppetdb_client.facts_for_node(certnames)
   end
 end

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -307,7 +307,7 @@ Available options are:
       def read_arg_file(file)
         File.read(file)
       rescue StandardError => err
-        raise Bolt::CLIError, "Error attempting to read #{file}: #{err}"
+        raise Bolt::FileError.new("Error attempting to read #{file}: #{err}", file)
       end
     end
 
@@ -481,8 +481,6 @@ Available options are:
 
     def query_puppetdb_nodes(query)
       puppetdb_client.query_certnames(query)
-    rescue StandardError => e
-      raise Bolt::CLIError, "Could not retrieve targets from PuppetDB: #{e}"
     end
 
     def execute(options)
@@ -618,12 +616,12 @@ Available options are:
       stat = file_stat(path)
 
       if !stat.readable?
-        raise Bolt::CLIError, "The #{type} '#{path}' is unreadable"
+        raise Bolt::FileError.new("The #{type} '#{path}' is unreadable", path)
       elsif !stat.file?
-        raise Bolt::CLIError, "The #{type} '#{path}' is not a file"
+        raise Bolt::FileError.new("The #{type} '#{path}' is not a file", path)
       end
     rescue Errno::ENOENT
-      raise Bolt::CLIError, "The #{type} '#{path}' does not exist"
+      raise Bolt::FileError.new("The #{type} '#{path}' does not exist", path)
     end
 
     def file_stat(path)

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -200,16 +200,16 @@ module Bolt
     def validate
       self[:log].each_pair do |name, params|
         if params.key?(:level) && !Bolt::Logger.valid_level?(params[:level])
-          raise Bolt::CLIError,
+          raise Bolt::ValidationError,
                 "level of log #{name} must be one of: #{Bolt::Logger.levels.join(', ')}; received #{params[:level]}"
         end
         if params.key?(:append) && params[:append] != true && params[:append] != false
-          raise Bolt::CLIError, "append flag of log #{name} must be a Boolean, received #{params[:append]}"
+          raise Bolt::ValidationError, "append flag of log #{name} must be a Boolean, received #{params[:append]}"
         end
       end
 
       unless %w[human json].include? self[:format]
-        raise Bolt::CLIError, "Unsupported format: '#{self[:format]}'"
+        raise Bolt::ValidationError, "Unsupported format: '#{self[:format]}'"
       end
 
       unless self[:transport].nil? || Bolt::TRANSPORTS.include?(self[:transport].to_sym)

--- a/lib/bolt/error.rb
+++ b/lib/bolt/error.rb
@@ -64,6 +64,7 @@ module Bolt
     end
   end
 
+  # This class is used to treat a Puppet Error datatype as a ruby error outside PAL
   class PuppetError < Error
     def self.from_error(err)
       new(err.msg, err.kind, err.details, err.issue_code)
@@ -76,6 +77,18 @@ module Bolt
             'bolt/invalid-plan-result',
             { 'plan_name' => plan_name,
               'result_string' => result_str })
+    end
+  end
+
+  class ValidationError < Bolt::Error
+    def initialize(msg)
+      super(msg, 'bolt.transport/validation-error')
+    end
+  end
+
+  class FileError < Bolt::Error
+    def initialize(msg, path)
+      super(msg, 'bolt/file-error', { "path" => path })
     end
   end
 end

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -45,7 +45,7 @@ module Bolt
         begin
           data = YAML.safe_load(ENV[ENVIRONMENT_VAR])
         rescue Psych::Exception
-          raise Bolt::CLIError, "Could not parse inventory from $#{ENVIRONMENT_VAR}"
+          raise Bolt::Error.new("Could not parse inventory from $#{ENVIRONMENT_VAR}", 'bolt/parse-error')
         end
       else
         data = Bolt::Util.read_config_file(config[:inventoryfile], default_paths, 'inventory')

--- a/lib/bolt/logger.rb
+++ b/lib/bolt/logger.rb
@@ -56,7 +56,7 @@ module Bolt
               level: default_level
             )
           rescue ArgumentError => e
-            raise Bolt::CLIError, "Failed to open log #{name}: #{e.message}"
+            raise Bolt::Error.new("Failed to open log #{name}: #{e.message}", 'bolt/log-error')
           end
 
           root_logger.add_appenders appender

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -25,7 +25,7 @@ module Bolt
       def self.validate(options)
         validation_flag = options['local-validation']
         unless !!validation_flag == validation_flag
-          raise Bolt::CLIError, 'local-validation option must be a Boolean true or false'
+          raise Bolt::ValidationError, 'local-validation option must be a Boolean true or false'
         end
       end
 

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -22,12 +22,12 @@ module Bolt
 
         host_key = options['host-key-check']
         unless !!host_key == host_key
-          raise Bolt::CLIError, 'host-key-check option must be a Boolean true or false'
+          raise Bolt::ValidationError, 'host-key-check option must be a Boolean true or false'
         end
 
         if (key_opt = options['private-key'])
           unless key_opt.instance_of?(String) || (key_opt.instance_of?(Hash) && key_opt.include?('key-data'))
-            raise Bolt::CLIError,
+            raise Bolt::ValidationError,
                   "private-key option must be the path to a private key file or a hash containing the 'key-data'"
           end
         end
@@ -35,7 +35,7 @@ module Bolt
         timeout_value = options['connect-timeout']
         unless timeout_value.is_a?(Integer) || timeout_value.nil?
           error_msg = "connect-timeout value must be an Integer, received #{timeout_value}:#{timeout_value.class}"
-          raise Bolt::CLIError, error_msg
+          raise Bolt::ValidationError, error_msg
         end
       end
 

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -16,18 +16,18 @@ module Bolt
       def self.validate(options)
         ssl_flag = options['ssl']
         unless !!ssl_flag == ssl_flag
-          raise Bolt::CLIError, 'ssl option must be a Boolean true or false'
+          raise Bolt::ValidationError, 'ssl option must be a Boolean true or false'
         end
 
         ssl_verify_flag = options['ssl-verify']
         unless !!ssl_verify_flag == ssl_verify_flag
-          raise Bolt::CLIError, 'ssl-verify option must be a Boolean true or false'
+          raise Bolt::ValidationError, 'ssl-verify option must be a Boolean true or false'
         end
 
         timeout_value = options['connect-timeout']
         unless timeout_value.is_a?(Integer) || timeout_value.nil?
           error_msg = "connect-timeout value must be an Integer, received #{timeout_value}:#{timeout_value.class}"
-          raise Bolt::CLIError, error_msg
+          raise Bolt::ValidationError, error_msg
         end
       end
 

--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -20,12 +20,12 @@ module Bolt
         File.open(path, "r:UTF-8") { |f| YAML.safe_load(f.read) }
       rescue Errno::ENOENT
         if path_passed
-          raise Bolt::CLIError, "Could not read #{file_name} file: #{path}"
+          raise Bolt::FileError.new("Could not read #{file_name} file: #{path}", path)
         end
       rescue Psych::Exception
-        raise Bolt::CLIError, "Could not parse #{file_name} file: #{path}"
+        raise Bolt::FileError.new("Could not parse #{file_name} file: #{path}", path)
       rescue IOError, SystemCallError
-        raise Bolt::CLIError, "Could not read #{file_name} file: #{path}"
+        raise Bolt::FileError.new("Could not read #{file_name} file: #{path}", path)
       end
 
       def deep_merge(hash1, hash2)

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -268,7 +268,7 @@ bar
         allow(cli).to receive(:puppetdb_client).and_return(puppetdb)
 
         expect { cli.parse }
-          .to raise_error(Bolt::CLIError, /Could not retrieve targets from PuppetDB.*failed to puppetdb the nodes/)
+          .to raise_error(Bolt::PuppetDBError, /failed to puppetdb the nodes/)
       end
 
       it "fails if both --nodes and --query are specified" do
@@ -544,7 +544,7 @@ bar
                                  --modulepath .])
           expect {
             cli.parse
-          }.to raise_error(Bolt::CLIError, /No such file/)
+          }.to raise_error(Bolt::FileError, /No such file/)
         end
       end
 
@@ -727,7 +727,7 @@ bar
           stub_non_existent_file(script)
 
           expect { cli.execute(options) }.to raise_error(
-            Bolt::CLIError, /The script '#{script}' does not exist/
+            Bolt::FileError, /The script '#{script}' does not exist/
           )
           expect(JSON.parse(output.string)).to be
         end
@@ -736,7 +736,7 @@ bar
           stub_unreadable_file(script)
 
           expect { cli.execute(options) }.to raise_error(
-            Bolt::CLIError, /The script '#{script}' is unreadable/
+            Bolt::FileError, /The script '#{script}' is unreadable/
           )
           expect(JSON.parse(output.string)).to be
         end
@@ -745,7 +745,7 @@ bar
           stub_directory(script)
 
           expect { cli.execute(options) }.to raise_error(
-            Bolt::CLIError, /The script '#{script}' is not a file/
+            Bolt::FileError, /The script '#{script}' is not a file/
           )
           expect(JSON.parse(output.string)).to be
         end
@@ -891,7 +891,7 @@ bar
           expect {
             cli.execute(options)
           }.to raise_error(
-            Bolt::CLIError,
+            Bolt::Error,
             'Could not find a task named "abcdefg". For a list of available tasks, run "bolt task show"'
           )
         end
@@ -1000,7 +1000,7 @@ bar
           expect {
             cli.execute(options)
           }.to raise_error(
-            Bolt::CLIError,
+            Bolt::Error,
             'Could not find a plan named "abcdefg". For a list of available plans, run "bolt plan show"'
           )
         end
@@ -1050,7 +1050,7 @@ bar
           task_name.replace 'dne::task1'
 
           expect { cli.execute(options) }.to raise_error(
-            Bolt::CLIError, /Could not find a task named "dne::task1"/
+            Bolt::PAL::PALError, /Could not find a task named "dne::task1"/
           )
           expect(JSON.parse(output.string)).to be
         end
@@ -1059,7 +1059,7 @@ bar
           task_name.replace 'sample::dne'
 
           expect { cli.execute(options) }.to raise_error(
-            Bolt::CLIError, /Could not find a task named "sample::dne"/
+            Bolt::PAL::PALError, /Could not find a task named "sample::dne"/
           )
           expect(JSON.parse(output.string)).to be
         end
@@ -1149,7 +1149,7 @@ bar
             )
 
             expect { cli.execute(options) }.to raise_error(
-              Bolt::CLIError,
+              Bolt::PAL::PALError,
               /Task sample::params:\n(?x:
                )\s*has no parameter named 'foo'\n(?x:
                )\s*has no parameter named 'bar'/
@@ -1161,7 +1161,7 @@ bar
             task_params['mandatory_string'] = 'str'
 
             expect { cli.execute(options) }.to raise_error(
-              Bolt::CLIError,
+              Bolt::PAL::PALError,
               /Task sample::params:\n(?x:
                )\s*expects a value for parameter 'mandatory_integer'\n(?x:
                )\s*expects a value for parameter 'mandatory_boolean'/
@@ -1179,7 +1179,7 @@ bar
             )
 
             expect { cli.execute(options) }.to raise_error(
-              Bolt::CLIError,
+              Bolt::PAL::PALError,
               /Task sample::params:\n(?x:
                )\s*parameter 'mandatory_boolean' expects a Boolean value, got String\n(?x:
                )\s*parameter 'optional_string' expects a value of type Undef or String,(?x:
@@ -1198,7 +1198,7 @@ bar
             )
 
             expect { cli.execute(options) }.to raise_error(
-              Bolt::CLIError,
+              Bolt::PAL::PALError,
               /Task sample::params:\n(?x:
                )\s*parameter 'mandatory_string' expects a String\[1, 10\] value, got String\n(?x:
                )\s*parameter 'optional_integer' expects a value of type Undef or Integer\[-5, 5\],(?x:
@@ -1243,14 +1243,14 @@ bar
               task_name.replace 'unknown::task'
 
               expect { cli.execute(options) }.to raise_error(
-                Bolt::CLIError, /Could not find a task named "unknown::task"/
+                Bolt::PAL::PALError, /Could not find a task named "unknown::task"/
               )
               expect(JSON.parse(output.string)).to be
             end
 
             it "errors as usual if invalid (according to the local task definition) parameters are specified" do
               expect { cli.execute(options) }.to raise_error(
-                Bolt::CLIError,
+                Bolt::PAL::PALError,
                 /Task sample::params:\n(?x:
                  )\s*has no parameter named 'foo'\n(?x:
                  )\s*has no parameter named 'bar'/
@@ -1274,14 +1274,14 @@ bar
                 task_name.replace 'unknown::task'
 
                 expect { cli.execute(options) }.to raise_error(
-                  Bolt::CLIError, /Could not find a task named "unknown::task"/
+                  Bolt::PAL::PALError, /Could not find a task named "unknown::task"/
                 )
                 expect(JSON.parse(output.string)).to be
               end
 
               it "errors as usual if invalid (according to the local task definition) parameters are specified" do
                 expect { cli.execute(options) }.to raise_error(
-                  Bolt::CLIError,
+                  Bolt::PAL::PALError,
                   /Task sample::params:\n(?x:
                    )\s*has no parameter named 'foo'\n(?x:
                    )\s*has no parameter named 'bar'/
@@ -1491,7 +1491,7 @@ bar
           stub_non_existent_file(source)
 
           expect { cli.execute(options) }.to raise_error(
-            Bolt::CLIError, /The source file '#{source}' does not exist/
+            Bolt::FileError, /The source file '#{source}' does not exist/
           )
           expect(JSON.parse(output.string)).to be
         end
@@ -1500,7 +1500,7 @@ bar
           stub_unreadable_file(source)
 
           expect { cli.execute(options) }.to raise_error(
-            Bolt::CLIError, /The source file '#{source}' is unreadable/
+            Bolt::FileError, /The source file '#{source}' is unreadable/
           )
           expect(JSON.parse(output.string)).to be
         end
@@ -1509,7 +1509,7 @@ bar
           stub_directory(source)
 
           expect { cli.execute(options) }.to raise_error(
-            Bolt::CLIError, /The source file '#{source}' is not a file/
+            Bolt::FileError, /The source file '#{source}' is not a file/
           )
           expect(JSON.parse(output.string)).to be
         end
@@ -1762,7 +1762,7 @@ bar
       cli = Bolt::CLI.new(%W[command run --configfile #{File.join(configdir, 'invalid.yml')} --nodes foo])
       expect {
         cli.parse
-      }.to raise_error(Bolt::CLIError, /Could not parse/)
+      }.to raise_error(Bolt::FileError, /Could not parse/)
     end
   end
 

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -96,7 +96,7 @@ describe Bolt::Config do
       expect(File).not_to receive(:exist?).with(default_path)
       expect(File).not_to receive(:exist?).with(alt_path)
       expect(File).to receive(:open).with(expanded_path, 'r:UTF-8').and_raise(Errno::ENOENT)
-      expect { config.load_file(path) }.to raise_error(Bolt::CLIError)
+      expect { config.load_file(path) }.to raise_error(Bolt::FileError)
     end
   end
 
@@ -138,7 +138,7 @@ describe Bolt::Config do
           ssh: { 'connect-timeout' => '42s' }
         }
       )
-      expect { config.validate }.to raise_error(Bolt::CLIError)
+      expect { config.validate }.to raise_error(Bolt::ValidationError)
     end
 
     it "accepts a boolean for host-key-check" do
@@ -160,7 +160,7 @@ describe Bolt::Config do
       }
       expect {
         Bolt::Config.new(config).validate
-      }.to raise_error(Bolt::CLIError)
+      }.to raise_error(Bolt::ValidationError)
     end
 
     it "accepts a private-key hash" do
@@ -182,7 +182,7 @@ describe Bolt::Config do
       }
       expect {
         Bolt::Config.new(config).validate
-      }.to raise_error(Bolt::CLIError)
+      }.to raise_error(Bolt::ValidationError)
     end
 
     it "accepts a boolean for ssl" do
@@ -204,7 +204,7 @@ describe Bolt::Config do
       }
       expect {
         Bolt::Config.new(config).validate
-      }.to raise_error(Bolt::CLIError)
+      }.to raise_error(Bolt::ValidationError)
     end
 
     it "accepts a boolean for ssl-verify" do
@@ -226,7 +226,7 @@ describe Bolt::Config do
       }
       expect {
         Bolt::Config.new(config).validate
-      }.to raise_error(Bolt::CLIError)
+      }.to raise_error(Bolt::ValidationError)
     end
 
     it "accepts a boolean for local-validation" do
@@ -248,7 +248,7 @@ describe Bolt::Config do
       }
       expect {
         Bolt::Config.new(config).validate
-      }.to raise_error(Bolt::CLIError)
+      }.to raise_error(Bolt::ValidationError)
     end
   end
 end

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -402,7 +402,7 @@ describe Bolt::Inventory do
         }
 
         it 'fails validation' do
-          expect { inventory.get_targets('node') }.to raise_error(Bolt::CLIError)
+          expect { inventory.get_targets('node') }.to raise_error(Bolt::ValidationError)
         end
       end
 
@@ -415,7 +415,7 @@ describe Bolt::Inventory do
         }
 
         it 'fails validation' do
-          expect { inventory.get_targets('node') }.to raise_error(Bolt::CLIError)
+          expect { inventory.get_targets('node') }.to raise_error(Bolt::ValidationError)
         end
       end
 
@@ -428,7 +428,7 @@ describe Bolt::Inventory do
         }
 
         it 'fails validation' do
-          expect { inventory.get_targets('node') }.to raise_error(Bolt::CLIError)
+          expect { inventory.get_targets('node') }.to raise_error(Bolt::ValidationError)
         end
       end
 
@@ -441,7 +441,7 @@ describe Bolt::Inventory do
         }
 
         it 'fails validation' do
-          expect { inventory.get_targets('node') }.to raise_error(Bolt::CLIError)
+          expect { inventory.get_targets('node') }.to raise_error(Bolt::ValidationError)
         end
       end
 


### PR DESCRIPTION
CLIError was being used as a generic error in many parts of bolt. This
limits the use of CLIError to the CLI class. In most cases error that
were CLIErrors become Bolt::ValidationError or generic Bolt::Errors.
    
CLIError is still probably overused in the CLI class.