### PR TITLE
(BOLT-380) Bump net-ssh to 5.0+ release

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "logging", "~> 2.2"
   spec.add_dependency "minitar", "~> 0.6"
   spec.add_dependency "net-scp", "~> 1.2"
-  spec.add_dependency "net-ssh", "~> 4.2"
+  spec.add_dependency "net-ssh", "~> 5.0"
   spec.add_dependency "orchestrator_client", "~> 0.3.1"
   spec.add_dependency "puppet", [">= 6.0.1", "< 7"]
   spec.add_dependency "r10k", "~> 2.6"

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -102,9 +102,9 @@ module Bolt
           options[:port] = target.port if target.port
           options[:password] = target.password if target.password
           options[:verify_host_key] = if target.options['host-key-check']
-                                        Net::SSH::Verifiers::Secure.new
+                                        Net::SSH::Verifiers::Always.new
                                       else
-                                        Net::SSH::Verifiers::Null.new
+                                        Net::SSH::Verifiers::Never.new
                                       end
           options[:timeout] = target.options['connect-timeout'] if target.options['connect-timeout']
 

--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -62,7 +62,7 @@ BASH
         .with(anything,
               anything,
               hash_including(
-                verify_host_key: instance_of(Net::SSH::Verifiers::Secure)
+                verify_host_key: instance_of(Net::SSH::Verifiers::Always)
               ))
       ssh.with_connection(target) {}
     end
@@ -73,7 +73,7 @@ BASH
         .with(anything,
               anything,
               hash_including(
-                verify_host_key: instance_of(Net::SSH::Verifiers::Null)
+                verify_host_key: instance_of(Net::SSH::Verifiers::Never)
               ))
       ssh.with_connection(make_target(conf: no_host_key_check)) {}
     end


### PR DESCRIPTION
This enables adding the ed25519 gem in packaging to support those keys.