### PR TITLE
(BOLT-719) Allow modulepath relative to Boltdir

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -202,7 +202,10 @@ Available options are:
       end
       define('--modulepath MODULES',
              "List of directories containing modules, separated by '#{File::PATH_SEPARATOR}'") do |modulepath|
-        @options[:modulepath] = modulepath.split(File::PATH_SEPARATOR)
+        # When specified from the CLI, modulepath entries are relative to pwd
+        @options[:modulepath] = modulepath.split(File::PATH_SEPARATOR).map do |moduledir|
+          File.expand_path(moduledir)
+        end
       end
       define('--boltdir FILEPATH',
              'Specify what Boltdir to load config from (default: autodiscovered from current working dir)') do |path|
@@ -217,7 +220,7 @@ Available options are:
         if ENV.include?(Bolt::Inventory::ENVIRONMENT_VAR)
           raise Bolt::CLIError, "Cannot pass inventory file when #{Bolt::Inventory::ENVIRONMENT_VAR} is set"
         end
-        @options[:inventoryfile] = path
+        @options[:inventoryfile] = File.expand_path(path)
       end
 
       separator 'Transports:'

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -148,11 +148,17 @@ module Bolt
         update_logs(data['log'])
       end
 
-      @modulepath = data['modulepath'].split(File::PATH_SEPARATOR) if data.key?('modulepath')
+      # Expand paths relative to the Boltdir. Any settings that came from the
+      # CLI will already be absolute, so the expand will be skipped.
+      if data.key?('modulepath')
+        @modulepath = data['modulepath'].split(File::PATH_SEPARATOR).map do |moduledir|
+          File.expand_path(moduledir, @boltdir.path)
+        end
+      end
 
-      @inventoryfile = data['inventoryfile'] if data.key?('inventoryfile')
+      @inventoryfile = File.expand_path(data['inventoryfile'], @boltdir.path) if data.key?('inventoryfile')
 
-      @hiera_config = data['hiera-config'] if data.key?('hiera-config')
+      @hiera_config = File.expand_path(data['hiera-config'], @boltdir.path) if data.key?('hiera-config')
       @compile_concurrency = data['compile-concurrency'] if data.key?('compile-concurrency')
 
       %w[concurrency format puppetdb color transport].each do |key|

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -8,8 +8,8 @@ require 'bolt/applicator'
 
 module Bolt
   class PAL
-    BOLTLIB_PATH = File.join(__dir__, '../../bolt-modules')
-    MODULES_PATH = File.join(__dir__, '../../modules')
+    BOLTLIB_PATH = File.expand_path('../../bolt-modules', __dir__)
+    MODULES_PATH = File.expand_path('../../modules', __dir__)
 
     # PALError is used to convert errors from executing puppet code into
     # Bolt::Errors
@@ -47,6 +47,11 @@ module Bolt
       @modulepath = [BOLTLIB_PATH, *modulepath, MODULES_PATH]
       @hiera_config = hiera_config
       @max_compiles = max_compiles
+
+      @logger = Logging.logger[self]
+      if modulepath && !modulepath.empty?
+        @logger.info("Loading modules from #{@modulepath.join(File::PATH_SEPARATOR)}")
+      end
     end
 
     # Puppet logging is global so this is class method to avoid confusion

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -420,9 +420,11 @@ bar
     end
 
     describe "modulepath" do
-      it "accepts a modulepath directory" do
-        cli = Bolt::CLI.new(%w[command run --modulepath ./modules --nodes foo])
-        expect(cli.parse).to include(modulepath: ['./modules'])
+      it "treats relative modulepath as relative to pwd" do
+        site = File.expand_path('site')
+        modulepath = [site, 'modules'].join(File::PATH_SEPARATOR)
+        cli = Bolt::CLI.new(%W[command run --modulepath #{modulepath} --nodes foo])
+        expect(cli.parse).to include(modulepath: [site, File.expand_path('modules')])
       end
 
       it "generates an error message if no value is given" do
@@ -1735,8 +1737,9 @@ bar
 
   describe 'configfile' do
     let(:configdir) { File.join(__dir__, '..', 'fixtures', 'configs') }
+    let(:modulepath) { [File.expand_path('/foo/bar'), File.expand_path('/baz/qux')] }
     let(:complete_config) do
-      { 'modulepath' => "/foo/bar#{File::PATH_SEPARATOR}/baz/qux",
+      { 'modulepath' => modulepath.join(File::PATH_SEPARATOR),
         'inventoryfile' => File.join(__dir__, '..', 'fixtures', 'inventory', 'empty.yml'),
         'concurrency' => 14,
         'compile-concurrency' => 2,
@@ -1776,7 +1779,7 @@ bar
       with_tempfile_containing('conf', YAML.dump(complete_config)) do |conf|
         cli = Bolt::CLI.new(%W[command run --configfile #{conf.path} --nodes foo --no-host-key-check])
         cli.parse
-        expect(cli.config.modulepath).to eq(['/foo/bar', '/baz/qux'])
+        expect(cli.config.modulepath).to eq(modulepath)
       end
     end
 

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -21,6 +21,12 @@ describe Bolt::Config do
       config = Bolt::Config.new(boltdir, { 'concurrency' => 200 }, concurrency: 100)
       expect(config.concurrency).to eq(100)
     end
+
+    it "treats relative modulepath as relative to Boltdir" do
+      module_dirs = %w[site modules]
+      config = Bolt::Config.new(boltdir, 'modulepath' => module_dirs.join(File::PATH_SEPARATOR))
+      expect(config.modulepath).to eq(module_dirs.map { |dir| (boltdir.path + dir).to_s })
+    end
   end
 
   describe "deep_clone" do

--- a/spec/integration/logging_spec.rb
+++ b/spec/integration/logging_spec.rb
@@ -46,19 +46,21 @@ describe "when logging executor activity", ssh: true do
 
   it 'logs with a plan that includes a description' do
     result = run_cli_json(%W[plan run #{echo_plan} description=somemessage] + config_flags)
-    expect(@log_output.readline).to match(/NOTICE.*Starting: plan #{echo_plan}/)
-    expect(@log_output.readline).to match(/Starting: somemessage on/)
-    expect(@log_output.readline).to match(/Finished: somemessage/)
-    expect(@log_output.readline).to match(/NOTICE.*Finished: plan #{echo_plan}/)
+    lines = @log_output.readlines
+    expect(lines).to include(match(/NOTICE.*Starting: plan #{echo_plan}/))
+    expect(lines).to include(match(/Starting: somemessage on/))
+    expect(lines).to include(match(/Finished: somemessage/))
+    expect(lines).to include(match(/NOTICE.*Finished: plan #{echo_plan}/))
     expect(result[0]['result']['_output'].strip).to match(/hi there/)
   end
 
   it 'logs extra with a plan' do
     result = run_cli_json(%W[plan run #{echo_plan}] + config_flags)
-    expect(@log_output.readline).to match(/NOTICE.*Starting: plan #{echo_plan}/)
-    expect(@log_output.readline).to match(/Starting: task sample::echo/)
-    expect(@log_output.readline).to match(/Finished: task sample::echo/)
-    expect(@log_output.readline).to match(/NOTICE.*Finished: plan #{echo_plan}/)
+    lines = @log_output.readlines
+    expect(lines).to include(match(/NOTICE.*Starting: plan #{echo_plan}/))
+    expect(lines).to include(match(/Starting: task sample::echo/))
+    expect(lines).to include(match(/Finished: task sample::echo/))
+    expect(lines).to include(match(/NOTICE.*Finished: plan #{echo_plan}/))
     expect(result[0]['result']['_output'].strip).to match(/hi there/)
   end
 
@@ -74,41 +76,45 @@ describe "when logging executor activity", ssh: true do
 
     it 'logs actions with a command' do
       result = run_cli_json(%W[command run #{whoami}] + config_flags)
-      expect(@log_output.readline).to match(/Starting: command '#{whoami}'/)
-      expect(@log_output.readline).to match(/Running command '#{whoami}'/)
-      expect(@log_output.readline).to match(/#{conn_info('ssh')[:user]}/)
-      expect(@log_output.readline).to match(/Finished: command '#{whoami}'/)
+      lines = @log_output.readlines
+      expect(lines).to include(match(/Starting: command '#{whoami}'/))
+      expect(lines).to include(match(/Running command '#{whoami}'/))
+      expect(lines).to include(match(/#{conn_info('ssh')[:user]}/))
+      expect(lines).to include(match(/Finished: command '#{whoami}'/))
       expect(result['items'][0]['result']['stdout'].strip).to eq(conn_info('ssh')[:user])
     end
 
     it 'logs actions with a task' do
       result = run_cli_json(%W[task run #{stdin_task} message=somemessage] + config_flags)
-      expect(@log_output.readline).to match(/Starting: task #{stdin_task}/)
-      expect(@log_output.readline).to match(/Running task #{stdin_task} with/)
-      expect(@log_output.readline).to match(/somemessage/)
-      expect(@log_output.readline).to match(/Finished: task #{stdin_task}/)
+      lines = @log_output.readlines
+      expect(lines).to include(match(/Starting: task #{stdin_task}/))
+      expect(lines).to include(match(/Running task #{stdin_task} with/))
+      expect(lines).to include(match(/somemessage/))
+      expect(lines).to include(match(/Finished: task #{stdin_task}/))
       expect(result['items'][0]['result']['message'].strip).to eq('somemessage')
     end
 
     it 'logs extra with a plan' do
       result = run_cli_json(%W[plan run #{echo_plan}] + config_flags)
-      expect(@log_output.readline).to match(/NOTICE.*Starting: plan #{echo_plan}/)
-      expect(@log_output.readline).to match(/Starting: task sample::echo/)
-      expect(@log_output.readline).to match(/Running task sample::echo with/)
-      expect(@log_output.readline).to match(/hi there/)
-      expect(@log_output.readline).to match(/Finished: task sample::echo/)
-      expect(@log_output.readline).to match(/NOTICE.*Finished: plan #{echo_plan}/)
+      lines = @log_output.readlines
+      expect(lines).to include(match(/NOTICE.*Starting: plan #{echo_plan}/))
+      expect(lines).to include(match(/Starting: task sample::echo/))
+      expect(lines).to include(match(/Running task sample::echo with/))
+      expect(lines).to include(match(/hi there/))
+      expect(lines).to include(match(/Finished: task sample::echo/))
+      expect(lines).to include(match(/NOTICE.*Finished: plan #{echo_plan}/))
       expect(result[0]['result']['_output'].strip).to match(/hi there/)
     end
 
     it 'logs extra without_default in a plan' do
       run_cli_json(%W[plan run #{without_default_plan}] + config_flags)
-      expect(@log_output.readline).to match(/NOTICE.*Starting: plan #{without_default_plan}/)
-      expect(@log_output.readline).to match(/Starting: task logging::echo/)
-      expect(@log_output.readline).to match(/Running task logging::echo with/)
-      expect(@log_output.readline).to match(/hi there/)
-      expect(@log_output.readline).to match(/Finished: task logging::echo/)
-      expect(@log_output.readline).to match(/NOTICE.*Finished: plan #{without_default_plan}/)
+      lines = @log_output.readlines
+      expect(lines).to include(match(/NOTICE.*Starting: plan #{without_default_plan}/))
+      expect(lines).to include(match(/Starting: task logging::echo/))
+      expect(lines).to include(match(/Running task logging::echo with/))
+      expect(lines).to include(match(/hi there/))
+      expect(lines).to include(match(/Finished: task logging::echo/))
+      expect(lines).to include(match(/NOTICE.*Finished: plan #{without_default_plan}/))
     end
   end
 end


### PR DESCRIPTION
Previously, relative paths in the bolt.yaml file were treated as relative
to pwd, which is almost never what's expected. We now treat them as
relative to Boltdir, allowing a modulepath like site:modules to be used to
represent .../Boltdir/site:.../Boltdir/modules, regardless of where the
Boltdir is located on disk.

When modulepath is specified on the CLI, relative paths are still
interpreted as relative to the pwd, which should be less surprising for new
users than making it implicitly based on a directory (Boltdir) they may not
even know exists.