### PR TITLE
(BOLT-1018) Implement wait_until_available for the Docker transport

### DIFF
--- a/lib/bolt/transport/docker.rb
+++ b/lib/bolt/transport/docker.rb
@@ -116,6 +116,12 @@ module Bolt
           end
         end
       end
+
+      def connected?(target)
+        with_connection(target) { true }
+      rescue Bolt::Node::ConnectError
+        false
+      end
     end
   end
 end

--- a/spec/bolt/transport/docker_spec.rb
+++ b/spec/bolt/transport/docker_spec.rb
@@ -18,6 +18,14 @@ describe Bolt::Transport::Docker, docker: true do
     let(:runner) { docker }
     let(:os_context) { posix_context }
 
+    it "can test whether the target is available" do
+      expect(runner.connected?(target)).to eq(true)
+    end
+
+    it "returns false if the target is not available" do
+      expect(runner.connected?(Bolt::Target.new('unknownfoo'))).to eq(false)
+    end
+
     include_examples 'transport api'
 
     context 'file errors' do


### PR DESCRIPTION
This was missed when `wait_until_available` and the `docker` transport
were merged around the same time.