### PR TITLE
(BOLT-650) Add bolt as a service

### DIFF
--- a/ext/debian/pe-bolt-server.default
+++ b/ext/debian/pe-bolt-server.default
@@ -1,0 +1,4 @@
+# Defaults for pe-bolt-server - sourced by /etc/init.d/pe-bolt-server
+
+# Startup options
+#PE_BOLT_SERVER_OPTIONS=--loglevel=debug

--- a/ext/debian/pe-bolt-server.init
+++ b/ext/debian/pe-bolt-server.init
@@ -1,0 +1,114 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:          pe-bolt-server
+# Required-Start:    $network $named $remote_fs $syslog
+# Required-Stop:     $network $named $remote_fs $syslog
+# Should-Start:      pe-bolt-server
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+### END INIT INFO
+
+exec=/opt/puppetlabs/server/apps/bolt-server/bin/pe-bolt-server
+prog="pe-bolt-server"
+desc="PE Bolt Server"
+
+piddir=/var/run/puppetlabs
+pidfile="${piddir}/${prog}.pid"
+logdir=/var/log/puppetlabs
+
+[ -x $exec ] || exit 5
+
+[ -r /etc/default/pe-bolt-server ] && . /etc/default/pe-bolt-server
+
+. /lib/lsb/init-functions
+
+reload_pe_bolt_server() {
+    start-stop-daemon --stop --quiet --signal HUP --pidfile $pidfile --name $prog
+}
+
+start_pe_bolt_server() {
+    mkdir -p $piddir $logdir
+    start-stop-daemon --start --quiet --pidfile $pidfile --startas $exec -- $PE_BOLT_SERVER_OPTIONS
+}
+
+stop_pe_bolt_server() {
+    start-stop-daemon --stop --retry TERM/10/KILL/5 --quiet --oknodo --pidfile $pidfile --name $prog && rm -f "${pidfile}"
+}
+
+restart_pe_bolt_server() {
+    log_begin_msg "Restarting $desc"
+    stop_pe_bolt_server
+    start_pe_bolt_server
+    log_end_msg $?
+}
+
+status_pe_bolt_server() {
+    if (type status_of_proc > /dev/null 2>&1) ; then
+        status_of_proc -p "${pidfile}" "${exec}" "${prog}"
+    else
+        status_of_proc() {
+            local pidfile daemon name status
+
+            pidfile=
+            OPTIND=1
+            while getopts p: opt ; do
+                case "$opt" in
+                    p)  pidfile="$OPTARG";;
+                esac
+            done
+            shift $(($OPTIND - 1))
+
+            if [ -n "$pidfile" ]; then
+                pidfile="-p $pidfile"
+            fi
+            daemon="$1"
+            name="$2"
+            status="0"
+            pidofproc $pidfile $daemon >/dev/null || status="$?"
+            if [ "$status" = 0 ]; then
+                log_success_msg "$name is running"
+                return 0
+            elif [ "$status" = 4 ]; then
+                log_failure_msg "could not access PID file for $name"
+                return $status
+            else
+                log_failure_msg "$name is not running"
+                return $status
+            fi
+        }
+        status_of_proc -p "${pidfile}" "${exec}"
+    fi
+}
+
+case "$1" in
+    start)
+        log_begin_msg "Starting $desc"
+        start_pe_bolt_server
+        log_end_msg $?
+    ;;
+    stop)
+        log_begin_msg "Stopping $desc"
+        stop_pe_bolt_server
+        log_end_msg $?
+    ;;
+    reload)
+        log_begin_msg "Reloading $desc"
+        reload_pe_bolt_server
+        log_end_msg $?
+    ;;
+    status)
+        status_pe_bolt_server
+    ;;
+    restart|force-reload)
+        restart_pe_bolt_server
+    ;;
+    condrestart)
+        if status_pe_bolt_server >/dev/null 2>&1; then
+            restart_pe_bolt_server
+        fi
+    ;;
+    *)
+        echo "Usage: $0 {start|stop|status|restart|condrestart}" >&2
+        exit 1
+    ;;
+esac

--- a/ext/systemd/pe-bolt-server.logrotate
+++ b/ext/systemd/pe-bolt-server.logrotate
@@ -1,0 +1,11 @@
+/var/log/puppetlabs/pe-bolt-service/*.log {
+    daily
+    missingok
+    rotate 30
+    compress
+    notifempty
+    sharedscripts
+    postrotate
+        systemctl is-active --quiet pe-bolt-server.service && systemctl kill --signal=USR2 --kill-who=main pe-bolt-server.service
+    endscript
+}

--- a/ext/systemd/pe-bolt-server.service
+++ b/ext/systemd/pe-bolt-server.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=PE Bolt Server
+After=syslog.target network.target
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/sysconfig/pe-bolt-server-service
+EnvironmentFile=-/etc/default/pe-bolt-server-service
+ExecStart=/opt/puppetlabs/puppet/bin/pe-bolt-server $PE_BOLT_SERVER_OPTIONS --foreground
+Restart=always
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target

--- a/lib/bolt/puppetdb/config.rb
+++ b/lib/bolt/puppetdb/config.rb
@@ -6,10 +6,18 @@ require 'bolt/util'
 module Bolt
   module PuppetDB
     class Config
-      DEFAULT_TOKEN = File.expand_path('~/.puppetlabs/token')
-      DEFAULT_CONFIG = { user: File.expand_path('~/.puppetlabs/client-tools/puppetdb.conf'),
-                         global: '/etc/puppetlabs/client-tools/puppetdb.conf',
-                         win_global: 'C:/ProgramData/PuppetLabs/client-tools/puppetdb.conf' }.freeze
+      if !ENV['HOME'].nil?
+        DEFAULT_TOKEN = File.expand_path('~/.puppetlabs/token')
+        DEFAULT_CONFIG = { user: File.expand_path('~/.puppetlabs/client-tools/puppetdb.conf'),
+                           global: '/etc/puppetlabs/client-tools/puppetdb.conf',
+                           win_global: 'C:/ProgramData/PuppetLabs/client-tools/puppetdb.conf' }.freeze
+      else
+        DEFAULT_TOKEN = "/etc/puppetlabs/client-tools/pe-bolt-server/token"
+        DEFAULT_CONFIG = { user: "/etc/puppetlabs/puppet/puppetdb.conf",
+                           global: '/etc/puppetlabs/puppet/puppetdb.conf',
+                           win_global: 'C:/ProgramData/PuppetLabs/client-tools/puppetdb.conf' }.freeze
+
+      end
 
       def initialize(config_file, options)
         @settings = load_config(config_file)

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -11,7 +11,11 @@ require 'bolt/result'
 module Bolt
   module Transport
     class Orch < Base
-      CONF_FILE = File.expand_path('~/.puppetlabs/client-tools/orchestrator.conf')
+      CONF_FILE = if !ENV['HOME'].nil?
+                    File.expand_path('~/.puppetlabs/client-tools/orchestrator.conf')
+                  else
+                    '/etc/puppetlabs/client-tools/orchestrator.conf'
+                  end
       BOLT_COMMAND_TASK = Struct.new(:name).new('bolt_shim::command').freeze
       BOLT_SCRIPT_TASK = Struct.new(:name).new('bolt_shim::script').freeze
       BOLT_UPLOAD_TASK = Struct.new(:name).new('bolt_shim::upload').freeze


### PR DESCRIPTION
This adds the necessary infra to deploy the pe-bolt-server as a service, including service init files, defaults, and the unit file. We also need to check if the `$HOME` environment variable exists and set paths more explicitly if it doesn't, since when the service starts that env var won't be avialable.

To test this:
* Copy exe/bolt-server to /opt/puppetlabs/puppet/bin
* Copy ext/systemd/pe-bolt-server.service file to /lib/systemd/system/ 
    * Create symlink to /etc/systemd/system/multi-user.target.wants/
* Copy ext/systemd/pe-bolt-server.logrotate to /etc/logrotate.d/pe-bolt-server
* Copy ext/debian/pe-bolt-server.default file to /etc/default/pe-bolt-server
* Copy ext/debian/pe-bolt-server.init file to /etc/init.d/pe-bolt-server
* `systemctl daemon-reload`
* `service pe-bolt-server start`

```
sudo cp exe/bolt-server /opt/puppetlabs/puppet/bin
sudo cp ext/systemd/pe-bolt-server.service /lib/systemd/system/pe-bolt-server
sudo cp ext/debian/pe-bolt-server.default /etc/default/pe-bolt-server
sudo cp ext/debian/pe-bolt-server.init /etc/init.d/pe-bolt-server
systemctl daemon-reload
service pe-bolt-server start
```