### PR TITLE
(maint) Fix typo in options hash

### DIFF
--- a/lib/bolt_server/file_cache.rb
+++ b/lib/bolt_server/file_cache.rb
@@ -105,7 +105,7 @@ module BoltServer
     end
 
     def serial_execute(&block)
-      promise = Concurrent::Promise.new(exector: @executor, &block).execute.wait
+      promise = Concurrent::Promise.new(executor: @executor, &block).execute.wait
       raise promise.reason if promise.state == :rejected
       promise.value
     end


### PR DESCRIPTION
The `:executor` option in the concurrent promise instantiation had a typo that resulted in non-parallel download resulting in non-serial execution of `download_file`.