### PR TITLE
(BOLT-705) Bundled content for plan/task only

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -385,14 +385,16 @@ module Bolt
     end
 
     def bundled_content
-      default_content = Bolt::PAL.new([], nil)
-      plans = default_content.list_plans.each_with_object([]) do |iter, col|
-        col << iter&.first
+      if %w[plan task].include?(options[:subcommand])
+        default_content = Bolt::PAL.new([], nil)
+        plans = default_content.list_plans.each_with_object([]) do |iter, col|
+          col << iter&.first
+        end
+        tasks = default_content.list_tasks.each_with_object([]) do |iter, col|
+          col << iter&.first
+        end
+        plans.concat tasks
       end
-      tasks = default_content.list_tasks.each_with_object([]) do |iter, col|
-        col << iter&.first
-      end
-      plans.concat tasks
     end
   end
 end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -631,6 +631,38 @@ bar
       end
     end
 
+    describe "bundled_content" do
+      it "does not calculate bundled content for a command" do
+        cli = Bolt::CLI.new(%w[command run foo --nodes bar])
+        cli.parse
+        expect(cli.bundled_content).to be_nil
+      end
+
+      it "does not calculate bundled content for a script" do
+        cli = Bolt::CLI.new(%w[script run foo --nodes bar])
+        cli.parse
+        expect(cli.bundled_content).to be_nil
+      end
+
+      it "does not calculate bundled content for a file" do
+        cli = Bolt::CLI.new(%w[file upload /tmp /var foo --nodes bar])
+        cli.parse
+        expect(cli.bundled_content).to be_nil
+      end
+
+      it "calculates bundled content for a task" do
+        cli = Bolt::CLI.new(%w[task run foo --nodes bar])
+        cli.parse
+        expect(cli.bundled_content).to be
+      end
+
+      it "calculates bundled content for a plan" do
+        cli = Bolt::CLI.new(%w[plan run foo --nodes bar])
+        cli.parse
+        expect(cli.bundled_content).to be
+      end
+    end
+
     describe "execute" do
       let(:executor) { double('executor', noop: false) }
       let(:cli) { Bolt::CLI.new({}) }


### PR DESCRIPTION
Only generate a list of bundled plan/task content when running a plan or task. Building list of bundled content is expensive and not required when not running a plan or task.