### PR TITLE
(maint) Fix rubocop 0.59 issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,9 @@ Style/NumericLiterals:
 Style/NumericPredicate:
   Enabled: false
 
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+
 Layout/IndentHeredoc:
   Enabled: false
 

--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -58,10 +58,10 @@ module Bolt
         callback&.call(type: :node_start, target: target)
 
         result = begin
-          yield
-        rescue StandardError => ex
-          Bolt::Result.from_exception(target, ex)
-        end
+                   yield
+                 rescue StandardError => ex
+                   Bolt::Result.from_exception(target, ex)
+                 end
 
         callback&.call(type: :node_result, result: result)
         result


### PR DESCRIPTION
This version enabled by default a new cop we had previously been
ignoring (Layout/EmptyLineAfterGuardClause). This commit disables it
explicitly. It also fixes one indentation issue.