### PR TITLE
(BOLT-717) Add BoltSpec::Run public helper

### DIFF
--- a/lib/bolt/catalog.rb
+++ b/lib/bolt/catalog.rb
@@ -56,12 +56,9 @@ module Bolt
       config.overwrite_transport_data(inventory['config']['transport'],
                                       Bolt::Util.symbolize_top_level_keys(inventory['config']['transports']))
 
-      bolt_inventory = Bolt::Inventory.new(inventory['data'],
-                                           config,
-                                           Bolt::Util.symbolize_top_level_keys(inventory['target_hash']))
-
-      bolt_inventory.collect_groups
-      bolt_inventory
+      Bolt::Inventory.new(inventory['data'],
+                          config,
+                          Bolt::Util.symbolize_top_level_keys(inventory['target_hash']))
     end
 
     def compile_catalog(request)

--- a/lib/bolt/error.rb
+++ b/lib/bolt/error.rb
@@ -47,7 +47,7 @@ module Bolt
     end
   end
 
-  class RunFailure < Error
+  class RunFailure < Bolt::Error
     attr_reader :result_set
 
     def initialize(result_set, action, object)

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -49,7 +49,6 @@ module Bolt
 
       inventory = new(data, config)
       inventory.validate
-      inventory.collect_groups
       inventory
     end
 
@@ -63,6 +62,7 @@ module Bolt
       @target_vars = target_vars
       @target_facts = target_facts
       @target_features = target_features
+      collect_groups
     end
 
     def validate

--- a/lib/bolt/node/errors.rb
+++ b/lib/bolt/node/errors.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bolt/error'
+
 module Bolt
   class Node
     class BaseError < Bolt::Error

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -97,6 +97,8 @@ module Bolt
           alias_types(compiler)
           begin
             yield compiler
+          rescue Bolt::Error => err
+            err
           rescue Puppet::PreformattedError => err
             PALError.from_preformatted_error(err)
           rescue StandardError => err

--- a/lib/bolt/result_set.rb
+++ b/lib/bolt/result_set.rb
@@ -82,6 +82,10 @@ module Bolt
       self.class == other.class && @results == other.results
     end
 
+    def to_a
+      @results.map(&:status_hash)
+    end
+
     def to_json(opts = nil)
       @results.map(&:status_hash).to_json(opts)
     end

--- a/lib/bolt_spec/run.rb
+++ b/lib/bolt_spec/run.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+# shorthand for requiring the parts of bolt we need
+require 'bolt/cli'
+require 'bolt/util'
+
+# This is intended to provide a relatively stable method of executing bolt in process from tests.
+# Currently it provides run_task, run_plan and run_command helpers.
+module BoltSpec
+  module Run
+    def run_task(task_name, targets, params = nil, config: nil, inventory: nil)
+      result = BoltRunner.with_runner(config, inventory) do |runner|
+        runner.run_task(task_name, targets, params || {})
+      end
+      result = result.to_a
+      Bolt::Util.walk_keys(result, &:to_s)
+    end
+
+    def run_plan(plan_name, params = nil, config: nil, inventory: nil)
+      # Users copying code from run_task may forget that targets is not a parameter for run plan
+      raise ArgumentError, "params must be a hash" unless params.is_a?(Hash)
+
+      result = BoltRunner.with_runner(config, inventory) do |runner|
+        runner.run_plan(plan_name, params || {})
+      end
+
+      { "status" => result.status,
+        "value" => JSON.parse(result.value.to_json) }
+    end
+
+    def run_command(command, targets, params = nil, config: nil, inventory: nil)
+      result = BoltRunner.with_runner(config, inventory) do |runner|
+        runner.run_command(command, targets, params)
+      end
+      result = result.to_a
+      Bolt::Util.walk_keys(result, &:to_s)
+    end
+
+    class BoltRunner
+      # Creates a temporary boltdir so no settings are picked up
+      # WARNING: puppetdb config and orch config which do not use the boltdir may
+      # still be loaded
+      def self.with_runner(config_data, inventory_data)
+        Dir.mktmpdir do |boltdir_path|
+          config = Bolt::Config.new(Bolt::Boltdir.new(boltdir_path), config_data || {})
+          inventory = Bolt::Inventory.new(inventory_data || {}, config)
+          yield new(config, inventory)
+        end
+      end
+
+      attr_reader :config, :inventory
+
+      def initialize(config, inventory)
+        @config = config
+        @inventory = inventory
+        @analytics = Bolt::Analytics::NoopClient.new
+      end
+
+      def puppetdb_client
+        @puppetdb_client ||= begin
+                               puppetdb_config = Bolt::PuppetDB::Config.load_config(nil, config.puppetdb)
+                               Bolt::PuppetDB::Client.new(puppetdb_config)
+                             end
+      end
+
+      def pal
+        @pal ||= Bolt::PAL.new(config.modulepath, config.hiera_config, config.compile_concurrency)
+      end
+
+      def resolve_targets(target_spec)
+        @inventory.get_targets(target_spec).map(&:name)
+      end
+
+      # Adapted from CLI
+      def run_task(task_name, targets, params, noop: false)
+        executor = Bolt::Executor.new(config.concurrency, @analytics, noop)
+        pal.run_task(task_name, targets, params, executor, inventory, nil) { |_ev| nil }
+      end
+
+      # Adapted from CLI does not handle nodes or plan_job reporting
+      def run_plan(plan_name, params, noop: false)
+        executor = Bolt::Executor.new(config.concurrency, @analytics, noop)
+        pal.run_plan(plan_name, params, executor, inventory, puppetdb_client)
+      end
+
+      def run_command(command, targets, params = nil)
+        executor = Bolt::Executor.new(config.concurrency, @analytics)
+        targets = inventory.get_targets(targets)
+        executor.run_command(targets, command, params || {})
+      end
+    end
+  end
+end

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -135,20 +135,17 @@ describe Bolt::Inventory do
   describe :collect_groups do
     it 'finds the all group with an empty inventory' do
       inventory = Bolt::Inventory.new({})
-      inventory.collect_groups
       expect(inventory.get_targets('all')).to eq([])
     end
 
     it 'finds the all group with a non-empty inventory' do
       inventory = Bolt::Inventory.new(data)
-      inventory.collect_groups
       targets = inventory.get_targets('all')
       expect(targets.size).to eq(9)
     end
 
     it 'finds nodes in a subgroup' do
       inventory = Bolt::Inventory.new(data)
-      inventory.collect_groups
       targets = inventory.get_targets('group2')
       expect(targets).to eq(targets(%w[node6 node7 ssh://node8 node9]))
     end
@@ -248,7 +245,6 @@ describe Bolt::Inventory do
     context 'non-empty inventory' do
       let(:inventory) {
         inv = Bolt::Inventory.new(data)
-        inv.collect_groups
         inv
       }
 

--- a/spec/bolt_spec/run_spec.rb
+++ b/spec/bolt_spec/run_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/conn'
+require 'bolt_spec/run'
+
+# In order to speed up tests there are only ssh versions of these specs
+# While the target shouldn't matter this does mean this helper is not tested on
+# windows controllers.
+describe "BoltSpec::Run", ssh: true do
+  include BoltSpec::Run
+  include BoltSpec::Conn
+
+  let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
+  let(:config_data) {
+    { "modulepath" => modulepath,
+      "ssh" =>  { "host-key-check" => false },
+      "winrm" => { "ssl" => false } }
+  }
+  let(:inventory_data) { conn_inventory }
+
+  describe 'run_task' do
+    it 'should run a task on a node' do
+      result = run_task('sample::echo', 'ssh', config: config_data, inventory: inventory_data)
+      expect(result[0]['status']).to eq('success')
+    end
+
+    it 'should accept _catch_errors' do
+      result = run_task('sample::echo', 'non_existent_ndoe', { '_catch_errors' => true },
+                        config: config_data, inventory: inventory_data)
+
+      expect(result[0]['status']).to eq('failure')
+      expect(result[0]['result']['_error']['kind']).to eq('puppetlabs.tasks/connect-error')
+    end
+  end
+
+  describe 'run_command' do
+    it 'should run a command on a node', ssh: true do
+      result = run_command('echo hello', 'ssh', config: config_data, inventory: inventory_data)
+      expect(result[0]['status']).to eq('success')
+    end
+
+    it 'should accept _catch_errors' do
+      result = run_command('echo hello', 'non_existent_ndoe', { '_catch_errors' => true },
+                           config: config_data, inventory: inventory_data)
+
+      expect(result[0]['status']).to eq('failure')
+      expect(result[0]['result']['_error']['kind']).to eq('puppetlabs.tasks/connect-error')
+    end
+  end
+
+  describe 'run_plan' do
+    it 'should run a plan' do
+      result = run_plan('sample::single_task', { 'nodes' => 'ssh' }, config: config_data, inventory: inventory_data)
+      expect(result['status']).to eq('success')
+      data = result['value'][0]
+      expect(data['status']).to eq('success')
+    end
+
+    it 'should return a failure' do
+      result = run_plan('error::run_fail', { 'target' => 'ssh' }, config: config_data, inventory: inventory_data)
+      expect(result['status']).to eq('failure')
+      expect(result['value']['kind']).to eq('bolt/run-failure')
+    end
+  end
+end

--- a/spec/lib/bolt_spec/conn.rb
+++ b/spec/lib/bolt_spec/conn.rb
@@ -35,5 +35,16 @@ module BoltSpec
       port = override_port || conn[:port]
       "#{conn[:protocol]}://#{conn[:user]}#{passwd}@#{conn[:host]}:#{port}"
     end
+
+    def conn_inventory
+      groups = %w[ssh winrm].map do |transport|
+        { "name" => transport,
+          "nodes" => [conn_uri(transport)],
+          "config" => {
+            transport => Bolt::Util.walk_keys(conn_info(transport), &:to_s)
+          } }
+      end
+      { "groups" => groups }
+    end
   end
 end


### PR DESCRIPTION
This adds a new set of BoltSpec spec helpers that can be used to run
tasks, commands, and plans from tests without handling cli flags or
running in a separate process.