### PR TITLE
(docs) Recommend `gem install --user-install`

### DIFF
--- a/pre-docs/bolt_installing.md
+++ b/pre-docs/bolt_installing.md
@@ -193,12 +193,13 @@ The Puppet repository for the YUM package management system is [http://yum.puppe
 
 Bolt packages include their own copy of Ruby.
 
-To install a gem for use with Bolt:
+When you install gems for use with Bolt, use the `--user-install` flag to avoid requiring privileged access for installation. This option also enables sharing gem content with Puppet installations — such as when running `apply` on `​localhost` — that use the same Ruby version.​
+
+To install a gem for use with Bolt, use the command appropriate to your operating system: 
 
 -   On Windows with the default install location, `"C:/Program Files/Puppet Labs/Bolt/bin/gem.bat" install --user-install <gem>`
 -   On other platforms, `/opt/puppetlabs/bolt/bin/gem install --user-install <gem>`
 
-The `--user-install` flag is recommended to avoid requiring privileged access to add functionality to Bolt. It also allows sharing gem content with Puppet installations (such as when running `apply` on `localhost`) that use the same Ruby version (currently Puppet 6).
 
 ## Install Bolt as a gem
 

--- a/pre-docs/bolt_installing.md
+++ b/pre-docs/bolt_installing.md
@@ -195,8 +195,10 @@ Bolt packages include their own copy of Ruby.
 
 To install a gem for use with Bolt:
 
--   On Windows with the default install location, `"C:/Program Files/Puppet Labs/Bolt/bin/gem.bat" install <gem>`
--   On other platforms, `/opt/puppetlabs/bolt/bin/gem install <gem>`
+-   On Windows with the default install location, `"C:/Program Files/Puppet Labs/Bolt/bin/gem.bat" install --user-install <gem>`
+-   On other platforms, `/opt/puppetlabs/bolt/bin/gem install --user-install <gem>`
+
+The `--user-install` flag is recommended to avoid requiring privileged access to add functionality to Bolt. It also allows sharing gem content with Puppet installations (such as when running `apply` on `localhost`) that use the same Ruby version (currently Puppet 6).
 
 ## Install Bolt as a gem
 


### PR DESCRIPTION
Our previous instructions for using gems with Bolt required
root/Admnistrator access on the host. That is not required to install
Puppet modules, which meant you might be able to install a module but
not the gems required for it to work. Provide instructions that work as
a non-privileged user.