### PR TITLE
(BOLT-931) Put task executable in installdir when present

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = "~> 2.3"
 
   spec.add_dependency "addressable", '~> 2.5'
+  spec.add_dependency "CFPropertyList", "~> 2.2"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "logging", "~> 2.2"
   spec.add_dependency "minitar", "~> 0.6"

--- a/lib/bolt/task.rb
+++ b/lib/bolt/task.rb
@@ -32,6 +32,14 @@ module Bolt
       metadata['supports_noop']
     end
 
+    def module_name
+      name.split('::').first
+    end
+
+    def tasks_dir
+      File.join(module_name, 'tasks')
+    end
+
     def file_map
       @file_map ||= files.each_with_object({}) { |file, hsh| hsh[file['name']] = file }
     end

--- a/pre-docs/writing_tasks.md
+++ b/pre-docs/writing_tasks.md
@@ -310,7 +310,7 @@ The `files` property can be included both as a top-level metadata property, and 
 }
 ```
 
-When a task includes the `files` property, all files listed in the top-level property and in the specific implementation chosen for a target will be copied to a temporary directory on that target. The directory structure of the specified files will be preserved such that paths specified with the `files` metadata option will be available to tasks prefixed with `_installdir`.
+When a task includes the `files` property, all files listed in the top-level property and in the specific implementation chosen for a target will be copied to a temporary directory on that target. The directory structure of the specified files will be preserved such that paths specified with the `files` metadata option will be available to tasks prefixed when with the `_installdir` parameter passed to tasks. The task executable itself will be located in its module location under the `_installdir` as well, so other files can be found at `../../mymodule/files/` relatve to the task executable's location.
 
 ### Python Example
 
@@ -318,13 +318,13 @@ When a task includes the `files` property, all files listed in the top-level pro
 
 ```json
 {
-  "files": ["multi_task/files/py_util/py_helper.py"]
+  "files": ["multi_task/files/py_helper.py"]
 }
 ```
 
 #### Files
 
-`multi_task/files/py_util/py_helper.py`
+`multi_task/files/py_helper.py`
 
 ```python
 def useful_python():
@@ -340,7 +340,9 @@ import os
 import json
 
 params = json.load(sys.stdin)
-sys.path.append(os.path.join(params['_installdir'], 'python_helpers', 'files'))
+sys.path.append(os.path.join(params['_installdir'], 'multi_task', 'files'))
+# Alternatively use relative path
+# sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', 'multi_task', 'files'))
 import py_helper
 
 print(json.dumps(py_helper.useful_python()))
@@ -364,13 +366,13 @@ Ran on 1 node in 0.12 seconds
 
 ```json
 {
-  "files": ["multi_task/files/rb_util/rb_helper.rb"]
+  "files": ["multi_task/files/rb_helper.rb"]
 }
 ```
 
 #### File Resource
 
-`multi_task/files/rb_util/rb_helper.rb`
+`multi_task/files/rb_helper.rb`
 
 ```ruby
 def useful_ruby
@@ -385,7 +387,9 @@ end
 require 'json'
 
 params = JSON.parse(STDIN.read)
-require_relative File.join(params['_installdir'], '/ruby_helpers/files/rb_helper.rb')
+require_relative File.join(params['_installdir'], 'multi_task', 'files', 'rb_helper.rb')
+# Alternatively use relative path
+# require_relative File.join(__dir__, '..', '..', 'multi_task', 'files', 'rb_helper.rb')
 
 puts useful_ruby.to_json
 ```

--- a/spec/bolt/transport/local_spec.rb
+++ b/spec/bolt/transport/local_spec.rb
@@ -296,9 +296,10 @@ SHELL
           end
 
           files = local.run_task(target, task, arguments).message.split("\n")
+          expected_files = ["tasks/#{File.basename(task['files'][0]['path'])}"] + expected_files
           expect(files.count).to eq(expected_files.count)
           files.sort.zip(expected_files.sort).each do |file, expected_file|
-            expect(file).to match(%r{_installdir/tasks_test/#{expected_file}$})
+            expect(file).to match(%r{/tasks_test/#{expected_file}$})
           end
         end
       end
@@ -316,10 +317,11 @@ SHELL
           task['files'] << { 'name' => 'tasks_test/files/no', 'path' => task['files'][0]['path'] }
 
           files = local.run_task(target, task, arguments).message.split("\n").sort
-          expect(files.count).to eq(3)
-          expect(files[0]).to match(%r{_installdir/other_mod/lib/puppet_x/a.rb$})
-          expect(files[1]).to match(%r{_installdir/other_mod/lib/puppet_x/b.rb$})
-          expect(files[2]).to match(%r{_installdir/tasks_test/files/yes$})
+          expect(files.count).to eq(4)
+          expect(files[0]).to match(%r{/other_mod/lib/puppet_x/a.rb$})
+          expect(files[1]).to match(%r{/other_mod/lib/puppet_x/b.rb$})
+          expect(files[2]).to match(%r{/tasks_test/files/yes$})
+          expect(files[3]).to match(%r{/tasks_test/tasks/#{File.basename(task['files'][0]['path'])}$})
         end
       end
     end

--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -544,9 +544,10 @@ SHELL
           end
 
           files = ssh.run_task(target, task, arguments).message.split("\n")
+          expected_files = ["tasks/#{File.basename(task['files'][0]['path'])}"] + expected_files
           expect(files.count).to eq(expected_files.count)
           files.sort.zip(expected_files.sort).each do |file, expected_file|
-            expect(file).to match(%r{_installdir/tasks_test/#{expected_file}$})
+            expect(file).to match(%r{/tasks_test/#{expected_file}$})
           end
         end
       end
@@ -564,10 +565,11 @@ SHELL
           task['files'] << { 'name' => 'tasks_test/files/no', 'path' => task['files'][0]['path'] }
 
           files = ssh.run_task(target, task, arguments).message.split("\n").sort
-          expect(files.count).to eq(3)
-          expect(files[0]).to match(%r{_installdir/other_mod/lib/puppet_x/a.rb$})
-          expect(files[1]).to match(%r{_installdir/other_mod/lib/puppet_x/b.rb$})
-          expect(files[2]).to match(%r{_installdir/tasks_test/files/yes$})
+          expect(files.count).to eq(4)
+          expect(files[0]).to match(%r{/other_mod/lib/puppet_x/a.rb$})
+          expect(files[1]).to match(%r{/other_mod/lib/puppet_x/b.rb$})
+          expect(files[2]).to match(%r{/tasks_test/files/yes$})
+          expect(files[3]).to match(%r{/tasks_test/tasks/#{File.basename(task['files'][0]['path'])}$})
         end
       end
     end

--- a/spec/bolt/transport/winrm_spec.rb
+++ b/spec/bolt/transport/winrm_spec.rb
@@ -693,6 +693,7 @@ PS
           end
 
           files = winrm.run_task(target, task, arguments).message.split("\n")
+          expected_files = ["tasks/#{File.basename(task['files'][0]['path'])}"] + expected_files
           expect(files.count).to eq(expected_files.count)
           files.sort.zip(expected_files.sort).each do |file, expected_file|
             expect(file.strip).to eq("tasks_test\\#{expected_file.gsub(%r{/}, '\\')}")
@@ -713,10 +714,11 @@ PS
           task['files'] << { 'name' => 'tasks_test/files/no', 'path' => task['files'][0]['path'] }
 
           files = winrm.run_task(target, task, arguments).message.split("\n").sort
-          expect(files.count).to eq(3)
+          expect(files.count).to eq(4)
           expect(files[0].strip).to eq("other_mod\\lib\\puppet_x\\a.rb")
           expect(files[1].strip).to eq("other_mod\\lib\\puppet_x\\b.rb")
           expect(files[2].strip).to eq("tasks_test\\files\\yes")
+          expect(files[3].strip).to eq("tasks_test\\tasks\\#{File.basename(task['files'][0]['path'])}")
         end
       end
     end

--- a/spec/fixtures/modules/shareable/tasks/list.ps1
+++ b/spec/fixtures/modules/shareable/tasks/list.ps1
@@ -1,3 +1,4 @@
 (Get-Item $env:PT__installdir/shareable/tasks/unknown_module.json).length
+(Get-Item $env:PT__installdir/shareable/tasks/list.ps1).length
 (Get-Item $env:PT__installdir/error/tasks/fail.sh).length
 (Get-Item $env:PT__installdir/results/lib/puppet/functions/results/make_result.rb).length

--- a/spec/fixtures/modules/shareable/tasks/list.sh
+++ b/spec/fixtures/modules/shareable/tasks/list.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 wc -c $PT__installdir/shareable/tasks/unknown_file.json
+wc -c $PT__installdir/shareable/tasks/list.sh
 wc -c $PT__installdir/error/tasks/fail.sh
 wc -c $PT__installdir/results/lib/puppet/functions/results/make_result.rb

--- a/spec/integration/shareable_task_spec.rb
+++ b/spec/integration/shareable_task_spec.rb
@@ -59,9 +59,11 @@ describe "Shareable tasks with files" do
     it 'runs a task with multiple files' do
       result = run_cli_json(%w[task run shareable] + config_flags)
       files = result['items'][0]['result']['_output'].split("\n").map(&:strip).sort
-      expect(files[0]).to match(%r{^174 .*/_installdir/shareable/tasks/unknown_file.json$})
-      expect(files[1]).to match(%r{^310 .*/_installdir/results/lib/puppet/functions/results/make_result.rb$})
-      expect(files[2]).to match(%r{^43 .*/_installdir/error/tasks/fail.sh$})
+      expect(files.count).to eq(4)
+      expect(files[0]).to match(%r{^174 .*/shareable/tasks/unknown_file.json$})
+      expect(files[1]).to match(%r{^236 .*/shareable/tasks/list.sh})
+      expect(files[2]).to match(%r{^310 .*/results/lib/puppet/functions/results/make_result.rb$})
+      expect(files[3]).to match(%r{^43 .*/error/tasks/fail.sh$})
     end
 
     include_examples "invalid metadata"
@@ -74,7 +76,7 @@ describe "Shareable tasks with files" do
     it 'runs a task with multiple files' do
       result = run_cli_json(%w[task run shareable] + config_flags)
       files = result['items'][0]['result']['_output'].split("\n").map(&:strip).sort
-      expect(files).to eq(%w[178 310 43])
+      expect(files).to eq(%w[178 284 310 43])
     end
 
     include_examples "invalid metadata"
@@ -87,9 +89,11 @@ describe "Shareable tasks with files" do
     it 'runs a task with multiple files' do
       result = run_cli_json(%w[task run shareable] + config_flags)
       files = result['items'][0]['result']['_output'].split("\n").map(&:strip).sort
-      expect(files[0]).to match(%r{^174 .*/_installdir/shareable/tasks/unknown_file.json$})
-      expect(files[1]).to match(%r{^310 .*/_installdir/results/lib/puppet/functions/results/make_result.rb$})
-      expect(files[2]).to match(%r{^43 .*/_installdir/error/tasks/fail.sh$})
+      expect(files.count).to eq(4)
+      expect(files[0]).to match(%r{^174 .*/shareable/tasks/unknown_file.json$})
+      expect(files[1]).to match(%r{^236 .*/shareable/tasks/list.sh})
+      expect(files[2]).to match(%r{^310 .*/results/lib/puppet/functions/results/make_result.rb$})
+      expect(files[3]).to match(%r{^43 .*/error/tasks/fail.sh$})
     end
 
     include_examples "invalid metadata"


### PR DESCRIPTION
When using an installdir for extra files, put the task executable there under its own module path to simplify writing and testing tasks that use other files as libraries. Updating according to clarification of the tasks specification.