### PR TITLE
(BOLT-521) Allow users to specify the run-as-command for ssh

### DIFF
--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -9,7 +9,7 @@ module Bolt
   module Transport
     class SSH < Base
       def self.options
-        %w[port user password sudo-password private-key host-key-check connect-timeout tmpdir run-as tty]
+        %w[port user password sudo-password private-key host-key-check connect-timeout tmpdir run-as tty run-as-command]
       end
 
       PROVIDED_FEATURES = ['shell'].freeze
@@ -38,6 +38,11 @@ module Bolt
         unless timeout_value.is_a?(Integer) || timeout_value.nil?
           error_msg = "connect-timeout value must be an Integer, received #{timeout_value}:#{timeout_value.class}"
           raise Bolt::ValidationError, error_msg
+        end
+
+        run_as_cmd = options['run-as-command']
+        if run_as_cmd && (!run_as_cmd.is_a?(Array) || run_as_cmd.any? { |n| !n.is_a?(String) })
+          raise Bolt::ValidationError, "run-as-command must be an Array of Strings, received #{run_as_cmd}"
         end
       end
 

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -184,14 +184,20 @@ module Bolt
         def execute(command, sudoable: false, **options)
           result_output = Bolt::Node::Output.new
           run_as = options[:run_as] || self.run_as
-          use_sudo = sudoable && run_as && @user != run_as
+          escalate = sudoable && run_as && @user != run_as
+          use_sudo = escalate && @target.options['run-as-command'].nil?
 
           command_str = command.is_a?(String) ? command : Shellwords.shelljoin(command)
-          if use_sudo
-            sudo_flags = ["sudo", "-S", "-u", run_as, "-p", sudo_prompt]
-            sudo_flags += ["-E"] if options[:environment]
-            sudo_str = Shellwords.shelljoin(sudo_flags)
-            command_str = "#{sudo_str} #{command_str}"
+          if escalate
+            if use_sudo
+              sudo_flags = ["sudo", "-S", "-u", run_as, "-p", sudo_prompt]
+              sudo_flags += ["-E"] if options[:environment]
+              sudo_str = Shellwords.shelljoin(sudo_flags)
+              command_str = "#{sudo_str} #{command_str}"
+            else
+              run_as_str = Shellwords.shelljoin(@target.options['run-as-command'] + [run_as])
+              command_str = "#{run_as_str} #{command_str}"
+            end
           end
 
           # Including the environment declarations in the shelljoin will escape

--- a/pre-docs/bolt_configuration_options.md
+++ b/pre-docs/bolt_configuration_options.md
@@ -39,7 +39,10 @@ groups of nodes on the commandline and from plans.
 
 `connect-timeout`: How long Bolt should wait when establishing connections.
 
-`tmpdir`: The directory to upload and execute temporary files on the target.
+`run-as-command`: The command to escalate permissions. The user to escalate to
+and command will be appended to this command. This command must not require an
+interactive password prompt and the `sudo-password` option is ignored when
+`run-as-command` is specified. The runas command must be specified as an array.
 
 `port`: Connection port. Default is `22`.
 
@@ -51,6 +54,7 @@ groups of nodes on the commandline and from plans.
 
 `sudo-password`: Password to use when changing users via `run-as`.
 
+`tmpdir`: The directory to upload and execute temporary files on the target.
 
 ## WinRM transport configuration options
 `connect-timeout`: How long Bolt should wait when establishing connections.

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -185,6 +185,28 @@ describe Bolt::Config do
       }.to raise_error(Bolt::ValidationError)
     end
 
+    it "does accepts an array for run-as-command" do
+      config = {
+        transports: {
+          ssh: { 'run-as-command' => ['sudo -n'] }
+        }
+      }
+      expect {
+        Bolt::Config.new(config).validate
+      }.not_to raise_error
+    end
+
+    it "does not accept a non-array for run-as-command" do
+      config = {
+        transports: {
+          ssh: { 'run-as-command' => 'sudo -n' }
+        }
+      }
+      expect {
+        Bolt::Config.new(config).validate
+      }.to raise_error(Bolt::ValidationError)
+    end
+
     it "accepts a boolean for ssl" do
       config = {
         transports: {

--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -519,4 +519,16 @@ SHELL
       end
     end
   end
+
+  context "using a custom run-as-command" do
+    let(:config) {
+      mk_config('host-key-check' => false, 'sudo-password' => password, 'run-as' => 'root',
+                user: user, password: password,
+                'run-as-command' => ["sudo", "-nSEu"])
+    }
+
+    it "can fails to execute with sudo -n", ssh: true do
+      expect(ssh.run_command(target, 'whoami')['stderr']).to match("sudo: a password is required")
+    end
+  end
 end


### PR DESCRIPTION
This adds a new config option run-as-command to the ssh transport. This
command can be used to override the sudo support either to use a
different command than sudo or to specify which sudo options to use. It
will not use the sudo-password option.