### PR TITLE
(maint) Bump task helper modules

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -26,9 +26,9 @@ mod 'puppetlabs-zone_core', '1.0.1'
 # Useful additional modules
 mod 'puppetlabs-package', '0.3.0'
 mod 'puppetlabs-puppet_conf', '0.3.0'
-mod 'puppetlabs-python_task_helper', '0.1.3'
+mod 'puppetlabs-python_task_helper', '0.2.0'
 mod 'puppetlabs-reboot', '2.1.1'
-mod 'puppetlabs-ruby_task_helper', '0.1.0'
+mod 'puppetlabs-ruby_task_helper', '0.2.0'
 
 # If we don't list these modules explicitly, r10k will purge them
 mod 'canary', local: true

--- a/Puppetfile
+++ b/Puppetfile
@@ -27,7 +27,7 @@ mod 'puppetlabs-zone_core', '1.0.1'
 mod 'puppetlabs-package', '0.3.0'
 mod 'puppetlabs-puppet_conf', '0.3.0'
 mod 'puppetlabs-python_task_helper', '0.2.0'
-mod 'puppetlabs-reboot', '2.1.1'
+mod 'puppetlabs-reboot', '2.1.2'
 mod 'puppetlabs-ruby_task_helper', '0.2.0'
 
 # If we don't list these modules explicitly, r10k will purge them


### PR DESCRIPTION
The {ruby,python}_task_helper modules have been refactored to be structured under the `files` instead of the `lib` directory.