### PR TITLE
(BOLT-900) Allow deprecations in functions used in a manifest block

### DIFF
--- a/spec/fixtures/apply/basic/manifests/strict.pp
+++ b/spec/fixtures/apply/basic/manifests/strict.pp
@@ -1,0 +1,4 @@
+class basic::strict() {
+  $hash = { a => 1, a => 2 }
+  notify { 'hello': message => $hash }
+}

--- a/spec/fixtures/apply/basic/manifests/strict_variables.pp
+++ b/spec/fixtures/apply/basic/manifests/strict_variables.pp
@@ -1,0 +1,3 @@
+class basic::strict_variables() {
+  notify { 'hello': message => "hello ${some_var_name}" }
+}

--- a/spec/fixtures/apply/basic/plans/strict.pp
+++ b/spec/fixtures/apply/basic/plans/strict.pp
@@ -1,0 +1,7 @@
+plan basic::strict(TargetSpec $nodes) {
+  return apply($nodes) {
+    # Use a class. While we don't enforce strict language on the CatalogCompiler,
+    # we still do in the plan language which is parsing manifest blocks.
+    include basic::strict
+  }
+}

--- a/spec/fixtures/apply/basic/plans/strict_variables.pp
+++ b/spec/fixtures/apply/basic/plans/strict_variables.pp
@@ -1,0 +1,7 @@
+plan basic::strict_variables(TargetSpec $nodes) {
+  return apply($nodes) {
+    # Use a class. While we don't enforce strict_variables on the CatalogCompiler,
+    # we still do in the plan language which is parsing manifest blocks.
+    include basic::strict_variables
+  }
+}

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -78,6 +78,22 @@ describe "passes parsed AST to the apply_catalog task" do
       expect(notify.count).to eq(1)
     end
 
+    it 'allows and warns on language violations (strict=warning)' do
+      result = run_cli_json(%w[plan run basic::strict] + config_flags)
+      notify = get_notifies(result)
+      expect(notify.count).to eq(1)
+      expect(notify[0]['parameters']['message']).to eq('a' => 2)
+      logs = @log_output.readlines
+      expect(logs).to include(/WARN.*The key 'a' is declared more than once/)
+    end
+
+    it 'allows undefined variables (strict_variables=false)' do
+      result = run_cli_json(%w[plan run basic::strict_variables] + config_flags)
+      notify = get_notifies(result)
+      expect(notify.count).to eq(1)
+      expect(notify[0]['parameters']['message']).to eq('hello ')
+    end
+
     it 'applies a complex type from the modulepath' do
       result = run_cli_json(%w[plan run basic::type] + config_flags)
       report = result[0]['result']['report']


### PR DESCRIPTION
We want Bolt to be able to compile most Puppet 4+ manifests, so we need to allow deprecated functions. TODO: this should be configurable.