### PR TITLE
(maint) Return self from ResultSet#each

### DIFF
--- a/lib/bolt/result_set.rb
+++ b/lib/bolt/result_set.rb
@@ -27,6 +27,7 @@ module Bolt
 
     def each
       @results.each { |r| yield r }
+      self
     end
 
     def result_hash


### PR DESCRIPTION
The convention for Enumerable is to return the original object when
calling `each`. ResultSet wasn't doing that, and was instead implicitly
returning the results array.