### PR TITLE
(maint) Add note to install modules with gem install

### DIFF
--- a/pre-docs/applying_manifest_blocks.md
+++ b/pre-docs/applying_manifest_blocks.md
@@ -8,6 +8,10 @@ Within a plan, you can use Bolt to apply blocks of Puppet code (manifest blocks)
 
 [Writing plans](writing_plans.md)
 
+**Note:** If you installed bolt as a ruby gem, you'll want to:
+1. Create a Puppetfile with the contents of [bolt's Puppetfile](../Puppetfile) at `~/.puppetlabs/bolt/Puppetfile`
+2. Run `bolt puppetfile install`
+
 ## Create a sample manifest for nginx on Linux
 
 Create a manifest to set up a web server with [nginx](https://nginx.org) and run it as a plan. 

--- a/pre-docs/bolt_installing.md
+++ b/pre-docs/bolt_installing.md
@@ -201,7 +201,8 @@ If Ruby is already included in your operating system, verify that it is version 
     ```
     bolt --help
     ```
-
+4. Copy the contents of [bolt's Puppetfile](../Puppetfile) to `~/.puppetlabs/bolt/Puppetfile`
+5. Run `bolt puppetfile install`
 
 ## Analytics data collection
 


### PR DESCRIPTION
**What this changes** This adds a note to the gem install docs and the apply manifest docs about installing bolt's required puppet modules
**Why** `apply_prep` specifically doesn't work without modules installed, and it's difficult to find documentation on why or know that it's related to installing from a gem.