### PR TITLE
(maint) bolt-inventory-pdb errors to stderr, and add unit tests

### DIFF
--- a/exe/bolt-inventory-pdb
+++ b/exe/bolt-inventory-pdb
@@ -3,5 +3,11 @@
 
 require 'bolt_ext/puppetdb_inventory'
 
-exitcode = Bolt::PuppetDBInventory::CLI.new(ARGV).run
-exit exitcode
+begin
+  Bolt::PuppetDBInventory::CLI.new(ARGV).run
+  exit 0
+rescue StandardError => e
+  warn "Error: #{e}"
+  warn e.backtrace if @trace
+  exit 1
+end

--- a/lib/bolt_ext/puppetdb_inventory.rb
+++ b/lib/bolt_ext/puppetdb_inventory.rb
@@ -71,7 +71,7 @@ query results.
 
         if @show_help
           puts @parser.help
-          return 0
+          return
         end
 
         inventory_file = positional_args.shift
@@ -100,12 +100,6 @@ query results.
         else
           puts result
         end
-
-        0
-      rescue StandardError => e
-        puts "Error: #{e}"
-        puts e.backtrace if @trace
-        1
       end
 
       def resolve_group(group)

--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -379,13 +379,47 @@ SHELL
         end
       end
 
-      it "can run a task", ssh: true do
+      it "errors when it tries to run a task", ssh: true do
         contents = "#!/bin/sh\necho -n ${PT_message_one} ${PT_message_two}"
         arguments = { message_one: 'Hello from task', message_two: 'Goodbye' }
         with_task_containing('tasks_test', contents, 'environment') do |task|
           expect {
             ssh.run_task(target, task, arguments)
           }.to raise_error(Bolt::Node::FileError, 'no tmpdir')
+        end
+      end
+    end
+
+    context "when implementations are provided", ssh: true do
+      let(:contents) { "#!/bin/sh\necho -n ${PT_message_one} ${PT_message_two}" }
+      let(:arguments) { { message_one: 'Hello from task', message_two: 'Goodbye' } }
+
+      it "runs a task requires 'shell'" do
+        with_task_containing('tasks_test', contents, 'environment') do |task|
+          impls = task.implementations.map { |impl| impl.merge('requirements' => ['shell']) }
+          expect(task).to receive(:implementations).and_return(impls)
+          expect(ssh.run_task(target, task, arguments).message)
+            .to eq('Hello from task Goodbye')
+        end
+      end
+
+      it "errors when a task only requires an unsupported requirement" do
+        with_task_containing('tasks_test', contents, 'environment') do |task|
+          impls = task.implementations.map { |impl| impl.merge('requirements' => ['powershell']) }
+          expect(task).to receive(:implementations).and_return(impls)
+          expect {
+            ssh.run_task(target, task, arguments)
+          }.to raise_error("No suitable implementation of #{task.name} for #{target.name}")
+        end
+      end
+
+      it "errors when a task only requires an unknown requirement" do
+        with_task_containing('tasks_test', contents, 'environment') do |task|
+          impls = task.implementations.map { |impl| impl.merge('requirements' => ['foobar']) }
+          expect(task).to receive(:implementations).and_return(impls)
+          expect {
+            ssh.run_task(target, task, arguments)
+          }.to raise_error("No suitable implementation of #{task.name} for #{target.name}")
         end
       end
     end

--- a/spec/bolt_ext/puppetdb_inventory_spec.rb
+++ b/spec/bolt_ext/puppetdb_inventory_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'bolt_ext/puppetdb_inventory'
+require 'bolt_spec/files'
+
+describe "Bolt::PuppetDBInventory::CLI" do
+  include BoltSpec::Files
+
+  let(:args) {}
+  subject { Bolt::PuppetDBInventory::CLI.new(args) }
+
+  let(:pdb_args) { %w[--url localhost --cacert /tmp/ca.pem] }
+
+  it { should be }
+
+  context 'with --help' do
+    let(:args) { '--help' }
+
+    it 'displays usage' do
+      expect { subject.run }.to output(/Usage: bolt-inventory-pdb/).to_stdout
+    end
+  end
+
+  it 'requires an inventory file' do
+    expect { subject.run }.to raise_error('Please specify an input file (see --help for details)')
+  end
+
+  context 'with file name' do
+    let(:args) { pdb_args + ['/path/does/not/exist'] }
+
+    it 'errors if the file cannot be read' do
+      expect { subject.run }.to raise_error("Can't read the inventory file /path/does/not/exist")
+    end
+  end
+
+  it 'updates the inventory file' do
+    content = <<INVENTORY
+---
+config:
+  transport: pcp
+groups:
+- name: windows
+  query: inventory[certname] { facts.os.family = "windows" }
+  facts:
+    osfamily: windows
+INVENTORY
+
+    with_tempfile_containing('inventory', content, '.yml') do |file|
+      nodes = %w[nodea nodeb nodec]
+      pdb_client = double('pdb')
+      expect(pdb_client).to receive(:query_certnames).and_return([], nodes)
+      expect(Bolt::PuppetDB::Client).to receive(:new).and_return(pdb_client)
+      cli = Bolt::PuppetDBInventory::CLI.new([file.path, '--output', file.path] + pdb_args)
+      cli.run
+
+      expected = YAML.safe_load(content)
+      expected['groups'][0]['nodes'] = nodes
+      expected['nodes'] = []
+      expect(YAML.load_file(file)).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
bolt-inventory-pdb now writes errors to stderr. Also adds unit tests for task implementations over transports that support them and bolt-inventory-pdb.