### PR TITLE
(PE-24721) Correctly daemonize

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -35,6 +35,10 @@ bind_addr << "&key=#{config.ssl_key}"
 bind_addr << "&ca=#{config.ssl_ca_cert}"
 bind_addr << "&verify_mode=force_peer"
 
+# This doesn't seem ideal, but it behaves well. I couldn't figure out how to get Puma or Rack to do
+# it for me. An alternative might be rewriting this to use 'puma -C config.rb'.
+Process.daemon
 Rack::Handler::Puma.run(TransportAPI,
+                        pidfile: '/var/run/puppetlabs/bolt-server/bolt-server.pid',
                         Port: config.port,
                         Host: bind_addr)

--- a/exe/bolt-server
+++ b/exe/bolt-server
@@ -4,4 +4,4 @@
 # ARGV[0] is the path to config.ru, the rackup file that configures the bolt-server
 
 require 'rack'
-Rack::Server.start(environment: 'production', daemonize: true, config: ARGV[0])
+Rack::Server.start(config: ARGV[0])

--- a/ext/redhat/pe-bolt-server.init
+++ b/ext/redhat/pe-bolt-server.init
@@ -15,14 +15,14 @@
 prefix='/opt/puppetlabs/server/apps/bolt-server'
 export GEM_HOME="${prefix}/lib/ruby/gems/2.4.0"
 exec="${prefix}/bin/bolt-server"
-prog="pe-bolt-server"
+prog="bolt-server"
 desc="PE Bolt Server"
 owner="pe-bolt-server"
 
 lockfile=/var/lock/subsys/$prog
-piddir=/var/run/puppetlabs
+piddir=/var/run/puppetlabs/$prog
 pidfile="${piddir}/${prog}.pid"
-logdir=/var/log/puppetlabs
+logdir=/var/log/puppetlabs/$prog
 pid=$(cat $pidfile 2> /dev/null)
 RETVAL=0
 

--- a/ext/systemd/pe-bolt-server.service
+++ b/ext/systemd/pe-bolt-server.service
@@ -3,7 +3,8 @@ Description=PE Bolt Server
 After=syslog.target network.target
 
 [Service]
-Type=simple
+Type=fork
+PIDFile=/var/run/puppetlabs/bolt-server/bolt-server.pid
 User=pe-bolt-server
 Group=pe-bolt-server
 EnvironmentFile=-/etc/sysconfig/pe-bolt-server-service


### PR DESCRIPTION
Pass daemonize option to the correct handler. Also ensure pidfile is configured. Update services to match.

Put pidfile and logs in subdirectories so pe-bolt-server can be made owner of them.