### PR TITLE
(BOLT-735) Avoid Etc.getlogin

### DIFF
--- a/libexec/apply_catalog.rb
+++ b/libexec/apply_catalog.rb
@@ -46,7 +46,7 @@ exit_code = 0
 Dir.mktmpdir do |moduledir|
   Tempfile.open('plugins.tar.gz') do |plugins|
     File.binwrite(plugins, Base64.decode64(args['plugins']))
-    Puppet::ModuleTool::Tar.instance.unpack(plugins, moduledir, Etc.getlogin)
+    Puppet::ModuleTool::Tar.instance.unpack(plugins, moduledir, Etc.getpwuid.name)
   end
 
   env = Puppet.lookup(:environments).get('production').override_with(modulepath: [moduledir])

--- a/libexec/custom_facts.rb
+++ b/libexec/custom_facts.rb
@@ -11,7 +11,7 @@ args = JSON.parse(STDIN.read)
 Dir.mktmpdir do |moduledir|
   Tempfile.open('plugins.tar.gz') do |plugins|
     File.binwrite(plugins, Base64.decode64(args['plugins']))
-    Puppet::ModuleTool::Tar.instance.unpack(plugins, moduledir, Etc.getlogin)
+    Puppet::ModuleTool::Tar.instance.unpack(plugins, moduledir, Etc.getpwuid.name)
   end
 
   Puppet.initialize_settings


### PR DESCRIPTION
According to Ruby's docs at
https://ruby-doc.org/stdlib-2.4.0/libdoc/etc/rdoc/Etc.html#method-c-getlogin
we should avoid `getlogin` for security-related purposes and try
`getpwuid` if it fails. `getlogin` returns `nil` in containers under
Docker for Mac. Use `getwpuid.name` instead to get the current user name
when deciding what user should own the files that we untar.