### PR TITLE
(BOLT-380) Make Bolt compatible with net-ssh 4 and 5

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "logging", "~> 2.2"
   spec.add_dependency "minitar", "~> 0.6"
   spec.add_dependency "net-scp", "~> 1.2"
-  spec.add_dependency "net-ssh", "~> 5.0"
+  spec.add_dependency "net-ssh", ">= 4.0"
   spec.add_dependency "orchestrator_client", "~> 0.3.1"
   spec.add_dependency "puppet", [">= 6.0.1", "< 7"]
   spec.add_dependency "r10k", "~> 2.6"

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -101,10 +101,18 @@ module Bolt
 
           options[:port] = target.port if target.port
           options[:password] = target.password if target.password
+          # Support both net-ssh 4 and 5. We use 5 in packaging, but Beaker pins to 4 so we
+          # want the gem to be compatible with version 4.
           options[:verify_host_key] = if target.options['host-key-check']
-                                        Net::SSH::Verifiers::Always.new
-                                      else
+                                        if defined?(Net::SSH::Verifiers::Always)
+                                          Net::SSH::Verifiers::Always.new
+                                        else
+                                          Net::SSH::Verifiers::Secure.new
+                                        end
+                                      elsif defined?(Net::SSH::Verifiers::Never)
                                         Net::SSH::Verifiers::Never.new
+                                      else
+                                        Net::SSH::Verifiers::Null.new
                                       end
           options[:timeout] = target.options['connect-timeout'] if target.options['connect-timeout']
 


### PR DESCRIPTION
We plan to package Bolt with net-ssh 5, primarily for ed25519 support.
However many things that might be used alongside bolt-as-a-gem - such as
Beaker - still pin to net-ssh 4. Make it compatible with both.