### PR TITLE
(BOLT-966) Configure Bolt-Server from environment variables

### DIFF
--- a/developer-docs/bolt-server.md
+++ b/developer-docs/bolt-server.md
@@ -22,6 +22,18 @@ Bolt server can be configured by defining content in HOCON format at one of the 
 - `whitelist`: Array, *optional* - A list of hosts which can connect to pe-bolt-server.
 - `concurrency`: Integer, *optional* - The maximum number of server threads (default `100`).
 
+**Environmnet Variable Options**
+The following configuration options can be set with environment variables. 
+- `BOLT_SSL_CERT`
+- `BOLT_SSL_KEY`
+- `BOLT_SSL_CA_CERT`
+- `BOLT_LOGLEVEL`
+- `BOLT_CONCURRENCY`
+- `BOLT_FILE_SERVER_CONN_TIMEOUT`
+- `BOLT_FILE_SERVER_URI`
+
+**Note**: Configuration options set with environment variables will override those defined in `bolt-server.conf`
+
 ### Default SSL Cipher Suites
 Based on https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
 ```

--- a/puma_config.rb
+++ b/puma_config.rb
@@ -15,7 +15,10 @@ Bolt::Logger.initialize_logging
 
 config_path = ENV['BOLT_SERVER_CONF'] || '/etc/puppetlabs/bolt-server/conf.d/bolt-server.conf'
 
-config = BoltServer::Config.new.load_config(config_path)
+config = BoltServer::Config.new
+config.load_file_config(config_path)
+config.load_env_config
+config.validate
 
 Logging.logger[:root].add_appenders Logging.appenders.stderr(
   'console',


### PR DESCRIPTION
This commit allows select configuration options to be set with environment variables. Environment variable options take precedence over options defined in `bolt-server.conf`.