### PR TITLE
(BOLT-734) Hide private tasks from task list UI

### DIFF
--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -179,9 +179,11 @@ module Bolt
     def list_tasks
       in_bolt_compiler do |compiler|
         tasks = compiler.list_tasks
-        tasks.map(&:name).sort.map do |task_name|
+        tasks.map(&:name).sort.each_with_object([]) do |task_name, data|
           task_sig = compiler.task_signature(task_name)
-          [task_name, task_sig.task_hash['metadata']['description']]
+          unless task_sig.task_hash['metadata']['private']
+            data << [task_name, task_sig.task_hash['metadata']['description']]
+          end
         end
       end
     end

--- a/pre-docs/bolt_command_reference.md
+++ b/pre-docs/bolt_command_reference.md
@@ -46,7 +46,7 @@ Bolt commands use the syntax: `bolt <subcommand> <action> [options]`
 
 
  |
-| `bolt task show` | Lists all the tasks on the modulepath. Will note whether a task supports no-operation mode.
+| `bolt task show` | Lists all the tasks on the modulepath that have not been marked `private`. Will note whether a task supports no-operation mode.
 
  | -   Adding a specific task name displays details and parameters for the task.
 

--- a/pre-docs/inspecting_tasks_and_plans.md
+++ b/pre-docs/inspecting_tasks_and_plans.md
@@ -12,7 +12,7 @@ bolt task run package name=vim action=install --noop -n example.com
 
 ## Show a task list
 
-View a list of what tasks are installed in the current module path:
+View a list of what tasks are installed in the current module path. Note that tasks marked with the `private` metadata key will not be shown:
 
 ```
 bolt task show

--- a/pre-docs/writing_tasks.md
+++ b/pre-docs/writing_tasks.md
@@ -633,28 +633,12 @@ The following table shows task metadata keys, values, and default values.
 
 |Metadata key|Description|Value|Default|
 |------------|-----------|-----|-------|
-|"description"|A description of what the task does.|A string.|None.|
-|"input\_method"|What input method the task runner should use to pass parameters to the task.| -    `environment` 
-
--    `stdin` 
-
--    `powershell` 
-
-
- | -   both `environment` and `stdin`
-
--   for `.ps1` tasks, `powershell`
-
-
- |
-|"parameters"|The parameters or input the task accepts listed with a puppet type string and optional description. See [adding parameters to metadata](writing_tasks.md#) for usage information.| -   String specifying the Puppet data type
-
--   String describing the parameter
-
-
- |None.|
-|"puppet\_task\_version"|The version of the spec used.|An integer.|1 \(This is the only valid value.\)|
-|"supports\_noop"|Whether the task supports no-op mode. Required for the task to accept the `--noop` option on the command line.|Boolean.|False.|
+|"description"|A description of what the task does.|String|None|
+|"input\_method"|What input method the task runner should use to pass parameters to the task.| `environment`, `stdin`, `powershell`| Both `environment` and `stdin` unless `.ps1` tasks in which case `powershell`. |
+|"parameters"|The parameters or input the task accepts listed with a puppet type string and optional description. See [adding parameters to metadata](writing_tasks.md#) for usage information.|String describing the parameter |None|
+|"puppet\_task\_version"|The version of the spec used.|Integer|1 \(This is the only valid value.\)|
+|"supports\_noop"|Whether the task supports no-op mode. Required for the task to accept the `--noop` option on the command line.|Boolean|False|
+|"private"|Do not display task by default when listing for UI.|Boolean|False|
 
 ### Task metadata types
 

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -871,6 +871,35 @@ bar
           end
         end
 
+        it "does not list a private task" do
+          options = {
+            subcommand: 'task',
+            action: 'show'
+          }
+          cli.execute(options)
+          tasks = JSON.parse(output.string)
+          expect(tasks).not_to include(['sample::private', 'Do not list this task'])
+        end
+
+        it "shows invidual private task" do
+          task_name = 'sample::private'
+          options = {
+            subcommand: 'task',
+            action: 'show',
+            object: task_name
+          }
+          cli.execute(options)
+          json = JSON.parse(output.string)
+          json.delete("files")
+          expect(json).to eq(
+            "name" => "sample::private",
+            "metadata" => { "name" => "Private Task",
+                            "description" => "Do not list this task",
+                            "private" => true },
+            "module_dir" => File.absolute_path(File.join(__dir__, "..", "fixtures", "modules", "sample"))
+          )
+        end
+
         it "shows an individual task data" do
           task_name = 'sample::params'
           options = {

--- a/spec/fixtures/modules/sample/tasks/private.json
+++ b/spec/fixtures/modules/sample/tasks/private.json
@@ -1,0 +1,5 @@
+{
+  "name": "Private Task",
+  "description": "Do not list this task", 
+  "private": true
+}

--- a/spec/fixtures/modules/sample/tasks/private.sh
+++ b/spec/fixtures/modules/sample/tasks/private.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "private"


### PR DESCRIPTION
When a task is marked as `private` in metadata, do not list it when listing tasks.