### PR TITLE
(BOLT-879) Add note to docs about installing kerberos

### DIFF
--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -55,7 +55,8 @@ module Bolt
           require 'net/ssh/krb'
         rescue LoadError
           logger.debug {
-            "Authentication method 'gssapi-with-mic' is not available"
+            "Authentication method 'gssapi-with-mic' is not available. "\
+            "Please install the kerberos gem with `gem install net-ssh-krb`"
           }
         end
 

--- a/pre-docs/bolt_installing.md
+++ b/pre-docs/bolt_installing.md
@@ -209,4 +209,10 @@ To disable the collection of analytics data add the following line to `~/.puppe
 ```
 disabled: true
 ```
+## A Note on Kerberos over SSH
+
+We support using Kerberos over SSH for authentication, but due to license incompatibility with other components we are distributing you'll need to install the gem yourself. You can do this with
+```
+gem install net-ssh-krb
+```
 


### PR DESCRIPTION
**What this changes** Adds a note to the docs that the user needs to install the kerberos gem on their own
**Why** The license for kerberos is incompatible with other components we distribute, so we need to remove it from our packaging and users who need it need to install it on their own.