### PR TITLE
(BOLT-591) Standardize on markdown output for function reference

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,8 +5,10 @@ require "rspec/core/rake_task"
 require "rubocop/rake_task"
 
 require_relative 'vendored/require_vendored'
-require "puppet-strings/tasks/generate"
+require "puppet-strings"
 require "fileutils"
+require "json"
+require "erb"
 
 desc "Run all RSpec tests"
 RSpec::Core::RakeTask.new(:spec)
@@ -37,18 +39,67 @@ task :default do
   system "rake --tasks"
 end
 
-namespace :docs do
-  desc "Generate markdown docs for Bolt's core Puppet functions"
-  task :md do
-    Rake::Task['strings:generate'].invoke(nil, nil, nil, nil, nil, 'true', 'bolt-modules/boltlib')
-  end
+def format_links(text)
+  text.gsub(/{([^}]+)}/, '[`\1`](#\1)')
+end
 
-  desc "Generate a JSON file containing docs for Bolt's core Puppet functions"
-  task :json do
-    FileUtils.mkdir_p 'doc'
-    puts 'Docs for the boltlib module will be saved to doc/boltlib.json'
-    Rake::Task['strings:generate'].invoke(nil, nil, nil, nil, 'pre-docs/boltlib.json', nil, 'bolt-modules/boltlib')
+desc "Generate markdown docs for Bolt's core Puppet functions"
+task :docs do
+  FileUtils.mkdir_p 'tmp'
+  tmpfile = 'tmp/boltlib.json'
+  PuppetStrings.generate(PuppetStrings::DEFAULT_SEARCH_PATTERNS,
+                         markup: 'markdown', json: true, path: tmpfile,
+                         yard_args: ['bolt-modules/boltlib'])
+  json = JSON.parse(File.read(tmpfile))
+  funcs = json.delete('puppet_functions')
+  json.each { |k, v| raise "Expected #{k} to be empty, found #{v}" unless v.empty? }
+
+  # @functions will be a list of function descriptions, structured as
+  #   name: function name
+  #   text: function description; first line should be usable as a summary
+  #   signatures: a list of function overloads
+  #     text: overload description
+  #     signature: function signature
+  #     returns: list of return statements
+  #       text: return description
+  #       types: list of types (probably only one entry)
+  #     params: list of params
+  #       name: parameter name
+  #       text: description
+  #       types: list of types (probably only one entry)
+  #     examples: list of examples
+  #       name: description
+  #       text: example body
+  @functions = funcs.map do |func|
+    func['text'] = func['docstring']['text']
+
+    overloads = func['docstring']['tags'].select { |tag| tag['tag_name'] == 'overload' }
+    sig_tags = overloads.map { |overload| overload['docstring']['tags'] }
+    sig_tags = [func['docstring']['tags']] if sig_tags.empty?
+
+    func['signatures'] = func['signatures'].zip(sig_tags).map do |sig, tags|
+      sig['text'] = sig['docstring']['text']
+      sects = sig['docstring']['tags'].group_by { |t| t['tag_name'] }
+      sig['returns'] = sects['return'].map do |ret|
+        ret['text'] = format_links(ret['text'])
+        ret
+      end
+      sig['params'] = sects['param'].map do |param|
+        param['text'] = format_links(param['text'])
+        param
+      end
+
+      # get examples from overload docstring; puppet-strings should probably do this.
+      examples = tags.select { |t| t['tag_name'] == 'example' }
+      sig['examples'] = examples
+      sig.delete('docstring')
+      sig
+    end
+
+    func
   end
+  renderer = ERB.new(File.read('pre-docs/reference.md.erb'), nil, '-')
+  File.write('REFERENCE.md', renderer.result)
 end
 
 namespace :integration do

--- a/bolt-modules/boltlib/lib/puppet/functions/add_facts.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/add_facts.rb
@@ -5,7 +5,7 @@ require 'bolt/error'
 # Deep merges a hash of facts with the existing facts on a target.
 Puppet::Functions.create_function(:add_facts) do
   # @param target A target.
-  # @param facts A hash of fact names to values that my include structured facts.
+  # @param facts A hash of fact names to values that may include structured facts.
   # @return The target's new facts.
   # @example Adding facts to a target
   #   add_facts($target, { 'os' => { 'family' => 'windows', 'name' => 'windows' } })

--- a/bolt-modules/boltlib/lib/puppet/functions/fail_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/fail_plan.rb
@@ -2,7 +2,7 @@
 
 require 'bolt/error'
 
-# Raises a Bolt::PlanFailure exception to signal to callers that the plan failed
+# Raises a Bolt::PlanFailure exception to signal to callers that the plan failed.
 #
 # Plan authors should call this function when their plan is not successful. The
 # error may then be caught by another plans run_plan function or in bolt itself

--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -2,7 +2,7 @@
 
 require 'bolt/error'
 
-# Runs the `plan` referenced by its name. A plan is autoloaded from <moduleroot>/plans.
+# Runs the `plan` referenced by its name. A plan is autoloaded from `<moduleroot>/plans`.
 Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction) do
   # @param plan_name The plan to run.
   # @param named_args Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.

--- a/bolt-modules/boltlib/lib/puppet/functions/set_feature.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_feature.rb
@@ -2,8 +2,10 @@
 
 require 'bolt/error'
 
-# Sets a particular feature to present on a target. Features are used to determine what implementation
-# of a task should be run. Currently supported features are
+# Sets a particular feature to present on a target.
+#
+# Features are used to determine what implementation of a task should be run.
+# Currently supported features are
 # - powershell
 # - shell
 # - puppet-agent

--- a/bolt-modules/boltlib/lib/puppet/functions/vars.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/vars.rb
@@ -2,9 +2,9 @@
 
 require 'bolt/error'
 
-# Returns a hash of the 'vars' (variables) assigned to a target through the
-# inventory file or `set_var` function.
+# Returns a hash of the 'vars' (variables) assigned to a target.
 #
+# Vars can be assigned through the inventory file or `set_var` function.
 # Plan authors can call this function on a target to get the variable hash
 # for that target.
 Puppet::Functions.create_function(:vars) do

--- a/bolt-modules/boltlib/lib/puppet/functions/without_default_logging.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/without_default_logging.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
-# Define a block where default logging is suppressed. Messages for actions within this block
-# will be logged at `info` level instead of `notice`, so they will not be seen normally but
-# will still be present when `verbose` logging is requested.
+# Define a block where default logging is suppressed.
+#
+# Messages for actions within this block will be logged at `info` level instead
+# of `notice`, so they will not be seen normally but # will still be present
+# when `verbose` logging is requested.
 Puppet::Functions.create_function(:without_default_logging) do
   # @param block The block where action logging is suppressed.
   # @return [Undef]

--- a/pre-docs/reference.md.erb
+++ b/pre-docs/reference.md.erb
@@ -1,0 +1,40 @@
+# Bolt Functions
+
+<% for func in @functions -%>
+* [`<%= func['name'] %>`](#<%= func['name'] %>): <%= func['text'].lines.first.chomp %>
+<% end -%>
+
+<% for func in @functions %>
+## <%= func['name'] %>
+
+<%= func['text'] %>
+
+<% for sig in func['signatures'] %>
+<% if func['signatures'].count > 1 -%>
+----
+
+<% end -%>
+<% if sig['text'] != func['text'] -%>
+<%= sig['text'] %>
+
+<% end -%>
+```
+<%= sig['signature'] %>
+```
+
+<% for ret in sig['returns'] -%>
+*Returns:* `<%= ret['types'].first %>` <%= ret['text'] %>
+<% end -%>
+
+<% for param in sig['params'] -%>
+* **<%= param['name'] %>** `<%= param['types'].first %>` <%= param['text'] %>
+<% end -%>
+
+<% for example in sig['examples'] -%>
+**Example:** <%= example['name'] %>
+```
+<%= example['text'] %>
+```
+<% end -%>
+<% end %>
+<% end %>


### PR DESCRIPTION
Drop the separate JSON and Markdown docs generation, and standardize on customized markdown output for the function reference. REFERENCE.md is generated with `rake docs`.