### PR TITLE
Revert "Merge pull request #779 from structuralartistry/fix_ssh_port"

### DIFF
--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -99,7 +99,7 @@ module Bolt
             end
           end
 
-          options[:port] = target.port || 22
+          options[:port] = target.port if target.port
           options[:password] = target.password if target.password
           # Support both net-ssh 4 and 5. We use 5 in packaging, but Beaker pins to 4 so we
           # want the gem to be compatible with version 4.


### PR DESCRIPTION
This change prevented bolt from honoring port directives in ssh config

This reverts commit 4a50b1500e0a47745c4328d29d3ea06e36d9b731, reversing
changes made to 50fbfc8f47e3132468f9b40e17e009f5574a25e0.