### PR TITLE
(BOLT-640) Build and sync plugin tarball to agents

### DIFF
--- a/acceptance/files/example_apply/files/motd
+++ b/acceptance/files/example_apply/files/motd
@@ -1,0 +1,1 @@
+Today's #WordOfTheDay is 'gloss'

--- a/acceptance/files/example_apply/lib/puppet/type/warn.rb
+++ b/acceptance/files/example_apply/lib/puppet/type/warn.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+Puppet::Type.newtype(:warn) do
+  @doc = "Sends a warning message to the agent run-time log."
+
+  newproperty(:message, idempotent: false) do
+    desc "The message to be sent to the log."
+    def sync
+      Puppet.warning(should)
+    end
+
+    def retrieve
+      :absent
+    end
+
+    def insync?(_is)
+      false
+    end
+
+    defaultto { @resource[:name] }
+  end
+
+  newparam(:name) do
+    desc "An arbitrary tag for your own reference; the name of the message."
+    isnamevar
+  end
+end

--- a/acceptance/files/example_apply/plans/init.pp
+++ b/acceptance/files/example_apply/plans/init.pp
@@ -19,5 +19,11 @@ plan example_apply (
       ensure  => file,
       content => "hi there I'm ${$facts['os']['family']}\n",
     }
+
+    warn { 'Writing a MOTD!':
+    } -> file { "${filepath}/motd":
+      ensure => file,
+      source => 'puppet:///modules/example_apply/motd',
+    }
   }
 }

--- a/acceptance/tests/apply_nonroot.rb
+++ b/acceptance/tests/apply_nonroot.rb
@@ -34,10 +34,8 @@ FILE
   end
 
   step "create plan on bolt controller" do
-    on(bolt, "mkdir -p #{dir}/modules/example_apply/plans")
-    create_remote_file(bolt,
-                       "#{dir}/modules/example_apply/plans/init.pp",
-                       File.read(File.join(fixtures, 'example_apply.pp')))
+    on(bolt, "mkdir -p #{dir}/modules")
+    scp_to(bolt, File.join(fixtures, 'example_apply'), "#{dir}/modules/example_apply")
   end
 
   bolt_command = "bolt plan run example_apply filepath=#{filepath} nodes=ssh_nodes"

--- a/acceptance/tests/apply_ssh.rb
+++ b/acceptance/tests/apply_ssh.rb
@@ -11,13 +11,11 @@ test_name "bolt plan run with should apply manifest block on remote hosts via ss
 
   dir = bolt.tmpdir('apply_ssh')
   fixtures = File.absolute_path('files')
-  filepath = '/tmp/test'
+  filepath = bolt.tmpdir('example_apply')
 
   step "create plan on bolt controller" do
-    on(bolt, "mkdir -p #{dir}/modules/example_apply/plans")
-    create_remote_file(bolt,
-                       "#{dir}/modules/example_apply/plans/init.pp",
-                       File.read(File.join(fixtures, 'example_apply.pp')))
+    on(bolt, "mkdir -p #{dir}/modules")
+    scp_to(bolt, File.join(fixtures, 'example_apply'), "#{dir}/modules/example_apply")
   end
 
   bolt_command = "bolt plan run example_apply filepath=#{filepath} nodes=ssh_nodes"
@@ -73,9 +71,18 @@ test_name "bolt plan run with should apply manifest block on remote hosts via ss
       assert_equal('success', result[0]['status'],
                    "The task did not succeed on #{host}")
 
+      # Verify the custom type was invoked
+      logs = result[0]['result']['logs']
+      warnings = logs.select { |l| l['level'] == 'warning' }
+      assert_equal(1, warnings.count)
+      assert_equal('Writing a MOTD!', warnings[0]['message'])
+
       # Verify that files were created on the target
-      content = on(node, "cat #{filepath}/hello.txt")
-      assert_match(/^hi there I'm [a-zA-Z]+$/, content.stdout)
+      hello = on(node, "cat #{filepath}/hello.txt")
+      assert_match(/^hi there I'm [a-zA-Z]+$/, hello.stdout)
+
+      motd = on(node, "cat #{filepath}/motd")
+      assert_equal("Today's #WordOfTheDay is 'gloss'", motd.stdout)
     end
   end
 end

--- a/acceptance/tests/apply_winrm.rb
+++ b/acceptance/tests/apply_winrm.rb
@@ -14,13 +14,11 @@ test_name "bolt plan run with should apply manifest block on remote hosts via wi
 
   dir = bolt.tmpdir('apply_winrm')
   fixtures = File.absolute_path('files')
-  filepath = 'C:/test'
+  filepath = winrm_nodes.first.tmpdir('example_apply')
 
   step "create plan on bolt controller" do
-    on(bolt, "mkdir -p #{dir}/modules/example_apply/plans")
-    create_remote_file(bolt,
-                       "#{dir}/modules/example_apply/plans/init.pp",
-                       File.read(File.join(fixtures, 'example_apply.pp')))
+    on(bolt, "mkdir -p #{dir}/modules")
+    scp_to(bolt, File.join(fixtures, 'example_apply'), "#{dir}/modules/example_apply")
   end
 
   bolt_command = "bolt plan run example_apply filepath=#{filepath} nodes=winrm_nodes"
@@ -76,9 +74,18 @@ test_name "bolt plan run with should apply manifest block on remote hosts via wi
       assert_equal('success', result[0]['status'],
                    "The task did not succeed on #{host}")
 
+      # Verify the custom type was invoked
+      logs = result[0]['result']['logs']
+      warnings = logs.select { |l| l['level'] == 'warning' }
+      assert_equal(1, warnings.count)
+      assert_equal('Writing a MOTD!', warnings[0]['message'])
+
       # Verify that files were created on the target
-      content = on(node, 'cat C:/test/hello.txt')
-      assert_match(/^hi there I'm windows$/, content.stdout)
+      hello = on(node, "cat #{filepath}/hello.txt")
+      assert_match(/^hi there I'm windows$/, hello.stdout)
+
+      motd = on(node, "cat #{filepath}/motd")
+      assert_equal("Today's #WordOfTheDay is 'gloss'", motd.stdout)
     end
   end
 end

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
+require 'base64'
+require 'concurrent'
+require 'find'
 require 'json'
 require 'logging'
+require 'minitar'
 require 'open3'
-require 'concurrent'
 require 'bolt/util/puppet_log_level'
 
 module Bolt
@@ -19,6 +22,7 @@ module Bolt
 
       @pool = Concurrent::ThreadPoolExecutor.new(max_threads: max_compiles)
       @logger = Logging.logger[self]
+      @plugin_tarball = Concurrent::Delay.new { build_plugin_tarball }
     end
 
     private def libexec
@@ -171,7 +175,7 @@ module Bolt
         result_promises = targets.zip(futures).flat_map do |target, future|
           @executor.queue_execute([target]) do |transport, batch|
             @executor.with_node_logging("Applying manifest block", batch) do
-              arguments = { 'catalog' => future.value, '_noop' => options['_noop'] }
+              arguments = { 'catalog' => future.value, 'plugins' => plugins, '_noop' => options['_noop'] }
               raise future.reason if future.rejected?
               result = transport.batch_task(batch, catalog_apply_task, arguments, options, &notify)
               result = provide_puppet_missing_errors(result)
@@ -187,6 +191,48 @@ module Bolt
         raise Bolt::ApplyFailure, r
       end
       r
+    end
+
+    def plugins
+      @plugin_tarball.value ||
+        raise(Bolt::Error.new("Failed to pack module plugins: #{@plugin_tarball.reason}", 'bolt/plugin-error'))
+    end
+
+    def build_plugin_tarball
+      start_time = Time.now
+      sio = StringIO.new
+      output = Minitar::Output.new(Zlib::GzipWriter.new(sio))
+
+      Puppet.lookup(:current_environment).modules.each do |mod|
+        search_dirs = []
+        search_dirs << mod.plugins if mod.plugins?
+        search_dirs << mod.files if mod.files?
+
+        parent = Pathname.new(mod.path).parent
+        files = Find.find(*search_dirs).select { |file| File.file?(file) }
+
+        files.each do |file|
+          tar_path = Pathname.new(file).relative_path_from(parent)
+          @logger.debug("Packing plugin #{file} to #{tar_path}")
+          stat = File.stat(file)
+          content = File.binread(file)
+          output.tar.add_file_simple(
+            tar_path.to_s,
+            data: content,
+            size: content.size,
+            mode: stat.mode & 0o777,
+            mtime: stat.mtime
+          )
+        end
+      end
+
+      duration = Time.now - start_time
+      @logger.debug("Packed plugins in #{duration * 1000} ms")
+
+      output.close
+      Base64.encode64(sio.string)
+    ensure
+      output&.close
     end
   end
 end

--- a/libexec/apply_catalog.rb
+++ b/libexec/apply_catalog.rb
@@ -40,6 +40,8 @@ Puppet[:skip_tags] = nil
 Puppet[:prerun_command] = nil
 Puppet[:postrun_command] = nil
 
+Puppet[:default_file_terminus] = :file_server
+
 moduledir = Dir.mktmpdir
 plugins = Tempfile.new('plugins.tar.gz')
 File.binwrite(plugins, Base64.decode64(args['plugins']))

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -115,7 +115,7 @@ describe Bolt::Applicator do
 
   context 'with Puppet mocked' do
     before(:each) do
-      allow(Puppet).to receive(:lookup).and_return(double(:type, type: nil))
+      allow(Puppet).to receive(:lookup).and_return(double(:type, type: nil, modules: []))
       allow(Puppet::Pal).to receive(:assert_type)
       allow(Puppet::Pops::Serialization::ToDataConverter).to receive(:convert).and_return(:ast)
     end


### PR DESCRIPTION
When using the apply() keyword, we now copy the contents of the `lib`
and `files` directories of every module to the agent. This allows native
types and providers to be used, as well as for puppet:// file sources to
resolve correctly.

This is accomplished by packing those files into a gzipped tarball,
which is then passed as a parameter to the apply_catalog internal
task. That tarball is then written to disk on the agent, unpacked, and
set as the modulepath for the catalog application.