### PR TITLE
(BOLT-644) Add analytics for size of applied manifests

### DIFF
--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -15,7 +15,7 @@ require 'bolt/puppetdb'
 
 module Bolt
   class Executor
-    attr_reader :noop, :transports
+    attr_reader :noop, :transports, :analytics
     attr_accessor :run_as
 
     # FIXME: There must be a better way

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -180,8 +180,7 @@ module Bolt
     # Parses a snippet of Puppet manifest code and returns the AST represented
     # in JSON.
     def parse_manifest(code, filename)
-      raw_ast = Puppet::Pops::Parser::EvaluatingParser.new.parse_string(code, filename)
-      Puppet::Pops::Serialization::ToDataConverter.convert(raw_ast, rich_data: true, symbol_to_string: true)
+      Puppet::Pops::Parser::EvaluatingParser.new.parse_string(code, filename)
     rescue Puppet::Error => e
       raise Bolt::PAL::PALError, "Failed to parse manifest: #{e}"
     end

--- a/lib/bolt_spec/plans/mock_executor.rb
+++ b/lib/bolt_spec/plans/mock_executor.rb
@@ -224,6 +224,8 @@ module BoltSpec
       def report_function_call(_function); end
 
       def report_bundled_content(_mode, _name); end
+
+      def analytics; end
     end
   end
 end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -720,7 +720,7 @@ bar
     end
 
     describe "execute" do
-      let(:executor) { double('executor', noop: false) }
+      let(:executor) { double('executor', noop: false, analytics: nil) }
       let(:cli) { Bolt::CLI.new({}) }
       let(:targets) { [target] }
       let(:output) { StringIO.new }
@@ -1659,7 +1659,7 @@ bar
     end
 
     describe "execute with noop" do
-      let(:executor) { double('executor', noop: true) }
+      let(:executor) { double('executor', noop: true, analytics: nil) }
       let(:cli) { Bolt::CLI.new({}) }
       let(:targets) { [target] }
       let(:output) { StringIO.new }

--- a/spec/bolt/pal_spec.rb
+++ b/spec/bolt/pal_spec.rb
@@ -17,8 +17,7 @@ describe Bolt::PAL do
 
     it "should parse a manifest string" do
       ast = pal.parse_manifest('notify { "hello world": }', 'test.pp')
-      expect(ast).to be_a(Hash)
-      expect(ast['__ptype']).to eq('Puppet::AST::Program')
+      expect(ast).to be_a(Puppet::Pops::Model::Program)
     end
 
     it "should convert puppet errors to pal errors" do


### PR DESCRIPTION
For apply actions - via `bolt apply` or the `apply` function in a Plan -
capture events counting the size of the code being run (in number of
statements), and number of resources produced by those manifests.