### PR TITLE
(BOLT-536) Default input method for PowerShell

### DIFF
--- a/bolt-modules/boltlib/spec/functions/run_task_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_spec.rb
@@ -43,7 +43,7 @@ describe 'run_task' do
     it 'when running a task without metadata the input method is "both"' do
       executable = File.join(tasks_root, 'echo.sh')
 
-      executor.expects(:run_task).with([target], mock_task(executable, 'both'), default_args, {}).returns(result_set)
+      executor.expects(:run_task).with([target], mock_task(executable, nil), default_args, {}).returns(result_set)
       inventory.expects(:get_targets).with(hostname).returns([target])
 
       is_expected.to run.with_params('Test::Echo', hostname, default_args).and_return(result_set)
@@ -74,7 +74,7 @@ describe 'run_task' do
     it 'when called without without args hash (for a task where this is allowed)' do
       executable = File.join(tasks_root, 'yes.sh')
 
-      executor.expects(:run_task).with([target], mock_task(executable, 'both'), {}, {}).returns(result_set)
+      executor.expects(:run_task).with([target], mock_task(executable, nil), {}, {}).returns(result_set)
       inventory.expects(:get_targets).with(hostname).returns([target])
 
       is_expected.to run.with_params('test::yes', hostname).and_return(result_set)
@@ -190,7 +190,7 @@ describe 'run_task' do
       it 'finds task named after the module' do
         executable = File.join(tasks_root, 'init.sh')
 
-        executor.expects(:run_task).with([target], mock_task(executable, 'both'), {}, {}).returns(result_set)
+        executor.expects(:run_task).with([target], mock_task(executable, nil), {}, {}).returns(result_set)
         inventory.expects(:get_targets).with(hostname).returns([target])
 
         is_expected.to run.with_params('test', hostname).and_return(result_set)

--- a/lib/bolt/transport/local.rb
+++ b/lib/bolt/transport/local.rb
@@ -83,7 +83,7 @@ module Bolt
         executable = target.select_impl(task, PROVIDED_FEATURES)
         raise "No suitable implementation of #{task.name} for #{target.name}" unless executable
 
-        input_method = task.input_method
+        input_method = task.input_method ? task.input_method : "both"
         stdin = STDIN_METHODS.include?(input_method) ? JSON.dump(arguments) : nil
         env = ENVIRONMENT_METHODS.include?(input_method) ? arguments : nil
 

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -113,7 +113,7 @@ module Bolt
         executable = target.select_impl(task, PROVIDED_FEATURES)
         raise "No suitable implementation of #{task.name} for #{target.name}" unless executable
 
-        input_method = task.input_method
+        input_method = task.input_method ? task.input_method : "both"
         with_connection(target) do |conn|
           conn.running_as(options['_run_as']) do
             stdin, output = nil

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -104,6 +104,7 @@ catch
         raise "No suitable implementation of #{task.name} for #{target.name}" unless executable
 
         input_method = task.input_method
+        input_method ||= powershell_file?(executable) ? 'powershell' : 'both'
         with_connection(target) do |conn|
           if STDIN_METHODS.include?(input_method)
             stdin = JSON.dump(arguments)

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1020,7 +1020,7 @@ bar
             params_parsed: true
           }
         }
-        let(:input_method) { +'both' }
+        let(:input_method) { nil }
         let(:task_path) { +'modules/sample/tasks/echo.sh$' }
         let(:task_t) { task_type(task_name, Regexp.new(task_path), input_method) }
 
@@ -1033,7 +1033,6 @@ bar
             .to receive(:run_task)
             .with(targets, task_t, task_params, {})
             .and_return(Bolt::ResultSet.new([]))
-
           expect(cli.execute(options)).to eq(0)
           expect(JSON.parse(output.string)).to be
         end
@@ -1089,32 +1088,33 @@ bar
           expect(JSON.parse(output.string)).to be
         end
 
-        it "runs a task passing input on stdin" do
-          task_name.replace 'sample::stdin'
-          task_path.replace 'modules/sample/tasks/stdin.sh$'
-          input_method.replace 'stdin'
+        context "input_method stdin" do
+          let(:input_method) { 'stdin' }
+          it "runs a task passing input on stdin" do
+            task_name.replace 'sample::stdin'
+            task_path.replace 'modules/sample/tasks/stdin.sh$'
 
-          expect(executor)
-            .to receive(:run_task)
-            .with(targets, task_t, task_params, {})
-            .and_return(Bolt::ResultSet.new([]))
+            expect(executor)
+              .to receive(:run_task)
+              .with(targets, task_t, task_params, {})
+              .and_return(Bolt::ResultSet.new([]))
 
-          cli.execute(options)
-          expect(JSON.parse(output.string)).to be
-        end
+            cli.execute(options)
+            expect(JSON.parse(output.string)).to be
+          end
 
-        it "runs a powershell task passing input on stdin" do
-          task_name.replace 'sample::winstdin'
-          task_path.replace 'modules/sample/tasks/winstdin.ps1$'
-          input_method.replace 'stdin'
+          it "runs a powershell task passing input on stdin" do
+            task_name.replace 'sample::winstdin'
+            task_path.replace 'modules/sample/tasks/winstdin.ps1$'
 
-          expect(executor)
-            .to receive(:run_task)
-            .with(targets, task_t, task_params, {})
-            .and_return(Bolt::ResultSet.new([]))
+            expect(executor)
+              .to receive(:run_task)
+              .with(targets, task_t, task_params, {})
+              .and_return(Bolt::ResultSet.new([]))
 
-          cli.execute(options)
-          expect(JSON.parse(output.string)).to be
+            cli.execute(options)
+            expect(JSON.parse(output.string)).to be
+          end
         end
 
         it "traps SIGINT", :signals_self do
@@ -1293,7 +1293,7 @@ bar
 
             context "when all targets use the PCP transport" do
               let(:target) { Bolt::Target.new('pcp://foo') }
-              let(:task_t) { task_type(task_name, /\A\z/, 'both') }
+              let(:task_t) { task_type(task_name, /\A\z/, nil) }
 
               it "runs the task even when it is not installed locally" do
                 task_name.replace 'unknown::task'
@@ -1333,7 +1333,7 @@ bar
             task_options: plan_params
           }
         }
-        let(:task_t) { task_type('sample::echo', %r{modules/sample/tasks/echo.sh$}, 'both') }
+        let(:task_t) { task_type('sample::echo', %r{modules/sample/tasks/echo.sh$}, nil) }
 
         before :each do
           cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
@@ -1544,7 +1544,7 @@ bar
             noop: true
           }
         }
-        let(:task_t) { task_type(task_name, %r{modules/sample/tasks/noop.sh$}, 'both') }
+        let(:task_t) { task_type(task_name, %r{modules/sample/tasks/noop.sh$}, nil) }
 
         before :each do
           cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]

--- a/spec/bolt/transport/winrm_spec.rb
+++ b/spec/bolt/transport/winrm_spec.rb
@@ -485,20 +485,28 @@ PS
       end
     end
 
-    it "can run a task passing input on stdin and environment", winrm: true do
+    it "can run a task passing input on environment", winrm: true do
       contents = <<PS
 Write-Host "$env:PT_message_one $env:PT_message_two"
-$line = [Console]::In.ReadLine()
-Write-Host $line
 PS
       arguments = { message_one: 'Hello from task', message_two: 'Goodbye' }
-      with_task_containing('tasks-test-both-winrm', contents, 'both', '.ps1') do |task|
+      with_task_containing('tasks-test-both-winrm', contents, 'environment', '.ps1') do |task|
         expect(
           winrm.run_task(target, task, arguments).message
-        ).to eq([
-          "Hello from task Goodbye\r\n",
-          "{\"message_one\":\"Hello from task\",\"message_two\":\"Goodbye\"}\r\n"
-        ].join(''))
+        ).to eq("Hello from task Goodbye\r\n")
+      end
+    end
+
+    it "defaults to powershell input method when executing .ps1", winrm: true do
+      contents = <<PS
+param ($message_one, $message_two)
+Write-Host "$message_one $message_two"
+PS
+      arguments = { message_one: 'Hello from task', message_two: 'Goodbye' }
+      with_task_containing('tasks-test-both-winrm', contents, nil, '.ps1') do |task|
+        expect(
+          winrm.run_task(target, task, arguments).message
+        ).to eq("Hello from task Goodbye\r\n")
       end
     end
 

--- a/spec/fixtures/modules/sample/tasks/ps_noop.ps1
+++ b/spec/fixtures/modules/sample/tasks/ps_noop.ps1
@@ -1,1 +1,2 @@
-echo "$env:PT_message with noop $env:PT__noop"
+param ($message, $_noop)
+echo "$message with noop $_noop"

--- a/spec/integration/winrm_spec.rb
+++ b/spec/integration/winrm_spec.rb
@@ -47,7 +47,7 @@ describe "when runnning over the winrm transport", winrm: true do
 
     it 'passes noop to a task that supports noop', :reset_puppet_settings do
       result = run_one_node(%w[task run sample::ps_noop message=somemessage --noop] + config_flags)
-      expect(result['_output'].strip).to eq("somemessage with noop true")
+      expect(result['_output'].strip).to eq("somemessage with noop True")
     end
 
     it 'does not pass noop to a task by default', :reset_puppet_settings do

--- a/spec/lib/bolt_spec/task.rb
+++ b/spec/lib/bolt_spec/task.rb
@@ -20,12 +20,12 @@ module BoltSpec
       end
     end
 
-    def mock_task(name, executable = name, input_method = 'both')
+    def mock_task(name, executable = name, input_method = nil)
       impls = [{ 'name' => executable, 'path' => executable }]
       double('task', name: name, implementations: impls, input_method: input_method)
     end
 
-    def task_type(name, executable = nil, input_method = 'both')
+    def task_type(name, executable = nil, input_method = nil)
       TaskTypeMatcher.new(name, executable || name, input_method)
     end
 


### PR DESCRIPTION
When powershell task is run over winrm, parameters are passed by default as powershell named arguments.