### PR TITLE
(BOLT-608) Set provided features for local transport  

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,9 @@ for:
       only:
         - configuration: Agentless
 
+    environment:
+      BOLT_WINDOWS: true
+
     before_test:
       - ps: |
           ruby -v

--- a/lib/bolt/transport/local.rb
+++ b/lib/bolt/transport/local.rb
@@ -15,7 +15,11 @@ module Bolt
       end
 
       def provided_features
-        ['shell']
+        if Bolt::Util.windows?
+          ['powershell']
+        else
+          ['shell']
+        end
       end
 
       def default_input_method(executable)

--- a/spec/bolt/transport/local_spec.rb
+++ b/spec/bolt/transport/local_spec.rb
@@ -8,11 +8,11 @@ require 'bolt_spec/transport'
 
 require_relative 'shared_examples'
 
-describe Bolt::Transport::Local, bash: true do
+describe Bolt::Transport::Local do
   include BoltSpec::Transport
 
   let(:transport) { :local }
-  let(:os_context) { posix_context }
+  let(:os_context) { Bolt::Util.windows? ? windows_context : posix_context }
   let(:target) { Bolt::Target.new('local://localhost', transport_conf) }
 
   it 'is always connected' do

--- a/spec/bolt/transport/local_spec.rb
+++ b/spec/bolt/transport/local_spec.rb
@@ -19,6 +19,14 @@ describe Bolt::Transport::Local, bash: true do
     expect(runner.connected?(target)).to eq(true)
   end
 
+  it 'provides platform specific features' do
+    if Bolt::Util.windows?
+      expect(runner.provided_features).to eq(['powershell'])
+    else
+      expect(runner.provided_features).to eq(['shell'])
+    end
+  end
+
   include_examples 'transport api'
 
   context 'file errors' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,7 @@ RSpec.configure do |config|
   end
 
   config.filter_run_excluding appveyor_agents: true unless ENV['APPVEYOR_AGENTS']
+  config.filter_run_excluding windows: true unless ENV['BOLT_WINDOWS']
 
   # rspec-mocks config
   config.mock_with :rspec do |mocks|


### PR DESCRIPTION
When using the local transport set `provided_features` to `shell` or `powershell` to reflect running on a windows or POSIX system. 

Run the local transport unit tests on windows bolt controllers.