### PR TITLE
(BOLT-863) Correctly generate errors when apply_task fails

### DIFF
--- a/lib/bolt/apply_result.rb
+++ b/lib/bolt/apply_result.rb
@@ -33,7 +33,7 @@ module Bolt
     end
 
     def self.resource_error(result)
-      if result.ok? && result.value['status'] == 'failed'
+      if result.value['status'] == 'failed'
         resources = result.value['resource_statuses']
         failed = resources.select { |_, r| r['failed'] }.flat_map do |key, resource|
           resource['events'].select { |e| e['status'] == 'failure' }.map do |event|
@@ -51,6 +51,8 @@ module Bolt
         new(result.target,
             error: puppet_missing,
             report: result.value.delete('_error'))
+      elsif !result.ok?
+        new(result.target, error: result.error_hash)
       elsif (resource_error = resource_error(result))
         new(result.target,
             error: resource_error,

--- a/spec/integration/apply_error_spec.rb
+++ b/spec/integration/apply_error_spec.rb
@@ -23,6 +23,15 @@ describe "errors gracefully attempting to apply a manifest block" do
       expect(error['kind']).to eq('bolt/apply-error')
       expect(error['msg']).to eq("Puppet is not installed on the target, please install it to enable 'apply'")
     end
+
+    context 'when it cannot connect to the target' do
+      let(:password) { 'incorrect_password' }
+      it 'displays a connection error' do
+        result = run_cli_json(%w[plan run basic::class] + config_flags)
+        error = result['details']['result_set'][0]['result']['_error']
+        expect(error['kind']).to eq('puppetlabs.tasks/connect-error')
+      end
+    end
   end
 
   describe 'over winrm', winrm: true do


### PR DESCRIPTION
This ensures that errors other than puppet-missing are correctly
generated when the apply test fails.