### PR TITLE
(BOLT-788) Update bolt server to accept documented API

### DIFF
--- a/lib/bolt_ext/server.rb
+++ b/lib/bolt_ext/server.rb
@@ -10,9 +10,9 @@ class TransportAPI < Sinatra::Base
     content_type :json
 
     body = JSON.parse(request.body.read)
-    keys = %w[user password port ssh-key-content]
+    keys = %w[user password port ssh-key-content connect-timeout run-as-command
+              run-as tmpdir host-key-check known-hosts-content sudo-password]
     opts = body['target'].select { |k, _| keys.include? k }
-    opts.merge(body['target']['options'])
     target = [Bolt::Target.new(body['target']['hostname'], opts)]
     task = Bolt::Task.new(body['task'])
     parameters = body['parameters']

--- a/spec/bolt_ext/server_spec.rb
+++ b/spec/bolt_ext/server_spec.rb
@@ -25,22 +25,22 @@ echo $PT_message
 TASK
 
       body = {
-        'task' => {
-          'name' => 'echo',
-          'metadata' => {
-            'description' => 'Echo a message',
-            'parameters' => { 'message' => 'Hello world!' }
+        'task': {
+          'name': 'echo',
+          'metadata': {
+            'description': 'Echo a message',
+            'parameters': { 'message': 'Default message' }
           },
-          'file_content' => Base64.encode64(impl)
+          'file_content': Base64.encode64(impl)
         },
-        'target' => {
-          'hostname' => target[:host],
-          'user' => target[:user],
-          'password' => target[:password],
-          'port' => target[:port],
-          'options' => { "host-key-check" => "false" }
+        'target': {
+          'hostname': target[:host],
+          'user': target[:user],
+          'password': target[:password],
+          'port': target[:port],
+          'host-key-check': false
         },
-        'parameters' => { "message" => "Hello!" }
+        'parameters': { "message": "Hello!" }
       }
 
       post path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json'


### PR DESCRIPTION
The bolt-server expected API and the documented API have gotten out of sync.
This updates the bolt server to expect the structure in the documented api, specifically moving the 'options' keys out a level and removing 'options' as a key.