### PR TITLE
(maint) Skip testing on SLES

### DIFF
--- a/acceptance/tests/apply_ssh.rb
+++ b/acceptance/tests/apply_ssh.rb
@@ -9,6 +9,9 @@ test_name "bolt plan run should apply manifest block on remote hosts via ssh" do
   ssh_nodes = select_hosts(roles: ['ssh'])
   skip_test('no applicable nodes to test on') if ssh_nodes.empty?
 
+  sles_nodes = ssh_nodes.select { |host| host['platform'] =~ /sles/ }
+  skip_test('FIX: agent install does not support SLES') unless sles_nodes.empty?
+
   dir = bolt.tmpdir('apply_ssh')
   fixtures = File.absolute_path('files')
   filepath = File.join('/tmp', SecureRandom.uuid.to_s)


### PR DESCRIPTION
Until SLES is supported by the puppet_agent::install task (MODULES-7655)
we skip apply tests if SLES is a target.