### PR TITLE
(maint) Update JSON schema paths

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ENV['BOLT_DISABLE_ANALYTICS'] = 'true'
 
 gemspec
 gem "hocon"
+gem "json-schema"
 gem "puma"
 gem "rack"
 gem "rails-auth"

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.license       = "Apache-2.0"
   spec.files         = Dir['exe/*'] +
                        Dir['lib/**/*.rb'] +
+                       Dir['lib/**/*.json'] +
                        Dir['libexec/*'] +
                        Dir['vendored/*.rb'] +
                        Dir['vendored/*/lib/**/*.rb'] +

--- a/lib/bolt_ext/schemas/ssh-run_task.json
+++ b/lib/bolt_ext/schemas/ssh-run_task.json
@@ -61,7 +61,7 @@
       "required": ["hostname", "user"],
       "additionalProperties": false
     },
-    "task": { "$ref": "file:lib/bolt_ext/schemas/task.json"},
+    "task": { "$ref": "file:task"},
     "parameters": {
       "type": "object",
       "description": "JSON formatted parameters to be provided to task"

--- a/lib/bolt_ext/schemas/ssh-run_task.json
+++ b/lib/bolt_ext/schemas/ssh-run_task.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "SSH run_task request",
+  "description": "POST ssh/run_task request schema",
+  "type": "object",
+  "properties": {
+    "target": {
+      "type": "object",
+      "description": "Target information to run task on",
+      "properties": {
+        "hostname": {
+          "type": "string",
+          "description": "Target identifier"
+        },
+        "user": {
+          "type": "string",
+          "description": "Login user"
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for SSH transport authentication"
+        },
+        "private-key-content": {
+          "type": "string",
+          "description": "Contents of private key for SSH"
+        },
+        "port": {
+          "type": "integer",
+          "description": "Connection port"
+        },
+        "connect-timeout": {
+          "type": "integer",
+          "description": "How long Bolt should wait when establishing connections"
+        },
+        "run-as-command": {
+          "type": "array",
+          "description": "Command elevate permissions",
+          "items": { "type": "string" }
+        },
+        "run-as": {
+          "type": "string",
+          "description": "A different user to run commands as after login"
+        },
+        "tmpdir": {
+          "type": "string",
+          "description": "The directory to upload and execute temporary files on the target"
+        },
+        "host-key-check": {
+          "type": "boolean",
+          "description": "Whether to perform host key validation when connecting over SSH"
+        },
+        "sudo-password": {
+          "type": "string",
+          "description": "Password to use when changing users via run-as"
+        }
+      },
+      "oneOf": [
+        { "required": ["password"] },
+        { "required": ["private-key-content"] }
+      ],
+      "required": ["hostname", "user"],
+      "additionalProperties": false
+    },
+    "task": { "$ref": "file:lib/bolt_ext/schemas/task.json"},
+    "parameters": {
+      "type": "object",
+      "description": "JSON formatted parameters to be provided to task"
+    }  
+  },
+  "required": ["target", "task"]
+}

--- a/lib/bolt_ext/schemas/task.json
+++ b/lib/bolt_ext/schemas/task.json
@@ -1,5 +1,5 @@
 {
-  "id": "file:lib/bolt_ext/schemas/task.json",
+  "id": "file:task",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Task",
   "description": "Task schema for bolt-server",

--- a/lib/bolt_ext/schemas/task.json
+++ b/lib/bolt_ext/schemas/task.json
@@ -1,0 +1,57 @@
+{
+  "id": "file:lib/bolt_ext/schemas/task.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Task",
+  "description": "Task schema for bolt-server",
+  "type": "object",
+  "description": "The task is a JSON object which includes the following keys",
+  "properties": {
+    "name": {
+      "type": "string",
+       "description": "Task name"
+    },
+    "metadata": {
+      "type": "object",
+      "description": "The metadata object is optional, and contains metadata about the task being run",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "The task description from it's metadata"
+        },
+        "parameters": {
+          "type": "object",
+          "description": "Object whose keys are parameter names, and values are objects",
+          "properties": {
+            "description": {
+              "type": "string",
+              "description": "Parameter description"
+            },
+            "type": {
+              "type": "string",
+              "description": "The type the parameter should accept"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "file": {
+      "type": "object",
+      "description": "File name and content",
+      "properties": {
+        "filename": {
+          "type": "string",
+          "description": "Name of the task file"
+        },
+        "file_content": {
+          "type": "string",
+          "description": "Task's base64 encoded file content"
+        }
+      },
+      "required": ["filename", "file_content"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["name", "file"],
+  "additionalProperties": false
+}

--- a/lib/bolt_ext/schemas/winrm-run_task.json
+++ b/lib/bolt_ext/schemas/winrm-run_task.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "WinRm run_task request",
+  "description": "POST winrm/run_task request schema",
+  "type": "object",
+  "properties": {
+    "target": {
+      "type": "object",
+      "description": "Target information to run task on",
+      "properties": {
+        "hostname": {
+          "type": "string",
+          "description": "Target identifier"
+        },
+        "user": {
+          "type": "string",
+          "description": "Login user"
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for SSH transport authentication"
+        },
+        "port": {
+          "type": "integer",
+          "description": "Connection port"
+        },
+        "connect-timeout": {
+          "type": "integer",
+          "description": "How long Bolt should wait when establishing connections"
+        },
+        "tmpdir": {
+          "type": "string",
+          "description": "The directory to upload and execute temporary files on the target"
+        },
+        "ssl": {
+          "type": "boolean",
+          "description": "When true, Bolt will use https connections for WinRM"
+        },
+        "ssl-verify": {
+          "type": "boolean",
+          "description": "When true, verifies the targets certificate matches the cacert"
+        },
+        "cacert": {
+          "type": "string",
+          "description": "The path to the CA certificate"
+        },
+        "extensions": {
+          "type": "array",
+          "description": "List of file extensions that are accepted for scripts or tasks"
+        }
+      },
+      "required": ["hostname", "user", "password"],
+      "additionalProperties": false
+    },
+    "task": { "$ref": "file:lib/bolt_ext/schemas/task.json"},
+    "parameters": {
+      "type": "object",
+      "description": "JSON formatted parameters to be provided to task"
+    }  
+  },
+  "required": ["target", "task"]
+}

--- a/lib/bolt_ext/schemas/winrm-run_task.json
+++ b/lib/bolt_ext/schemas/winrm-run_task.json
@@ -52,7 +52,7 @@
       "required": ["hostname", "user", "password"],
       "additionalProperties": false
     },
-    "task": { "$ref": "file:lib/bolt_ext/schemas/task.json"},
+    "task": { "$ref": "file:task"},
     "parameters": {
       "type": "object",
       "description": "JSON formatted parameters to be provided to task"

--- a/lib/bolt_ext/server.rb
+++ b/lib/bolt_ext/server.rb
@@ -4,6 +4,7 @@ require 'sinatra'
 require 'bolt'
 require 'bolt/task'
 require 'json'
+require 'json-schema'
 
 class TransportAPI < Sinatra::Base
   # This disables Sinatra's error page generation
@@ -21,13 +22,14 @@ class TransportAPI < Sinatra::Base
     content_type :json
 
     body = JSON.parse(request.body.read)
+    schema = "lib/bolt_ext/schemas/ssh-run_task.json"
+    schema_error = JSON::Validator.fully_validate(schema, body)
+    return [400, schema_error.join] if schema_error.any?
+
     keys = %w[user password port ssh-key-content connect-timeout run-as-command run-as
               tmpdir host-key-check known-hosts-content private-key-content sudo-password]
     opts = body['target'].select { |k, _| keys.include? k }
 
-    if opts['private-key-content'] && opts['password']
-      return [400, "Only include one of 'password' and 'private-key-content'"]
-    end
     if opts['private-key-content']
       opts['private-key'] = { 'key-data' => opts['private-key-content'] }
       opts.delete('private-key-content')
@@ -48,6 +50,10 @@ class TransportAPI < Sinatra::Base
     content_type :json
 
     body = JSON.parse(request.body.read)
+    schema = "lib/bolt_ext/schemas/winrm-run_task.json"
+    schema_error = JSON::Validator.fully_validate(schema, body)
+    return [400, schema_error.join] if schema_error.any?
+
     keys = %w[user password port connect-timeout ssl ssl-verify tmpdir cacert extensions]
     opts = body['target'].select { |k, _| keys.include? k }
     opts['protocol'] = 'winrm'

--- a/lib/bolt_ext/server.rb
+++ b/lib/bolt_ext/server.rb
@@ -10,6 +10,17 @@ class TransportAPI < Sinatra::Base
   # This disables Sinatra's error page generation
   set :show_exceptions, false
 
+  def initialize(app = nil)
+    @schemas = {
+      "ssh-run_task" => JSON.parse(File.read(File.join(__dir__, 'schemas', 'ssh-run_task.json'))),
+      "winrm-run_task" => JSON.parse(File.read(File.join(__dir__, 'schemas', 'winrm-run_task.json')))
+    }
+    shared_schema = JSON::Schema.new(JSON.parse(File.read(File.join(__dir__, 'schemas', 'task.json'))),
+                                     Addressable::URI.parse("file:task"))
+    JSON::Validator.add_schema(shared_schema)
+    super(app)
+  end
+
   get '/' do
     200
   end
@@ -22,8 +33,7 @@ class TransportAPI < Sinatra::Base
     content_type :json
 
     body = JSON.parse(request.body.read)
-    schema = "lib/bolt_ext/schemas/ssh-run_task.json"
-    schema_error = JSON::Validator.fully_validate(schema, body)
+    schema_error = JSON::Validator.fully_validate(@schemas["ssh-run_task"], body)
     return [400, schema_error.join] if schema_error.any?
 
     keys = %w[user password port ssh-key-content connect-timeout run-as-command run-as
@@ -50,8 +60,7 @@ class TransportAPI < Sinatra::Base
     content_type :json
 
     body = JSON.parse(request.body.read)
-    schema = "lib/bolt_ext/schemas/winrm-run_task.json"
-    schema_error = JSON::Validator.fully_validate(schema, body)
+    schema_error = JSON::Validator.fully_validate(@schemas["winrm-run_task"], body)
     return [400, schema_error.join] if schema_error.any?
 
     keys = %w[user password port connect-timeout ssl ssl-verify tmpdir cacert extensions]

--- a/spec/lib/bolt_spec/conn.rb
+++ b/spec/lib/bolt_spec/conn.rb
@@ -19,12 +19,14 @@ module BoltSpec
         raise Error, "The transport must be either 'ssh' or 'winrm'"
       end
 
+      port = ENV["BOLT_#{tu}_PORT"] || default_port
+
       {
         protocol: transport,
         host: ENV["BOLT_#{tu}_HOST"] || "localhost",
         user: ENV["BOLT_#{tu}_USER"] || default_user,
         password: ENV["BOLT_#{tu}_PASSWORD"] || default_password,
-        port: ENV["BOLT_#{tu}_PORT"] || default_port,
+        port: port.to_i,
         key: ENV["BOLT_#{tu}_KEY"] || default_key
       }
     end


### PR DESCRIPTION
Previously the paths for validating JSON schema templates only worked when running from Rspec tests as they were relative to the root directory of Bolt. This commit handles the paths accordingly.