### PR TITLE
(BOLT-534) Fix sudo hanging when user shell is bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,8 @@ ENV LC_ALL="en_US.UTF-8"
 ENV LANG="en_US.UTF-8"
 ENV LANGUAGE="en_US.UTF-8"
 
-# Add bolt user
+# Add bolt user with authorized key
 RUN useradd bolt && echo "bolt:bolt" | chpasswd && adduser bolt sudo
-RUN useradd test && echo "test:test" | chpasswd && adduser test sudo
-
-# Add SSH key support
 RUN mkdir -p /home/bolt/.ssh/
 COPY spec/fixtures/keys/id_rsa.pub /home/bolt/.ssh/id_rsa.pub
 COPY spec/fixtures/keys/id_rsa.pub /home/bolt/.ssh/authorized_keys
@@ -19,6 +16,9 @@ RUN chmod 700 /home/bolt/.ssh/
 RUN chmod 600 /home/bolt/.ssh/authorized_keys
 RUN chown -R bolt:sudo /home/bolt
 
+# Add test user without authorized key and different login shell
+RUN useradd test && echo "test:test" | chpasswd && adduser test sudo
+RUN echo test | chsh -s /bin/bash test
 RUN mkdir -p /home/test/
 RUN chown -R test:sudo /home/test
 

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -267,6 +267,9 @@ module Bolt
             @logger.info { "Command failed with exit code #{result_output.exit_code}" }
           end
           result_output
+        rescue StandardError
+          @logger.debug { "Command aborted" }
+          raise
         end
 
         def write_remote_file(source, destination)

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -239,14 +239,14 @@ module Bolt
                 unless use_sudo && handled_sudo(channel, data)
                   result_output.stdout << data
                 end
-                @logger.debug { "stdout: #{data}" }
+                @logger.debug { "stdout: #{data.strip}" }
               end
 
               channel.on_extended_data do |_, _, data|
                 unless use_sudo && handled_sudo(channel, data)
                   result_output.stderr << data
                 end
-                @logger.debug { "stderr: #{data}" }
+                @logger.debug { "stderr: #{data.strip}" }
               end
 
               channel.on_request("exit-status") do |_, data|

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -167,6 +167,8 @@ module Bolt
               channel.wait
               return true
             else
+              # Cancel the sudo prompt to prevent later commands getting stuck
+              channel.close
               raise Bolt::Node::EscalateError.new(
                 "Sudo password for user #{@user} was not provided for #{target.uri}",
                 'NO_PASSWORD'

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -403,6 +403,9 @@ PS
             @logger.info { "Command failed with exit code #{output.exitcode}" }
           end
           result_output
+        rescue StandardError
+          @logger.debug { "Command aborted" }
+          raise
         end
 
         # 10 minutes in seconds


### PR DESCRIPTION
When run-as is requested without a password but the password is required we should fail. However when attempting that against targets where the user's login shell is bash, a 2nd sudo attempt would hang. Fix the issue causing us to attempt a 2nd sudo in the first place, and close the connection after when no password is available to prevent future issues.