### PR TITLE
(BOLT-562) Send inventory size with screen_view

### DIFF
--- a/lib/bolt/analytics.rb
+++ b/lib/bolt/analytics.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'bolt/util'
 require 'bolt/version'
 require 'httpclient'
 require 'json'
@@ -13,6 +14,11 @@ module Bolt
     APPLICATION_NAME = 'bolt'
     TRACKING_ID = 'UA-120367942-1'
     TRACKING_URL = 'https://google-analytics.com/collect'
+    CUSTOM_DIMENSIONS = {
+      operating_system: :cd1,
+      inventory_nodes: :cd2,
+      inventory_groups: :cd3
+    }.freeze
 
     def self.build_client
       logger = Logging.logger[self]
@@ -60,13 +66,17 @@ module Bolt
         @os = compute_os
       end
 
-      def screen_view(screen)
+      def screen_view(screen, **kwargs)
+        custom_dimensions = Bolt::Util.walk_keys(kwargs) do |k|
+          CUSTOM_DIMENSIONS[k] || raise("Unknown analytics key '#{k}'")
+        end
+
         screen_view_params = {
           # Type
           t: 'screenview',
           # Screen Name
           cd: screen
-        }
+        }.merge(custom_dimensions)
 
         submit(base_params.merge(screen_view_params))
       end
@@ -146,7 +156,7 @@ module Bolt
         @logger = Logging.logger[self]
       end
 
-      def screen_view(screen)
+      def screen_view(screen, **_kwargs)
         @logger.debug "Skipping submission of '#{screen}' screenview because analytics is disabled"
       end
 

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -501,7 +501,9 @@ Available options are:
       if options[:action] == 'show' && options[:object]
         screen += '_object'
       end
-      @analytics.screen_view(screen)
+      @analytics.screen_view(screen,
+                             inventory_nodes: inventory.node_names.count,
+                             inventory_groups: inventory.group_names.count)
 
       if options[:mode] == 'plan' || options[:mode] == 'task'
         pal = Bolt::PAL.new(config)

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -78,6 +78,14 @@ module Bolt
       @group_lookup = @groups.collect_groups
     end
 
+    def group_names
+      @group_lookup.keys
+    end
+
+    def node_names
+      @groups.node_names
+    end
+
     def get_targets(targets)
       targets = expand_targets(targets)
       targets = if targets.is_a? Array

--- a/spec/bolt/analytics_spec.rb
+++ b/spec/bolt/analytics_spec.rb
@@ -73,6 +73,18 @@ describe Bolt::Analytics::Client do
 
       subject.screen_view('job_run')
     end
+
+    it 'sets custom dimensions correctly' do
+      params = base_params.merge(t: 'screenview', cd: 'job_run', cd2: 12, cd3: 17)
+
+      expect(subject).to receive(:submit).with params
+
+      subject.screen_view('job_run', inventory_nodes: 12, inventory_groups: 17)
+    end
+
+    it 'raises an error if an unknown custom dimension is specified' do
+      expect { subject.screen_view('job_run', random_field: 'foo') }.to raise_error(/Unknown analytics key/)
+    end
   end
 
   describe "#event" do


### PR DESCRIPTION
We now include the number of nodes and number of groups (as custom
dimensions 2 and 3) in the screen_view hit submitted whenever a bolt
command is run.

This also adds a mapping of custom dimension name to id, to make it
easier to correctly match fields and values.