### PR TITLE
Set default port to 22 for ssh connection if not otherwise specified

### DIFF
--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -99,7 +99,7 @@ module Bolt
             end
           end
 
-          options[:port] = target.port ? target.port : 22
+          options[:port] = target.port || 22
           options[:password] = target.password if target.password
           # Support both net-ssh 4 and 5. We use 5 in packaging, but Beaker pins to 4 so we
           # want the gem to be compatible with version 4.

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -99,7 +99,7 @@ module Bolt
             end
           end
 
-          options[:port] = target.port if target.port
+          options[:port] = target.port ? target.port : 22
           options[:password] = target.password if target.password
           # Support both net-ssh 4 and 5. We use 5 in packaging, but Beaker pins to 4 so we
           # want the gem to be compatible with version 4.


### PR DESCRIPTION
Bolt was timing out on my first trial command:

`bolt command run uptime --nodes mynode`

Verified in code that problem was that Bolt was going out on port 22474 and that the options[:port] in lib/bolt/transport/ssh/connection.rb was empty (same issue and port trying in Ruby 2.5.3 irb) 'mynode' is sub for one of our servers dns:
`#akaruna /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/bolt-1.4.0 $ bolt command run uptime --nodes mynode
#Started on mynode...
#{:verify_host_key=>#<Net::SSH::Verifiers::Always:0x00007f94db37d530>, :timeout=>10, :verbose=>:debug}
#D, [2018-12-05T23:02:12.219769 #57362] DEBUG -- net.ssh.transport.session[3fca6d9ceed4]: establishing connection to mynode:22474`

Verified that setting the port to 22 if not otherwise specified fixed this issue:
`options = { :verbose=>:debug, :port=>22 }
Finished on mynode:
  STDOUT:
       05:51:06 up 64 days, 17:57,  0 users,  load average: 0.01, 0.14, 0.13
       Successful on 1 node: mynode
       Ran on 1 node in 8.57 seconds`

Hence this fix.