### PR TITLE
(BOLT-791) Don't allow remote targets to run on other remote targets.

### DIFF
--- a/lib/bolt/transport/remote.rb
+++ b/lib/bolt/transport/remote.rb
@@ -26,10 +26,15 @@ module Bolt
       end
 
       def get_proxy(target)
-        # TODO: This needs to have access to the inventory
         inventory = target.inventory
         raise "Target was created without inventory? Not get_targets?" unless inventory
-        inventory.get_targets(target.options['run-on'] || 'localhost').first
+        proxy = inventory.get_targets(target.options['run-on'] || 'localhost').first
+
+        if proxy.transport == 'remote'
+          msg = "#{proxy.name} is not a valid run-on target for #{target.name} since is also remote."
+          raise Bolt::Error.new(msg, 'bolt/invalid-remote-target')
+        end
+        proxy
       end
 
       # Cannot batch because arugments differ

--- a/spec/bolt/transport/remote_spec.rb
+++ b/spec/bolt/transport/remote_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/executor'
+require 'bolt/inventory'
+
+describe Bolt::Transport::Remote do
+  it 'errors when a poxy is remote' do
+    inventory = Bolt::Inventory.new('nodes' =>
+                                     ["node1",
+                                      { "name" => "node2",
+                                        "config" => {
+                                          "remote" => {
+                                            "run-on" => "node1"
+                                          }
+                                        } }],
+                                    'config' => { "transport" => "remote" })
+
+    executor = Bolt::Executor.new(load_config: false)
+    remote_transport = executor.transports['remote'].value
+    target = inventory.get_targets("node2").first
+
+    expect { remote_transport.run_task(target, nil, {}) }.to raise_error(/node1 is not a valid run-on target/)
+  end
+end


### PR DESCRIPTION
Remote targets should always point to a non-remote target with run-on.
This prevents multiple levels of lookups in loops in trying to determine
the correct proxy and makes behavior clearer when run-on is a group.