### PR TITLE
(maint) Add windows path to analytics disabling docs

### DIFF
--- a/pre-docs/bolt_installing.md
+++ b/pre-docs/bolt_installing.md
@@ -236,7 +236,7 @@ Bolt collects data to help us understand how it's being used and make decisions 
 
 ### How can I opt out of Bolt data collection?
 
-To disable the collection of analytics data add the following line to `~/.puppetlabs/bolt/analytics.yaml`:
+To disable the collection of analytics data add the following line to `~/.puppetlabs/bolt/analytics.yaml` on Unix systems or ` %USERPROFILE%\.puppetlabs\bolt\analytics.yaml` on Windows:
 
 ```
 disabled: true


### PR DESCRIPTION
**What this changes** Includes the path to the analytics config file in the docs for disabling analytics
**Why** so that Windows users don't have to find the path on their own.