### PR TITLE
(BOLT-928) Add daily purge process to bolt-server's file cache

### DIFF
--- a/spec/bolt_server/file_cache_spec.rb
+++ b/spec/bolt_server/file_cache_spec.rb
@@ -57,16 +57,51 @@ describe BoltServer::FileCache, puppetserver: true do
     data = get_task_data('sample::echo')['files'].first
     file_content = 'good-data'
     data['sha256'] = Digest::SHA256.hexdigest(file_content)
-    expected_path = File.join(default_config['cache-dir'], data['sha256'], data['filename'])
-    FileUtils.mkdir_p(File.dirname(expected_path))
+    expected_dir = File.join(default_config['cache-dir'], data['sha256'])
+    expected_path = File.join(expected_dir, data['filename'])
+    FileUtils.mkdir_p(expected_dir)
     File.write(expected_path, file_content)
-    mtime = File.mtime(expected_path)
+    mtime = File.mtime(expected_dir)
     sleep(1)
 
     path = file_cache.update_file(data)
     expect(path).to eq(expected_path)
     expect(File.read(path)).to eq(file_content)
-    expect(File.mtime(path)).not_to eq(mtime)
+    expect(File.mtime(expected_dir)).not_to eq(mtime)
+  end
+
+  it 'purges old files on startup' do
+    file_content = 'good-data'
+    sha = Digest::SHA256.hexdigest(file_content)
+    expected_dir = File.join(default_config['cache-dir'], sha)
+    FileUtils.mkdir_p(expected_dir)
+    File.write(File.join(expected_dir, 'task'), file_content)
+    FileUtils.touch(expected_dir, mtime: Time.now - (BoltServer::FileCache::PURGE_TTL + 1))
+
+    expect(file_cache).to be
+    gone = 10.times do
+      sleep 0.1
+      break true unless File.exist?(expected_dir)
+    end
+    expect(gone).to eq(true)
+  end
+
+  it 'purges old files after the purge_interval' do
+    file_content = 'good-data'
+    sha = Digest::SHA256.hexdigest(file_content)
+    expected_dir = File.join(default_config['cache-dir'], sha)
+    FileUtils.mkdir_p(expected_dir)
+    File.write(File.join(expected_dir, 'task'), file_content)
+
+    cache = BoltServer::FileCache.new(config, purge_interval: 1)
+    cache.setup
+
+    FileUtils.touch(expected_dir, mtime: Time.now - (BoltServer::FileCache::PURGE_TTL + 1))
+    gone = 10.times do
+      sleep 0.5
+      break true unless File.exist?(expected_dir)
+    end
+    expect(gone).to eq(true)
   end
 
   it 'fails when the downloaded file is invalid' do


### PR DESCRIPTION
Add a purge process - run on startup and every day after - to remove
tasks from the file cache that haven't been used in over a week.