### PR TITLE
(maint) Pin Rubocop to 0.60.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group(:test) do
   gem "gettext-setup", '~> 0.28', require: false
   gem "mocha", '~> 1.4.0'
   gem "rack-test", '~> 1.0'
-  gem "rubocop", '~> 0.50', require: false
+  gem "rubocop", '0.60.0', require: false
 end
 
 group(:development) do


### PR DESCRIPTION
The `0.61.0` Rubocop release has a bug tracked with https://github.com/rubocop-hq/rubocop/issues/6550

Pin to `0.60.0` until resolved.