### PR TITLE
(BOLT-840) Include "vendored" Puppet types

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -12,6 +12,18 @@ mod 'puppet_agent',
     git: 'https://github.com/puppetlabs/puppetlabs-puppet_agent',
     ref: '319ce44a65e73bcf2712ad17be01f9636f0673c9'
 
+# Core types and providers for Puppet 6
+mod 'puppetlabs-augeas_core', '1.0.1'
+mod 'puppetlabs-host_core', '1.0.1'
+mod 'puppetlabs-scheduled_task', '1.0.0'
+mod 'puppetlabs-sshkeys_core', '1.0.1'
+mod 'puppetlabs-zfs_core', '1.0.1'
+mod 'puppetlabs-cron_core', '1.0.0'
+mod 'puppetlabs-mount_core', '1.0.1'
+mod 'puppetlabs-selinux_core', '1.0.1'
+mod 'puppetlabs-yumrepo_core', '1.0.1'
+mod 'puppetlabs-zone_core', '1.0.1'
+
 # If we don't list these modules explicitly, r10k will purge them
 mod 'canary', local: true
 mod 'aggregate', local: true

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -12,10 +12,11 @@ require 'bolt/util/puppet_log_level'
 
 module Bolt
   class Applicator
-    def initialize(inventory, executor, modulepath, pdb_client, hiera_config, max_compiles)
+    def initialize(inventory, executor, modulepath, plugin_dirs, pdb_client, hiera_config, max_compiles)
       @inventory = inventory
       @executor = executor
       @modulepath = modulepath
+      @plugin_dirs = plugin_dirs
       @pdb_client = pdb_client
       @hiera_config = hiera_config ? validate_hiera_config(hiera_config) : nil
 
@@ -222,7 +223,7 @@ module Bolt
       sio = StringIO.new
       output = Minitar::Output.new(Zlib::GzipWriter.new(sio))
 
-      Puppet.lookup(:current_environment).modules.each do |mod|
+      Puppet.lookup(:current_environment).override_with(modulepath: @plugin_dirs).modules.each do |mod|
         search_dirs = yield mod
 
         parent = Pathname.new(mod.path).parent

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -44,6 +44,7 @@ module Bolt
       # This makes sure we don't accidentally create puppet dirs
       with_puppet_settings { |_| nil }
 
+      @original_modulepath = modulepath
       @modulepath = [BOLTLIB_PATH, *modulepath, MODULES_PATH]
       @hiera_config = hiera_config
       @max_compiles = max_compiles
@@ -128,6 +129,10 @@ module Bolt
           inventory,
           executor,
           @modulepath,
+          # Skip syncing built-in plugins, since we vendor some Puppet 6
+          # versions of "core" types, which are already present on the agent,
+          # but may cause issues on Puppet 5 agents.
+          @original_modulepath,
           pdb_client,
           @hiera_config,
           @max_compiles

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -15,12 +15,13 @@ describe Bolt::Applicator do
                                'token' => 'token')
   end
   let(:pdb_client) { Bolt::PuppetDB::Client.new(config) }
-  let(:applicator) { Bolt::Applicator.new(inventory, executor, :mod, pdb_client, nil, 2) }
+  let(:modulepath) { [Bolt::PAL::BOLTLIB_PATH, Bolt::PAL::MODULES_PATH] }
+  let(:applicator) { Bolt::Applicator.new(inventory, executor, modulepath, [], pdb_client, nil, 2) }
 
   let(:input) {
     {
       code_ast: :ast,
-      modulepath: :mod,
+      modulepath: modulepath,
       pdb_config: config.to_hash,
       hiera_config: nil,
       target: {
@@ -135,7 +136,9 @@ describe Bolt::Applicator do
 
   context 'with Puppet mocked' do
     before(:each) do
-      allow(Puppet).to receive(:lookup).and_return(double(:type, type: nil, modules: []))
+      env = Puppet::Node::Environment.create(:testing, modulepath)
+      allow(Puppet).to receive(:lookup).with(:pal_script_compiler).and_return(double(:script_compiler, type: nil))
+      allow(Puppet).to receive(:lookup).with(:current_environment).and_return(env)
       allow(Puppet::Pal).to receive(:assert_type)
       allow(Puppet::Pops::Serialization::ToDataConverter).to receive(:convert).and_return(:ast)
     end


### PR DESCRIPTION
In Puppet 6, many types and providers have been removed from core into
their own modules. Those modules are included in the puppet-agent package
so the out-of-the-box experience remains the same. In order to preserve
that same experience when using the apply() functionality, we now vendor
the same modules in Bolt.

Because we vendor the externalized "core" Puppet modules, we need to avoid
syncing them to agents. These plugins are included out-of-the-box in
puppet-agent 5 (where they are core) and 6 (as modules). That means it's
unnecessary to copy any of this content to agents. Moreover, because the
vendored modules are only intended to be used by Puppet 6 agents, they can
cause problems when syncing to Puppet 5 agents, where they can supersede
the built-in plugins with potentially backward-incompatible code.