### PR TITLE
(BOLT-488) Submit data to Google Analytics for each command invocation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,9 @@
 
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
+# Disable analytics when running in development
+ENV['BOLT_DISABLE_ANALYTICS'] = 'true'
+
 gemspec
 
 # Required to pick up plan specs in the rake spec task

--- a/acceptance/setup/common/pre-suite/050_build_bolt_inventory.rb
+++ b/acceptance/setup/common/pre-suite/050_build_bolt_inventory.rb
@@ -32,4 +32,6 @@ test_name "build bolt inventory file" do
 
   on bolt, "mkdir -p #{bolt_confdir}"
   create_remote_file(bolt, "#{bolt_confdir}/inventory.yaml", inventory.to_yaml)
+
+  create_remote_file(bolt, "#{bolt_confdir}/analytics.yaml", { 'disabled' => true }.to_yaml)
 end

--- a/lib/bolt/analytics.rb
+++ b/lib/bolt/analytics.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require 'bolt/version'
+require 'httpclient'
+require 'json'
+require 'locale'
+require 'logging'
+require 'securerandom'
+
+module Bolt
+  module Analytics
+    PROTOCOL_VERSION = 1
+    APPLICATION_NAME = 'bolt'
+    TRACKING_ID = 'UA-120367942-1'
+    TRACKING_URL = 'https://google-analytics.com/collect'
+
+    def self.build_client
+      logger = Logging.logger[self]
+
+      config_file = File.expand_path('~/.puppetlabs/bolt/analytics.yaml')
+      config = load_config(config_file)
+
+      if config['disabled'] || ENV['BOLT_DISABLE_ANALYTICS']
+        logger.debug "Analytics opt-out is set, analytics will be disabled"
+        NoopClient.new
+      else
+        unless config.key?('user-id')
+          config['user-id'] = SecureRandom.uuid
+          write_config(config_file, config)
+        end
+
+        Client.new(config['user-id'])
+      end
+    rescue StandardError => e
+      logger.debug "Failed to initialize analytics client, analytics will be disabled: #{e}"
+      NoopClient.new
+    end
+
+    def self.load_config(filename)
+      if File.exist?(filename)
+        YAML.load_file(filename)
+      else
+        {}
+      end
+    end
+
+    def self.write_config(filename, config)
+      FileUtils.mkdir_p(File.dirname(filename))
+      File.write(filename, config.to_yaml)
+    end
+
+    class Client
+      attr_reader :user_id
+
+      def initialize(user_id)
+        @logger = Logging.logger[self]
+        @http = HTTPClient.new
+        @user_id = user_id
+        @executor = Concurrent.global_io_executor
+      end
+
+      def screen_view(screen)
+        screen_view_params = {
+          # Type
+          t: 'screenview',
+          # Screen Name
+          cd: screen
+        }
+
+        submit(base_params.merge(screen_view_params))
+      end
+
+      def event(category, action)
+        event_params = {
+          # Type
+          t: 'event',
+          # Event Category
+          ec: category,
+          # Event Action
+          ea: action
+        }
+
+        submit(base_params.merge(event_params))
+      end
+
+      def submit(params)
+        # Handle analytics submission in the background to avoid blocking the
+        # app or polluting the log with errors
+        Concurrent::Future.execute(executor: @executor) do
+          @logger.debug "Submitting analytics: #{JSON.pretty_generate(params)}"
+          @http.post(TRACKING_URL, params)
+          @logger.debug "Completed analytics submission"
+        end
+      end
+
+      # These parameters have terrible names. See this page for complete documentation:
+      # https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
+      def base_params
+        {
+          v: PROTOCOL_VERSION,
+          # Client ID
+          cid: @user_id,
+          # Tracking ID
+          tid: TRACKING_ID,
+          # Application Name
+          an: APPLICATION_NAME,
+          # Application Version
+          av: Bolt::VERSION,
+          # Anonymize IPs
+          aip: true,
+          # User locale
+          ul: Locale.current.to_rfc
+        }
+      end
+
+      # If the user is running a very fast command, there may not be time for
+      # analytics submission to complete before the command is finished. In
+      # that case, we give a little buffer for any stragglers to finish up.
+      # 250ms strikes a balance between accomodating slower networks while not
+      # introducing a noticeable "hang".
+      def finish
+        @executor.shutdown
+        @executor.wait_for_termination(0.25)
+      end
+    end
+
+    class NoopClient
+      def initialize
+        @logger = Logging.logger[self]
+      end
+
+      def screen_view(screen)
+        @logger.debug "Skipping submission of '#{screen}' screenview because analytics is disabled"
+      end
+
+      def event(category, action)
+        @logger.debug "Skipping submission of '#{category} #{action}' event because analytics is disabled"
+      end
+
+      def finish; end
+    end
+  end
+end

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -6,6 +6,7 @@ require 'json'
 require 'io/console'
 require 'logging'
 require 'optparse'
+require 'bolt/analytics'
 require 'bolt/config'
 require 'bolt/error'
 require 'bolt/executor'
@@ -493,6 +494,15 @@ Available options are:
         exit!
       end
 
+      @analytics = Bolt::Analytics.build_client
+
+      screen = "#{options[:mode]}_#{options[:action]}"
+      # submit a different screen for `bolt task show` and `bolt task show foo`
+      if options[:action] == 'show' && options[:object]
+        screen += '_object'
+      end
+      @analytics.screen_view(screen)
+
       if options[:mode] == 'plan' || options[:mode] == 'task'
         pal = Bolt::PAL.new(config)
       end
@@ -606,6 +616,7 @@ Available options are:
     ensure
       # restore original signal handler
       Signal.trap :INT, handler if handler
+      @analytics&.finish
     end
 
     def validate_file(type, path)

--- a/pre-docs/bolt_analytics.md
+++ b/pre-docs/bolt_analytics.md
@@ -1,0 +1,25 @@
+# Bolt analytics collection
+
+Bolt automatically collects data about how you use it.
+
+## What data does Bolt collect?
+
+* Version of Bolt
+* The Bolt command executed (eg. `bolt task run`, `bolt plan show`), excluding arguments
+* User locale
+
+This data is associated with a random, non-identifiable user UUID.
+
+You can see the data Bolt is sending by running with `--debug`.
+
+## Why does Bolt collect data?
+
+Bolt collects data to help us understand how it's being used and make decisions about how to improve it.
+
+## Opt-out
+
+You can disable the collection of analytics data by adding the following line to `~/.puppetlabs/bolt/analytics.yaml`:
+
+```
+disabled: true
+```

--- a/pre-docs/bolt_installing.md
+++ b/pre-docs/bolt_installing.md
@@ -4,6 +4,9 @@
 Packaged versions of Bolt are available for many modern Linux distributions,
 as well as macOS and Windows.
 
+> Note: Bolt automatically collects data about how it's being used. [Learn more
+> about what is collected and how to opt-out.](bolt_analytics.md)
+
 ## Install Bolt on Windows
 
 ### Install with Chocolatey

--- a/spec/bolt/analytics_spec.rb
+++ b/spec/bolt/analytics_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/analytics'
+
+describe Bolt::Analytics do
+  let(:default_config) { {} }
+
+  before :each do
+    # We use a hard override to disable analytics for tests, but that obviously
+    # interferes with these tests...
+    ENV.delete('BOLT_DISABLE_ANALYTICS')
+
+    # Ensure these tests will never read or write a local config
+    allow(subject).to receive(:load_config).and_return(default_config)
+    allow(subject).to receive(:write_config)
+  end
+
+  it 'creates a NoopClient if analytics is disabled' do
+    default_config.replace('disabled' => true)
+    expect(subject).not_to receive(:write_config)
+
+    expect(subject.build_client).to be_instance_of(Bolt::Analytics::NoopClient)
+  end
+
+  it 'creates a regular Client if analytics is not disabled' do
+    expect(subject.build_client).to be_instance_of(Bolt::Analytics::Client)
+  end
+
+  it 'uses the uuid in the config if it exists' do
+    uuid = SecureRandom.uuid
+    default_config.replace('user-id' => uuid)
+
+    expect(subject.build_client.user_id).to eq(uuid)
+  end
+
+  it "assigns the user a uuid if one doesn't exist" do
+    uuid = SecureRandom.uuid
+    allow(SecureRandom).to receive(:uuid).and_return(uuid)
+
+    expect(subject).to receive(:write_config).with(kind_of(String), include('user-id' => uuid))
+
+    expect(subject.build_client.user_id).to eq(uuid)
+  end
+end
+
+describe Bolt::Analytics::Client do
+  let(:uuid) { SecureRandom.uuid }
+  let(:base_params) do
+    {
+      v: 1,
+      an: 'bolt',
+      av: Bolt::VERSION,
+      cid: uuid,
+      tid: 'UA-120367942-1',
+      ul: Locale.current.to_rfc,
+      aip: true
+    }
+  end
+
+  subject { described_class.new(uuid) }
+
+  describe "#screen_view" do
+    it 'properly formats the screenview' do
+      params = base_params.merge(t: 'screenview', cd: 'job_run')
+
+      expect(subject).to receive(:submit).with params
+
+      subject.screen_view('job_run')
+    end
+  end
+
+  describe "#event" do
+    it 'properly formats the event' do
+      params = base_params.merge(t: 'event', ec: 'run', ea: 'task')
+
+      expect(subject).to receive(:submit).with params
+
+      subject.event('run', 'task')
+    end
+  end
+end
+
+describe Bolt::Analytics::NoopClient do
+  describe "#screen_view" do
+    it 'succeeds' do
+      subject.screen_view('job_run')
+    end
+  end
+
+  describe "#event" do
+    it 'succeeds' do
+      subject.event('run', 'task')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,11 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.before :each do
+    # Disable analytics while running tests
+    ENV['BOLT_DISABLE_ANALYTICS'] = 'true'
+  end
+
   # This will be default in future rspec, leave it on
   config.shared_context_metadata_behavior = :apply_to_host_groups
 


### PR DESCRIPTION
Every time the user runs a command (`bolt task run`, `bolt plan show`),
we now submit a "screenview" event to Google Analytics, where the
"screen" is the command that was run. The information included is:

a) bolt version
b) user locale
c) the "screen" run
d) a unique, random user id

IP addresses are anonymized, and we do *not* include the name of the
task or plan run.

The unique ID is stored in ~/.puppetlabs/bolt/analytics.yaml. That
file also accepts the setting `disabled: true` which will disable the
collection of analytics.

To avoid polluting the data with development and test runs, we also use
a BOLT_DISABLE_ANALYTICS environment variable, which is automatically
set when running via bundler and while running the tests.

Analytics submission is performed in the background and errors are
ignored, both so as not to disrupt normal usage of bolt. There is a
grace period of 250ms at the end of the application to allow any
outstanding event submissions to complete without introducing a
noticeable hang.

The complete data submitted is logged at debug level so that users can
be aware of the information we're collecting.