### PR TITLE
(BOLT-754) Use rails-auth to enforce a whitelist

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gemspec
 gem "hocon"
 gem "puma"
 gem "rack"
+gem "rails-auth"
 gem "sinatra"
 
 # Required to pick up plan specs in the rake spec task

--- a/lib/bolt_ext/server_acl.rb
+++ b/lib/bolt_ext/server_acl.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails/auth/rack'
+
+class TransportACL < Rails::Auth::ErrorPage::Middleware
+  class X509Matcher
+    def initialize(options)
+      @options = options.freeze
+    end
+
+    def match(env)
+      certificate = Rails::Auth::X509::Certificate.new(env['puma.peercert'])
+      # This can be extended fairly easily to search OpenSSL::X509::Certificate#extensions for subjectAltNames.
+      @options.all? { |name, value| certificate[name] == value }
+    end
+  end
+
+  def initialize(app, whitelist)
+    acls = []
+    whitelist.each do |entry|
+      acls << {
+        'resources' => [
+          {
+            'method' => 'ALL',
+            'path' => '/.*'
+          }
+        ],
+        'allow_x509_subject' => {
+          'cn' => entry
+        }
+      }
+    end
+    acl = Rails::Auth::ACL.new(acls, matchers: { allow_x509_subject: X509Matcher })
+    mid = Rails::Auth::ACL::Middleware.new(app, acl: acl)
+    super(mid, page_body: 'Access denied')
+  end
+end

--- a/lib/bolt_ext/server_config.rb
+++ b/lib/bolt_ext/server_config.rb
@@ -3,7 +3,7 @@
 require 'hocon'
 
 class TransportConfig
-  attr_accessor :host, :port, :ssl_cert, :ssl_key, :ssl_ca_cert, :loglevel, :logfile
+  attr_accessor :host, :port, :ssl_cert, :ssl_key, :ssl_ca_cert, :loglevel, :logfile, :whitelist
 
   def initialize(global = nil, local = nil)
     @host = '127.0.0.1'
@@ -14,6 +14,7 @@ class TransportConfig
 
     @loglevel = 'notice'
     @logfile = nil
+    @whitelist = nil
 
     global_path = global || '/etc/puppetlabs/bolt-server/conf.d/bolt-server.conf'
     local_path = local || File.join(ENV['HOME'].to_s, ".puppetlabs", "bolt-server.conf")
@@ -33,7 +34,7 @@ class TransportConfig
     end
 
     unless parsed_hocon.nil?
-      %w[host port ssl-cert ssl-key ssl-ca-cert loglevel logfile].each do |key|
+      %w[host port ssl-cert ssl-key ssl-ca-cert loglevel logfile whitelist].each do |key|
         varname = '@' + key.tr('-', '_')
         instance_variable_set(varname, parsed_hocon[key]) if parsed_hocon.key?(key)
       end
@@ -57,6 +58,10 @@ You must configure #{k} in either /etc/puppetlabs/bolt-server/conf.d/bolt-server
       unless File.file?(send(sk)) && File.readable?(send(sk))
         raise Bolt::ValidationError, "Configured #{sk} must be a valid filepath"
       end
+    end
+
+    unless @whitelist.nil? || @whitelist.is_a?(Array)
+      raise Bolt::ValidationError, "Configured 'whitelist' must be an array of names"
     end
   end
 end

--- a/spec/bolt_ext/server_acl_spec.rb
+++ b/spec/bolt_ext/server_acl_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_ext/server_acl'
+require 'json'
+require 'rack/test'
+
+def x509_certificate(name)
+  cert = OpenSSL::X509::Certificate.new
+  cert.subject = OpenSSL::X509::Name.parse("/CN=#{name}")
+  cert
+end
+
+describe TransportACL do
+  include Rack::Test::Methods
+
+  let(:yes_app) { ->(_) { [200, { 'Content-Type' => 'text/plain' }, ['OK']] } }
+  let(:app) { described_class.new(yes_app, whitelist) }
+
+  context 'with empty whitelist' do
+    let(:whitelist) { [] }
+
+    it 'rejects all requests' do
+      get '/'
+      expect(last_response).not_to be_ok
+      expect(last_response.status).to eq(403)
+      expect(last_response.body).to eq('Access denied')
+    end
+  end
+
+  context 'with whitelist' do
+    let(:whitelist) { %w[cert1 cert2] }
+
+    it 'accepts requests from whitelisted certs' do
+      whitelist.each do |name|
+        get '/', {}, 'HTTPS' => 'on', 'puma.peercert' => x509_certificate(name)
+
+        expect(last_response).to be_ok
+        expect(last_response.status).to eq(200)
+      end
+    end
+
+    it 'rejects requests from other certs' do
+      get '/', {}, 'HTTPS' => 'on', 'puma.peercert' => x509_certificate('invalid')
+
+      expect(last_response).not_to be_ok
+      expect(last_response.status).to eq(403)
+    end
+  end
+end

--- a/spec/fixtures/configs/bad-whitelist.conf
+++ b/spec/fixtures/configs/bad-whitelist.conf
@@ -1,0 +1,3 @@
+bolt-server: {
+  whitelist: 'name'
+}

--- a/spec/fixtures/configs/global-bolt-server.conf
+++ b/spec/fixtures/configs/global-bolt-server.conf
@@ -7,4 +7,5 @@ bolt-server: {
 
     loglevel: debug
     logfile: /var/log/global
+    whitelist: [a]
 }

--- a/spec/fixtures/configs/local-bolt-server.conf
+++ b/spec/fixtures/configs/local-bolt-server.conf
@@ -7,4 +7,5 @@ bolt-server: {
 
     loglevel: info
     logfile: /var/log/local
+    whitelist: [b]
 }


### PR DESCRIPTION
Allow configuring a whitelist as an array of certnames. Use rails-auth to enforce the whitelist of services allowed to make requests via bolt-server.