### PR TITLE
(BOLT-672, BOLT-673) Add plan variables and trusted data

### DIFF
--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -23,13 +23,16 @@ module Bolt
     end
 
     def compile(target, ast, plan_vars)
+      trusted = Puppet::Context::TrustedInformation.new('local', target.host, {})
+
       catalog_input = {
         code_ast: ast,
         modulepath: [],
         target: {
           name: target.host,
           facts: @inventory.facts(target),
-          variables: @inventory.vars(target).merge(plan_vars)
+          variables: @inventory.vars(target).merge(plan_vars),
+          trusted: trusted.to_h
         }
       }
 

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -22,14 +22,14 @@ module Bolt
       Task.new('apply_catalog', [impl], 'stdin')
     end
 
-    def compile(target, ast)
+    def compile(target, ast, plan_vars)
       catalog_input = {
         code_ast: ast,
         modulepath: [],
         target: {
           name: target.host,
           facts: @inventory.facts(target),
-          variables: @inventory.vars(target)
+          variables: @inventory.vars(target).merge(plan_vars)
         }
       }
 
@@ -44,7 +44,7 @@ module Bolt
       JSON.parse(out)
     end
 
-    def apply(args, apply_body, _scope)
+    def apply(args, apply_body, scope)
       raise(ArgumentError, 'apply requires a TargetSpec') if args.empty?
       type0 = Puppet.lookup(:pal_script_compiler).type('TargetSpec')
       Puppet::Pal.assert_type(type0, args[0], 'apply targets')
@@ -56,10 +56,14 @@ module Bolt
         params = args[1]
       end
 
+      # collect plan vars and merge them over target vars
+      plan_vars = scope.to_hash
+      %w[trusted server_facts facts].each { |k| plan_vars.delete(k) }
+
       targets = @inventory.get_targets(args[0])
       ast = Puppet::Pops::Serialization::ToDataConverter.convert(apply_body, rich_data: true, symbol_to_string: true)
       results = targets.map do |target|
-        params['catalog'] = compile(target, ast)
+        params['catalog'] = compile(target, ast, plan_vars)
         @executor.run_task([target], catalog_apply_task, params, '_description' => 'apply catalog')
       end
       ResultSet.new results.reduce([]) { |result, result_set| result + result_set.results }

--- a/lib/bolt/catalog.rb
+++ b/lib/bolt/catalog.rb
@@ -66,15 +66,13 @@ module Bolt
       end
     end
 
-    def setup_node(node)
+    def setup_node(node, trusted)
       facts = Puppet.lookup(:pal_facts)
       node_facts = Puppet::Node::Facts.new(Puppet[:node_name_value], facts)
       node.fact_merge(node_facts)
 
       node.parameters = node.parameters.merge(Puppet.lookup(:pal_variables))
-      # TODO: setup server_facts
-      # TODO: setup trusted in params
-      # TODO: setup serverversion/clientversion in params
+      node.trusted_data = trusted
     end
 
     def compile_node(node)
@@ -105,7 +103,7 @@ module Bolt
           variables: target["variables"] || {}
         ) do |_pal|
           node = Puppet.lookup(:pal_current_node)
-          setup_node(node)
+          setup_node(node, target["trusted"])
 
           Puppet.override(pal_main: pal_main) do
             compile_node(node)

--- a/libexec/bolt_catalog
+++ b/libexec/bolt_catalog
@@ -12,7 +12,8 @@ require 'json'
 #   "target": {
 #   "name": "the name of the node usually fqdn fro url",
 #   "facts": "Hash of facts to use for the node",
-#   "variables": "Hash of variables to use for compilation"
+#   "variables": "Hash of variables to use for compilation",
+#   "trusted": "Hash of trusted data for the node"
 #   }
 # }
 

--- a/spec/fixtures/apply/basic/plans/plan_vars.pp
+++ b/spec/fixtures/apply/basic/plans/plan_vars.pp
@@ -1,0 +1,9 @@
+plan basic::plan_vars(TargetSpec $nodes) {
+  $targets = get_targets($nodes)
+  $targets.each |$t| { $t.set_var('foo', 'hello there') }
+
+  $foo = 'hello world'
+  return apply($nodes) {
+    notify { $foo: }
+  }
+}

--- a/spec/fixtures/apply/basic/plans/target_vars.pp
+++ b/spec/fixtures/apply/basic/plans/target_vars.pp
@@ -1,0 +1,8 @@
+plan basic::target_vars(TargetSpec $nodes) {
+  $targets = get_targets($nodes)
+  $targets.each |$t| { $t.set_var('foo', 'hello there') }
+
+  return apply($nodes) {
+    notify { $foo: }
+  }
+}

--- a/spec/fixtures/apply/basic/plans/trusted.pp
+++ b/spec/fixtures/apply/basic/plans/trusted.pp
@@ -1,0 +1,5 @@
+plan basic::trusted(TargetSpec $nodes) {
+  return apply($nodes) {
+    notify { "trusted ${trusted}": }
+  }
+}

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -10,7 +10,7 @@ describe "Passes parsed AST to the apply_catalog task" do
   include BoltSpec::Conn
 
   let(:modulepath) { File.join(__dir__, '../fixtures/apply') }
-  let(:config_flags) { %W[--format json --nodes #{uri} --password #{password} --modulepath #{modulepath}] }
+  let(:config_flags) { %W[--format json --nodes #{uri} --password #{password} --modulepath #{modulepath}] + tflags }
 
   before(:each) do
     allow_any_instance_of(Bolt::Applicator).to receive(:catalog_apply_task) {
@@ -24,9 +24,10 @@ describe "Passes parsed AST to the apply_catalog task" do
     let(:uri) { conn_uri('ssh') }
     let(:password) { conn_info('ssh')[:password] }
     let(:apply_task) { 'apply_catalog.sh' }
+    let(:tflags) { %w[--no-host-key-check] }
 
     it 'echos the catalog ast' do
-      result = run_cli_json(%w[plan run basic --no-host-key-check] + config_flags)
+      result = run_cli_json(%w[plan run basic] + config_flags)
       ast = result[0]['result']
       expect(ast).to be
       expect(ast['catalog_uuid']).to be
@@ -38,15 +39,42 @@ describe "Passes parsed AST to the apply_catalog task" do
       expect(files.count).to eq(1)
       expect(files[0]['parameters']['content']).to match(/hi there I'm Debian/)
     end
+
+    it 'uses trusted facts' do
+      result = run_cli_json(%w[plan run basic::trusted] + config_flags)
+      ast = result[0]['result']
+      notify = ast['resources'].select { |r| r['type'] == 'Notify' }
+      expect(notify.count).to eq(1)
+      expect(notify[0]['title']).to eq(
+        'trusted {authenticated => local, certname => localhost, extensions => {}, hostname => localhost, domain => }'
+      )
+    end
+
+    it 'uses target vars' do
+      result = run_cli_json(%w[plan run basic::target_vars] + config_flags)
+      ast = result[0]['result']
+      notify = ast['resources'].select { |r| r['type'] == 'Notify' }
+      expect(notify.count).to eq(1)
+      expect(notify[0]['title']).to eq('hello there')
+    end
+
+    it 'plan vars override target vars' do
+      result = run_cli_json(%w[plan run basic::plan_vars] + config_flags)
+      ast = result[0]['result']
+      notify = ast['resources'].select { |r| r['type'] == 'Notify' }
+      expect(notify.count).to eq(1)
+      expect(notify[0]['title']).to eq('hello world')
+    end
   end
 
   describe 'over winrm', winrm: true do
     let(:uri) { conn_uri('winrm') }
     let(:password) { conn_info('winrm')[:password] }
     let(:apply_task) { 'apply_catalog.ps1' }
+    let(:tflags) { %w[--no-ssl --no-ssl-verify] }
 
     it 'echos the catalog ast' do
-      result = run_cli_json(%w[plan run basic --no-ssl --no-ssl-verify] + config_flags)
+      result = run_cli_json(%w[plan run basic] + config_flags)
       ast = result[0]['result']
       expect(ast).to be
       expect(ast['catalog_uuid']).to be
@@ -57,6 +85,32 @@ describe "Passes parsed AST to the apply_catalog task" do
       files = resources['File'].select { |f| f['title'] == '/root/test/hello.txt' }
       expect(files.count).to eq(1)
       expect(files[0]['parameters']['content']).to match(/hi there I'm windows/)
+    end
+
+    it 'uses trusted facts' do
+      result = run_cli_json(%w[plan run basic::trusted] + config_flags)
+      ast = result[0]['result']
+      notify = ast['resources'].select { |r| r['type'] == 'Notify' }
+      expect(notify.count).to eq(1)
+      expect(notify[0]['title']).to eq(
+        'trusted {authenticated => local, certname => localhost, extensions => {}, hostname => localhost, domain => }'
+      )
+    end
+
+    it 'uses target vars' do
+      result = run_cli_json(%w[plan run basic::target_vars] + config_flags)
+      ast = result[0]['result']
+      notify = ast['resources'].select { |r| r['type'] == 'Notify' }
+      expect(notify.count).to eq(1)
+      expect(notify[0]['title']).to eq('hello there')
+    end
+
+    it 'plan vars override target vars' do
+      result = run_cli_json(%w[plan run basic::plan_vars] + config_flags)
+      ast = result[0]['result']
+      notify = ast['resources'].select { |r| r['type'] == 'Notify' }
+      expect(notify.count).to eq(1)
+      expect(notify[0]['title']).to eq('hello world')
     end
   end
 end


### PR DESCRIPTION
Include plan variables and trusted data when compiling a manifest block.