### PR TITLE
(BOLT-630) Only pass expected params for powershell input to function

### DIFF
--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -128,9 +128,12 @@ catch
                 # fortunately, using PS with stdin input_method should never happen
                 if input_method == 'powershell'
                   conn.execute(<<-PS)
-$private:taskArgs = Get-ContentAsJson (
+$private:tempArgs = Get-ContentAsJson (
   $utf8.GetString([System.Convert]::FromBase64String('#{Base64.encode64(JSON.dump(arguments))}'))
 )
+$allowedArgs = (Get-Command "#{remote_path}").Parameters.Keys
+$private:taskArgs = @{}
+$private:tempArgs.Keys | ? { $allowedArgs -contains $_ } | % { $private:taskArgs[$_] = $private:tempArgs[$_] }
 try { & "#{remote_path}" @taskArgs } catch { Write-Error $_.Exception; exit 1 }
               PS
                 else

--- a/spec/bolt/transport/winrm_spec.rb
+++ b/spec/bolt/transport/winrm_spec.rb
@@ -401,22 +401,18 @@ Height: $Height ($(if ($Height -ne $null) { $Height.GetType().Name } else { 'nul
       end
     end
 
-    it "fails when the powershell input method is used to pass unexpected parameters to a task", winrm: true do
+    it "ignores unexpected parameters when the powershell input method is used", winrm: true do
       contents = <<-PS
         param (
           [Parameter()]
           [String]$foo
         )
 
-        $bar = $env:PT_bar
-        Write-Host `
-          "foo: $foo ($(if ($foo -ne $null) { $foo.GetType().Name } else { 'null' }))," `
-          "bar: $bar ($(if ($bar -ne $null) { $bar.GetType().Name } else { 'null' }))"
+        Write-Host "foo=$foo"
       PS
-      arguments = { bar: 30 } # note that the script doesn't recognize the 'bar' parameter
+      arguments = { foo: 30 } # note that the script doesn't recognize the 'bar' parameter
       with_task_containing('task-params-test-winrm', contents, 'powershell', '.ps1') do |task|
-        expect(winrm.run_task(target, task, arguments).error_hash)
-          .to_not be_nil
+        expect(winrm.run_task(target, task, arguments).message).to eq("foo=30\r\n")
       end
     end
 

--- a/spec/fixtures/complex_params/input.json
+++ b/spec/fixtures/complex_params/input.json
@@ -1,0 +1,27 @@
+{
+  "argstring": "hello all",
+  "argint32": 5,
+  "argfloat": 42.42,
+  "arghashtable": {
+    "key": "value",
+    "key2": 2,
+    "key3": true
+  },
+  "argarray": [0, "foo", true, { "key": "value" }],
+  "argarrayofhashes": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 3.7.0 < 6.0.0"
+    },
+    {
+      "name": "pe",
+      "version_requirement": ">= 5.0.0"
+    }
+  ],
+  "argfileinfo": "/Users/foo/source/puppet/Gemfile",
+  "argbool": false,
+  "argtimespan": "12:34:56",
+  "argguid": "74be6039-e777-45fe-aa56-3d356443e096",
+  "argregex": "^http:\\/\\/",
+  "argswitch": true
+}

--- a/spec/fixtures/complex_params/output
+++ b/spec/fixtures/complex_params/output
@@ -1,0 +1,47 @@
+Defined with arguments:
+* ArgArray of type array
+* ArgArrayOfHashes of type hashtable[]
+* ArgBool of type bool
+* ArgFileInfo of type System.IO.FileInfo
+* ArgFloat of type float
+* ArgGuid of type guid
+* ArgHashtable of type hashtable
+* ArgInt32 of type int
+* ArgRegex of type regex
+* ArgString of type string
+* ArgSwitch of type switch
+* ArgTimeSpan of type timespan
+
+Received arguments:
+* ArgArray (System.Object[]):
+0
+foo
+True
+key: value
+* ArgArrayOfHashes (hashtable[]):
+name: puppet
+version_requirement: >= 3.7.0 < 6.0.0
+name: pe
+version_requirement: >= 5.0.0
+* ArgBool (bool):
+False
+* ArgFileInfo (System.IO.FileInfo):
+/Users/foo/source/puppet/Gemfile
+* ArgFloat (float):
+42.42
+* ArgGuid (guid):
+74be6039-e777-45fe-aa56-3d356443e096
+* ArgHashtable (hashtable):
+key: value
+key2: 2
+key3: True
+* ArgInt32 (int):
+5
+* ArgRegex (regex):
+^http:\/\/
+* ArgString (string):
+hello all
+* ArgSwitch (switch):
+True
+* ArgTimeSpan (timespan):
+12:34:56

--- a/spec/fixtures/modules/sample/tasks/complex_params.ps1
+++ b/spec/fixtures/modules/sample/tasks/complex_params.ps1
@@ -1,0 +1,103 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $True)]
+  [string]
+  $ArgString,
+
+  [Parameter(Mandatory = $False)]
+  [Int32] # aka [Int]
+  $ArgInt32,
+
+  [Parameter(Mandatory = $False)]
+  [Float] # aka [Single]
+  $ArgFloat,
+
+  [Parameter(Mandatory = $False)]
+  [Hashtable]
+  $ArgHashtable,
+
+  [Parameter(Mandatory = $False)]
+  [Array]
+  $ArgArray,
+
+  [Parameter(Mandatory = $False)]
+  [Hashtable[]] # any array of type[] should work
+  $ArgArrayOfHashes,
+
+  [Parameter(Mandatory = $False)]
+  [IO.FileInfo] # aka a file path
+  $ArgFileInfo,
+
+  [Parameter(Mandatory = $False)]
+  [Bool]
+  $ArgBool,
+
+  [Parameter(Mandatory = $False)]
+  [TimeSpan]
+  $ArgTimeSpan,
+
+  [Parameter(Mandatory = $False)]
+  [Guid]
+  $ArgGuid,
+
+  [Parameter(Mandatory = $False)]
+  [Regex]
+  $ArgRegex,
+
+  [Parameter(Mandatory = $False)]
+  [Switch]
+  $ArgSwitch
+)
+
+function ConvertTo-String
+{
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $True, ValueFromPipeline = $True)]
+    $Object
+  )
+
+  begin
+  {
+    $outputs = @()
+  }
+  process
+  {
+    if ($Object -is [Hashtable])
+    {
+      $outputs += (HashtableTo-String $Object)
+    }
+    else
+    {
+      $outputs += $Object
+    }
+  }
+  end
+  {
+    $outputs -join "`r`n"
+  }
+}
+
+function HashtableTo-String
+{
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $True, ValueFromPipeline = $True)]
+    [Hashtable]
+    $Hashtable
+  )
+
+  ($Hashtable.GetEnumerator() | Sort-Object -Property Key | % { "$($_.Key): $($_.Value)" }) -join "`r`n"
+}
+
+Write-Output "Defined with arguments:"
+
+$PSCmdlet.MyInvocation.MyCommand.Parameters.GetEnumerator() | Sort-Object -Property Key | Where-Object { $_.Key -match "Arg.+" } | % {
+  Write-Output "* $($_.Key) of type $($_.Value.ParameterType)"
+}
+
+Write-Output "`r`nReceived arguments:"
+
+$PSBoundParameters.GetEnumerator() | Sort-Object -Property Key | % {
+  Write-Output "* $($_.Key) ($($_.Value.GetType())):`r`n$($_.Value | ConvertTo-String)"
+}

--- a/spec/fixtures/modules/sample/tasks/winparams.json
+++ b/spec/fixtures/modules/sample/tasks/winparams.json
@@ -1,0 +1,3 @@
+{
+    "supports_noop": true
+}

--- a/spec/fixtures/modules/sample/tasks/winparams.ps1
+++ b/spec/fixtures/modules/sample/tasks/winparams.ps1
@@ -1,0 +1,8 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $True)]
+  [string]
+  $Message
+)
+
+Write-Output "Message: $Message"

--- a/spec/fixtures/modules/task_param/tasks/win.json
+++ b/spec/fixtures/modules/task_param/tasks/win.json
@@ -1,0 +1,3 @@
+{
+    "supports_noop": true
+}

--- a/spec/fixtures/modules/task_param/tasks/win.ps1
+++ b/spec/fixtures/modules/task_param/tasks/win.ps1
@@ -1,0 +1,8 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $False)]
+  [String]
+  $_task
+)
+
+Write-Output "Running task $_task"

--- a/spec/integration/task_param.rb
+++ b/spec/integration/task_param.rb
@@ -9,18 +9,23 @@ describe "Passes the _task metaparameter" do
   include BoltSpec::Conn
 
   let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
-  let(:config_flags) {
-    %W[--format json
-       --modulepath #{modulepath}
-       --no-host-key-check ]
-  }
-  let(:uri) { conn_uri('ssh') }
-  let(:password) { conn_info('ssh')[:password] }
-  let(:target) { conn_uri('ssh', include_password: true) }
+  let(:config_flags) { %W[--format json --nodes #{target} --modulepath #{modulepath}] }
 
-  it 'prints the _task metaparameter in a task' do
-    params = ['--nodes', uri, '--password', password]
-    result = run_cli_json(%w[task run task_param] + params + config_flags)
-    expect(result['items'][0]['result']['_output']).to eq("Running task task_param\n")
+  describe 'over ssh', ssh: true do
+    let(:target) { conn_uri('ssh', include_password: true) }
+
+    it 'prints the _task metaparameter in a task' do
+      result = run_cli_json(%w[task run task_param --no-host-key-check] + config_flags)
+      expect(result['items'][0]['result']['_output']).to eq("Running task task_param\n")
+    end
+  end
+
+  describe 'over winrm', winrm: true do
+    let(:target) { conn_uri('winrm', include_password: true) }
+
+    it 'prints the _task metaparameter in a task' do
+      result = run_cli_json(%w[task run task_param::win --no-ssl] + config_flags)
+      expect(result['items'][0]['result']['_output']).to eq("Running task task_param::win\r\n")
+    end
   end
 end

--- a/spec/integration/winrm_spec.rb
+++ b/spec/integration/winrm_spec.rb
@@ -41,8 +41,16 @@ describe "when runnning over the winrm transport", winrm: true do
     end
 
     it 'runs a task with parameters', :reset_puppet_settings do
-      result = run_one_node(%W[task run #{param_task} message=somemessage] + config_flags)
+      result = run_one_node(%w[task run sample::winparams message=somemessage] + config_flags)
       expect(result['_output'].strip).to match(/Message: somemessage/)
+    end
+
+    it 'runs a task with complex parameters', :reset_puppet_settings do
+      complex_input_file = File.join(__dir__, '../fixtures/complex_params/input.json')
+      expected = File.open(File.join(__dir__, '../fixtures/complex_params/output'), 'rb', &:read)
+
+      result = run_one_node(%W[task run sample::complex_params --params @#{complex_input_file}] + config_flags)
+      expect(result['_output']).to eq(expected)
     end
 
     it 'reports errors when task fails', :reset_puppet_settings do

--- a/spec/integration/winrm_spec.rb
+++ b/spec/integration/winrm_spec.rb
@@ -13,6 +13,7 @@ describe "when runnning over the winrm transport", winrm: true do
   let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
   let(:whoami) { "echo $env:UserName" }
   let(:stdin_task) { "sample::winstdin" }
+  let(:param_task) { "sample::winparams" }
   let(:uri) { conn_uri('winrm') }
   let(:password) { conn_info('winrm')[:password] }
   let(:user) { conn_info('winrm')[:user] }
@@ -37,6 +38,11 @@ describe "when runnning over the winrm transport", winrm: true do
     it 'runs a task', :reset_puppet_settings do
       result = run_one_node(%W[task run #{stdin_task} message=somemessage] + config_flags)
       expect(result['_output'].strip).to match(/STDIN: {"messa/)
+    end
+
+    it 'runs a task with parameters', :reset_puppet_settings do
+      result = run_one_node(%W[task run #{param_task} message=somemessage] + config_flags)
+      expect(result['_output'].strip).to match(/Message: somemessage/)
     end
 
     it 'reports errors when task fails', :reset_puppet_settings do


### PR DESCRIPTION
When using powershell input method, only pass expected parameters to the
function. When it receives unexpected parameters the function call will
fail, and we don't want that to happen due to metaparameters that aren't
used.

This restriction requires that functions explicitly mention all
parameters they wish to use, rather than using a collector array for any
remaining parameters.