### PR TITLE
(maint) Fix Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
-sudo: false
+sudo: required
 language: ruby
 cache: bundler
+services:
+- docker
 rvm:
 - 2.4
 - 2.3
@@ -8,7 +10,7 @@ before_script:
 - eval `ssh-agent`
 - cat Gemfile.lock
 - bundle exec r10k puppetfile install
-- docker-compose build && docker-compose up -d
+- docker-compose up -d --build
 
 script:
 - bundle exec rake travisci


### PR DESCRIPTION
Somehow we were previously running docker-compose without the setup
Travis CI docs outline. Yesterday it stopped working. Add sudo:required
and services:docker to fix.