### PR TITLE
(BOLT-767) Add logging messages for plans

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -53,40 +53,40 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
       )
     end
 
-    # print starting log message and begin profiling
-    start_time = executor.log_start_plan(plan_name)
-
     if (run_as = named_args['_run_as'])
       old_run_as = executor.run_as
       executor.run_as = run_as
     end
-    result = nil
-    begin
-      # If the plan does not throw :return by calling the return function it's result is
-      # undef/nil
-      result = catch(:return) do
-        func.class.dispatcher.dispatchers[0].call_by_name_with_scope(scope, params, true)
-        nil
-      end&.value
-      # Validate the result is a PlanResult
-      unless Puppet::Pops::Types::TypeParser.singleton.parse('Boltlib::PlanResult').instance?(result)
-        raise Bolt::InvalidPlanResult.new(plan_name, result.to_s)
-      end
-      result
-    rescue Puppet::PreformattedError => err
-      if named_args['_catch_errors'] && err.cause.is_a?(Bolt::Error)
-        result = err.cause.to_puppet_error
-      else
-        raise err
-      end
-    ensure
-      if run_as
-        executor.run_as = old_run_as
-      end
-      # print finished message and end profiling
-      executor.log_finish_plan(plan_name, start_time)
-    end
 
-    result
+    # wrap plan execution in logging messages
+    executor.log_plan(plan_name) do
+      result = nil
+      begin
+        # If the plan does not throw :return by calling the return function it's result is
+        # undef/nil
+        result = catch(:return) do
+          func.class.dispatcher.dispatchers[0].call_by_name_with_scope(scope, params, true)
+          nil
+        end&.value
+        # Validate the result is a PlanResult
+        unless Puppet::Pops::Types::TypeParser.singleton.parse('Boltlib::PlanResult').instance?(result)
+          raise Bolt::InvalidPlanResult.new(plan_name, result.to_s)
+        end
+
+        result
+      rescue Puppet::PreformattedError => err
+        if named_args['_catch_errors'] && err.cause.is_a?(Bolt::Error)
+          result = err.cause.to_puppet_error
+        else
+          raise err
+        end
+      ensure
+        if run_as
+          executor.run_as = old_run_as
+        end
+      end
+
+      result
+    end
   end
 end

--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -30,6 +30,8 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
       )
     end
 
+    start_time = executor.log_start_plan(plan_name)
+    
     # Bolt calls this function internally to trigger plans from the CLI. We
     # don't want to count those invocations.
     unless named_args['_bolt_api_call']
@@ -83,6 +85,8 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
       end
     end
 
+    executor.log_finish_plan(plan_name, start_time)
+    
     result
   end
 end

--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -29,7 +29,7 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
         Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('run a plan')
       )
     end
-    
+
     # Bolt calls this function internally to trigger plans from the CLI. We
     # don't want to count those invocations.
     unless named_args['_bolt_api_call']
@@ -55,7 +55,7 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
 
     # print starting log message and begin profiling
     start_time = executor.log_start_plan(plan_name)
-    
+
     if (run_as = named_args['_run_as'])
       old_run_as = executor.run_as
       executor.run_as = run_as
@@ -86,7 +86,7 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
       # print finished message and end profiling
       executor.log_finish_plan(plan_name, start_time)
     end
-    
+
     result
   end
 end

--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -29,8 +29,6 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
         Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('run a plan')
       )
     end
-
-    start_time = executor.log_start_plan(plan_name)
     
     # Bolt calls this function internally to trigger plans from the CLI. We
     # don't want to count those invocations.
@@ -55,7 +53,9 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
       )
     end
 
-    # TODO: Add profiling around this
+    # print starting log message and begin profiling
+    start_time = executor.log_start_plan(plan_name)
+    
     if (run_as = named_args['_run_as'])
       old_run_as = executor.run_as
       executor.run_as = run_as
@@ -83,9 +83,9 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
       if run_as
         executor.run_as = old_run_as
       end
+      # print finished message and end profiling
+      executor.log_finish_plan(plan_name, start_time)
     end
-
-    executor.log_finish_plan(plan_name, start_time)
     
     result
   end

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -134,16 +134,20 @@ module Bolt
       results
     end
 
-    def log_start_plan(plan_name)
+    def log_plan(plan_name)
       log_method = @plan_logging ? :notice : :info
       @logger.send(log_method, "Starting: plan #{plan_name}")
-      Time.now
-    end
+      start_time = Time.now
 
-    def log_finish_plan(plan_name, start_time)
-      log_method = @plan_logging ? :notice : :info
-      duration = Time.now - start_time
-      @logger.send(log_method, "Finished: plan #{plan_name} in #{duration.round(2)} sec")
+      results = nil
+      begin
+        results = yield
+      ensure
+        duration = Time.now - start_time
+        @logger.send(log_method, "Finished: plan #{plan_name} in #{duration.round(2)} sec")
+      end
+
+      results
     end
 
     def report_transport(transport, count)

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -134,6 +134,18 @@ module Bolt
       results
     end
 
+    def log_start_plan(plan_name)
+      log_method = @plan_logging ? :notice : :info
+      @logger.send(log_method, "Starting: plan #{plan_name}")
+      Time.now
+    end
+
+    def log_finish_plan(plan_name, start_time)
+      log_method = @plan_logging ? :notice : :info
+      duration = Time.now - start_time
+      @logger.send(log_method, "Finished: plan #{plan_name} in #{duration.round(2)} sec")
+    end
+
     def report_transport(transport, count)
       name = transport.class.name.split('::').last.downcase
       @analytics&.event('Transport', 'initialize', name, count) unless @reported_transports.include?(name)

--- a/lib/bolt_spec/plans/mock_executor.rb
+++ b/lib/bolt_spec/plans/mock_executor.rb
@@ -209,12 +209,12 @@ module BoltSpec
         @task_doubles[task_name] ||= TaskDouble.new
       end
 
-      def log_start_plan(plan_name)
+      def log_start_plan(_plan_name)
         Time.now
       end
-      
-      def log_finish_plan(plan_name, start_time); end
-      
+
+      def log_finish_plan(_plan_name, _start_time); end
+
       def report_function_call(_function); end
 
       def report_bundled_content(_mode, _name); end

--- a/lib/bolt_spec/plans/mock_executor.rb
+++ b/lib/bolt_spec/plans/mock_executor.rb
@@ -209,6 +209,12 @@ module BoltSpec
         @task_doubles[task_name] ||= TaskDouble.new
       end
 
+      def log_start_plan(plan_name)
+        Time.now
+      end
+      
+      def log_finish_plan(plan_name, start_time); end
+      
       def report_function_call(_function); end
 
       def report_bundled_content(_mode, _name); end

--- a/lib/bolt_spec/plans/mock_executor.rb
+++ b/lib/bolt_spec/plans/mock_executor.rb
@@ -209,11 +209,9 @@ module BoltSpec
         @task_doubles[task_name] ||= TaskDouble.new
       end
 
-      def log_start_plan(_plan_name)
-        Time.now
+      def log_plan(_plan_name)
+        yield
       end
-
-      def log_finish_plan(_plan_name, _start_time); end
 
       def report_function_call(_function); end
 

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -686,6 +686,7 @@ bar
 
       before :each do
         allow(Bolt::Executor).to receive(:new).and_return(executor)
+        allow(executor).to receive(:log_plan) { |_plan_name, &block| block.call }
 
         outputter = Bolt::Outputter::JSON.new(false, false, output)
 
@@ -1421,8 +1422,7 @@ bar
             .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'yes', '', 0)]))
 
           expect(executor).to receive(:start_plan)
-          expect(executor).to receive(:log_start_plan)
-          expect(executor).to receive(:log_finish_plan)
+          expect(executor).to receive(:log_plan)
           expect(executor).to receive(:finish_plan)
 
           cli.execute(options)
@@ -1448,8 +1448,7 @@ bar
             .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'yes', '', 0)]))
 
           expect(executor).to receive(:start_plan)
-          expect(executor).to receive(:log_start_plan)
-          expect(executor).to receive(:log_finish_plan)
+          expect(executor).to receive(:log_plan)
           expect(executor).to receive(:finish_plan)
 
           cli.execute(options)
@@ -1465,8 +1464,7 @@ bar
             .and_raise("Could not connect to target")
 
           expect(executor).to receive(:start_plan)
-          expect(executor).to receive(:log_start_plan)
-          expect(executor).to receive(:log_finish_plan)
+          expect(executor).to receive(:log_plan)
           expect(executor).to receive(:finish_plan)
 
           expect(cli.execute(options)).to eq(1)
@@ -1480,8 +1478,7 @@ bar
             .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'no', '', 1)]))
 
           expect(executor).to receive(:start_plan)
-          expect(executor).to receive(:log_start_plan)
-          expect(executor).to receive(:log_finish_plan)
+          expect(executor).to receive(:log_plan)
           expect(executor).to receive(:finish_plan)
 
           cli.execute(options)
@@ -1524,8 +1521,7 @@ bar
             end
 
           expect(executor).to receive(:start_plan)
-          expect(executor).to receive(:log_start_plan)
-          expect(executor).to receive(:log_finish_plan)
+          expect(executor).to receive(:log_plan)
           expect(executor).to receive(:finish_plan)
 
           expect(cli).to receive(:exit!) do

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1421,6 +1421,8 @@ bar
             .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'yes', '', 0)]))
 
           expect(executor).to receive(:start_plan)
+          expect(executor).to receive(:log_start_plan)
+          expect(executor).to receive(:log_finish_plan)
           expect(executor).to receive(:finish_plan)
 
           cli.execute(options)
@@ -1446,6 +1448,8 @@ bar
             .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'yes', '', 0)]))
 
           expect(executor).to receive(:start_plan)
+          expect(executor).to receive(:log_start_plan)
+          expect(executor).to receive(:log_finish_plan)
           expect(executor).to receive(:finish_plan)
 
           cli.execute(options)
@@ -1461,6 +1465,8 @@ bar
             .and_raise("Could not connect to target")
 
           expect(executor).to receive(:start_plan)
+          expect(executor).to receive(:log_start_plan)
+          expect(executor).to receive(:log_finish_plan)
           expect(executor).to receive(:finish_plan)
 
           expect(cli.execute(options)).to eq(1)
@@ -1474,6 +1480,8 @@ bar
             .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'no', '', 1)]))
 
           expect(executor).to receive(:start_plan)
+          expect(executor).to receive(:log_start_plan)
+          expect(executor).to receive(:log_finish_plan)
           expect(executor).to receive(:finish_plan)
 
           cli.execute(options)
@@ -1516,6 +1524,8 @@ bar
             end
 
           expect(executor).to receive(:start_plan)
+          expect(executor).to receive(:log_start_plan)
+          expect(executor).to receive(:log_finish_plan)
           expect(executor).to receive(:finish_plan)
 
           expect(cli).to receive(:exit!) do

--- a/spec/integration/logging_spec.rb
+++ b/spec/integration/logging_spec.rb
@@ -46,15 +46,19 @@ describe "when logging executor activity", ssh: true do
 
   it 'logs with a plan that includes a description' do
     result = run_cli_json(%W[plan run #{echo_plan} description=somemessage] + config_flags)
+    expect(@log_output.readline).to match(/NOTICE.*Starting: plan #{echo_plan}/)
     expect(@log_output.readline).to match(/Starting: somemessage on/)
     expect(@log_output.readline).to match(/Finished: somemessage/)
+    expect(@log_output.readline).to match(/NOTICE.*Finished: plan #{echo_plan}/)
     expect(result[0]['result']['_output'].strip).to match(/hi there/)
   end
 
   it 'logs extra with a plan' do
     result = run_cli_json(%W[plan run #{echo_plan}] + config_flags)
+    expect(@log_output.readline).to match(/NOTICE.*Starting: plan #{echo_plan}/)
     expect(@log_output.readline).to match(/Starting: task sample::echo/)
     expect(@log_output.readline).to match(/Finished: task sample::echo/)
+    expect(@log_output.readline).to match(/NOTICE.*Finished: plan #{echo_plan}/)
     expect(result[0]['result']['_output'].strip).to match(/hi there/)
   end
 
@@ -88,19 +92,23 @@ describe "when logging executor activity", ssh: true do
 
     it 'logs extra with a plan' do
       result = run_cli_json(%W[plan run #{echo_plan}] + config_flags)
+      expect(@log_output.readline).to match(/NOTICE.*Starting: plan #{echo_plan}/)
       expect(@log_output.readline).to match(/Starting: task sample::echo/)
       expect(@log_output.readline).to match(/Running task sample::echo with/)
       expect(@log_output.readline).to match(/hi there/)
       expect(@log_output.readline).to match(/Finished: task sample::echo/)
+      expect(@log_output.readline).to match(/NOTICE.*Finished: plan #{echo_plan}/)
       expect(result[0]['result']['_output'].strip).to match(/hi there/)
     end
 
     it 'logs extra without_default in a plan' do
       run_cli_json(%W[plan run #{without_default_plan}] + config_flags)
+      expect(@log_output.readline).to match(/NOTICE.*Starting: plan #{without_default_plan}/)
       expect(@log_output.readline).to match(/Starting: task logging::echo/)
       expect(@log_output.readline).to match(/Running task logging::echo with/)
       expect(@log_output.readline).to match(/hi there/)
       expect(@log_output.readline).to match(/Finished: task logging::echo/)
+      expect(@log_output.readline).to match(/NOTICE.*Finished: plan #{without_default_plan}/)
     end
   end
 end


### PR DESCRIPTION
Current plans do not have a `Starting: plan xxx` and `Finished: plan xxx in SS.ss sec`.

This PR adds those logging messages into plan executions.

A timestamp is returned from the `log_start_plan()` function so that nested plans produce accurate time measurements. 