### PR TITLE
(maint) Use $HOME to determine home directory on all platforms

### DIFF
--- a/acceptance/setup/common/pre-suite/050_build_bolt_inventory.rb
+++ b/acceptance/setup/common/pre-suite/050_build_bolt_inventory.rb
@@ -28,11 +28,7 @@ test_name "build bolt inventory file" do
     ]
   }
 
-  bolt_confdir = if bolt.platform =~ /win/
-                   '/cygdrive/c/Users/Administrator/.puppetlabs/bolt'
-                 else
-                   "#{on(bolt, 'echo $HOME').stdout.chomp}/.puppetlabs/bolt"
-                 end
+  bolt_confdir = "#{on(bolt, 'echo $HOME').stdout.chomp}/.puppetlabs/bolt"
 
   on bolt, "mkdir -p #{bolt_confdir}"
   create_remote_file(bolt, "#{bolt_confdir}/inventory.yaml", inventory.to_yaml)


### PR DESCRIPTION
The previous hard-coded Windows path was incorrect, because cygwin has
its own home directory (set by $HOME) which is what bolt uses for the
inventory.

Now with extra `I Tested It`!