### PR TITLE
(BOLT-631) Support Hiera config for plan apply

### DIFF
--- a/lib/bolt/catalog.rb
+++ b/lib/bolt/catalog.rb
@@ -55,7 +55,7 @@ end
 
 module Bolt
   class Catalog
-    def with_puppet_settings
+    def with_puppet_settings(hiera_config)
       Dir.mktmpdir('bolt') do |dir|
         cli = []
         Puppet::Settings::REQUIRED_APP_SETTINGS.each do |setting|
@@ -63,6 +63,7 @@ module Bolt
         end
         Puppet.settings.send(:clear_everything_for_tests)
         Puppet.initialize_settings(cli)
+        Puppet.settings[:hiera_config] = hiera_config
         # self.class.configure_logging
         yield
       end
@@ -101,7 +102,7 @@ module Bolt
         Bolt::PuppetDB::Client.from_config(pdb_config)
       end
 
-      with_puppet_settings do
+      with_puppet_settings(request['hiera_config']) do
         Puppet[:code] = ''
         Puppet[:node_name_value] = target['name']
         Puppet::Pal.in_tmp_environment(

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -119,7 +119,11 @@ module Bolt
         bolt_executor: executor,
         bolt_inventory: inventory,
         bolt_pdb_client: pdb_client,
-        apply_executor: Applicator.new(inventory, executor, full_modulepath(@config[:modulepath]), @config.puppetdb)
+        apply_executor: Applicator.new(inventory,
+                                       executor,
+                                       full_modulepath(@config[:modulepath]),
+                                       @config.puppetdb,
+                                       @config[:'hiera-config'])
       }
       Puppet.override(opts, &block)
     end

--- a/libexec/bolt_catalog
+++ b/libexec/bolt_catalog
@@ -10,6 +10,7 @@ require 'json'
 #   "code_string": "String of code, ignored if AST is provided",
 #   "modulepath": "Array of directories to use as the modulepath for catalog compilation",
 #   "pdb_config": "A hash of PDB client config options as supplied to Bolt",
+#   "hiera_config": "File path to hiera config file",
 #   "target": {
 #     "name": "the name of the node usually fqdn fro url",
 #     "facts": "Hash of facts to use for the node",

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -6,7 +6,7 @@ require 'bolt/target'
 
 describe Bolt::Applicator do
   let(:inventory) { nil }
-  let(:applicator) { Bolt::Applicator.new(inventory, nil, :mod, :pdb) }
+  let(:applicator) { Bolt::Applicator.new(inventory, nil, :mod, :pdb, nil) }
 
   it 'instantiates' do
     expect(applicator).to be
@@ -21,6 +21,7 @@ describe Bolt::Applicator do
         code_ast: :ast,
         modulepath: :mod,
         pdb_config: :pdb,
+        hiera_config: nil,
         target: {
           name: 'foobar',
           facts: {},

--- a/spec/fixtures/apply/basic/plans/hiera_lookup.pp
+++ b/spec/fixtures/apply/basic/plans/hiera_lookup.pp
@@ -1,0 +1,5 @@
+plan basic::hiera_lookup(TargetSpec $nodes) {
+  return apply($nodes) {
+    notify { "hello ${hiera('hiera_data')}": }
+  }
+}

--- a/spec/fixtures/apply/data/common.yaml
+++ b/spec/fixtures/apply/data/common.yaml
@@ -1,0 +1,2 @@
+---
+hiera_data: "default datadir"

--- a/spec/fixtures/apply/hiera.yaml
+++ b/spec/fixtures/apply/hiera.yaml
@@ -1,0 +1,9 @@
+---
+version: 5 
+
+defaults:
+  data_hash: yaml_data
+
+hierarchy:
+  - name: "Common"
+    path: "common.yaml"

--- a/spec/fixtures/apply/hiera_datadir.yaml
+++ b/spec/fixtures/apply/hiera_datadir.yaml
@@ -1,0 +1,10 @@
+---
+version: 5
+
+defaults:
+  datadir: "hiera_datadir"
+  data_hash: yaml_data
+
+hierarchy:
+  - name: "Common"
+    path: "common.yaml"

--- a/spec/fixtures/apply/hiera_datadir/common.yaml
+++ b/spec/fixtures/apply/hiera_datadir/common.yaml
@@ -1,0 +1,2 @@
+---
+hiera_data: "custom datadir"

--- a/spec/fixtures/apply/hiera_invalid.yaml
+++ b/spec/fixtures/apply/hiera_invalid.yaml
@@ -1,0 +1,10 @@
+---
+# without specifying version 5, puppet would assume version 3. Apply only supports v5
+# version: 5 
+
+defaults:
+  data_hash: yaml_data
+
+hierarchy:
+  - name: "Common"
+    path: "common.yaml"


### PR DESCRIPTION
When compiling catalogs for apply bolt should configure and use hiera. This data should by default come from the boltdir not the global or user specific puppet path.