### PR TITLE
(maint) Update JSON schema paths

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.license       = "Apache-2.0"
   spec.files         = Dir['exe/*'] +
                        Dir['lib/**/*.rb'] +
+                       Dir['lib/**/*.json'] +
                        Dir['libexec/*'] +
                        Dir['vendored/*.rb'] +
                        Dir['vendored/*/lib/**/*.rb'] +

--- a/lib/bolt_ext/schemas/ssh-run_task.json
+++ b/lib/bolt_ext/schemas/ssh-run_task.json
@@ -61,7 +61,7 @@
       "required": ["hostname", "user"],
       "additionalProperties": false
     },
-    "task": { "$ref": "file:lib/bolt_ext/schemas/task.json"},
+    "task": { "$ref": "file:task"},
     "parameters": {
       "type": "object",
       "description": "JSON formatted parameters to be provided to task"

--- a/lib/bolt_ext/schemas/task.json
+++ b/lib/bolt_ext/schemas/task.json
@@ -1,5 +1,5 @@
 {
-  "id": "file:lib/bolt_ext/schemas/task.json",
+  "id": "file:task",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Task",
   "description": "Task schema for bolt-server",

--- a/lib/bolt_ext/schemas/winrm-run_task.json
+++ b/lib/bolt_ext/schemas/winrm-run_task.json
@@ -52,7 +52,7 @@
       "required": ["hostname", "user", "password"],
       "additionalProperties": false
     },
-    "task": { "$ref": "file:lib/bolt_ext/schemas/task.json"},
+    "task": { "$ref": "file:task"},
     "parameters": {
       "type": "object",
       "description": "JSON formatted parameters to be provided to task"


### PR DESCRIPTION
Previously the paths for validating JSON schema templates only worked when running from Rspec tests as they were relative to the root directory of Bolt. This commit handles the paths accordingly.