### PR TITLE
(BOLT-633) Set modulepath, enable puppetdb functions during apply

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/puppetdb_fact.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/puppetdb_fact.rb
@@ -17,14 +17,8 @@ Puppet::Functions.create_function(:puppetdb_fact) do
   end
 
   def puppetdb_fact(certnames)
-    unless Puppet[:tasks]
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, operation: 'puppetdb_fact'
-      )
-    end
-
     puppetdb_client = Puppet.lookup(:bolt_pdb_client) { nil }
-    unless puppetdb_client && Puppet.features.bolt?
+    unless puppetdb_client
       raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
         Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('query facts from puppetdb')
       )

--- a/bolt-modules/boltlib/lib/puppet/functions/puppetdb_query.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/puppetdb_query.rb
@@ -16,7 +16,7 @@ Puppet::Functions.create_function(:puppetdb_query) do
 
   def make_query(query)
     puppetdb_client = Puppet.lookup(:bolt_pdb_client) { nil }
-    unless Puppet[:tasks] && puppetdb_client && Puppet.features.bolt?
+    unless puppetdb_client
       raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
         Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('query facts from puppetdb')
       )

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -7,9 +7,11 @@ module Bolt
   Task = Struct.new(:name, :implementations, :input_method)
 
   class Applicator
-    def initialize(inventory, executor)
+    def initialize(inventory, executor, modulepath, pdb_config)
       @inventory = inventory
       @executor = executor
+      @modulepath = modulepath
+      @pdb_config = pdb_config
     end
 
     private def libexec
@@ -27,7 +29,8 @@ module Bolt
 
       catalog_input = {
         code_ast: ast,
-        modulepath: [],
+        modulepath: @modulepath,
+        pdb_config: @pdb_config,
         target: {
           name: target.host,
           facts: @inventory.facts(target),

--- a/lib/bolt/catalog.rb
+++ b/lib/bolt/catalog.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'bolt/pal'
+require 'bolt/puppetdb'
+require 'bolt/util/on_access'
 
 Bolt::PAL.load_puppet
 
@@ -93,6 +95,12 @@ module Bolt
     def compile_catalog(request)
       pal_main = request['code_ast'] || request['code_string']
       target = request['target']
+
+      pdb_client = Bolt::Util::OnAccess.new do
+        pdb_config = Bolt::PuppetDB::Config.new(nil, request['pdb_config'])
+        Bolt::PuppetDB::Client.from_config(pdb_config)
+      end
+
       with_puppet_settings do
         Puppet[:code] = ''
         Puppet[:node_name_value] = target['name']
@@ -105,7 +113,7 @@ module Bolt
           node = Puppet.lookup(:pal_current_node)
           setup_node(node, target["trusted"])
 
-          Puppet.override(pal_main: pal_main) do
+          Puppet.override(pal_main: pal_main, bolt_pdb_client: pdb_client) do
             compile_node(node)
           end
         end

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -119,7 +119,7 @@ module Bolt
         bolt_executor: executor,
         bolt_inventory: inventory,
         bolt_pdb_client: pdb_client,
-        apply_executor: Applicator.new(inventory, executor)
+        apply_executor: Applicator.new(inventory, executor, full_modulepath(@config[:modulepath]), @config.puppetdb)
       }
       Puppet.override(opts, &block)
     end

--- a/libexec/bolt_catalog
+++ b/libexec/bolt_catalog
@@ -7,13 +7,14 @@ require 'json'
 
 # This accepts a catalog request on stdin:
 # { "code_ast": "JSON serialized Puppet AST",
-#   "code_string": "String of code, ignored if AST is provided,
-#   "modulepath": "Array of directories to use as the modulepath for catalog compilation.
+#   "code_string": "String of code, ignored if AST is provided",
+#   "modulepath": "Array of directories to use as the modulepath for catalog compilation",
+#   "pdb_config": "A hash of PDB client config options as supplied to Bolt",
 #   "target": {
-#   "name": "the name of the node usually fqdn fro url",
-#   "facts": "Hash of facts to use for the node",
-#   "variables": "Hash of variables to use for compilation",
-#   "trusted": "Hash of trusted data for the node"
+#     "name": "the name of the node usually fqdn fro url",
+#     "facts": "Hash of facts to use for the node",
+#     "variables": "Hash of variables to use for compilation",
+#     "trusted": "Hash of trusted data for the node"
 #   }
 # }
 

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/applicator'
+require 'bolt/target'
+
+describe Bolt::Applicator do
+  let(:inventory) { nil }
+  let(:applicator) { Bolt::Applicator.new(inventory, nil, :mod, :pdb) }
+
+  it 'instantiates' do
+    expect(applicator).to be
+  end
+
+  context 'with inventory' do
+    let(:inventory) { double(:inventory, facts: {}, vars: {}) }
+
+    it 'passes catalog input' do
+      target = Bolt::Target.new('pcp://foobar')
+      input = {
+        code_ast: :ast,
+        modulepath: :mod,
+        pdb_config: :pdb,
+        target: {
+          name: 'foobar',
+          facts: {},
+          variables: {},
+          trusted: {
+            authenticated: 'local',
+            certname: 'foobar',
+            extensions: {},
+            hostname: 'foobar',
+            domain: nil
+          }
+        }
+      }
+      expect(Open3).to receive(:capture3)
+        .with('ruby', /bolt_catalog/, 'compile', stdin_data: input.to_json)
+        .and_return(['{}', :err, double(:status, success?: true)])
+      expect(applicator.compile(target, :ast, {})).to eq({})
+    end
+  end
+end

--- a/spec/fixtures/apply/basic/manifests/init.pp
+++ b/spec/fixtures/apply/basic/manifests/init.pp
@@ -1,0 +1,3 @@
+class basic() {
+  notify { 'hello world': }
+}

--- a/spec/fixtures/apply/basic/plans/class.pp
+++ b/spec/fixtures/apply/basic/plans/class.pp
@@ -1,0 +1,5 @@
+plan basic::class(TargetSpec $nodes) {
+  return apply($nodes) {
+    include 'basic'
+  }
+}

--- a/spec/fixtures/apply/basic/plans/disabled.pp
+++ b/spec/fixtures/apply/basic/plans/disabled.pp
@@ -1,0 +1,5 @@
+plan basic::disabled(TargetSpec $nodes) {
+  return apply($nodes) {
+    run_task('foo', ['foo'])
+  }
+}

--- a/spec/fixtures/apply/basic/plans/pdb_fact.pp
+++ b/spec/fixtures/apply/basic/plans/pdb_fact.pp
@@ -1,0 +1,6 @@
+plan basic::pdb_fact(TargetSpec $nodes) {
+  return apply($nodes) {
+    $facts = puppetdb_fact(['foo'])
+    notify { "found ${facts}": }
+  }
+}

--- a/spec/fixtures/apply/basic/plans/pdb_query.pp
+++ b/spec/fixtures/apply/basic/plans/pdb_query.pp
@@ -1,0 +1,6 @@
+plan basic::pdb_query(TargetSpec $nodes) {
+  return apply($nodes) {
+    $certs = puppetdb_query('nodes[certname] {}')
+    notify { "found ${certs}": }
+  }
+}


### PR DESCRIPTION
Sets modulepath to Bolt's modulepath. Enables Bolt's puppetdb functions
when compiling a manifest block. Other functions continue to be
disabled.