### PR TITLE
(BOLT-813) Expand tilde in nodes file path

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -306,7 +306,7 @@ Available options are:
     end
 
     def read_arg_file(file)
-      File.read(file)
+      File.read(File.expand_path(file))
     rescue StandardError => err
       raise Bolt::FileError.new("Error attempting to read #{file}: #{err}", file)
     end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -210,6 +210,13 @@ bar
         end
       end
 
+      it "expands tilde to a user directory when --nodes starts with @" do
+        expect(File).to receive(:read).with(File.join(Dir.home, 'nodes.txt')).and_return("foo\nbar\n")
+        cli = Bolt::CLI.new(%w[command run --nodes @~/nodes.txt])
+        result = cli.parse
+        expect(result[:targets]).to eq(targets)
+      end
+
       it "generates an error message if no nodes given" do
         cli = Bolt::CLI.new(%w[command run --nodes])
         expect {


### PR DESCRIPTION
Let `bolt command run whoami --nodes @~/hosts.csv` find the `hosts.csv`
file in your home directory.

Fixes #600