### PR TITLE
(maint) improve connect-timeout documentation for bolt-server

### DIFF
--- a/developer-docs/bolt-server.md
+++ b/developer-docs/bolt-server.md
@@ -126,7 +126,7 @@ The Target be a JSON object. The following keys are available:
   - `password`: String - Password for SSH transport authentication.
   - `private-key-content`: String - Contents of private key for SSH.
 - `port`: Integer, *optional* - Connection port (Default: `22`).
-- `connect-timeout`: Integer, *optional* - How long Bolt should wait when establishing connections.
+- `connect-timeout`: Integer, *optional* - Number of seconds Bolt should wait when establishing connections before failing.
 - `tmpdir`: String, *optional* - The directory to upload and execute temporary files on the target.
 - `run-as-command`: Array, *optional* - Command elevate permissions. Bolt appends the user and command strings to the configured `run-as` command before running it on the target. This command must not require an interactive password prompt, and the `sudo-password` option is ignored when `run-as-command` is specified.
 - `run-as`: String, *optional* - A different user to run commands as after login.
@@ -139,7 +139,7 @@ The Target be a JSON object. The following keys are available:
 - `user`: String, *required* - Login user.
 - `password`: String, *required* - Password for WinRM transport authentication.
 - `port`: Integer, *optional* - Connection port (Default: `5986`, or `5985` if `ssl: false`.)
-- `connect-timeout`: Integer, *optional* - How long Bolt should wait when establishing connections.
+- `connect-timeout`: Integer, *optional* - Number of seconds Bolt should wait when establishing connections before failing.
 - `tmpdir`: String, *optional* - The directory to upload and execute temporary files on the target.
 - `ssl`: Boolean, *optional* - When true, Bolt will use https connections for WinRM (Default: `true`).
 - `ssl-verify`: Boolean, *optional* - When true, verifies the targets certificate matches the cacert (Default: `true`).


### PR DESCRIPTION
Bolt server allows a `connect-timeout` parameter for ssh and winrm
targets.  The units of the parameter were not documented.  This
updates the description to include the units and describe what
happens when the timeout is exceeded.