### PR TITLE
(BOLT-797) Support apply_prep on SLES

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -11,7 +11,7 @@ mod 'puppetlabs-apply', '0.1.0'
 mod 'puppetlabs-facts', '0.2.0'
 mod 'puppet_agent',
     git: 'https://github.com/puppetlabs/puppetlabs-puppet_agent',
-    ref: 'e38bc2113f22f475a245bfa3b453b24b1ef2b063'
+    ref: '319ce44a65e73bcf2712ad17be01f9636f0673c9'
 
 # If we don't list these modules explicitly, r10k will purge them
 mod 'canary', local: true

--- a/acceptance/setup/common/pre-suite/071_install_modules.rb
+++ b/acceptance/setup/common/pre-suite/071_install_modules.rb
@@ -11,7 +11,7 @@ mod 'puppetlabs-facts', '0.2.0'
 mod 'puppetlabs-service', '0.3.1'
 mod 'puppet_agent',
     git: 'https://github.com/puppetlabs/puppetlabs-puppet_agent',
-    ref: 'e38bc2113f22f475a245bfa3b453b24b1ef2b063'
+    ref: '319ce44a65e73bcf2712ad17be01f9636f0673c9'
 PUPPETFILE
 
   bolt_command_on(bolt, 'bolt puppetfile install')

--- a/acceptance/tests/apply_ssh.rb
+++ b/acceptance/tests/apply_ssh.rb
@@ -9,9 +9,6 @@ test_name "bolt plan run should apply manifest block on remote hosts via ssh" do
   ssh_nodes = select_hosts(roles: ['ssh'])
   skip_test('no applicable nodes to test on') if ssh_nodes.empty?
 
-  sles_nodes = ssh_nodes.select { |host| host['platform'] =~ /sles/ }
-  skip_test('FIX: agent install does not support SLES') unless sles_nodes.empty?
-
   dir = bolt.tmpdir('apply_ssh')
   fixtures = File.absolute_path('files')
   filepath = File.join('/tmp', SecureRandom.uuid.to_s)

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -930,7 +930,7 @@ bar
               ["facts::powershell", "Gather system facts using powershell"],
               ["facts::ruby", "Gather system facts using ruby and facter"],
               ["package", "Manage and inspect the state of packages"],
-              ["puppet_agent::install", "Install the Puppet 5 agent package"],
+              ["puppet_agent::install", "Install the Puppet agent package"],
               ["puppet_agent::install_powershell", nil],
               ["puppet_agent::install_shell", nil],
               ["puppet_agent::version",


### PR DESCRIPTION
Update the puppet_agent shipped with Bolt to include support for
installing on SLES so apply_prep works.