### PR TITLE
(BOLT-758) Support different input_methods for implementations

### DIFF
--- a/lib/bolt/task.rb
+++ b/lib/bolt/task.rb
@@ -54,9 +54,12 @@ module Bolt
                files.first.dup
              end
 
-      unless (inmethod = metadata['input_method']).nil?
-        impl['input_method'] = inmethod
-      end
+      inmethod = impl['input_method'] || metadata['input_method']
+      impl['input_method'] = inmethod unless inmethod.nil?
+
+      mfiles = impl.fetch('files', []) + metadata.fetch('files', [])
+      impl['files'] = mfiles.map { |file| { 'name' => file, 'path' => file_map[file] } } unless mfiles.empty?
+
       impl
     end
   end

--- a/spec/bolt/task_spec.rb
+++ b/spec/bolt/task_spec.rb
@@ -22,6 +22,19 @@ describe Bolt::Task do
       allow(target).to receive(:features).and_return(Set.new(['powershell']))
     end
 
+    context 'with input_method in metadata' do
+      let(:implementations) { [{ 'name' => 'foo.sh', 'requirements' => [] }] }
+      let(:metadata) { { 'input_method' => 'stdin', 'implementations' => implementations } }
+
+      it { expect(task.select_implementation(target)).to eq(files.first.merge('input_method' => 'stdin')) }
+
+      context 'with input_method in implementation' do
+        let(:implementations) { [{ 'name' => 'foo.sh', 'requirements' => [], 'input_method' => 'environment' }] }
+
+        it { expect(task.select_implementation(target)).to eq(files.first.merge('input_method' => 'environment')) }
+      end
+    end
+
     context 'no metadata present' do
       let(:metadata) { {} }
 

--- a/spec/bolt/transport/local_spec.rb
+++ b/spec/bolt/transport/local_spec.rb
@@ -230,6 +230,16 @@ SHELL
         end
       end
 
+      it "runs a task with the implementation's input method" do
+        with_task_containing('tasks_test', contents, 'stdin') do |task|
+          task['metadata']['implementations'] = [{
+            'name' => 'tasks_test', 'requirements' => ['shell'], 'input_method' => 'environment'
+          }]
+          expect(local.run_task(target, task, arguments).message.chomp)
+            .to eq('Hello from task Goodbye')
+        end
+      end
+
       it "errors when a task only requires an unsupported requirement" do
         with_task_containing('tasks_test', contents, 'environment') do |task|
           task['metadata']['implementations'] = [{ 'name' => 'tasks_test', 'requirements' => ['powershell'] }]

--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -478,6 +478,16 @@ SHELL
         end
       end
 
+      it "runs a task with the implementation's input method" do
+        with_task_containing('tasks_test', contents, 'stdin') do |task|
+          task['metadata']['implementations'] = [{
+            'name' => 'tasks_test', 'requirements' => ['shell'], 'input_method' => 'environment'
+          }]
+          expect(ssh.run_task(target, task, arguments).message.chomp)
+            .to eq('Hello from task Goodbye')
+        end
+      end
+
       it "errors when a task only requires an unsupported requirement" do
         with_task_containing('tasks_test', contents, 'environment') do |task|
           task['metadata']['implementations'] = [{ 'name' => 'tasks_test', 'requirements' => ['powershell'] }]

--- a/spec/bolt/transport/winrm_spec.rb
+++ b/spec/bolt/transport/winrm_spec.rb
@@ -623,6 +623,16 @@ PS
         end
       end
 
+      it "runs a task with the implementation's input method" do
+        with_task_containing('tasks_test', contents, 'stdin', '.ps1') do |task|
+          task['metadata']['implementations'] = [{
+            'name' => 'tasks_test', 'requirements' => ['powershell'], 'input_method' => 'environment'
+          }]
+          expect(winrm.run_task(target, task, arguments).message.chomp)
+            .to eq('Hello from task Goodbye')
+        end
+      end
+
       it "errors when a task only requires an unsupported requirement" do
         with_task_containing('tasks_test', contents, 'environment', '.ps1') do |task|
           task['metadata']['implementations'] = [{ 'name' => 'tasks_test', 'requirements' => ['shell'] }]


### PR DESCRIPTION
Update for task spec revision 3: support input_method in individual implementations.

Depends on https://github.com/puppetlabs/bolt/pull/651.