### PR TITLE
(BOLT-682) Provide helpful error messages if we detect Puppet missing

### DIFF
--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -68,11 +68,67 @@ describe Bolt::Applicator do
     )
   end
 
+  describe '#provide_puppet_missing_errors' do
+    it 'returns the result if no identifiable errors are found' do
+      result = Bolt::Result.for_task(:target, '', 'blah', 1)
+      expect(applicator.provide_puppet_missing_errors(result)).to eq(result)
+    end
+
+    it 'returns the result if no errors are present' do
+      result = Bolt::Result.for_task(:target, 'hello', '', 0)
+      expect(applicator.provide_puppet_missing_errors(result)).to eq(result)
+    end
+
+    it 'errors if /opt/puppetlabs/puppet/bin/ruby not found on Linux' do
+      orig_result = Bolt::Result.for_task(:target, '', 'blah', 127)
+      new_result = applicator.provide_puppet_missing_errors(orig_result)
+      expect(new_result.error_hash['kind']).to eq('bolt/apply-error')
+      expect(new_result.error_hash['msg'])
+        .to eq("Puppet is not installed on the target, please install it to enable 'apply'")
+    end
+
+    it 'errors if /opt/puppetlabs/puppet/bin/ruby not found on macOS' do
+      orig_result = Bolt::Result.for_task(:target, '', 'blah', 126)
+      new_result = applicator.provide_puppet_missing_errors(orig_result)
+      expect(new_result.error_hash['kind']).to eq('bolt/apply-error')
+      expect(new_result.error_hash['msg'])
+        .to eq("Puppet is not installed on the target, please install it to enable 'apply'")
+    end
+
+    it 'errors if Ruby cannot be found on Windows' do
+      orig_result = Bolt::Result.for_task(:target, '', "Could not find executable 'ruby.exe'", 1)
+      new_result = applicator.provide_puppet_missing_errors(orig_result)
+      expect(new_result.error_hash['kind']).to eq('bolt/apply-error')
+      expect(new_result.error_hash['msg'])
+        .to eq("Puppet is not installed on the target in $env:ProgramFiles, please install it to enable 'apply'")
+    end
+
+    it 'errors if Puppet cannot be found on Windows' do
+      orig_result = Bolt::Result.for_task(:target, '', 'cannot load such file -- puppet (LoadError)', 1)
+      new_result = applicator.provide_puppet_missing_errors(orig_result)
+      expect(new_result.error_hash['kind']).to eq('bolt/apply-error')
+      expect(new_result.error_hash['msg'])
+        .to eq('Found a Ruby without Puppet present, please install Puppet ' \
+              "or remove Ruby from $env:Path to enable 'apply'")
+    end
+  end
+
   context 'with Puppet mocked' do
     before(:each) do
       allow(Puppet).to receive(:lookup).and_return(double(:type, type: nil))
       allow(Puppet::Pal).to receive(:assert_type)
       allow(Puppet::Pops::Serialization::ToDataConverter).to receive(:convert).and_return(:ast)
+    end
+
+    it 'replaces failures to find Puppet' do
+      expect(applicator).to receive(:compile).and_return(:ast)
+      allow_any_instance_of(Bolt::Transport::SSH).to receive(:batch_task).and_return(:result)
+
+      target = Bolt::Target.new('node')
+      result = Bolt::Result.new(target)
+      expect(applicator).to receive(:provide_puppet_missing_errors).with(:result).and_return(result)
+
+      applicator.apply([target], :body, {})
     end
 
     it 'captures compile errors in a result set' do

--- a/spec/integration/apply_error_spec.rb
+++ b/spec/integration/apply_error_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/conn'
+require 'bolt_spec/files'
+require 'bolt_spec/integration'
+require 'bolt/catalog'
+
+describe "errors gracefully attempting to apply a manifest block" do
+  include BoltSpec::Conn
+  include BoltSpec::Integration
+
+  let(:modulepath) { File.join(__dir__, '../fixtures/apply') }
+  let(:config_flags) { %W[--format json --nodes #{uri} --password #{password} --modulepath #{modulepath}] + tflags }
+
+  describe 'over ssh', ssh: true do
+    let(:uri) { conn_uri('ssh') }
+    let(:password) { conn_info('ssh')[:password] }
+    let(:tflags) { %w[--no-host-key-check] }
+
+    it 'prints a helpful error if Puppet is not present' do
+      result = run_cli_json(%w[plan run basic::class] + config_flags)
+      error = result[0]['result']['_error']
+      expect(error['kind']).to eq('bolt/apply-error')
+      expect(error['msg']).to eq("Puppet is not installed on the target, please install it to enable 'apply'")
+    end
+  end
+
+  describe 'over winrm', winrm: true do
+    let(:uri) { conn_uri('winrm') }
+    let(:password) { conn_info('winrm')[:password] }
+    let(:tflags) { %w[--no-ssl --no-ssl-verify] }
+
+    it 'prints a helpful error if Puppet is not present' do
+      result = run_cli_json(%w[plan run basic::class] + config_flags)
+      error = result[0]['result']['_error']
+      expect(error['kind']).to eq('bolt/apply-error')
+      expect(error['msg'])
+        .to eq("Puppet is not installed on the target in $env:ProgramFiles, please install it to enable 'apply'")
+        .or eq("Found a Ruby without Puppet present, please install Puppet or " \
+               "remove Ruby from $env:Path to enable 'apply'")
+    end
+  end
+end

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -6,7 +6,7 @@ require 'bolt_spec/files'
 require 'bolt_spec/integration'
 require 'bolt/catalog'
 
-describe "Passes parsed AST to the apply_catalog task" do
+describe "passes parsed AST to the apply_catalog task" do
   include BoltSpec::Conn
   include BoltSpec::Files
   include BoltSpec::Integration


### PR DESCRIPTION
Process errors returned by apply. If a known pattern identifying that
Puppet is not installed, replace it with a helpful error message.