### PR TITLE
(BOLT-812) Bolt correctly identifies missing Puppet on newer Powershell

### DIFF
--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -121,7 +121,9 @@ module Bolt
             'msg' => "Puppet is not installed on the target, please install it to enable 'apply'",
             'kind' => 'bolt/apply-error'
           })
-      elsif exit_code == 1 && error_hash['msg'] =~ /Could not find executable 'ruby.exe'/
+      elsif exit_code == 1 &&
+            (error_hash['msg'] =~ /Could not find executable 'ruby.exe'/ ||
+             error_hash['msg'] =~ /The term 'ruby.exe' is not recognized as the name of a cmdlet/)
         # Windows does not have Ruby present
         Result.new(result.target, error:
           {


### PR DESCRIPTION
On newer versions of powershell, such as the one in Nano Server that we
use for local testing, the error reported when trying to run 'apply'
changed from `Could not find executable 'ruby.exe'` to `The term
'ruby.exe' is not recognized as the name of a cmdlet`. This does not
seem to apply to older versions of Powershell such as used in AppVeyor
CI. Correctly match the new error string and report that Puppet is not
installed when trying to use `apply`.