### PR TITLE
(BOLT-807) Serialize environment input as JSON in local transport

### DIFF
--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -75,6 +75,15 @@ module Bolt
         end
       end
 
+      # Transform a parameter map to an environment variable map, with parameter names prefixed
+      # with 'PT_' and values transformed to JSON unless they're strings.
+      def envify_params(params)
+        params.each_with_object({}) do |(k, v), h|
+          v = v.to_json unless v.is_a?(String)
+          h["PT_#{k}"] = v
+        end
+      end
+
       # Raises an error if more than one target was given in the batch.
       #
       # The default implementations of batch_* strictly assume the transport is

--- a/lib/bolt/transport/local.rb
+++ b/lib/bolt/transport/local.rb
@@ -86,7 +86,7 @@ module Bolt
 
         input_method = task.input_method || "both"
         stdin = STDIN_METHODS.include?(input_method) ? JSON.dump(arguments) : nil
-        env = ENVIRONMENT_METHODS.include?(input_method) ? arguments : nil
+        env = ENVIRONMENT_METHODS.include?(input_method) ? envify_params(arguments) : nil
 
         with_tmpscript(executable, target.options['tmpdir']) do |script|
           logger.debug("Running '#{script}' with #{arguments}")

--- a/lib/bolt/transport/local/shell.rb
+++ b/lib/bolt/transport/local/shell.rb
@@ -8,10 +8,7 @@ module Bolt
     class Local
       class Shell
         def execute(*command, options)
-          if options[:env]
-            env = options[:env].each_with_object({}) { |(k, v), h| h["PT_#{k}"] = v.to_s }
-            command = [env] + command
-          end
+          command = [options[:env]] + command if options[:env]
 
           if options[:stdin]
             stdout, stderr, rc = Open3.capture3(*command, stdin_data: options[:stdin])

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -134,11 +134,7 @@ module Bolt
             end
 
             if ENVIRONMENT_METHODS.include?(input_method)
-              environment = arguments.inject({}) do |env, (param, val)|
-                val = val.to_json unless val.is_a?(String)
-                env.merge("PT_#{param}" => val)
-              end
-              execute_options[:environment] = environment
+              execute_options[:environment] = envify_params(arguments)
             end
 
             conn.with_remote_tempdir do |dir|

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -114,12 +114,11 @@ catch
           end
 
           if ENVIRONMENT_METHODS.include?(input_method)
-            arguments.each do |(arg, val)|
-              val = val.to_json unless val.is_a?(String)
-              cmd = "[Environment]::SetEnvironmentVariable('PT_#{arg}', @'\n#{val}\n'@)"
+            envify_params(arguments).each do |(arg, val)|
+              cmd = "[Environment]::SetEnvironmentVariable('#{arg}', @'\n#{val}\n'@)"
               result = conn.execute(cmd)
               if result.exit_code != 0
-                raise EnvironmentVarError(var, value)
+                raise Bolt::Node::EnvironmentVarError.new(arg, val)
               end
             end
           end

--- a/spec/bolt/transport/local_spec.rb
+++ b/spec/bolt/transport/local_spec.rb
@@ -122,6 +122,15 @@ SHELLWORDS
       end
     end
 
+    it "serializes hashes as json in environment input" do
+      contents = "#!/bin/sh\nprintenv PT_message"
+      arguments = { message: { key: 'val' } }
+      with_task_containing('tasks_test_hash', contents, 'environment') do |task|
+        expect(local.run_task(target, task, arguments).value)
+          .to eq('key' => 'val')
+      end
+    end
+
     it "can run a task passing input on stdin and environment" do
       contents = <<SHELL
 #!/bin/sh

--- a/spec/bolt/transport/winrm_spec.rb
+++ b/spec/bolt/transport/winrm_spec.rb
@@ -401,6 +401,16 @@ SHELLWORDS
       end
     end
 
+    it 'errors if environment variables cannot be set', winrm: true do
+      contents = 'Write-Host "$env:PT_message"'
+      arguments = { message: "it's a hello world" }
+      result = double('result', exit_code: 1)
+      expect_any_instance_of(Bolt::Transport::WinRM::Connection).to receive(:execute).and_return(result)
+      with_task_containing('task-test-winrm', contents, 'environment', '.ps1') do |task|
+        expect { winrm.run_task(target, task, arguments) }.to raise_error(Bolt::Node::EnvironmentVarError)
+      end
+    end
+
     it "ignores _run_as", winrm: true do
       contents = 'Write-Host "$env:PT_message_one ${env:PT_message two}"'
       arguments = { message_one: 'task is running',


### PR DESCRIPTION
Previously serializing environment input as JSON was fixed for SSH and
WinRM, but the Local transport was missed. Fix it.