### PR TITLE
(BOLT-855) Make Deferred work in 'apply'

### DIFF
--- a/libexec/apply_catalog.rb
+++ b/libexec/apply_catalog.rb
@@ -6,6 +6,7 @@ require 'json'
 require 'puppet'
 require 'puppet/configurer'
 require 'puppet/module_tool/tar'
+require 'securerandom'
 require 'tempfile'
 
 args = JSON.parse(ARGV[0] ? File.read(ARGV[0]) : STDIN.read)
@@ -58,7 +59,7 @@ begin
   end
 
   # Ensure custom facts are available for provider suitability tests
-  Puppet::Node::Facts.indirection.find('puppetversion', environment: env)
+  facts = Puppet::Node::Facts.indirection.find(SecureRandom.uuid, environment: env)
 
   report = if Puppet::Util::Package.versioncmp(Puppet.version, '5.0.0') > 0
              Puppet::Transaction::Report.new
@@ -69,9 +70,14 @@ begin
   Puppet.override(current_environment: env,
                   environments: Puppet::Environments::Static.new(env),
                   loaders: Puppet::Pops::Loaders.new(env)) do
-    catalog = Puppet::Resource::Catalog.from_data_hash(args['catalog']).to_ral
+    catalog = Puppet::Resource::Catalog.from_data_hash(args['catalog'])
     catalog.environment = env.name.to_s
     catalog.environment_instance = env
+    if defined?(Puppet::Pops::Evaluator::DeferredResolver)
+      # Only available in Puppet 6
+      Puppet::Pops::Evaluator::DeferredResolver.resolve_and_replace(facts, catalog)
+    end
+    catalog = catalog.to_ral
 
     configurer = Puppet::Configurer.new
     configurer.run(catalog: catalog, report: report, pluginsync: false)

--- a/spec/fixtures/apply/basic/lib/puppet/functions/pid.rb
+++ b/spec/fixtures/apply/basic/lib/puppet/functions/pid.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Puppet::Functions.create_function(:pid) do
+  def pid
+    Process.pid.to_s
+  end
+end

--- a/spec/fixtures/apply/basic/plans/defer.pp
+++ b/spec/fixtures/apply/basic/plans/defer.pp
@@ -1,0 +1,10 @@
+plan basic::defer(TargetSpec $nodes) {
+  return apply($nodes) {
+    notify { 'local pid':
+      message => pid(),
+    }
+    notify { 'remote pid':
+      message => Deferred('pid', []),
+    }
+  }
+}

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -84,6 +84,19 @@ describe "apply" do
         resources = result[0]['result']['report']['resource_statuses']
         expect(resources).to include('Notify[hello world]')
       end
+
+      it 'applies the deferred type' do
+        result = run_cli_json(%w[plan run basic::defer] + config_flags)
+        expect(result).not_to include('kind')
+        expect(result[0]['status']).to eq('success')
+        resources = result[0]['result']['report']['resource_statuses']
+
+        local_pid = resources['Notify[local pid]']['events'][0]['desired_value'][/(\d+)/, 1]
+        raise 'local pid was not found' if local_pid.nil?
+        remote_pid = resources['Notify[remote pid]']['events'][0]['desired_value'][/(\d+)/, 1]
+        raise 'remote pid was not found' if remote_pid.nil?
+        expect(local_pid).not_to eq(remote_pid)
+      end
     end
   end
 end


### PR DESCRIPTION
Makes the `Deferred` type work in `apply` statements. This type allows
Puppet functions to be invoked when the catalog is being applied on the
agent rather than during compilation.