### PR TITLE
(BOLT-615) Update puppet_agent git ref

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -11,7 +11,7 @@ mod 'puppetlabs-apply', '0.1.0'
 mod 'puppetlabs-facts', '0.2.0'
 mod 'puppet_agent',
     git: 'https://github.com/puppetlabs/puppetlabs-puppet_agent',
-    ref: 'fa0c9e2ecb0cfde1d916fedf97559e2e91daf763'
+    ref: 'e38bc2113f22f475a245bfa3b453b24b1ef2b063'
 
 # If we don't list these modules explicitly, r10k will purge them
 mod 'canary', local: true

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -930,6 +930,7 @@ bar
               ["facts::ruby", "Gather system facts using ruby and facter"],
               ["package", "Manage and inspect the state of packages"],
               ["puppet_agent::install", "Install the Puppet 5 agent package"],
+              ["puppet_agent::install_powershell", nil],
               ["puppet_agent::install_shell", nil],
               ["puppet_agent::version",
                "Get the version of the Puppet 5 agent package installed. Returns nothing if none present."],


### PR DESCRIPTION
Addition of windows support for installing Puppet Agent on windows targets introduces a new powershell implementation for install_agent task. This commit updates the git reference to puppet_agent repo and updates cli spec accordingly.