### PR TITLE
(BOLT-583) Do not default to localhost on windows

### DIFF
--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -138,7 +138,9 @@ module Bolt
 
       unless data
         data = {}
-        data['config'] = { 'transport' => 'local' } if target.name == 'localhost'
+        unless Bolt::Util.windows?
+          data['config'] = { 'transport' => 'local' } if target.name == 'localhost'
+        end
       end
 
       unless data['config']

--- a/pre-docs/bolt_options.md
+++ b/pre-docs/bolt_options.md
@@ -52,7 +52,7 @@ the `--nodes` flag and an `@` symbol: `bolt command run --nodes @nodes.txt`
 To pass nodes on `stdin`, on the command line, use a command to generate a node
 list, and pipe the result to Bolt with `-` after `--nodes` : `<COMMAND> | bolt command run --nodes -` For
 example, if you have a node list in a text file, you might run `cat nodes.txt |
-bolt command run --nodes`
+bolt command run --nodes -`
 
 
 ### Specifying nodes from an inventory file
@@ -96,6 +96,8 @@ This is useful on Windows, so that you do not have to include the winrm
 transport for each node. To override the default transport, specify the
 protocol on a per-host basis, such as `bolt command run facter --nodes
 win1,ssh://linux --transport winrm`
+
+If `localhost` is passed to `--nodes` when invoking Bolt on a non-windows OS the `local` transport is used automatically. This behaviour can be avoided by prepending the target with the desired transport (ex: `ssh://localhost`).
 
 
 ## Specifying connection credentials

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -206,6 +206,12 @@ describe 'running with an inventory file', reset_puppet_settings: true do
         expect(run_one_node(run_command)).to be
       end
 
+      it 'does not set transport local on to windows' do
+        allow(Bolt::Util).to receive(:windows?).and_return(true)
+        result = run_failed_node(run_command)
+        expect(result['_error']['kind']).to eq('puppetlabs.tasks/connect-error')
+      end
+
       it 'connects to run a plan' do
         expect(run_cli_json(run_plan)[0]['status']).to eq('success')
       end


### PR DESCRIPTION
When bolt is invoked from a windows OS with the target of localhost, do not set the default transport to 'local'