### PR TITLE
(maint) Suppress logging during tests

### DIFF
--- a/lib/bolt/catalog.rb
+++ b/lib/bolt/catalog.rb
@@ -12,6 +12,10 @@ require 'bolt/catalog/logging'
 
 module Bolt
   class Catalog
+    def initialize(log_level = 'debug')
+      @log_level = log_level
+    end
+
     def with_puppet_settings(hiera_config = {})
       Dir.mktmpdir('bolt') do |dir|
         cli = []
@@ -24,7 +28,7 @@ module Bolt
 
         # Use a special logdest that serializes all log messages and their level to stderr.
         Puppet::Util::Log.newdestination(:stderr)
-        Puppet.settings[:log_level] = 'debug'
+        Puppet.settings[:log_level] = @log_level
         yield
       end
     end

--- a/spec/bolt/catalog_spec.rb
+++ b/spec/bolt/catalog_spec.rb
@@ -20,7 +20,7 @@ describe Bolt::Catalog do
                                'key'          => '/path/to/key',
                                'token'        => 'token')
   end
-  let(:catalog) { Bolt::Catalog.new }
+  let(:catalog) { Bolt::Catalog.new('warning') }
   let(:notify) { "notify { \"trusted ${trusted}\": }" }
   let(:files) {
     <<-CODE


### PR DESCRIPTION
The Bolt::Catalog by default logs all messages from Puppet's compile.
This creates a lot of extra output during testing that we ignore.
Suppress everything below warnings during unit tests.