### PR TITLE
(BOLT-956) Add wait_until_available function

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
@@ -26,7 +26,7 @@ Puppet::Functions.create_function(:run_command) do
   # @param options Additional options: '_catch_errors', '_run_as'.
   # @return A list of results, one entry per target.
   # @example Run a command on targets
-  #   run_command('hostname', $targets, '_catch_errors' => true)
+  #   run_command('hostname', $targets, 'Get hostname')
   dispatch :run_command_with_description do
     param 'String[1]', :command
     param 'Boltlib::TargetSpec', :targets

--- a/bolt-modules/boltlib/lib/puppet/functions/wait_until_available.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/wait_until_available.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'bolt/util'
+
+# Wait until all targets accept connections.
+Puppet::Functions.create_function(:wait_until_available) do
+  # Wait until targets are available.
+  # @param targets A pattern identifying zero or more targets. See {get_targets} for accepted patterns.
+  # @param options Additional options: 'description', 'wait_time', 'retry_interval', '_catch_errors'.
+  # @return A list of results, one entry per target. Successful results have no value.
+  # @example Wait for targets
+  #   wait_until_available($targets, wait_time => 300)
+  dispatch :wait_until_available do
+    param 'Boltlib::TargetSpec', :targets
+    optional_param 'Hash[String[1], Any]', :options
+    return_type 'ResultSet'
+  end
+
+  def wait_until_available(targets, options = nil)
+    options ||= {}
+
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, operation: 'wait_until_available'
+      )
+    end
+
+    executor = Puppet.lookup(:bolt_executor) { nil }
+    inventory = Puppet.lookup(:bolt_inventory) { nil }
+    unless executor && inventory && Puppet.features.bolt?
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('wait until targets are available')
+      )
+    end
+
+    executor.report_function_call('wait_until_available')
+
+    # Ensure that given targets are all Target instances
+    targets = inventory.get_targets(targets)
+
+    if targets.empty?
+      call_function('debug', "Simulating wait_until_available - no targets given")
+      r = Bolt::ResultSet.new([])
+    else
+      opts = Bolt::Util.symbolize_top_level_keys(options.reject { |k| k == '_catch_errors' })
+      r = executor.wait_until_available(targets, **opts)
+    end
+
+    if !r.ok && !options['_catch_errors']
+      raise Bolt::RunFailure.new(r, 'wait_until_available')
+    end
+    r
+  end
+end

--- a/bolt-modules/boltlib/spec/functions/wait_until_available_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/wait_until_available_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/executor'
+require 'bolt/target'
+
+describe 'wait_until_available' do
+  let(:executor) { Bolt::Executor.new }
+  let(:inventory) { mock('inventory') }
+  let(:target) { Bolt::Target.new('test.example.com') }
+  let(:tasks_enabled) { true }
+  let(:result_set) { Bolt::ResultSet.new([Bolt::Result.new(target)]) }
+
+  around(:each) do |example|
+    Puppet[:tasks] = tasks_enabled
+    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
+      example.run
+    end
+  end
+
+  context 'with bolt feature present' do
+    before(:each) do
+      Puppet.features.stubs(:bolt?).returns(true)
+    end
+
+    it 'calls executor wait_until_available' do
+      executor.expects(:wait_until_available).with([target], anything).returns(result_set)
+      inventory.expects(:get_targets).with(target).returns([target])
+
+      is_expected.to run.with_params(target).and_return(result_set)
+    end
+
+    it 'passes extra parameters' do
+      executor.expects(:wait_until_available)
+              .with([target], description: 'desc', wait_time: 5, retry_interval: 0)
+              .returns(result_set)
+      inventory.expects(:get_targets).with(target).returns([target])
+
+      is_expected.to run.with_params(target, 'description' => 'desc', 'wait_time' => 5, 'retry_interval' => 0)
+                        .and_return(result_set)
+    end
+
+    it 'errors on unknown parameters' do
+      inventory.expects(:get_targets).with(target).returns([target])
+      is_expected.to run.with_params(target, 'foo' => true)
+                        .and_raise_error(/unknown keyword: foo/)
+    end
+  end
+
+  context 'without bolt feature present' do
+    it 'fails and reports that bolt library is required' do
+      Puppet.features.stubs(:bolt?).returns(false)
+      is_expected.to run.with_params('echo hello')
+                        .and_raise_error(/The 'bolt' library is required to wait until targets are available/)
+    end
+  end
+end

--- a/lib/bolt/error.rb
+++ b/lib/bolt/error.rb
@@ -50,13 +50,14 @@ module Bolt
   class RunFailure < Bolt::Error
     attr_reader :result_set
 
-    def initialize(result_set, action, object)
+    def initialize(result_set, action, object = nil)
       details = {
         'action' => action,
         'object' => object,
         'result_set' => result_set
       }
-      message = "Plan aborted: #{action} '#{object}' failed on #{result_set.error_set.length} nodes"
+      object_msg = " '#{object}'" if object
+      message = "Plan aborted: #{action}#{object_msg} failed on #{result_set.error_set.length} nodes"
       super(message, 'bolt/run-failure', details)
       @result_set = result_set
       @error_code = 2

--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -153,6 +153,11 @@ module Bolt
         end
       end
 
+      def batch_connected?(targets)
+        assert_batch_size_one("connected?()", targets)
+        connected?(targets.first)
+      end
+
       # Split the given list of targets into a list of batches. The default
       # implementation returns single-node batches.
       #
@@ -180,6 +185,11 @@ module Bolt
       # Transports should override this method with their own implementation of file upload.
       def upload(*_args)
         raise NotImplementedError, "upload() must be implemented by the transport class"
+      end
+
+      # Transports should override this method with their own implementation of a connection test.
+      def connected?(_targets)
+        raise NotImplementedError, "connected?() must be implemented by the transport class"
       end
 
       # Unwraps any Sensitive data in an arguments Hash, so the plain-text is passed

--- a/lib/bolt/transport/local.rb
+++ b/lib/bolt/transport/local.rb
@@ -117,6 +117,10 @@ module Bolt
           Bolt::Result.for_task(target, output.stdout.string, output.stderr.string, output.exit_code)
         end
       end
+
+      def connected?(_targets)
+        true
+      end
     end
   end
 end

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -211,6 +211,11 @@ module Bolt
         end
       end
 
+      def batch_connected?(targets)
+        resp = get_connection(targets.first.options).query_inventory(targets)
+        resp['items'].all? { |node| node['connected'] }
+      end
+
       # run_task generates a result that makes sense for a generic task which
       # needs to be unwrapped to extract stdout/stderr/exitcode.
       #

--- a/lib/bolt/transport/orch/connection.rb
+++ b/lib/bolt/transport/orch/connection.rb
@@ -75,6 +75,10 @@ module Bolt
           body = build_request(targets, task, arguments, options['_description'])
           @client.run_task(body)
         end
+
+        def query_inventory(targets)
+          @client.post('inventory', nodes: targets.map(&:host))
+        end
       end
     end
   end

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -187,6 +187,12 @@ module Bolt
 EOF
 SCRIPT
       end
+
+      def connected?(target)
+        with_connection(target) { true }
+      rescue Bolt::Node::ConnectError
+        false
+      end
     end
   end
 end

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -216,6 +216,12 @@ try { & "#{remote_task_path}" @taskArgs } catch { Write-Error $_.Exception; exit
           end
         end
       end
+
+      def connected?(target)
+        with_connection(target) { true }
+      rescue Bolt::Node::ConnectError
+        false
+      end
     end
   end
 end

--- a/spec/bolt/transport/local_spec.rb
+++ b/spec/bolt/transport/local_spec.rb
@@ -31,6 +31,10 @@ BASH
   end
 
   context "when executing", bash: true do
+    it 'is always connected' do
+      expect(local.connected?(target)).to eq(true)
+    end
+
     it "executes a command" do
       expect(local.run_command(target, 'echo $HOME').value['stdout'].strip).to eq(ENV['HOME'])
     end

--- a/spec/bolt/transport/orch_spec.rb
+++ b/spec/bolt/transport/orch_spec.rb
@@ -562,4 +562,25 @@ describe Bolt::Transport::Orch, orchestrator: true do
       end
     end
   end
+
+  describe 'batch_connected?' do
+    it 'returns true if all targets are connected' do
+      result = { 'items' => targets.map { |_| { 'connected' => true } } }
+      expect(mock_client).to receive(:post).with('inventory', nodes: targets.map(&:host)).and_return(result)
+      expect(orch.batch_connected?(targets)).to eq(true)
+    end
+
+    it 'returns false if all targets are not connected' do
+      result = { 'items' => targets.map { |_| { 'connected' => false } } }
+      expect(mock_client).to receive(:post).with('inventory', nodes: targets.map(&:host)).and_return(result)
+      expect(orch.batch_connected?(targets)).to eq(false)
+    end
+
+    it 'returns false if any targets are not connected' do
+      result = { 'items' => targets.map { |_| { 'connected' => true } } }
+      result['items'][0]['connected'] = false
+      expect(mock_client).to receive(:post).with('inventory', nodes: targets.map(&:host)).and_return(result)
+      expect(orch.batch_connected?(targets)).to eq(false)
+    end
+  end
 end

--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -222,6 +222,14 @@ BASH
       expect(ssh.run_command(target, "echo 'hello \" world'").value).to eq(result_value("hello \" world\n"))
     end
 
+    it "can test whether the target is available", ssh: true do
+      expect(ssh.connected?(target)).to eq(true)
+    end
+
+    it "returns false if the target is not available", ssh: true do
+      expect(ssh.connected?(Bolt::Target.new('unknownfoo'))).to eq(false)
+    end
+
     it "can upload a file to a host", ssh: true do
       contents = "kljhdfg"
       with_tempfile_containing('upload-test', contents) do |file|

--- a/spec/bolt/transport/winrm_spec.rb
+++ b/spec/bolt/transport/winrm_spec.rb
@@ -143,6 +143,10 @@ PS
   context "connecting over SSL", winrm: true do
     let(:target) { make_target(port_: ssl_port, conf: ssl_config) }
 
+    it "can test whether the target is available", winrm: true do
+      expect(winrm.connected?(target)).to eq(true)
+    end
+
     it "executes a command on a host" do
       expect(winrm.run_command(target, command)['stdout']).to eq("#{user}\r\n")
     end
@@ -174,6 +178,14 @@ PS
   end
 
   context "with an open connection" do
+    it "can test whether the target is available", winrm: true do
+      expect(winrm.connected?(target)).to eq(true)
+    end
+
+    it "returns false if the target is not available", winrm: true do
+      expect(winrm.connected?(Bolt::Target.new('winrm://unknownfoo'))).to eq(false)
+    end
+
     it "executes a command on a host", winrm: true do
       expect(winrm.run_command(target, command)['stdout']).to eq("#{user}\r\n")
     end


### PR DESCRIPTION
Add the `wait_until_available` function to wait for all targets to be available for connections. Accepts a description, wait_time in seconds (default 120), and retry_interval in seconds (default 1).