### PR TITLE
(BOLT-643) Enable apply() over PCP

### DIFF
--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -199,9 +199,10 @@ module Bolt
             @executor.with_node_logging("Applying manifest block", batch) do
               arguments = { 'catalog' => future.value, 'plugins' => plugins, '_noop' => options['_noop'] }
               raise future.reason if future.rejected?
-              result = transport.batch_task(batch, catalog_apply_task, arguments, options, &notify)
-              result = provide_puppet_missing_errors(result)
-              identify_resource_failures(result)
+              results = transport.batch_task(batch, catalog_apply_task, arguments, options, &notify)
+              Array(results).map do |result|
+                identify_resource_failures(provide_puppet_missing_errors(result))
+              end
             end
           end
         end

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -42,7 +42,7 @@ module Bolt
         path = File.join(libexec, 'custom_facts.rb')
         file = { 'name' => 'custom_facts.rb', 'path' => path }
         metadata = { 'supports_noop' => true, 'input_method' => 'stdin' }
-        Bolt::Task.new(name: 'custom_facts', files: [file], metadata: metadata)
+        Bolt::Task.new(name: 'apply_helpers::custom_facts', files: [file], metadata: metadata)
       end
     end
 
@@ -51,7 +51,7 @@ module Bolt
         path = File.join(libexec, 'apply_catalog.rb')
         file = { 'name' => 'apply_catalog.rb', 'path' => path }
         metadata = { 'supports_noop' => true, 'input_method' => 'stdin' }
-        Bolt::Task.new(name: 'apply_catalog', files: [file], metadata: metadata)
+        Bolt::Task.new(name: 'apply_helpers::apply_catalog', files: [file], metadata: metadata)
       end
     end
 


### PR DESCRIPTION
This fixes a couple of issues preventing the apply() functionality from working
in a PE environment.

### Handle apply results from PCP

Previously, we were assuming that running the apply_catalog task would
always return a single result. Since the PCP transport can properly batch
nodes, it's possible for it to return several results at once, which we
need to account for.

### Use module-qualified name for apply tasks

Because these tasks are actually mocked in Bolt, their name is irrelevant.
However, in order to run them in PE, a task with the same name needs to
actually be installed. These tasks have been copied into the
puppetlabs-apply_helpers module for installation in PE.  Therefore, we need
to refer to them by the names `apply_helpers::custom_facts` and
`apply_helpers::apply_catalog` in order to work in PE.

This requires the [`puppetlabs-apply_helpers
module`](https://github.com/puppetlabs/puppetlabs-apply_helpers) to be
installed on the PE master.