### PR TITLE
(BOLT-857) Properly override environment in all cases

### DIFF
--- a/libexec/apply_catalog.rb
+++ b/libexec/apply_catalog.rb
@@ -66,7 +66,9 @@ begin
              Puppet::Transaction::Report.new('apply')
            end
 
-  Puppet.override(current_environment: env, loaders: Puppet::Pops::Loaders.new(env)) do
+  Puppet.override(current_environment: env,
+                  environments: Puppet::Environments::Static.new(env),
+                  loaders: Puppet::Pops::Loaders.new(env)) do
     catalog = Puppet::Resource::Catalog.from_data_hash(args['catalog']).to_ral
     catalog.environment = env.name.to_s
     catalog.environment_instance = env


### PR DESCRIPTION
Previously, when using the apply() function, it was possible for Puppet
"features" to be loaded from the default modulepath, rather than from
the temporary modulepath we set up. This could cause incorrect versions
of features to be loaded or for necessary features to be missed.

This happened because there are two methods that parts of Puppet use to
find the current environment:
* Puppet.lookup(:current_environment)
* Puppet.lookup(:environments).get(name)

We override the production environment with our custom modulepath and
set that as :current_environment in the Puppet context. However, that
doesn't affect the :environments value in the context, which still
contains the default directory environments. Thus, any code that looks
up the environment that way will find the original version of the
production environment with its default modulepath. This includes the
code that loads features.

We now explicitly override :environments with a static environments list
that only includes our modified production environment.