### PR TITLE
(TBD) Provides a '--stream' option for streaming output

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -251,6 +251,9 @@ Usage: bolt apply <manifest.pp> [options]
       define('--tmpdir DIR', 'The directory to upload and execute temporary files on the target') do |tmpdir|
         @options[:tmpdir] = tmpdir
       end
+      define('--[no-]stream', 'Request results be streamed for transports that support streaming output') do |stream|
+        @options[:stream] = stream
+      end
 
       separator 'Display:'
       define('--format FORMAT', 'Output format to use: human or json') do |format|

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -34,7 +34,7 @@ module Bolt
 
     TRANSPORT_OPTIONS = %i[password run-as sudo-password extensions
                            private-key tty tmpdir user connect-timeout
-                           cacert token-file service-url].freeze
+                           stream cacert token-file service-url].freeze
 
     TRANSPORT_DEFAULTS = {
       'connect-timeout' => 10,

--- a/lib/bolt/logger.rb
+++ b/lib/bolt/logger.rb
@@ -14,7 +14,7 @@ module Bolt
       # redefs, so skip it if it's already been initialized
       return if Logging.initialized?
 
-      Logging.init :debug, :info, :notice, :warn, :error, :fatal, :any
+      Logging.init :debug, :info, :notice, :warn, :error, :fatal, :stream, :any
 
       Logging.color_scheme(
         'bolt',

--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -5,6 +5,18 @@ require 'bolt/result'
 
 module Bolt
   module Transport
+    # Provides a common pattern for streaming output from a transport.
+    # Requires @logger and @target.
+    module Streaming
+      def log_output(msg, level = :debug)
+        if @target.options['stream']
+          @logger.stream { "[#{@target.name}] #{msg.chomp}" }
+        else
+          @logger.send(level) { "[#{@target.name}] #{msg.chomp}" }
+        end
+      end
+    end
+
     # This class provides the default behavior for Transports. A Transport is
     # responsible for uploading files and running commands, scripts, and tasks
     # on Targets.

--- a/lib/bolt/transport/local.rb
+++ b/lib/bolt/transport/local.rb
@@ -22,8 +22,6 @@ module Bolt
 
         if Bolt::Util.windows?
           raise NotImplementedError, "The local transport is not yet implemented on Windows"
-        else
-          @conn = Shell.new
         end
       end
 
@@ -60,7 +58,7 @@ module Bolt
 
       def run_command(target, command, _options = {})
         in_tmpdir(target.options['tmpdir']) do |dir|
-          output = @conn.execute(command, dir: dir)
+          output = Shell.new(target).execute(command, dir: dir)
           Bolt::Result.for_command(target, output.stdout.string, output.stderr.string, output.exit_code)
         end
       end
@@ -76,7 +74,7 @@ module Bolt
             # argument as the entire command string for script paths containing spaces.
             arguments = ['']
           end
-          output = @conn.execute(file, *arguments, dir: dir)
+          output = Shell.new(target).execute(file, *arguments, dir: dir)
           Bolt::Result.for_command(target, output.stdout.string, output.stderr.string, output.exit_code)
         end
       end
@@ -115,7 +113,7 @@ module Bolt
           # log the arguments with sensitive data redacted, do NOT log unwrapped_arguments
           logger.debug("Running '#{script}' with #{arguments}")
 
-          output = @conn.execute(script, stdin: stdin, env: env, dir: dir)
+          output = Shell.new(target).execute(script, stdin: stdin, env: env, dir: dir)
           Bolt::Result.for_task(target, output.stdout.string, output.stderr.string, output.exit_code)
         end
       end

--- a/lib/bolt/transport/local/shell.rb
+++ b/lib/bolt/transport/local/shell.rb
@@ -5,15 +5,46 @@ require 'bolt/node/output'
 
 module Bolt
   module Transport
-    class Local
+    class Local < Base
       class Shell
+        include Streaming
+
+        def initialize(target)
+          @target = target
+          @logger = Logging.logger[@target.host]
+        end
+
         def execute(*command, options)
           command = [options[:env]] + command if options[:env]
 
-          if options[:stdin]
-            stdout, stderr, rc = Open3.capture3(*command, stdin_data: options[:stdin], chdir: options[:dir])
+          opts = { chdir: options[:dir] }
+          stdin_data = options[:stdin] if options[:stdin]
+
+          log_output "Executing: #{command}"
+          stdout, stderr, rc = Open3.popen3(*command, opts) do |i, o, e, t|
+            readers = { out: o, err: e }.map do |key, stream|
+              Thread.new do
+                output = StringIO.new
+                until (raw_line = stream.gets).nil?
+                  output << raw_line
+                  log_output "#{key}: #{raw_line}"
+                end
+                output.string
+              end
+            end
+            begin
+              i.write stdin_data
+            rescue Errno::EPIPE => e
+              @logger.debug "Pipe closed while running #{command} on #{@target.name}: #{e}"
+            end
+            i.close
+            (readers + [t]).map(&:value)
+          end
+
+          if rc.to_i == 0
+            log_output "Command returned successfully"
           else
-            stdout, stderr, rc = Open3.capture3(*command, chdir: options[:dir])
+            log_output("Command failed with exit code #{rc}", :info)
           end
 
           result_output = Bolt::Node::Output.new
@@ -21,6 +52,9 @@ module Bolt
           result_output.stderr << stderr unless stderr.nil?
           result_output.exit_code = rc.to_i
           result_output
+        rescue StandardError
+          log_output "Command aborted"
+          raise
         end
       end
     end

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -9,7 +9,8 @@ module Bolt
   module Transport
     class SSH < Base
       def self.options
-        %w[port user password sudo-password private-key host-key-check connect-timeout tmpdir run-as tty run-as-command]
+        %w[port user password sudo-password private-key host-key-check
+           connect-timeout tmpdir run-as stream tty run-as-command]
       end
 
       PROVIDED_FEATURES = ['shell'].freeze

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -11,7 +11,7 @@ module Bolt
       ].freeze
 
       def self.options
-        %w[port user password connect-timeout ssl ssl-verify tmpdir cacert extensions]
+        %w[port user password connect-timeout ssl ssl-verify stream tmpdir cacert extensions]
       end
 
       PROVIDED_FEATURES = ['powershell'].freeze

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -7,6 +7,8 @@ module Bolt
   module Transport
     class WinRM < Base
       class Connection
+        include Streaming
+
         attr_reader :logger, :target
 
         DEFAULT_EXTENSIONS = ['.ps1', '.rb', '.pp'].freeze
@@ -295,23 +297,23 @@ PS
         def execute(command)
           result_output = Bolt::Node::Output.new
 
-          @logger.debug { "Executing command: #{command}" }
+          log_output "Executing: #{command}"
 
           output = @session.run(command) do |stdout, stderr|
             result_output.stdout << stdout
-            @logger.debug { "stdout: #{stdout}" }
+            log_output "out: #{stdout}"
             result_output.stderr << stderr
-            @logger.debug { "stderr: #{stderr}" }
+            log_output "err: #{stderr}"
           end
           result_output.exit_code = output.exitcode
           if output.exitcode.zero?
-            @logger.debug { "Command returned successfully" }
+            log_output "Command returned successfully"
           else
-            @logger.info { "Command failed with exit code #{output.exitcode}" }
+            log_output("Command failed with exit code #{output.exitcode}", :info)
           end
           result_output
         rescue StandardError
-          @logger.debug { "Command aborted" }
+          log_output { "Command aborted" }
           raise
         end
 

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -98,7 +98,7 @@ describe Bolt::Config do
       }
 
       expect { Bolt::Config.new(boltdir, config) }.to raise_error(
-        /level of log file:.* must be one of: debug, info, notice, warn, error, fatal, any; received foo/
+        /level of log file:.* must be one of: debug, info, notice, warn, error, fatal, stream, any; received foo/
       )
     end
 

--- a/spec/bolt/logger_spec.rb
+++ b/spec/bolt/logger_spec.rb
@@ -36,7 +36,7 @@ describe Bolt::Logger do
       Bolt::Logger.initialize_logging
 
       expect(Logging::LEVELS).to eq(
-        %w[debug info notice warn error fatal any].each_with_object({}) { |l, h| h[l] = h.count }
+        %w[debug info notice warn error fatal stream any].each_with_object({}) { |l, h| h[l] = h.count }
       )
     end
   end


### PR DESCRIPTION
Adds a `stream` transport option for streaming output that's implemented
on SSH and WinRM. Augments logging to include target name, and when
`stream` is enabled outputs stdout and stderr from executing commands to
a special `stream` log level (that can be used to direct it to a
specific file).

Fxes #102.