### PR TITLE
(BOLT-691) Fix running task with tty echoing input

### DIFF
--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -226,7 +226,7 @@ module Bolt
 
           session_channel = @session.open_channel do |channel|
             # Request a pseudo tty
-            channel.request_pty if target.options['tty']
+            channel.request_pty(modes: { Net::SSH::Connection::Term::ECHO => 0 }) if target.options['tty']
 
             channel.exec(command_str) do |_, success|
               unless success


### PR DESCRIPTION
When running a task with tty and using sudo to execute as a non-root
user, if stdin isn't consumed (like in the `facts` task) but is sent
over SSH it appears to be echoed back. Disable echo mode when using tty
to ensure it's not echoed.

Note that when using `--tty`, Puppet prints errors on stdout instead of
stderr.