### PR TITLE
(BOLT-564) Collect data about calls to boltlib functions

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/add_facts.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/add_facts.rb
@@ -30,6 +30,9 @@ Puppet::Functions.create_function(:add_facts) do
       )
     end
 
+    executor = Puppet.lookup(:bolt_executor) { nil }
+    executor&.report_function_call('add_facts')
+
     inventory.add_facts(target, facts)
   end
 end

--- a/bolt-modules/boltlib/lib/puppet/functions/facts.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/facts.rb
@@ -28,6 +28,9 @@ Puppet::Functions.create_function(:facts) do
       )
     end
 
+    executor = Puppet.lookup(:bolt_executor) { nil }
+    executor&.report_function_call('facts')
+
     inventory.facts(target)
   end
 end

--- a/bolt-modules/boltlib/lib/puppet/functions/fail_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/fail_plan.rb
@@ -32,6 +32,9 @@ Puppet::Functions.create_function(:fail_plan) do
   end
 
   def from_args(msg, kind = nil, details = nil, issue_code = nil)
+    executor = Puppet.lookup(:bolt_executor) { nil }
+    executor&.report_function_call('fail_plan')
+
     raise Bolt::PlanFailure.new(msg, kind || 'bolt/plan-failure', details, issue_code)
   end
 

--- a/bolt-modules/boltlib/lib/puppet/functions/file_upload.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/file_upload.rb
@@ -67,6 +67,8 @@ Puppet::Functions.create_function(:file_upload, Puppet::Functions::InternalFunct
       )
     end
 
+    executor.report_function_call('file_upload')
+
     found = Puppet::Parser::Files.find_file(source, scope.compiler.environment)
     unless found && Puppet::FileSystem.exist?(found)
       raise Puppet::ParseErrorWithIssue.from_issue_and_stack(

--- a/bolt-modules/boltlib/lib/puppet/functions/get_targets.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/get_targets.rb
@@ -36,6 +36,9 @@ Puppet::Functions.create_function(:get_targets) do
       )
     end
 
+    executor = Puppet.lookup(:bolt_executor) { nil }
+    executor&.report_function_call('get_targets')
+
     inventory.get_targets(names)
   end
 end

--- a/bolt-modules/boltlib/lib/puppet/functions/puppetdb_fact.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/puppetdb_fact.rb
@@ -30,6 +30,9 @@ Puppet::Functions.create_function(:puppetdb_fact) do
       )
     end
 
+    executor = Puppet.lookup(:bolt_executor) { nil }
+    executor&.report_function_call('puppetdb_fact')
+
     puppetdb_client.facts_for_node(certnames)
   end
 end

--- a/bolt-modules/boltlib/lib/puppet/functions/puppetdb_query.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/puppetdb_query.rb
@@ -22,6 +22,9 @@ Puppet::Functions.create_function(:puppetdb_query) do
       )
     end
 
+    executor = Puppet.lookup(:bolt_executor) { nil }
+    executor&.report_function_call('puppetdb_query')
+
     puppetdb_client.make_query(query)
   end
 end

--- a/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
@@ -57,6 +57,8 @@ Puppet::Functions.create_function(:run_command) do
       )
     end
 
+    executor.report_function_call('run_command')
+
     # Ensure that given targets are all Target instances
     targets = inventory.get_targets(targets)
 

--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -29,6 +29,12 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
       )
     end
 
+    # Bolt calls this function internally to trigger plans from the CLI. We
+    # don't want to count those invocations.
+    unless named_args['_bolt_api_call']
+      executor.report_function_call('run_plan')
+    end
+
     params = named_args.reject { |k, _| k.start_with?('_') }
 
     loaders = closure_scope.compiler.loaders

--- a/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
@@ -63,6 +63,8 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
       )
     end
 
+    executor.report_function_call('run_script')
+
     found = Puppet::Parser::Files.find_file(script, scope.compiler.environment)
     unless found && Puppet::FileSystem.exist?(found)
       raise Puppet::ParseErrorWithIssue.from_issue_and_stack(

--- a/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
@@ -80,6 +80,12 @@ Puppet::Functions.create_function(:run_task) do
       )
     end
 
+    # Bolt calls this function internally to trigger tasks from the CLI. We
+    # don't want to count those invocations.
+    unless task_args['_bolt_api_call']
+      executor.report_function_call('run_task')
+    end
+
     # Ensure that given targets are all Target instances
     targets = inventory.get_targets(targets)
 

--- a/bolt-modules/boltlib/lib/puppet/functions/set_feature.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_feature.rb
@@ -35,6 +35,9 @@ Puppet::Functions.create_function(:set_feature) do
       )
     end
 
+    executor = Puppet.lookup(:bolt_executor) { nil }
+    executor&.report_function_call('set_feature')
+
     inventory.set_feature(target, feature, value)
 
     target

--- a/bolt-modules/boltlib/lib/puppet/functions/set_var.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_var.rb
@@ -31,6 +31,9 @@ Puppet::Functions.create_function(:set_var) do
       )
     end
 
+    executor = Puppet.lookup(:bolt_executor) { nil }
+    executor&.report_function_call('set_var')
+
     inventory.set_var(target, key, value)
   end
 end

--- a/bolt-modules/boltlib/lib/puppet/functions/vars.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/vars.rb
@@ -32,6 +32,9 @@ Puppet::Functions.create_function(:vars) do
       )
     end
 
+    executor = Puppet.lookup(:bolt_executor) { nil }
+    executor&.report_function_call('vars')
+
     inventory.vars(target)
   end
 end

--- a/bolt-modules/boltlib/lib/puppet/functions/without_default_logging.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/without_default_logging.rb
@@ -19,6 +19,8 @@ Puppet::Functions.create_function(:without_default_logging) do
 
   def without_default_logging
     executor = Puppet.lookup(:bolt_executor) { nil }
+    executor.report_function_call('without_default_logging')
+
     old_log = executor.plan_logging
     executor.plan_logging = false
     begin

--- a/bolt-modules/boltlib/spec/functions/add_facts_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/add_facts_spec.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'bolt/executor'
 require 'bolt/target'
 
 describe 'add_facts' do
   include PuppetlabsSpec::Fixtures
-  let(:executor) { mock('bolt_executor') }
+  let(:executor) { Bolt::Executor.new }
   let(:inventory) { mock('inventory') }
   let(:target) { Bolt::Target.new('example') }
 
@@ -28,5 +29,12 @@ describe 'add_facts' do
     is_expected.to run.with_params(target, 1)
                       .and_raise_error(ArgumentError,
                                        "'add_facts' parameter 'facts' expects a Hash value, got Integer")
+  end
+
+  it 'reports the call to analytics' do
+    executor.expects(:report_function_call).with('add_facts')
+    inventory.expects(:add_facts).returns({})
+
+    is_expected.to run.with_params(target, {})
   end
 end

--- a/bolt-modules/boltlib/spec/functions/facts_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/facts_spec.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'bolt/executor'
 require 'bolt/target'
 
 describe 'facts' do
   include PuppetlabsSpec::Fixtures
 
-  let(:executor) { mock('bolt_executor') }
+  let(:executor) { Bolt::Executor.new }
   let(:inventory) { mock('inventory') }
   let(:hostname) { 'example' }
   let(:target) { Bolt::Target.new(hostname) }
@@ -23,5 +24,12 @@ describe 'facts' do
   it 'should return an empty hash if no facts are set' do
     inventory.expects(:facts).with(target).returns({})
     is_expected.to run.with_params(target).and_return({})
+  end
+
+  it 'reports the call to analytics' do
+    executor.expects(:report_function_call).with('facts')
+    inventory.expects(:facts).returns({})
+
+    is_expected.to run.with_params(target)
   end
 end

--- a/bolt-modules/boltlib/spec/functions/fail_plan_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/fail_plan_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'bolt/executor'
 require 'bolt/error'
 
 describe 'fail_plan' do
@@ -13,5 +14,14 @@ describe 'fail_plan' do
   it 'raises an error from an Error object' do
     error = Puppet::DataTypes::Error.new('oops')
     is_expected.to run.with_params(error).and_raise_error(Bolt::PlanFailure)
+  end
+
+  it 'reports the call to analytics' do
+    executor = Bolt::Executor.new
+    executor.expects(:report_function_call).with('fail_plan')
+
+    Puppet.override(bolt_executor: executor) do
+      is_expected.to run.with_params('foo').and_raise_error(Bolt::PlanFailure)
+    end
   end
 end

--- a/bolt-modules/boltlib/spec/functions/file_upload_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/file_upload_spec.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'bolt/executor'
 require 'bolt/result'
 require 'bolt/result_set'
 require 'bolt/target'
 
 describe 'file_upload' do
   include PuppetlabsSpec::Fixtures
-  let(:executor) { mock('bolt_executor') }
+  let(:executor) { Bolt::Executor.new }
   let(:inventory) { mock('inventory') }
   let(:tasks_enabled) { true }
 
@@ -61,6 +62,14 @@ describe 'file_upload' do
       inventory.stubs(:get_targets).with(target).returns([target])
 
       is_expected.to run.with_params('test/uploads', destination, target, '_run_as' => 'soandso').and_return(result_set)
+    end
+
+    it 'reports the call to analytics' do
+      executor.expects(:file_upload).with([target], full_path, destination, {}).returns(result_set)
+      inventory.stubs(:get_targets).with(hostname).returns([target])
+      executor.expects(:report_function_call).with('file_upload')
+
+      is_expected.to run.with_params('test/uploads/index.html', destination, hostname).and_return(result_set)
     end
 
     context 'with description' do

--- a/bolt-modules/boltlib/spec/functions/get_targets_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/get_targets_spec.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'bolt/executor'
 require 'bolt/target'
 
 describe 'get_targets' do
+  let(:executor) { Bolt::Executor.new }
   let(:inventory) { mock('inventory') }
   let(:tasks_enabled) { true }
 
   around(:each) do |example|
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_inventory: inventory) do
+    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
       example.run
     end
   end
@@ -53,6 +55,13 @@ describe 'get_targets' do
 
     it 'errors on unknown types' do
       is_expected.to run.with_params(mock('anything')).and_raise_error(ArgumentError)
+    end
+
+    it 'reports the call to analytics' do
+      inventory.expects(:get_targets).with(hostname).returns([target])
+      executor.expects(:report_function_call).with('get_targets')
+
+      is_expected.to run.with_params(hostname).and_return([target])
     end
   end
 

--- a/bolt-modules/boltlib/spec/functions/run_command_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_command_spec.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'bolt/executor'
 require 'bolt/result'
 require 'bolt/result_set'
 require 'bolt/target'
 
 describe 'run_command' do
-  let(:executor) { mock('bolt_executor') }
+  let(:executor) { Bolt::Executor.new }
   let(:inventory) { mock('inventory') }
   let(:tasks_enabled) { true }
 
@@ -46,6 +47,14 @@ describe 'run_command' do
       inventory.expects(:get_targets).with(target).returns([target])
 
       is_expected.to run.with_params(command, target, '_run_as' => 'root').and_return(result_set)
+    end
+
+    it 'reports the call to analytics' do
+      executor.expects(:report_function_call).with('run_command')
+      executor.expects(:run_command).with([target], command, {}).returns(result_set)
+      inventory.expects(:get_targets).with(hostname).returns([target])
+
+      is_expected.to run.with_params(command, hostname).and_return(result_set)
     end
 
     context 'with description' do

--- a/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
@@ -2,10 +2,11 @@
 
 require 'spec_helper'
 require 'puppet_pal'
+require 'bolt/executor'
 
 describe 'run_plan' do
   include PuppetlabsSpec::Fixtures
-  let(:executor) { mock('bolt_executor') }
+  let(:executor) { Bolt::Executor.new }
 
   around(:each) do |example|
     Puppet[:tasks] = true
@@ -47,6 +48,16 @@ describe 'run_plan' do
 
         is_expected.to run.with_params('test::run_me', '_run_as' => 'bar').and_return('worked2')
       end
+    end
+
+    it 'reports the call to analytics' do
+      executor.expects(:report_function_call).with('run_plan')
+      is_expected.to run.with_params('test::run_me').and_return('worked2')
+    end
+
+    it 'skips reporting the call to analytics if called internally from Bolt' do
+      executor.expects(:report_function_call).never
+      is_expected.to run.with_params('test::run_me', '_bolt_api_call' => true).and_return('worked2')
     end
 
     context 'using the name of the module' do

--- a/bolt-modules/boltlib/spec/functions/run_script_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_script_spec.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'bolt/executor'
 require 'bolt/target'
 require 'bolt/result'
 require 'bolt/result_set'
 
 describe 'run_script' do
   include PuppetlabsSpec::Fixtures
-  let(:executor) { mock('bolt_executor') }
+  let(:executor) { Bolt::Executor.new }
   let(:inventory) { mock('inventory') }
   let(:tasks_enabled) { true }
 
@@ -64,6 +65,14 @@ describe 'run_script' do
       inventory.expects(:get_targets).with(target).returns([target])
 
       is_expected.to run.with_params('test/uploads/hostname.sh', target, '_run_as' => 'root').and_return(result_set)
+    end
+
+    it 'reports the call to analytics' do
+      executor.expects(:report_function_call).with('run_script')
+      executor.expects(:run_script).with([target], full_path, [], {}).returns(result_set)
+      inventory.expects(:get_targets).with(hostname).returns([target])
+
+      is_expected.to run.with_params('test/uploads/hostname.sh', hostname).and_return(result_set)
     end
 
     context 'with description' do

--- a/bolt-modules/boltlib/spec/functions/set_var_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/set_var_spec.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'bolt/executor'
 require 'bolt/target'
 
 describe 'set_var' do
   include PuppetlabsSpec::Fixtures
-  let(:executor) { mock('bolt_executor') }
+  let(:executor) { Bolt::Executor.new }
   let(:inventory) { mock('inventory') }
   let(:target) { Bolt::Target.new('example') }
 
@@ -27,5 +28,12 @@ describe 'set_var' do
     is_expected.to run.with_params(target, 1, 'one')
                       .and_raise_error(ArgumentError,
                                        "'set_var' parameter 'key' expects a String value, got Integer")
+  end
+
+  it 'reports the call to analytics' do
+    executor.expects(:report_function_call).with('set_var')
+    inventory.expects(:set_var).with(target, 'a', 'b').returns(nil)
+
+    is_expected.to run.with_params(target, 'a', 'b').and_return(nil)
   end
 end

--- a/bolt-modules/boltlib/spec/functions/vars_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/vars_spec.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'bolt/executor'
 require 'bolt/target'
 
 describe 'vars' do
   include PuppetlabsSpec::Fixtures
 
-  let(:executor) { mock('bolt_executor') }
+  let(:executor) { Bolt::Executor.new }
   let(:inventory) { mock('inventory') }
   let(:hostname) { 'example' }
   let(:target) { Bolt::Target.new(hostname) }
@@ -22,6 +23,13 @@ describe 'vars' do
 
   it 'should return an empty hash if no vars are set' do
     inventory.expects(:vars).with(target).returns({})
+    is_expected.to run.with_params(target).and_return({})
+  end
+
+  it 'reports the call to analytics' do
+    executor.expects(:report_function_call).with('vars')
+    inventory.expects(:vars).with(target).returns({})
+
     is_expected.to run.with_params(target).and_return({})
   end
 end

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -123,6 +123,10 @@ module Bolt
       @reported_transports.add(name)
     end
 
+    def report_function_call(function)
+      @analytics&.event('Plan', 'call_function', function)
+    end
+
     def with_node_logging(description, batch)
       @logger.info("#{description} on #{batch.map(&:uri)}")
       result = yield

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -240,13 +240,14 @@ module Bolt
 
     def run_task(task_name, targets, params, executor, inventory, description = nil, &eventblock)
       in_task_compiler(executor, inventory) do |compiler|
+        params = params.merge('_bolt_api_call' => true)
         compiler.call_function('run_task', task_name, targets, description, params, &eventblock)
       end
     end
 
     def run_plan(plan_name, params, executor = nil, inventory = nil, pdb_client = nil)
       in_plan_compiler(executor, inventory, pdb_client) do |compiler|
-        r = compiler.call_function('run_plan', plan_name, params)
+        r = compiler.call_function('run_plan', plan_name, params.merge('_bolt_api_call' => true))
         Bolt::PlanResult.from_pcore(r, 'success')
       end
     rescue Bolt::Error => e

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1037,7 +1037,7 @@ bar
         it "runs a task given a name" do
           expect(executor)
             .to receive(:run_task)
-            .with(targets, task_t, task_params, {})
+            .with(targets, task_t, task_params, '_bolt_api_call' => true)
             .and_return(Bolt::ResultSet.new([]))
           expect(cli.execute(options)).to eq(0)
           expect(JSON.parse(output.string)).to be
@@ -1046,7 +1046,7 @@ bar
         it "returns 2 if any node fails" do
           expect(executor)
             .to receive(:run_task)
-            .with(targets, task_t, task_params, {})
+            .with(targets, task_t, task_params, '_bolt_api_call' => true)
             .and_return(fail_set)
 
           expect(cli.execute(options)).to eq(2)
@@ -1075,7 +1075,7 @@ bar
 
           expect(executor)
             .to receive(:run_task)
-            .with(targets, task_t, {}, {})
+            .with(targets, task_t, {}, '_bolt_api_call' => true)
             .and_raise("Could not connect to target")
 
           expect { cli.execute(options) }.to raise_error(/Could not connect to target/)
@@ -1087,7 +1087,7 @@ bar
 
           expect(executor)
             .to receive(:run_task)
-            .with(targets, task_t, task_params, {})
+            .with(targets, task_t, task_params, '_bolt_api_call' => true)
             .and_return(Bolt::ResultSet.new([]))
 
           cli.execute(options)
@@ -1102,7 +1102,7 @@ bar
 
             expect(executor)
               .to receive(:run_task)
-              .with(targets, task_t, task_params, {})
+              .with(targets, task_t, task_params, '_bolt_api_call' => true)
               .and_return(Bolt::ResultSet.new([]))
 
             cli.execute(options)
@@ -1115,7 +1115,7 @@ bar
 
             expect(executor)
               .to receive(:run_task)
-              .with(targets, task_t, task_params, {})
+              .with(targets, task_t, task_params, '_bolt_api_call' => true)
               .and_return(Bolt::ResultSet.new([]))
 
             cli.execute(options)
@@ -1126,7 +1126,7 @@ bar
         it "traps SIGINT", :signals_self do
           expect(executor)
             .to receive(:run_task)
-            .with(targets, task_t, task_params, {}) do
+            .with(targets, task_t, task_params, '_bolt_api_call' => true) do
               Process.kill :INT, Process.pid
               sync_thread.join(1) # give ruby some time to handle the signal
               Bolt::ResultSet.new([])
@@ -1217,7 +1217,7 @@ bar
           it "runs the task when the specified parameters are successfully validated" do
             expect(executor)
               .to receive(:run_task)
-              .with(targets, task_t, task_params, {})
+              .with(targets, task_t, task_params, '_bolt_api_call' => true)
               .and_return(Bolt::ResultSet.new([]))
             task_params.merge!(
               'mandatory_string'  => ' ',
@@ -1306,7 +1306,7 @@ bar
 
                 expect(executor)
                   .to receive(:run_task)
-                  .with(targets, task_t, task_params, {})
+                  .with(targets, task_t, task_params, '_bolt_api_call' => true)
                   .and_return(Bolt::ResultSet.new([]))
 
                 cli.execute(options)
@@ -1316,7 +1316,7 @@ bar
               it "runs the task even when invalid (according to the local task definition) parameters are specified" do
                 expect(executor)
                   .to receive(:run_task)
-                  .with(targets, task_t, task_params, {})
+                  .with(targets, task_t, task_params, '_bolt_api_call' => true)
                   .and_return(Bolt::ResultSet.new([]))
 
                 cli.execute(options)
@@ -1342,6 +1342,7 @@ bar
         let(:task_t) { task_type('sample::echo', %r{modules/sample/tasks/echo.sh$}, nil) }
 
         before :each do
+          allow(executor).to receive(:report_function_call)
           cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
         end
 
@@ -1565,7 +1566,7 @@ bar
         it "runs a task that supports noop" do
           expect(executor)
             .to receive(:run_task)
-            .with(targets, task_t, task_params.merge('_noop' => true), {})
+            .with(targets, task_t, task_params.merge('_noop' => true), '_bolt_api_call' => true)
             .and_return(Bolt::ResultSet.new([]))
 
           cli.execute(options)

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -408,6 +408,14 @@ describe "Bolt::Executor" do
       executor.batch_execute(targets) {}
       executor.batch_execute(targets) {}
     end
+
+    context "#report_function_call" do
+      it 'reports an event for the given function' do
+        expect(analytics).to receive(:event).with('Plan', 'call_function', 'add_facts')
+
+        executor.report_function_call('add_facts')
+      end
+    end
   end
 
   context "When running a plan" do

--- a/spec/lib/bolt_spec/plans/mock_executor.rb
+++ b/spec/lib/bolt_spec/plans/mock_executor.rb
@@ -208,6 +208,8 @@ module BoltSpec
       def stub_task(task_name)
         @task_doubles[task_name] ||= TaskDouble.new
       end
+
+      def report_function_call(_function); end
     end
   end
 end


### PR DESCRIPTION
This adds a report_function_call method to the Executor, which is now
used in each of the built-in functions included in boltlib. The
report_function_call method submits an event with category = "Plan",
action = "call_function" and label = the function name.

This will allow us to understand which built-in content is being used
most frequently and most widely.

Because Bolt uses the run_task and run_plan functions internally to run
tasks and plans from the CLI, we now pass an underscore parameter called
`_bolt_api_call` to those functions, which causes them to skip reporting
in that case. This way, we can track calls to run_task and run_plan that
happen *exclusively* from within a plan.