### PR TITLE
(BOLT-545) Explicitly set group based on id -g for chown

### DIFF
--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -439,6 +439,7 @@ SHELL
         expect(ssh.upload(target, file.path, dest).message).to match(/Uploaded/)
         expect(ssh.run_command(target, "cat #{dest}")['stdout']).to eq(contents)
         expect(ssh.run_command(target, "stat -c %U #{dest}")['stdout'].chomp).to eq('root')
+        expect(ssh.run_command(target, "stat -c %G #{dest}")['stdout'].chomp).to eq('root')
       end
 
       ssh.run_command(target, "rm #{dest}", sudoable: true, run_as: 'root')
@@ -486,6 +487,7 @@ SHELL
           expect(ssh.upload(target, file.path, dest, '_run_as' => 'root').message).to match(/Uploaded/)
           expect(ssh.run_command(target, "cat #{dest}", '_run_as' => 'root')['stdout']).to eq(contents)
           expect(ssh.run_command(target, "stat -c %U #{dest}", '_run_as' => 'root')['stdout'].chomp).to eq('root')
+          expect(ssh.run_command(target, "stat -c %G #{dest}", '_run_as' => 'root')['stdout'].chomp).to eq('root')
         end
 
         ssh.run_command(target, "rm #{dest}", sudoable: true, run_as: 'root')


### PR DESCRIPTION
The `chown <user>:` syntax to inherit group from user is not portable.
Use `id -g <user>` to get the user's group and explicitly use it when
changing ownership to make it more portable.

Note that this will still fail on some platforms with very old versions
of `id` that don't support `-g`, such as the default `id` on Solaris 10.