### PR TITLE
(maint) Address new rubocop cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,9 @@ AllCops:
 Style/IfUnlessModifier:
   Enabled: false
 
+Style/AccessModifierDeclarations:
+  Enabled: false
+
 Style/StringLiterals:
   Enabled: false
 
@@ -26,6 +29,9 @@ Style/NumericPredicate:
   Enabled: false
 
 Layout/IndentHeredoc:
+  Enabled: false
+
+Layout/ClosingHeredocIndentation:
   Enabled: false
 
 Style/GuardClause:

--- a/bolt-modules/boltlib/lib/puppet/datatypes/target.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/target.rb
@@ -14,7 +14,7 @@ Puppet::DataTypes.create_type('Target') do
       protocol => Callable[[], Optional[String[1]]],
       user => Callable[[], Optional[String[1]]],
     }
-    PUPPET
+  PUPPET
 
   load_file('bolt/target')
 

--- a/lib/bolt/transport/local.rb
+++ b/lib/bolt/transport/local.rb
@@ -84,7 +84,7 @@ module Bolt
         executable = target.select_impl(task, PROVIDED_FEATURES)
         raise "No suitable implementation of #{task.name} for #{target.name}" unless executable
 
-        input_method = task.input_method ? task.input_method : "both"
+        input_method = task.input_method || "both"
         stdin = STDIN_METHODS.include?(input_method) ? JSON.dump(arguments) : nil
         env = ENVIRONMENT_METHODS.include?(input_method) ? arguments : nil
 

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -118,7 +118,7 @@ module Bolt
         executable = target.select_impl(task, PROVIDED_FEATURES)
         raise "No suitable implementation of #{task.name} for #{target.name}" unless executable
 
-        input_method = task.input_method ? task.input_method : "both"
+        input_method = task.input_method || "both"
         with_connection(target) do |conn|
           conn.running_as(options['_run_as']) do
             stdin, output = nil

--- a/spec/lib/bolt_spec/conn.rb
+++ b/spec/lib/bolt_spec/conn.rb
@@ -32,7 +32,7 @@ module BoltSpec
     def conn_uri(transport, include_password: false, override_port: nil)
       conn = conn_info(transport)
       passwd = include_password ? ":#{conn[:password]}" : ''
-      port = override_port ? override_port : conn[:port]
+      port = override_port || conn[:port]
       "#{conn[:protocol]}://#{conn[:user]}#{passwd}@#{conn[:host]}:#{port}"
     end
   end


### PR DESCRIPTION
Disable ones where style doesn't fit existing practice. Fix unnecessary
ternary operators.