### PR TITLE
(BOLT-852) Ensure user and password aren't mangled

### DIFF
--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -107,15 +107,11 @@ module Bolt
     end
 
     def user
-      Addressable::URI.unencode_component(
-        @uri_obj.user || @user
-      )
+      Addressable::URI.unencode_component(@uri_obj.user) || @user
     end
 
     def password
-      Addressable::URI.unencode_component(
-        @uri_obj.password || @password
-      )
+      Addressable::URI.unencode_component(@uri_obj.password) || @password
     end
   end
 end

--- a/spec/bolt/target_spec.rb
+++ b/spec/bolt/target_spec.rb
@@ -7,6 +7,7 @@ describe Bolt::Target do
   describe "when parsing userinfo" do
     let(:user)     { 'günther' }
     let(:password) { 'foobar' }
+    let(:complex)  { '~%F3/-w@ho!#$%^* ' }
 
     it "accepts userinfo when a port is specified" do
       uri = Bolt::Target.new("ssh://#{user}:#{password}@neptune:2222")
@@ -27,13 +28,13 @@ describe Bolt::Target do
     end
 
     it "defaults user from options" do
-      uri = Bolt::Target.new("neptune", 'user' => 'none')
-      expect(uri.user).to eq('none')
+      uri = Bolt::Target.new("neptune", 'user' => complex)
+      expect(uri.user).to eq(complex)
     end
 
     it "defaults password from options" do
-      uri = Bolt::Target.new("neptune", 'password' => 'none')
-      expect(uri.password).to eq('none')
+      uri = Bolt::Target.new("neptune", 'password' => complex)
+      expect(uri.password).to eq(complex)
     end
 
     it "defaults port from options" do


### PR DESCRIPTION
When a user or password are passed via the URI, Bolt unencodes them to
allow passing complex strings in the URI. It shouldn't do that for
users and passwords passed via CLI flags or inventary, but did, meaning
passwords that include things like `%F3` get mangled and don't work. Fix
so only URI components are unencoded.