### PR TITLE
(BOLT-883) Redirect all Puppet input and output to temp dir

### DIFF
--- a/libexec/apply_catalog.rb
+++ b/libexec/apply_catalog.rb
@@ -10,7 +10,14 @@ require 'tempfile'
 
 args = JSON.parse(ARGV[0] ? File.read(ARGV[0]) : STDIN.read)
 
-Puppet.initialize_settings([])
+# Create temporary directories for all core Puppet settings so we don't clobber
+# existing state or read from puppet.conf
+puppet_root = Dir.mktmpdir
+moduledir = File.join(puppet_root, 'modules')
+Dir.mkdir(moduledir)
+cli = Puppet::Settings::REQUIRED_APP_SETTINGS.flat_map { |setting| ["--#{setting}", puppet_root] }
+cli << '--modulepath' << moduledir
+Puppet.initialize_settings(cli)
 run_mode = Puppet::Util::RunMode[:user]
 Puppet.settings.initialize_app_defaults(Puppet::Settings.app_defaults_for_run_mode(run_mode))
 
@@ -18,15 +25,8 @@ Puppet::ApplicationSupport.push_application_context(run_mode)
 
 # Avoid extraneous output
 Puppet[:summarize] = false
-
-# Don't interfere with the normal agent
 Puppet[:report] = false
 Puppet[:graph] = false
-
-# Get a unique temporary path, but ensure the file doesn't exist or Puppet will report 'State got corrupted'
-statefile = Tempfile.new('puppet-state')
-Puppet[:statefile] = statefile.path
-statefile.close!
 
 # Make sure to apply the catalog
 Puppet[:use_cached_catalog] = false
@@ -44,14 +44,13 @@ Puppet[:postrun_command] = nil
 Puppet[:default_file_terminus] = :file_server
 
 exit_code = 0
-moduledir = Dir.mktmpdir
 begin
   Tempfile.open('plugins.tar.gz') do |plugins|
     File.binwrite(plugins, Base64.decode64(args['plugins']))
     Puppet::ModuleTool::Tar.instance.unpack(plugins, moduledir, Etc.getlogin || Etc.getpwuid.name)
   end
 
-  env = Puppet.lookup(:environments).get('production').override_with(modulepath: [moduledir])
+  env = Puppet.lookup(:environments).get('production')
   # Needed to ensure features are loaded
   env.each_plugin_directory do |dir|
     $LOAD_PATH << dir unless $LOAD_PATH.include?(dir)
@@ -67,7 +66,6 @@ begin
            end
 
   Puppet.override(current_environment: env,
-                  environments: Puppet::Environments::Static.new(env),
                   loaders: Puppet::Pops::Loaders.new(env)) do
     catalog = Puppet::Resource::Catalog.from_data_hash(args['catalog']).to_ral
     catalog.environment = env.name.to_s
@@ -81,7 +79,7 @@ begin
   exit_code = report.exit_status != 1
 ensure
   begin
-    FileUtils.remove_dir(moduledir)
+    FileUtils.remove_dir(puppet_root)
   rescue Errno::ENOTEMPTY => e
     STDERR.puts("Could not cleanup temporary directory: #{e}")
   end

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -77,7 +77,10 @@ describe "apply" do
         expect(error['msg']).to match(/Resources failed to apply/)
       end
 
-      it 'applies a notify' do
+      it 'applies a notify and ignores local settings' do
+        run_command('echo environment=doesnotexist > /etc/puppetlabs/puppet/puppet.conf',
+                    uri, config: root_config, inventory: conn_inventory)
+
         result = run_cli_json(%w[plan run basic::class] + config_flags)
         expect(result).not_to include('kind')
         expect(result[0]).to include('status' => 'success')


### PR DESCRIPTION
Bolt Apply still picked up settings from `puppet.conf`, which can lead
to confusing failures. Update `apply_catalog` to override required app
settings - similar to how Bolt sets up Puppet - to point to a temp
directory. The result should be that we ignore any config on the system,
write any logs and runtime state to that temporary directory, and read
environments from that location (i.e. the only available environment
will be the built-in `production`).