### PR TITLE
(maint) Fix acceptance helpers so Rototiller and beaker subcommands work

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -288,11 +288,15 @@ Example of running test suite using gem install using an existing hosts file:
     ```
     bundle exec beaker provision
     ```
-1. Run tests with specified environment variables
+1. Run pre-suite and tests with specified environment variables
     ```
     SSH_USER=root           \
     SSH_PASSWORD='S3@ret3'       \
     WINRM_USER=Administator      \
     WINRM_PASSWORD='S3@ret3'      \
     bundle exec beaker exec -t ./tests
+    ```
+1. Re-run tests
+    ```
+    bundle exec beaker exec ./tests
     ```

--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 require 'rototiller'
+require_relative 'lib/acceptance/bolt_setup_helper'
+
+# rubocop:disable Style/MixinUsage
+extend Acceptance::BoltSetupHelper
+# rubocop:enable Style/MixinUsage
 
 desc "Generate Beaker Host config"
 rototiller_task :host_config do |task|
@@ -74,10 +79,10 @@ beaker_options = [
     } }
 ]
 beaker_env = [
-  { name: 'SSH_USER',       default: 'root' },
-  { name: 'SSH_PASSWORD',   default: 'bolt_secret_password' },
-  { name: 'WINRM_USER',     default: 'Administrator' },
-  { name: 'WINRM_PASSWORD', default: 'bolt_secret_password' }
+  { name: 'SSH_USER',       default: ssh_user },
+  { name: 'SSH_PASSWORD',   default: ssh_password },
+  { name: 'WINRM_USER',     default: winrm_user },
+  { name: 'WINRM_PASSWORD', default: winrm_password }
 ]
 namespace :test do
   desc "Run bolt acceptance tests against a published gem"
@@ -88,8 +93,8 @@ namespace :test do
       add_argument: { name: 'config/gem/options.rb' }
     }
     beaker_env.each { |env| task.add_env(env) }
-    task.add_env(name: 'GEM_VERSION', default: '> 0.1.0')
-    task.add_env(name: 'GEM_SOURCE',  default: 'https://rubygems.org')
+    task.add_env(name: 'GEM_VERSION', default: gem_version)
+    task.add_env(name: 'GEM_SOURCE',  default: gem_source)
     task.add_command do |cmd|
       # without 'bundle exec' testing in jenkins fails
       # with 'beaker not found'. We do not know why so
@@ -108,10 +113,10 @@ namespace :test do
       add_argument: { name: 'config/git/options.rb' }
     }
     beaker_env.each { |env| task.add_env(env) }
-    task.add_env(name: 'GIT_SERVER', default: 'https://github.com')
-    task.add_env(name: 'GIT_FORK',   default: 'puppetlabs/bolt.git')
-    task.add_env(name: 'GIT_BRANCH', default: 'master')
-    task.add_env(name: 'GIT_SHA',    default: '')
+    task.add_env(name: 'GIT_SERVER', default: git_server)
+    task.add_env(name: 'GIT_FORK',   default: git_fork)
+    task.add_env(name: 'GIT_BRANCH', default: git_branch)
+    task.add_env(name: 'GIT_SHA',    default: git_sha)
     task.add_command do |cmd|
       # without 'bundle exec' testing in jenkins fails
       # with 'beaker not found'. We do not know why so

--- a/acceptance/lib/acceptance/bolt_setup_helper.rb
+++ b/acceptance/lib/acceptance/bolt_setup_helper.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Acceptance
+  module BoltSetupHelper
+    def ssh_user
+      ENV['SSH_USER'] || 'root'
+    end
+
+    def ssh_password
+      ENV['SSH_PASSWORD'] || 'bolt_secret_password'
+    end
+
+    def winrm_user
+      ENV['WINRM_USER'] || 'Administrator'
+    end
+
+    def winrm_password
+      ENV['WINRM_PASSWORD'] || 'bolt_secret_password'
+    end
+
+    def gem_version
+      ENV['GEM_VERSION'] || '> 0.1.0'
+    end
+
+    def gem_source
+      ENV['GEM_SOURCE'] || 'https://rubygems.org'
+    end
+
+    def git_server
+      ENV['GIT_SERVER'] || 'https://github.com'
+    end
+
+    def git_fork
+      ENV['GIT_FORK'] || 'puppetlabs/bolt'
+    end
+
+    def git_branch
+      ENV['GIT_BRANCH'] || 'master'
+    end
+
+    def git_sha
+      ENV['GIT_SHA'] || ''
+    end
+  end
+end

--- a/acceptance/setup/common/pre-suite/030_set_password.rb
+++ b/acceptance/setup/common/pre-suite/030_set_password.rb
@@ -1,19 +1,22 @@
 # frozen_string_literal: true
 
+require 'bolt_setup_helper'
+
 test_name "Set root/Administrator password to a known value" do
   extend Beaker::HostPrebuiltSteps
+  extend Acceptance::BoltSetupHelper
 
   hosts.each do |host|
     case host['platform']
     when /windows/
-      on host, "passwd #{ENV['WINRM_USER']}", stdin: ENV['WINRM_PASSWORD']
+      on host, "passwd #{winrm_user}", stdin: winrm_password
     when /osx/
       # Our VMs default to PermitRootLogin prohibit-password
-      on host, 'echo "PermitRootLogin yes" >> /etc/ssh/sshd_config' if ENV['SSH_USER'] == 'root'
-      on host, "dscl . -passwd /Users/#{ENV['SSH_USER']}", stdin: ENV['SSH_PASSWORD']
+      on host, 'echo "PermitRootLogin yes" >> /etc/ssh/sshd_config' if ssh_user == 'root'
+      on host, "dscl . -passwd /Users/#{ssh_user}", stdin: ssh_password
     else
       # Some platforms support --stdin, but repeating it seems to work everywhere
-      on host, "passwd #{ENV['SSH_USER']}", stdin: "#{ENV['SSH_PASSWORD']}\n#{ENV['SSH_PASSWORD']}"
+      on host, "passwd #{ssh_user}", stdin: "#{ssh_password}\n#{ssh_password}"
     end
   end
 end

--- a/acceptance/setup/common/pre-suite/050_build_bolt_inventory.rb
+++ b/acceptance/setup/common/pre-suite/050_build_bolt_inventory.rb
@@ -1,22 +1,27 @@
 # frozen_string_literal: true
 
+require 'bolt_setup_helper'
+
 test_name "build bolt inventory file" do
+  extend Acceptance::BoltSetupHelper
+
   ssh_nodes = select_hosts(roles: ['ssh'])
   winrm_nodes = select_hosts(roles: ['winrm'])
 
   ssh_config = {
     'transport' => 'ssh',
     'ssh' => {
-      'user' => ENV['SSH_USER'],
-      'password' => ENV['SSH_PASSWORD'],
+      'user' => ssh_user,
+      'password' => ssh_password,
       'host-key-check' => false
     }
   }
+
   winrm_config = {
     'transport' => 'winrm',
     'winrm' => {
-      'user' => ENV['WINRM_USER'],
-      'password' => ENV['WINRM_PASSWORD'],
+      'user' => winrm_user,
+      'password' => winrm_password,
       'ssl' => false
     }
   }

--- a/acceptance/setup/gem/pre-suite/020_install.rb
+++ b/acceptance/setup/gem/pre-suite/020_install.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-gem_source = ENV['GEM_SOURCE'] || "https://rubygems.org"
-gem_version = ENV['BOLT_GEM'] || ""
+require 'bolt_setup_helper'
 
 test_name "Install Bolt gem" do
+  extend Acceptance::BoltSetupHelper
+
   step "Install Bolt gem" do
     install_command = "gem install bolt --source #{gem_source} --no-ri --no-rdoc"
     install_command += " -v '#{gem_version}'" unless gem_version.empty?
@@ -14,6 +15,7 @@ test_name "Install Bolt gem" do
       on(bolt, install_command)
     end
   end
+
   step "Ensure install succeeded" do
     cmd = 'bolt --help'
     case bolt['platform']

--- a/acceptance/setup/git/pre-suite/020_install.rb
+++ b/acceptance/setup/git/pre-suite/020_install.rb
@@ -1,24 +1,30 @@
 # frozen_string_literal: true
 
+require 'bolt_setup_helper'
+
 test_name "Install Bolt via git" do
+  extend Acceptance::BoltSetupHelper
+
   sha = ''
   version = ''
   step "Clone repo" do
-    on(bolt, "git clone #{ENV['GIT_SERVER']}/#{ENV['GIT_FORK']} bolt")
-    if ENV['GIT_SHA'].empty?
-      on(bolt, "cd bolt && git checkout #{ENV['GIT_BRANCH']}")
+    on(bolt, "git clone #{git_server}/#{git_fork} bolt")
+    if git_sha.empty?
+      on(bolt, "cd bolt && git checkout #{git_branch}")
     else
-      on(bolt, "cd bolt && git checkout #{ENV['GIT_SHA']}")
+      on(bolt, "cd bolt && git checkout #{git_sha}")
     end
   end
+
   step "Update submodules" do
     on(bolt, "cd bolt && git submodule update --init --recursive")
   end
+
   step "Construct version based on SHA" do
-    sha = if ENV['GIT_SHA'].empty?
+    sha = if git_sha.empty?
             on(bolt, 'cd bolt && git rev-parse --short HEAD').stdout.chomp
           else
-            ENV['GIT_SHA']
+            git_sha
           end
     version = "9.9.#{sha}"
     create_remote_file(bolt, 'bolt/lib/bolt/version.rb', <<-VERS)
@@ -27,6 +33,7 @@ test_name "Install Bolt via git" do
     end
     VERS
   end
+
   step "Build gem" do
     build_command = "cd bolt; gem build bolt.gemspec"
     case bolt['platform']
@@ -36,6 +43,7 @@ test_name "Install Bolt via git" do
       on(bolt, build_command)
     end
   end
+
   step "Install custom gem" do
     install_command = "cd bolt; gem install bolt-#{version}.gem --no-ri --no-rdoc"
     case bolt['platform']
@@ -45,6 +53,7 @@ test_name "Install Bolt via git" do
       on(bolt, install_command)
     end
   end
+
   step "Ensure install succeeded" do
     cmd = 'bolt --version'
     case bolt['platform']

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -47,10 +47,12 @@ Gem::Specification.new do |spec|
   spec.add_dependency "locale", "~> 2.1"
   spec.add_dependency "minitar", "~> 0.6"
   spec.add_dependency "semantic_puppet", "~> 1.0.2"
-  spec.add_dependency "win32-dir", "= 0.4.9"
-  spec.add_dependency "win32-process", "= 0.7.5"
-  spec.add_dependency "win32-security", "= 0.2.5"
-  spec.add_dependency "win32-service", "= 0.8.8"
+  if Gem.win_platform?
+    spec.add_dependency "win32-dir", "= 0.4.9"
+    spec.add_dependency "win32-process", "= 0.7.5"
+    spec.add_dependency "win32-security", "= 0.2.5"
+    spec.add_dependency "win32-service", "= 0.8.8"
+  end
 
   # there is a bug in puppetlabs_spec_helper for modules without fixtures
   spec.add_development_dependency "bundler", "~> 1.14"


### PR DESCRIPTION
Rototiller expects defaults to be declared in the Rakefile, while beaker
subcommands don't use the Rakefile. The end of the acceptance README
provides instructions for running with beaker subcommands that didn't
work unless you explicitly set all the optional environment variables
you needed. Refactor so that both paths share defaults.