### PR TITLE
(maint) Add tests across multiple targets for ssh, winrm

### DIFF
--- a/spec/integration/winrm_spec.rb
+++ b/spec/integration/winrm_spec.rb
@@ -91,24 +91,30 @@ describe "when runnning over the winrm transport", winrm: true do
       {
         'format' => 'json',
         'modulepath' => modulepath,
-        'winrm' => { 'ssl' => false,
-                     'ssl-verify' => false }
+        'winrm' => {
+          'user' => user,
+          'password' => password,
+          'ssl' => false,
+          'ssl-verify' => false
+        }
       }
     }
-    let(:config_flags) { %W[--nodes #{uri} --password #{password}] }
+    let(:uri) { (1..2).map { |i| "#{conn_uri('winrm')}?id=#{i}" }.join(',') }
+    let(:config_flags) { %W[--nodes #{uri}] }
 
-    it 'runs a command' do
+    it 'runs multiple commands' do
       with_tempfile_containing('conf', YAML.dump(config)) do |conf|
-        result = run_one_node(%W[command run #{whoami} --configfile #{conf.path}] + config_flags)
-        expect(result['stdout'].strip).to eq(user)
+        result = run_nodes(%W[command run #{whoami} --configfile #{conf.path}] + config_flags)
+        expect(result.map { |r| r['stdout'].strip }).to eq([user, user])
       end
     end
 
-    it 'runs a task', :reset_puppet_settings do
+    it 'runs multiple tasks', :reset_puppet_settings do
       with_tempfile_containing('conf', YAML.dump(config)) do |conf|
-        cmd = %W[task run sample::winstdin message=somemessage --configfile #{conf.path}] + config_flags
-        result = run_one_node(cmd)
-        expect(result['_output'].strip).to match(/STDIN: {"messa/)
+        results = run_nodes(%W[task run sample::winstdin message=somemessage --configfile #{conf.path}] + config_flags)
+        results.each do |result|
+          expect(result['_output'].strip).to match(/STDIN: {"messa/)
+        end
       end
     end
   end


### PR DESCRIPTION
Extend integration tests to include running against the same target
multiple times. This test helps prevent clobbering other runs on the
same target.