### PR TITLE
(BOLT-685) Avoid setting `level=` on log level repeatedly

### DIFF
--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -58,10 +58,13 @@ module Bolt
             "Authentication method 'gssapi-with-mic' is not available"
           }
         end
+
+        @transport_logger = Logging.logger[Net::SSH]
+        @transport_logger.level = :warn
       end
 
       def with_connection(target)
-        conn = Connection.new(target)
+        conn = Connection.new(target, @transport_logger)
         conn.connect
         yield conn
       ensure

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -54,13 +54,14 @@ module Bolt
         attr_reader :logger, :user, :target
         attr_writer :run_as
 
-        def initialize(target)
+        def initialize(target, transport_logger)
           @target = target
 
           @user = @target.user || Net::SSH::Config.for(target.host)[:user] || Etc.getlogin
           @run_as = nil
 
           @logger = Logging.logger[@target.host]
+          @transport_logger = transport_logger
         end
 
         if Bolt::Util.windows?
@@ -74,10 +75,8 @@ module Bolt
         end
 
         def connect
-          transport_logger = Logging.logger[Net::SSH]
-          transport_logger.level = :warn
           options = {
-            logger: transport_logger,
+            logger: @transport_logger,
             non_interactive: true
           }
 

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -37,10 +37,13 @@ module Bolt
         super
         require 'winrm'
         require 'winrm-fs'
+
+        @transport_logger = Logging.logger[::WinRM]
+        @transport_logger.level = :warn
       end
 
       def with_connection(target)
-        conn = Connection.new(target)
+        conn = Connection.new(target, @transport_logger)
         conn.connect
         yield conn
       ensure

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -11,7 +11,7 @@ module Bolt
 
         DEFAULT_EXTENSIONS = ['.ps1', '.rb', '.pp'].freeze
 
-        def initialize(target)
+        def initialize(target, transport_logger)
           @target = target
 
           default_port = target.options['ssl'] ? HTTPS_PORT : HTTP_PORT
@@ -23,6 +23,7 @@ module Bolt
           @extensions = DEFAULT_EXTENSIONS.to_set.merge(extensions)
 
           @logger = Logging.logger[@target.host]
+          @transport_logger = transport_logger
         end
 
         HTTP_PORT = 5985
@@ -47,9 +48,7 @@ module Bolt
 
           Timeout.timeout(target.options['connect-timeout']) do
             @connection = ::WinRM::Connection.new(options)
-            transport_logger = Logging.logger[::WinRM]
-            transport_logger.level = :warn
-            @connection.logger = transport_logger
+            @connection.logger = @transport_logger
 
             @session = @connection.shell(:powershell)
             @session.run('$PSVersionTable.PSVersion')


### PR DESCRIPTION
I believe there's a race condition that can be triggered in the Logging
library when creating many loggers and setting `level=` concurrently.
Filed as https://github.com/TwP/logging/issues/200.

This fix avoids the race by setting up the shared transport logger once
and passing it to connection instances.