### PR TITLE
(BOLT-766) Add 'site' to default modulepath

### DIFF
--- a/lib/bolt/boltdir.rb
+++ b/lib/bolt/boltdir.rb
@@ -25,7 +25,7 @@ module Bolt
       @path = Pathname.new(path).expand_path
       @config_file = @path + 'bolt.yaml'
       @inventory_file = @path + 'inventory.yaml'
-      @modulepath = [(@path + 'modules').to_s]
+      @modulepath = [(@path + 'modules').to_s, (@path + 'site').to_s]
       @hiera_config = @path + 'hiera.yaml'
       @puppetfile = @path + 'Puppetfile'
     end

--- a/pre-docs/bolt_configuration_options.md
+++ b/pre-docs/bolt_configuration_options.md
@@ -5,7 +5,7 @@ Your Bolt config file can contain global and transport options.
 ## Sample Bolt config file
 
 ```
-modulepath: "~/.puppetlabs/bolt-code/site:~/.puppetlabs/bolt-code/modules"
+modulepath: "~/.puppetlabs/bolt-code/modules:~/.puppetlabs/bolt-code/site"
 inventoryfile: "~/.puppetlabs/bolt/inventory.yaml"
 concurrency: 10
 format: human
@@ -20,7 +20,7 @@ ssh:
 
 `format`: The format to use when printing results. Options are `human` and `json`. Default is `human`.
 
-`modulepath`: The module path for loading tasks and plan code. This is a list of directories separated by the OS specific file path separator. The default path for modules is `modules` inside the `Boltdir`.
+`modulepath`: The module path for loading tasks and plan code. This is a list of directories separated by the OS specific file path separator. The default path for modules is `modules:site` inside the `Boltdir`.
 
 `inventoryfile`: The path to a structured data inventory file used to refer to groups of nodes on the commandline and from plans. The default path for the inventory file is `inventory.yaml` inside the `Boltdir`.
 

--- a/pre-docs/bolt_installing_modules.md
+++ b/pre-docs/bolt_installing_modules.md
@@ -24,6 +24,8 @@ For more details about specifying modules in a Puppetfile, see the [Puppetfile d
      mod 'myteam/app_foo', local: true
      ```
 
+     Alternately, any modules you don't want to manage with the Puppetfile can be manually installed to a different subdirectory in the Boltdir, such as `site`.
+
 4.   From a terminal, install the modules listed in the Puppetfile: `bolt puppetfile install`.
 
      By default, Bolt installs modules to the modules subdirectory inside the Boltdir. To override this location, update the modulepath setting in the Bolt config file.


### PR DESCRIPTION
Previously, the default modulepath was just `modules`. That made it
difficult to use a Puppetfile with `bolt puppetfile install` while also
using some custom module content, as every custom module needed to be
added to Puppetfile with `local: true` simply in order to be preserved
when updating.

Now, we use `modules:site` as the default modulepath, which provides
users a location to install modules via the Puppetfile (`modules`) as
well as a location for custom content that should not be managed with
the Puppetfile (`site`). `bolt puppetfile install` will always install
to the first element of the modulepath, so we break the typical Puppet
convention and put `modules` *first*.