### PR TITLE
(BOLT-922) Ensure NotImplementedError messages are not lost

### DIFF
--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -79,9 +79,14 @@ module Bolt
               Array(results).each do |result|
                 result_promises[result.target].set(result)
               end
-            # NotImplementedError can be thrown if the transport is implemented improperly
+            # NotImplementedError can be thrown if the transport is not implemented improperly
             rescue StandardError, NotImplementedError => e
               result_promises.each do |target, promise|
+                # If an exception happens while running, the result won't be logged
+                # by the CLI. Log a warning, as this is probably a problem with the transport.
+                # If batch_* commands are used from the Base transport, then exceptions
+                # normally shouldn't reach here.
+                @logger.warn(e)
                 promise.set(Bolt::Result.from_exception(target, e))
               end
             ensure

--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -60,7 +60,7 @@ module Bolt
 
         result = begin
                    yield
-                 rescue StandardError => ex
+                 rescue StandardError, NotImplementedError => ex
                    Bolt::Result.from_exception(target, ex)
                  end
 


### PR DESCRIPTION
Previously a NotImplementedError thrown by the transport would get added to the result, but never printed. Ensure that errors not handled by the transport get logged. Our normal expectation is that the transport handles all errors and adds them to the error result.