### PR TITLE
(BOLT-776) Apply with older Puppet 4

### DIFF
--- a/libexec/apply_catalog.rb
+++ b/libexec/apply_catalog.rb
@@ -13,7 +13,7 @@ Puppet.initialize_settings([])
 run_mode = Puppet::Util::RunMode[:user]
 Puppet.settings.initialize_app_defaults(Puppet::Settings.app_defaults_for_run_mode(run_mode))
 
-Puppet::ApplicationSupport.push_application_context(run_mode, :local)
+Puppet::ApplicationSupport.push_application_context(run_mode)
 
 # Avoid extraneous output
 Puppet[:summarize] = false


### PR DESCRIPTION
Puppet 4.10.9 and older did not include a second argument for
`push_application_context`. In all versions since then, the 2nd argument
has been optional, defaulting to the value we're passing in. So drop
passing the 2nd argument to support older Puppet 4 versions.