### PR TITLE
(maint) Fix test failure resulting from multiple merges

### DIFF
--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -61,7 +61,7 @@ describe Bolt::Applicator do
     expect(applicator.compile(target, :ast, {})).to eq({})
     expect(@log_output.readlines).to eq(
       [
-        " DEBUG  Bolt::Executor : Started with 100 max thread(s)\n",
+        " DEBUG  Bolt::Executor : Started with 1 max thread(s)\n",
         " DEBUG  Bolt::Applicator : #{target.uri}: A message\n",
         "NOTICE  Bolt::Applicator : #{target.uri}: Stuff happened\n"
       ]


### PR DESCRIPTION
A change to the Executor's default arguments and testing of log messages
were both merged independently, introducing a test failure that wasn't
caught by PR testing. Fix the test.