### PR TITLE
(BOLT-399) Add `facts` metadata task

### DIFF
--- a/modules/facts/plans/retrieve.pp
+++ b/modules/facts/plans/retrieve.pp
@@ -1,32 +1,8 @@
 # A plan that retrieves facts from the specified nodes by running
-# an appropriate facts::* task on each. Care is taken to run a
-# facts::* task corresponding to the node's platfrom on each
-# node.
+# the 'facts' task on each.
 #
 # The $nodes parameter is a list of the nodes to retrieve the facts
 # from.
 plan facts::retrieve(TargetSpec $nodes) {
-  $targets = get_targets($nodes)
-
-  # Build a mapping from the names of the tasks to run to the lists of
-  # targets to run the tasks on
-  $task_targets = $targets.facts::group_by |$target| {
-    $target.protocol ? {
-      'ssh'   => 'facts::bash',
-      'winrm' => 'facts::powershell',
-      'pcp'   => 'facts::ruby',
-      'local' => 'facts::bash',
-    }
-  }
-
-  # Return a single result set composed of results from the result sets
-  # returned by the individual task runs.
-  return ResultSet(
-    $task_targets.map |$task, $targets| {
-      run_task($task, $targets, '_catch_errors' => true)
-    }.reduce([]) |$results, $result_set| {
-      # Collect the results from the individual result sets
-      $results + $result_set.results
-    }
-  )
+  return run_task('facts', $nodes, '_catch_errors' => true)
 }

--- a/modules/facts/spec/plans/info_spec.rb
+++ b/modules/facts/spec/plans/info_spec.rb
@@ -10,13 +10,13 @@ describe 'facts::info' do
     let(:node) { 'ssh://host' }
 
     it 'contains OS information for target' do
-      expect_task('facts::bash').always_return('os' => { 'name' => 'unix', 'family' => 'unix', 'release' => {} })
+      expect_task('facts').always_return('os' => { 'name' => 'unix', 'family' => 'unix', 'release' => {} })
 
       expect(run_plan('facts::info', 'nodes' => [node]).value).to eq(["#{node}: unix  (unix)"])
     end
 
     it 'omits failed targets' do
-      expect_task('facts::bash').always_return('_error' => { 'msg' => "Failed on #{node}" })
+      expect_task('facts').always_return('_error' => { 'msg' => "Failed on #{node}" })
 
       expect(run_plan('facts::info', 'nodes' => [node]).value).to eq([])
     end
@@ -26,13 +26,13 @@ describe 'facts::info' do
     let(:node) { 'winrm://host' }
 
     it 'contains OS information for target' do
-      expect_task('facts::powershell').always_return('os' => { 'name' => 'win', 'family' => 'win', 'release' => {} })
+      expect_task('facts').always_return('os' => { 'name' => 'win', 'family' => 'win', 'release' => {} })
 
       expect(run_plan('facts::info', 'nodes' => [node]).value).to eq(["#{node}: win  (win)"])
     end
 
     it 'omits failed targets' do
-      expect_task('facts::powershell').always_return('_error' => { 'msg' => "Failed on #{node}" })
+      expect_task('facts').always_return('_error' => { 'msg' => "Failed on #{node}" })
 
       expect(run_plan('facts::info', 'nodes' => [node]).value).to eq([])
     end
@@ -42,13 +42,13 @@ describe 'facts::info' do
     let(:node) { 'pcp://host' }
 
     it 'contains OS information for target' do
-      expect_task('facts::ruby').always_return('os' => { 'name' => 'any', 'family' => 'any', 'release' => {} })
+      expect_task('facts').always_return('os' => { 'name' => 'any', 'family' => 'any', 'release' => {} })
 
       expect(run_plan('facts::info', 'nodes' => [node]).value).to eq(["#{node}: any  (any)"])
     end
 
     it 'omits failed targets' do
-      expect_task('facts::ruby').always_return('_error' => { 'msg' => "Failed on #{node}" })
+      expect_task('facts').always_return('_error' => { 'msg' => "Failed on #{node}" })
 
       expect(run_plan('facts::info', 'nodes' => [node]).value).to eq([])
     end
@@ -58,13 +58,13 @@ describe 'facts::info' do
     let(:node) { 'local://' }
 
     it 'contains OS information for target' do
-      expect_task('facts::bash').always_return('os' => { 'name' => 'any', 'family' => 'any', 'release' => {} })
+      expect_task('facts').always_return('os' => { 'name' => 'any', 'family' => 'any', 'release' => {} })
 
       expect(run_plan('facts::info', 'nodes' => [node]).value).to eq(["#{node}: any  (any)"])
     end
 
     it 'omits failed targets' do
-      expect_task('facts::bash').always_return('_error' => { 'msg' => "Failed on #{node}" })
+      expect_task('facts').always_return('_error' => { 'msg' => "Failed on #{node}" })
 
       expect(run_plan('facts::info', 'nodes' => [node]).value).to eq([])
     end
@@ -74,13 +74,11 @@ describe 'facts::info' do
     let(:nodes) { %w[ssh://host1 winrm://host2 pcp://host3] }
 
     it 'contains OS information for target' do
-      [
-        ['facts::bash', { 'os' => { 'name' => 'unix', 'family' => 'unix', 'release' => {} } }],
-        ['facts::powershell', { 'os' => { 'name' => 'win', 'family' => 'win', 'release' => {} } }],
-        ['facts::ruby', { 'os' => { 'name' => 'any', 'family' => 'any', 'release' => {} } }]
-      ].zip(nodes).each do |(task, result), node|
-        expect_task(task).return_for_targets(node => result)
-      end
+      expect_task('facts').return_for_targets(
+        nodes[0] => { 'os' => { 'name' => 'unix', 'family' => 'unix', 'release' => {} } },
+        nodes[1] => { 'os' => { 'name' => 'win', 'family' => 'win', 'release' => {} } },
+        nodes[2] => { 'os' => { 'name' => 'any', 'family' => 'any', 'release' => {} } }
+      )
 
       expect(run_plan('facts::info', 'nodes' => nodes).value).to eq(
         ["#{nodes[0]}: unix  (unix)", "#{nodes[1]}: win  (win)", "#{nodes[2]}: any  (any)"]
@@ -88,9 +86,10 @@ describe 'facts::info' do
     end
 
     it 'omits failed targets' do
-      %w[facts::bash facts::powershell facts::ruby].zip(nodes).each do |fact, node|
-        expect_task(fact).return_for_targets(node => { '_error' => { 'msg' => "Failed on #{node}" } })
+      target_results = nodes.each_with_object({}) do |node, h|
+        h[node] = { '_error' => { 'msg' => "Failed on #{node}" } }
       end
+      expect_task('facts').return_for_targets(target_results)
 
       expect(run_plan('facts::info', 'nodes' => nodes).value).to eq([])
     end

--- a/modules/facts/spec/plans/init_spec.rb
+++ b/modules/facts/spec/plans/init_spec.rb
@@ -25,14 +25,14 @@ describe 'facts' do
     let(:node) { 'ssh://host' }
 
     it 'adds facts to the Target' do
-      expect_task('facts::bash').always_return(fact_output)
+      expect_task('facts').always_return(fact_output)
       inventory.expects(:add_facts).with(target, fact_output)
 
       expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(fact_output))
     end
 
     it 'omits failed targets' do
-      expect_task('facts::bash').always_return(err_output)
+      expect_task('facts').always_return(err_output)
       inventory.expects(:add_facts).never
 
       expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(err_output))
@@ -43,14 +43,14 @@ describe 'facts' do
     let(:node) { 'winrm://host' }
 
     it 'adds facts to the Target' do
-      expect_task('facts::powershell').always_return(fact_output)
+      expect_task('facts').always_return(fact_output)
       inventory.expects(:add_facts).with(target, fact_output)
 
       expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(fact_output))
     end
 
     it 'omits failed targets' do
-      expect_task('facts::powershell').always_return(err_output)
+      expect_task('facts').always_return(err_output)
       inventory.expects(:add_facts).never
 
       expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(err_output))
@@ -61,14 +61,14 @@ describe 'facts' do
     let(:node) { 'pcp://host' }
 
     it 'adds facts to the Target' do
-      expect_task('facts::ruby').always_return(fact_output)
+      expect_task('facts').always_return(fact_output)
       inventory.expects(:add_facts).with(target, fact_output)
 
       expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(fact_output))
     end
 
     it 'omits failed targets' do
-      expect_task('facts::ruby').always_return(err_output)
+      expect_task('facts').always_return(err_output)
       inventory.expects(:add_facts).never
 
       expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(err_output))
@@ -79,14 +79,14 @@ describe 'facts' do
     let(:node) { 'local://' }
 
     it 'adds facts to the Target' do
-      expect_task('facts::bash').always_return(fact_output)
+      expect_task('facts').always_return(fact_output)
       inventory.expects(:add_facts).with(target, fact_output)
 
       expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(fact_output))
     end
 
     it 'omits failed targets' do
-      expect_task('facts::bash').always_return(err_output)
+      expect_task('facts').always_return(err_output)
       inventory.expects(:add_facts).never
 
       expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(err_output))
@@ -97,10 +97,9 @@ describe 'facts' do
     let(:nodes) { %w[ssh://host1 winrm://host2 pcp://host3] }
 
     it 'contains OS information for target' do
-      %w[facts::bash facts::powershell facts::ruby].zip(nodes).each do |task, node|
-        expect_task(task).return_for_targets(node => fact_output(node))
-        inventory.expects(:add_facts).with(Bolt::Target.new(node), fact_output(node))
-      end
+      target_results = nodes.each_with_object({}) { |node, h| h[node] = fact_output(node) }
+      expect_task('facts').return_for_targets(target_results)
+      nodes.each { |node| inventory.expects(:add_facts).with(Bolt::Target.new(node), fact_output(node)) }
 
       result_set = Bolt::ResultSet.new(
         nodes.map { |node| Bolt::Result.new(Bolt::Target.new(node), value: fact_output(node)) }
@@ -109,9 +108,8 @@ describe 'facts' do
     end
 
     it 'omits failed targets' do
-      %w[facts::bash facts::powershell facts::ruby].zip(nodes).each do |task, node|
-        expect_task(task).return_for_targets(node => err_output(node))
-      end
+      target_results = nodes.each_with_object({}) { |node, h| h[node] = err_output(node) }
+      expect_task('facts').return_for_targets(target_results)
       inventory.expects(:add_facts).never
 
       result_set = Bolt::ResultSet.new(

--- a/modules/facts/spec/plans/retrieve_spec.rb
+++ b/modules/facts/spec/plans/retrieve_spec.rb
@@ -25,13 +25,13 @@ describe 'facts::retrieve' do
     let(:node) { 'ssh://host' }
 
     it 'retrieves facts' do
-      expect_task('facts::bash').always_return(fact_output)
+      expect_task('facts').always_return(fact_output)
 
       expect(run_plan('facts::retrieve', 'nodes' => [node]).value).to eq(results(fact_output))
     end
 
     it 'omits failed targets' do
-      expect_task('facts::bash').always_return(err_output)
+      expect_task('facts').always_return(err_output)
 
       expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(err_output))
     end
@@ -41,13 +41,13 @@ describe 'facts::retrieve' do
     let(:node) { 'winrm://host' }
 
     it 'retrieves facts' do
-      expect_task('facts::powershell').always_return(fact_output)
+      expect_task('facts').always_return(fact_output)
 
       expect(run_plan('facts::retrieve', 'nodes' => [node]).value).to eq(results(fact_output))
     end
 
     it 'omits failed targets' do
-      expect_task('facts::powershell').always_return(err_output)
+      expect_task('facts').always_return(err_output)
 
       expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(err_output))
     end
@@ -57,13 +57,13 @@ describe 'facts::retrieve' do
     let(:node) { 'pcp://host' }
 
     it 'retrieves facts' do
-      expect_task('facts::ruby').always_return(fact_output)
+      expect_task('facts').always_return(fact_output)
 
       expect(run_plan('facts::retrieve', 'nodes' => [node]).value).to eq(results(fact_output))
     end
 
     it 'omits failed targets' do
-      expect_task('facts::ruby').always_return(err_output)
+      expect_task('facts').always_return(err_output)
 
       expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(err_output))
     end
@@ -73,13 +73,13 @@ describe 'facts::retrieve' do
     let(:node) { 'local://' }
 
     it 'retrieves facts' do
-      expect_task('facts::bash').always_return(fact_output)
+      expect_task('facts').always_return(fact_output)
 
       expect(run_plan('facts::retrieve', 'nodes' => [node]).value).to eq(results(fact_output))
     end
 
     it 'omits failed targets' do
-      expect_task('facts::bash').always_return(err_output)
+      expect_task('facts').always_return(err_output)
 
       expect(run_plan('facts::retrieve', 'nodes' => [node]).value).to eq(results(err_output))
     end
@@ -89,9 +89,8 @@ describe 'facts::retrieve' do
     let(:nodes) { %w[ssh://host1 winrm://host2 pcp://host3] }
 
     it 'contains OS information for target' do
-      %w[facts::bash facts::powershell facts::ruby].zip(nodes).each do |task, node|
-        expect_task(task).return_for_targets(node => fact_output(node))
-      end
+      target_results = nodes.each_with_object({}) { |node, h| h[node] = fact_output(node) }
+      expect_task('facts').return_for_targets(target_results)
 
       result_set = Bolt::ResultSet.new(
         nodes.map { |node| Bolt::Result.new(Bolt::Target.new(node), value: fact_output(node)) }
@@ -100,9 +99,8 @@ describe 'facts::retrieve' do
     end
 
     it 'omits failed targets' do
-      %w[facts::bash facts::powershell facts::ruby].zip(nodes).each do |task, node|
-        expect_task(task).return_for_targets(node => err_output(node))
-      end
+      target_results = nodes.each_with_object({}) { |node, h| h[node] = err_output(node) }
+      expect_task('facts').return_for_targets(target_results)
 
       result_set = Bolt::ResultSet.new(
         nodes.map { |node| Bolt::Result.new(Bolt::Target.new(node), value: err_output(node)) }

--- a/modules/facts/tasks/init.json
+++ b/modules/facts/tasks/init.json
@@ -1,0 +1,9 @@
+{
+  "description": "Gather system facts",
+  "parameters": {},
+  "implementations": [
+    {"name": "ruby.rb", "requirements": ["puppet-agent"]},
+    {"name": "powershell.ps1", "requirements": ["powershell"]},
+    {"name": "bash.sh", "requirements": ["shell"]}
+  ]
+}

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -867,7 +867,8 @@ bar
           }
           cli.execute(options)
           json = JSON.parse(output.string)
-          expect(json).to eq([["facts::bash", nil],
+          expect(json).to eq([["facts", "Gather system facts"],
+                              ["facts::bash", nil],
                               ["facts::powershell", nil],
                               ["facts::ruby", nil],
                               ['sample::ok', nil]])


### PR DESCRIPTION
Adds `facts` metadata-only task that dispatches to specific
implementations based on features in transports. Use it to simplify
`facts` plans.