### PR TITLE
(BOLT-635) Parallelize multi-target apply

### DIFF
--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -8,15 +8,14 @@ module Bolt
   Task = Struct.new(:name, :implementations, :input_method)
 
   class Applicator
-    def initialize(inventory, executor, modulepath, pdb_config, hiera_config, max_compiles = nil)
+    def initialize(inventory, executor, modulepath, pdb_config, hiera_config, max_compiles)
       @inventory = inventory
       @executor = executor
       @modulepath = modulepath
       @pdb_config = pdb_config
       @hiera_config = hiera_config ? validate_hiera_config(hiera_config) : nil
 
-      max_threads = max_compiles || Concurrent.processor_count
-      @pool = Concurrent::ThreadPoolExecutor.new(max_threads: max_threads)
+      @pool = Concurrent::ThreadPoolExecutor.new(max_threads: max_compiles)
     end
 
     private def libexec

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -183,6 +183,10 @@ Available options are:
              'Maximum number of simultaneous connections (default: 100)') do |concurrency|
         @options[:concurrency] = concurrency
       end
+      define('--compile-concurrency CONCURRENCY', Integer,
+             'Maximum number of simultaneous manifest block compiles (default: number of cores)') do |concurrency|
+        @options[:'compile-concurrency'] = concurrency
+      end
       define('--modulepath MODULES',
              "List of directories containing modules, separated by '#{File::PATH_SEPARATOR}'") do |modulepath|
         @options[:modulepath] = modulepath.split(File::PATH_SEPARATOR)

--- a/lib/bolt/error.rb
+++ b/lib/bolt/error.rb
@@ -94,7 +94,7 @@ module Bolt
 
   class ValidationError < Bolt::Error
     def initialize(msg)
-      super(msg, 'bolt.transport/validation-error')
+      super(msg, 'bolt/validation-error')
     end
   end
 

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -50,15 +50,14 @@ module Bolt
       impl.value
     end
 
-    # Execute the given block on a list of nodes in parallel, one thread per "batch".
+    # Starts executing the given block on a list of nodes in parallel, one thread per "batch".
     #
     # This is the main driver of execution on a list of targets. It first
     # groups targets by transport, then divides each group into batches as
-    # defined by the transport. Each batch, along with the corresponding
-    # transport, is yielded to the block in turn and the results all collected
-    # into a single ResultSet.
-    def batch_execute(targets)
-      promises = targets.group_by(&:protocol).flat_map do |protocol, protocol_targets|
+    # defined by the transport. Yields each batch, along with the corresponding
+    # transport, to the block in turn and returns an array of result promises.
+    def queue_execute(targets)
+      targets.group_by(&:protocol).flat_map do |protocol, protocol_targets|
         transport = transport(protocol)
         report_transport(transport, protocol_targets.count)
         transport.batches(protocol_targets).flat_map do |batch|
@@ -94,7 +93,23 @@ module Bolt
           batch_promises.values
         end
       end
+    end
+
+    # Create a ResultSet from the results of all promises.
+    def await_results(promises)
       ResultSet.new(promises.map(&:value))
+    end
+
+    # Execute the given block on a list of nodes in parallel, one thread per "batch".
+    #
+    # This is the main driver of execution on a list of targets. It first
+    # groups targets by transport, then divides each group into batches as
+    # defined by the transport. Each batch, along with the corresponding
+    # transport, is yielded to the block in turn and the results all collected
+    # into a single ResultSet.
+    def batch_execute(targets, &block)
+      promises = queue_execute(targets, &block)
+      await_results(promises)
     end
 
     def log_action(description, targets)
@@ -119,7 +134,6 @@ module Bolt
 
       results
     end
-    private :log_action
 
     def report_transport(transport, count)
       name = transport.class.name.split('::').last.downcase
@@ -143,7 +157,6 @@ module Bolt
       @logger.info(result.to_json)
       result
     end
-    private :with_node_logging
 
     def run_command(targets, command, options = {}, &callback)
       description = options.fetch('_description', "command '#{command}'")

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -119,11 +119,14 @@ module Bolt
         bolt_executor: executor,
         bolt_inventory: inventory,
         bolt_pdb_client: pdb_client,
-        apply_executor: Applicator.new(inventory,
-                                       executor,
-                                       full_modulepath(@config[:modulepath]),
-                                       @config.puppetdb,
-                                       @config[:'hiera-config'])
+        apply_executor: Applicator.new(
+          inventory,
+          executor,
+          full_modulepath(@config[:modulepath]),
+          @config.puppetdb,
+          @config[:'hiera-config'],
+          @config[:'compile-concurrency']
+        )
       }
       Puppet.override(opts, &block)
     end

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -5,40 +5,88 @@ require 'bolt/applicator'
 require 'bolt/target'
 
 describe Bolt::Applicator do
-  let(:inventory) { nil }
-  let(:applicator) { Bolt::Applicator.new(inventory, nil, :mod, :pdb, nil) }
+  let(:uri) { 'foobar' }
+  let(:target) { Bolt::Target.new(uri) }
+  let(:inventory) { Bolt::Inventory.new(nil) }
+  let(:executor) { Bolt::Executor.new }
+  let(:applicator) { Bolt::Applicator.new(inventory, executor, :mod, :pdb, nil) }
 
   it 'instantiates' do
     expect(applicator).to be
   end
 
-  context 'with inventory' do
-    let(:inventory) { double(:inventory, facts: {}, vars: {}) }
-
-    it 'passes catalog input' do
-      target = Bolt::Target.new('pcp://foobar')
-      input = {
-        code_ast: :ast,
-        modulepath: :mod,
-        pdb_config: :pdb,
-        hiera_config: nil,
-        target: {
-          name: 'foobar',
-          facts: {},
-          variables: {},
-          trusted: {
-            authenticated: 'local',
-            certname: 'foobar',
-            extensions: {},
-            hostname: 'foobar',
-            domain: nil
-          }
+  it 'passes catalog input' do
+    input = {
+      code_ast: :ast,
+      modulepath: :mod,
+      pdb_config: :pdb,
+      hiera_config: nil,
+      target: {
+        name: uri,
+        facts: {},
+        variables: {},
+        trusted: {
+          authenticated: 'local',
+          certname: uri,
+          extensions: {},
+          hostname: uri,
+          domain: nil
         }
       }
-      expect(Open3).to receive(:capture3)
-        .with('ruby', /bolt_catalog/, 'compile', stdin_data: input.to_json)
-        .and_return(['{}', :err, double(:status, success?: true)])
-      expect(applicator.compile(target, :ast, {})).to eq({})
+    }
+    expect(Open3).to receive(:capture3)
+      .with('ruby', /bolt_catalog/, 'compile', stdin_data: input.to_json)
+      .and_return(['{}', :err, double(:status, success?: true)])
+    expect(applicator.compile(target, :ast, {})).to eq({})
+  end
+
+  context 'with Puppet mocked' do
+    before(:each) do
+      allow(Puppet).to receive(:lookup).and_return(double(:type, type: nil))
+      allow(Puppet::Pal).to receive(:assert_type)
+      allow(Puppet::Pops::Serialization::ToDataConverter).to receive(:convert).and_return(:ast)
+    end
+
+    it 'captures compile errors in a result set' do
+      expect(applicator).to receive(:compile).and_raise('Something weird happened')
+
+      resultset = applicator.apply([uri], :body, {})
+      expect(resultset).to be_a(Bolt::ResultSet)
+      expect(resultset.count).to eq(1)
+      expect(resultset.first.ok).to be(false)
+      expect(resultset.first.error_hash['msg']).to eq('Something weird happened')
+    end
+
+    it "only creates 2 threads" do
+      running = Concurrent::AtomicFixnum.new
+      promises = Concurrent::Array.new
+      allow(applicator).to receive(:compile) do
+        count = running.increment
+        if count <= 2
+          # Only first two will block, simplifying cleanup at the end
+          delay = Concurrent::Promise.new { {} }
+          promises << delay
+          delay.value
+        else
+          {}
+        end
+      end
+
+      targets = [Bolt::Target.new('node1'), Bolt::Target.new('node2'), Bolt::Target.new('node3')]
+      results = targets.map { |target| Bolt::Result.new(target) }
+      allow_any_instance_of(Bolt::Transport::SSH).to receive(:batch_task).and_return(*results)
+
+      t = Thread.new {
+        applicator.apply([targets], :body, {})
+      }
+      sleep(0.1)
+
+      expect(running.value).to eq(2)
+
+      # execute all the promises to release the threads
+      expect(promises.count).to eq(2)
+      promises.each(&:execute)
+      t.join
     end
   end
 end

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -9,7 +9,7 @@ describe Bolt::Applicator do
   let(:target) { Bolt::Target.new(uri) }
   let(:inventory) { Bolt::Inventory.new(nil) }
   let(:executor) { Bolt::Executor.new }
-  let(:applicator) { Bolt::Applicator.new(inventory, executor, :mod, :pdb, nil) }
+  let(:applicator) { Bolt::Applicator.new(inventory, executor, :mod, :pdb, nil, 2) }
 
   it 'instantiates' do
     expect(applicator).to be

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -287,6 +287,65 @@ describe Bolt::Config do
         Bolt::Config.new(config).validate
       }.to raise_error(Bolt::ValidationError)
     end
+
+    it "does not accept negative concurrency" do
+      config = { concurrency: -1 }
+      expect {
+        Bolt::Config.new(config).validate
+      }.to raise_error(Bolt::ValidationError)
+    end
+
+    it "does not accept zero concurrency" do
+      config = { concurrency: 0 }
+      expect {
+        Bolt::Config.new(config).validate
+      }.to raise_error(Bolt::ValidationError)
+    end
+
+    it "does not accept string concurrency" do
+      config = { concurrency: '1' }
+      expect {
+        Bolt::Config.new(config).validate
+      }.to raise_error(Bolt::ValidationError)
+    end
+
+    it "accepts positive concurrency" do
+      config = { concurrency: 1 }
+      Bolt::Config.new(config).validate
+    end
+
+    it "does not accept negative compile-concurrency" do
+      config = { 'compile-concurrency': -1 }
+      expect {
+        Bolt::Config.new(config).validate
+      }.to raise_error(Bolt::ValidationError)
+    end
+
+    it "does not accept zero compile-concurrency" do
+      config = { 'compile-concurrency': 0 }
+      expect {
+        Bolt::Config.new(config).validate
+      }.to raise_error(Bolt::ValidationError)
+    end
+
+    it "does not accept large compile-concurrency" do
+      config = { 'compile-concurrency': 1000000 }
+      expect {
+        Bolt::Config.new(config).validate
+      }.to raise_error(Bolt::ValidationError)
+    end
+
+    it "does not accept string compile-concurrency" do
+      config = { 'compile-concurrency': '1' }
+      expect {
+        Bolt::Config.new(config).validate
+      }.to raise_error(Bolt::ValidationError)
+    end
+
+    it "accepts positive compile-concurrency" do
+      config = { 'compile-concurrency': 1 }
+      Bolt::Config.new(config).validate
+    end
   end
 
   describe 'boltdir' do

--- a/spec/fixtures/apply/apply_catalog.ps1
+++ b/spec/fixtures/apply/apply_catalog.ps1
@@ -1,1 +1,0 @@
-echo $env:PT_catalog

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -22,6 +22,7 @@ describe "Passes parsed AST to the apply_catalog task" do
     }
   end
 
+  # SSH only required to simplify capturing stdin passed to the task. WinRM omitted as slower and unnecessary.
   describe 'over ssh', ssh: true do
     let(:uri) { conn_uri('ssh') }
     let(:password) { conn_info('ssh')[:password] }
@@ -86,135 +87,6 @@ describe "Passes parsed AST to the apply_catalog task" do
             'server_urls' => 'https://localhost:99999',
             'cacert' => File.join(Gem::Specification.find_by_name('bolt').gem_dir, 'resources', 'ca.pem')
 
-          }
-        }
-      }
-
-      it 'calls puppetdb_query' do
-        with_tempfile_containing('conf', YAML.dump(config)) do |conf|
-          result = run_cli_json(%W[plan run basic::pdb_query --configfile #{conf.path}] + config_flags)
-          expect(result['kind']).to eq('bolt/apply-error')
-          expect(result['msg']).to match(/Failed to query PuppetDB: /)
-        end
-      end
-
-      it 'calls puppetdb_fact' do
-        with_tempfile_containing('conf', YAML.dump(config)) do |conf|
-          result = run_cli_json(%W[plan run basic::pdb_fact --configfile #{conf.path}] + config_flags)
-          expect(result['kind']).to eq('bolt/apply-error')
-          expect(result['msg']).to match(/Failed to query PuppetDB: /)
-        end
-      end
-    end
-
-    context 'with hiera config stubbed' do
-      let(:default_datadir) {
-        {
-          'hiera-config' => File.join(__dir__, '../fixtures/apply/hiera.yaml').to_s
-        }
-      }
-      let(:custom_datadir) {
-        {
-          'hiera-config' => File.join(__dir__, '../fixtures/apply/hiera_datadir.yaml').to_s
-        }
-      }
-      let(:bad_hiera_version) {
-        {
-          'hiera-config' => File.join(__dir__, '../fixtures/apply/hiera_invalid.yaml').to_s
-        }
-      }
-
-      it 'default datadir is accessible' do
-        with_tempfile_containing('conf', YAML.dump(default_datadir)) do |conf|
-          result = run_cli_json(%W[plan run basic::hiera_lookup --configfile #{conf.path}] + config_flags)
-          ast = result[0]['result']
-          notify = ast['resources'].select { |r| r['type'] == 'Notify' }
-          expect(notify[0]['title']).to eq("hello default datadir")
-        end
-      end
-
-      it 'non-default datadir specified in hiera config is accessible' do
-        with_tempfile_containing('conf', YAML.dump(custom_datadir)) do |conf|
-          result = run_cli_json(%W[plan run basic::hiera_lookup --configfile #{conf.path}] + config_flags)
-          ast = result[0]['result']
-          notify = ast['resources'].select { |r| r['type'] == 'Notify' }
-          expect(notify[0]['title']).to eq("hello custom datadir")
-        end
-      end
-
-      it 'hiera 5 version not specified' do
-        with_tempfile_containing('conf', YAML.dump(bad_hiera_version)) do |conf|
-          result = run_cli_json(%W[plan run basic::hiera_lookup --configfile #{conf.path}] + config_flags)
-          expect(result['kind']).to eq('bolt/apply-error')
-          expect(result['msg']).to match(/Hiera v5 is required./)
-        end
-      end
-    end
-  end
-
-  describe 'over winrm', winrm: true do
-    let(:uri) { conn_uri('winrm') }
-    let(:password) { conn_info('winrm')[:password] }
-    let(:apply_task) { 'apply_catalog.ps1' }
-    let(:tflags) { %w[--no-ssl --no-ssl-verify] }
-
-    it 'echos the catalog ast' do
-      result = run_cli_json(%w[plan run basic] + config_flags)
-      ast = result[0]
-      expect(ast.count).to eq(5)
-
-      resources = ast.group_by { |r| r['type'] }
-      expect(resources['File'].count).to eq(2)
-      files = resources['File'].select { |f| f['title'] == '/root/test/hello.txt' }
-      expect(files.count).to eq(1)
-      expect(files[0]['parameters']['content']).to match(/hi there I'm windows/)
-    end
-
-    it 'uses trusted facts' do
-      result = run_cli_json(%w[plan run basic::trusted] + config_flags)
-      ast = result[0]['result']
-      notify = ast['resources'].select { |r| r['type'] == 'Notify' }
-      expect(notify.count).to eq(1)
-      expect(notify[0]['title']).to eq(
-        'trusted {authenticated => local, certname => localhost, extensions => {}, hostname => localhost, domain => }'
-      )
-    end
-
-    it 'uses target vars' do
-      result = run_cli_json(%w[plan run basic::target_vars] + config_flags)
-      ast = result[0]['result']
-      notify = ast['resources'].select { |r| r['type'] == 'Notify' }
-      expect(notify.count).to eq(1)
-      expect(notify[0]['title']).to eq('hello there')
-    end
-
-    it 'plan vars override target vars' do
-      result = run_cli_json(%w[plan run basic::plan_vars] + config_flags)
-      ast = result[0]['result']
-      notify = ast['resources'].select { |r| r['type'] == 'Notify' }
-      expect(notify.count).to eq(1)
-      expect(notify[0]['title']).to eq('hello world')
-    end
-
-    it 'applies a class from the modulepath' do
-      result = run_cli_json(%w[plan run basic::class] + config_flags)
-      ast = result[0]['result']
-      notify = ast['resources'].select { |r| r['type'] == 'Notify' }
-      expect(notify.count).to eq(1)
-    end
-
-    it 'errors calling run_task' do
-      result = run_cli_json(%w[plan run basic::disabled] + config_flags)
-      expect(result['kind']).to eq('bolt/apply-error')
-      expect(result['msg']).to match(/The task operation 'run_task' is not available when compiling a catalog/)
-    end
-
-    context 'with puppetdb stubbed' do
-      let(:config) {
-        {
-          'puppetdb' => {
-            'server_urls' => 'https://localhost:99999',
-            'cacert' => File.join(Gem::Specification.find_by_name('bolt').gem_dir, 'resources', 'ca.pem')
           }
         }
       }

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -76,8 +76,9 @@ describe "Passes parsed AST to the apply_catalog task" do
 
     it 'errors calling run_task' do
       result = run_cli_json(%w[plan run basic::disabled] + config_flags)
-      expect(result['kind']).to eq('bolt/apply-error')
-      expect(result['msg']).to match(/The task operation 'run_task' is not available when compiling a catalog/)
+      error = result[0]['result']['_error']
+      expect(error['kind']).to eq('bolt/apply-error')
+      expect(error['msg']).to match(/The task operation 'run_task' is not available when compiling a catalog/)
     end
 
     context 'with puppetdb stubbed' do
@@ -94,16 +95,18 @@ describe "Passes parsed AST to the apply_catalog task" do
       it 'calls puppetdb_query' do
         with_tempfile_containing('conf', YAML.dump(config)) do |conf|
           result = run_cli_json(%W[plan run basic::pdb_query --configfile #{conf.path}] + config_flags)
-          expect(result['kind']).to eq('bolt/apply-error')
-          expect(result['msg']).to match(/Failed to query PuppetDB: /)
+          error = result[0]['result']['_error']
+          expect(error['kind']).to eq('bolt/apply-error')
+          expect(error['msg']).to match(/Failed to query PuppetDB: /)
         end
       end
 
       it 'calls puppetdb_fact' do
         with_tempfile_containing('conf', YAML.dump(config)) do |conf|
           result = run_cli_json(%W[plan run basic::pdb_fact --configfile #{conf.path}] + config_flags)
-          expect(result['kind']).to eq('bolt/apply-error')
-          expect(result['msg']).to match(/Failed to query PuppetDB: /)
+          error = result[0]['result']['_error']
+          expect(error['kind']).to eq('bolt/apply-error')
+          expect(error['msg']).to match(/Failed to query PuppetDB: /)
         end
       end
     end


### PR DESCRIPTION
Refactors the executor to expose `queue_execute` and `await_results` as async components. `apply` uses them to parallelize compiling and executing manifest blocks across multiple targets, using separate thread pools for compilation (a local CPU-intensive operation) and execution. Compilation thread pool is limited by a new `compile-concurrency` config option.