### PR TITLE
(BOLT-597) Don't send metaparams as params to orchestrator

### DIFF
--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -87,7 +87,7 @@ module Bolt
 
       def batch_command(targets, command, options = {}, &callback)
         params = {
-          command: command
+          'command' => command
         }
         results = run_task_job(targets,
                                BOLT_COMMAND_TASK,
@@ -105,8 +105,8 @@ module Bolt
         content = File.open(script, &:read)
         content = Base64.encode64(content)
         params = {
-          content: content,
-          arguments: arguments
+          'content' => content,
+          'arguments' => arguments
         }
         callback ||= proc {}
         results = run_task_job(targets, BOLT_SCRIPT_TASK, params, options, &callback)
@@ -121,9 +121,9 @@ module Bolt
         content = Base64.encode64(content)
         mode = File.stat(source).mode
         params = {
-          path: destination,
-          content: content,
-          mode: mode
+          'path' => destination,
+          'content' => content,
+          'mode' => mode
         }
         callback ||= proc {}
         results = run_task_job(targets, BOLT_UPLOAD_TASK, params, options, &callback)

--- a/lib/bolt/transport/orch/connection.rb
+++ b/lib/bolt/transport/orch/connection.rb
@@ -62,7 +62,7 @@ module Bolt
           body = { task: task.name,
                    environment: @environment,
                    noop: arguments['_noop'],
-                   params: arguments.reject { |k, _| k == '_noop' },
+                   params: arguments.reject { |k, _| k.start_with?('_') },
                    scope: {
                      nodes: targets.map(&:host)
                    } }

--- a/spec/bolt/transport/orch_spec.rb
+++ b/spec/bolt/transport/orch_spec.rb
@@ -31,7 +31,7 @@ describe Bolt::Transport::Orch, orchestrator: true do
   end
 
   let(:mtask) { mock_task('foo', 'foo/tasks/init', 'input') }
-  let(:params) { { param: 'val' } }
+  let(:params) { { 'param' => 'val' } }
 
   let(:result_state) { 'finished' }
   let(:result) { { '_output' => 'ok' } }
@@ -87,6 +87,12 @@ describe Bolt::Transport::Orch, orchestrator: true do
     it "doesn't pass noop as a parameter" do
       params = { 'foo' => 1, 'bar' => 'baz' }
       body = conn.build_request(targets, mtask, params.merge('_noop' => true))
+      expect(body[:params]).to eq(params)
+    end
+
+    it "doesn't pass _task as a parameter" do
+      params = { 'foo' => 1, 'bar' => 'baz' }
+      body = conn.build_request(targets, mtask, params.merge('_task' => 'my::task'))
       expect(body[:params]).to eq(params)
     end
 
@@ -284,7 +290,7 @@ describe Bolt::Transport::Orch, orchestrator: true do
     let(:body) {
       {
         task: 'bolt_shim::command',
-        params: { command: command }
+        params: { 'command' => command }
       }
     }
 
@@ -352,7 +358,7 @@ describe Bolt::Transport::Orch, orchestrator: true do
 
       {
         task: 'bolt_shim::upload',
-        params: { path: dest_path, content: content, mode: mode }
+        params: { 'path' => dest_path, 'content' => content, 'mode' => mode }
       }
     }
 
@@ -399,7 +405,7 @@ describe Bolt::Transport::Orch, orchestrator: true do
 
       {
         task: 'bolt_shim::script',
-        params: { content: content, arguments: args }
+        params: { 'content' => content, 'arguments' => args }
       }
     }
 


### PR DESCRIPTION
Orhcestrator will reject requests with metaparams in the params.
Metaparams should be stripped from a task before sending a request to
orchestrator. Some like noop will have to be added back in elsewhere in
the request.