### PR TITLE
(BOLT-491) Collect number of targeted nodes for each bolt command

### DIFF
--- a/lib/bolt/analytics.rb
+++ b/lib/bolt/analytics.rb
@@ -17,7 +17,8 @@ module Bolt
     CUSTOM_DIMENSIONS = {
       operating_system: :cd1,
       inventory_nodes: :cd2,
-      inventory_groups: :cd3
+      inventory_groups: :cd3,
+      target_nodes: :cd4
     }.freeze
 
     def self.build_client

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -501,7 +501,9 @@ Available options are:
       if options[:action] == 'show' && options[:object]
         screen += '_object'
       end
+
       @analytics.screen_view(screen,
+                             target_nodes: options.fetch(:targets, []).count,
                              inventory_nodes: inventory.node_names.count,
                              inventory_groups: inventory.group_names.count)
 

--- a/pre-docs/bolt_analytics.md
+++ b/pre-docs/bolt_analytics.md
@@ -10,6 +10,7 @@ Bolt automatically collects data about how you use it.
 * Operating system and version
 * Which transports (SSH, WinRM, PCP) are used and with how many targets
 * The number of nodes and groups defined in the Bolt inventory file
+* The number of nodes targeted with a Bolt command
 
 This data is associated with a random, non-identifiable user UUID.
 


### PR DESCRIPTION
We now include the number of targeted nodes with the screen_view hit
that we submit each time a bolt command is run. This counts the
*resolved* targets, after groups and PuppetDB queries have been taken
into consideration. This does not account for the number of nodes run as
part of a plan, unless those nodes were passed using --nodes or --query.