### PR TITLE
(BOLT-648, BOLT-649) Support _catch_errors, _run_as

### DIFF
--- a/acceptance/files/example_apply.pp
+++ b/acceptance/files/example_apply.pp
@@ -2,6 +2,7 @@ plan example_apply (
   TargetSpec $nodes,
   String $filepath,
   Boolean $noop = false,
+  Optional[String] $run_as = undef,
 ) {
   $result = run_plan('facts', nodes => $nodes)
   if !$result.ok {
@@ -11,7 +12,7 @@ plan example_apply (
   $targets = get_targets($nodes)
   $targets.each |$t| { $t.set_var('filepath', $filepath) }
 
-  return apply($targets, _noop => $noop) {
+  return apply($targets, _noop => $noop, _run_as => $run_as, _catch_errors => true) {
     file { $filepath:
       ensure => directory,
     } -> file { "${filepath}/hello.txt":

--- a/acceptance/tests/apply_nonroot.rb
+++ b/acceptance/tests/apply_nonroot.rb
@@ -9,9 +9,28 @@ test_name "bolt plan run with should apply manifest block on remote hosts via ss
   ssh_nodes = select_hosts(roles: ['ssh'])
   skip_test('no applicable nodes to test on') if ssh_nodes.empty?
 
-  dir = bolt.tmpdir('apply_ssh')
+  dir = bolt.tmpdir('apply_nonroot')
   fixtures = File.absolute_path('files')
-  filepath = '/tmp/test'
+  filepath = '/etc/puppetlabs/test'
+  user = 'apply_nonroot'
+
+  step 'create nonroot user on targets' do
+    on(ssh_nodes, puppet('resource', 'user', user, 'ensure=present'))
+
+    teardown do
+      on(ssh_nodes, puppet('resource', 'user', user, 'ensure=absent'))
+    end
+  end
+
+  step 'disable requiretty for root user' do
+    create_remote_file(ssh_nodes, "/etc/sudoers.d/#{user}", <<-FILE)
+Defaults:root !requiretty
+FILE
+
+    teardown do
+      on(ssh_nodes, "rm /etc/sudoers.d/#{user}")
+    end
+  end
 
   step "create plan on bolt controller" do
     on(bolt, "mkdir -p #{dir}/modules/example_apply/plans")
@@ -26,12 +45,8 @@ test_name "bolt plan run with should apply manifest block on remote hosts via ss
     '--format'     => 'json'
   }
 
-  teardown do
-    on(ssh_nodes, "rm -rf #{filepath}")
-  end
-
-  step "execute `bolt plan run noop=true` via SSH with json output" do
-    result = bolt_command_on(bolt, bolt_command + ' noop=true', flags)
+  step "execute `bolt plan run run_as=#{user}` via SSH with json output" do
+    result = bolt_command_on(bolt, bolt_command + " run_as=#{user}", flags)
     assert_equal(0, result.exit_code,
                  "Bolt did not exit with exit code 0")
 
@@ -46,36 +61,12 @@ test_name "bolt plan run with should apply manifest block on remote hosts via ss
       # Verify that node succeeded
       host = node.hostname
       result = json.select { |n| n['node'] == host }
-      assert_equal('success', result[0]['status'],
-                   "The task did not succeed on #{host}")
+      assert_equal('failure', result[0]['status'],
+                   "The task did not fail on #{host}")
+      assert_match(/Permission denied/, result[0]['result']['_error']['msg'])
 
       # Verify that files were not created on the target
       on(node, "cat #{filepath}/hello.txt", acceptable_exit_codes: [1])
-    end
-  end
-
-  step "execute `bolt plan run` via SSH with json output" do
-    result = bolt_command_on(bolt, bolt_command, flags)
-    assert_equal(0, result.exit_code,
-                 "Bolt did not exit with exit code 0")
-
-    begin
-      json = JSON.parse(result.stdout)
-    rescue JSON.ParserError
-      assert_equal("Output should be JSON", result.string,
-                   "Output should be JSON")
-    end
-
-    ssh_nodes.each do |node|
-      # Verify that node succeeded
-      host = node.hostname
-      result = json.select { |n| n['node'] == host }
-      assert_equal('success', result[0]['status'],
-                   "The task did not succeed on #{host}")
-
-      # Verify that files were created on the target
-      content = on(node, "cat #{filepath}/hello.txt")
-      assert_match(/^hi there I'm [a-zA-Z]+$/, content.stdout)
     end
   end
 end

--- a/acceptance/tests/apply_winrm.rb
+++ b/acceptance/tests/apply_winrm.rb
@@ -29,9 +29,11 @@ test_name "bolt plan run with should apply manifest block on remote hosts via wi
     '--format'     => 'json'
   }
 
-  step "execute `bolt plan run noop=true` via WinRM with json output" do
+  teardown do
     on(winrm_nodes, "rm -rf #{filepath}")
+  end
 
+  step "execute `bolt plan run noop=true` via WinRM with json output" do
     result = bolt_command_on(bolt, bolt_command + ' noop=true', flags)
     assert_equal(0, result.exit_code,
                  "Bolt did not exit with exit code 0")

--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -471,9 +471,13 @@ SHELL
 
     context "as non-root" do
       let(:config) {
-        mk_config('host-key-check' => false, 'sudo-password' => password, 'run_as' => user,
-                  user: user, password: password)
+        mk_config('host-key-check' => false, 'sudo-password' => bash_password, 'run-as' => user,
+                  user: bash_user, password: bash_password)
       }
+
+      it 'runs as that user', ssh: true do
+        expect(ssh.run_command(target, 'whoami')['stdout'].chomp).to eq(user)
+      end
 
       it "can override run_as for command via an option", ssh: true do
         expect(ssh.run_command(target, 'whoami', '_run_as' => 'root')['stdout']).to eq("root\n")

--- a/spec/fixtures/apply/basic/plans/catch_error.pp
+++ b/spec/fixtures/apply/basic/plans/catch_error.pp
@@ -1,0 +1,7 @@
+plan basic::catch_error(TargetSpec $nodes, Boolean $catch) {
+  $result = apply($nodes, _catch_errors => $catch) {
+    fail('stop the insanity')
+  }
+
+  return $result.first.error
+}

--- a/spec/fixtures/run_as/test/plans/run_as_user.pp
+++ b/spec/fixtures/run_as/test/plans/run_as_user.pp
@@ -1,6 +1,6 @@
 plan test::run_as_user(String $target, String $user) {
   run_command('whoami', $target, _run_as => $user)
   file_upload('test/id.sh', "/home/${user}/id.sh", $target, _run_as => $user)
-  run_script("test/id.sh", $target, _run_as => $user)
+  run_script('test/id.sh', $target, _run_as => $user)
   return run_plan(test::whoami, target => $target, _run_as => $user)
 }

--- a/spec/integration/apply_error_spec.rb
+++ b/spec/integration/apply_error_spec.rb
@@ -20,7 +20,7 @@ describe "errors gracefully attempting to apply a manifest block" do
 
     it 'prints a helpful error if Puppet is not present' do
       result = run_cli_json(%w[plan run basic::class] + config_flags)
-      error = result[0]['result']['_error']
+      error = result['details']['result_set'][0]['result']['_error']
       expect(error['kind']).to eq('bolt/apply-error')
       expect(error['msg']).to eq("Puppet is not installed on the target, please install it to enable 'apply'")
     end
@@ -33,7 +33,7 @@ describe "errors gracefully attempting to apply a manifest block" do
 
     it 'prints a helpful error if Puppet is not present' do
       result = run_cli_json(%w[plan run basic::class] + config_flags)
-      error = result[0]['result']['_error']
+      error = result['details']['result_set'][0]['result']['_error']
       expect(error['kind']).to eq('bolt/apply-error')
       expect(error['msg'])
         .to eq("Puppet is not installed on the target in $env:ProgramFiles, please install it to enable 'apply'")

--- a/spec/integration/run_as_spec.rb
+++ b/spec/integration/run_as_spec.rb
@@ -14,7 +14,7 @@ describe "when running a plan using run_as", ssh: true do
   let(:uri) { conn_uri('ssh', include_password: true) }
   let(:user) { conn_info('ssh')[:user] }
   let(:password) { conn_info('ssh')[:password] }
-  let(:config_flags) { %W[--no-host-key-check --format json --modulepath #{modulepath}] }
+  let(:config_flags) { %W[--no-host-key-check --format json --sudo-password #{password} --modulepath #{modulepath}] }
 
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
@@ -22,44 +22,38 @@ describe "when running a plan using run_as", ssh: true do
     run_cli(['plan', 'run', plan, "--params", params.to_json] + config_flags)
   end
 
-  context 'when using CLI options' do
-    let(:config_flags) { %W[--no-host-key-check --format json --sudo-password #{password} --modulepath #{modulepath}] }
-    let(:non_root_flags) {
+  it 'runs sudo when specified' do
+    output = run_plan('test::id', target: uri)
+    expect(JSON.parse(output)).to eq(%W[#{user}\n root\n #{user}\n root\n #{user}\n root\n])
+  end
+
+  it 'runs sudo within a plan when specified' do
+    output = run_plan('test::incept', target: uri)
+    expect(JSON.parse(output)).to eq(%W[#{user}\n root\n #{user}\n root\n #{user}\n root\n])
+  end
+
+  it 'runs sudo within a plan when specified' do
+    output = run_plan('test::except', target: uri)
+    expect(JSON.parse(output)).to eq(%W[root\n root\n root\n root\n root\n root\n])
+  end
+
+  it 'runs a plan as root passing in non-root user' do
+    non_root = 'test'
+    output = run_plan('test::run_as_user', target: uri, user: non_root)
+    parsed = JSON.parse(output)[0]
+    expect(parsed['result']['stdout']).to eq("#{non_root}\n")
+    expect(parsed['status']).to eq('success')
+    expect(parsed['result']['exit_code']).to eq(0)
+  end
+
+  context 'as a non-root user' do
+    let(:config_flags) {
       %W[-u bolt -p bolt --no-host-key-check --format json --sudo-password bolt --modulepath #{modulepath}]
     }
 
-    it 'runs sudo when specified' do
-      params = { target: uri }.to_json
-      output = run_cli(['plan', 'run', 'test::id', "--params", params] + config_flags)
-      expect(JSON.parse(output)).to eq(%W[#{user}\n root\n #{user}\n root\n #{user}\n root\n])
-    end
-
-    it 'runs sudo within a plan when specified' do
-      params = { target: uri }.to_json
-      output = run_cli(['plan', 'run', 'test::incept', "--params", params] + config_flags)
-      expect(JSON.parse(output)).to eq(%W[#{user}\n root\n #{user}\n root\n #{user}\n root\n])
-    end
-
-    it 'runs sudo within a plan when specified' do
-      params = { target: uri }.to_json
-      output = run_cli(['plan', 'run', 'test::except', "--params", params] + config_flags)
-      expect(JSON.parse(output)).to eq(%W[root\n root\n root\n root\n root\n root\n])
-    end
-
-    it 'runs a plan as root passing in non-root user' do
-      non_root = 'test'
-      params = { target: uri, user: non_root }
-      output = run_plan('test::run_as_user', params)
-      parsed = JSON.parse(output)[0]
-      expect(parsed['result']['stdout']).to eq("#{non_root}\n")
-      expect(parsed['status']).to eq('success')
-      expect(parsed['result']['exit_code']).to eq(0)
-    end
-
     it 'runs a plan as a non-root user passing in a non-root user' do
       non_root = 'test'
-      params = { target: uri, user: non_root }.to_json
-      output = run_cli(['plan', 'run', 'test::run_as_user', "--params", params] + non_root_flags)
+      output = run_plan('test::run_as_user', target: uri, user: non_root)
       parsed = JSON.parse(output)[0]
       expect(parsed['result']['stdout']).to eq("#{non_root}\n")
       expect(parsed['status']).to eq('success')


### PR DESCRIPTION
Add support for `_catch_errors` and `_run_as` to `apply`. Previously
`_catch_errors=true` was the default behavior, now it will default to
false and allow it to be changed to true.