### PR TITLE
(maint) Simplify the usage string for task info

### DIFF
--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -117,7 +117,7 @@ module Bolt
         # Building lots of strings...
         pretty_params = +""
         task_info = +""
-        usage = +"bolt task run --nodes, -n <node-name> #{task['name']}"
+        usage = +"bolt task run --nodes <node-name> #{task['name']}"
 
         if task['parameters']
           replace_data_type(task['parameters'])

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -109,7 +109,7 @@ c1   d
 cinnamon_roll - A delicious sweet bun
 
 USAGE:
-bolt task run --nodes, -n <node-name> cinnamon_roll icing=<value>
+bolt task run --nodes <node-name> cinnamon_roll icing=<value>
 
 PARAMETERS:
 - icing: Cream cheese
@@ -139,7 +139,7 @@ PARAMETERS:
 sticky_bun - A delicious sweet bun with nuts
 
 USAGE:
-bolt task run --nodes, -n <node-name> sticky_bun glaze=<value> pecans=<value>
+bolt task run --nodes <node-name> sticky_bun glaze=<value> pecans=<value>
 
 PARAMETERS:
 - glaze: Sticky


### PR DESCRIPTION
Previously `task show <task>` would include `--nodes, -n <node-name>` in
the USAGE string. It's redundant and slightly confusing to include both
`--nodes` and `-n` as option. Use just one to simplify the usage
suggestion.