### PR TITLE
(BOLT-816) Enable control repos as Boltdirs

### DIFF
--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -105,7 +105,7 @@ module Bolt
 
     def validate_hiera_config(hiera_config)
       if File.exist?(File.path(hiera_config))
-        data = File.open(File.path(hiera_config), "r:UTF-8") { |f| YAML.safe_load(f.read) }
+        data = File.open(File.path(hiera_config), "r:UTF-8") { |f| YAML.safe_load(f.read, [Symbol]) }
         unless data['version'] == 5
           raise Bolt::ParseError, "Hiera v5 is required, found v#{data['version'] || 3} in #{hiera_config}"
         end

--- a/spec/bolt/boltdir_spec.rb
+++ b/spec/bolt/boltdir_spec.rb
@@ -5,44 +5,82 @@ require 'bolt/boltdir'
 
 describe Bolt::Boltdir do
   describe "::find_boltdir" do
-    let(:boltdir_path) { Pathname.new(File.join(@tmpdir, "foo", "Boltdir")) }
+    let(:boltdir_path) { @tmpdir + 'foo' + 'Boltdir' }
     let(:boltdir) { Bolt::Boltdir.new(boltdir_path) }
 
     around(:each) do |example|
       Dir.mktmpdir do |tmpdir|
-        @tmpdir = tmpdir
+        @tmpdir = Pathname.new(tmpdir)
         FileUtils.mkdir_p(boltdir_path)
         example.run
       end
     end
 
-    it 'finds Boltdir from inside Boltdir' do
-      pwd = boltdir_path
-      expect(Bolt::Boltdir.find_boltdir(pwd)).to eq(boltdir)
+    describe "when the Boltdir is named Boltdir" do
+      it 'finds Boltdir from inside Boltdir' do
+        pwd = boltdir_path
+        expect(Bolt::Boltdir.find_boltdir(pwd)).to eq(boltdir)
+      end
+
+      it 'finds Boltdir from the parent directory' do
+        pwd = boltdir_path.parent
+        expect(Bolt::Boltdir.find_boltdir(pwd)).to eq(boltdir)
+      end
+
+      it 'does not find Boltdir from the grandparent directory' do
+        pwd = boltdir_path.parent.parent
+        expect(Bolt::Boltdir.find_boltdir(pwd)).not_to eq(boltdir)
+      end
+
+      it 'finds the Boltdir from a sibling directory' do
+        pwd = boltdir_path.parent + 'bar'
+        FileUtils.mkdir_p(pwd)
+
+        expect(Bolt::Boltdir.find_boltdir(pwd)).to eq(boltdir)
+      end
+
+      it 'finds the Boltdir from a child directory' do
+        pwd = boltdir_path + 'baz'
+        FileUtils.mkdir_p(pwd)
+
+        expect(Bolt::Boltdir.find_boltdir(pwd)).to eq(boltdir)
+      end
     end
 
-    it 'finds Boltdir from the parent directory' do
-      pwd = boltdir_path.parent
-      expect(Bolt::Boltdir.find_boltdir(pwd)).to eq(boltdir)
+    describe "when using a control repo-style Boltdir" do
+      it 'uses the current directory if it has a bolt.yaml' do
+        pwd = @tmpdir
+        FileUtils.touch(pwd + 'bolt.yaml')
+        expect(Bolt::Boltdir.find_boltdir(pwd)).to eq(Bolt::Boltdir.new(pwd))
+      end
+
+      it 'ignores non-Boltdir children with bolt.yaml' do
+        pwd = @tmpdir
+        FileUtils.mkdir_p(pwd + 'bar')
+        FileUtils.touch(pwd + 'bar' + 'bolt.yaml')
+
+        expect(Bolt::Boltdir.find_boltdir(pwd)).to eq(Bolt::Boltdir.default_boltdir)
+      end
+
+      it 'prefers a directory called Boltdir over the local directory' do
+        pwd = boltdir_path.parent
+        FileUtils.touch(pwd + 'bolt.yaml')
+
+        expect(Bolt::Boltdir.find_boltdir(pwd)).to eq(boltdir)
+      end
+
+      it 'prefers a directory called Boltdir over the parent directory' do
+        pwd = boltdir_path.parent + 'bar'
+        FileUtils.mkdir_p(pwd)
+        FileUtils.touch(boltdir_path.parent + 'bolt.yaml')
+
+        expect(Bolt::Boltdir.find_boltdir(pwd)).to eq(boltdir)
+      end
     end
 
-    it 'does not find Boltdir from the grandparent directory' do
-      pwd = boltdir_path.parent.parent
-      expect(Bolt::Boltdir.find_boltdir(pwd)).not_to eq(boltdir)
-    end
-
-    it 'finds the Boltdir from a sibling directory' do
-      pwd = boltdir_path.parent + 'bar'
-      FileUtils.mkdir_p(pwd)
-
-      expect(Bolt::Boltdir.find_boltdir(pwd)).to eq(boltdir)
-    end
-
-    it 'finds the Boltdir from a child directory' do
-      pwd = boltdir_path + 'baz'
-      FileUtils.mkdir_p(pwd)
-
-      expect(Bolt::Boltdir.find_boltdir(pwd)).to eq(boltdir)
+    it 'returns the default when no Boltdir is found' do
+      pwd = @tmpdir
+      expect(Bolt::Boltdir.find_boltdir(pwd)).to eq(Bolt::Boltdir.default_boltdir)
     end
   end
 end


### PR DESCRIPTION
For existing Puppet users, the control repo is a source of Puppet content
including modules and hiera data. It's helpful to be able to use Bolt from
within that context and pick up all of the content that's deployed in the
Puppet environment. However, doing that currently requires creating a
Boltdir with a bolt.yaml that refers to the hiera config and modulepath
using relative paths like ../modules.

We now look for a bolt.yaml in the current directory (if there is no
Boltdir) and treat the local directory as the Boltdir if one is found. This
allows the defaults for hiera config and modulepath to work when running
Bolt from a standard control repo.

This also fixes an issue where hiera.yaml files containing symbols wouldn't be
loaded. Since many existing hiera.yaml configs do contain symbols, fixing that
is an important part of enabling Bolt usage from a control repo.