### PR TITLE
(BOLT-755) Add shareable task code

### DIFF
--- a/lib/bolt/task.rb
+++ b/lib/bolt/task.rb
@@ -58,19 +58,17 @@ module Bolt
       impl['input_method'] = inmethod unless inmethod.nil?
 
       mfiles = impl.fetch('files', []) + metadata.fetch('files', [])
-      unless mfiles.empty?
-        dirnames, filenames = mfiles.partition { |file| file.end_with?('/') }
-        impl['files'] = filenames.map do |file|
-          path = file_map[file]
-          raise "No file found for reference #{file}" if path.nil?
-          { 'name' => file, 'path' => path }
-        end
+      dirnames, filenames = mfiles.partition { |file| file.end_with?('/') }
+      impl['files'] = filenames.map do |file|
+        path = file_map[file]
+        raise "No file found for reference #{file}" if path.nil?
+        { 'name' => file, 'path' => path }
+      end
 
-        unless dirnames.empty?
-          files.each do |file|
-            if dirnames.any? { |dirname| file['name'].start_with?(dirname) }
-              impl['files'] << file
-            end
+      unless dirnames.empty?
+        files.each do |file|
+          if dirnames.any? { |dirname| file['name'].start_with?(dirname) }
+            impl['files'] << file
           end
         end
       end

--- a/lib/bolt/task.rb
+++ b/lib/bolt/task.rb
@@ -58,7 +58,22 @@ module Bolt
       impl['input_method'] = inmethod unless inmethod.nil?
 
       mfiles = impl.fetch('files', []) + metadata.fetch('files', [])
-      impl['files'] = mfiles.map { |file| { 'name' => file, 'path' => file_map[file] } } unless mfiles.empty?
+      unless mfiles.empty?
+        dirnames, filenames = mfiles.partition { |file| file.end_with?('/') }
+        impl['files'] = filenames.map do |file|
+          path = file_map[file]
+          raise "No file found for reference #{file}" if path.nil?
+          { 'name' => file, 'path' => path }
+        end
+
+        unless dirnames.empty?
+          files.each do |file|
+            if dirnames.any? { |dirname| file['name'].start_with?(dirname) }
+              impl['files'] << file
+            end
+          end
+        end
+      end
 
       impl
     end

--- a/lib/bolt/transport/local.rb
+++ b/lib/bolt/transport/local.rb
@@ -86,7 +86,7 @@ module Bolt
         extra_files = implementation['files']
 
         with_tmpscript(executable, target.options['tmpdir']) do |script, dir|
-          if extra_files
+          unless extra_files.empty?
             installdir = File.join(dir, '_installdir')
             arguments['_installdir'] = installdir
             FileUtils.mkdir_p(extra_files.map { |file| File.join(installdir, File.dirname(file['name'])) })

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -126,6 +126,7 @@ module Bolt
           executable = task.file['filename']
           file_content = Base64.decode64(task.file['file_content'])
           input_method = task.metadata['input_method']
+          extra_files = []
         else
           implementation = task.select_implementation(target, PROVIDED_FEATURES)
           executable = implementation['path']
@@ -149,7 +150,7 @@ module Bolt
                                    conn.write_remote_executable(dir, executable)
                                  end
 
-              if extra_files
+              unless extra_files.empty?
                 # TODO: optimize upload of directories
                 installdir = File.join(dir.to_s, '_installdir')
                 arguments['_installdir'] = installdir

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -130,6 +130,7 @@ module Bolt
           implementation = task.select_implementation(target, PROVIDED_FEATURES)
           executable = implementation['path']
           input_method = implementation['input_method']
+          extra_files = implementation['files']
         end
         input_method ||= 'both'
 
@@ -138,17 +139,8 @@ module Bolt
         with_connection(target, options.fetch('_load_config', true)) do |conn|
           conn.running_as(options['_run_as']) do
             stdin, output = nil
-
             command = []
             execute_options = {}
-
-            if STDIN_METHODS.include?(input_method)
-              stdin = JSON.dump(arguments)
-            end
-
-            if ENVIRONMENT_METHODS.include?(input_method)
-              execute_options[:environment] = envify_params(arguments)
-            end
 
             conn.with_remote_tempdir do |dir|
               remote_task_path = if from_api?(task)
@@ -156,6 +148,24 @@ module Bolt
                                  else
                                    conn.write_remote_executable(dir, executable)
                                  end
+
+              if extra_files
+                # TODO: optimize upload of directories
+                installdir = File.join(dir.to_s, '_installdir')
+                arguments['_installdir'] = installdir
+                dir.mkdirs(extra_files.map { |file| File.join('_installdir', File.dirname(file['name'])) })
+                extra_files.each do |file|
+                  conn.write_remote_file(file['path'], File.join(installdir, file['name']))
+                end
+              end
+
+              if STDIN_METHODS.include?(input_method)
+                stdin = JSON.dump(arguments)
+              end
+
+              if ENVIRONMENT_METHODS.include?(input_method)
+                execute_options[:environment] = envify_params(arguments)
+              end
 
               if conn.run_as && stdin
                 wrapper = make_wrapper_stringio(remote_task_path, stdin)

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -22,6 +22,15 @@ module Bolt
             @path
           end
 
+          def mkdirs(subdirs)
+            abs_subdirs = subdirs.map { |subdir| File.join(@path, subdir) }
+            result = @node.execute(['mkdir', '-p'] + abs_subdirs)
+            if result.exit_code != 0
+              message = "Could not create subdirectories in '#{@path}': #{result.stderr.string}"
+              raise Bolt::Node::FileError.new(message, 'MKDIR_ERROR')
+            end
+          end
+
           def chown(owner)
             return if owner.nil? || owner == @owner
 

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -112,6 +112,7 @@ catch
           executable = task.file['filename']
           file_content = StringIO.new(Base64.decode64(task.file['file_content']))
           input_method = task.metadata['input_method']
+          extra_files = []
         else
           implementation = task.select_implementation(target, PROVIDED_FEATURES)
           executable = implementation['path']
@@ -130,7 +131,7 @@ catch
                                  conn.write_remote_executable(dir, executable)
                                end
 
-            if extra_files
+            unless extra_files.empty?
               # TODO: optimize upload of directories
               installdir = File.join(dir, '_installdir')
               arguments['_installdir'] = installdir

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -334,6 +334,14 @@ exit $LASTEXITCODE
 PS
         end
 
+        def mkdirs(dirs)
+          result = execute("mkdir -Force #{dirs.uniq.sort.join(',')}")
+          if result.exit_code != 0
+            message = "Could not create directories: #{result.stderr}"
+            raise Bolt::Node::FileError.new(message, 'MKDIR_ERROR')
+          end
+        end
+
         def write_remote_file(source, destination)
           fs = ::WinRM::FS::FileManager.new(@connection)
           fs.upload(source, destination)

--- a/lib/bolt_ext/server.rb
+++ b/lib/bolt_ext/server.rb
@@ -2,6 +2,7 @@
 
 require 'sinatra'
 require 'bolt'
+require 'bolt/target'
 require 'bolt/task'
 require 'json'
 require 'json-schema'

--- a/spec/bolt/task_spec.rb
+++ b/spec/bolt/task_spec.rb
@@ -25,20 +25,22 @@ describe Bolt::Task do
     context 'with input_method in metadata' do
       let(:implementations) { [{ 'name' => 'foo.sh', 'requirements' => [] }] }
       let(:metadata) { { 'input_method' => 'stdin', 'implementations' => implementations } }
+      let(:expected) { files.first.merge('input_method' => 'stdin', 'files' => []) }
 
-      it { expect(task.select_implementation(target)).to eq(files.first.merge('input_method' => 'stdin')) }
+      it { expect(task.select_implementation(target)).to eq(expected) }
 
       context 'with input_method in implementation' do
         let(:implementations) { [{ 'name' => 'foo.sh', 'requirements' => [], 'input_method' => 'environment' }] }
+        let(:expected) { files.first.merge('input_method' => 'environment', 'files' => []) }
 
-        it { expect(task.select_implementation(target)).to eq(files.first.merge('input_method' => 'environment')) }
+        it { expect(task.select_implementation(target)).to eq(expected) }
       end
     end
 
     context 'no metadata present' do
       let(:metadata) { {} }
 
-      it { expect(task.select_implementation(target)).to eq(files.first) }
+      it { expect(task.select_implementation(target)).to eq(files.first.merge('files' => [])) }
     end
 
     context 'implementations have no requirements' do
@@ -47,7 +49,7 @@ describe Bolt::Task do
          { 'name' => 'foo.ps1', 'requirements' => [] }]
       }
 
-      it { expect(task.select_implementation(target)).to eq(files.first) }
+      it { expect(task.select_implementation(target)).to eq(files.first.merge('files' => [])) }
     end
 
     context 'second implementation matches available feature' do
@@ -56,7 +58,7 @@ describe Bolt::Task do
          { 'name' => 'foo.ps1', 'requirements' => ['powershell'] }]
       }
 
-      it { expect(task.select_implementation(target)).to eq(files[1]) }
+      it { expect(task.select_implementation(target)).to eq(files[1].merge('files' => [])) }
     end
 
     context 'first implementation requires extra features' do
@@ -65,10 +67,10 @@ describe Bolt::Task do
          { 'name' => 'foo.ps1', 'requirements' => ['powershell'] }]
       }
 
-      it { expect(task.select_implementation(target)).to eq(files[1]) }
+      it { expect(task.select_implementation(target)).to eq(files[1].merge('files' => [])) }
 
       it 'uses additional features passed as arguments' do
-        expect(task.select_implementation(target, ['puppet-agent'])).to eq(files[2])
+        expect(task.select_implementation(target, ['puppet-agent'])).to eq(files[2].merge('files' => []))
       end
     end
 

--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -507,6 +507,48 @@ SHELL
         end
       end
     end
+
+    context "when files are provided", ssh: true do
+      let(:contents) { "#!/bin/sh\nfind ${PT__installdir} -type f" }
+      let(:arguments) { {} }
+
+      it "puts files at _installdir" do
+        with_task_containing('tasks_test', contents, 'environment') do |task|
+          task['metadata']['files'] = []
+          expected_files = %w[files/foo files/bar/baz lib/puppet_x/file.rb tasks/init]
+          expected_files.each do |file|
+            task['metadata']['files'] << "tasks_test/#{file}"
+            task['files'] << { 'name' => "tasks_test/#{file}", 'path' => task['files'][0]['path'] }
+          end
+
+          files = ssh.run_task(target, task, arguments).message.split("\n")
+          expect(files.count).to eq(expected_files.count)
+          files.sort.zip(expected_files.sort).each do |file, expected_file|
+            expect(file).to match(%r{_installdir/tasks_test/#{expected_file}$})
+          end
+        end
+      end
+
+      it "includes files from the selected implementation" do
+        with_task_containing('tasks_test', contents, 'environment') do |task|
+          task['metadata']['implementations'] = [
+            { 'name' => 'tasks_test.alt', 'requirements' => ['foobar'], 'files' => ['tasks_test/files/no'] },
+            { 'name' => 'tasks_test', 'requirements' => [], 'files' => ['tasks_test/files/yes'] }
+          ]
+          task['metadata']['files'] = ['other_mod/lib/puppet_x/']
+          task['files'] << { 'name' => 'tasks_test/files/yes', 'path' => task['files'][0]['path'] }
+          task['files'] << { 'name' => 'other_mod/lib/puppet_x/a.rb', 'path' => task['files'][0]['path'] }
+          task['files'] << { 'name' => 'other_mod/lib/puppet_x/b.rb', 'path' => task['files'][0]['path'] }
+          task['files'] << { 'name' => 'tasks_test/files/no', 'path' => task['files'][0]['path'] }
+
+          files = ssh.run_task(target, task, arguments).message.split("\n").sort
+          expect(files.count).to eq(3)
+          expect(files[0]).to match(%r{_installdir/other_mod/lib/puppet_x/a.rb$})
+          expect(files[1]).to match(%r{_installdir/other_mod/lib/puppet_x/b.rb$})
+          expect(files[2]).to match(%r{_installdir/tasks_test/files/yes$})
+        end
+      end
+    end
   end
 
   context 'when tmpdir is specified' do

--- a/spec/fixtures/modules/shareable/tasks/init.json
+++ b/spec/fixtures/modules/shareable/tasks/init.json
@@ -1,0 +1,7 @@
+{
+  "implementations": [
+    {"name": "list.sh", "requirements": ["shell"], "files": ["shareable/tasks/unknown_file.json"]},
+    {"name": "list.ps1", "requirements": ["powershell"], "files": ["shareable/tasks/unknown_module.json"], "input_method": "environment"}
+  ],
+  "files": ["results/lib/", "error/tasks/fail.sh"]
+}

--- a/spec/fixtures/modules/shareable/tasks/invalid_path.json
+++ b/spec/fixtures/modules/shareable/tasks/invalid_path.json
@@ -1,0 +1,7 @@
+{
+  "implementations": [
+    {"name": "list.sh", "requirements": ["shell"]},
+    {"name": "list.ps1", "requirements": ["powershell"]}
+  ],
+  "files": ["shareable/"]
+}

--- a/spec/fixtures/modules/shareable/tasks/list.ps1
+++ b/spec/fixtures/modules/shareable/tasks/list.ps1
@@ -1,0 +1,3 @@
+(Get-Item $env:PT__installdir/shareable/tasks/unknown_module.json).length
+(Get-Item $env:PT__installdir/error/tasks/fail.sh).length
+(Get-Item $env:PT__installdir/results/lib/puppet/functions/results/make_result.rb).length

--- a/spec/fixtures/modules/shareable/tasks/list.sh
+++ b/spec/fixtures/modules/shareable/tasks/list.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+wc -c $PT__installdir/shareable/tasks/unknown_file.json
+wc -c $PT__installdir/error/tasks/fail.sh
+wc -c $PT__installdir/results/lib/puppet/functions/results/make_result.rb

--- a/spec/fixtures/modules/shareable/tasks/not_a_directory.json
+++ b/spec/fixtures/modules/shareable/tasks/not_a_directory.json
@@ -1,0 +1,7 @@
+{
+  "implementations": [
+    {"name": "list.sh", "requirements": ["shell"]},
+    {"name": "list.ps1", "requirements": ["powershell"]}
+  ],
+  "files": ["results/lib/puppet/functions/results/make_result.rb/"]
+}

--- a/spec/fixtures/modules/shareable/tasks/not_a_file.json
+++ b/spec/fixtures/modules/shareable/tasks/not_a_file.json
@@ -1,0 +1,7 @@
+{
+  "implementations": [
+    {"name": "list.sh", "requirements": ["shell"]},
+    {"name": "list.ps1", "requirements": ["powershell"]}
+  ],
+  "files": ["results/lib/puppet"]
+}

--- a/spec/fixtures/modules/shareable/tasks/unknown_file.json
+++ b/spec/fixtures/modules/shareable/tasks/unknown_file.json
@@ -1,0 +1,7 @@
+{
+  "implementations": [
+    {"name": "list.sh", "requirements": ["shell"]},
+    {"name": "list.ps1", "requirements": ["powershell"]}
+  ],
+  "files": ["shareable/lib/nope"]
+}

--- a/spec/fixtures/modules/shareable/tasks/unknown_module.json
+++ b/spec/fixtures/modules/shareable/tasks/unknown_module.json
@@ -1,0 +1,7 @@
+{
+  "implementations": [
+    {"name": "list.sh", "requirements": ["shell"]},
+    {"name": "list.ps1", "requirements": ["powershell"]}
+  ],
+  "files": ["not_a_module/files/meh"]
+}

--- a/spec/integration/shareable_task_spec.rb
+++ b/spec/integration/shareable_task_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/integration'
+require 'bolt_spec/conn'
+require 'bolt/util'
+
+shared_examples "invalid metadata" do
+  it 'fails with an unknown file' do
+    expect {
+      run_cli_json(%w[task run shareable::unknown_file] + config_flags)
+    }.to raise_error(Bolt::PAL::PALError, %r{Could not find .*shareable/lib/nope on disk})
+  end
+
+  it 'fails with an unknown module' do
+    expect {
+      run_cli_json(%w[task run shareable::unknown_module] + config_flags)
+    }.to raise_error(Bolt::PAL::PALError, /Could not find module not_a_module containing task file meh/)
+  end
+
+  it 'fails with an invalid path' do
+    msg = /Files must be saved in module directories that Puppet makes available via mount points: lib, files, tasks/
+    expect {
+      run_cli_json(%w[task run shareable::invalid_path] + config_flags)
+    }.to raise_error(Bolt::PAL::PALError, msg)
+  end
+
+  it 'fails with a file referenced as a directory' do
+    msg = if Bolt::Util.windows?
+            'Files specified in task metadata cannot include a trailing slash: ' \
+            'results/lib/puppet/functions/results/make_result.rb/'
+          else
+            %r{Could not find .*results/lib/puppet/functions/results/make_result.rb/ on disk}
+          end
+    expect {
+      run_cli_json(%w[task run shareable::not_a_directory] + config_flags)
+    }.to raise_error(Bolt::PAL::PALError, msg)
+  end
+
+  it 'fails with a directory referenced as a file' do
+    msg = %r{Directories specified in task metadata must include a trailing slash: results/lib/puppet}
+    expect {
+      run_cli_json(%w[task run shareable::not_a_file] + config_flags)
+    }.to raise_error(Bolt::PAL::PALError, msg)
+  end
+end
+
+describe "Shareable tasks with files" do
+  include BoltSpec::Integration
+  include BoltSpec::Conn
+
+  let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
+  let(:config_flags) { %W[--format json --nodes #{target} --modulepath #{modulepath}] + options }
+
+  describe 'over ssh', ssh: true do
+    let(:target) { conn_uri('ssh', include_password: true) }
+    let(:options) { %w[--no-host-key-check] }
+
+    it 'runs a task with multiple files' do
+      result = run_cli_json(%w[task run shareable] + config_flags)
+      files = result['items'][0]['result']['_output'].split("\n").map(&:strip).sort
+      expect(files[0]).to match(%r{^174 .*/_installdir/shareable/tasks/unknown_file.json$})
+      expect(files[1]).to match(%r{^310 .*/_installdir/results/lib/puppet/functions/results/make_result.rb$})
+      expect(files[2]).to match(%r{^43 .*/_installdir/error/tasks/fail.sh$})
+    end
+
+    include_examples "invalid metadata"
+  end
+
+  describe 'over winrm', winrm: true do
+    let(:target) { conn_uri('winrm') }
+    let(:options) { %W[--no-ssl --password #{conn_info('winrm')[:password]}] }
+
+    it 'runs a task with multiple files' do
+      result = run_cli_json(%w[task run shareable] + config_flags)
+      files = result['items'][0]['result']['_output'].split("\n").map(&:strip).sort
+      expect(files).to eq(%w[178 310 43])
+    end
+
+    include_examples "invalid metadata"
+  end
+
+  describe 'over local:bash', bash: true do
+    let(:target) { 'localhost' }
+    let(:options) { [] }
+
+    it 'runs a task with multiple files' do
+      result = run_cli_json(%w[task run shareable] + config_flags)
+      files = result['items'][0]['result']['_output'].split("\n").map(&:strip).sort
+      expect(files[0]).to match(%r{^174 .*/_installdir/shareable/tasks/unknown_file.json$})
+      expect(files[1]).to match(%r{^310 .*/_installdir/results/lib/puppet/functions/results/make_result.rb$})
+      expect(files[2]).to match(%r{^43 .*/_installdir/error/tasks/fail.sh$})
+    end
+
+    include_examples "invalid metadata"
+  end
+end


### PR DESCRIPTION
Add shareable task code in the form of the `files` metadata property. Implemented specifically for the SSH, WinRM, and Local transports; the PCP transport doesn't use it because Bolt only sends the name of the task, and Orchestrator handles the rest.