### PR TITLE
(BOLT-854) Properly escape stdin when using --run-as

### DIFF
--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -174,7 +174,7 @@ module Bolt
       def make_wrapper_stringio(task_path, stdin)
         StringIO.new(<<-SCRIPT)
 #!/bin/sh
-'#{task_path}' <<EOF
+'#{task_path}' <<'EOF'
 #{stdin}
 EOF
 SCRIPT

--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -359,6 +359,18 @@ SHELL
       end
     end
 
+    it "can run a task with params containing variable references", ssh: true do
+      contents = <<SHELL
+#!/bin/sh
+cat
+SHELL
+
+      arguments = { message: "$PATH" }
+      with_task_containing('tasks_test_var', contents, 'both') do |task|
+        expect(ssh.run_task(target, task, arguments)['message']).to eq("$PATH")
+      end
+    end
+
     it "can run a task with Sensitive params via environment", ssh: true do
       contents = <<SHELL
 #!/bin/sh
@@ -540,6 +552,18 @@ SHELL
       with_task_containing('tasks_test', contents, 'environment') do |task|
         expect(ssh.run_task(target, task, arguments).message)
           .to eq('Hello from task then Goodbye')
+      end
+    end
+
+    it "can run a task with params containing variable references", ssh: true do
+      contents = <<SHELL
+#!/bin/sh
+cat
+SHELL
+
+      arguments = { message: "$PATH" }
+      with_task_containing('tasks_test_var', contents, 'both') do |task|
+        expect(ssh.run_task(target, task, arguments)['message']).to eq("$PATH")
       end
     end
 


### PR DESCRIPTION
When using --run-as, we create a wrapper script around the task and
embed the stdin directly into the script inside a heredoc. Previously,
it was possible for escape sequences within that heredoc to corrupt the
stdin, resulting in incorrect task behavior. We now properly set the
heredoc to ignore all escape sequences, ensuring the task receives
the stdin exactly as intended.

Because we always send stdin as a single line of JSON, it's impossible
for it to escape the heredoc by including a line starting with EOF (our
heredoc marker).