### PR TITLE
(BOLT-750) Remove apply module and apply::resource task

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -7,7 +7,6 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 mod 'puppetlabs-package', '0.2.0'
 mod 'puppetlabs-service', '0.3.1'
 mod 'puppetlabs-puppet_conf', '0.2.0'
-mod 'puppetlabs-apply', '0.1.0'
 mod 'puppetlabs-facts', '0.2.0'
 mod 'puppet_agent',
     git: 'https://github.com/puppetlabs/puppetlabs-puppet_agent',

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -929,28 +929,15 @@ bar
           }
           cli.execute(options)
           json = JSON.parse(output.string)
-          expect(json).to eq(
-            [
-              ["apply::resource", "Apply a single Puppet resource"],
-              ["facts", "Gather system facts"],
-              ["facts::bash", "Gather system facts using bash"],
-              ["facts::powershell", "Gather system facts using powershell"],
-              ["facts::ruby", "Gather system facts using ruby and facter"],
-              ["package", "Manage and inspect the state of packages"],
-              ["puppet_agent::install", "Install the Puppet agent package"],
-              ["puppet_agent::install_powershell", nil],
-              ["puppet_agent::install_shell", nil],
-              ["puppet_agent::version",
-               "Get the version of the Puppet 5 agent package installed. Returns nothing if none present."],
-              ["puppet_agent::version_powershell", nil],
-              ["puppet_agent::version_shell", nil],
-              ["puppet_conf", "Inspect puppet agent configuration settings"],
-              ["sample::ok", nil],
-              ["service", "Manage and inspect the state of services"],
-              ["service::linux", "Manage the state of services (without a puppet agent)"],
-              ["service::windows", "Manage the state of Windows services (without a puppet agent)"]
-            ]
-          )
+          tasks = [
+            ["package", "Manage and inspect the state of packages"],
+            ["service", "Manage and inspect the state of services"],
+            ["service::linux", "Manage the state of services (without a puppet agent)"],
+            ["service::windows", "Manage the state of Windows services (without a puppet agent)"]
+          ]
+          tasks.each do |task|
+            expect(json).to include(task)
+          end
           output = @log_output.readlines.join
           expect(output).to match(/unexpected token.*params\.json/m)
         end


### PR DESCRIPTION
This module was an experimental inclusion to provide basic functionality
to reuse existing Puppet resource types. Since we've now introduced the
apply() keyword as a general, supported solution to this problem, the
apply module is no longer necessary. We're choosing to immediately
remove this rather than add a deprecation based on the fact that we have
no known users of the feature.