### PR TITLE
(BOLT-722) Don't load ssh config if using bolt via api

### DIFF
--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -60,8 +60,8 @@ module Bolt
         end
       end
 
-      def with_connection(target)
-        conn = Connection.new(target)
+      def with_connection(target, load_config = true)
+        conn = Connection.new(target, load_config)
         conn.connect
         yield conn
       ensure
@@ -125,7 +125,7 @@ module Bolt
 
       def run_task(target, task, arguments, options = {})
         input_method = task.input_method || "both"
-        with_connection(target) do |conn|
+        with_connection(target, options.fetch('_load_config', true)) do |conn|
           conn.running_as(options['_run_as']) do
             stdin, output = nil
 

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -54,10 +54,12 @@ module Bolt
         attr_reader :logger, :user, :target
         attr_writer :run_as
 
-        def initialize(target)
+        def initialize(target, load_config = true)
           @target = target
+          @load_config = load_config
 
-          @user = @target.user || Net::SSH::Config.for(target.host)[:user] || Etc.getlogin
+          ssh_user = load_config ? Net::SSH::Config.for(target.host)[:user] : nil
+          @user = @target.user || ssh_user || Etc.getlogin
           @run_as = nil
 
           @logger = Logging.logger[@target.host]
@@ -97,6 +99,7 @@ module Bolt
                                         Net::SSH::Verifiers::Lenient.new
                                       end
           options[:timeout] = target.options['connect-timeout'] if target.options['connect-timeout']
+          options[:config] = @load_config
 
           # Mirroring:
           # https://github.com/net-ssh/net-ssh/blob/master/lib/net/ssh/authentication/agent.rb#L80

--- a/lib/bolt_ext/server.rb
+++ b/lib/bolt_ext/server.rb
@@ -17,7 +17,7 @@ class TransportAPI < Sinatra::Base
     task = Bolt::Task.new(body['task'])
     parameters = body['parameters'] || {}
 
-    executor = Bolt::Executor.new
+    executor = Bolt::Executor.new(load_config: false)
 
     # Since this will only be on one node we can just set r to the result
     executor.run_task(target, task, parameters) do |event|


### PR DESCRIPTION
Ensure we don't read from the users system SSH config or the global Bolt config when running bolt via the API
