### PR TITLE
(BOLT-636) Add logger for manifest block compilation

### DIFF
--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -61,7 +61,7 @@ module Bolt
       if File.exist?(File.path(hiera_config))
         data = File.open(File.path(hiera_config), "r:UTF-8") { |f| YAML.safe_load(f.read) }
         unless data['version'] == 5
-          raise ApplyError.new("All Targets", "Hiera v5 is required.")
+          raise Bolt::ParseError, "Hiera v5 is required, found v#{data['version'] || 3} in #{hiera_config}"
         end
         hiera_config
       end

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'logging'
 require 'open3'
 require 'concurrent'
+require 'bolt/util/puppet_log_level'
 
 module Bolt
   Task = Struct.new(:name, :implementations, :input_method)
@@ -16,6 +18,7 @@ module Bolt
       @hiera_config = hiera_config ? validate_hiera_config(hiera_config) : nil
 
       @pool = Concurrent::ThreadPoolExecutor.new(max_threads: max_compiles)
+      @logger = Logging.logger[self]
     end
 
     private def libexec
@@ -53,7 +56,28 @@ module Bolt
       out, err, stat = Open3.capture3('ruby', bolt_catalog_exe, 'compile', stdin_data: catalog_input.to_json)
       ENV['PATH'] = old_path
 
-      raise ApplyError.new(target.to_s, err) unless stat.success?
+      # stderr may contain formatted logs from Puppet's logger or other errors.
+      # Print them in order, but handle them separately. Anything not a formatted log is assumed
+      # to be an error message.
+      logs = err.lines.map do |l|
+        begin
+          JSON.parse(l)
+        rescue StandardError
+          l
+        end
+      end
+      logs.each do |log|
+        if log.is_a?(String)
+          @logger.error(log.chomp)
+        else
+          log.map { |k, v| [k.to_sym, v] }.each do |level, msg|
+            bolt_level = Bolt::Util::PuppetLogLevel::MAPPING[level]
+            @logger.send(bolt_level, "#{target.uri}: #{msg.chomp}")
+          end
+        end
+      end
+
+      raise(ApplyError, target.uri) unless stat.success?
       JSON.parse(out)
     end
 

--- a/lib/bolt/catalog.rb
+++ b/lib/bolt/catalog.rb
@@ -7,6 +7,7 @@ require 'bolt/util/on_access'
 Bolt::PAL.load_puppet
 
 require 'bolt/catalog/compiler'
+require 'bolt/catalog/logging'
 
 module Bolt
   class Catalog
@@ -19,7 +20,10 @@ module Bolt
         Puppet.settings.send(:clear_everything_for_tests)
         Puppet.initialize_settings(cli)
         Puppet.settings[:hiera_config] = hiera_config
-        # self.class.configure_logging
+
+        # Use a special logdest that serializes all log messages and their level to stderr.
+        Puppet::Util::Log.newdestination(:stderr)
+        Puppet.settings[:log_level] = 'debug'
         yield
       end
     end

--- a/lib/bolt/catalog.rb
+++ b/lib/bolt/catalog.rb
@@ -6,52 +6,7 @@ require 'bolt/util/on_access'
 
 Bolt::PAL.load_puppet
 
-# This class exists to override evaluate_main and let us inject
-# AST instead of looking for the main manifest. A better option may be to set up the
-# node environment so our AST is in the '' hostclass instead of doing it here.
-module Puppet
-  module Parser
-    class BoltCompiler < Puppet::Parser::Compiler
-      def internal_evaluator
-        @internal_evaluator ||= Puppet::Pops::Parser::EvaluatingParser.new
-      end
-
-      def dump_ast(ast)
-        Puppet::Pops::Serialization::ToDataConverter.convert(ast, rich_data: true, symbol_to_string: true)
-      end
-
-      def load_ast(ast_data)
-        Puppet::Pops::Serialization::FromDataConverter.convert(ast_data)
-      end
-
-      def parse_string(string, file = '')
-        internal_evaluator.parse_string(string, file)
-      end
-
-      def evaluate_main
-        main = Puppet.lookup(:pal_main)
-        ast = if main.is_a?(String)
-                parse_string(main)
-              else
-                load_ast(main)
-              end
-
-        bridge = Puppet::Parser::AST::PopsBridge::Program.new(ast)
-
-        # This is more or less copypaste from the super but we don't use the
-        # original host_class.
-        krt = environment.known_resource_types
-        @main = krt.add(Puppet::Resource::Type.new(:hostclass, '', code: bridge))
-        @topscope.source = @main
-        @main_resource = Puppet::Parser::Resource.new('class', :main, scope: @topscope, source: @main)
-        @topscope.resource = @main_resource
-        add_resource(@topscope, @main_resource)
-
-        @main_resource.evaluate
-      end
-    end
-  end
-end
+require 'bolt/catalog/compiler'
 
 module Bolt
   class Catalog

--- a/lib/bolt/catalog/compiler.rb
+++ b/lib/bolt/catalog/compiler.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# This class exists to override evaluate_main and let us inject
+# AST instead of looking for the main manifest. A better option may be to set up the
+# node environment so our AST is in the '' hostclass instead of doing it here.
+module Puppet
+  module Parser
+    class BoltCompiler < Puppet::Parser::Compiler
+      def internal_evaluator
+        @internal_evaluator ||= Puppet::Pops::Parser::EvaluatingParser.new
+      end
+
+      def dump_ast(ast)
+        Puppet::Pops::Serialization::ToDataConverter.convert(ast, rich_data: true, symbol_to_string: true)
+      end
+
+      def load_ast(ast_data)
+        Puppet::Pops::Serialization::FromDataConverter.convert(ast_data)
+      end
+
+      def parse_string(string, file = '')
+        internal_evaluator.parse_string(string, file)
+      end
+
+      def evaluate_main
+        main = Puppet.lookup(:pal_main)
+        ast = if main.is_a?(String)
+                parse_string(main)
+              else
+                load_ast(main)
+              end
+
+        bridge = Puppet::Parser::AST::PopsBridge::Program.new(ast)
+
+        # This is more or less copypaste from the super but we don't use the
+        # original host_class.
+        krt = environment.known_resource_types
+        @main = krt.add(Puppet::Resource::Type.new(:hostclass, '', code: bridge))
+        @topscope.source = @main
+        @main_resource = Puppet::Parser::Resource.new('class', :main, scope: @topscope, source: @main)
+        @topscope.resource = @main_resource
+        add_resource(@topscope, @main_resource)
+
+        @main_resource.evaluate
+      end
+    end
+  end
+end

--- a/lib/bolt/catalog/logging.rb
+++ b/lib/bolt/catalog/logging.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Puppet::Util::Log.newdesttype :stderr do
+  def initialize
+    # Flush output immediately.
+    $stderr.sync = true
+  end
+
+  # Emits message as a single line of JSON mapping level to message string.
+  def handle(msg)
+    str = msg.respond_to?(:multiline) ? msg.multiline : msg.to_s
+    str = msg.source == "Puppet" ? str : "#{msg.source}: #{str}"
+    warn({ msg.level => str }.to_json)
+  end
+end

--- a/lib/bolt/error.rb
+++ b/lib/bolt/error.rb
@@ -83,6 +83,12 @@ module Bolt
     end
   end
 
+  class ParseError < Error
+    def initialize(msg)
+      super(msg, 'bolt/parse-error')
+    end
+  end
+
   class InvalidPlanResult < Error
     def initialize(plan_name, result_str)
       super("Plan #{plan_name} returned an invalid result: #{result_str}",

--- a/lib/bolt/error.rb
+++ b/lib/bolt/error.rb
@@ -78,8 +78,8 @@ module Bolt
   end
 
   class ApplyError < Error
-    def initialize(target, err)
-      super("Apply failed to compile for #{target}: #{err}", 'bolt/apply-error')
+    def initialize(target)
+      super("Apply failed to compile for #{target}", 'bolt/apply-error')
     end
   end
 

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -41,7 +41,7 @@ module Bolt
         begin
           data = YAML.safe_load(ENV[ENVIRONMENT_VAR])
         rescue Psych::Exception
-          raise Bolt::Error.new("Could not parse inventory from $#{ENVIRONMENT_VAR}", 'bolt/parse-error')
+          raise Bolt::ParseError, "Could not parse inventory from $#{ENVIRONMENT_VAR}"
         end
       else
         data = Bolt::Util.read_config_file(config[:inventoryfile], [config.default_inventory], 'inventory')

--- a/lib/bolt/pal/logging.rb
+++ b/lib/bolt/pal/logging.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bolt/util/puppet_log_level'
+
 Puppet::Util::Log.newdesttype :logging do
   match "Logging::Logger"
 
@@ -7,22 +9,9 @@ Puppet::Util::Log.newdesttype :logging do
   # an explicit mapping.
   def initialize(logger)
     @external_logger = logger
-
-    @log_level_map = {
-      debug: :debug,
-      info: :info,
-      notice: :notice,
-      warning: :warn,
-      err: :error,
-      # Nothing in Puppet actually uses alert, emerg or crit, so it's hard to say
-      # what they indicate, but they sound pretty bad.
-      alert: :error,
-      emerg: :fatal,
-      crit: :fatal
-    }
   end
 
   def handle(log)
-    @external_logger.send(@log_level_map[log.level], log.to_s)
+    @external_logger.send(Bolt::Util::PuppetLogLevel::MAPPING[log.level], log.to_s)
   end
 end

--- a/lib/bolt/util/puppet_log_level.rb
+++ b/lib/bolt/util/puppet_log_level.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Bolt
+  module Util
+    module PuppetLogLevel
+      MAPPING = {
+        debug: :debug,
+        info: :info,
+        notice: :notice,
+        warning: :warn,
+        err: :error,
+        # The following are used by Puppet functions of the same name, and are all treated as
+        # error types in the Windows EventLog and log colors.
+        alert: :error,
+        emerg: :fatal,
+        crit: :fatal
+      }.freeze
+    end
+  end
+end

--- a/spec/fixtures/apply/basic/plans/error.pp
+++ b/spec/fixtures/apply/basic/plans/error.pp
@@ -1,0 +1,12 @@
+plan basic::error(TargetSpec $nodes) {
+  return apply($nodes) {
+    debug('Debugging')
+    info('Meh')
+    notice('Helpful')
+    warning('Warned')
+    err('Fire')
+    alert('Stop')
+    crit('Drop')
+    emerg('Roll')
+  }
+}

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -149,8 +149,8 @@ describe "Passes parsed AST to the apply_catalog task" do
       it 'hiera 5 version not specified' do
         with_tempfile_containing('conf', YAML.dump(bad_hiera_version)) do |conf|
           result = run_cli_json(%W[plan run basic::hiera_lookup --configfile #{conf.path}] + config_flags)
-          expect(result['kind']).to eq('bolt/apply-error')
-          expect(result['msg']).to match(/Hiera v5 is required./)
+          expect(result['kind']).to eq('bolt/parse-error')
+          expect(result['msg']).to match(/Hiera v5 is required, found v3/)
         end
       end
     end

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -74,11 +74,27 @@ describe "Passes parsed AST to the apply_catalog task" do
       expect(notify.count).to eq(1)
     end
 
+    it 'logs messages emitted during compilation' do
+      result = run_cli_json(%w[plan run basic::error] + config_flags)
+      expect(result[0]['status']).to eq('success')
+      logs = @log_output.readlines
+      expect(logs).to include(/DEBUG.*Debugging/)
+      expect(logs).to include(/INFO.*Meh/)
+      expect(logs).to include(/WARN.*Warned/)
+      expect(logs).to include(/NOTICE.*Helpful/)
+      expect(logs).to include(/ERROR.*Fire/)
+      expect(logs).to include(/ERROR.*Stop/)
+      expect(logs).to include(/FATAL.*Drop/)
+      expect(logs).to include(/FATAL.*Roll/)
+    end
+
     it 'errors calling run_task' do
       result = run_cli_json(%w[plan run basic::disabled] + config_flags)
       error = result[0]['result']['_error']
       expect(error['kind']).to eq('bolt/apply-error')
-      expect(error['msg']).to match(/The task operation 'run_task' is not available when compiling a catalog/)
+      expect(error['msg']).to match(/Apply failed to compile for #{uri}/)
+      expect(@log_output.readlines)
+        .to include(/The task operation 'run_task' is not available when compiling a catalog/)
     end
 
     context 'with puppetdb stubbed' do
@@ -97,7 +113,8 @@ describe "Passes parsed AST to the apply_catalog task" do
           result = run_cli_json(%W[plan run basic::pdb_query --configfile #{conf.path}] + config_flags)
           error = result[0]['result']['_error']
           expect(error['kind']).to eq('bolt/apply-error')
-          expect(error['msg']).to match(/Failed to query PuppetDB: /)
+          expect(error['msg']).to match(/Apply failed to compile for #{uri}/)
+          expect(@log_output.readlines).to include(/Failed to query PuppetDB: /)
         end
       end
 
@@ -106,7 +123,8 @@ describe "Passes parsed AST to the apply_catalog task" do
           result = run_cli_json(%W[plan run basic::pdb_fact --configfile #{conf.path}] + config_flags)
           error = result[0]['result']['_error']
           expect(error['kind']).to eq('bolt/apply-error')
-          expect(error['msg']).to match(/Failed to query PuppetDB: /)
+          expect(error['msg']).to match(/Apply failed to compile for #{uri}/)
+          expect(@log_output.readlines).to include(/Failed to query PuppetDB: /)
         end
       end
     end


### PR DESCRIPTION
Adds a logger to handle messages from compiling manifest blocks for
targets that gathers all log messages created during the compilation and
redirects them to Bolt's logging facilities.