### PR TITLE
(BOLT-971) Fix functions and initialization with BoltSpec

### DIFF
--- a/lib/bolt_spec/plans.rb
+++ b/lib/bolt_spec/plans.rb
@@ -91,6 +91,16 @@ require 'bolt/pal'
 #
 module BoltSpec
   module Plans
+    def self.init
+      # Ensure tasks are enabled when rspec-puppet sets up an environment so we get task loaders.
+      # Note that this is probably not safe to do in modules that also test Puppet manifest code.
+      Bolt::PAL.load_puppet
+      Puppet[:tasks] = true
+
+      # Ensure logger is initialized with Puppet levels so 'notice' works when running plan specs.
+      Logging.init :debug, :info, :notice, :warn, :error, :fatal, :any
+    end
+
     # Override in your tests if needed
     def modulepath
       [RSpec.configuration.module_path]

--- a/lib/bolt_spec/plans/mock_executor.rb
+++ b/lib/bolt_spec/plans/mock_executor.rb
@@ -209,7 +209,15 @@ module BoltSpec
         @task_doubles[task_name] ||= TaskDouble.new
       end
 
+      def wait_until_available(targets, _options)
+        targets.map { |target| Bolt::Result.new(target) }
+      end
+
       def log_plan(_plan_name)
+        yield
+      end
+
+      def without_default_logging
         yield
       end
 


### PR DESCRIPTION
BoltSpec plan testing didn't implement `without_default_logging` or `wait_until_available`. Add them to support running plans that use them. Also add an init helper so that logging is configured ready (so `notice` doesn't error).