### PR TITLE
(BOLT-944) Only print selected options for a target

### DIFF
--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -8,6 +8,8 @@ module Bolt
     attr_reader :uri, :options
     attr_writer :inventory
 
+    PRINT_OPTS ||= %w[host user port protocol].freeze
+
     # Satisfies the Puppet datatypes API
     def self.from_asserted_hash(hash)
       new(hash['uri'], hash['options'])
@@ -79,7 +81,8 @@ module Bolt
     end
 
     def to_s
-      "Target('#{@uri}', #{@options})"
+      opts = @options.select { |k, _| PRINT_OPTS.include? k }
+      "Target('#{@uri}', #{opts})"
     end
 
     def host

--- a/spec/bolt/target_spec.rb
+++ b/spec/bolt/target_spec.rb
@@ -102,6 +102,16 @@ describe Bolt::Target do
     expect(uri.port).to be_nil
   end
 
+  it "does not print password when converted to string" do
+    opts = { 'user' => 'person',
+             'password' => 'secret',
+             'host' => 'machine',
+             'protocol' => 'ssh' }
+    target = Bolt::Target.new('example.com', opts)
+    expect(target.to_s).to eq("Target('example.com', "\
+                              "#{opts.reject { |k, _| k == 'password' }})")
+  end
+
   describe "with winrm" do
     it "accepts 'winrm://host:port'" do
       uri = Bolt::Target.new('winrm://neptune:55985')

--- a/spec/fixtures/apply/basic/plans/inventory_lookup.pp
+++ b/spec/fixtures/apply/basic/plans/inventory_lookup.pp
@@ -11,9 +11,9 @@ plan basic::inventory_lookup(TargetSpec $nodes) {
     notify { "Target 1 Facts: ${$t[1].facts}": }
     # Vars from target
     notify { "Target 1 Vars: ${$t[1].vars}": }
-    # Prove config is respected (tty set to 11 in config)
-    notify { "Target 0 Config: ${t[0]}": }
+    # Prove config is respected (tty set to 11 in config) 
+    notify { "Target 0 Config: ${$t[0].options}": }
     # Prove inventory config is respected (password set to 'secret' in inventoryfile)
-    notify { "Target 1 Password: ${t[1].password}": }
+    notify { "Target 1 Password: ${$t[1].password}": }
   }
 }

--- a/spec/fixtures/modules/results/plans/test_printing.pp
+++ b/spec/fixtures/modules/results/plans/test_printing.pp
@@ -1,0 +1,9 @@
+plan results::test_printing(
+  String $host,
+  String $user,
+  String $password,
+  Integer $port
+) {
+  $target = Target($host, {'user' => $user, 'password' => $password, 'port' => $port})
+  notice("Connected to ${target}")
+}

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -234,7 +234,7 @@ describe "passes parsed AST to the apply_catalog task" do
           expect(notify[0]['title']).to eq("Num Targets: 3")
           expect(notify[1]['title']).to eq("Target 1 Facts: {operatingsystem => Ubuntu, added => fact}")
           expect(notify[2]['title']).to eq("Target 1 Vars: {environment => production, features => [puppet-agent]}")
-          res = "Target 0 Config: Target('foo', {\"connect-timeout\"=>11, \"tty\"=>false, \"host-key-check\"=>false})"
+          res = "Target 0 Config: {connect-timeout => 11, tty => false, host-key-check => false}"
           expect(notify[3]['title']).to eq(res)
           expect(notify[4]['title']).to eq("Target 1 Password: secret")
         end


### PR DESCRIPTION
**What this changes** Modify the `to_s` method of `Bolt::Target` to only print the user, host, protocol, and port of the target
**Why** So that sensitive and unnecessary information is not displayed when printing targets