### PR TITLE
(BOLT-915) Add run_script to BoltSpec

### DIFF
--- a/lib/bolt_spec/run.rb
+++ b/lib/bolt_spec/run.rb
@@ -9,7 +9,7 @@ require 'bolt/puppetdb'
 require 'bolt/util'
 
 # This is intended to provide a relatively stable method of executing bolt in process from tests.
-# Currently it provides run_task, run_plan and run_command helpers.
+# Currently it provides run_task, run_plan, run_script and run_command helpers.
 module BoltSpec
   module Run
     def run_task(task_name, targets, params = nil, config: nil, inventory: nil)
@@ -36,6 +36,14 @@ module BoltSpec
     def run_command(command, targets, params = nil, config: nil, inventory: nil)
       result = BoltRunner.with_runner(config, inventory) do |runner|
         runner.run_command(command, targets, params)
+      end
+      result = result.to_a
+      Bolt::Util.walk_keys(result, &:to_s)
+    end
+
+    def run_script(script, targets, arguments = nil, options = {}, config: nil, inventory: nil)
+      result = BoltRunner.with_runner(config, inventory) do |runner|
+        runner.run_script(script, targets, arguments, options)
       end
       result = result.to_a
       Bolt::Util.walk_keys(result, &:to_s)
@@ -92,6 +100,12 @@ module BoltSpec
         executor = Bolt::Executor.new(config.concurrency, @analytics)
         targets = inventory.get_targets(targets)
         executor.run_command(targets, command, params || {})
+      end
+
+      def run_script(script, targets, arguments = nil, options = {})
+        executor = Bolt::Executor.new(config.concurrency, @analytics)
+        targets = inventory.get_targets(targets)
+        executor.run_script(targets, script, arguments, options)
       end
     end
   end

--- a/spec/bolt_spec/run_spec.rb
+++ b/spec/bolt_spec/run_spec.rb
@@ -26,7 +26,7 @@ describe "BoltSpec::Run", ssh: true do
     end
 
     it 'should accept _catch_errors' do
-      result = run_task('sample::echo', 'non_existent_ndoe', { '_catch_errors' => true },
+      result = run_task('sample::echo', 'non_existent_node', { '_catch_errors' => true },
                         config: config_data, inventory: inventory_data)
 
       expect(result[0]['status']).to eq('failure')
@@ -41,8 +41,26 @@ describe "BoltSpec::Run", ssh: true do
     end
 
     it 'should accept _catch_errors' do
-      result = run_command('echo hello', 'non_existent_ndoe', { '_catch_errors' => true },
+      result = run_command('echo hello', 'non_existent_node', { '_catch_errors' => true },
                            config: config_data, inventory: inventory_data)
+
+      expect(result[0]['status']).to eq('failure')
+      expect(result[0]['result']['_error']['kind']).to eq('puppetlabs.tasks/connect-error')
+    end
+  end
+
+  describe 'run_script' do
+    let(:script) { File.join(config_data['modulepath'], '..', 'scripts', 'success.sh') }
+
+    it 'should run a command on a node with an argument', ssh: true do
+      result = run_script(script, 'ssh', ['hi'], config: config_data, inventory: inventory_data)
+      expect(result[0]['status']).to eq('success')
+      expect(result[0]['result']['stdout']).to match(/arg: hi/)
+    end
+
+    it 'should accept _catch_errors' do
+      result = run_script('missing.sh', 'non_existent_node', nil, { '_catch_errors' => true },
+                          config: config_data, inventory: inventory_data)
 
       expect(result[0]['status']).to eq('failure')
       expect(result[0]['result']['_error']['kind']).to eq('puppetlabs.tasks/connect-error')


### PR DESCRIPTION
This commit adds `run_script` to the BoltSpec::Run module to support running scripts for automated testing.