### PR TITLE
(BOLT-722, BOLT-793) Disable ssh-agent, accept private-key-content in bolt-server

### DIFF
--- a/developer-docs/bolt_server.md
+++ b/developer-docs/bolt_server.md
@@ -99,8 +99,10 @@ For example, the following runs 'echo' task on localhost:
 ### SSH Target Object
 The Target be a JSON object. The following keys are available:
 - `hostname`: String, *required* - Target identifier.
-- `user`: String, *required* - Login user
-- `password`: String, *required* - Password for SSH transport authentication.
+- `user`: String, *required* - Login user.
+- *Require one and only one of*
+  - `password`: String - Password for SSH transport authentication.
+  - `private-key-content`: String - Contents of private key for SSH.
 - `port`: Integer, *optional* - Connection port (Default: `22`).
 - `connect-timeout`: Integer, *optional* - How long Bolt should wait when establishing connections.
 - `run-as-command`: Array, *optional* - Command elevate permissions. Bolt appends the user and command strings to the configured `run-as` command before running it on the target. This command must not require an interactive password prompt, and the `sudo-password` option is ignored when `run-as-command` is specified.
@@ -112,7 +114,7 @@ The Target be a JSON object. The following keys are available:
 ### WinRM Target Object
 The Target be a JSON object. The following keys are available:
 - `hostname`: String, *required* - Target identifier.
-- `user`: String, *required* - Login user
+- `user`: String, *required* - Login user.
 - `password`: String, *required* - Password for WinRM transport authentication.
 - `port`: Integer, *optional* - Connection port (Default: `5986`, or `5985` if `ssl: false`.)
 - `connect-timeout`: Integer, *optional* - How long Bolt should wait when establishing connections.

--- a/lib/bolt_ext/server.rb
+++ b/lib/bolt_ext/server.rb
@@ -23,14 +23,9 @@ class TransportAPI < Sinatra::Base
 
     executor = Bolt::Executor.new(load_config: false)
 
-    # Since this will only be on one node we can just set r to the result
-    executor.run_task(target, task, parameters) do |event|
-      if event[:type] == :node_result
-        @r = event[:result].to_json
-      end
-
-      [200, [@r]]
-    end
+    # Since this will only be on one node we can just return the first result
+    results = executor.run_task(target, task, parameters)
+    [200, results.first.to_json]
   end
 
   post '/winrm/run_task' do
@@ -46,12 +41,8 @@ class TransportAPI < Sinatra::Base
 
     executor = Bolt::Executor.new(load_config: false)
 
-    executor.run_task(target, task, parameters) do |event|
-      if event[:type] == :node_result
-        @r = event[:result].to_json
-      end
-
-      [200, [@r]]
-    end
+    # Since this will only be on one node we can just return the first result
+    results = executor.run_task(target, task, parameters)
+    [200, results.first.to_json]
   end
 end


### PR DESCRIPTION
When the Executor is asked not to load config, include the `ssh-agent` in that. The Executor is expected not to use any external SSH input in this mode.

Use `private-key-content` if passed to `/ssh/run_task`. Error if both `private-key-content` and `password` are set.