### PR TITLE
(BOLT-844) Add Puppet 6 PATH for Ruby on Windows

### DIFF
--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -99,6 +99,7 @@ module Bolt
           return nil if @shell_initialized
           result = execute(<<-PS)
 $ENV:PATH += ";${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\bin\\;" +
+"${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\puppet\\bin;" +
 "${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\sys\\ruby\\bin\\"
 $ENV:RUBYLIB = "${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\puppet\\lib;" +
 "${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\facter\\lib;" +


### PR DESCRIPTION
Ensure ruby tasks continue to work on Windows when upgrading to Puppet 6.