### PR TITLE
(BOLT-1036) Include 'files' content from bundled modules

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -21,7 +21,9 @@ Gem::Specification.new do |spec|
                        Dir['libexec/*'] +
                        Dir['bolt-modules/boltlib/lib/**/*.rb'] +
                        Dir['bolt-modules/boltlib/types/**/*.pp'] +
+                       Dir['modules/*/files/**/*'] +
                        Dir['modules/*/lib/**/*.rb'] +
+                       Dir['modules/*/locales/**/*'] +
                        Dir['modules/*/plans/**/*.pp'] +
                        Dir['modules/*/tasks/**/*']
   spec.bindir        = "exe"


### PR DESCRIPTION
Tasks can now make use of `files` content from other modules. Ensure the
bundled modules include the `files` directory, particularly for
`python_task_helper` and `ruby_task_helper`. Also include `locales` for
translations that might be used in plans.

We explicitly exclude other things to restrict this to plan and task
content. We'd rather manifests and other traditional Puppet content be
explicitly pulled in by users that want them.