### PR TITLE
(BOLT-723) Add winrm run_task endpoint

### DIFF
--- a/examples/server-client.rb
+++ b/examples/server-client.rb
@@ -35,9 +35,9 @@ body['task']['metadata'] = {
   "description": "Echo a message",
   "parameters": { "message" => "Hello world!" }
 }
-# This is just so the file isn't overtaken with base64 file content
 file = File.open(File.join(File.dirname(__FILE__), "echo-task"))
-body['task']['file_content'] = file.read
+body['task']['file'] = { 'filename': 'echo.rb',
+                         'file_content': file.read }
 body['target']['hostname'] = 'localhost'
 body['target']['user'] = ENV['BOLT_USER']
 body['target']['password'] = ENV['BOLT_PW']
@@ -48,9 +48,9 @@ make_request(body)
 
 # Second request
 file = File.open(File.join(File.dirname(__FILE__), "package-task"))
-body['task']['file_content'] = file.read
+body['task']['file'] = { 'filename': 'package',
+                         'file_content': file.read }
 body['task']['name'] = 'package::status'
-# This is a little gross but works
 body['parameters'] = { 'name' => 'cowsay',
                        'action' => "status",
                        'version' => "",

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -30,6 +30,10 @@ module Bolt
       if @options['port']
         @port = @options['port']
       end
+
+      if @options['protocol']
+        @protocol = @options['protocol']
+      end
     end
 
     def update_conf(conf)

--- a/lib/bolt/task.rb
+++ b/lib/bolt/task.rb
@@ -5,7 +5,7 @@ module Bolt
     :name,
     :implementations,
     :input_method,
-    :file_content,
+    :file,
     :metadata
   ) do
 

--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -152,6 +152,15 @@ module Bolt
         targets.map { |target| [target] }
       end
 
+      def from_api?(task)
+        if task.respond_to? :file
+          unless task.file.nil?
+            return true
+          end
+        end
+        false
+      end
+
       # Transports should override this method with their own implementation of running a command.
       def run_command(*_args)
         raise NotImplementedError, "run_command() must be implemented by the transport class"

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -117,15 +117,6 @@ module Bolt
         end
       end
 
-      def from_api?(task)
-        if task.respond_to? :file_content
-          unless task.file_content.nil?
-            return true
-          end
-        end
-        false
-      end
-
       def run_task(target, task, arguments, options = {})
         input_method = task.input_method || "both"
         with_connection(target, options.fetch('_load_config', true)) do |conn|
@@ -149,9 +140,9 @@ module Bolt
 
             conn.with_remote_tempdir do |dir|
               if from_api?(task)
-                filename = task.name.split("::").last
+                filename = task.file['filename']
                 remote_task_path = conn.write_executable_from_content(dir,
-                                                                      Base64.decode64(task.file_content),
+                                                                      Base64.decode64(task.file['file_content']),
                                                                       filename)
               else
                 executable = target.select_impl(task, PROVIDED_FEATURES)

--- a/spec/bolt_ext/server_spec.rb
+++ b/spec/bolt_ext/server_spec.rb
@@ -37,7 +37,10 @@ TASK
             'description': 'Echo a message',
             'parameters': { 'message': 'Default message' }
           },
-          'file_content': Base64.encode64(impl)
+          'file': {
+            'file_content': Base64.encode64(impl),
+            'filename': "echo.sh"
+          }
         },
         'target': {
           'hostname': target[:host],
@@ -45,6 +48,46 @@ TASK
           'password': target[:password],
           'port': target[:port],
           'host-key-check': false
+        },
+        'parameters': { "message": "Hello!" }
+      }
+
+      post path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json'
+      expect(last_response).to be_ok
+      expect(last_response.status).to eq(200)
+      result = JSON.parse(last_response.body)
+      expect(result['status']).to eq('success')
+      expect(result['result']['_output'].chomp).to eq('Hello!')
+    end
+  end
+
+  context 'with winrm target', winrm: true do
+    let(:target) { conn_info('winrm') }
+    let(:path) { '/winrm/run_task' }
+
+    it 'runs an echo task' do
+      impl = <<TASK
+param ($message)
+Write-Output "$message"
+TASK
+
+      body = {
+        'task': {
+          'name': 'echo',
+          'metadata': {
+            'description': 'Echo a message',
+            'parameters': { 'message': 'Default message' }
+          },
+          'file': {
+            'filename': 'echo.ps1',
+            'file_content': Base64.encode64(impl)
+          }
+        },
+        'target': {
+          'hostname': target[:host],
+          'user': target[:user],
+          'password': target[:password],
+          'port': target[:port]
         },
         'parameters': { "message": "Hello!" }
       }


### PR DESCRIPTION
This adds a new `/winrm/run_task` endpoint to pe-bolt-server which runs a task on a node over the winrm transport. It currently writes a `.ps1` file to the bolt controller system, and uses that as an executable to run the task over winrm. It also sets the `input_method` to 'powershell' in order for the parameters key to work.