### PR TITLE
(BOLT-1047) Add short commands

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -214,7 +214,7 @@ Usage: bolt apply <manifest.pp> [options]
              'Maximum number of simultaneous manifest block compiles (default: number of cores)') do |concurrency|
         @options[:'compile-concurrency'] = concurrency
       end
-      define('--modulepath MODULES',
+      define('-m', '--modulepath MODULES',
              "List of directories containing modules, separated by '#{File::PATH_SEPARATOR}'") do |modulepath|
         # When specified from the CLI, modulepath entries are relative to pwd
         @options[:modulepath] = modulepath.split(File::PATH_SEPARATOR).map do |moduledir|
@@ -229,7 +229,7 @@ Usage: bolt apply <manifest.pp> [options]
              'Specify where to load config from (default: ~/.puppetlabs/bolt/bolt.yaml)') do |path|
         @options[:configfile] = path
       end
-      define('--inventoryfile FILEPATH',
+      define('-i', '--inventoryfile FILEPATH',
              'Specify where to load inventory from (default: ~/.puppetlabs/bolt/inventory.yaml)') do |path|
         if ENV.include?(Bolt::Inventory::ENVIRONMENT_VAR)
           raise Bolt::CLIError, "Cannot pass inventory file when #{Bolt::Inventory::ENVIRONMENT_VAR} is set"
@@ -262,7 +262,7 @@ Usage: bolt apply <manifest.pp> [options]
       define('-h', '--help', 'Display help') do |_|
         @options[:help] = true
       end
-      define('--verbose', 'Display verbose logging') do |_|
+      define('-v', '--verbose', 'Display verbose logging') do |_|
         @options[:verbose] = true
       end
       define('--debug', 'Display debug logging') do |_|

--- a/pre-docs/bolt_command_reference.md
+++ b/pre-docs/bolt_command_reference.md
@@ -74,10 +74,10 @@ Options are optional unless marked as required. 
 |Option|Description|
 |------|-----------|
 |`--concurrency`, `-c`|Maximum number of simultaneous connections \(default: 100\).|
-| `--modulepath` |**Required for tasks and plans**. The path to the module containing the task. Separate multiple paths with a semicolon \(`;`\) on Windows or a colon \(`:`\) on all other platforms.|
+| `--modulepath`, `-m` |**Required for tasks and plans**. The path to the module containing the task. Separate multiple paths with a semicolon \(`;`\) on Windows or a colon \(`:`\) on all other platforms.|
 | `--configfile` |Specify where to load config from \(default: `bolt.yaml` inside the `Boltdir`\).|
 | `--boltdir` |Specify what Boltdir to load config from \(default: autodiscovered from current working dir\).|
-| `--inventoryfile` |Specify where to load inventory from \(default: `inventory.yaml` inside the `Boltdir`\).|
+| `--inventoryfile`, `-i` |Specify where to load inventory from \(default: `inventory.yaml` inside the `Boltdir`\).|
 
 ## Transport options
 
@@ -97,7 +97,7 @@ Options are optional unless marked as required. 
 | `--format` |Determines the output format to use: human readable or JSON.|
 |`--color`, `--no-color`|Whether to show output in color.|
 |`--help`, `-h`|Shows help for the `bolt` command.|
-| `--verbose` |Shows verbose logging.|
+| `--verbose`, `-v` |Shows verbose logging.|
 | `--debug` |Shows debug logging.|
 | `--version` |Shows the Bolt version.|
 

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -442,6 +442,13 @@ bar
         expect(cli.parse).to include(modulepath: [site, File.expand_path('modules')])
       end
 
+      it "accepts shorthand -m" do
+        site = File.expand_path('site')
+        modulepath = [site, 'modules'].join(File::PATH_SEPARATOR)
+        cli = Bolt::CLI.new(%W[command run -m #{modulepath} --nodes foo])
+        expect(cli.parse).to include(modulepath: [site, File.expand_path('modules')])
+      end
+
       it "generates an error message if no value is given" do
         cli = Bolt::CLI.new(%w[command run --nodes foo --modulepath])
         expect {


### PR DESCRIPTION
**What this changes** Adds shortened command syntax for description, modulepath, inventoryfile, transport, and verbose.
**Why** So they're faster to type.