### PR TITLE
(maint) Add `--trace` option

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -234,6 +234,9 @@ Available options are:
       define('--debug', 'Display debug logging') do |_|
         @options[:debug] = true
       end
+      define('--trace', 'Display error stack traces') do |_|
+        @options[:trace] = true
+      end
       define('--version', 'Display the version') do |_|
         puts Bolt::VERSION
         raise Bolt::CLIExit

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -351,7 +351,7 @@ module Bolt
     end
 
     def outputter
-      @outputter ||= Bolt::Outputter.for_format(config[:format], config[:color])
+      @outputter ||= Bolt::Outputter.for_format(config[:format], config[:color], config[:trace])
     end
   end
 end

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -26,6 +26,7 @@ module Bolt
   Config = Struct.new(
     :concurrency,
     :format,
+    :trace,
     :inventoryfile,
     :log,
     :modulepath,
@@ -197,7 +198,7 @@ module Bolt
     end
 
     def update_from_cli(options)
-      %i[concurrency transport format modulepath inventoryfile color].each do |key|
+      %i[concurrency transport format trace modulepath inventoryfile color].each do |key|
         self[key] = options[key] if options.key?(key)
       end
 

--- a/lib/bolt/outputter.rb
+++ b/lib/bolt/outputter.rb
@@ -2,19 +2,20 @@
 
 module Bolt
   class Outputter
-    def self.for_format(format, color)
+    def self.for_format(format, color, trace)
       case format
       when 'human'
-        Bolt::Outputter::Human.new(color)
+        Bolt::Outputter::Human.new(color, trace)
       when 'json'
-        Bolt::Outputter::JSON.new(color)
+        Bolt::Outputter::JSON.new(color, trace)
       when nil
         raise "Cannot use outputter before parsing."
       end
     end
 
-    def initialize(color, stream = $stdout)
+    def initialize(color, trace, stream = $stdout)
       @color = color
+      @trace = trace
       @stream = stream
     end
 

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -175,6 +175,12 @@ module Bolt
         if err.is_a? Bolt::RunFailure
           @stream.puts ::JSON.pretty_generate(err.result_set)
         end
+
+        if @trace && err.backtrace
+          err.backtrace.each do |line|
+            @stream.puts(colorize(:red, "\t#{line}"))
+          end
+        end
       end
     end
 

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -3,11 +3,11 @@
 module Bolt
   class Outputter
     class JSON < Bolt::Outputter
-      def initialize(color, stream = $stdout)
+      def initialize(color, trace, stream = $stdout)
         @items_open = false
         @object_open = false
         @preceding_item = false
-        super(color, stream)
+        super(color, trace, stream)
       end
 
       def print_head
@@ -60,7 +60,12 @@ module Bolt
       def fatal_error(err)
         @stream.puts "],\n" if @items_open
         @stream.puts '"_error": ' if @object_open
-        @stream.puts err.to_json
+        err_obj = err.to_h
+        if @trace && err.backtrace
+          err_obj[:details] ||= {}
+          err_obj[:details][:backtrace] = err.backtrace
+        end
+        @stream.puts err_obj.to_json
         @stream.puts '}' if @object_open
       end
 

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -13,7 +13,7 @@ describe "Bolt::CLI" do
   let(:target) { Bolt::Target.new('foo') }
 
   before(:each) do
-    outputter = Bolt::Outputter::Human.new(false, StringIO.new)
+    outputter = Bolt::Outputter::Human.new(false, false, StringIO.new)
 
     allow_any_instance_of(Bolt::CLI).to receive(:outputter).and_return(outputter)
     allow_any_instance_of(Bolt::CLI).to receive(:warn)
@@ -633,7 +633,7 @@ bar
       before :each do
         allow(Bolt::Executor).to receive(:new).and_return(executor)
 
-        outputter = Bolt::Outputter::JSON.new(false, output)
+        outputter = Bolt::Outputter::JSON.new(false, false, output)
 
         allow(cli).to receive(:outputter).and_return(outputter)
       end
@@ -1539,7 +1539,7 @@ bar
       before :each do
         expect(Bolt::Executor).to receive(:new).with(config, anything, true).and_return(executor)
 
-        outputter = Bolt::Outputter::JSON.new(false, output)
+        outputter = Bolt::Outputter::JSON.new(false, false, output)
 
         allow(cli).to receive(:outputter).and_return(outputter)
       end

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -7,7 +7,7 @@ require 'bolt/plan_result'
 
 describe "Bolt::Outputter::Human" do
   let(:output) { StringIO.new }
-  let(:outputter) { Bolt::Outputter::Human.new(false, output) }
+  let(:outputter) { Bolt::Outputter::Human.new(false, false, output) }
   let(:config) { Bolt::Config.new }
   let(:target) { Bolt::Target.new('node1') }
   let(:target2) { Bolt::Target.new('node2') }

--- a/spec/bolt/outputter/json_spec.rb
+++ b/spec/bolt/outputter/json_spec.rb
@@ -6,7 +6,7 @@ require 'bolt/cli'
 
 describe "Bolt::Outputter::JSON" do
   let(:output) { StringIO.new }
-  let(:outputter) { Bolt::Outputter::JSON.new(false, output) }
+  let(:outputter) { Bolt::Outputter::JSON.new(false, false, output) }
   let(:config)  { Bolt::Config.new }
   let(:target1) { Bolt::Target.new('node1') }
   let(:target2) { Bolt::Target.new('node2') }

--- a/spec/lib/bolt_spec/integration.rb
+++ b/spec/lib/bolt_spec/integration.rb
@@ -9,7 +9,7 @@ module BoltSpec
       allow(cli.config).to receive(:default_config).and_return(File.join('.', 'path', 'does not exist'))
       allow(cli.config).to receive(:default_inventory).and_return(File.join('.', 'path', 'does not exist'))
       output =  StringIO.new
-      outputter = outputter.new(false, output)
+      outputter = outputter.new(false, false, output)
       allow(cli).to receive(:outputter).and_return(outputter)
       allow(Bolt::Logger).to receive(:configure)
 


### PR DESCRIPTION
Adds a `--trace` option that prints error backtraces.