### PR TITLE
(BOLT-490) Collect events for each transport used

### DIFF
--- a/lib/bolt/analytics.rb
+++ b/lib/bolt/analytics.rb
@@ -71,7 +71,7 @@ module Bolt
         submit(base_params.merge(screen_view_params))
       end
 
-      def event(category, action)
+      def event(category, action, label = nil, value = nil)
         event_params = {
           # Type
           t: 'event',
@@ -80,6 +80,11 @@ module Bolt
           # Event Action
           ea: action
         }
+
+        # Event Label
+        event_params[:el] = label if label
+        # Event Value
+        event_params[:ev] = value if value
 
         submit(base_params.merge(event_params))
       end
@@ -145,7 +150,7 @@ module Bolt
         @logger.debug "Skipping submission of '#{screen}' screenview because analytics is disabled"
       end
 
-      def event(category, action)
+      def event(category, action, _label = nil, _value = nil)
         @logger.debug "Skipping submission of '#{category} #{action}' event because analytics is disabled"
       end
 

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -550,7 +550,7 @@ Available options are:
                          params: params }
         plan_context[:description] = options[:description] if options[:description]
 
-        executor = Bolt::Executor.new(config, options[:noop])
+        executor = Bolt::Executor.new(config, @analytics, options[:noop])
         executor.start_plan(plan_context)
         result = pal.run_plan(options[:object], options[:task_options], executor, inventory, puppetdb_client)
 
@@ -560,7 +560,7 @@ Available options are:
         outputter.print_plan_result(result)
         code = result.ok? ? 0 : 1
       else
-        executor = Bolt::Executor.new(config, options[:noop])
+        executor = Bolt::Executor.new(config, @analytics, options[:noop])
         targets = options[:targets]
 
         results = nil

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -5,6 +5,8 @@ require 'English'
 require 'json'
 require 'concurrent'
 require 'logging'
+require 'set'
+require 'bolt/analytics'
 require 'bolt/result'
 require 'bolt/config'
 require 'bolt/notifier'
@@ -16,14 +18,18 @@ module Bolt
     attr_reader :noop, :transports
     attr_accessor :run_as, :plan_logging
 
-    def initialize(config = Bolt::Config.new, noop = nil)
+    def initialize(config = Bolt::Config.new, analytics = Bolt::Analytics::NoopClient.new, noop = nil)
       @config = config
+      @analytics = analytics
       @logger = Logging.logger[self]
       @plan_logging = false
 
       @transports = Bolt::TRANSPORTS.each_with_object({}) do |(key, val), coll|
-        coll[key.to_s] = Concurrent::Delay.new { val.new }
+        coll[key.to_s] = Concurrent::Delay.new do
+          val.new
+        end
       end
+      @reported_transports = Set.new
 
       @noop = noop
       @run_as = nil
@@ -50,6 +56,7 @@ module Bolt
     def batch_execute(targets)
       promises = targets.group_by(&:protocol).flat_map do |protocol, protocol_targets|
         transport = transport(protocol)
+        report_transport(transport, protocol_targets.count)
         transport.batches(protocol_targets).flat_map do |batch|
           batch_promises = Array(batch).each_with_object({}) do |target, h|
             h[target] = Concurrent::Promise.new(executor: :immediate)
@@ -109,6 +116,12 @@ module Bolt
       results
     end
     private :log_action
+
+    def report_transport(transport, count)
+      name = transport.class.name.split('::').last.downcase
+      @analytics&.event('Transport', 'initialize', name, count) unless @reported_transports.include?(name)
+      @reported_transports.add(name)
+    end
 
     def with_node_logging(description, batch)
       @logger.info("#{description} on #{batch.map(&:uri)}")

--- a/pre-docs/bolt_analytics.md
+++ b/pre-docs/bolt_analytics.md
@@ -8,6 +8,7 @@ Bolt automatically collects data about how you use it.
 * The Bolt command executed (eg. `bolt task run`, `bolt plan show`), excluding arguments
 * User locale
 * Operating system and version
+* Which transports (SSH, WinRM, PCP) are used and with how many targets
 
 This data is associated with a random, non-identifiable user UUID.
 

--- a/spec/bolt/analytics_spec.rb
+++ b/spec/bolt/analytics_spec.rb
@@ -83,6 +83,22 @@ describe Bolt::Analytics::Client do
 
       subject.event('run', 'task')
     end
+
+    it 'sends the event label if supplied' do
+      params = base_params.merge(t: 'event', ec: 'run', ea: 'task', el: 'happy')
+
+      expect(subject).to receive(:submit).with params
+
+      subject.event('run', 'task', 'happy')
+    end
+
+    it 'sends the event metric if supplied' do
+      params = base_params.merge(t: 'event', ec: 'run', ea: 'task', ev: 12)
+
+      expect(subject).to receive(:submit).with params
+
+      subject.event('run', 'task', nil, 12)
+    end
   end
 end
 
@@ -96,6 +112,14 @@ describe Bolt::Analytics::NoopClient do
   describe "#event" do
     it 'succeeds' do
       subject.event('run', 'task')
+    end
+
+    it 'succeeds with a label' do
+      subject.event('run', 'task', 'happy')
+    end
+
+    it 'succeeds with a metric' do
+      subject.event('run', 'task', nil, 12)
     end
   end
 end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1524,7 +1524,7 @@ bar
       let(:output) { StringIO.new }
 
       before :each do
-        expect(Bolt::Executor).to receive(:new).with(config, true).and_return(executor)
+        expect(Bolt::Executor).to receive(:new).with(config, anything, true).and_return(executor)
 
         outputter = Bolt::Outputter::JSON.new(false, output)
 

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -8,7 +8,8 @@ describe "Bolt::Executor" do
   include BoltSpec::Task
 
   let(:config) { Bolt::Config.new(concurrency: 1) }
-  let(:executor) { Bolt::Executor.new(config) }
+  let(:analytics) { Bolt::Analytics::NoopClient.new }
+  let(:executor) { Bolt::Executor.new(config, analytics) }
   let(:command) { "hostname" }
   let(:script) { '/path/to/script.sh' }
   let(:dest) { '/tmp/upload' }
@@ -388,6 +389,24 @@ describe "Bolt::Executor" do
     results = executor.run_command(targets, command)
     results.each do |result|
       expect(result.error_hash['kind']).to eq('puppetlabs.tasks/exception-error')
+    end
+  end
+
+  context 'reporting analytics data' do
+    let(:targets) {
+      [Bolt::Target.new('ssh://node1'),
+       Bolt::Target.new('ssh://node2'),
+       Bolt::Target.new('winrm://node3'),
+       Bolt::Target.new('pcp://node4')]
+    }
+
+    it 'reports one event for each transport used' do
+      expect(analytics).to receive(:event).with('Transport', 'initialize', 'ssh', 2).once
+      expect(analytics).to receive(:event).with('Transport', 'initialize', 'winrm', 1).once
+      expect(analytics).to receive(:event).with('Transport', 'initialize', 'orch', 1).once
+
+      executor.batch_execute(targets) {}
+      executor.batch_execute(targets) {}
     end
   end
 


### PR DESCRIPTION
We now send one event per-transport when a transport is first
initialized. This allows us to understand how commonly each transport is
being used and whether they're being used together.