### PR TITLE
(BOLT-809) Add 'concurrency' option to configure bolt-server threads

### DIFF
--- a/lib/bolt_ext/server_config.rb
+++ b/lib/bolt_ext/server_config.rb
@@ -3,7 +3,7 @@
 require 'hocon'
 
 class TransportConfig
-  attr_accessor :host, :port, :ssl_cert, :ssl_key, :ssl_ca_cert, :loglevel, :logfile, :whitelist
+  attr_accessor :host, :port, :ssl_cert, :ssl_key, :ssl_ca_cert, :loglevel, :logfile, :whitelist, :concurrency
 
   def initialize(global = nil, local = nil)
     @host = '127.0.0.1'
@@ -15,6 +15,7 @@ class TransportConfig
     @loglevel = 'notice'
     @logfile = nil
     @whitelist = nil
+    @concurrency = 100
 
     global_path = global || '/etc/puppetlabs/bolt-server/conf.d/bolt-server.conf'
     local_path = local || File.join(ENV['HOME'].to_s, ".puppetlabs", "bolt-server.conf")
@@ -34,7 +35,7 @@ class TransportConfig
     end
 
     unless parsed_hocon.nil?
-      %w[host port ssl-cert ssl-key ssl-ca-cert loglevel logfile whitelist].each do |key|
+      %w[host port ssl-cert ssl-key ssl-ca-cert loglevel logfile whitelist concurrency].each do |key|
         varname = '@' + key.tr('-', '_')
         instance_variable_set(varname, parsed_hocon[key]) if parsed_hocon.key?(key)
       end
@@ -62,6 +63,10 @@ You must configure #{k} in either /etc/puppetlabs/bolt-server/conf.d/bolt-server
 
     unless @whitelist.nil? || @whitelist.is_a?(Array)
       raise Bolt::ValidationError, "Configured 'whitelist' must be an array of names"
+    end
+
+    unless @concurrency.is_a?(Integer) && @concurrency.positive?
+      raise Bolt::ValidationError, "Configured 'concurrency' must be a positive integer"
     end
   end
 end

--- a/puma_config.rb
+++ b/puma_config.rb
@@ -36,6 +36,8 @@ bind_addr << "&ca=#{config.ssl_ca_cert}"
 bind_addr << "&verify_mode=force_peer"
 bind bind_addr
 
+threads 0, config.concurrency
+
 impl = TransportAPI.new
 unless config.whitelist.nil?
   impl = TransportACL.new(impl, config.whitelist)

--- a/spec/fixtures/configs/global-bolt-server.conf
+++ b/spec/fixtures/configs/global-bolt-server.conf
@@ -8,4 +8,5 @@ bolt-server: {
     loglevel: debug
     logfile: /var/log/global
     whitelist: [a]
+    concurrency: 12
 }

--- a/spec/fixtures/configs/local-bolt-server.conf
+++ b/spec/fixtures/configs/local-bolt-server.conf
@@ -8,4 +8,5 @@ bolt-server: {
     loglevel: info
     logfile: /var/log/local
     whitelist: [b]
+    concurrency: 1
 }


### PR DESCRIPTION
In bolt-server, concurrency is synonymous with how many threads are
available to process run task requests. Allow configuring the max number
of server threads with `concurrency`, which defaults to 100.