### PR TITLE
(BOLT-546) Avoid mktemp to work on AIX

### DIFF
--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -271,12 +271,10 @@ module Bolt
         end
 
         def make_tempdir
-          if target.options['tmpdir']
-            tmppath = "#{target.options['tmpdir']}/#{SecureRandom.uuid}"
-            command = ['mkdir', '-m', 700, tmppath]
-          else
-            command = ['mktemp', '-d']
-          end
+          tmpdir = target.options.fetch('tmpdir', '/tmp')
+          tmppath = "#{tmpdir}/#{SecureRandom.uuid}"
+          command = ['mkdir', '-m', 700, tmppath]
+
           result = execute(command)
           if result.exit_code != 0
             raise Bolt::Node::FileError.new("Could not make tempdir: #{result.stderr.string}", 'TEMPDIR_ERROR')


### PR DESCRIPTION
AIX, and possibly other such systems, doesn't have `mktemp` available by
default. That was causing remote tempdir creation to fail. Since we
already have a functioning alternative using UUIDs, we now use that in
all cases. If the user supplied an explicit tmpdir, that remains the
parent, and we default to /tmp otherwise.