### PR TITLE
(BOLT-641) Use consistent HOME dir when testing Bolt

### DIFF
--- a/acceptance/lib/acceptance/bolt_command_helper.rb
+++ b/acceptance/lib/acceptance/bolt_command_helper.rb
@@ -29,7 +29,7 @@ module Acceptance
 
     def default_boltdir
       @default_boltdir ||= begin
-        query = bolt['platform'] =~ /windows/ ? 'cygpath -m $(printenv USERPROFILE)' : 'echo $HOME'
+        query = bolt['platform'] =~ /windows/ ? 'cygpath -m $(printenv HOME)' : 'printenv HOME'
         home = on(bolt, query).stdout.chomp
         File.join(home, '.puppetlabs/bolt')
       end

--- a/acceptance/setup/common/pre-suite/050_build_bolt_inventory.rb
+++ b/acceptance/setup/common/pre-suite/050_build_bolt_inventory.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require 'bolt_command_helper'
 require 'bolt_setup_helper'
 
 test_name "build bolt inventory file" do
+  extend Acceptance::BoltCommandHelper
   extend Acceptance::BoltSetupHelper
 
   ssh_nodes = select_hosts(roles: ['ssh'])
@@ -33,10 +35,8 @@ test_name "build bolt inventory file" do
     ]
   }
 
-  bolt_confdir = "#{on(bolt, 'echo $HOME').stdout.chomp}/.puppetlabs/bolt"
+  on bolt, "mkdir -p #{default_boltdir}"
+  create_remote_file(bolt, "#{default_boltdir}/inventory.yaml", inventory.to_yaml)
 
-  on bolt, "mkdir -p #{bolt_confdir}"
-  create_remote_file(bolt, "#{bolt_confdir}/inventory.yaml", inventory.to_yaml)
-
-  create_remote_file(bolt, "#{bolt_confdir}/analytics.yaml", { 'disabled' => true }.to_yaml)
+  create_remote_file(bolt, "#{default_boltdir}/analytics.yaml", { 'disabled' => true }.to_yaml)
 end

--- a/acceptance/setup/common/pre-suite/071_install_modules.rb
+++ b/acceptance/setup/common/pre-suite/071_install_modules.rb
@@ -5,6 +5,7 @@ require 'bolt_command_helper'
 test_name "Install modules" do
   extend Acceptance::BoltCommandHelper
 
+  on(bolt, "mkdir -p #{default_boltdir}")
   create_remote_file(bolt, "#{default_boltdir}/Puppetfile", <<-PUPPETFILE)
 mod 'puppetlabs-facts', '0.2.0'
 mod 'puppet_agent',

--- a/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
@@ -27,6 +27,7 @@ Puppet::Functions.create_function(:apply_prep) do
 
         # Ensure Puppet is installed
         version_task = script_compiler.task_signature('puppet_agent::version')
+        raise Bolt::Error.new('puppet_agent::version could not be found', 'bolt/apply-prep') unless version_task
         versions = executor.run_task(targets, version_task.task, {})
         raise Bolt::RunFailure.new(versions, 'run_task', version_task.name) unless versions.ok?
         need_install, installed = versions.partition { |r| r['version'].nil? }
@@ -36,6 +37,7 @@ Puppet::Functions.create_function(:apply_prep) do
 
         unless need_install.empty?
           install_task = script_compiler.task_signature('puppet_agent::install')
+          raise Bolt::Error.new('puppet_agent::install could not be found', 'bolt/apply-prep') unless install_task
           installed = executor.run_task(need_install.map(&:target), install_task.task, {})
           raise Bolt::RunFailure.new(installed, 'run_task', install_task.name) unless installed.ok?
         end

--- a/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
@@ -76,6 +76,13 @@ describe 'apply_prep' do
       end
     end
 
+    it 'fails if version task is not found' do
+      Puppet::Pal::ScriptCompiler.any_instance.expects(:task_signature).with('puppet_agent::version')
+      is_expected.to run.with_params(hostnames).and_raise_error(
+        Bolt::Error, 'puppet_agent::version could not be found'
+      )
+    end
+
     it 'fails if version check fails' do
       failed_results = Bolt::ResultSet.new(
         targets.map { |t| Bolt::Result.new(t, error: { 'msg' => 'could not get version' }) }
@@ -84,6 +91,16 @@ describe 'apply_prep' do
 
       is_expected.to run.with_params(hostnames).and_raise_error(
         Bolt::RunFailure, "Plan aborted: run_task 'puppet_agent::version' failed on 2 nodes"
+      )
+    end
+
+    it 'fails if install task is not found' do
+      versions = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: {}) })
+      executor.expects(:run_task).with(targets, :version_task, anything, anything).returns(versions)
+
+      Puppet::Pal::ScriptCompiler.any_instance.expects(:task_signature).with('puppet_agent::install')
+      is_expected.to run.with_params(hostnames).and_raise_error(
+        Bolt::Error, 'puppet_agent::install could not be found'
       )
     end
 

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -227,7 +227,7 @@ MSG
       t = Thread.new {
         applicator.apply([targets], :body, {})
       }
-      sleep(0.1)
+      sleep(0.2)
 
       expect(running.value).to eq(2)
 


### PR DESCRIPTION
Previously we used two different HOME locations when running Bolt on
Windows. This was to provide path to modules that we could put on the
command-line that both Cygwin and Bolt would understand. However with
the move to using Bolt to install from a Puppetfile to Boltdir, we need
to use a single location for Boltdir. Update test helpers to use the
Windows paths to the default Boltdir.

Also, always ensure the default_boltdir exists before we try to copy to
it.