### PR TITLE
(BOLT-644) Send a single event for apply with metrics

### DIFF
--- a/lib/bolt/analytics.rb
+++ b/lib/bolt/analytics.rb
@@ -19,7 +19,9 @@ module Bolt
       inventory_nodes: :cd2,
       inventory_groups: :cd3,
       target_nodes: :cd4,
-      output_format: :cd5
+      output_format: :cd5,
+      statement_count: :cd6,
+      resource_mean: :cd7
     }.freeze
 
     def self.build_client
@@ -82,7 +84,11 @@ module Bolt
         submit(base_params.merge(screen_view_params))
       end
 
-      def event(category, action, label = nil, value = nil)
+      def event(category, action, label: nil, value: nil, **kwargs)
+        custom_dimensions = Bolt::Util.walk_keys(kwargs) do |k|
+          CUSTOM_DIMENSIONS[k] || raise("Unknown analytics key '#{k}'")
+        end
+
         event_params = {
           # Type
           t: 'event',
@@ -90,7 +96,7 @@ module Bolt
           ec: category,
           # Event Action
           ea: action
-        }
+        }.merge(custom_dimensions)
 
         # Event Label
         event_params[:el] = label if label
@@ -160,7 +166,7 @@ module Bolt
         @logger.debug "Skipping submission of '#{screen}' screenview because analytics is disabled"
       end
 
-      def event(category, action, _label = nil, _value = nil)
+      def event(category, action, **_kwargs)
         @logger.debug "Skipping submission of '#{category} #{action}' event because analytics is disabled"
       end
 

--- a/lib/bolt_spec/plans/mock_executor.rb
+++ b/lib/bolt_spec/plans/mock_executor.rb
@@ -131,7 +131,7 @@ module BoltSpec
 
       def report_bundled_content(_mode, _name); end
 
-      def analytics; end
+      def report_apply(_statements, _resources); end
 
       # Mocked for Apply so it does not compile and execute.
       def with_node_logging(_description, targets)
@@ -145,8 +145,9 @@ module BoltSpec
 
       def await_results(promises)
         raise "Unexpected call to apply(#{targets})" unless @allow_apply
-        Bolt::ResultSet.new(promises.map { |target| Bolt::Result.new(target) })
+        Bolt::ResultSet.new(promises.map { |target| Bolt::ApplyResult.new(target) })
       end
+      # End Apply mocking
     end
   end
 end

--- a/spec/bolt/analytics_spec.rb
+++ b/spec/bolt/analytics_spec.rb
@@ -101,7 +101,7 @@ describe Bolt::Analytics::Client do
 
       expect(subject).to receive(:submit).with params
 
-      subject.event('run', 'task', 'happy')
+      subject.event('run', 'task', label: 'happy')
     end
 
     it 'sends the event metric if supplied' do
@@ -109,7 +109,7 @@ describe Bolt::Analytics::Client do
 
       expect(subject).to receive(:submit).with params
 
-      subject.event('run', 'task', nil, 12)
+      subject.event('run', 'task', value: 12)
     end
   end
 end
@@ -127,11 +127,11 @@ describe Bolt::Analytics::NoopClient do
     end
 
     it 'succeeds with a label' do
-      subject.event('run', 'task', 'happy')
+      subject.event('run', 'task', label: 'happy')
     end
 
     it 'succeeds with a metric' do
-      subject.event('run', 'task', nil, 12)
+      subject.event('run', 'task', value: 12)
     end
   end
 end

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -185,7 +185,7 @@ MSG
 
       targets = [Bolt::Target.new('node1'), Bolt::Target.new('node2'), Bolt::Target.new('node3')]
       allow_any_instance_of(Bolt::Transport::SSH).to receive(:batch_task) do |_, batch|
-        Bolt::Result.new(batch.first)
+        Bolt::ApplyResult.new(batch.first)
       end
 
       t = Thread.new {

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -522,9 +522,9 @@ describe "Bolt::Executor" do
     }
 
     it 'reports one event for each transport used' do
-      expect(analytics).to receive(:event).with('Transport', 'initialize', 'ssh', 2).once
-      expect(analytics).to receive(:event).with('Transport', 'initialize', 'winrm', 1).once
-      expect(analytics).to receive(:event).with('Transport', 'initialize', 'orch', 1).once
+      expect(analytics).to receive(:event).with('Transport', 'initialize', label: 'ssh', value: 2).once
+      expect(analytics).to receive(:event).with('Transport', 'initialize', label: 'winrm', value: 1).once
+      expect(analytics).to receive(:event).with('Transport', 'initialize', label: 'orch', value: 1).once
 
       executor.batch_execute(targets) {}
       executor.batch_execute(targets) {}
@@ -532,7 +532,7 @@ describe "Bolt::Executor" do
 
     context "#report_function_call" do
       it 'reports an event for the given function' do
-        expect(analytics).to receive(:event).with('Plan', 'call_function', 'add_facts')
+        expect(analytics).to receive(:event).with('Plan', 'call_function', label: 'add_facts')
 
         executor.report_function_call('add_facts')
       end
@@ -542,13 +542,13 @@ describe "Bolt::Executor" do
       let(:executor) { Bolt::Executor.new(2, analytics, bundled_content: %w[canary facts]) }
 
       it 'reports an event when bundled plan is used' do
-        expect(analytics).to receive(:event).with('Bundled Content', 'Plan', 'canary')
+        expect(analytics).to receive(:event).with('Bundled Content', 'Plan', label: 'canary')
 
         executor.report_bundled_content('Plan', 'canary')
       end
 
       it 'reports an event when bundled task is used' do
-        expect(analytics).to receive(:event).with('Bundled Content', 'Task', 'facts')
+        expect(analytics).to receive(:event).with('Bundled Content', 'Task', label: 'facts')
 
         executor.report_bundled_content('Task', 'facts')
       end


### PR DESCRIPTION
Send a single event for each `apply` that includes metrics for that
apply as custom dimensions: statement count, mean and standard deviation
of resource counts across targets. This provides more flexibility in how
to use the data than sending event values.