### PR TITLE
(BOLT-591) Update REFERENCE.md layout

### DIFF
--- a/pre-docs/reference.md.erb
+++ b/pre-docs/reference.md.erb
@@ -1,21 +1,13 @@
 # Bolt Functions
 
-<% for func in @functions -%>
-* [`<%= func['name'] %>`](#<%= func['name'] %>): <%= func['text'].lines.first.chomp %>
-<% end -%>
-
 <% for func in @functions %>
 ## <%= func['name'] %>
 
 <%= func['text'] %>
 
 <% for sig in func['signatures'] %>
-<% if func['signatures'].count > 1 -%>
-----
-
-<% end -%>
 <% if sig['text'] != func['text'] -%>
-<%= sig['text'] %>
+### <%= sig['text'] %>
 
 <% end -%>
 ```


### PR DESCRIPTION
Drop TOC, it doesn't map well to the docs page format. Also use headers
for signatures rather than line separators that also don't work well
with the docs page format.