### PR TITLE
(BOLT-642) Support inventory function in apply

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/facts.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/facts.rb
@@ -14,12 +14,6 @@ Puppet::Functions.create_function(:facts) do
   end
 
   def facts(target)
-    unless Puppet[:tasks]
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, operation: 'facts'
-      )
-    end
-
     inventory = Puppet.lookup(:bolt_inventory) { nil }
 
     unless inventory

--- a/bolt-modules/boltlib/lib/puppet/functions/get_targets.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/get_targets.rb
@@ -22,12 +22,6 @@ Puppet::Functions.create_function(:get_targets) do
   end
 
   def get_targets(names)
-    unless Puppet[:tasks]
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, operation: 'get_targets'
-      )
-    end
-
     inventory = Puppet.lookup(:bolt_inventory) { nil }
 
     unless inventory && Puppet.features.bolt?

--- a/bolt-modules/boltlib/lib/puppet/functions/vars.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/vars.rb
@@ -18,12 +18,6 @@ Puppet::Functions.create_function(:vars) do
   end
 
   def vars(target)
-    unless Puppet[:tasks]
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, operation: 'vars'
-      )
-    end
-
     inventory = Puppet.lookup(:bolt_inventory) { nil }
 
     unless inventory

--- a/bolt-modules/boltlib/spec/functions/get_targets_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/get_targets_spec.rb
@@ -72,13 +72,4 @@ describe 'get_targets' do
                         .and_raise_error(/The 'bolt' library is required to process targets through inventory/)
     end
   end
-
-  context 'without tasks enabled' do
-    let(:tasks_enabled) { false }
-
-    it 'fails and reports that run_command is not available' do
-      is_expected.to run.with_params('echo hello')
-                        .and_raise_error(/The task operation 'get_targets' is not available/)
-    end
-  end
 end

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -46,11 +46,11 @@ module Bolt
           facts: @inventory.facts(target),
           variables: @inventory.vars(target).merge(plan_vars),
           trusted: trusted.to_h
-        }
+        },
+        inventory: @inventory.data_hash
       }
 
       bolt_catalog_exe = File.join(libexec, 'bolt_catalog')
-
       old_path = ENV['PATH']
       ENV['PATH'] = "#{RbConfig::CONFIG['bindir']}#{File::PATH_SEPARATOR}#{old_path}"
       out, err, stat = Open3.capture3('ruby', bolt_catalog_exe, 'compile', stdin_data: catalog_input.to_json)

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -106,6 +106,15 @@ module Bolt
       validate
     end
 
+    def overwrite_transport_data(transport, transports)
+      @transport = transport
+      @transports = transports
+    end
+
+    def transport_data_get
+      { transport: @transport, transports: @transports }
+    end
+
     def deep_clone
       Bolt::Util.deep_clone(self)
     end

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -53,16 +53,16 @@ module Bolt
       inventory
     end
 
-    def initialize(data, config = nil)
+    def initialize(data, config = nil, target_vars: {}, target_facts: {}, target_features: {})
       @logger = Logging.logger[self]
       # Config is saved to add config options to targets
       @config = config || Bolt::Config.default
       @data = data ||= {}
       @groups = Group.new(data.merge('name' => 'all'))
       @group_lookup = {}
-      @target_vars = {}
-      @target_facts = {}
-      @target_features = {}
+      @target_vars = target_vars
+      @target_facts = target_facts
+      @target_features = target_features
     end
 
     def validate
@@ -121,6 +121,18 @@ module Bolt
 
     def features(target)
       @target_features[target.name] || Set.new
+    end
+
+    def data_hash
+      {
+        data: @data,
+        target_hash: {
+          target_vars: @target_vars,
+          target_facts: @target_facts,
+          target_features: @target_features
+        },
+        config: @config.transport_data_get
+      }
     end
 
     #### PRIVATE ####

--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -117,6 +117,11 @@ module Bolt
       def windows?
         !!File::ALT_SEPARATOR
       end
+
+      # Accept hash and return hash with top level keys of type "String" converted to symbols.
+      def symbolize_top_level_keys(hsh)
+        hsh.each_with_object({}) { |(k, v), h| k.is_a?(String) ? h[k.to_sym] = v : h[k] = v }
+      end
     end
   end
 end

--- a/libexec/bolt_catalog
+++ b/libexec/bolt_catalog
@@ -16,6 +16,18 @@ require 'json'
 #     "facts": "Hash of facts to use for the node",
 #     "variables": "Hash of variables to use for compilation",
 #     "trusted": "Hash of trusted data for the node"
+#   },
+#   "inventory": JSON serialized information about inventory {
+#       "data": Data stored in inventory @data instance variable,
+#       "target_hash": {
+#         "target_vars": Vars that may have been updated plan,
+#         "target_facts": Facts that may have been updated in plan,
+#         "target_features": Features that may have been updated in plan,
+#       },
+#       "config": {
+#         "transport": Transport to use,
+#         "transports": Array of transport configs (note that transport keys are stringified)
+#       }
 #   }
 # }
 

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -34,6 +34,26 @@ describe Bolt::Applicator do
           hostname: uri,
           domain: nil
         }
+      },
+      inventory: {
+        data: {},
+        target_hash: {
+          target_vars: {},
+          target_facts: {},
+          target_features: {}
+        },
+        config: {
+          transport: "ssh",
+          transports: {
+            ssh: { 'connect-timeout' => 10, tty: false, "host-key-check" => true },
+            winrm: { 'connect-timeout' => 10, tty: false, ssl: true, "ssl-verify" => true },
+            pcp: { 'connect-timeout' => 10,
+                   tty: false,
+                   "task-environment" => "production",
+                   "local-validation" => false },
+            local: { 'connect-timeout' => 10, tty: false }
+          }
+        }
       }
     }
   }

--- a/spec/fixtures/apply/basic/plans/inventory_lookup.pp
+++ b/spec/fixtures/apply/basic/plans/inventory_lookup.pp
@@ -1,0 +1,19 @@
+plan basic::inventory_lookup(TargetSpec $nodes) {
+  # add a fact durring plan execution
+  $target = get_targets('all')
+  add_facts($target[1], {'added' => 'fact'})
+
+  return apply($nodes) {
+  	$t = get_targets('all')
+    # Number of targets queried from inventory
+    notify { "Num Targets: ${$t.length}": }
+    # Facts from target (should include added fact)
+    notify { "Target 1 Facts: ${$t[1].facts}": }
+    # Vars from target
+    notify { "Target 1 Vars: ${$t[1].vars}": }
+    # Prove config is respected (tty set to 11 in config)
+    notify { "Target 0 Config: ${t[0]}": }
+    # Prove inventory config is respected (password set to 'secret' in inventoryfile)
+    notify { "Target 1 Password: ${t[1].password}": }
+  }
+}

--- a/spec/fixtures/apply/basic/plans/xfail_set_feature.pp
+++ b/spec/fixtures/apply/basic/plans/xfail_set_feature.pp
@@ -1,0 +1,6 @@
+plan basic::xfail_set_feature(TargetSpec $nodes) {
+  return apply($nodes) {
+  	$t = get_targets('foo')
+    set_features($t, 'puppet-agent')
+  }
+}

--- a/spec/fixtures/apply/basic/plans/xfail_set_var.pp
+++ b/spec/fixtures/apply/basic/plans/xfail_set_var.pp
@@ -1,0 +1,6 @@
+plan basic::xfail_set_var(TargetSpec $nodes) {
+  return apply($nodes) {
+  	$t = get_targets('foo')
+    set_var($t, 'key', 'value')
+  }
+}

--- a/spec/fixtures/apply/inventory.yaml
+++ b/spec/fixtures/apply/inventory.yaml
@@ -1,0 +1,19 @@
+groups:
+  - name: group_1
+    nodes: 
+      - foo
+    config:
+      transport: ssh
+  - name: group_2
+    vars:
+      environment: production
+      features: ['puppet-agent']
+    nodes: 
+      - bar
+      - baz
+    facts:
+      operatingsystem: Ubuntu
+    config:
+      transport: ssh
+      ssh:
+        password: secret


### PR DESCRIPTION
Serialize information about targets in inventory. Pass this data
to bolt_catalog and load into puppet so that get_targets etc can
be used in an apply block.