### PR TITLE
(maint) Hard-code GEM_PATH for bolt-server

### DIFF
--- a/ext/redhat/pe-bolt-server.init
+++ b/ext/redhat/pe-bolt-server.init
@@ -16,7 +16,7 @@ umask 027
 [ -f /etc/sysconfig/pe-bolt-server ] && . /etc/sysconfig/pe-bolt-server
 
 prefix='/opt/puppetlabs/server/apps/bolt-server'
-export GEM_HOME="${prefix}/lib/ruby/gems/2.4.0"
+export GEM_PATH="${prefix}/lib/ruby/gems/2.4.0:/opt/puppetlabs/puppet/lib/ruby/gems/2.4.0:/opt/puppetlabs/puppet/lib/ruby/vendor_gems"
 exec="${prefix}/bin/bolt-server"
 prog="bolt-server"
 desc="PE Bolt Server"

--- a/ext/systemd/pe-bolt-server.service
+++ b/ext/systemd/pe-bolt-server.service
@@ -7,7 +7,7 @@ User=pe-bolt-server
 Group=pe-bolt-server
 EnvironmentFile=-/etc/sysconfig/pe-bolt-server-service
 EnvironmentFile=-/etc/default/pe-bolt-server-service
-Environment=GEM_HOME=/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/2.4.0
+Environment=GEM_PATH=/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/2.4.0:/opt/puppetlabs/puppet/lib/ruby/gems/2.4.0:/opt/puppetlabs/puppet/lib/ruby/vendor_gems
 ExecStart=/opt/puppetlabs/server/apps/bolt-server/bin/bolt-server -C /opt/puppetlabs/server/apps/bolt-server/puma_config.rb
 Restart=always
 #set default privileges to -rw-r-----


### PR DESCRIPTION
GEM_HOME appears to be appended to GEM_PATH. If a different version of
Bolt is installed in puppet-agent, that impacts how bolt-server
functions. Set GEM_PATH instead to ensure we use the bolt-server
specific gems first.

This ties bolt-server's service config more closely to the puppet-agent
Ruby setup, since we have to include its GEM_PATH as well.