### PR TITLE
(maint) Bump Rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group(:test) do
   gem "gettext-setup", '~> 0.28', require: false
   gem "mocha", '~> 1.4.0'
   gem "rack-test", '~> 1.0'
-  gem "rubocop", '0.60.0', require: false
+  gem "rubocop", '~> 0.61', require: false
 end
 
 group(:development) do


### PR DESCRIPTION
Version 0.61.0 contained a bug so we pinned to 0.60.0 with https://github.com/puppetlabs/bolt/pull/778 PR. The 0.61.1 tag fixes the issue.