### PR TITLE
(BOLT-959) Successfully finish a plan without a result

### DIFF
--- a/lib/bolt/transport/orch/connection.rb
+++ b/lib/bolt/transport/orch/connection.rb
@@ -52,7 +52,7 @@ module Bolt
           if @plan_job
             @client.command.plan_finish(
               plan_job: @plan_job,
-              result: plan_result.value,
+              result: plan_result.value || '',
               status: plan_result.status
             )
           end


### PR DESCRIPTION
The Orchestrator endpoint for finishing a plan requires a value.
Previously a plan without a return value would fail to finish the plan.
Send an empty string so the plan is successfully finished.