### PR TITLE
(BOLT-940) Simplify setup for apply with Orchestrator

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
@@ -3,7 +3,15 @@
 require 'fileutils'
 require 'bolt/task'
 
+# Installs the puppet-agent package on targets if needed then collects facts, including any custom
+# facts found in Bolt's modulepath.
+#
+# If no agent is detected on the target using the 'puppet_agent::version' task, it's installed
+# using 'puppet_agent::install' and the puppet service is stopped/disabled using the 'service' task.
 Puppet::Functions.create_function(:apply_prep) do
+  # @param targets A pattern or array of patterns identifying a set of targets.
+  # @example Prepare targets by name.
+  #   apply_prep('target1,target2')
   dispatch :apply_prep do
     param 'Boltlib::TargetSpec', :targets
   end

--- a/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
@@ -26,8 +26,9 @@ describe 'apply_prep' do
   end
 
   context 'with targets' do
-    let(:hostnames) { %w[a.b.com x.y.com] }
+    let(:hostnames) { %w[a.b.com winrm://x.y.com pcp://foo] }
     let(:targets) { hostnames.map { |h| Bolt::Target.new(h) } }
+    let(:unknown_targets) { targets.reject { |target| target.protocol == 'pcp' } }
     let(:fact) { { 'osfamily' => 'none' } }
     let(:custom_facts_task) { Bolt::Task.new(name: 'custom_facts_task') }
     let(:version_task) { Bolt::Task.new(name: 'puppet_agent::version') }
@@ -50,8 +51,8 @@ describe 'apply_prep' do
     end
 
     it 'sets feature and gathers facts' do
-      versions = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: { 'version' => '5.0.0' }) })
-      executor.expects(:run_task).with(targets, version_task, anything, anything).returns(versions)
+      versions = Bolt::ResultSet.new(unknown_targets.map { |t| Bolt::Result.new(t, value: { 'version' => '5.0.0' }) })
+      executor.expects(:run_task).with(unknown_targets, version_task, anything, anything).returns(versions)
 
       facts = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: fact) })
       executor.expects(:run_task).with(targets, custom_facts_task, includes('plugins')).returns(facts)
@@ -65,9 +66,9 @@ describe 'apply_prep' do
 
     it 'installs the agent if not present' do
       versions = Bolt::ResultSet.new(
-        targets.zip(['yes', nil]).map { |t, v| Bolt::Result.new(t, value: { 'version' => v }) }
+        unknown_targets.zip(['yes', nil]).map { |t, v| Bolt::Result.new(t, value: { 'version' => v }) }
       )
-      executor.expects(:run_task).with(targets, version_task, anything, anything).returns(versions)
+      executor.expects(:run_task).with(unknown_targets, version_task, anything, anything).returns(versions)
       ok_result = Bolt::ResultSet.new([])
       executor.expects(:run_task).with(targets[1..1], install_task, anything, anything).returns(ok_result)
       executor.expects(:run_task).with(targets[1..1], service_task, anything, anything).returns(ok_result).twice
@@ -91,9 +92,9 @@ describe 'apply_prep' do
 
     it 'fails if version check fails' do
       failed_results = Bolt::ResultSet.new(
-        targets.map { |t| Bolt::Result.new(t, error: { 'msg' => 'could not get version' }) }
+        unknown_targets.map { |t| Bolt::Result.new(t, error: { 'msg' => 'could not get version' }) }
       )
-      executor.expects(:run_task).with(targets, version_task, anything, anything).returns(failed_results)
+      executor.expects(:run_task).with(unknown_targets, version_task, anything, anything).returns(failed_results)
 
       is_expected.to run.with_params(hostnames).and_raise_error(
         Bolt::RunFailure, "Plan aborted: run_task 'puppet_agent::version' failed on 2 nodes"
@@ -101,8 +102,8 @@ describe 'apply_prep' do
     end
 
     it 'fails if install task is not found' do
-      versions = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: {}) })
-      executor.expects(:run_task).with(targets, version_task, anything, anything).returns(versions)
+      versions = Bolt::ResultSet.new(unknown_targets.map { |t| Bolt::Result.new(t, value: {}) })
+      executor.expects(:run_task).with(unknown_targets, version_task, anything, anything).returns(versions)
 
       Puppet::Pal::ScriptCompiler.any_instance.expects(:task_signature).with('puppet_agent::install')
       is_expected.to run.with_params(hostnames).and_raise_error(
@@ -111,13 +112,13 @@ describe 'apply_prep' do
     end
 
     it 'fails if install fails' do
-      versions = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: {}) })
-      executor.expects(:run_task).with(targets, version_task, anything, anything).returns(versions)
+      versions = Bolt::ResultSet.new(unknown_targets.map { |t| Bolt::Result.new(t, value: {}) })
+      executor.expects(:run_task).with(unknown_targets, version_task, anything, anything).returns(versions)
 
       failed_results = Bolt::ResultSet.new(
-        targets.map { |t| Bolt::Result.new(t, error: { 'msg' => 'could not install package' }) }
+        unknown_targets.map { |t| Bolt::Result.new(t, error: { 'msg' => 'could not install package' }) }
       )
-      executor.expects(:run_task).with(targets, install_task, anything, anything).returns(failed_results)
+      executor.expects(:run_task).with(unknown_targets, install_task, anything, anything).returns(failed_results)
 
       is_expected.to run.with_params(hostnames).and_raise_error(
         Bolt::RunFailure, "Plan aborted: run_task 'puppet_agent::install' failed on 2 nodes"
@@ -125,8 +126,8 @@ describe 'apply_prep' do
     end
 
     it 'fails if fact gathering fails' do
-      versions = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: { 'version' => '5.0.0' }) })
-      executor.expects(:run_task).with(targets, version_task, anything, anything).returns(versions)
+      versions = Bolt::ResultSet.new(unknown_targets.map { |t| Bolt::Result.new(t, value: { 'version' => '5.0.0' }) })
+      executor.expects(:run_task).with(unknown_targets, version_task, anything, anything).returns(versions)
 
       results = Bolt::ResultSet.new(
         targets.map { |t| Bolt::Result.new(t, error: { 'msg' => 'could not gather facts' }) }
@@ -134,8 +135,31 @@ describe 'apply_prep' do
       executor.expects(:run_task).with(targets, custom_facts_task, includes('plugins')).returns(results)
 
       is_expected.to run.with_params(hostnames).and_raise_error(
-        Bolt::RunFailure, "Plan aborted: run_task 'custom_facts_task' failed on 2 nodes"
+        Bolt::RunFailure, "Plan aborted: run_task 'custom_facts_task' failed on #{targets.count} nodes"
       )
+    end
+  end
+
+  context 'with only pcp targets' do
+    let(:hostnames) { %w[pcp://foo pcp://bar] }
+    let(:targets) { hostnames.map { |h| Bolt::Target.new(h) } }
+    let(:fact) { { 'osfamily' => 'none' } }
+    let(:custom_facts_task) { Bolt::Task.new(name: 'custom_facts_task') }
+
+    before(:each) do
+      applicator.stubs(:build_plugin_tarball).returns(:tarball)
+      applicator.stubs(:custom_facts_task).returns(custom_facts_task)
+    end
+
+    it 'sets feature and gathers facts' do
+      facts = Bolt::ResultSet.new(targets.map { |t| Bolt::Result.new(t, value: fact) })
+      executor.expects(:run_task).with(targets, custom_facts_task, includes('plugins')).returns(facts)
+
+      is_expected.to run.with_params(hostnames.join(',')).and_return(nil)
+      targets.each do |target|
+        expect(inventory.features(target)).to include('puppet-agent')
+        expect(inventory.facts(target)).to eq(fact)
+      end
     end
   end
 end

--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -68,6 +68,10 @@ module Bolt
         result
       end
 
+      def provided_features
+        []
+      end
+
       def filter_options(target, options)
         if target.options['run-as']
           options.reject { |k, _v| k == '_run_as' }

--- a/lib/bolt/transport/docker.rb
+++ b/lib/bolt/transport/docker.rb
@@ -11,7 +11,9 @@ module Bolt
         %w[service-url service-options tmpdir]
       end
 
-      PROVIDED_FEATURES = ['shell'].freeze
+      def provided_features
+        ['shell']
+      end
 
       def self.validate(options)
         if (url = options['service-url'])
@@ -75,7 +77,7 @@ module Bolt
       end
 
       def run_task(target, task, arguments, _options = {})
-        implementation = task.select_implementation(target, PROVIDED_FEATURES)
+        implementation = task.select_implementation(target, provided_features)
         executable = implementation['path']
         input_method = implementation['input_method']
         extra_files = implementation['files']

--- a/lib/bolt/transport/local.rb
+++ b/lib/bolt/transport/local.rb
@@ -13,7 +13,9 @@ module Bolt
         %w[tmpdir]
       end
 
-      PROVIDED_FEATURES = ['shell'].freeze
+      def provided_features
+        ['shell']
+      end
 
       def self.validate(_options); end
 
@@ -82,7 +84,7 @@ module Bolt
       end
 
       def run_task(target, task, arguments, _options = {})
-        implementation = task.select_implementation(target, PROVIDED_FEATURES)
+        implementation = task.select_implementation(target, provided_features)
         executable = implementation['path']
         input_method = implementation['input_method'] || 'both'
         extra_files = implementation['files']

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -29,7 +29,9 @@ module Bolt
         %w[service-url cacert token-file task-environment]
       end
 
-      PROVIDED_FEATURES = ['puppet-agent'].freeze
+      def provided_features
+        ['puppet-agent']
+      end
 
       def self.validate(options); end
 

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -12,7 +12,9 @@ module Bolt
         %w[port user password sudo-password private-key host-key-check connect-timeout tmpdir run-as tty run-as-command]
       end
 
-      PROVIDED_FEATURES = ['shell'].freeze
+      def provided_features
+        ['shell']
+      end
 
       def self.validate(options)
         logger = Logging.logger[self]
@@ -119,7 +121,7 @@ module Bolt
       end
 
       def run_task(target, task, arguments, options = {})
-        implementation = task.select_implementation(target, PROVIDED_FEATURES)
+        implementation = task.select_implementation(target, provided_features)
         executable = implementation['path']
         input_method = implementation['input_method']
         extra_files = implementation['files']

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -14,7 +14,9 @@ module Bolt
         %w[port user password connect-timeout ssl ssl-verify tmpdir cacert extensions]
       end
 
-      PROVIDED_FEATURES = ['powershell'].freeze
+      def provided_features
+        ['powershell']
+      end
 
       def self.validate(options)
         ssl_flag = options['ssl']
@@ -108,7 +110,7 @@ catch
       end
 
       def run_task(target, task, arguments, _options = {})
-        implementation = task.select_implementation(target, PROVIDED_FEATURES)
+        implementation = task.select_implementation(target, provided_features)
         executable = implementation['path']
         input_method = implementation['input_method']
         extra_files = implementation['files']

--- a/lib/bolt_spec/plans.rb
+++ b/lib/bolt_spec/plans.rb
@@ -202,7 +202,6 @@ module BoltSpec
     end
 
     def allow_apply_prep
-      allow_task('puppet_agent::version').always_return('version' => '6.0')
       allow_task('apply_helpers::custom_facts')
       nil
     end

--- a/lib/bolt_spec/plans/mock_executor.rb
+++ b/lib/bolt_spec/plans/mock_executor.rb
@@ -148,6 +148,17 @@ module BoltSpec
         Bolt::ResultSet.new(promises.map { |target| Bolt::ApplyResult.new(target) })
       end
       # End Apply mocking
+
+      # Mocked for apply_prep
+      def transport(_protocol)
+        # Always return a transport that includes the puppet-agent feature so version/install are skipped.
+        Class.new do
+          def provided_features
+            ['puppet-agent']
+          end
+        end.new
+      end
+      # End apply_prep mocking
     end
   end
 end

--- a/pre-docs/bolt_configure_orchestrator.md
+++ b/pre-docs/bolt_configure_orchestrator.md
@@ -46,8 +46,6 @@ The Bolt `apply` action can be enabled by installing the [puppetlabs-apply_helpe
 mod 'puppetlabs-apply_helpers', '0.1.0'
 ```
 
-The `apply_prep` helper function requires the `puppetlabs-puppet_agent` module version described in [Set up Bolt to download and install modules](installing_tasks_from_the_forge.md#).
-
 **Note:** Bolt over orchestrator can require a large amount of memory to convey large messages, such as the plugins and catalogs sent by `apply`. The default settings might be insufficient.
 
 ## Assign task permissions to a user role


### PR DESCRIPTION
When Bolt connects to a target over the Orchestrator transport, we know
that the puppet-agent package is installed. Skip querying version to
check. That removes the requirement that the correct version of the
puppetlabs-puppet_agent module is installed in your PE infrastructure to
run `apply_prep`.