### PR TITLE
(BOLT-523) Add r10k to gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ end
 
 group(:development) do
   gem "puppet-strings", "~> 2.0"
-  gem "r10k", "~> 2.6"
 end
 
 local_gemfile = File.join(__dir__, 'Gemfile.local')

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-scp", "~> 1.2"
   spec.add_dependency "net-ssh", "~> 4.2"
   spec.add_dependency "orchestrator_client", "~> 0.2"
+  spec.add_dependency "r10k", "~> 2.6"
   spec.add_dependency "terminal-table", "~> 1.8"
   spec.add_dependency "winrm", "~> 2.0"
   spec.add_dependency "winrm-fs", "~> 1.1"


### PR DESCRIPTION
Ensure r10k is listed as a gem dependency rather than listed in the
Gemfile as Bolt now uses it directly.