### PR TITLE
(BOLT-655) Include umask on pe-bolt-server to lock down logfile

### DIFF
--- a/ext/redhat/pe-bolt-server.init
+++ b/ext/redhat/pe-bolt-server.init
@@ -10,6 +10,9 @@
 # Source function library.
 . /etc/rc.d/init.d/functions
 
+#set default privileges to -rw-r-----
+umask 027
+
 [ -f /etc/sysconfig/pe-bolt-server ] && . /etc/sysconfig/pe-bolt-server
 
 prefix='/opt/puppetlabs/server/apps/bolt-server'

--- a/ext/systemd/pe-bolt-server.service
+++ b/ext/systemd/pe-bolt-server.service
@@ -10,6 +10,8 @@ EnvironmentFile=-/etc/default/pe-bolt-server-service
 Environment=GEM_HOME=/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/2.4.0
 ExecStart=/opt/puppetlabs/server/apps/bolt-server/bin/bolt-server -C /opt/puppetlabs/server/apps/bolt-server/puma_config.rb
 Restart=always
+#set default privileges to -rw-r-----
+UMask=027
 KillMode=process
 
 [Install]


### PR DESCRIPTION
Set a umask to prevent bolt-server's logfile being world-readable when
running as a service.