### PR TITLE
(maint) Fix typo in exception handler

### DIFF
--- a/lib/bolt_server/file_cache.rb
+++ b/lib/bolt_server/file_cache.rb
@@ -89,7 +89,7 @@ module BoltServer
           end
         end
       rescue StandardError => e
-        if e.is_a(Bolt::Error)
+        if e.is_a?(Bolt::Error)
           raise e
         else
           @logger.warn e


### PR DESCRIPTION
When a `Bolt::error` is rescued there was a typo in the `is_a?` method where the `?` was ommitted. This was causing acceptance tests failures in ORCH.