### PR TITLE
(maint) Fix transient failures in executor spec test

### DIFF
--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -366,12 +366,18 @@ describe "Bolt::Executor" do
           result
         end
       }
-      # without pausing here running seems to evaluate to 0
-      sleep(0.1)
 
-      running = state.reduce(0) do |acc, (_k, v)|
-        acc += 1 if v[:running]
-        acc
+      running = 0
+      time = 0
+      timer = Time.now
+
+      while (time < 5) && (running != 2)
+        sleep(0.1)
+        running = state.reduce(0) do |acc, (_k, v)|
+          acc += 1 if v[:running]
+          acc
+        end
+        time = Time.now - timer
       end
 
       expect(running).to eq(2)


### PR DESCRIPTION
We are seeing transient issues around the default sleep time for checking threads used by executor. When we first observed the transient failures we bumped the wait time from 0.1 to 0.2 seconds. Instead of bumping the wait time again Nick Lewis suggested looping until the threads are done with a max timeout to avoid continuing to hard code wait times that may not be needed in tests.