### PR TITLE
(BOLT-533) Move facts module tests to bolt spec tests

### DIFF
--- a/spec/modules/facts/functions/group_by_spec.rb
+++ b/spec/modules/facts/functions/group_by_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'facts::group_by' do
+  it 'delegates to the native group_by function' do
+    collection = mock('Puppet::Pops::Types::Iterable').extend(Puppet::Pops::Types::Iterable)
+    return_value = {}
+
+    verifier = mock('verifier')
+    token = mock('token')
+
+    collection.expects(:group_by).with.yields(token).returns(return_value)
+    # this is to verify that the block passed to the 'facts::group_by' function
+    # is yielded to from the stubbed group_by method
+    verifier.expects(:verify).with(token)
+
+    is_expected.to run.with_params(collection).with_lambda(&(proc do |t|
+      verifier.verify(t)
+    end)).and_return(return_value)
+  end
+end

--- a/spec/modules/facts/plans/info_spec.rb
+++ b/spec/modules/facts/plans/info_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/plans'
+
+describe 'facts::info' do
+  include BoltSpec::Plans
+
+  context 'an ssh target' do
+    let(:node) { 'ssh://host' }
+
+    it 'contains OS information for target' do
+      expect_task('facts').always_return('os' => { 'name' => 'unix', 'family' => 'unix', 'release' => {} })
+
+      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq(["#{node}: unix  (unix)"])
+    end
+
+    it 'omits failed targets' do
+      expect_task('facts').always_return('_error' => { 'msg' => "Failed on #{node}" })
+
+      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq([])
+    end
+  end
+
+  context 'a winrm target' do
+    let(:node) { 'winrm://host' }
+
+    it 'contains OS information for target' do
+      expect_task('facts').always_return('os' => { 'name' => 'win', 'family' => 'win', 'release' => {} })
+
+      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq(["#{node}: win  (win)"])
+    end
+
+    it 'omits failed targets' do
+      expect_task('facts').always_return('_error' => { 'msg' => "Failed on #{node}" })
+
+      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq([])
+    end
+  end
+
+  context 'a pcp target' do
+    let(:node) { 'pcp://host' }
+
+    it 'contains OS information for target' do
+      expect_task('facts').always_return('os' => { 'name' => 'any', 'family' => 'any', 'release' => {} })
+
+      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq(["#{node}: any  (any)"])
+    end
+
+    it 'omits failed targets' do
+      expect_task('facts').always_return('_error' => { 'msg' => "Failed on #{node}" })
+
+      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq([])
+    end
+  end
+
+  context 'a local target' do
+    let(:node) { 'local://' }
+
+    it 'contains OS information for target' do
+      expect_task('facts').always_return('os' => { 'name' => 'any', 'family' => 'any', 'release' => {} })
+
+      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq(["#{node}: any  (any)"])
+    end
+
+    it 'omits failed targets' do
+      expect_task('facts').always_return('_error' => { 'msg' => "Failed on #{node}" })
+
+      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq([])
+    end
+  end
+
+  context 'ssh, winrm, and pcp targets' do
+    let(:nodes) { %w[ssh://host1 winrm://host2 pcp://host3] }
+
+    it 'contains OS information for target' do
+      expect_task('facts').return_for_targets(
+        nodes[0] => { 'os' => { 'name' => 'unix', 'family' => 'unix', 'release' => {} } },
+        nodes[1] => { 'os' => { 'name' => 'win', 'family' => 'win', 'release' => {} } },
+        nodes[2] => { 'os' => { 'name' => 'any', 'family' => 'any', 'release' => {} } }
+      )
+
+      expect(run_plan('facts::info', 'nodes' => nodes).value).to eq(
+        ["#{nodes[0]}: unix  (unix)", "#{nodes[1]}: win  (win)", "#{nodes[2]}: any  (any)"]
+      )
+    end
+
+    it 'omits failed targets' do
+      target_results = nodes.each_with_object({}) do |node, h|
+        h[node] = { '_error' => { 'msg' => "Failed on #{node}" } }
+      end
+      expect_task('facts').return_for_targets(target_results)
+
+      expect(run_plan('facts::info', 'nodes' => nodes).value).to eq([])
+    end
+  end
+end

--- a/spec/modules/facts/plans/init_spec.rb
+++ b/spec/modules/facts/plans/init_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/plans'
+
+describe 'facts' do
+  include BoltSpec::Plans
+
+  let(:node) { '' }
+  let(:target) { Bolt::Target.new(node) }
+
+  def fact_output(node_ = node)
+    { 'fqdn' => node_ }
+  end
+
+  def err_output(node_ = node)
+    { '_error' => { 'msg' => "Failed on #{node_}" } }
+  end
+
+  def results(output)
+    Bolt::ResultSet.new([Bolt::Result.new(target, value: output)])
+  end
+
+  context 'an ssh target' do
+    let(:node) { 'ssh://host' }
+
+    it 'adds facts to the Target' do
+      expect_task('facts').always_return(fact_output)
+      inventory.expects(:add_facts).with(target, fact_output)
+
+      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(fact_output))
+    end
+
+    it 'omits failed targets' do
+      expect_task('facts').always_return(err_output)
+      inventory.expects(:add_facts).never
+
+      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(err_output))
+    end
+  end
+
+  context 'a winrm target' do
+    let(:node) { 'winrm://host' }
+
+    it 'adds facts to the Target' do
+      expect_task('facts').always_return(fact_output)
+      inventory.expects(:add_facts).with(target, fact_output)
+
+      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(fact_output))
+    end
+
+    it 'omits failed targets' do
+      expect_task('facts').always_return(err_output)
+      inventory.expects(:add_facts).never
+
+      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(err_output))
+    end
+  end
+
+  context 'a pcp target' do
+    let(:node) { 'pcp://host' }
+
+    it 'adds facts to the Target' do
+      expect_task('facts').always_return(fact_output)
+      inventory.expects(:add_facts).with(target, fact_output)
+
+      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(fact_output))
+    end
+
+    it 'omits failed targets' do
+      expect_task('facts').always_return(err_output)
+      inventory.expects(:add_facts).never
+
+      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(err_output))
+    end
+  end
+
+  context 'a local target' do
+    let(:node) { 'local://' }
+
+    it 'adds facts to the Target' do
+      expect_task('facts').always_return(fact_output)
+      inventory.expects(:add_facts).with(target, fact_output)
+
+      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(fact_output))
+    end
+
+    it 'omits failed targets' do
+      expect_task('facts').always_return(err_output)
+      inventory.expects(:add_facts).never
+
+      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(err_output))
+    end
+  end
+
+  context 'ssh, winrm, and pcp targets' do
+    let(:nodes) { %w[ssh://host1 winrm://host2 pcp://host3] }
+
+    it 'contains OS information for target' do
+      target_results = nodes.each_with_object({}) { |node, h| h[node] = fact_output(node) }
+      expect_task('facts').return_for_targets(target_results)
+      nodes.each { |node| inventory.expects(:add_facts).with(Bolt::Target.new(node), fact_output(node)) }
+
+      result_set = Bolt::ResultSet.new(
+        nodes.map { |node| Bolt::Result.new(Bolt::Target.new(node), value: fact_output(node)) }
+      )
+      expect(run_plan('facts', 'nodes' => nodes).value).to eq(result_set)
+    end
+
+    it 'omits failed targets' do
+      target_results = nodes.each_with_object({}) { |node, h| h[node] = err_output(node) }
+      expect_task('facts').return_for_targets(target_results)
+      inventory.expects(:add_facts).never
+
+      result_set = Bolt::ResultSet.new(
+        nodes.map { |node| Bolt::Result.new(Bolt::Target.new(node), value: err_output(node)) }
+      )
+      expect(run_plan('facts', 'nodes' => nodes).value).to eq(result_set)
+    end
+  end
+end

--- a/spec/modules/facts/plans/retrieve_spec.rb
+++ b/spec/modules/facts/plans/retrieve_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/plans'
+
+describe 'facts::retrieve' do
+  include BoltSpec::Plans
+
+  let(:node) { '' }
+  let(:target) { Bolt::Target.new(node) }
+
+  def fact_output(node_ = node)
+    { 'fqdn' => node_ }
+  end
+
+  def err_output(node_ = node)
+    { '_error' => { 'msg' => "Failed on #{node_}" } }
+  end
+
+  def results(output)
+    Bolt::ResultSet.new([Bolt::Result.new(target, value: output)])
+  end
+
+  context 'an ssh target' do
+    let(:node) { 'ssh://host' }
+
+    it 'retrieves facts' do
+      expect_task('facts').always_return(fact_output)
+
+      expect(run_plan('facts::retrieve', 'nodes' => [node]).value).to eq(results(fact_output))
+    end
+
+    it 'omits failed targets' do
+      expect_task('facts').always_return(err_output)
+
+      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(err_output))
+    end
+  end
+
+  context 'a winrm target' do
+    let(:node) { 'winrm://host' }
+
+    it 'retrieves facts' do
+      expect_task('facts').always_return(fact_output)
+
+      expect(run_plan('facts::retrieve', 'nodes' => [node]).value).to eq(results(fact_output))
+    end
+
+    it 'omits failed targets' do
+      expect_task('facts').always_return(err_output)
+
+      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(err_output))
+    end
+  end
+
+  context 'a pcp target' do
+    let(:node) { 'pcp://host' }
+
+    it 'retrieves facts' do
+      expect_task('facts').always_return(fact_output)
+
+      expect(run_plan('facts::retrieve', 'nodes' => [node]).value).to eq(results(fact_output))
+    end
+
+    it 'omits failed targets' do
+      expect_task('facts').always_return(err_output)
+
+      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(err_output))
+    end
+  end
+
+  context 'a local target' do
+    let(:node) { 'local://' }
+
+    it 'retrieves facts' do
+      expect_task('facts').always_return(fact_output)
+
+      expect(run_plan('facts::retrieve', 'nodes' => [node]).value).to eq(results(fact_output))
+    end
+
+    it 'omits failed targets' do
+      expect_task('facts').always_return(err_output)
+
+      expect(run_plan('facts::retrieve', 'nodes' => [node]).value).to eq(results(err_output))
+    end
+  end
+
+  context 'ssh, winrm, and pcp targets' do
+    let(:nodes) { %w[ssh://host1 winrm://host2 pcp://host3] }
+
+    it 'contains OS information for target' do
+      target_results = nodes.each_with_object({}) { |node, h| h[node] = fact_output(node) }
+      expect_task('facts').return_for_targets(target_results)
+
+      result_set = Bolt::ResultSet.new(
+        nodes.map { |node| Bolt::Result.new(Bolt::Target.new(node), value: fact_output(node)) }
+      )
+      expect(run_plan('facts::retrieve', 'nodes' => nodes).value).to eq(result_set)
+    end
+
+    it 'omits failed targets' do
+      target_results = nodes.each_with_object({}) { |node, h| h[node] = err_output(node) }
+      expect_task('facts').return_for_targets(target_results)
+
+      result_set = Bolt::ResultSet.new(
+        nodes.map { |node| Bolt::Result.new(Bolt::Target.new(node), value: err_output(node)) }
+      )
+      expect(run_plan('facts::retrieve', 'nodes' => nodes).value).to eq(result_set)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,11 @@ require_relative '../vendored/require_vendored'
 
 $LOAD_PATH.unshift File.join(__dir__, 'lib')
 
+# Ensure tasks are enabled when rspec-puppet sets up an environment
+# so we get task loaders.
+Puppet[:tasks] = true
+require 'puppetlabs_spec_helper/module_spec_helper'
+
 RSpec.shared_context 'reset puppet settings' do
   after :each do
     # reset puppet settings so that they can be initialized again


### PR DESCRIPTION
This PR moves the spec tests from the facts module included with bolt to live with the 'general' spec tests. This is so that we can maintain some spec testing while rewriting most of the spec tests to be beaker acceptance tests for the actual puppetlabs-facts module that we're replacing the local facts module with.