### PR TITLE
(BOLT-788) Make parameters key optional

### DIFF
--- a/lib/bolt_ext/server.rb
+++ b/lib/bolt_ext/server.rb
@@ -15,7 +15,7 @@ class TransportAPI < Sinatra::Base
     opts = body['target'].select { |k, _| keys.include? k }
     target = [Bolt::Target.new(body['target']['hostname'], opts)]
     task = Bolt::Task.new(body['task'])
-    parameters = body['parameters']
+    parameters = body['parameters'] || {}
 
     executor = Bolt::Executor.new
 


### PR DESCRIPTION
This adds a valid default for parameters if it's not provided