### PR TITLE
(BOLT-942) Allow target to be added to group during plan execution

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/add_to_group.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/add_to_group.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'bolt/error'
+
+# Adds a target to specified inventory group.
+Puppet::Functions.create_function(:add_to_group) do
+  # @param targets A pattern or array of patterns identifying a set of targets.
+  # @param The name of the group to add targets to.
+  # @example Add new Target to group.
+  #   Target.new('foo@example.com', 'password' => 'secret').add_to_group('group1')
+  # @example Add new target to group by name.
+  #   add_to_group('bolt:bolt@web.com', 'group1')
+  # @example Add an array of targets to group by name.
+  #   add_to_group(['host1', 'group1', 'winrm://host2:54321'], 'group1')
+  # @example Add a comma separated list list of targets to group by name.
+  #   add_to_group('foo,bar,baz', 'group1')
+  dispatch :add_to_group do
+    param 'Boltlib::TargetSpec', :targets
+    param 'String[1]', :group
+  end
+
+  def add_to_group(targets, group)
+    inventory = Puppet.lookup(:bolt_inventory) { nil }
+
+    unless inventory && Puppet.features.bolt?
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('process targets through inventory')
+      )
+    end
+
+    executor = Puppet.lookup(:bolt_executor) { nil }
+    executor&.report_function_call('add_to_group')
+
+    inventory.add_to_group(inventory.get_targets(targets), group)
+  end
+end

--- a/lib/bolt/inventory/group.rb
+++ b/lib/bolt/inventory/group.rb
@@ -5,7 +5,7 @@ module Bolt
     # Group is a specific implementation of Inventory based on nested
     # structured data.
     class Group
-      attr_accessor :name, :nodes, :groups, :config, :rest
+      attr_accessor :name, :nodes, :groups, :config, :rest, :facts, :vars, :features
 
       def initialize(data)
         @logger = Logging.logger[self]

--- a/spec/fixtures/modules/add_group/plans/init.pp
+++ b/spec/fixtures/modules/add_group/plans/init.pp
@@ -1,0 +1,30 @@
+plan add_group (TargetSpec $nodes) {
+  $new_target = Target.new(
+    "0.0.0.0:20024",
+    "host-key-check" => false,
+    "user" => 'bolt',
+    'password' => 'bolt'
+  )
+  $t = get_targets('add_me')
+  # Add new facts/var, specifically one that is novel, the other that should override existing.
+  $new_target.add_facts({'plan_context' => 'keep', 'override_parent' => 'keep'})
+  $new_target.set_var('plan_context','keep')
+  $new_target.set_var('override_parent', 'keep')
+  # Add from Target object
+  $new_target.add_to_group('add_me')
+  # Add from string
+  add_to_group('bar_1', 'bar')
+  # Add to default "all" group
+  add_to_group('add_to_all', 'all')
+  $add_me_targets = get_targets('add_me')
+
+  $result = { 'addme_group' => $add_me_targets,
+			  'existing_facts' => $add_me_targets[0].facts,
+			  'existing_vars' => $add_me_targets[0].vars,
+			  'added_facts' => $add_me_targets[1].facts,
+			  'added_vars' => $add_me_targets[1].vars,
+			  'target_from_string' => get_targets('bar'),
+			  'target_to_all_group' => get_targets('all')}
+
+  return $result
+}

--- a/spec/fixtures/modules/add_group/plans/x_fail_group_name_exists.pp
+++ b/spec/fixtures/modules/add_group/plans/x_fail_group_name_exists.pp
@@ -1,0 +1,3 @@
+plan add_group::x_fail_group_name_exists (TargetSpec $nodes) {
+  add_to_group(Target.new('foo'), 'foo')
+}

--- a/spec/fixtures/modules/add_group/plans/x_fail_non_existent_group.pp
+++ b/spec/fixtures/modules/add_group/plans/x_fail_non_existent_group.pp
@@ -1,0 +1,3 @@
+plan add_group::x_fail_non_existent_group (TargetSpec $nodes) {
+  add_to_group('foo', 'does_not_exist')
+}


### PR DESCRIPTION
This commit adds an `add_to_group` method callable from `Target` objects in plans. The method can be called from a `Target` object with the argument of the group to add the `Target` to. When a group does not exist the target will not be added to ANY group. If a `Target` of the same name exists in the requested group it will be overridden by the added `Target`.