### PR TITLE
(BOLT-532) Restore message when plan returns no results

### DIFF
--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -161,22 +161,12 @@ module Bolt
         @stream.puts(plan_info)
       end
 
-      # @param [Hash] A hash representing the plan result
-      def print_plan_result(result)
-        if result.nil?
+      # @param [Bolt::PlanResult] A PlanResult object
+      def print_plan_result(plan_result)
+        if plan_result.value.nil?
           @stream.puts("Plan completed successfully with no result")
-        # Otherwise if object has a json representation display it
-        elsif result.respond_to?(:to_json)
-          # Guard against to_json methods that don't accept options
-          # and don't print empty results on multiple lines
-          if result.method(:to_json).arity == 0 ||
-             (result.respond_to?(:empty?) && result.empty?)
-            @stream.puts(result.to_json)
-          else
-            @stream.puts(::JSON.pretty_generate(result, quirks_mode: true))
-          end
         else
-          @stream.puts result.to_s
+          @stream.puts(::JSON.pretty_generate(plan_result, quirks_mode: true))
         end
       end
 

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 require 'bolt/outputter'
 require 'bolt/cli'
+require 'bolt/plan_result'
 
 describe "Bolt::Outputter::Human" do
   let(:output) { StringIO.new }
@@ -195,8 +196,8 @@ PARAMETERS:
   end
 
   it "prints empty results from a plan" do
-    outputter.print_plan_result([])
-    expect(output.string).to eq("[]\n")
+    outputter.print_plan_result(Bolt::PlanResult.new([], 'success'))
+    expect(output.string).to eq("[\n\n]\n")
   end
 
   it "formats unwrapped ExecutionResult from a plan" do
@@ -209,7 +210,7 @@ PARAMETERS:
                         'partial_result' => { 'stdout' => 'no', 'stderr' => '', 'exit_code' => 2 },
                         'details' => { 'exit_code' => 2 } } } }
     ]
-    outputter.print_plan_result(result)
+    outputter.print_plan_result(Bolt::PlanResult.new(result, 'failure'))
 
     result_hash = JSON.parse(output.string)
     expect(result_hash).to eq(result)
@@ -217,18 +218,18 @@ PARAMETERS:
 
   it "formats hash results from a plan" do
     result = { 'some' => 'data' }
-    outputter.print_plan_result(result)
+    outputter.print_plan_result(Bolt::PlanResult.new(result, 'success'))
     expect(JSON.parse(output.string)).to eq(result)
   end
 
   it "prints simple output from a plan" do
     result = "some data"
-    outputter.print_plan_result(result)
+    outputter.print_plan_result(Bolt::PlanResult.new(result, 'success'))
     expect(output.string.strip).to eq("\"#{result}\"")
   end
 
   it "prints a message when a plan returns undef" do
-    outputter.print_plan_result(nil)
+    outputter.print_plan_result(Bolt::PlanResult.new(nil, 'success'))
     expect(output.string.strip).to eq("Plan completed successfully with no result")
   end
 


### PR DESCRIPTION
A prior change introduced PlanResult, an object that wraps all plan
output. That broke the message when no results are returned; fix it.