### PR TITLE
(BOLT-735) Cross-platform fix

### DIFF
--- a/libexec/apply_catalog.rb
+++ b/libexec/apply_catalog.rb
@@ -46,7 +46,7 @@ exit_code = 0
 Dir.mktmpdir do |moduledir|
   Tempfile.open('plugins.tar.gz') do |plugins|
     File.binwrite(plugins, Base64.decode64(args['plugins']))
-    Puppet::ModuleTool::Tar.instance.unpack(plugins, moduledir, Etc.getpwuid.name)
+    Puppet::ModuleTool::Tar.instance.unpack(plugins, moduledir, Etc.getlogin || Etc.getpwuid.name)
   end
 
   env = Puppet.lookup(:environments).get('production').override_with(modulepath: [moduledir])

--- a/libexec/custom_facts.rb
+++ b/libexec/custom_facts.rb
@@ -11,7 +11,7 @@ args = JSON.parse(STDIN.read)
 Dir.mktmpdir do |moduledir|
   Tempfile.open('plugins.tar.gz') do |plugins|
     File.binwrite(plugins, Base64.decode64(args['plugins']))
-    Puppet::ModuleTool::Tar.instance.unpack(plugins, moduledir, Etc.getpwuid.name)
+    Puppet::ModuleTool::Tar.instance.unpack(plugins, moduledir, Etc.getlogin || Etc.getpwuid.name)
   end
 
   Puppet.initialize_settings


### PR DESCRIPTION
Windows returns nil for `getpwuid`. So try `getlogin`, and fall back to
`getpwuid` for containers where `getlogin` doesn't work.