### PR TITLE
(BOLT-794) Remove requirement that Puppet is initialized for transports

### DIFF
--- a/acceptance/tests/script_ssh.rb
+++ b/acceptance/tests/script_ssh.rb
@@ -14,20 +14,19 @@ test_name "C100548: \
   step "create script on bolt controller" do
     create_remote_file(bolt, script, <<-FILE)
     #!/bin/sh
-    echo "hello from $(hostname)"
+    echo "$* from $(hostname)"
     FILE
   end
 
   step "execute `bolt script run` via SSH" do
-    bolt_command = "bolt script run #{script}"
+    bolt_command = "bolt script run #{script} hello"
 
     flags = { '--nodes' => 'ssh_nodes' }
 
     result = bolt_command_on(bolt, bolt_command, flags)
     ssh_nodes.each do |node|
       message = "Unexpected output from the command:\n#{result.cmd}"
-      regex = /hello from #{node.hostname.split('.')[0]}/
-      assert_match(regex, result.stdout, message)
+      assert_match(/hello from #{node.hostname.split('.')[0]}/, result.stdout, message)
     end
   end
 end

--- a/acceptance/tests/script_winrm.rb
+++ b/acceptance/tests/script_winrm.rb
@@ -13,19 +13,18 @@ test_name "C100549: \
 
   step "create powershell script on bolt controller" do
     create_remote_file(bolt, script, <<-FILE)
-    [System.Net.Dns]::GetHostByName(($env:computerName))
+    Write-Host "${args} from $([System.Net.Dns]::GetHostByName($env:computername).hostname)"
     FILE
   end
 
   step "execute `bolt script run` via WinRM" do
-    bolt_command = "bolt script run #{script}"
+    bolt_command = "bolt script run #{script} hello"
     flags = { '--nodes' => 'winrm_nodes' }
 
     result = bolt_command_on(bolt, bolt_command, flags)
     winrm_nodes.each do |node|
       message = "Unexpected output from the command:\n#{result.cmd}"
-      assert_match(/#{node.hostname.split('.')[0]}/, result.stdout, message)
-      assert_match(/{#{node.ip}}/, result.stdout, message)
+      assert_match(/hello from #{node.hostname.split('.')[0]}/, result.stdout, message)
     end
   end
 end

--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -196,6 +196,9 @@ module Bolt
       # This works on deeply nested data structures composed of Hashes, Arrays, and
       # and plain-old data types (int, string, etc).
       def unwrap_sensitive_args(arguments)
+        # Skip this if Puppet isn't loaded
+        return arguments unless defined?(Puppet::Pops::Types::PSensitiveType::Sensitive)
+
         case arguments
         when Array
           # iterate over the array, unwrapping all elements


### PR DESCRIPTION
Transports must be usable even when Puppet is not initialized. Only
check for Sensitive types if they're loaded, and add an argument to
acceptance tests for `script run` to ensure that it's not used when
Puppet isn't loaded.