### PR TITLE
(BOLT-547) Finish plan when execution ends

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -555,8 +555,7 @@ Available options are:
         result = pal.run_plan(options[:object], options[:task_options], executor, inventory, puppetdb_client)
 
         # If a non-bolt exeception bubbles up the plan won't get finished
-        # TODO: finish the plan once ORCH-2224
-        # executor.finish_plan(result)
+        executor.finish_plan(result)
         outputter.print_plan_result(result)
         code = result.ok? ? 0 : 1
       else

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -42,7 +42,7 @@ module Bolt
             begin
               conn.finish_plan(result)
             rescue StandardError => e
-              @logger.error("Failed to finish plan on #{conn.key}: #{e.message}")
+              @logger.debug("Failed to finish plan on #{conn.key}: #{e.message}")
             end
           end
         end

--- a/lib/bolt/transport/orch/connection.rb
+++ b/lib/bolt/transport/orch/connection.rb
@@ -28,6 +28,7 @@ module Bolt
 
           @client = OrchestratorClient.new(client_opts, true)
           @plan_job = start_plan(plan_context)
+          logger.debug("Started plan #{@plan_job}")
           @environment = opts["task-environment"]
         end
 

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1349,6 +1349,7 @@ bar
             .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'yes', '', 0)]))
 
           expect(executor).to receive(:start_plan)
+          expect(executor).to receive(:finish_plan)
 
           cli.execute(options)
           expect(JSON.parse(output.string)).to eq(
@@ -1373,6 +1374,7 @@ bar
             .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'yes', '', 0)]))
 
           expect(executor).to receive(:start_plan)
+          expect(executor).to receive(:finish_plan)
 
           cli.execute(options)
           expect(JSON.parse(output.string)).to eq(
@@ -1387,6 +1389,7 @@ bar
             .and_raise("Could not connect to target")
 
           expect(executor).to receive(:start_plan)
+          expect(executor).to receive(:finish_plan)
 
           expect(cli.execute(options)).to eq(1)
           expect(JSON.parse(output.string)['msg']).to match(/Could not connect to target/)
@@ -1399,6 +1402,7 @@ bar
             .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'no', '', 1)]))
 
           expect(executor).to receive(:start_plan)
+          expect(executor).to receive(:finish_plan)
 
           cli.execute(options)
           expect(JSON.parse(output.string)).to eq(
@@ -1424,6 +1428,7 @@ bar
           plan_name.replace 'sample::dne'
 
           expect(executor).to receive(:start_plan)
+          expect(executor).to receive(:finish_plan)
 
           expect(cli.execute(options)).to eq(1)
           expect(JSON.parse(output.string)['msg']).to match(/Could not find a plan named "sample::dne"/)
@@ -1439,6 +1444,7 @@ bar
             end
 
           expect(executor).to receive(:start_plan)
+          expect(executor).to receive(:finish_plan)
 
           expect(cli).to receive(:exit!) do
             sync_thread.kill


### PR DESCRIPTION
If a plan includes any targets that use the PCP transport, send
finish_plan to the configured transport variants after all plan
execution has finished with results and status.

Error responses to finish plan are logged at debug level.