### PR TITLE
(BOLT-915) Update facts and puppet_agent modules

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,10 +6,10 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '0.4.0'
-mod 'puppetlabs-facts', '0.3.1'
+mod 'puppetlabs-facts', '0.4.1'
 mod 'puppet_agent',
     git: 'https://github.com/puppetlabs/puppetlabs-puppet_agent',
-    ref: '443c9b2dc8e7b302fbac83976887e4ea011365a5'
+    ref: '52b5b6abc2d10fb8827edead34ef8ebe4adf1e29'
 
 # Core types and providers for Puppet 6
 mod 'puppetlabs-augeas_core', '1.0.3'


### PR DESCRIPTION
The `puppet_agent::install_shell` task has been updated to use the `bash.sh` implementation for the `facts` task. This commit updates the references to the updated modules.