### PR TITLE
(maint) Add notes about not installing bolt as a gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Additionally the Bolt project includes:
 * [bolt-server](developer-documentation/bolt-server.md), an experimental HTTP API for executing tasks over SSH and WinRM.
 * bolt-inventory-pdb, a command-line tool for generating an inventory file from a template containing PuppetDB queries.
 
+> Installing bolt from a gem is not recommended since core modules will not be available. Please [install bolt](https://puppet.com/docs/bolt/latest/bolt_installing.md) as a package
+
 ## Supported platforms
 
 * Linux, OSX, Windows

--- a/pre-docs/bolt_installing.md
+++ b/pre-docs/bolt_installing.md
@@ -170,39 +170,7 @@ The Puppet repository for the YUM package management system is [http://yum.puppe
 
 ## Install Bolt as a gem
 
-Install Ruby 2.3 or above and Bolt.
-
-If Ruby is already included in your operating system, verify that it is version 2.3 or above. Run `ruby -v`.
-
-1.   To install the dependencies required to install Bolt, run the command that corresponds to your operating system. 
-    -   For Fedora 27
-
-        ```
-        dnf install -y ruby rubygem-json rubygem-ffi rubygem-bigdecimal rubygem-io-console
-        ```
-
-    -   For Debian 9 or Ubuntu 16.04
-
-        ```
-        apt-get install -y ruby ruby-ffi
-        ```
-
-    -   For Mac OS X 10.13 \(High Sierra\)
-
-        ```
-        xcode-select --install
-        
-        ```
-
-    -   For Windows, you can download Ruby from [https://rubyinstaller.org/](https://rubyinstaller.org/) or the Chocolatey Windows package manager. Run subsequent commands in a Windows PowerShell session.
-2.   To install Bolt, run `gem install bolt` 
-3.   Run a Bolt command and get started. 
-
-    ```
-    bolt --help
-    ```
-4. Copy the contents of [bolt's Puppetfile](../Puppetfile) to `~/.puppetlabs/bolt/Puppetfile`
-5. Run `bolt puppetfile install`
+Installing bolt from a gem is not recommended since core modules will not be available.
 
 ## Analytics data collection
 


### PR DESCRIPTION
**What this changes** Add notes to readme and official docs recommending installing bolt as a package
**Why** Because users often install bolt as a gem and it doesn't work as they expect out of the box.