### PR TITLE
(maint) Add links to PQL information

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/puppetdb_query.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/puppetdb_query.rb
@@ -2,12 +2,16 @@
 
 require 'bolt/error'
 
-# Makes a query to puppetdb using Bolt's PuppetDB client.
+# Makes a query to {https://puppet.com/docs/puppetdb/latest/index.html puppetdb}
+# using Bolt's PuppetDB client.
 Puppet::Functions.create_function(:puppetdb_query) do
+  # rubocop:disable Metrics/LineLength
   # @param query A PQL query.
+  #   {https://puppet.com/docs/puppetdb/latest/api/query/tutorial-pql.html Learn more about Puppet's query language, PQL}
   # @return Results of the PuppetDB query.
   # @example Request certnames for all nodes
   #   puppetdb_query('nodes[certname] {}')
+  # rubocop:enable Metrics/LineLength
   dispatch :make_query do
     param 'Variant[String, Array[Data]]', :query
     return_type 'Array[Data]'

--- a/pre-docs/inventory_file_generating.md
+++ b/pre-docs/inventory_file_generating.md
@@ -1,6 +1,6 @@
 # Generating inventory files
 
-Use the `bolt-inventory-pdb` script to generate inventory files based on PuppetDB queries.
+Use the `bolt-inventory-pdb` script to generate inventory files based on PuppetDB queries. [Learn more about Puppet's query language, PQL](https://puppet.com/docs/puppetdb/latest/api/query/tutorial-pql.html)
 
 ## Usage
 

--- a/pre-docs/plan_functions.md
+++ b/pre-docs/plan_functions.md
@@ -200,7 +200,7 @@ puppetdb_fact(['app.example.com', 'db.example.com'])
 
 ### puppetdb\_query
 
-Makes a query to puppetdb using Bolt's PuppetDB client.
+Makes a query to [puppetdb](https://puppet.com/docs/puppetdb/latest/index.html) using Bolt's PuppetDB client.
 
 ```
 puppetdb_query(Variant[String, Array[Data]] $query)
@@ -208,7 +208,7 @@ puppetdb_query(Variant[String, Array[Data]] $query)
 
  *Returns:* `Array[Data]` Results of the PuppetDB query.
 
--    **query** `Variant[String, Array[Data]]` A PQL query.
+-    **query** `Variant[String, Array[Data]]` A PQL query. [Learn more about Puppet's query language, PQL](https://puppet.com/docs/puppetdb/latest/api/query/tutorial-pql.html)
 
  **Example:** Request certnames for all nodes
 


### PR DESCRIPTION
**What this changes** This adds links to more information about PQL to relevant parts of the documentation
**Why** Because it's not obvious to new users what PQL is or how it's different from other query languages, and providing direct links to PQL information in 'obvious' places is helpful for finding that info