### PR TITLE
(BOLT-544) add secondary default for puppetdb.conf

### DIFF
--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -3,6 +3,7 @@
 require 'bolt/executor'
 require 'bolt/error'
 require 'bolt/plan_result'
+require 'bolt/util'
 
 module Bolt
   class PAL
@@ -54,7 +55,7 @@ module Bolt
     end
 
     def self.load_puppet
-      if Gem.win_platform?
+      if Bolt::Util.windows?
         # Windows 'fix' for openssl behaving strangely. Prevents very slow operation
         # of random_bytes later when establishing winrm connections from a Windows host.
         # See https://github.com/rails/rails/issues/25805 for background.

--- a/lib/bolt/transport/local.rb
+++ b/lib/bolt/transport/local.rb
@@ -5,6 +5,7 @@ require 'fileutils'
 require 'tmpdir'
 require 'bolt/transport/base'
 require 'bolt/result'
+require 'bolt/util'
 
 module Bolt
   module Transport
@@ -20,7 +21,7 @@ module Bolt
       def initialize
         super
 
-        if Gem.win_platform?
+        if Bolt::Util.windows?
           raise NotImplementedError, "The local transport is not yet implemented on Windows"
         else
           @conn = Shell.new

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -4,6 +4,7 @@ require 'logging'
 require 'shellwords'
 require 'bolt/node/errors'
 require 'bolt/node/output'
+require 'bolt/util'
 
 module Bolt
   module Transport
@@ -59,7 +60,7 @@ module Bolt
           @logger = Logging.logger[@target.host]
         end
 
-        if !!File::ALT_SEPARATOR
+        if Bolt::Util.windows?
           require 'ffi'
           module Win
             extend FFI::Library
@@ -102,7 +103,7 @@ module Bolt
               @logger.debug { "Disabling use_agent in net-ssh: ssh-agent is not available" }
               options[:use_agent] = false
             end
-          elsif !!File::ALT_SEPARATOR
+          elsif Bolt::Util.windows?
             pageant_wide = 'Pageant'.encode('UTF-16LE')
             if Win.FindWindow(pageant_wide, pageant_wide).to_i == 0
               @logger.debug { "Disabling use_agent in net-ssh: pageant process not running" }

--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -107,6 +107,11 @@ module Bolt
           return cl
         end
       end
+
+      # Returns true if windows false if not.
+      def windows?
+        !!File::ALT_SEPARATOR
+      end
     end
   end
 end

--- a/lib/bolt_ext/puppetdb_inventory.rb
+++ b/lib/bolt_ext/puppetdb_inventory.rb
@@ -37,7 +37,8 @@ module Bolt
           end
           opts.on('--config CONFIG',
                   "The puppetdb.conf file to read configuration from",
-                  "Default: #{Bolt::PuppetDB::Config::DEFAULT_CONFIG} if present") do |file|
+                  "Defaults: #{Bolt::PuppetDB::Config::DEFAULT_CONFIG[:user]} or",
+                  "#{Bolt::PuppetDB::Config::DEFAULT_CONFIG[:global]} if present") do |file|
             @config_file = File.expand_path(file)
           end
           opts.on('--output FILE', '-o FILE',

--- a/pre-docs/bolt_configure_puppetdb.md
+++ b/pre-docs/bolt_configure_puppetdb.md
@@ -59,6 +59,8 @@ puppetdb:
   cert: /etc/puppetlabs/puppet/ssl/certs/my-host.example.com.pem
   key: /etc/puppetlabs/puppet/ssl/private_keys/my-host.example.com.pem
 ```
+If Puppet Enterprise is installed and puppetdb is not defined in a configfile bolt will default to use puppetdb config defined in either`$HOME/.puppetlabs/client-tools/puppetdb.conf` or `/etc/puppetlabs/client-tools/puppetdb.conf` (`C:\ProgramData\PuppetLabs\client-tools\puppetdb.conf` if windows OS).
+> **Note**: Bolt **will not** merge config files into a conf.d format the way that pe-client-tools will.
 
 To use PE RBAC auth
 ```yaml

--- a/pre-docs/inventory_file_generating.md
+++ b/pre-docs/inventory_file_generating.md
@@ -26,10 +26,11 @@ is stored at:
 
 Windows `%USERPROFILE%\.puppetlabs\client-tools\puppetdb.conf`
 
-> Note: If you use a global configuration file stored at
-> /etc/puppetlabs/client-tools/puppetdb.conf, copy the file to your home
-> directory.  The configuration file is shared with the puppet-query tool. For
-> details on the format of the file see the PuppetDB documentation.
+> Note: The presedence used to load puppetdb config is
+> 1. configfile (optionally specified with --configfile)
+> 2. $HOME/.puppetlabs/client-tools/puppetdb.conf
+> 3. /etc/puppetlabs/client-tools/puppetdb.conf (windows: C:\ProgramData\PuppetLabs\client-tools\puppetdb.conf)
+
 
 `bolt-inventory-pdb` requires the following file settings:
 

--- a/spec/bolt/puppetdb/config_spec.rb
+++ b/spec/bolt/puppetdb/config_spec.rb
@@ -2,10 +2,9 @@
 
 require 'spec_helper'
 require 'bolt/puppetdb/config'
+require 'bolt/util'
 
 describe Bolt::PuppetDB::Config do
-  let(:config_file) { nil }
-  let(:config) { Bolt::PuppetDB::Config.new(config_file, @options) }
   let(:options) do
     {
       'server_urls' => ['https://puppetdb:8081'],
@@ -16,47 +15,79 @@ describe Bolt::PuppetDB::Config do
     }
   end
 
-  before :each do
-    allow_any_instance_of(Bolt::PuppetDB::Config).to receive(:load_config).and_return({})
-    allow_any_instance_of(Bolt::PuppetDB::Config).to receive(:validate_file_exists)
+  context "when validating that options" do
+    let(:config_file) { nil }
+    let(:config) { Bolt::PuppetDB::Config.new(config_file, @options) }
+
+    before :each do
+      allow_any_instance_of(Bolt::PuppetDB::Config).to receive(:load_config).and_return({})
+      allow_any_instance_of(Bolt::PuppetDB::Config).to receive(:validate_file_exists)
+    end
+
+    describe "#validate" do
+      it "fails if no url is set" do
+        options.delete('server_urls')
+
+        expect { described_class.new(config_file, options) }.to raise_error(/server_urls must be specified/)
+      end
+
+      it "fails if no cacert is set" do
+        options.delete('cacert')
+
+        expect { described_class.new(config_file, options) }.to raise_error(/cacert must be specified/)
+      end
+
+      it "accepts only a token with cert/key" do
+        options.delete('cert')
+        options.delete('key')
+
+        expect { described_class.new(config_file, options) }.not_to raise_error
+      end
+
+      it "accepts a cert and key without a token" do
+        options.delete('token')
+
+        expect { described_class.new(config_file, options) }.not_to raise_error
+      end
+
+      it "fails if only cert and no key is specified" do
+        options.delete('key')
+
+        expect { described_class.new(config_file, options) }.to raise_error(/cert and key must be specified together/)
+      end
+
+      it "fails if only key and no cert is specified" do
+        options.delete('cert')
+
+        expect { described_class.new(config_file, options) }.to raise_error(/cert and key must be specified together/)
+      end
+    end
   end
 
-  describe "#validate" do
-    it "fails if no url is set" do
-      options.delete('server_urls')
+  context "when loading config_file " do
+    let(:user_supplied) { File.join('test', 'file') }
 
-      expect { described_class.new(config_file, options) }.to raise_error(/server_urls must be specified/)
+    before :each do
+      allow_any_instance_of(Bolt::PuppetDB::Config).to receive(:validate_file_exists)
     end
 
-    it "fails if no cacert is set" do
-      options.delete('cacert')
-
-      expect { described_class.new(config_file, options) }.to raise_error(/cacert must be specified/)
+    it "#load_config loads from specified filename when given" do
+      expect(File).to receive(:exist?).with(user_supplied)
+      expect { Bolt::PuppetDB::Config.new(user_supplied, options) }.to raise_error(/does not exist/)
     end
 
-    it "accepts only a token with cert/key" do
-      options.delete('cert')
-      options.delete('key')
-
-      expect { described_class.new(config_file, options) }.not_to raise_error
+    it "on non-windows OS #load_config loads from default location when filename is nil" do
+      allow(Bolt::Util).to receive(:windows?).and_return(false)
+      expect(File).to receive(:exist?).with(Bolt::PuppetDB::Config::DEFAULT_CONFIG[:user])
+      expect(File).to receive(:exist?).with(Bolt::PuppetDB::Config::DEFAULT_CONFIG[:global])
+      Bolt::PuppetDB::Config.new(nil, options)
     end
 
-    it "accepts a cert and key without a token" do
-      options.delete('token')
-
-      expect { described_class.new(config_file, options) }.not_to raise_error
-    end
-
-    it "fails if only cert and no key is specified" do
-      options.delete('key')
-
-      expect { described_class.new(config_file, options) }.to raise_error(/cert and key must be specified together/)
-    end
-
-    it "fails if only key and no cert is specified" do
-      options.delete('cert')
-
-      expect { described_class.new(config_file, options) }.to raise_error(/cert and key must be specified together/)
+    it "on windows OS #load_config loads from default location when filename is nil" do
+      allow(Bolt::Util).to receive(:windows?).and_return(true)
+      expect(File).to receive(:exist?).with(Bolt::PuppetDB::Config::DEFAULT_CONFIG[:user])
+      expect(File).to receive(:exist?).with(Bolt::PuppetDB::Config::DEFAULT_CONFIG[:win_global])
+      Bolt::PuppetDB::Config.new(nil, options)
     end
   end
 end

--- a/spec/signal_helper.rb
+++ b/spec/signal_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bolt/util'
+
 RSpec.shared_context 'synchronization thread' do
   let(:sync_thread) { Thread.new { Thread.stop } }
 
@@ -33,5 +35,5 @@ RSpec.configure do |config|
   # enabled by specifying `--tag ~~signals_self` on the rspec command
   # line. Note the double tilde.
   config.filter_run_excluding :signals_self \
-    if Gem.win_platform? && !config.exclusion_filter[:'~signals_self']
+    if Bolt::Util.windows? && !config.exclusion_filter[:'~signals_self']
 end


### PR DESCRIPTION
Try to load puppetdb config first from user supplied configfile, second from ~/.puppetlabs/client-tools, finally from /etc/puppetlabs/client-tools. This simplifies Bolt-PE integration out of the box.