### PR TITLE
(BOLT-865) Bump facts to 0.3.1

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -7,7 +7,7 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 mod 'puppetlabs-package', '0.2.0'
 mod 'puppetlabs-service', '0.3.1'
 mod 'puppetlabs-puppet_conf', '0.2.0'
-mod 'puppetlabs-facts', '0.2.0'
+mod 'puppetlabs-facts', '0.3.1'
 mod 'puppet_agent',
     git: 'https://github.com/puppetlabs/puppetlabs-puppet_agent',
     ref: '319ce44a65e73bcf2712ad17be01f9636f0673c9'

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1035,7 +1035,6 @@ bar
                               ["canary"],
                               ["facts"],
                               ["facts::info"],
-                              ["facts::retrieve"],
                               ["puppetdb_fact"],
                               ["sample::ok"]])
 


### PR DESCRIPTION
Bump the puppetlabs-facts module to 0.3.1 so failure gathering facts will no longer be hidden.