### PR TITLE
(maint) Add Puppetfile code inline to docs

### DIFF
--- a/pre-docs/applying_manifest_blocks.md
+++ b/pre-docs/applying_manifest_blocks.md
@@ -9,7 +9,26 @@ Within a plan, you can use Bolt to apply blocks of Puppet code (manifest blocks)
 [Writing plans](writing_plans.md)
 
 **Note:** If you installed bolt as a ruby gem, you'll want to:
-1. Create a Puppetfile with the contents of [bolt's Puppetfile](../Puppetfile) at `~/.puppetlabs/bolt/Puppetfile`
+1. Create a Puppetfile with the contents of [bolt's Puppetfile](../Puppetfile) at `~/.puppetlabs/bolt/Puppetfile`:
+```
+forge "http://forge.puppetlabs.com"
+
+moduledir File.join(File.dirname(__FILE__), 'modules')
+
+mod 'puppetlabs-package', '0.2.0'
+mod 'puppetlabs-service', '0.3.1'
+mod 'puppetlabs-puppet_conf', '0.2.0'
+mod 'puppetlabs-facts', '0.2.0'
+mod 'puppet_agent',
+    git: 'https://github.com/puppetlabs/puppetlabs-puppet_agent',
+    ref: '319ce44a65e73bcf2712ad17be01f9636f0673c9'
+
+# If we don't list these modules explicitly, r10k will purge them
+mod 'canary', local: true
+mod 'aggregate', local: true
+mod 'puppetdb_fact', local: true
+```
+
 2. Run `bolt puppetfile install`
 
 ## Create a sample manifest for nginx on Linux

--- a/pre-docs/bolt_installing.md
+++ b/pre-docs/bolt_installing.md
@@ -201,7 +201,25 @@ If Ruby is already included in your operating system, verify that it is version 
     ```
     bolt --help
     ```
-4. Copy the contents of [bolt's Puppetfile](../Puppetfile) to `~/.puppetlabs/bolt/Puppetfile`
+4. Copy the contents of [bolt's Puppetfile](../Puppetfile) to `~/.puppetlabs/bolt/Puppetfile`:
+```
+forge "http://forge.puppetlabs.com"
+
+moduledir File.join(File.dirname(__FILE__), 'modules')
+
+mod 'puppetlabs-package', '0.2.0'
+mod 'puppetlabs-service', '0.3.1'
+mod 'puppetlabs-puppet_conf', '0.2.0'
+mod 'puppetlabs-facts', '0.2.0'
+mod 'puppet_agent',
+    git: 'https://github.com/puppetlabs/puppetlabs-puppet_agent',
+    ref: '319ce44a65e73bcf2712ad17be01f9636f0673c9'
+
+# If we don't list these modules explicitly, r10k will purge them
+mod 'canary', local: true
+mod 'aggregate', local: true
+mod 'puppetdb_fact', local: true
+```
 5. Run `bolt puppetfile install`
 
 ## Analytics data collection


### PR DESCRIPTION
**What this changes** Instead of linking to the Puppetfile in the bolt module, this should include the Puppetfile code inline to be copy-pasted
**Why** Since we don't expect to update the Puppetfile that often, having a better user experience of copy-pasting rather than having to go to the bolt repo outweighs the risk of having the Puppetfile content in 3 places.