### PR TITLE
(BOLT-969) Exclude cache tmp directory from purge

### DIFF
--- a/developer-docs/bolt-server.md
+++ b/developer-docs/bolt-server.md
@@ -250,9 +250,9 @@ Where `<TARGET>` is either:
 * A vmpooler VM. To use this, replace `<TARGET>` above with the hostname.
 * One of the containers brought up by the `docker-compose` in the `spec` directory. To use these, you'll want to:
 
-    * get the IP of the **bolt-server container** (not the target container):
+    * get the IP that the **bolt-server container** believes it is hosted on (for example the IP of the developer laptop hosting the bolt-server container):
       ```
-      docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' bolt_boltserver_1
+      bolt command run "/sbin/ip route" -n docker://bolt_boltserver_1 | awk '/default/ { print $3 }'
       # Should return an IP such as 172.20.0.1
       ```
     * Append the port of one of the 3 containers to that IP: `20022` (for an ubuntu node with no agent), `20023` (for a puppet 5 agent), or `20024` (for a puppet 6 agent). It's also helpful to include the protocol (`ssh`), user (`bolt`), and password (`bolt`) in the URI.

--- a/lib/bolt_server/file_cache.rb
+++ b/lib/bolt_server/file_cache.rb
@@ -166,7 +166,7 @@ module BoltServer
       expired_time = Time.now - purge_ttl
       @cache_dir_mutex.with_write_lock do
         Dir.glob(File.join(@cache_dir, '*')).select { |f| File.directory?(f) }.each do |dir|
-          if (mtime = File.mtime(dir)) < expired_time
+          if (mtime = File.mtime(dir)) < expired_time && dir != tmppath
             @logger.debug("Removing #{dir}, last used at #{mtime}")
             FileUtils.remove_dir(dir)
           end

--- a/spec/bolt_server/file_cache_spec.rb
+++ b/spec/bolt_server/file_cache_spec.rb
@@ -77,6 +77,7 @@ describe BoltServer::FileCache, puppetserver: true do
     FileUtils.mkdir_p(expected_dir)
     File.write(File.join(expected_dir, 'task'), file_content)
     FileUtils.touch(expected_dir, mtime: Time.now - (BoltServer::FileCache::PURGE_TTL + 1))
+    FileUtils.touch(file_cache.tmppath, mtime: Time.now - (BoltServer::FileCache::PURGE_TTL + 1))
 
     expect(file_cache).to be
     gone = 10.times do
@@ -84,6 +85,7 @@ describe BoltServer::FileCache, puppetserver: true do
       break true unless File.exist?(expected_dir)
     end
     expect(gone).to eq(true)
+    expect(File.exist?(file_cache.tmppath)).to eq(true)
   end
 
   it 'purges old files after the purge_interval' do
@@ -97,11 +99,13 @@ describe BoltServer::FileCache, puppetserver: true do
     cache.setup
 
     FileUtils.touch(expected_dir, mtime: Time.now - (BoltServer::FileCache::PURGE_TTL + 1))
+    FileUtils.touch(file_cache.tmppath, mtime: Time.now - (BoltServer::FileCache::PURGE_TTL + 1))
     gone = 10.times do
       sleep 0.5
       break true unless File.exist?(expected_dir)
     end
     expect(gone).to eq(true)
+    expect(File.exist?(file_cache.tmppath)).to eq(true)
   end
 
   it 'fails when the downloaded file is invalid' do


### PR DESCRIPTION
Previously when purging the temporary directory for downloading task files (weekly or on startup) the `tmppath` directory itself was deleted resulting in errors downloading files. Instead of deleting the temporary directory during a purge delete only the contents of the temporary directory.