### PR TITLE
(BOLT-751) Rename file_upload function to upload_file

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/file_upload.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/file_upload.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# This function wraps the upload_file function with a deprecation warning, for backward compatibility.
+Puppet::Functions.create_function(:file_upload, Puppet::Functions::InternalFunction) do
+  def file_upload(*args)
+    executor = Puppet.lookup(:bolt_executor) { nil }
+    executor&.report_function_call('file_upload')
+
+    file, line = Puppet::Pops::PuppetStack.top_of_stack
+
+    msg = "The file_upload function is deprecated and will be removed; use upload_file instead"
+    Puppet.puppet_deprecation_warning(msg, key: 'bolt-function/file_upload', file: file, line: line)
+
+    call_function('upload_file', *args)
+  end
+end

--- a/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
@@ -13,7 +13,7 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
   # @example Run a local script on Linux targets as 'root'
   #   run_script('/var/tmp/myscript', $targets, '_run_as' => 'root')
   # @example Run a module-provided script with arguments
-  #   file_upload('iis/setup.ps1', $target, 'arguments' => ['/u', 'Administrator'])
+  #   run_script('iis/setup.ps1', $target, 'arguments' => ['/u', 'Administrator'])
   dispatch :run_script do
     scope_param
     param 'String[1]', :script
@@ -31,7 +31,7 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
   #                Additional options: '_catch_errors', '_run_as'.
   # @return A list of results, one entry per target.
   # @example Run a script
-  #   file_upload('/var/tmp/myscript', $targets, 'Downloading my application')
+  #   run_script('/var/tmp/myscript', $targets, 'Downloading my application')
   dispatch :run_script_with_description do
     scope_param
     param 'String[1]', :script

--- a/bolt-modules/boltlib/spec/functions/upload_file_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/upload_file_spec.rb
@@ -6,7 +6,7 @@ require 'bolt/result'
 require 'bolt/result_set'
 require 'bolt/target'
 
-describe 'file_upload' do
+describe 'upload_file' do
   include PuppetlabsSpec::Fixtures
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { mock('inventory') }
@@ -19,7 +19,7 @@ describe 'file_upload' do
     end
   end
 
-  context 'it calls bolt executor file_upload' do
+  context 'it calls bolt executor upload_file' do
     let(:hostname) { 'test.example.com' }
     let(:target) { Bolt::Target.new(hostname) }
 
@@ -35,28 +35,28 @@ describe 'file_upload' do
     end
 
     it 'with fully resolved path of file and destination' do
-      executor.expects(:file_upload).with([target], full_path, destination, {}).returns(result_set)
+      executor.expects(:upload_file).with([target], full_path, destination, {}).returns(result_set)
       inventory.stubs(:get_targets).with(hostname).returns([target])
 
       is_expected.to run.with_params('test/uploads/index.html', destination, hostname).and_return(result_set)
     end
 
     it 'with fully resolved path of directory and destination' do
-      executor.expects(:file_upload).with([target], full_dir_path, destination, {}).returns(result_set)
+      executor.expects(:upload_file).with([target], full_dir_path, destination, {}).returns(result_set)
       inventory.stubs(:get_targets).with(hostname).returns([target])
 
       is_expected.to run.with_params('test/uploads', destination, hostname).and_return(result_set)
     end
 
     it 'with target specified as a Target' do
-      executor.expects(:file_upload).with([target], full_dir_path, destination, {}).returns(result_set)
+      executor.expects(:upload_file).with([target], full_dir_path, destination, {}).returns(result_set)
       inventory.stubs(:get_targets).with(target).returns([target])
 
       is_expected.to run.with_params('test/uploads', destination, target).and_return(result_set)
     end
 
     it 'runs as another user' do
-      executor.expects(:file_upload)
+      executor.expects(:upload_file)
               .with([target], full_dir_path, destination, '_run_as' => 'soandso')
               .returns(result_set)
       inventory.stubs(:get_targets).with(target).returns([target])
@@ -65,9 +65,9 @@ describe 'file_upload' do
     end
 
     it 'reports the call to analytics' do
-      executor.expects(:file_upload).with([target], full_path, destination, {}).returns(result_set)
+      executor.expects(:upload_file).with([target], full_path, destination, {}).returns(result_set)
       inventory.stubs(:get_targets).with(hostname).returns([target])
-      executor.expects(:report_function_call).with('file_upload')
+      executor.expects(:report_function_call).with('upload_file')
 
       is_expected.to run.with_params('test/uploads/index.html', destination, hostname).and_return(result_set)
     end
@@ -76,7 +76,7 @@ describe 'file_upload' do
       let(:message) { 'test message' }
 
       it 'passes the description through if parameters are passed' do
-        executor.expects(:file_upload)
+        executor.expects(:upload_file)
                 .with([target], full_dir_path, destination, '_description' => message)
                 .returns(result_set)
         inventory.stubs(:get_targets).with(target).returns([target])
@@ -85,7 +85,7 @@ describe 'file_upload' do
       end
 
       it 'passes the description through if no parameters are passed' do
-        executor.expects(:file_upload)
+        executor.expects(:upload_file)
                 .with([target], full_dir_path, destination, '_description' => message)
                 .returns(result_set)
         inventory.stubs(:get_targets).with(target).returns([target])
@@ -96,14 +96,14 @@ describe 'file_upload' do
 
     context 'without description' do
       it 'ignores description if parameters are passed' do
-        executor.expects(:file_upload).with([target], full_dir_path, destination, {}).returns(result_set)
+        executor.expects(:upload_file).with([target], full_dir_path, destination, {}).returns(result_set)
         inventory.stubs(:get_targets).with(target).returns([target])
 
         is_expected.to run.with_params('test/uploads', destination, target, {}).and_return(result_set)
       end
 
       it 'ignores description if no parameters are passed' do
-        executor.expects(:file_upload).with([target], full_dir_path, destination, {}).returns(result_set)
+        executor.expects(:upload_file).with([target], full_dir_path, destination, {}).returns(result_set)
         inventory.stubs(:get_targets).with(target).returns([target])
 
         is_expected.to run.with_params('test/uploads', destination, target).and_return(result_set)
@@ -119,7 +119,7 @@ describe 'file_upload' do
 
       it 'propagates multiple hosts and returns multiple results' do
         executor
-          .expects(:file_upload).with([target, target2], full_path, destination, {})
+          .expects(:upload_file).with([target, target2], full_path, destination, {})
           .returns(result_set)
         inventory.stubs(:get_targets).with([hostname, hostname2]).returns([target, target2])
 
@@ -131,7 +131,7 @@ describe 'file_upload' do
         let(:result2) { Bolt::Result.new(target2, error: { 'msg' => 'oops' }) }
 
         it 'errors by default' do
-          executor.expects(:file_upload).with([target, target2], full_path, destination, {})
+          executor.expects(:upload_file).with([target, target2], full_path, destination, {})
                   .returns(result_set)
           inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 
@@ -140,7 +140,7 @@ describe 'file_upload' do
         end
 
         it 'does not error with _catch_errors' do
-          executor.expects(:file_upload).with([target, target2], full_path, destination, '_catch_errors' => true)
+          executor.expects(:upload_file).with([target, target2], full_path, destination, '_catch_errors' => true)
                   .returns(result_set)
           inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 
@@ -151,7 +151,7 @@ describe 'file_upload' do
     end
 
     it 'without nodes - does not invoke bolt' do
-      executor.expects(:file_upload).never
+      executor.expects(:upload_file).never
       inventory.expects(:get_targets).with([]).returns([])
 
       is_expected.to run.with_params('test/uploads/index.html', destination, [])
@@ -159,7 +159,7 @@ describe 'file_upload' do
     end
 
     it 'errors when file is not found' do
-      executor.expects(:file_upload).never
+      executor.expects(:upload_file).never
 
       is_expected.to run.with_params('test/uploads/nonesuch.html', destination, [])
                         .and_raise_error(/No such file or directory: .*nonesuch\.html/)
@@ -177,9 +177,9 @@ describe 'file_upload' do
   context 'without tasks enabled' do
     let(:tasks_enabled) { false }
 
-    it 'fails and reports that file_upload is not available' do
+    it 'fails and reports that upload_file is not available' do
       is_expected.to run.with_params('test/uploads/nonesuch.html', '/some/place', [])
-                        .and_raise_error(/The task operation 'file_upload' is not available/)
+                        .and_raise_error(/The task operation 'upload_file' is not available/)
     end
   end
 end

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -296,7 +296,7 @@ module Bolt
                 raise Bolt::CLIError, "A destination path must be specified"
               end
               validate_file('source file', src)
-              executor.file_upload(targets, src, dest, executor_opts) do |event|
+              executor.upload_file(targets, src, dest, executor_opts) do |event|
                 outputter.print_event(event)
               end
             end

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -230,7 +230,7 @@ module Bolt
       end
     end
 
-    def file_upload(targets, source, destination, options = {}, &callback)
+    def upload_file(targets, source, destination, options = {}, &callback)
       description = options.fetch('_description', "file upload from #{source} to #{destination}")
       log_action(description, targets) do
         notify = proc { |event| @notifier.notify(callback, event) if callback }

--- a/pre-docs/plan_functions.md
+++ b/pre-docs/plan_functions.md
@@ -93,7 +93,7 @@ Uploads the given file or directory to the given set of targets and returns the 
 #### Upload a file.
 
 ```
-file_upload(String[1] $source, String[1] $destination, Boltlib::TargetSpec $targets, Optional[Hash[String[1], Any]] $options)
+upload_file(String[1] $source, String[1] $destination, Boltlib::TargetSpec $targets, Optional[Hash[String[1], Any]] $options)
 ```
 
  *Returns:* `ResultSet` A list of results, one entry per target.
@@ -106,19 +106,19 @@ file_upload(String[1] $source, String[1] $destination, Boltlib::TargetSpec $targ
  **Example:** Upload a local file to Linux targets and change owner to 'root'
 
 ```
-file_upload('/var/tmp/payload.tgz', '/tmp/payload.tgz', $targets, '_run_as' => 'root')
+upload_file('/var/tmp/payload.tgz', '/tmp/payload.tgz', $targets, '_run_as' => 'root')
 ```
 
  **Example:** Upload a module file to a Windows target
 
 ```
-file_upload('postgres/default.conf', 'C:/ProgramData/postgres/default.conf', $target)
+upload_file('postgres/default.conf', 'C:/ProgramData/postgres/default.conf', $target)
 ```
 
 #### Upload a file, logging the provided description.
 
 ```
-file_upload(String[1] $source, String[1] $destination, Boltlib::TargetSpec $targets, String $description, Optional[Hash[String[1], Any]] $options)
+upload_file(String[1] $source, String[1] $destination, Boltlib::TargetSpec $targets, String $description, Optional[Hash[String[1], Any]] $options)
 ```
 
  *Returns:* `ResultSet` A list of results, one entry per target.
@@ -132,7 +132,7 @@ file_upload(String[1] $source, String[1] $destination, Boltlib::TargetSpec $targ
  **Example:** Upload a file
 
 ```
-file_upload('/var/tmp/payload.tgz', '/tmp/payload.tgz', $targets, 'Uploading payload to unpack')
+upload_file('/var/tmp/payload.tgz', '/tmp/payload.tgz', $targets, 'Uploading payload to unpack')
 ```
 
 ### get\_targets
@@ -301,7 +301,7 @@ run_script('/var/tmp/myscript', $targets, '_run_as' => 'root')
  **Example:** Run a module-provided script with arguments
 
 ```
-file_upload('iis/setup.ps1', $target, 'arguments' => ['/u', 'Administrator'])
+run_script('iis/setup.ps1', $target, 'arguments' => ['/u', 'Administrator'])
 ```
 
 #### Run a script, logging the provided description.
@@ -320,7 +320,7 @@ run_script(String[1] $script, Boltlib::TargetSpec $targets, String $description,
  **Example:** Run a script
 
 ```
-file_upload('/var/tmp/myscript', $targets, 'Downloading my application')
+run_script('/var/tmp/myscript', $targets, 'Downloading my application')
 ```
 
 ### run\_task

--- a/pre-docs/writing_plans.md
+++ b/pre-docs/writing_plans.md
@@ -145,7 +145,7 @@ Any plan that completes execution without an error is considered successful. The
 
 ### Failing plans
 
-If `file_upload`, `run_command`, `run_script`, or `run_task` are called without the `_catch_errors` option and they fail on any nodes, the plan itself will fail. To fail a plan directly call the `fail_plan` function. Create a new error with a message and include the kind, details, or issue code, or pass an existing error to it.
+If `upload_file`, `run_command`, `run_script`, or `run_task` are called without the `_catch_errors` option and they fail on any nodes, the plan itself will fail. To fail a plan directly call the `fail_plan` function. Create a new error with a message and include the kind, details, or issue code, or pass an existing error to it.
 
 ```
 fail_plan('The plan is failing', 'mymodules/pear-shaped', {'failednodes' => $result.error_set.names})
@@ -407,7 +407,7 @@ To generate log messages from a plan, use the puppet log function that correspon
 
 ### Default Action Logging
 
-Bolt logs actions that a plan takes on targets through the  `file_upload`,  `run_command`, `run_script`, or `run_task`  functions. By default it logs a notice level message when an action starts and another when it completes. If you pass a description to the function, that will be used in place of the generic log message.
+Bolt logs actions that a plan takes on targets through the  `upload_file`,  `run_command`, `run_script`, or `run_task`  functions. By default it logs a notice level message when an action starts and another when it completes. If you pass a description to the function, that will be used in place of the generic log message.
 
 ```
 run_task(my_task, $targets, "Better description", param1 => "val")

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1548,7 +1548,7 @@ bar
           stub_file(source)
 
           expect(executor)
-            .to receive(:file_upload)
+            .to receive(:upload_file)
             .with(targets, source, dest, kind_of(Hash))
             .and_return(Bolt::ResultSet.new([]))
 
@@ -1560,7 +1560,7 @@ bar
           stub_file(source)
 
           expect(executor)
-            .to receive(:file_upload)
+            .to receive(:upload_file)
             .with(targets, source, dest, kind_of(Hash))
             .and_return(fail_set)
 

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -270,7 +270,7 @@ describe "Bolt::Executor" do
           .and_return(result)
       end
 
-      results = executor.file_upload(targets, script, dest)
+      results = executor.upload_file(targets, script, dest)
       results.each do |result|
         expect(result).to be_instance_of(Bolt::Result)
       end
@@ -285,7 +285,7 @@ describe "Bolt::Executor" do
       end
 
       results = []
-      executor.file_upload(targets, script, dest) do |result|
+      executor.upload_file(targets, script, dest) do |result|
         results << result
       end
       node_results.each do |target, result|
@@ -302,7 +302,7 @@ describe "Bolt::Executor" do
           .and_raise(Bolt::Error, 'failed', 'my-exception')
       end
 
-      executor.file_upload(targets, script, dest) do |result|
+      executor.upload_file(targets, script, dest) do |result|
         expect(result.error_hash['msg']).to eq('failed')
         expect(result.error_hash['kind']).to eq('my-exception')
       end
@@ -511,7 +511,7 @@ describe "Bolt::Executor" do
       end
 
       executor.start_plan(plan_context)
-      executor.file_upload(targets, script, dest)
+      executor.upload_file(targets, script, dest)
 
       expect(@log_output.readline).to match(/NOTICE.*Starting: file upload from .* to .* on .*/)
       expect(@log_output.readline).to match(/NOTICE.*Finished: file upload from .* to .* with 0 failures/)

--- a/spec/fixtures/run_as/test/plans/run_as_user.pp
+++ b/spec/fixtures/run_as/test/plans/run_as_user.pp
@@ -1,6 +1,6 @@
 plan test::run_as_user(String $target, String $user) {
   run_command('whoami', $target, _run_as => $user)
-  file_upload('test/id.sh', "/home/${user}/id.sh", $target, _run_as => $user)
+  upload_file('test/id.sh', "/home/${user}/id.sh", $target, _run_as => $user)
   run_script('test/id.sh', $target, _run_as => $user)
   return run_plan(test::whoami, target => $target, _run_as => $user)
 }


### PR DESCRIPTION
This function was inconsistent with the other plan functions, including
run_\* and set_\*, which are all \<verb\>\_\<object\> rather than \<object\>\_\<verb\>.
This change standardizes the plan functions so they should be easier to
remember.

This leaves behind a stub file_upload implementation that issues a deprecation
warning and calls upload_file in its place.