### PR TITLE
(BOLT-634) Fix modulepath on Windows

### DIFF
--- a/acceptance/setup/common/pre-suite/071_install_facts.rb
+++ b/acceptance/setup/common/pre-suite/071_install_facts.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'bolt_command_helper'
+
 test_name "Install puppetlabs-facts" do
-  on(hosts, puppet('module', 'install', 'puppetlabs-facts', '--target-dir', '$HOME/.puppetlabs/bolt/modules'))
+  extend Acceptance::BoltCommandHelper
+  on(bolt, puppet('module', 'install', 'puppetlabs-facts', '--target-dir', default_modulepath))
 end

--- a/acceptance/tests/apply_ssh.rb
+++ b/acceptance/tests/apply_ssh.rb
@@ -22,7 +22,7 @@ test_name "bolt plan run with should apply manifest block on remote hosts via ss
 
   bolt_command = "bolt plan run example_apply filepath=#{filepath} nodes=ssh_nodes"
   flags = {
-    '--modulepath' => "$HOME/.puppetlabs/bolt/modules:#{dir}/modules",
+    '--modulepath' => modulepath(File.join(dir, 'modules')),
     '--format'     => 'json'
   }
 

--- a/acceptance/tests/apply_winrm.rb
+++ b/acceptance/tests/apply_winrm.rb
@@ -9,6 +9,9 @@ test_name "bolt plan run with should apply manifest block on remote hosts via wi
   winrm_nodes = select_hosts(roles: ['winrm'])
   skip_test('no applicable nodes to test on') if winrm_nodes.empty?
 
+  controller_has_ruby = on(bolt, 'which ruby', accept_all_exit_codes: true).exit_code == 0
+  skip_test('FIX: apply uses wrong Ruby') if controller_has_ruby && bolt[:roles].include?('winrm')
+
   dir = bolt.tmpdir('apply_winrm')
   fixtures = File.absolute_path('files')
   filepath = 'C:/test'
@@ -22,7 +25,7 @@ test_name "bolt plan run with should apply manifest block on remote hosts via wi
 
   bolt_command = "bolt plan run example_apply filepath=#{filepath} nodes=winrm_nodes"
   flags = {
-    '--modulepath' => "$HOME/.puppetlabs/bolt/modules:#{dir}/modules",
+    '--modulepath' => modulepath(File.join(dir, 'modules')),
     '--format'     => 'json'
   }
 

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -36,7 +36,7 @@ module Bolt
       bolt_catalog_exe = File.join(libexec, 'bolt_catalog')
 
       old_path = ENV['PATH']
-      ENV['PATH'] = "#{RbConfig::CONFIG['bindir']}:#{old_path}"
+      ENV['PATH'] = "#{RbConfig::CONFIG['bindir']}#{File::PATH_SEPARATOR}#{old_path}"
       out, err, stat = Open3.capture3('ruby', bolt_catalog_exe, 'compile', stdin_data: catalog_input.to_json)
       ENV['PATH'] = old_path
 


### PR DESCRIPTION
Windows CLI uses a different modulepath, and needs a non-Cygwin
directory to install the facts module.

Skip the apply winrm test if the controller node is a winrm target and
has its own Ruby installed, as Bolt will fail to run apply in Puppet
Agent's Ruby. That will be fixed separately.