### PR TITLE
(BOLT-768) Fix acceptance tests without Beaker puppet install

### DIFF
--- a/acceptance/tests/apply_ssh.rb
+++ b/acceptance/tests/apply_ssh.rb
@@ -117,10 +117,10 @@ test_name "bolt plan run should apply manifest block on remote hosts via ssh" do
     user = 'apply_nonroot'
 
     step 'create nonroot user on targets' do
-      on(ssh_nodes, puppet('resource', 'user', user, 'ensure=present'))
+      on(ssh_nodes, "/opt/puppetlabs/bin/puppet resource user #{user} ensure=present")
 
       teardown do
-        on(ssh_nodes, puppet('resource', 'user', user, 'ensure=absent'))
+        on(ssh_nodes, "/opt/puppetlabs/bin/puppet resource user #{user} ensure=absent")
       end
     end
 

--- a/acceptance/tests/script_winrm.rb
+++ b/acceptance/tests/script_winrm.rb
@@ -28,31 +28,4 @@ test_name "C100549: \
       assert_match(/{#{node.ip}}/, result.stdout, message)
     end
   end
-
-  rb_script = "C100549.rb"
-  step "create ruby script on bolt controller" do
-    create_remote_file(bolt, rb_script, <<-FILE)
-    1001.times { |t| puts t }
-    FILE
-  end
-
-  step "execute `bolt script run` via WinRM for Ruby script and verify output is in-order" do
-    bolt_command = "bolt script run #{rb_script}"
-    flags = { '--nodes' => 'winrm_nodes', '--format' => 'json' }
-
-    result = bolt_command_on(bolt, bolt_command, flags)
-
-    begin
-      json = JSON.parse(result.stdout)
-    rescue JSON.ParserError
-      assert_equal("Output should be JSON", result.string,
-                   "Output should be JSON")
-    end
-
-    winrm_nodes.each do |node|
-      output = json['items'].select { |n| n['node'] == node.hostname }.first
-      expected = (0..1000).to_a.join("\r\n")
-      assert_equal(output['result']['stdout'].chomp, expected)
-    end
-  end
 end


### PR DESCRIPTION
beaker-puppet's install helpers also setup puppet to be found when
running the command. We're not using that so we can test apply. However
that means any use of puppet needs to use the full path, which is easy
to do because we're only using it on non-Windows tests.

Also remove test that's adequately covered by winrm transport tests and
relied on Puppet's ruby.