### PR TITLE
(BOLT-578) Report bundled content to GA

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -35,6 +35,9 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
       executor.report_function_call('run_plan')
     end
 
+    # Report bundled content, this should capture plans run from both CLI and Plans
+    executor.report_bundled_content('Plan', plan_name)
+
     params = named_args.reject { |k, _| k.start_with?('_') }
 
     loaders = closure_scope.compiler.loaders

--- a/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
@@ -86,6 +86,9 @@ Puppet::Functions.create_function(:run_task) do
       executor.report_function_call('run_task')
     end
 
+    # Report bundled content, this should capture tasks run from both CLI and Plans
+    executor.report_bundled_content('Task', task_name)
+
     # Ensure that given targets are all Target instances
     targets = inventory.get_targets(targets)
 

--- a/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
@@ -50,12 +50,13 @@ describe 'run_plan' do
       end
     end
 
-    it 'reports the call to analytics' do
+    it 'reports the function call to analytics' do
       executor.expects(:report_function_call).with('run_plan')
+      executor.expects(:report_bundled_content).with('Plan', 'test::run_me').once
       is_expected.to run.with_params('test::run_me').and_return('worked2')
     end
 
-    it 'skips reporting the call to analytics if called internally from Bolt' do
+    it 'skips reporting the function call to analytics if called internally from Bolt' do
       executor.expects(:report_function_call).never
       is_expected.to run.with_params('test::run_me', '_bolt_api_call' => true).and_return('worked2')
     end

--- a/bolt-modules/boltlib/spec/functions/run_task_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_spec.rb
@@ -86,8 +86,9 @@ describe 'run_task' do
       is_expected.to run.with_params('Test::Yes', []).and_return(Bolt::ResultSet.new([]))
     end
 
-    it 'reports the call to analytics' do
+    it 'reports the function call and task name to analytics' do
       executor.expects(:report_function_call).with('run_task')
+      executor.expects(:report_bundled_content).with('Task', 'Test::Echo').once
       executable = File.join(tasks_root, 'echo.sh')
 
       executor.expects(:run_task).with([target], mock_task(executable, nil), default_args, {}).returns(result_set)
@@ -96,7 +97,7 @@ describe 'run_task' do
       is_expected.to run.with_params('Test::Echo', hostname, default_args).and_return(result_set)
     end
 
-    it 'skips reporting the call to analytics if called internally from Bolt' do
+    it 'skips reporting the function call to analytics if called internally from Bolt' do
       executor.expects(:report_function_call).with('run_task').never
       executable = File.join(tasks_root, 'echo.sh')
 

--- a/lib/bolt/analytics.rb
+++ b/lib/bolt/analytics.rb
@@ -24,7 +24,6 @@ module Bolt
 
     def self.build_client
       logger = Logging.logger[self]
-
       config_file = File.expand_path('~/.puppetlabs/bolt/analytics.yaml')
       config = load_config(config_file)
 

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -262,7 +262,7 @@ module Bolt
                          params: params }
         plan_context[:description] = options[:description] if options[:description]
 
-        executor = Bolt::Executor.new(config, @analytics, options[:noop])
+        executor = Bolt::Executor.new(config, @analytics, options[:noop], bundled_content: bundled_content)
         executor.start_plan(plan_context)
         result = pal.run_plan(options[:object], options[:task_options], executor, inventory, puppetdb_client)
 
@@ -271,7 +271,7 @@ module Bolt
         outputter.print_plan_result(result)
         code = result.ok? ? 0 : 1
       else
-        executor = Bolt::Executor.new(config, @analytics, options[:noop])
+        executor = Bolt::Executor.new(config, @analytics, options[:noop], bundled_content: bundled_content)
         targets = options[:targets]
 
         results = nil
@@ -352,6 +352,17 @@ module Bolt
 
     def outputter
       @outputter ||= Bolt::Outputter.for_format(config[:format], config[:color], config[:trace])
+    end
+
+    def bundled_content
+      default_content = Bolt::PAL.new(Bolt::Config.new)
+      plans = default_content.list_plans.each_with_object([]) do |iter, col|
+        col << iter&.first
+      end
+      tasks = default_content.list_tasks.each_with_object([]) do |iter, col|
+        col << iter&.first
+      end
+      plans.concat tasks
     end
   end
 end

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -15,6 +15,25 @@ require 'bolt/puppetdb'
 
 module Bolt
   class Executor
+    BUNDLED_CONTENT = ['apply::resource',
+                       'facts',
+                       'facts::bash',
+                       'facts::powershell',
+                       'facts::ruby',
+                       'package',
+                       'puppet_conf',
+                       'service',
+                       'service::linux',
+                       'service::windows',
+                       # plans
+                       'aggregate::count',
+                       'aggregate::nodes',
+                       'canary',
+                       'facts',
+                       'facts::info',
+                       'facts::retrieve',
+                       'puppetdb_fact'].freeze
+
     attr_reader :noop, :transports
     attr_accessor :run_as, :plan_logging
 
@@ -125,6 +144,12 @@ module Bolt
 
     def report_function_call(function)
       @analytics&.event('Plan', 'call_function', function)
+    end
+
+    def report_bundled_content(mode, name)
+      if BUNDLED_CONTENT.include?(name)
+        @analytics&.event('Bundled Content', mode, name)
+      end
     end
 
     def with_node_logging(description, batch)

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -15,31 +15,16 @@ require 'bolt/puppetdb'
 
 module Bolt
   class Executor
-    BUNDLED_CONTENT = ['apply::resource',
-                       'facts',
-                       'facts::bash',
-                       'facts::powershell',
-                       'facts::ruby',
-                       'package',
-                       'puppet_conf',
-                       'service',
-                       'service::linux',
-                       'service::windows',
-                       # plans
-                       'aggregate::count',
-                       'aggregate::nodes',
-                       'canary',
-                       'facts',
-                       'facts::info',
-                       'facts::retrieve',
-                       'puppetdb_fact'].freeze
-
     attr_reader :noop, :transports
     attr_accessor :run_as, :plan_logging
 
-    def initialize(config = Bolt::Config.new, analytics = Bolt::Analytics::NoopClient.new, noop = nil)
+    def initialize(config = Bolt::Config.new,
+                   analytics = Bolt::Analytics::NoopClient.new,
+                   noop = nil,
+                   bundled_content: nil)
       @config = config
       @analytics = analytics
+      @bundled_content = bundled_content
       @logger = Logging.logger[self]
       @plan_logging = false
 
@@ -147,7 +132,7 @@ module Bolt
     end
 
     def report_bundled_content(mode, name)
-      if BUNDLED_CONTENT.include?(name)
+      if @bundled_content&.include?(name)
         @analytics&.event('Bundled Content', mode, name)
       end
     end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1537,13 +1537,17 @@ bar
       let(:cli) { Bolt::CLI.new({}) }
       let(:targets) { [target] }
       let(:output) { StringIO.new }
+      let(:bundled_content) { ['test'] }
 
       before :each do
-        expect(Bolt::Executor).to receive(:new).with(config, anything, true).and_return(executor)
-
+        allow(cli).to receive(:bundled_content).and_return(bundled_content)
+        expect(Bolt::Executor).to receive(:new).with(config,
+                                                     anything,
+                                                     true,
+                                                     bundled_content: bundled_content).and_return(executor)
         outputter = Bolt::Outputter::JSON.new(false, false, output)
-
         allow(cli).to receive(:outputter).and_return(outputter)
+        allow(executor).to receive(:report_bundled_content)
       end
 
       context "when running a task", :reset_puppet_settings do
@@ -1562,7 +1566,6 @@ bar
         let(:task_t) { task_type(task_name, %r{modules/sample/tasks/noop.sh$}, nil) }
 
         before :each do
-          allow(executor).to receive(:report_bundled_content)
           cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
         end
 

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1031,6 +1031,7 @@ bar
         let(:task_t) { task_type(task_name, Regexp.new(task_path), input_method) }
 
         before :each do
+          allow(executor).to receive(:report_bundled_content)
           cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
         end
 
@@ -1343,6 +1344,7 @@ bar
 
         before :each do
           allow(executor).to receive(:report_function_call)
+          allow(executor).to receive(:report_bundled_content)
           cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
         end
 
@@ -1560,6 +1562,7 @@ bar
         let(:task_t) { task_type(task_name, %r{modules/sample/tasks/noop.sh$}, nil) }
 
         before :each do
+          allow(executor).to receive(:report_bundled_content)
           cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
         end
 

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -418,6 +418,8 @@ describe "Bolt::Executor" do
     end
 
     context "#report_bundled_content" do
+      let(:executor) { Bolt::Executor.new(config, analytics, bundled_content: %w[canary facts]) }
+
       it 'reports an event when bundled plan is used' do
         expect(analytics).to receive(:event).with('Bundled Content', 'Plan', 'canary')
 

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -416,6 +416,32 @@ describe "Bolt::Executor" do
         executor.report_function_call('add_facts')
       end
     end
+
+    context "#report_bundled_content" do
+      it 'reports an event when bundled plan is used' do
+        expect(analytics).to receive(:event).with('Bundled Content', 'Plan', 'canary')
+
+        executor.report_bundled_content('Plan', 'canary')
+      end
+
+      it 'reports an event when bundled task is used' do
+        expect(analytics).to receive(:event).with('Bundled Content', 'Task', 'facts')
+
+        executor.report_bundled_content('Task', 'facts')
+      end
+
+      it 'does not report a an event when non-bundled plan is used' do
+        expect(analytics).to receive(:event).never
+
+        executor.report_bundled_content('plan', 'foo')
+      end
+
+      it 'does not report a an event when non-bundled task is used' do
+        expect(analytics).to receive(:event).never
+
+        executor.report_bundled_content('task', 'foo')
+      end
+    end
   end
 
   context "When running a plan" do

--- a/spec/lib/bolt_spec/plans/mock_executor.rb
+++ b/spec/lib/bolt_spec/plans/mock_executor.rb
@@ -210,6 +210,8 @@ module BoltSpec
       end
 
       def report_function_call(_function); end
+
+      def report_bundled_content(_mode, _name); end
     end
   end
 end


### PR DESCRIPTION
Include the name of the task/plan being run if that name refers to a piece of built-in content. The task/plan name should not be included if it isn't a piece of bundled content, as the name may be sensitive.