### PR TITLE
(BOLT-752) Add test with unknown metadata keys

### DIFF
--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -884,7 +884,9 @@ bar
           expect(json).to eq(
             "name" => "sample::params",
             "metadata" => {
+              "anything" => true,
               "description" => "Task with parameters",
+              "extensions" => {},
               "input_method" => 'stdin',
               "parameters" => {
                 "mandatory_string" => {

--- a/spec/fixtures/modules/sample/tasks/params.json
+++ b/spec/fixtures/modules/sample/tasks/params.json
@@ -29,5 +29,7 @@
     "no_type": {
       "description": "A parameter without a type"
     }
-  }
+  },
+  "extensions": {},
+  "anything": true
 }


### PR DESCRIPTION
Add a test showing Bolt no longer errors on unknown metadata keys.