### PR TITLE
(BOLT-866) Improve human format output for PlanResults

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/datatypes/applyresult.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/applyresult.rb
@@ -9,6 +9,7 @@ Puppet::DataTypes.create_type('ApplyResult') do
     functions => {
       error => Callable[[], Optional[Error]],
       ok => Callable[[], Boolean],
+      message => Callable[[], Optional[String]],
     }
   PUPPET
 

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -84,6 +84,7 @@ describe "apply" do
         result = run_cli_json(%w[plan run basic::class] + config_flags)
         expect(result).not_to include('kind')
         expect(result[0]).to include('status' => 'success')
+        expect(result[0]['result']['_output']).to eq('changed: 1, failed: 0, unchanged: 0 skipped: 0, noop: 0')
         resources = result[0]['result']['report']['resource_statuses']
         expect(resources).to include('Notify[hello world]')
       end

--- a/spec/integration/plan_spec.rb
+++ b/spec/integration/plan_spec.rb
@@ -30,9 +30,17 @@ describe "When a plan succeeds" do
 
   it 'prints a placeholder if no result is returned', ssh: true do
     result = run_cli(['plan', 'run', 'sample::single_task', '--nodes', target] + config_flags,
-                     outputter: Bolt::Outputter::Human)
+                     outputter: Bolt::Outputter::JSON)
     json = JSON.parse(result)[0]
     expect(json['node']).to eq(target.to_s)
     expect(json['status']).to eq('success')
+  end
+
+  it 'prints a placeholder if no result is returned', ssh: true do
+    result = run_cli(['plan', 'run', 'sample::single_task', '--nodes', target] + config_flags,
+                     outputter: Bolt::Outputter::Human)
+    expect(result).to match(/got passed the message: hi there/)
+    expect(result).to match(/Successful on 1 node:/)
+    expect(result).to match(/Ran on 1 node/)
   end
 end


### PR DESCRIPTION
Previously the human format for plan results was always JSON which was
hard to read. Now the human output of ResultSets looks like the human
output for task/command/script/file_upload results. Apply results have a
message that summarized resource changes for them.

I'm going to poke at refactoring "with_node_logging" to make it more human readable with apply but I think this bit will make nlews output easier. 