### PR TITLE
(BOLT-925) Scrub stack trace from bolt server errors

### DIFF
--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -30,6 +30,13 @@ module BoltServer
       super(nil)
     end
 
+    def scrub_stack_trace(result)
+      if result.dig(:result, '_error', 'details', 'stack_trace')
+        result[:result]['_error']['details'].reject! { |k| k == 'stack_trace' }
+      end
+      result
+    end
+
     get '/' do
       200
     end
@@ -70,7 +77,8 @@ module BoltServer
 
       # Since this will only be on one node we can just return the first result
       results = @executor.run_task(target, task, parameters)
-      [200, results.first.to_json]
+      result = scrub_stack_trace(results.first.status_hash)
+      [200, result.to_json]
     end
 
     post '/winrm/run_task' do
@@ -90,7 +98,8 @@ module BoltServer
 
       # Since this will only be on one node we can just return the first result
       results = @executor.run_task(target, task, parameters)
-      [200, results.first.to_json]
+      result = scrub_stack_trace(results.first.status_hash)
+      [200, result.to_json]
     end
 
     error 404 do


### PR DESCRIPTION
Remove stack traces from bolt-server responses by removing them from the result status hash in bolt server. This should preserve the trace in log messages. If a stack trace is included in the result of a task output (for example a task that throws and exception during it's execution) it will still be included in the response.