### PR TITLE
(maint) Suppress base64-encoded binary data in apply_prep

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
@@ -64,7 +64,8 @@ Puppet::Functions.create_function(:apply_prep) do
         end
 
         task = applicator.custom_facts_task
-        results = executor.run_task(targets, task, 'plugins' => plugins)
+        arguments = { 'plugins' => Puppet::Pops::Types::PSensitiveType::Sensitive.new(plugins) }
+        results = executor.run_task(targets, task, arguments)
         raise Bolt::RunFailure.new(results, 'run_task', task.name) unless results.ok?
 
         results.each do |result|

--- a/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
@@ -53,7 +53,7 @@ describe 'apply_prep' do
       executor.expects(:run_task).with(targets, version_task, anything, anything).returns(versions)
 
       facts = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: fact) })
-      executor.expects(:run_task).with(targets, custom_facts_task, 'plugins' => :tarball).returns(facts)
+      executor.expects(:run_task).with(targets, custom_facts_task, includes('plugins')).returns(facts)
 
       is_expected.to run.with_params(hostnames.join(',')).and_return(nil)
       targets.each do |target|
@@ -72,7 +72,7 @@ describe 'apply_prep' do
       executor.expects(:run_task).with(targets[1..1], service_task, anything, anything).returns(ok_result).twice
 
       facts = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: fact) })
-      executor.expects(:run_task).with(targets, custom_facts_task, 'plugins' => :tarball).returns(facts)
+      executor.expects(:run_task).with(targets, custom_facts_task, includes('plugins')).returns(facts)
 
       is_expected.to run.with_params(hostnames)
       targets.each do |target|
@@ -130,7 +130,7 @@ describe 'apply_prep' do
       results = Bolt::ResultSet.new(
         targets.map { |t| Bolt::Result.new(t, error: { 'msg' => 'could not gather facts' }) }
       )
-      executor.expects(:run_task).with(targets, custom_facts_task, 'plugins' => :tarball).returns(results)
+      executor.expects(:run_task).with(targets, custom_facts_task, includes('plugins')).returns(results)
 
       is_expected.to run.with_params(hostnames).and_raise_error(
         Bolt::RunFailure, "Plan aborted: run_task 'custom_facts_task' failed on 2 nodes"

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -197,7 +197,11 @@ module Bolt
         result_promises = targets.zip(futures).flat_map do |target, future|
           @executor.queue_execute([target]) do |transport, batch|
             @executor.with_node_logging("Applying manifest block", batch) do
-              arguments = { 'catalog' => future.value, 'plugins' => plugins, '_noop' => options['_noop'] }
+              arguments = {
+                'catalog' => Puppet::Pops::Types::PSensitiveType::Sensitive.new(future.value),
+                'plugins' => Puppet::Pops::Types::PSensitiveType::Sensitive.new(plugins),
+                '_noop' => options['_noop']
+              }
               raise future.reason if future.rejected?
               results = transport.batch_task(batch, catalog_apply_task, arguments, options, &notify)
               Array(results).map do |result|


### PR DESCRIPTION
Use the Sensitive type to suppress verbose logging of the base64-encoded
plugins data sent as part of apply_prep (gathering custom facts). Also
updates the catalog application arguments, but they're normal logging is
suppressed so it doesn't have visible impact at verbose.