### PR TITLE
(BOLT-805) No host key verify w/ host-key-check=false

### DIFF
--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -93,7 +93,7 @@ module Bolt
           options[:verify_host_key] = if target.options['host-key-check']
                                         Net::SSH::Verifiers::Secure.new
                                       else
-                                        Net::SSH::Verifiers::Lenient.new
+                                        Net::SSH::Verifiers::Null.new
                                       end
           options[:timeout] = target.options['connect-timeout'] if target.options['connect-timeout']
 

--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -69,7 +69,7 @@ BASH
         .with(anything,
               anything,
               hash_including(
-                verify_host_key: instance_of(Net::SSH::Verifiers::Lenient)
+                verify_host_key: instance_of(Net::SSH::Verifiers::Null)
               ))
       ssh.with_connection(make_target(conf: no_host_key_check)) {}
     end


### PR DESCRIPTION
This commit changes the netssh verifier from `lenient` to `null` when `host-key-check` is false. The lenient verifier will raise an exception (HostKeyMismatch) when a target is present in `~/.ssh/known_hosts`, but the key given does not match any known for that target. The `null` verifier does no host-key checking at all.