### PR TITLE
(BOLT-664) Upload file from memory over WinRM

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,11 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 ENV['BOLT_DISABLE_ANALYTICS'] = 'true'
 
 gemspec
-gem  "winrm-fs", git: "https://github.com/donoghuc/winrm-fs.git", branch: "BOLT-664"
 gem "hocon"
 gem "puma"
 gem "rack"
 gem "sinatra"
+gem "winrm-fs", git: "https://github.com/donoghuc/winrm-fs.git", branch: "BOLT-664"
 
 # Required to pick up plan specs in the rake spec task
 gem "puppetlabs_spec_helper",

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 ENV['BOLT_DISABLE_ANALYTICS'] = 'true'
 
 gemspec
+gem  "winrm-fs", git: "https://github.com/donoghuc/winrm-fs.git", branch: "BOLT-664"
 gem "hocon"
 gem "puma"
 gem "rack"

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem "hocon"
 gem "puma"
 gem "rack"
 gem "sinatra"
-gem "winrm-fs", git: "https://github.com/donoghuc/winrm-fs.git", branch: "BOLT-664"
 
 # Required to pick up plan specs in the rake spec task
 gem "puppetlabs_spec_helper",

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "r10k", "~> 2.6"
   spec.add_dependency "terminal-table", "~> 1.8"
   spec.add_dependency "winrm", "~> 2.0"
-  spec.add_dependency "winrm-fs", "~> 1.1"
+  spec.add_dependency "winrm-fs", "~> 1.3"
 
   # Dependencies of our vendored puppet, etc
   spec.add_dependency "CFPropertyList", "~> 2.2"

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -104,13 +104,9 @@ catch
 
       def run_task(target, task, arguments, _options = {})
         if from_api?(task)
-          # TODO: Remove as part of BOLT-664
-          dir = Dir.mktmpdir
-          executable = File.join(dir, task.file['filename'])
-          File.open(executable, 'w') { |f|
-            f.write(Base64.decode64(task.file['file_content']))
-          }
-          task.input_method = powershell_file?(executable) ? 'powershell' : 'both'
+          task.input_method = powershell_file?(task["file"]["filename"]) ? 'powershell' : 'both'
+          executable = { filename: task["file"]["filename"],
+                         file_content: StringIO.new(Base64.decode64(task.file['file_content']))} 
         else
           executable = target.select_impl(task, PROVIDED_FEATURES)
           raise "No suitable implementation of #{task.name} for #{target.name}" unless executable
@@ -157,9 +153,6 @@ try { & "#{remote_path}" @taskArgs } catch { Write-Error $_.Exception; exit 1 }
                 conn.execute_process(path, args, stdin)
               end
 
-            if from_api?(task)
-              FileUtils.remove_entry dir
-            end
             Bolt::Result.for_task(target, output.stdout.string,
                                   output.stderr.string,
                                   output.exit_code)

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -355,16 +355,23 @@ PS
         end
 
         def with_remote_file(file)
-          ext = File.extname(file)
+          if file.is_a?(Hash)
+            ext = File.extname(file[:filename])
+            file_base = File.basename(file[:filename])
+            from_mem = true
+          elsif File.file?(file)
+            ext = File.extname(file)
+            file_base = File.basename(file)
+          end
+
           unless @extensions.include?(ext)
             raise Bolt::Node::FileError.new("File extension #{ext} is not enabled, "\
                                 "to run it please add to 'winrm: extensions'", 'FILETYPE_ERROR')
           end
-          file_base = File.basename(file)
           dir = make_tempdir
           dest = "#{dir}\\#{file_base}"
           begin
-            write_remote_file(file, dest)
+            write_remote_file(from_mem ? file[:file_content] : file, dest)
             shell_init
             yield dest
           ensure

--- a/spec/bolt/transport/winrm_spec.rb
+++ b/spec/bolt/transport/winrm_spec.rb
@@ -229,6 +229,14 @@ PS
       end
     end
 
+    it "catches winrm-fs upload error", winrm: true do
+      expect_node_error(Bolt::Node::FileError,
+                        'WRITE_ERROR',
+                        /No such file or directory/) do
+        winrm.run_script(target, 'fake.ps1', [])
+      end
+    end
+
     it "can run a PowerShell script remotely", winrm: true do
       contents = "Write-Output \"hellote\""
       with_tempfile_containing('script-test-winrm', contents, '.ps1') do |file|


### PR DESCRIPTION
This commit uses a modified winrm-fs library to upload file contents received by the bolt-server API from memory instead of writing to a temporary file. The modifications to winrm-fs will be included in Bolt by extending relevant winrm-fs classes to avoid being blocked on changes getting accepted to winrm-fs. The winrm-fs work is currently being tracked with https://github.com/donoghuc/winrm-fs/tree/BOLT-664.