### PR TITLE
Revert "(BOLT-691) Fix running task with tty echoing input"

### DIFF
--- a/acceptance/tests/apply_nonroot.rb
+++ b/acceptance/tests/apply_nonroot.rb
@@ -22,6 +22,16 @@ test_name "bolt plan run with should apply manifest block on remote hosts via ss
     end
   end
 
+  step 'disable requiretty for root user' do
+    create_remote_file(ssh_nodes, "/etc/sudoers.d/#{user}", <<-FILE)
+Defaults:root !requiretty
+FILE
+
+    teardown do
+      on(ssh_nodes, "rm /etc/sudoers.d/#{user}")
+    end
+  end
+
   step "create plan on bolt controller" do
     on(bolt, "mkdir -p #{dir}/modules/example_apply/plans")
     create_remote_file(bolt,
@@ -32,8 +42,7 @@ test_name "bolt plan run with should apply manifest block on remote hosts via ss
   bolt_command = "bolt plan run example_apply filepath=#{filepath} nodes=ssh_nodes"
   flags = {
     '--modulepath' => modulepath(File.join(dir, 'modules')),
-    '--format'     => 'json',
-    '--tty'        => nil
+    '--format'     => 'json'
   }
 
   step "execute `bolt plan run run_as=#{user}` via SSH with json output" do
@@ -54,7 +63,7 @@ test_name "bolt plan run with should apply manifest block on remote hosts via ss
       result = json.select { |n| n['node'] == host }
       assert_equal('failure', result[0]['status'],
                    "The task did not fail on #{host}")
-      assert_match(/Permission denied/, result[0]['result']['_output'])
+      assert_match(/Permission denied/, result[0]['result']['_error']['msg'])
 
       # Verify that files were not created on the target
       on(node, "cat #{filepath}/hello.txt", acceptable_exit_codes: [1])

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -226,7 +226,7 @@ module Bolt
 
           session_channel = @session.open_channel do |channel|
             # Request a pseudo tty
-            channel.request_pty(modes: { Net::SSH::Connection::Term::ECHO => 0 }) if target.options['tty']
+            channel.request_pty if target.options['tty']
 
             channel.exec(command_str) do |_, success|
               unless success


### PR DESCRIPTION
This reverts commit e73a6fc680d78ee027fb45e6f867df4330908908. The
attempt to fix echoing back stdin did not work consistently across
platforms; in particular CentOS 6, SLES 12, and Ubuntu 14.04 still had
problems.