### PR TITLE
(BOLT-749) Remove support for legacy bolt.yaml location

### DIFF
--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -60,17 +60,7 @@ module Bolt
     end
 
     def self.from_boltdir(boltdir, overrides = {})
-      # *Optionally* load the boltdir config file, and fall back to the legacy
-      # config if that isn't found. Because logging is built in to the
-      # legacy_conf method, we don't want to look that up unless we need it.
-      configs = if boltdir.config_file.exist?
-                  [boltdir.config_file]
-                else
-                  [legacy_conf]
-                end
-
-      data = Bolt::Util.read_config_file(nil, configs, 'config') || {}
-
+      data = Bolt::Util.read_config_file(nil, [boltdir.config_file], 'config') || {}
       new(boltdir, data, overrides)
     end
 
@@ -173,21 +163,6 @@ module Bolt
       end
     end
     private :update_from_file
-
-    # TODO: This is deprecated in 0.21.0 and can be removed in release 0.22.0.
-    def self.legacy_conf
-      root_path = File.expand_path(File.join('~', '.puppetlabs'))
-      legacy_paths = [File.join(root_path, 'bolt.yaml'), File.join(root_path, 'bolt.yml')]
-      legacy_conf = legacy_paths.find { |path| File.exist?(path) }
-      found_legacy_conf = !!legacy_conf
-      legacy_conf ||= legacy_paths[0]
-      if found_legacy_conf
-        correct_path = Bolt::Boltdir.default_boltdir.config_file
-        msg = "Found configfile at deprecated location #{legacy_conf}. Global config should be in #{correct_path}"
-        Logging.logger[self].warn(msg)
-      end
-      legacy_conf
-    end
 
     def apply_overrides(options)
       %i[concurrency transport format trace modulepath inventoryfile color].each do |key|

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -66,31 +66,9 @@ describe Bolt::Config do
     let(:alt_path) { File.expand_path(File.join('~', '.puppetlabs', 'bolt.yml')) }
 
     it "loads from the boltdir config file if present" do
-      expect(boltdir.config_file).to receive(:exist?).and_return(true)
       expect(Bolt::Util).to receive(:read_config_file).with(nil, [boltdir.config_file], 'config')
 
       Bolt::Config.from_boltdir(boltdir)
-    end
-
-    it "loads from the old default bolt.yaml with a warning if the boltdir default isn't present" do
-      expect(boltdir.config_file).to receive(:exist?).and_return(false)
-      expect(File).to receive(:exist?).with(default_path).and_return(true)
-      expect(Bolt::Util).to receive(:read_config_file).with(nil, [default_path], 'config')
-
-      Bolt::Config.from_boltdir(boltdir)
-
-      expect(@log_output.readline).to match(/WARN.*Found configfile at deprecated location #{default_path}/)
-    end
-
-    it "loads from the old default bolt.yml with a warning if the boltdir default isn't present" do
-      expect(boltdir.config_file).to receive(:exist?).and_return(false)
-      expect(File).to receive(:exist?).with(default_path).and_return(false)
-      expect(File).to receive(:exist?).with(alt_path).and_return(true)
-      expect(Bolt::Util).to receive(:read_config_file).with(nil, [alt_path], 'config')
-
-      Bolt::Config.from_boltdir(boltdir)
-
-      expect(@log_output.readline).to match(/WARN.*Found configfile at deprecated location #{alt_path}/)
     end
   end
 

--- a/spec/lib/bolt_spec/integration.rb
+++ b/spec/lib/bolt_spec/integration.rb
@@ -6,7 +6,6 @@ module BoltSpec
       cli = Bolt::CLI.new(arguments)
 
       # prevent tests from reading users config
-      allow(Bolt::Config).to receive(:legacy_conf).and_return(File.join('.', 'path', 'does not exist'))
       allow(Bolt::Boltdir).to receive(:find_boltdir).and_return(Bolt::Boltdir.new(Dir.mktmpdir))
       puppetdb_config = Bolt::PuppetDB::Config.new('server_urls' => 'https://puppetdb.example.com',
                                                    'cacert' => '/path/to/cacert')


### PR DESCRIPTION
~/.puppetlabs/bolt.yaml(yml) has been deprecated for a few releases and
is removed with this commit.