### PR TITLE
(BOLT-794) Adjustments to sensitive handling

### DIFF
--- a/bolt-modules/boltlib/spec/functions/run_task_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_spec.rb
@@ -241,21 +241,6 @@ describe 'run_task' do
       let(:result_set) { Bolt::ResultSet.new([result]) }
       let(:task_params) { {} }
 
-      it 'with Sensitive types - matches parameter metadata' do
-        executable = File.join(tasks_root, 'sensitive_type.sh')
-        task_params.merge!(
-          'sensitive_string' => Sensitive.new(sensitive_string),
-          'sensitive_array'  => Sensitive.new(sensitive_array),
-          'sensitive_hash'   => Sensitive.new(sensitive_hash)
-        )
-
-        executor.expects(:run_task).with([target], mock_task(executable, nil), task_params, {})
-                .returns(result_set)
-        inventory.expects(:get_targets).with(hostname).returns([target])
-
-        is_expected.to run.with_params('Test::Sensitive_Type', hostname, task_params).and_return(result_set)
-      end
-
       it 'with Sensitive metadata - input parameters are wrapped in Sensitive' do
         executable = File.join(tasks_root, 'sensitive_meta.sh')
         input_params = {
@@ -355,7 +340,7 @@ describe 'run_task' do
       )
     end
 
-    it "errors when a specified parameter value is not Boltlib::ArgsSpec" do
+    it "errors when a specified parameter value is not Data" do
       task_params.merge!(
         'mandatory_string'  => 'str',
         'mandatory_integer' => 10,
@@ -364,7 +349,7 @@ describe 'run_task' do
       )
 
       is_expected.to run.with_params(task_name, hostname, task_params).and_raise_error(
-        Puppet::ParseError, /Task parameters are not of type Boltlib::ArgsSpec. run_task()/
+        Puppet::ParseError, /Task parameters are not of type Data. run_task()/
       )
     end
   end

--- a/bolt-modules/boltlib/types/argsspec.pp
+++ b/bolt-modules/boltlib/types/argsspec.pp
@@ -1,9 +1,0 @@
-# ArgsSpec represent the acceptable types to pass as arguments into the run_xxx() functions:
-#   - run_script()
-#   - run_plan()
-#   - run_task()
-#
-# @note this is simply module Puppet::Pops::Loader::StaticLoader::BUILTIN_ALIASES['Data']
-#       but it also has Sensitive within it and also does recursion with itself instead of the
-#       Data alias (necessary for nested Sensitive types)
-type Boltlib::ArgsSpec = Variant[Sensitive[Boltlib::ArgsSpec], ScalarData, Undef, Hash[String, Boltlib::ArgsSpec], Array[Boltlib::ArgsSpec]]

--- a/pre-docs/writing_plans.md
+++ b/pre-docs/writing_plans.md
@@ -292,7 +292,7 @@ $r.each |$result| {
 
 ## Passing sensitive data to tasks
 
-Tasks can define parameters to be `Sensitive`, meaning the parameter values will not be logged by Bolt.
+Tasks can define parameters to be `sensitive`, meaning the parameter values will not be logged by Bolt.
 
 If a parameter is declared with `"sensitive": true` within the task's metadata, then the task
 can be run normally. Bolt will automatically ensure that this parameter is not logged using
@@ -300,14 +300,6 @@ the metadata for that parameter.
 
 ```
 run_task('task_with_secrets', ..., password => '$ecret!')
-```
-
-Alternatively parameters can have a `Sensitive` type defined within the task metadata.
-In this case, when calling the task, the plan author must create a `Sensitive` data type
-and pass that into the `run_task()` function.
-
-```
-run_task('task_with_sensitive_type', ..., password => Sensitive('$ecret!'))
 ```
 
 ## Target objects

--- a/pre-docs/writing_plans.md
+++ b/pre-docs/writing_plans.md
@@ -302,6 +302,19 @@ the metadata for that parameter.
 run_task('task_with_secrets', ..., password => '$ecret!')
 ```
 
+### Working with the Sensitive type
+
+In Puppet the `Sensitive` type can be used to mask data from being output to logs.
+Since Plans are simply written in Puppet DSL this type can be used freely.
+The `run_task()` function does not allow parameters of `Sensitive` type to be passed.
+If a `Sensitive` vlue needs to be passed to a task, it must be unwrapped prior to
+the `run_task()` function call. 
+
+```
+$pass = Sensitive('$ecret!')
+run_task('task_with_secrets', ..., password => $pass.unwrap)
+```
+
 ## Target objects
 
 The `Target` object represents a node and its specific connection options.

--- a/pre-docs/writing_tasks.md
+++ b/pre-docs/writing_tasks.md
@@ -684,7 +684,6 @@ Some types supported by Puppet can not be represented as JSON, such as `Hash[Int
 | `Hash` |Matches a JSON object.|
 | `Variant[Integer, Pattern[/\A\d+\Z/]]` |Matches an integer or a String of an integer|
 | `Boolean` |Accepts Boolean values.|
-| `Sensitive` |Identifies data as sensitive. Values are masked when they appear in logs and API responses.|
 
 **Related information**  
 

--- a/pre-docs/writing_tasks.md
+++ b/pre-docs/writing_tasks.md
@@ -604,11 +604,7 @@ For example, the following code in a metadata file describes a `provider` parame
 
 ### Making parameters sensitive
 
-To prevent a task parameter's value from being written to the Bolt logs in plain-text the `Sensitive` property can be associated with the parameter. This construct should be used for things like passwords, API keys, secrets, etc.
-
-There are two options for defining a task parameter as `Sensitive`:
-
-1) Specify the `"sensitive": true` property on the parameter within the JSON metadata [**PREFERRED**]:
+To prevent a task parameter's value from being written to the Bolt logs in plain-text the `sensitive` property can be associated with the parameter in the task's metadata. This construct should be used for things like passwords, API keys, secrets, etc.
 
 ```
 {
@@ -628,25 +624,10 @@ There are two options for defining a task parameter as `Sensitive`:
 }
 ```
 
-2) Wrap the parameter with `Sensitive` in the `type` property within the JSON metadata: 
+When a parameter is `sensitive` the only expectation, currently, is that the parameter
+will not be logged (except when passing `--debug`). No other precautions are taken.
 
-```
-{
-  "description": "Task has a sensitive property denoted by its type",
-  "input_method": "stdin",
-  "parameters": {
-    "password": {
-      "description": "The password",
-      "type": "Sensitive[String[1]]",
-    }
-  }
-}
-```
-
-When a parameter is `Sensitive` the only expectation, currently, is that the parameter
-will not be logged. No other precautions are taken.
-
-It is up to the task author to implement their tasks in such a way that `Sensitive`
+It is up to the task author to implement their tasks in such a way that `sensitive`
 parameters are not exposed or logged. Please be mindful when coding your tasks!
 
 


### PR DESCRIPTION
### Changes

* Plans can no longer pass in `Sensitive` typed arguments
* `run_task()` validates input parameters against the `Data` type once again
* The `Boltlib::ArgsSpec` type has been removed, since `Sensitive` is no longer accepted as an argument type.
* The `Sensitive` type is no longer listed in the `writing_tasks` documentation for acceptable parameter data types


### Remains the same

* Task authors can still specify `"sensitive": true` on parameters and they will be wrapped with `Sensitive` under the hood and not logged (except in `--debug` mode).