### PR TITLE
(BOLT-653) Ensure rack server starts without rackup on PATH

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,6 @@ AllCops:
     - 'vendored/**/*'
     - 'acceptance/vendor/**/*'
     - 'modules/**/*'
-    - 'exe/**/*'
 
 # Checks for if and unless statements that would fit on one line if written as a
 # modifier if/unless.

--- a/exe/bolt-server
+++ b/exe/bolt-server
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-# ARGV[0] is the path to config.ru
-# The rackup file that configures the bolt-server
-exec 'rackup', '--env', 'production', '-D', ARGV[0]
+# ARGV[0] is the path to config.ru, the rackup file that configures the bolt-server
+
+require 'rack'
+Rack::Server.start(environment: 'production', daemonize: true, config: ARGV[0])


### PR DESCRIPTION
Ensure we start the rack server. This is safer than exec because with
exec we need to make sure we get the rackup application that points to
the correct Ruby.