### PR TITLE
(BOLT-791) Support remote tasks

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
@@ -99,7 +99,7 @@ Puppet::Functions.create_function(:run_task) do
     options['_description'] = description if description
 
     # Don't bother loading the local task definition if all targets use the 'pcp' transport.
-    if !targets.empty? && targets.all? { |t| t.protocol == 'pcp' }
+    if !targets.empty? && targets.all? { |t| t.transport == 'pcp' }
       # create a fake task
       task = Bolt::Task.new(name: task_name, files: [{ 'name' => '', 'path' => '' }])
     else

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-ssh", ">= 4.0"
   spec.add_dependency "orchestrator_client", "~> 0.3.1"
   spec.add_dependency "puppet", [">= 6.0.1", "< 7"]
+  spec.add_dependency "puppet-resource_api"
   spec.add_dependency "r10k", "~> 2.6"
   spec.add_dependency "terminal-table", "~> 1.8"
   spec.add_dependency "winrm", "~> 2.0"

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -10,6 +10,7 @@ require 'bolt/transport/winrm'
 require 'bolt/transport/orch'
 require 'bolt/transport/local'
 require 'bolt/transport/docker'
+require 'bolt/transport/remote'
 
 module Bolt
   TRANSPORTS = {
@@ -17,7 +18,8 @@ module Bolt
     winrm: Bolt::Transport::WinRM,
     pcp: Bolt::Transport::Orch,
     local: Bolt::Transport::Local,
-    docker: Bolt::Transport::Docker
+    docker: Bolt::Transport::Docker,
+    remote: Bolt::Transport::Remote
   }.freeze
 
   class UnknownTransportError < Bolt::Error
@@ -36,16 +38,15 @@ module Bolt
                            private-key tty tmpdir user connect-timeout
                            cacert token-file service-url].freeze
 
-    TRANSPORT_DEFAULTS = {
-      'connect-timeout' => 10,
-      'tty' => false
-    }.freeze
-
+    # TODO: move these to the transport themselves
     TRANSPORT_SPECIFIC_DEFAULTS = {
       ssh: {
-        'host-key-check' => true
+        'connect-timeout' => 10,
+        'host-key-check' => true,
+        'tty' => false
       },
       winrm: {
+        'connect-timeout' => 10,
         'ssl' => true,
         'ssl-verify' => true
       },
@@ -53,7 +54,10 @@ module Bolt
         'task-environment' => 'production'
       },
       local: {},
-      docker: {}
+      docker: {},
+      remote: {
+        'run-on' => 'localhost'
+      }
     }.freeze
 
     def self.default
@@ -88,7 +92,7 @@ module Bolt
 
       @transports = {}
       TRANSPORTS.each_key do |transport|
-        @transports[transport] = TRANSPORT_DEFAULTS.merge(TRANSPORT_SPECIFIC_DEFAULTS[transport])
+        @transports[transport] = TRANSPORT_SPECIFIC_DEFAULTS[transport].dup
       end
 
       update_from_file(config_data)
@@ -158,7 +162,7 @@ module Bolt
 
       TRANSPORTS.each do |key, impl|
         if data[key.to_s]
-          selected = data[key.to_s].select { |k| impl.options.include?(k) }
+          selected = impl.filter_options(data[key.to_s])
           @transports[key].merge!(selected)
         end
       end

--- a/lib/bolt/node/errors.rb
+++ b/lib/bolt/node/errors.rb
@@ -7,7 +7,8 @@ module Bolt
     class BaseError < Bolt::Error
       attr_reader :issue_code
 
-      def initialize(message, issue_code)
+      # TODO: can we just drop issue code here?
+      def initialize(message, issue_code = nil)
         super(message, kind, nil, issue_code)
       end
 
@@ -31,6 +32,12 @@ module Bolt
     class FileError < BaseError
       def kind
         'puppetlabs.tasks/task_file_error'
+      end
+    end
+
+    class RemoteError < BaseError
+      def kind
+        'puppetlabs.tasks/remote-task-error'
       end
     end
 

--- a/lib/bolt/task/remote.rb
+++ b/lib/bolt/task/remote.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'bolt/task'
+
+module Bolt
+  class Task
+    class Remote < Task
+      def self.from_task(task)
+        new(task.name, task.file, task.files, task.metadata)
+      end
+
+      def implementations
+        metadata['implementations']&.select { |i| i['remote'] || metadata['remote'] }
+      end
+
+      def select_implementation(target, *args)
+        unless implementations || metadata['remote']
+          raise NoImplementationError.new(target, self)
+        end
+
+        super(target, *args)
+      end
+    end
+  end
+end

--- a/lib/bolt/transport/local.rb
+++ b/lib/bolt/transport/local.rb
@@ -84,9 +84,9 @@ module Bolt
       end
 
       def run_task(target, task, arguments, _options = {})
-        implementation = task.select_implementation(target, provided_features)
+        implementation = select_implementation(target, task)
         executable = implementation['path']
-        input_method = implementation['input_method'] || 'both'
+        input_method = implementation['input_method']
         extra_files = implementation['files']
 
         in_tmpdir(target.options['tmpdir']) do |dir|

--- a/lib/bolt/transport/remote.rb
+++ b/lib/bolt/transport/remote.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'bolt/task/remote'
+require 'bolt/transport/base'
+
+module Bolt
+  module Transport
+    class Remote < Base
+      # The options for the remote transport not defined.
+      def self.filter_options(unfiltered)
+        unfiltered
+      end
+
+      def self.validate(options)
+        # This will fail when validating global config
+        # unless options['device-type']
+        #  raise Bolt::ValidationError, 'Must specify device-type for devices'
+        # end
+      end
+
+      # TODO: this should have access to inventory so target doesn't have to
+      def initialize(executor)
+        super()
+
+        @executor = executor
+      end
+
+      def get_proxy(target)
+        # TODO: This needs to have access to the inventory
+        inventory = target.inventory
+        raise "Target was created without inventory? Not get_targets?" unless inventory
+        inventory.get_targets(target.options['run-on'] || 'localhost').first
+      end
+
+      # Cannot batch because arugments differ
+      def run_task(target, task, arguments, options = {})
+        proxy_target = get_proxy(target)
+        transport = @executor.transport(proxy_target.protocol)
+        arguments = arguments.merge('_target' => target.to_h.reject { |_, v| v.nil? })
+
+        remote_task = Bolt::Task::Remote.new(task.to_h)
+
+        result = transport.run_task(proxy_target, remote_task, arguments, options)
+        Bolt::Result.new(target, value: result.value)
+      end
+    end
+  end
+end

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -121,11 +121,10 @@ module Bolt
       end
 
       def run_task(target, task, arguments, options = {})
-        implementation = task.select_implementation(target, provided_features)
+        implementation = select_implementation(target, task)
         executable = implementation['path']
         input_method = implementation['input_method']
         extra_files = implementation['files']
-        input_method ||= 'both'
 
         # unpack any Sensitive data
         arguments = unwrap_sensitive_args(arguments)

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -18,6 +18,10 @@ module Bolt
         ['powershell']
       end
 
+      def default_input_method
+        'powershell'
+      end
+
       def self.validate(options)
         ssl_flag = options['ssl']
         unless !!ssl_flag == ssl_flag
@@ -110,7 +114,7 @@ catch
       end
 
       def run_task(target, task, arguments, _options = {})
-        implementation = task.select_implementation(target, provided_features)
+        implementation = select_implementation(target, task)
         executable = implementation['path']
         input_method = implementation['input_method']
         extra_files = implementation['files']

--- a/pre-docs/bolt_configuration_options.md
+++ b/pre-docs/bolt_configuration_options.md
@@ -92,6 +92,15 @@ ssh:
 
 `service-options`: A hash of options to configure the Docker connection. Only necessary if using a non-default URL. See https://github.com/swipely/docker-api for supported options.
 
+## Remote transport configuration options
+
+*The remote transport is a new feature and currently experimental. It's configuration options and behavior may change between y releases*
+
+The remote transport can accept arbitrary option that depend on the underlying remote target for example `api-token`.
+
+`run-on`: The proxy target the task should execute on. Default is `localhost`
+
+
 ## Log file configuration options
 
 Capture the results of your plan runs in a log file.

--- a/pre-docs/inventory_file.md
+++ b/pre-docs/inventory_file.md
@@ -61,9 +61,9 @@ groups:
 ### Override a user for a specific node
 
 ```
-nodes: 
+nodes:
   - name: linux1.example.com
-    config: 
+    config:
       ssh:
         user: me
 ```
@@ -225,10 +225,30 @@ nodes:
           run-as: root
 ```
 
--   **[Generating inventory files](inventory_file_generating.md)**  
+## Remote Targets
+
+Configure a remote target. When using the remote transport the protocol of the
+node name does not have to map to the transport if you set the transport config
+option. This is useful if the target is an http API as in the following example.
+
+```yaml
+nodes:
+  - host1.example.com
+  - name: https://user1:secret@remote.example.com
+    config:
+      transport: remote
+      remote:
+        # The remote transport will use the host1.example.com target from
+        # inventory to proxy tasks execution on.
+        run-on: host1.example.com
+  # This will execute on localhost.
+  - remote://my_aws_account
+```
+
+-   **[Generating inventory files](inventory_file_generating.md)**
  Use the `bolt-inventory-pdb` script to generate inventory files based on PuppetDB queries.
 
-**Related information**  
+**Related information**
 
 
 [Naming tasks](writing_tasks.md#)

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -51,13 +51,14 @@ describe Bolt::Applicator do
         config: {
           transport: "ssh",
           transports: {
-            ssh: { 'connect-timeout' => 10, tty: false, "host-key-check" => true },
-            winrm: { 'connect-timeout' => 10, tty: false, ssl: true, "ssl-verify" => true },
-            pcp: { 'connect-timeout' => 10,
-                   tty: false,
-                   "task-environment" => "production" },
-            local: { 'connect-timeout' => 10, tty: false },
-            docker: { 'connect-timeout' => 10, tty: false }
+            ssh: { 'connect-timeout' => 10, "host-key-check" => true, tty: false },
+            winrm: { 'connect-timeout' => 10, ssl: true, "ssl-verify" => true },
+            pcp: {
+              "task-environment" => "production"
+            },
+            local: {},
+            docker: {},
+            remote: { 'run-on': 'localhost' }
           }
         }
       }

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -566,7 +566,6 @@ describe Bolt::Inventory do
         expect(target.port).to eq('12345winrm')
         expect(target.options).to eq(
           'connect-timeout' => 5,
-          'tty' => false,
           'ssl' => false,
           'ssl-verify' => false,
           'tmpdir' => "/winrm",
@@ -585,9 +584,7 @@ describe Bolt::Inventory do
         expect(target.password).to be nil
         expect(target.port).to be nil
         expect(target.options).to eq(
-          'connect-timeout' => 10,
           'task-environment' => "prod",
-          'tty' => false,
           'service-url' => "https://master",
           'cacert' => "pcp.pem",
           'token-file' => "token"

--- a/spec/bolt/transport/docker_spec.rb
+++ b/spec/bolt/transport/docker_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'bolt_spec/conn'
+require 'bolt_spec/transport'
 require 'bolt/transport/docker'
 require 'bolt/target'
 
@@ -9,13 +10,14 @@ require_relative 'shared_examples'
 
 describe Bolt::Transport::Docker, docker: true do
   include BoltSpec::Conn
+  include BoltSpec::Transport
+
   let(:hostname) { conn_info('docker')[:host] }
   let(:docker) { Bolt::Transport::Docker.new }
-  let(:transport_conf) { {} }
-  let(:target) { Bolt::Target.new(hostname, transport_conf) }
+  let(:target) { Bolt::Target.new("docker://#{hostname}", transport_conf) }
 
   context 'with docker' do
-    let(:runner) { docker }
+    let(:transport) { :docker }
     let(:os_context) { posix_context }
 
     it "can test whether the target is available" do

--- a/spec/bolt/transport/local_spec.rb
+++ b/spec/bolt/transport/local_spec.rb
@@ -3,13 +3,16 @@
 require 'spec_helper'
 require 'bolt/transport/local'
 require 'bolt/target'
+require 'bolt/inventory'
+require 'bolt_spec/transport'
 
 require_relative 'shared_examples'
 
 describe Bolt::Transport::Local, bash: true do
-  let(:runner) { Bolt::Transport::Local.new }
+  include BoltSpec::Transport
+
+  let(:transport) { :local }
   let(:os_context) { posix_context }
-  let(:transport_conf) { {} }
   let(:target) { Bolt::Target.new('local://localhost', transport_conf) }
 
   it 'is always connected' do

--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 require 'net/ssh'
 require 'bolt_spec/conn'
 require 'bolt_spec/errors'
+require 'bolt_spec/transport'
 require 'bolt/transport/ssh'
 require 'bolt/config'
 require 'bolt/target'
@@ -44,8 +45,10 @@ describe Bolt::Transport::SSH do
 
   context 'with ssh', ssh: true do
     let(:target) { make_target(conf: no_host_key_check) }
-    let(:runner) { ssh }
+    let(:transport) { :ssh }
     let(:os_context) { posix_context }
+
+    include BoltSpec::Transport
 
     include_examples 'transport api'
 

--- a/spec/fixtures/modules/remote/tasks/init.json
+++ b/spec/fixtures/modules/remote/tasks/init.json
@@ -1,0 +1,3 @@
+{
+  "remote": true
+}

--- a/spec/fixtures/modules/remote/tasks/init.sh
+++ b/spec/fixtures/modules/remote/tasks/init.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+cat

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -234,7 +234,7 @@ describe "passes parsed AST to the apply_catalog task" do
           expect(notify[0]['title']).to eq("Num Targets: 3")
           expect(notify[1]['title']).to eq("Target 1 Facts: {operatingsystem => Ubuntu, added => fact}")
           expect(notify[2]['title']).to eq("Target 1 Vars: {environment => production, features => [puppet-agent]}")
-          res = "Target 0 Config: {connect-timeout => 11, tty => false, host-key-check => false, password => bolt}"
+          res = "Target 0 Config: {connect-timeout => 11, host-key-check => false, tty => false, password => bolt}"
           expect(notify[3]['title']).to eq(res)
           expect(notify[4]['title']).to eq("Target 1 Password: secret")
         end

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -68,7 +68,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
     end
 
     it 'connects to run a plan' do
-      expect(run_cli_json(run_plan)[0]['status']).to eq('success')
+      expect(run_cli_json(run_plan)[0]).to include('status' => 'success')
     end
 
     context 'with a group' do

--- a/spec/integration/remote_spec.rb
+++ b/spec/integration/remote_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/config'
+require 'bolt_spec/conn'
+require 'bolt_spec/files'
+require 'bolt_spec/integration'
+require 'bolt_spec/run'
+
+describe 'running with an inventory file', reset_puppet_settings: true, ssh: true do
+  include BoltSpec::Config
+  include BoltSpec::Conn
+  include BoltSpec::Files
+  include BoltSpec::Integration
+  include BoltSpec::Run
+
+  let(:conn) { conn_info('ssh') }
+  let(:inventory) do
+    { 'nodes' => [
+      { 'name' => conn[:host],
+        'config' => {
+          'transport' => conn[:protocol],
+          conn[:protocol] => {
+            'user' => conn[:user],
+            'port' => conn[:port],
+            'password' => conn[:password]
+          }
+        } },
+      { 'name' => 'remote://simple.example.com',
+        'config' => {
+          'remote' => {
+            'run-on' => conn[:host],
+            'token' => 'token_val'
+          }
+        } },
+      { 'name' => 'https://www.example.com',
+        'config' => {
+          'transport' => 'remote',
+          'remote' => { 'run-on': conn[:host] }
+        } }
+    ],
+      'config' => {
+        'ssh' => { 'host-key-check' => false },
+        'winrm' => { 'ssl' => false, 'ssl-verify' => false }
+      } }
+  end
+
+  let(:modulepath) { fixture_path('modules') }
+  let(:config) { { 'modulepath' => modulepath } }
+
+  it 'runs a remote task' do
+    result = run_task('remote', 'remote://simple.example.com', {}, config: config, inventory: inventory).first
+    expect(result).to include('status' => 'success')
+    expect(result['result']['_target']).to include(
+      'uri' => 'remote://simple.example.com',
+      'host' => 'simple.example.com',
+      'token' => 'token_val'
+    )
+  end
+
+  it 'runs a remote task with the https protocol' do
+    result = run_task('remote', 'https://www.example.com', {}, config: config, inventory: inventory).first
+    expect(result).to include('status' => 'success')
+    expect(result['result']['_target']).to include(
+      'uri' => 'https://www.example.com',
+      'host' => 'www.example.com',
+      'protocol' => 'https'
+    )
+  end
+end

--- a/spec/lib/bolt_spec/transport.rb
+++ b/spec/lib/bolt_spec/transport.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'bolt/config'
+
+module BoltSpec
+  module Transport
+    def runner
+      Bolt::TRANSPORTS[transport].new
+    end
+
+    def transport_conf
+      {}
+    end
+  end
+end


### PR DESCRIPTION
This adds a remote transport to support revision 4 of the task spec. The
remote transport will proxy a task to the node defined as run-on its
config.

I still want to add a few more tests and update the predocs