### PR TITLE
(BOLT-413) Don't expand type alias names in bolt plan show

### DIFF
--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -241,7 +241,12 @@ module Bolt
     def plan_hash(plan_name, plan)
       elements = plan.params_type.elements || []
       parameters = elements.each_with_object({}) do |param, acc|
-        acc[param.name] = { 'type' => param.value_type }
+        type = if param.value_type.is_a?(Puppet::Pops::Types::PTypeAliasType)
+                 param.value_type.name
+               else
+                 param.value_type.to_s
+               end
+        acc[param.name] = { 'type' => type }
         acc[param.name]['default_value'] = nil if param.key_type.is_a?(Puppet::Pops::Types::POptionalType)
       end
       {

--- a/spec/integration/parsing_spec.rb
+++ b/spec/integration/parsing_spec.rb
@@ -32,11 +32,6 @@ describe "CLI parses input" do
 
   it 'shows a plan with aliased type' do
     result = run_cli_json(%w[plan show parsing] + config_flags)
-    target_spec_type = "TargetSpec = Boltlib::TargetSpec = Variant[String[1], Object[{name => 'Target', attributes =>"\
-    " {'uri' => String[1], 'options' => {type => Hash[String[1], Data], value => {}}}, functions => {'host' => "\
-    "Callable[[0, 0], String[1]], 'name' => Callable[[0, 0], String[1]], 'password' => Callable[[0, 0], "\
-    "Optional[String[1]]], 'port' => Callable[[0, 0], Optional[Integer]], 'protocol' => Callable[[0, 0], "\
-    "Optional[String[1]]], 'user' => Callable[[0, 0], Optional[String[1]]]}}], Array[Boltlib::TargetSpec]]"
 
     expect(result).to eq(
       "name" => "parsing",
@@ -44,7 +39,7 @@ describe "CLI parses input" do
       "parameters" => {
         "string" => { "type" => "String" },
         "string_bool" => { "type" => "Variant[String, Boolean]" },
-        "nodes" => { "type" => target_spec_type },
+        "nodes" => { "type" => "TargetSpec" },
         "array" => { "type" => "Optional[Array]", "default_value" => nil },
         "hash" => { "type" => "Optional[Hash]", "default_value" => nil }
       }


### PR DESCRIPTION
Previously, using `bolt plan show <plan-name>` for a plan with a
parameter of type TargetSpec would display the parameter type as

    TargetSpec = Boltlib::TargetSpec = Variant[String[1], Object[{name => 'Target', attributes => {'uri' => String[1], 'options' => {type => Hash[String[1], Data], value => {}}}, functions => {'host' => Callable[[0, 0], String[1]], 'name' => Callable[[0, 0], String[1]], 'password' => Callable[[0, 0], Optional[String[1]]], 'port' => Callable[[0, 0], Optional[Integer]], 'protocol' => Callable[[0, 0], Optional[String[1]]], 'user' => Callable[[0, 0], Optional[String[1]]]}}], Array[Boltlib::TargetSpec]]

Which is unhelpful.

We now explicitly check for alias types and just display the type name,
rather than the full string representation.