### PR TITLE
(WIP)(maint) Remove user from run-as-command command

### DIFF
--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -221,8 +221,9 @@ module Bolt
         def execute(command, sudoable: false, **options)
           result_output = Bolt::Node::Output.new
           run_as = options[:run_as] || self.run_as
-          escalate = sudoable && run_as && @user != run_as
-          use_sudo = escalate && @target.options['run-as-command'].nil?
+          run_as_cmd = @target.options['run-as-command']
+          escalate = sudoable && (run_as || run_as_cmd) && @user != run_as
+          use_sudo = escalate && run_as_cmd.nil?
 
           command_str = command.is_a?(String) ? command : Shellwords.shelljoin(command)
           if escalate
@@ -232,8 +233,7 @@ module Bolt
               sudo_str = Shellwords.shelljoin(sudo_flags)
               command_str = "#{sudo_str} #{command_str}"
             else
-              run_as_str = Shellwords.shelljoin(@target.options['run-as-command'] + [run_as])
-              command_str = "#{run_as_str} #{command_str}"
+              command_str = "#{run_as_cmd} #{command_str}"
             end
           end
 

--- a/spec/integration/ssh_spec.rb
+++ b/spec/integration/ssh_spec.rb
@@ -112,5 +112,16 @@ describe "when runnning over the ssh transport", ssh: true do
         expect(result.map { |r| r['stdout'].strip }).to eq([user, user])
       end
     end
+
+    it 'runs task with run-as-command', :reset_puppet_settings do
+      config['ssh']['run-as-command'] = ["sudo", "su", "-"]
+
+      with_tempfile_containing('conf', YAML.dump(config)) do |conf|
+        result = run_nodes(%W[command run #{whoami} --configfile #{conf.path}
+                           --tty --sudo-password #{password}] + config_flags)
+        puts result
+        expect(result.map { |r| r['stdout'].strip }).to eq(['root', 'root'])
+      end
+    end
   end
 end


### PR DESCRIPTION
**What this changes** We appended the user to the configured 'run-as-command' in the ssh transport. This removes that to allow greater flexibility for the run-as-command.
**Why** This made it difficult to construct a full run-as-command for users since they needed to anticipate the user being added to the command being run. It also made it impossible to run any command that didn't specify the user.