### PR TITLE
(WIP)(BOLT-630) Only supply scripts with expected args

### DIFF
--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -128,9 +128,12 @@ catch
                 # fortunately, using PS with stdin input_method should never happen
                 if input_method == 'powershell'
                   conn.execute(<<-PS)
-$private:taskArgs = Get-ContentAsJson (
+$private:tempArgs = Get-ContentAsJson (
   $utf8.GetString([System.Convert]::FromBase64String('#{Base64.encode64(JSON.dump(arguments))}'))
 )
+$allowedArgs = (Get-Command "#{remote_path}").Parameters.Keys
+$private:taskArgs = @{}
+$private:tempArgs.Keys | ? { $_ -in $allowedArgs } | % { $private:taskArgs[$_] = $private:tempArgs[$_] }
 try { & "#{remote_path}" @taskArgs } catch { Write-Error $_.Exception; exit 1 }
               PS
                 else


### PR DESCRIPTION
This is currently a naive take on guaranteeing scripts only get passed the correct named params, so that task authors may opt in to including newer metaparams.

This doesn't consider any PowerShell soaking behavior, but might not have to, considering args are passed by name. Requires some testing to further validate.

```
PS /Users/Iristyle/Documents> cat ./foo.ps1
[CmdletBinding()]
param (
  [Parameter(Mandatory = $true)]
  [String]
  $Message
)

Write-Host $Message
PS /Users/Iristyle/Documents> $scriptArgs = @{ "Message" = "hello"; "Extra" = 12 }
PS /Users/Iristyle/Documents> $allowedArgs = (Get-Command ./foo.ps1).Parameters.Keys
PS /Users/Iristyle/Documents> $sentArgs = @{}
PS /Users/Iristyle/Documents> $scriptArgs.Keys | ? { $_ -in $allowedArgs } | % { $sentArgs[$_] = $scriptArgs[$_]}
PS /Users/Iristyle/Documents> $sentArgs

Name                           Value
----                           -----
Message                        hello


PS /Users/Iristyle/Documents> ./foo.ps1 @sentArgs
hello
```