### PR TITLE
(docs) remove reference to unimplemented '_items' from example

### DIFF
--- a/pre-docs/writing_tasks.md
+++ b/pre-docs/writing_tasks.md
@@ -564,7 +564,7 @@ if ($Name -eq $null -or $Name -eq "") {
   if ($result.Count -eq 1) {
     ConvertTo-Json -InputObject $result[0] -Compress
   } elseif ($result.Count -gt 1) {
-    ConvertTo-Json -InputObject @{"_items" = $result} -Compress
+    ConvertTo-Json -InputObject @{"items" = $result} -Compress
   }
 }
 ```


### PR DESCRIPTION
_items was part of a pre rev1 task spec proposal and shouldn't appear in
documentation.