### PR TITLE
(BOLT-1035) Add get_resources function

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'fileutils'
 require 'bolt/task'
 
 # Installs the puppet-agent package on targets if needed then collects facts, including any custom

--- a/bolt-modules/boltlib/lib/puppet/functions/get_resources.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/get_resources.rb
@@ -41,6 +41,13 @@ Puppet::Functions.create_function(:get_resources) do
       )
     end
 
+    resources = [resources].flatten
+    resources.each do |resource|
+      if resource !~ /^\w+$/ && resource !~ /^\w+\[.+\]$/
+        raise Bolt::Error.new("#{resource} is not a valid resource type or type instance name", 'bolt/get-resources')
+      end
+    end
+
     executor.report_function_call('get_resources')
 
     targets = inventory.get_targets(target_spec)
@@ -57,7 +64,7 @@ Puppet::Functions.create_function(:get_resources) do
 
         task = applicator.query_resources_task
         arguments = {
-          'resources' => [resources].flatten,
+          'resources' => resources,
           'plugins' => Puppet::Pops::Types::PSensitiveType::Sensitive.new(plugins)
         }
         results = executor.run_task(targets, task, arguments)

--- a/bolt-modules/boltlib/lib/puppet/functions/get_resources.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/get_resources.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'bolt/task'
+
+# Query the state of resources on a list of targets using resource definitions in Bolt's modulepath.
+# The results are returned as a list of hashes representing each resource.
+#
+# Requires the Puppet Agent be installed on the target, which can be accomplished with apply_prep
+# or by directly running the puppet_agent::install task.
+Puppet::Functions.create_function(:get_resources) do
+  # @param targets A pattern or array of patterns identifying a set of targets.
+  # @param resources A resource type or instance, or an array of such.
+  # @example Collect resource states for packages and a file
+  #   get_resources('target1,target2', [Package, File[/etc/puppetlabs]])
+  dispatch :get_resources do
+    param 'Boltlib::TargetSpec', :targets
+    param 'Variant[String, Resource, Array[Variant[String, Resource]]]', :resources
+  end
+
+  def script_compiler
+    @script_compiler ||= Puppet::Pal::ScriptCompiler.new(closure_scope.compiler)
+  end
+
+  def run_task(executor, targets, name, args = {})
+    tasksig = script_compiler.task_signature(name)
+    raise Bolt::Error.new("#{name} could not be found", 'bolt/get-resources') unless tasksig
+
+    task = Bolt::Task.new(tasksig.task_hash)
+    results = executor.run_task(targets, task, args)
+    raise Bolt::RunFailure.new(results, 'run_task', task.name) unless results.ok?
+    results
+  end
+
+  def get_resources(target_spec, resources)
+    applicator = Puppet.lookup(:apply_executor) { nil }
+    executor = Puppet.lookup(:bolt_executor) { nil }
+    inventory = Puppet.lookup(:bolt_inventory) { nil }
+    unless applicator && executor && inventory && Puppet.features.bolt?
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('get_resources')
+      )
+    end
+
+    executor.report_function_call('get_resources')
+
+    targets = inventory.get_targets(target_spec)
+
+    executor.log_action('gather resources', targets) do
+      executor.without_default_logging do
+        # Gather facts, including custom facts
+        plugins = applicator.build_plugin_tarball do |mod|
+          search_dirs = []
+          search_dirs << mod.plugins if mod.plugins?
+          search_dirs << mod.pluginfacts if mod.pluginfacts?
+          search_dirs
+        end
+
+        task = applicator.query_resources_task
+        arguments = {
+          'resources' => [resources].flatten,
+          'plugins' => Puppet::Pops::Types::PSensitiveType::Sensitive.new(plugins)
+        }
+        results = executor.run_task(targets, task, arguments)
+        raise Bolt::RunFailure.new(results, 'run_task', task.name) unless results.ok?
+        results
+      end
+    end
+  end
+end

--- a/bolt-modules/boltlib/spec/functions/get_resources_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/get_resources_spec.rb
@@ -69,5 +69,17 @@ describe 'get_resources' do
         Bolt::RunFailure, "Plan aborted: run_task 'query_resources_task' failed on #{targets.count} nodes"
       )
     end
+
+    it 'errors if resource names are invalid' do
+      is_expected.to run.with_params(hostnames, 'not a type').and_raise_error(
+        Bolt::Error, "not a type is not a valid resource type or type instance name"
+      )
+    end
+
+    it 'errors if resource names are invalid' do
+      is_expected.to run.with_params(hostnames, 'not a type[hello there]').and_raise_error(
+        Bolt::Error, "not a type[hello there] is not a valid resource type or type instance name"
+      )
+    end
   end
 end

--- a/bolt-modules/boltlib/spec/functions/get_resources_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/get_resources_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/executor'
+require 'bolt/inventory'
+require 'bolt/result'
+require 'bolt/result_set'
+require 'bolt/target'
+require 'bolt/task'
+
+describe 'get_resources' do
+  include PuppetlabsSpec::Fixtures
+  let(:applicator) { mock('Bolt::Applicator') }
+  let(:executor) { Bolt::Executor.new }
+  let(:inventory) { Bolt::Inventory.new({}) }
+
+  around(:each) do |example|
+    Puppet[:tasks] = true
+    Puppet.features.stubs(:bolt?).returns(true)
+
+    executor.stubs(:noop).returns(false)
+
+    Puppet.override(bolt_executor: executor, bolt_inventory: inventory, apply_executor: applicator) do
+      example.run
+    end
+  end
+
+  context 'with targets' do
+    let(:hostnames) { %w[a.b.com winrm://x.y.com pcp://foo] }
+    let(:targets) { hostnames.map { |h| Bolt::Target.new(h) } }
+    let(:unknown_targets) { targets.reject { |target| target.protocol == 'pcp' } }
+    let(:query_resources_task) { Bolt::Task.new(name: 'query_resources_task') }
+
+    before(:each) do
+      applicator.stubs(:build_plugin_tarball).returns(:tarball)
+      applicator.stubs(:query_resources_task).returns(query_resources_task)
+    end
+
+    it 'queries a single resource' do
+      results = Bolt::ResultSet.new(
+        targets.map { |t| Bolt::Result.new(t, value: { 'some' => 'resources' }) }
+      )
+      executor.expects(:run_task).with(targets,
+                                       query_resources_task,
+                                       has_entry('resources', ['file'])).returns(results)
+
+      is_expected.to run.with_params(hostnames, 'file').and_return(results)
+    end
+
+    it 'queries requested resources' do
+      results = Bolt::ResultSet.new(
+        targets.map { |t| Bolt::Result.new(t, value: { 'some' => 'resources' }) }
+      )
+      resources = ['User', 'File[/tmp]']
+      executor.expects(:run_task).with(targets,
+                                       query_resources_task,
+                                       has_entry('resources', resources)).returns(results)
+
+      is_expected.to run.with_params(hostnames, resources).and_return(results)
+    end
+
+    it 'fails if querying resources fails' do
+      results = Bolt::ResultSet.new(
+        targets.map { |t| Bolt::Result.new(t, error: { 'msg' => 'could not query resources' }) }
+      )
+      executor.expects(:run_task).with(targets, query_resources_task, includes('plugins')).returns(results)
+
+      is_expected.to run.with_params(hostnames, []).and_raise_error(
+        Bolt::RunFailure, "Plan aborted: run_task 'query_resources_task' failed on #{targets.count} nodes"
+      )
+    end
+  end
+end

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -56,6 +56,15 @@ module Bolt
       end
     end
 
+    def query_resources_task
+      @query_resources_task ||= begin
+        path = File.join(libexec, 'query_resources.rb')
+        file = { 'name' => 'query_resources.rb', 'path' => path }
+        metadata = { 'supports_noop' => true, 'input_method' => 'stdin' }
+        Bolt::Task.new(name: 'apply_helpers::query_resources', files: [file], metadata: metadata)
+      end
+    end
+
     def compile(target, ast, plan_vars)
       trusted = Puppet::Context::TrustedInformation.new('local', target.host, {})
 

--- a/lib/bolt_spec/plans.rb
+++ b/lib/bolt_spec/plans.rb
@@ -211,6 +211,11 @@ module BoltSpec
       nil
     end
 
+    def allow_get_resources
+      allow_task('apply_helpers::query_resources').be_called_times(100)
+      nil
+    end
+
     # Example helpers to mock other run functions
     # The with_targets method makes sense for all stubs
     # with_params could be reused for options

--- a/lib/bolt_spec/plans.rb
+++ b/lib/bolt_spec/plans.rb
@@ -202,7 +202,7 @@ module BoltSpec
     end
 
     def allow_apply_prep
-      allow_task('apply_helpers::custom_facts')
+      allow_task('apply_helpers::custom_facts').be_called_times(100)
       nil
     end
 

--- a/lib/bolt_spec/plans/action_stubs/script_stub.rb
+++ b/lib/bolt_spec/plans/action_stubs/script_stub.rb
@@ -31,7 +31,7 @@ module BoltSpec
       end
 
       def parameters
-        @invocation[:arguments] + @invocation[:options]
+        @invocation[:arguments] + @invocation[:options] if @invocation.include[:arguments]
       end
 
       def result_for(target, stdout: '', stderr: '')

--- a/lib/bolt_spec/plans/action_stubs/task_stub.rb
+++ b/lib/bolt_spec/plans/action_stubs/task_stub.rb
@@ -30,7 +30,7 @@ module BoltSpec
       end
 
       def parameters
-        @invocation[:arguments] + @invocation[:options]
+        @invocation[:arguments] + @invocation[:options] if @invocation.include?(:arguments)
       end
 
       # Allow any data.

--- a/libexec/query_resources.rb
+++ b/libexec/query_resources.rb
@@ -1,0 +1,49 @@
+#! /opt/puppetlabs/puppet/bin/ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'puppet'
+require 'puppet/module_tool/tar'
+require 'tempfile'
+
+args = JSON.parse(STDIN.read)
+
+RESOURCE_INSTANCE = /^([^\[]+)\[([^\]]+)\]$/.freeze
+
+def instance(type_name, resource_name)
+  resource = Puppet::Resource.indirection.find("#{type_name}/#{resource_name}")
+  stringify_resource(resource)
+end
+
+Dir.mktmpdir do |puppet_root|
+  # Create temporary directories for all core Puppet settings so we don't clobber
+  # existing state or read from puppet.conf. Also create a temporary modulepath.
+  moduledir = File.join(puppet_root, 'modules')
+  Dir.mkdir(moduledir)
+  cli = Puppet::Settings::REQUIRED_APP_SETTINGS.flat_map do |setting|
+    ["--#{setting}", File.join(puppet_root, setting.to_s.chomp('dir'))]
+  end
+  cli << '--modulepath' << moduledir
+  Puppet.initialize_settings(cli)
+
+  Tempfile.open('plugins.tar.gz') do |plugins|
+    File.binwrite(plugins, Base64.decode64(args['plugins']))
+    Puppet::ModuleTool::Tar.instance.unpack(plugins, moduledir, Etc.getlogin || Etc.getpwuid.name)
+  end
+
+  env = Puppet.lookup(:environments).get('production')
+  env.each_plugin_directory do |dir|
+    $LOAD_PATH << dir unless $LOAD_PATH.include?(dir)
+  end
+
+  resources = args['resources'].flat_map do |resource_desc|
+    if (match = RESOURCE_INSTANCE.match(resource_desc))
+      Puppet::Resource.indirection.find("#{match[1]}/#{match[2]}", environment: env)
+    else
+      Puppet::Resource.indirection.search(resource_desc, environment: env)
+    end
+  end
+  puts({ 'resources' => resources }.to_json)
+end
+
+exit 0

--- a/spec/bolt_spec/plan_spec.rb
+++ b/spec/bolt_spec/plan_spec.rb
@@ -201,4 +201,18 @@ describe "BoltSpec::Plans" do
       expect(result).not_to be_ok
     end
   end
+
+  context 'with get_resources' do
+    let(:plan_name) { 'plans::get_resources' }
+
+    it 'runs' do
+      allow_get_resources
+      result = run_plan(plan_name, 'nodes' => targets)
+      expect(result).to be_ok
+    end
+
+    it 'fails' do
+      expect { run_plan(plan_name, 'nodes' => targets) }.to raise_error(RuntimeError, /Unexpected call to/)
+    end
+  end
 end

--- a/spec/fixtures/apply/basic/plans/resources.pp
+++ b/spec/fixtures/apply/basic/plans/resources.pp
@@ -1,0 +1,3 @@
+plan basic::resources(TargetSpec $nodes) {
+  return $nodes.get_resources(['user', 'File[/tmp]'])
+}

--- a/spec/fixtures/bolt_spec/plans/plans/apply_prep.pp
+++ b/spec/fixtures/bolt_spec/plans/plans/apply_prep.pp
@@ -1,3 +1,4 @@
 plan plans::apply_prep(TargetSpec $nodes) {
   $nodes.apply_prep
+  return $nodes.apply_prep
 }

--- a/spec/fixtures/bolt_spec/plans/plans/get_resources.pp
+++ b/spec/fixtures/bolt_spec/plans/plans/get_resources.pp
@@ -1,0 +1,4 @@
+plan plans::get_resources(TargetSpec $nodes) {
+  $nodes.get_resources('User')
+  return $nodes.get_resources(['user', 'File[/tmp]'])
+}


### PR DESCRIPTION
Adds a `get_resources` function that can be run against targets with Puppet Agent installed to query the state of resources on those nodes.