### PR TITLE
(maint) Skip Appveyor tests locally

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,6 +83,9 @@ for:
           RUBY_VERSION: 23
         - configuration: Agentfull
           RUBY_VERSION: 24
+    
+    environment:
+      APPVEYOR_AGENTS: true
 
     before_test:
       - ps: |

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,8 @@ RSpec.configure do |config|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
 
+  config.filter_run_excluding appveyor_agents: true unless ENV['APPVEYOR_AGENTS']
+
   # rspec-mocks config
   config.mock_with :rspec do |mocks|
     # Prevents you from mocking or stubbing a method that does not exist on


### PR DESCRIPTION
The Vagrant VM used for testing locally does not support installing packages using an MSI which is necessary for the puppet_agent::install task. The images used on Appveyor support MSI installation. Previously when testing locally (with something like `bundle exec rspec`) the Appveyor specific tests would fail. This commit configures Rspec to filter Appveyor specific tests when the environment variable `APPVEYOR_AGENTS` is not set.