### PR TITLE
(BOLT-753) Fix apply_prep when handling failed task runs

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
@@ -26,9 +26,9 @@ Puppet::Functions.create_function(:apply_prep) do
         script_compiler = Puppet::Pal::ScriptCompiler.new(closure_scope.compiler)
 
         # Ensure Puppet is installed
-        version_task = script_compiler.task_signature('puppet_agent::version')
+        version_task = script_compiler.task_signature('puppet_agent::version')&.task
         raise Bolt::Error.new('puppet_agent::version could not be found', 'bolt/apply-prep') unless version_task
-        versions = executor.run_task(targets, version_task.task, {})
+        versions = executor.run_task(targets, version_task, {})
         raise Bolt::RunFailure.new(versions, 'run_task', version_task.name) unless versions.ok?
         need_install, installed = versions.partition { |r| r['version'].nil? }
         installed.each do |r|
@@ -36,9 +36,9 @@ Puppet::Functions.create_function(:apply_prep) do
         end
 
         unless need_install.empty?
-          install_task = script_compiler.task_signature('puppet_agent::install')
+          install_task = script_compiler.task_signature('puppet_agent::install')&.task
           raise Bolt::Error.new('puppet_agent::install could not be found', 'bolt/apply-prep') unless install_task
-          installed = executor.run_task(need_install.map(&:target), install_task.task, {})
+          installed = executor.run_task(need_install.map(&:target), install_task, {})
           raise Bolt::RunFailure.new(installed, 'run_task', install_task.name) unless installed.ok?
         end
         targets.each { |target| inventory.set_feature(target, 'puppet-agent') }

--- a/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
@@ -28,25 +28,27 @@ describe 'apply_prep' do
     let(:targets) { hostnames.map { |h| Bolt::Target.new(h) } }
     let(:fact) { { 'osfamily' => 'none' } }
     let(:custom_facts_task) { mock('custom_facts_task') }
+    let(:version_task) { mock('version_task') }
+    let(:install_task) { mock('install_task') }
 
     before(:each) do
       applicator.stubs(:build_plugin_tarball).returns(:tarball)
       applicator.stubs(:custom_facts_task).returns(custom_facts_task)
       custom_facts_task.stubs(:name).returns('custom_facts_task')
 
-      task1 = mock('version_task')
-      task1.stubs(:name).returns('puppet_agent::version')
-      task1.stubs(:task).returns(:version_task)
+      task1 = mock('version_task_sig')
+      task1.stubs(:task).returns(version_task)
+      version_task.stubs(:name).returns('puppet_agent::version')
       Puppet::Pal::ScriptCompiler.any_instance.stubs(:task_signature).with('puppet_agent::version').returns(task1)
       task2 = mock('install_task')
-      task2.stubs(:name).returns('puppet_agent::install')
-      task2.stubs(:task).returns(:install_task)
+      task2.stubs(:task).returns(install_task)
+      install_task.stubs(:name).returns('puppet_agent::install')
       Puppet::Pal::ScriptCompiler.any_instance.stubs(:task_signature).with('puppet_agent::install').returns(task2)
     end
 
     it 'sets feature and gathers facts' do
       versions = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: { 'version' => '5.0.0' }) })
-      executor.expects(:run_task).with(targets, :version_task, anything, anything).returns(versions)
+      executor.expects(:run_task).with(targets, version_task, anything, anything).returns(versions)
 
       facts = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: fact) })
       executor.expects(:run_task).with(targets, custom_facts_task, 'plugins' => :tarball).returns(facts)
@@ -62,9 +64,9 @@ describe 'apply_prep' do
       versions = Bolt::ResultSet.new(
         targets.zip(['yes', nil]).map { |t, v| Bolt::Result.new(t, value: { 'version' => v }) }
       )
-      executor.expects(:run_task).with(targets, :version_task, anything, anything).returns(versions)
+      executor.expects(:run_task).with(targets, version_task, anything, anything).returns(versions)
       ok_result = Bolt::ResultSet.new([])
-      executor.expects(:run_task).with(targets[1..1], :install_task, anything, anything).returns(ok_result)
+      executor.expects(:run_task).with(targets[1..1], install_task, anything, anything).returns(ok_result)
 
       facts = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: fact) })
       executor.expects(:run_task).with(targets, custom_facts_task, 'plugins' => :tarball).returns(facts)
@@ -87,7 +89,7 @@ describe 'apply_prep' do
       failed_results = Bolt::ResultSet.new(
         targets.map { |t| Bolt::Result.new(t, error: { 'msg' => 'could not get version' }) }
       )
-      executor.expects(:run_task).with(targets, :version_task, anything, anything).returns(failed_results)
+      executor.expects(:run_task).with(targets, version_task, anything, anything).returns(failed_results)
 
       is_expected.to run.with_params(hostnames).and_raise_error(
         Bolt::RunFailure, "Plan aborted: run_task 'puppet_agent::version' failed on 2 nodes"
@@ -96,7 +98,7 @@ describe 'apply_prep' do
 
     it 'fails if install task is not found' do
       versions = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: {}) })
-      executor.expects(:run_task).with(targets, :version_task, anything, anything).returns(versions)
+      executor.expects(:run_task).with(targets, version_task, anything, anything).returns(versions)
 
       Puppet::Pal::ScriptCompiler.any_instance.expects(:task_signature).with('puppet_agent::install')
       is_expected.to run.with_params(hostnames).and_raise_error(
@@ -106,12 +108,12 @@ describe 'apply_prep' do
 
     it 'fails if install fails' do
       versions = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: {}) })
-      executor.expects(:run_task).with(targets, :version_task, anything, anything).returns(versions)
+      executor.expects(:run_task).with(targets, version_task, anything, anything).returns(versions)
 
       failed_results = Bolt::ResultSet.new(
         targets.map { |t| Bolt::Result.new(t, error: { 'msg' => 'could not install package' }) }
       )
-      executor.expects(:run_task).with(targets, :install_task, anything, anything).returns(failed_results)
+      executor.expects(:run_task).with(targets, install_task, anything, anything).returns(failed_results)
 
       is_expected.to run.with_params(hostnames).and_raise_error(
         Bolt::RunFailure, "Plan aborted: run_task 'puppet_agent::install' failed on 2 nodes"
@@ -120,7 +122,7 @@ describe 'apply_prep' do
 
     it 'fails if fact gathering fails' do
       versions = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: { 'version' => '5.0.0' }) })
-      executor.expects(:run_task).with(targets, :version_task, anything, anything).returns(versions)
+      executor.expects(:run_task).with(targets, version_task, anything, anything).returns(versions)
 
       results = Bolt::ResultSet.new(
         targets.map { |t| Bolt::Result.new(t, error: { 'msg' => 'could not gather facts' }) }


### PR DESCRIPTION
When apply_prep gets a failure attempting to run `puppet_agent::version`
or `puppet_agent::install`, it will no longer mask that error with an
error querying the task name. It now successfully gets the task name and
includes it with the original error.