### PR TITLE
(BOLT-684) Ensure we can operate on a ResultSet returned by apply

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -13,6 +13,7 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
     scope_param
     param 'String', :plan_name
     optional_param 'Hash', :named_args
+    return_type 'Boltlib::PlanResult'
   end
 
   def run_plan(scope, plan_name, named_args = {})

--- a/bolt-modules/boltlib/types/planresult.pp
+++ b/bolt-modules/boltlib/types/planresult.pp
@@ -1,4 +1,4 @@
-# A Planresult describes the supported return values of a plan. It
+# A PlanResult describes the supported return values of a plan. It
 # should be used as the return type of functions that run plans and return the
 # results.
 

--- a/spec/fixtures/apply/basic/plans/init.pp
+++ b/spec/fixtures/apply/basic/plans/init.pp
@@ -7,9 +7,11 @@ plan basic(TargetSpec $nodes) {
   return apply($nodes) {
     file { '/root/test/':
       ensure => directory,
-    } -> file { "/root/test/hello.txt":
-      ensure => file,
+    } -> file { '/root/test/hello.txt':
+      ensure  => file,
       content => "hi there I'm ${$facts['os']['family']}\n",
     }
+  }.map |$r| {
+    $r['resources']
   }
 }

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -30,12 +30,10 @@ describe "Passes parsed AST to the apply_catalog task" do
 
     it 'echos the catalog ast' do
       result = run_cli_json(%w[plan run basic] + config_flags)
-      ast = result[0]['result']
-      expect(ast).to be
-      expect(ast['catalog_uuid']).to be
-      expect(ast['resources'].count).to eq(5)
+      ast = result[0]
+      expect(ast.count).to eq(5)
 
-      resources = ast['resources'].group_by { |r| r['type'] }
+      resources = ast.group_by { |r| r['type'] }
       expect(resources['File'].count).to eq(2)
       files = resources['File'].select { |f| f['title'] == '/root/test/hello.txt' }
       expect(files.count).to eq(1)
@@ -118,12 +116,10 @@ describe "Passes parsed AST to the apply_catalog task" do
 
     it 'echos the catalog ast' do
       result = run_cli_json(%w[plan run basic] + config_flags)
-      ast = result[0]['result']
-      expect(ast).to be
-      expect(ast['catalog_uuid']).to be
-      expect(ast['resources'].count).to eq(5)
+      ast = result[0]
+      expect(ast.count).to eq(5)
 
-      resources = ast['resources'].group_by { |r| r['type'] }
+      resources = ast.group_by { |r| r['type'] }
       expect(resources['File'].count).to eq(2)
       files = resources['File'].select { |f| f['title'] == '/root/test/hello.txt' }
       expect(files.count).to eq(1)


### PR DESCRIPTION
Previously if only an `apply` was used, nothing would refer to ResultSet
and the type would not be loaded. Ensure the type is always loaded so we
can use it as the result of an `apply`.