### PR TITLE
(docs) Document support for Kerberos as a known issue (BOLT-980)

### DIFF
--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -54,10 +54,7 @@ module Bolt
         begin
           require 'net/ssh/krb'
         rescue LoadError
-          logger.debug {
-            "Authentication method 'gssapi-with-mic' is not available. "\
-            "Please install the kerberos gem with `gem install net-ssh-krb`"
-          }
+          logger.debug("Authentication method 'gssapi-with-mic' (Kerberos) is not available.")
         end
 
         @transport_logger = Logging.logger[Net::SSH]

--- a/pre-docs/bolt_installing.md
+++ b/pre-docs/bolt_installing.md
@@ -241,10 +241,3 @@ To disable the collection of analytics data add the following line to `~/.puppe
 ```
 disabled: true
 ```
-
-## Using Kerberos over SSH
-
-Bolt supports Kerberos authentication for SSH connections, however you must install the gem yourself to avoid license incompatibilities with other distributed components.
-
-To add Kerberos authentication, run `gem install net-ssh-krb`.
-

--- a/pre-docs/bolt_known_issues.md
+++ b/pre-docs/bolt_known_issues.md
@@ -27,3 +27,8 @@ Workaround: Generate new keys with the ssh-keygen flag `-m PEM`. For existing ke
 
 When running Bolt in PowerShell with commands to be run on \*nix nodes, string segments that can be interpreted by PowerShell need to be triple quoted. [\(BOLT-159\)](https://tickets.puppet.com/browse/BOLT-159)
 
+## No Kerberos support
+
+While we would like to support Kerberos over SSH for authentication, a license incompatibility with other components we are distributing means that we cannot recommend using the net-ssh-krb gem for this functionality. [\(BOLT-980\)](https://tickets.puppet.com/browse/BOLT-980)
+
+Note that support for Kerberos over WinRM, both from Windows and non-Windows hosts, is also unimplemented. [\(BOLT-126\)](https://tickets.puppet.com/browse/BOLT-126)

--- a/pre-docs/index.md
+++ b/pre-docs/index.md
@@ -17,7 +17,6 @@
     -   [Install gems with Bolt packages](bolt_installing.md#task-2023)
     -   [Install Bolt as a gem](bolt_installing.md#task-4877)
     -   [Analytics data collection](bolt_installing.md#concept-8242)
-    -   [Using Kerberos over SSH](bolt_installing.md#concept-7683)
 -   [Using Bolt to perform frequent tasks](running_bolt.md)
     -   [Running basic Bolt commands](running_bolt_commands.md#concept-3531)
         -   [Run a command on remote nodes](running_bolt_commands.md#concept-4161)


### PR DESCRIPTION
Add a known issue to explain our current lack of support for Kerberos because we had to remove it and can't support the obvious gem.