### PR TITLE
(maint) Relax gem dependencies

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "logging", "~> 2.2"
   spec.add_dependency "net-scp", "~> 1.2"
   spec.add_dependency "net-ssh", "~> 4.2"
-  spec.add_dependency "orchestrator_client", "~> 0.2.4"
+  spec.add_dependency "orchestrator_client", "~> 0.2"
   spec.add_dependency "terminal-table", "~> 1.8"
   spec.add_dependency "winrm", "~> 2.0"
   spec.add_dependency "winrm-fs", "~> 1.1"
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fast_gettext", "~> 1.1.2"
   spec.add_dependency "locale", "~> 2.1"
   spec.add_dependency "minitar", "~> 0.6"
-  spec.add_dependency "semantic_puppet", "~> 1.0.2"
+  spec.add_dependency "semantic_puppet", "~> 1.0"
   if Gem.win_platform?
     spec.add_dependency "win32-dir", "= 0.4.9"
     spec.add_dependency "win32-process", "= 0.7.5"


### PR DESCRIPTION
Relaxes gem dependency for semantic_puppet to be consistent with
puppet#master, and on orchestrator_client because there's no reason to
be so tightly pinned.