### PR TITLE
(BOLT-640) Fix filepath setup to be usable on many platforms

### DIFF
--- a/acceptance/tests/apply_ssh.rb
+++ b/acceptance/tests/apply_ssh.rb
@@ -11,7 +11,7 @@ test_name "bolt plan run with should apply manifest block on remote hosts via ss
 
   dir = bolt.tmpdir('apply_ssh')
   fixtures = File.absolute_path('files')
-  filepath = bolt.tmpdir('example_apply')
+  filepath = File.join('/tmp', SecureRandom.uuid.to_s)
 
   step "create plan on bolt controller" do
     on(bolt, "mkdir -p #{dir}/modules")

--- a/acceptance/tests/apply_winrm.rb
+++ b/acceptance/tests/apply_winrm.rb
@@ -14,7 +14,7 @@ test_name "bolt plan run with should apply manifest block on remote hosts via wi
 
   dir = bolt.tmpdir('apply_winrm')
   fixtures = File.absolute_path('files')
-  filepath = winrm_nodes.first.tmpdir('example_apply')
+  filepath = File.join('C:/', SecureRandom.uuid.to_s)
 
   step "create plan on bolt controller" do
     on(bolt, "mkdir -p #{dir}/modules")


### PR DESCRIPTION
In a previous commit filepath was updated to generate a unique name each
test run. However in the SSH tests it was created based on the Bolt
controller's concept of tmp, which may not be simply portable. Generate
a unique directory name in a known location that should be safe for SSH
targets. Do the same with WinRM for consistency.