### PR TITLE
(BOLT-965) bolt-server Dockerfile to use alpine

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 .git/
 # If we start shipping this we may reevaluate
 Gemfile.lock
+vendor/bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,38 @@
-FROM ruby:2.5.1
-RUN apt-get update -qq && apt-get install -y ruby-dev
+# Install gems
+FROM alpine:3.8 as build
+
+RUN \
+apk --no-cache add build-base ruby-dev ruby-bundler ruby-json ruby-bigdecimal git openssl-dev && \
+echo 'gem: --no-document' > /etc/gemrc && \
+bundle config --global silence_root_warning 1
 
 RUN mkdir /bolt-server
-WORKDIR /bolt-server
+# Gemfile requires gemspec which requires bolt/version which requires bolt
 ADD . /bolt-server
-RUN bundle install
+WORKDIR /bolt-server
+RUN bundle install --no-cache --path vendor/bundle
+
+# Final image
+FROM alpine:3.8
+ARG bolt_version=no-version
+LABEL org.label-schema.maintainer="Puppet Bolt Team <team-direct-change-bolt@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
+      org.label-schema.url="https://github.com/puppetlabs/bolt" \
+      org.label-schema.name="PE Bolt Server" \
+      org.label-schema.license="Apache-2.0" \
+      org.label-schema.version=${bolt_version} \
+      org.label-schema.vcs-url="https://github.com/puppetlabs/bolt" \
+      # Same with these
+      #org.label-schema.vcs-ref="b75674e1fbf52f7821f7900ab22a19f1a10cafdb" \
+      #org.label-schema.build-date="2018-05-09T20:10:01Z" \
+      #org.label-schema.schema-version="1.0" \
+      org.label-schema.dockerfile="/Dockerfile"
+
+RUN \
+apk --no-cache add ruby openssl ruby-bundler ruby-json ruby-bigdecimal
+
+COPY --from=build /bolt-server /bolt-server
+WORKDIR /bolt-server
 
 EXPOSE 62658
 ENV BOLT_SERVER_CONF /bolt-server/config/docker.conf


### PR DESCRIPTION
**What this changes** This updates the pe-bolt-server dockerfile to use the alpine linux base image instead of the ruby base image. It then installs ruby and dependencies, and installs and starts pe-bolt-server just as the previous dockerfile did.
**Why** This is slimmed-down container that only includes what we need for bolt-server, and is more consistent with the image layering we use throughout Puppet.