### PR TITLE
(BOLT-634, BOLT-647, BOLT-677) Add tests, fix non-string types with environment input

### DIFF
--- a/acceptance/config/gem/options.rb
+++ b/acceptance/config/gem/options.rb
@@ -5,7 +5,9 @@
     'setup/common/pre-suite/010_install_ruby.rb',
     'setup/gem/pre-suite/020_install.rb',
     'setup/common/pre-suite/030_set_password.rb',
-    'setup/common/pre-suite/050_build_bolt_inventory.rb'
+    'setup/common/pre-suite/050_build_bolt_inventory.rb',
+    'setup/common/pre-suite/070_install_puppet.rb',
+    'setup/common/pre-suite/071_install_facts.rb'
   ],
   load_path: './lib/acceptance'
 }

--- a/acceptance/config/git/options.rb
+++ b/acceptance/config/git/options.rb
@@ -6,7 +6,9 @@
     'setup/git/pre-suite/010_install_git.rb',
     'setup/git/pre-suite/020_install.rb',
     'setup/common/pre-suite/030_set_password.rb',
-    'setup/common/pre-suite/050_build_bolt_inventory.rb'
+    'setup/common/pre-suite/050_build_bolt_inventory.rb',
+    'setup/common/pre-suite/070_install_puppet.rb',
+    'setup/common/pre-suite/071_install_facts.rb'
   ],
   load_path: './lib/acceptance',
   ssh: { forward_agent: false }

--- a/acceptance/config/package/options.rb
+++ b/acceptance/config/package/options.rb
@@ -4,7 +4,8 @@
   pre_suite: [
     'setup/package/pre-suite/020_install.rb',
     'setup/common/pre-suite/030_set_password.rb',
-    'setup/common/pre-suite/050_build_bolt_inventory.rb'
+    'setup/common/pre-suite/050_build_bolt_inventory.rb',
+    'setup/common/pre-suite/070_install_puppet.rb'
   ],
   load_path: './lib/acceptance'
 }

--- a/acceptance/files/example_apply.pp
+++ b/acceptance/files/example_apply.pp
@@ -1,0 +1,22 @@
+plan example_apply (
+  TargetSpec $nodes,
+  String $filepath,
+  Boolean $noop = false,
+) {
+  $result = run_plan('facts', nodes => $nodes)
+  if !$result.ok {
+    return $result
+  }
+
+  $targets = get_targets($nodes)
+  $targets.each |$t| { $t.set_var('filepath', $filepath) }
+
+  return apply($targets, _noop => $noop) {
+    file { $filepath:
+      ensure => directory,
+    } -> file { "${filepath}/hello.txt":
+      ensure  => file,
+      content => "hi there I'm ${$facts['os']['family']}\n",
+    }
+  }
+}

--- a/acceptance/setup/common/pre-suite/070_install_puppet.rb
+++ b/acceptance/setup/common/pre-suite/070_install_puppet.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+test_name "Install Puppet Agent" do
+  install_puppet_agent_on(hosts, puppet_collection: 'puppet5', run_in_parallel: true)
+end

--- a/acceptance/setup/common/pre-suite/071_install_facts.rb
+++ b/acceptance/setup/common/pre-suite/071_install_facts.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+test_name "Install puppetlabs-facts" do
+  on(hosts, puppet('module', 'install', 'puppetlabs-facts', '--target-dir', '$HOME/.puppetlabs/bolt/modules'))
+end

--- a/acceptance/tests/apply_ssh.rb
+++ b/acceptance/tests/apply_ssh.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'bolt_command_helper'
+require 'json'
+
+test_name "bolt plan run with should apply manifest block on remote hosts via ssh" do
+  extend Acceptance::BoltCommandHelper
+
+  ssh_nodes = select_hosts(roles: ['ssh'])
+  skip_test('no applicable nodes to test on') if ssh_nodes.empty?
+
+  dir = bolt.tmpdir('apply_ssh')
+  fixtures = File.absolute_path('files')
+
+  step "create plan on bolt controller" do
+    on(bolt, "mkdir -p #{dir}/modules/example_apply/plans")
+    create_remote_file(bolt,
+                       "#{dir}/modules/example_apply/plans/init.pp",
+                       File.read(File.join(fixtures, 'example_apply.pp')))
+  end
+
+  step "execute `bolt plan run` via SSH with json output" do
+    bolt_command = "bolt plan run example_apply filepath=/tmp/test nodes=ssh_nodes"
+    flags = {
+      '--modulepath' => "$HOME/.puppetlabs/bolt/modules:#{dir}/modules",
+      '--format'     => 'json'
+    }
+
+    result = bolt_command_on(bolt, bolt_command, flags)
+    assert_equal(0, result.exit_code,
+                 "Bolt did not exit with exit code 0")
+
+    begin
+      json = JSON.parse(result.stdout)
+    rescue JSON.ParserError
+      assert_equal("Output should be JSON", result.string,
+                   "Output should be JSON")
+    end
+
+    ssh_nodes.each do |node|
+      # Verify that node succeeded
+      host = node.hostname
+      result = json.select { |n| n['node'] == host }
+      assert_equal('success', result[0]['status'],
+                   "The task did not succeed on #{host}")
+
+      # Verify that files were created on the target
+      content = on(node, 'cat /tmp/test/hello.txt')
+      assert_match(/^hi there I'm [a-zA-Z]+$/, content.stdout)
+    end
+  end
+end

--- a/acceptance/tests/apply_ssh.rb
+++ b/acceptance/tests/apply_ssh.rb
@@ -11,6 +11,7 @@ test_name "bolt plan run with should apply manifest block on remote hosts via ss
 
   dir = bolt.tmpdir('apply_ssh')
   fixtures = File.absolute_path('files')
+  filepath = '/tmp/test'
 
   step "create plan on bolt controller" do
     on(bolt, "mkdir -p #{dir}/modules/example_apply/plans")
@@ -19,13 +20,39 @@ test_name "bolt plan run with should apply manifest block on remote hosts via ss
                        File.read(File.join(fixtures, 'example_apply.pp')))
   end
 
-  step "execute `bolt plan run` via SSH with json output" do
-    bolt_command = "bolt plan run example_apply filepath=/tmp/test nodes=ssh_nodes"
-    flags = {
-      '--modulepath' => "$HOME/.puppetlabs/bolt/modules:#{dir}/modules",
-      '--format'     => 'json'
-    }
+  bolt_command = "bolt plan run example_apply filepath=#{filepath} nodes=ssh_nodes"
+  flags = {
+    '--modulepath' => "$HOME/.puppetlabs/bolt/modules:#{dir}/modules",
+    '--format'     => 'json'
+  }
 
+  step "execute `bolt plan run noop=true` via SSH with json output" do
+    on(ssh_nodes, "rm -rf #{filepath}")
+
+    result = bolt_command_on(bolt, bolt_command + ' noop=true', flags)
+    assert_equal(0, result.exit_code,
+                 "Bolt did not exit with exit code 0")
+
+    begin
+      json = JSON.parse(result.stdout)
+    rescue JSON.ParserError
+      assert_equal("Output should be JSON", result.string,
+                   "Output should be JSON")
+    end
+
+    ssh_nodes.each do |node|
+      # Verify that node succeeded
+      host = node.hostname
+      result = json.select { |n| n['node'] == host }
+      assert_equal('success', result[0]['status'],
+                   "The task did not succeed on #{host}")
+
+      # Verify that files were not created on the target
+      on(node, "cat #{filepath}/hello.txt", acceptable_exit_codes: [1])
+    end
+  end
+
+  step "execute `bolt plan run` via SSH with json output" do
     result = bolt_command_on(bolt, bolt_command, flags)
     assert_equal(0, result.exit_code,
                  "Bolt did not exit with exit code 0")
@@ -45,7 +72,7 @@ test_name "bolt plan run with should apply manifest block on remote hosts via ss
                    "The task did not succeed on #{host}")
 
       # Verify that files were created on the target
-      content = on(node, 'cat /tmp/test/hello.txt')
+      content = on(node, "cat #{filepath}/hello.txt")
       assert_match(/^hi there I'm [a-zA-Z]+$/, content.stdout)
     end
   end

--- a/acceptance/tests/apply_winrm.rb
+++ b/acceptance/tests/apply_winrm.rb
@@ -11,6 +11,7 @@ test_name "bolt plan run with should apply manifest block on remote hosts via wi
 
   dir = bolt.tmpdir('apply_winrm')
   fixtures = File.absolute_path('files')
+  filepath = 'C:/test'
 
   step "create plan on bolt controller" do
     on(bolt, "mkdir -p #{dir}/modules/example_apply/plans")
@@ -19,13 +20,39 @@ test_name "bolt plan run with should apply manifest block on remote hosts via wi
                        File.read(File.join(fixtures, 'example_apply.pp')))
   end
 
-  step "execute `bolt plan run` via WinRM with json output" do
-    bolt_command = "bolt plan run example_apply filepath='C:/test' nodes=winrm_nodes"
-    flags = {
-      '--modulepath' => "$HOME/.puppetlabs/bolt/modules:#{dir}/modules",
-      '--format'     => 'json'
-    }
+  bolt_command = "bolt plan run example_apply filepath=#{filepath} nodes=winrm_nodes"
+  flags = {
+    '--modulepath' => "$HOME/.puppetlabs/bolt/modules:#{dir}/modules",
+    '--format'     => 'json'
+  }
 
+  step "execute `bolt plan run noop=true` via WinRM with json output" do
+    on(winrm_nodes, "rm -rf #{filepath}")
+
+    result = bolt_command_on(bolt, bolt_command + ' noop=true', flags)
+    assert_equal(0, result.exit_code,
+                 "Bolt did not exit with exit code 0")
+
+    begin
+      json = JSON.parse(result.stdout)
+    rescue JSON.ParserError
+      assert_equal("Output should be JSON", result.string,
+                   "Output should be JSON")
+    end
+
+    winrm_nodes.each do |node|
+      # Verify that node succeeded
+      host = node.hostname
+      result = json.select { |n| n['node'] == host }
+      assert_equal('success', result[0]['status'],
+                   "The task did not succeed on #{host}")
+
+      # Verify that files were not created on the target
+      on(node, "cat #{filepath}/hello.txt", acceptable_exit_codes: [1])
+    end
+  end
+
+  step "execute `bolt plan run` via WinRM with json output" do
     result = bolt_command_on(bolt, bolt_command, flags)
     assert_equal(0, result.exit_code,
                  "Bolt did not exit with exit code 0")

--- a/acceptance/tests/apply_winrm.rb
+++ b/acceptance/tests/apply_winrm.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'bolt_command_helper'
+require 'json'
+
+test_name "bolt plan run with should apply manifest block on remote hosts via winrm" do
+  extend Acceptance::BoltCommandHelper
+
+  winrm_nodes = select_hosts(roles: ['winrm'])
+  skip_test('no applicable nodes to test on') if winrm_nodes.empty?
+
+  dir = bolt.tmpdir('apply_winrm')
+  fixtures = File.absolute_path('files')
+
+  step "create plan on bolt controller" do
+    on(bolt, "mkdir -p #{dir}/modules/example_apply/plans")
+    create_remote_file(bolt,
+                       "#{dir}/modules/example_apply/plans/init.pp",
+                       File.read(File.join(fixtures, 'example_apply.pp')))
+  end
+
+  step "execute `bolt plan run` via WinRM with json output" do
+    bolt_command = "bolt plan run example_apply filepath='C:/test' nodes=winrm_nodes"
+    flags = {
+      '--modulepath' => "$HOME/.puppetlabs/bolt/modules:#{dir}/modules",
+      '--format'     => 'json'
+    }
+
+    result = bolt_command_on(bolt, bolt_command, flags)
+    assert_equal(0, result.exit_code,
+                 "Bolt did not exit with exit code 0")
+
+    begin
+      json = JSON.parse(result.stdout)
+    rescue JSON.ParserError
+      assert_equal("Output should be JSON", result.string,
+                   "Output should be JSON")
+    end
+
+    winrm_nodes.each do |node|
+      # Verify that node succeeded
+      host = node.hostname
+      result = json.select { |n| n['node'] == host }
+      assert_equal('success', result[0]['status'],
+                   "The task did not succeed on #{host}")
+
+      # Verify that files were created on the target
+      content = on(node, 'cat C:/test/hello.txt')
+      assert_match(/^hi there I'm windows$/, content.stdout)
+    end
+  end
+end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ before_test:
       type Gemfile.lock
       $CACertFile = Join-Path -Path $ENV:AppData -ChildPath 'RubyCACert.pem'
 
-      If (-Not (Test-Path -Path $CACertFile)) {  
+      If (-Not (Test-Path -Path $CACertFile)) {
         "Downloading CA Cert bundle.."
           [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
             Invoke-WebRequest -Uri 'https://curl.haxx.se/ca/cacert.pem' -UseBasicParsing -OutFile $CACertFile | Out-Null

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -34,7 +34,12 @@ module Bolt
       }
 
       bolt_catalog_exe = File.join(libexec, 'bolt_catalog')
-      out, err, stat = Open3.capture3(bolt_catalog_exe, 'compile', stdin_data: catalog_input.to_json)
+
+      old_path = ENV['PATH']
+      ENV['PATH'] = "#{RbConfig::CONFIG['bindir']}:#{old_path}"
+      out, err, stat = Open3.capture3('ruby', bolt_catalog_exe, 'compile', stdin_data: catalog_input.to_json)
+      ENV['PATH'] = old_path
+
       raise ApplyError.new(target.to_s, err) unless stat.success?
       JSON.parse(out)
     end

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -12,6 +12,33 @@ module Bolt
       @executor = executor
     end
 
+    private def libexec
+      @libexec ||= File.join(Gem::Specification.find_by_name('bolt').gem_dir, 'libexec')
+    end
+
+    def catalog_apply_task
+      path = File.join(libexec, 'apply_catalog.rb')
+      impl = { 'name' => 'apply_catalog.rb', 'path' => path, 'requirements' => [], 'supports_noop' => true }
+      Task.new('apply_catalog', [impl], 'stdin')
+    end
+
+    def compile(target, ast)
+      catalog_input = {
+        code_ast: ast,
+        modulepath: [],
+        target: {
+          name: target.host,
+          facts: @inventory.facts(target),
+          variables: @inventory.vars(target)
+        }
+      }
+
+      bolt_catalog_exe = File.join(libexec, 'bolt_catalog')
+      out, err, stat = Open3.capture3(bolt_catalog_exe, 'compile', stdin_data: catalog_input.to_json)
+      raise ApplyError.new(target.to_s, err) unless stat.success?
+      JSON.parse(out)
+    end
+
     def apply(args, apply_body, _scope)
       raise(ArgumentError, 'apply requires a TargetSpec') if args.empty?
       type0 = Puppet.lookup(:pal_script_compiler).type('TargetSpec')
@@ -27,28 +54,8 @@ module Bolt
       targets = @inventory.get_targets(args[0])
       ast = Puppet::Pops::Serialization::ToDataConverter.convert(apply_body, rich_data: true, symbol_to_string: true)
       results = targets.map do |target|
-        catalog_input = {
-          code_ast: ast,
-          modulepath: [],
-          target: {
-            name: target.host,
-            facts: @inventory.facts(target),
-            variables: @inventory.vars(target)
-          }
-        }
-
-        libexec = File.join(Gem::Specification.find_by_name('bolt').gem_dir, 'libexec')
-
-        bolt_catalog_exe = File.join(libexec, 'bolt_catalog')
-        out, err, stat = Open3.capture3(bolt_catalog_exe, 'compile', stdin_data: catalog_input.to_json)
-        raise ApplyError.new(target.to_s, err) unless stat.success?
-        catalog = JSON.parse(out)
-
-        path = File.join(libexec, 'apply_catalog.rb')
-        impl = { 'name' => 'apply_catalog.rb', 'path' => path, 'requirements' => [], 'supports_noop' => true }
-        task = Task.new('apply_catalog', [impl], 'stdin')
-        params['catalog'] = catalog
-        @executor.run_task([target], task, params, '_description' => 'apply catalog')
+        params['catalog'] = compile(target, ast)
+        @executor.run_task([target], catalog_apply_task, params, '_description' => 'apply catalog')
       end
       ResultSet.new results.reduce([]) { |result, result_set| result + result_set.results }
     end

--- a/lib/bolt/catalog.rb
+++ b/lib/bolt/catalog.rb
@@ -53,12 +53,6 @@ end
 
 module Bolt
   class Catalog
-    def in_env
-      Puppet::Pal.in_tmp_environment('bolt_apply', modulepath: ['~/bolt/modules/'], facts: @scope['facts']) do |pal|
-        yield pal
-      end
-    end
-
     def with_puppet_settings
       Dir.mktmpdir('bolt') do |dir|
         cli = []

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -132,6 +132,7 @@ module Bolt
 
             if ENVIRONMENT_METHODS.include?(input_method)
               environment = arguments.inject({}) do |env, (param, val)|
+                val = val.to_json unless val.is_a?(String)
                 env.merge("PT_#{param}" => val)
               end
               execute_options[:environment] = environment

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -112,6 +112,7 @@ catch
 
           if ENVIRONMENT_METHODS.include?(input_method)
             arguments.each do |(arg, val)|
+              val = val.to_json unless val.is_a?(String)
               cmd = "[Environment]::SetEnvironmentVariable('PT_#{arg}', @'\n#{val}\n'@)"
               result = conn.execute(cmd)
               if result.exit_code != 0

--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -289,6 +289,15 @@ SHELLWORDS
       end
     end
 
+    it "serializes hashes as json in environment input", ssh: true do
+      contents = "#!/bin/sh\nprintenv PT_message"
+      arguments = { message: { key: 'val' } }
+      with_task_containing('tasks_test_hash', contents, 'environment') do |task|
+        expect(ssh.run_task(target, task, arguments).value)
+          .to eq('key' => 'val')
+      end
+    end
+
     it "can run a task passing input on stdin and environment", ssh: true do
       contents = <<SHELL
 #!/bin/sh

--- a/spec/bolt/transport/winrm_spec.rb
+++ b/spec/bolt/transport/winrm_spec.rb
@@ -493,6 +493,16 @@ PS
       end
     end
 
+    it "serializes hashes as json in environment input", winrm: true do
+      contents = "echo $env:PT_message"
+      arguments = { message: { key: 'val' } }
+      with_task_containing('tasks_test_hash', contents, 'environment', '.ps1') do |task|
+        expect(
+          winrm.run_task(target, task, arguments).value
+        ).to eq('key' => 'val')
+      end
+    end
+
     it "defaults to powershell input method when executing .ps1", winrm: true do
       contents = <<PS
 param ($message_one, $message_two)

--- a/spec/fixtures/apply/apply_catalog.ps1
+++ b/spec/fixtures/apply/apply_catalog.ps1
@@ -1,0 +1,1 @@
+echo $env:PT_catalog

--- a/spec/fixtures/apply/apply_catalog.sh
+++ b/spec/fixtures/apply/apply_catalog.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-echo $PT_catalog
+printenv PT_catalog

--- a/spec/fixtures/apply/apply_catalog.sh
+++ b/spec/fixtures/apply/apply_catalog.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo $PT_catalog

--- a/spec/fixtures/apply/basic/plans/init.pp
+++ b/spec/fixtures/apply/basic/plans/init.pp
@@ -1,0 +1,15 @@
+plan basic(TargetSpec $nodes) {
+  $result = run_plan('facts', nodes => $nodes)
+  if !$result.ok {
+    return $result
+  }
+
+  return apply($nodes) {
+    file { '/root/test/':
+      ensure => directory,
+    } -> file { "/root/test/hello.txt":
+      ensure => file,
+      content => "hi there I'm ${$facts['os']['family']}\n",
+    }
+  }
+}

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/integration'
+require 'bolt_spec/conn'
+require 'bolt/catalog'
+
+describe "Passes parsed AST to the apply_catalog task" do
+  include BoltSpec::Integration
+  include BoltSpec::Conn
+
+  let(:modulepath) { File.join(__dir__, '../fixtures/apply') }
+  let(:config_flags) { %W[--format json --nodes #{uri} --password #{password} --modulepath #{modulepath}] }
+
+  before(:each) do
+    allow_any_instance_of(Bolt::Applicator).to receive(:catalog_apply_task) {
+      path = File.join(__dir__, "../fixtures/apply/#{apply_task}")
+      impl = { 'name' => apply_task, 'path' => path, 'requirements' => [], 'supports_noop' => true }
+      Bolt::Task.new('apply_catalog', [impl], 'environment')
+    }
+  end
+
+  def read_ast(str)
+    Bolt::Catalog.new.with_puppet_settings do
+      # rubocop:disable Security/Eval
+      Puppet::Pops::Serialization::FromDataConverter.convert(eval(str))
+      # rubocop:enable Security/Eval
+    end
+  end
+
+  describe 'over ssh', ssh: true do
+    let(:uri) { conn_uri('ssh') }
+    let(:password) { conn_info('ssh')[:password] }
+    let(:apply_task) { 'apply_catalog.sh' }
+
+    it 'echos the catalog ast' do
+      result = run_cli_json(%w[plan run basic --no-host-key-check] + config_flags)
+      expect(result[0]['result']['_output']).to be
+      expect(result[0]['result']['_output']).to match(%r{File.*/root/test/})
+      expect(result[0]['result']['_output']).to match(/hi there I'm Debian/)
+
+      ast = read_ast(result[0]['result']['_output'])
+      expect(ast['catalog_uuid']).to be
+      expect(ast['resources'].count).to eq(5)
+    end
+  end
+
+  describe 'over winrm', winrm: true do
+    let(:uri) { conn_uri('winrm') }
+    let(:password) { conn_info('winrm')[:password] }
+    let(:apply_task) { 'apply_catalog.ps1' }
+
+    it 'echos the catalog ast' do
+      result = run_cli_json(%w[plan run basic --no-ssl --no-ssl-verify] + config_flags)
+      expect(result[0]['result']['_output']).to be
+      expect(result[0]['result']['_output']).to match(%r{File.*/root/test/})
+      expect(result[0]['result']['_output']).to match(/hi there I'm windows/)
+
+      ast = read_ast(result[0]['result']['_output'])
+      expect(ast['catalog_uuid']).to be
+      expect(ast['resources'].count).to eq(5)
+    end
+  end
+end


### PR DESCRIPTION
Add integration tests for applying a manifest block. Include tests that `_noop` works.

Also fix an issue where non-string types were not serialized as JSON when using the `environment` input method.