### PR TITLE
(BOLT-1035) Fixes based on further code review

### DIFF
--- a/bolt-modules/boltlib/spec/functions/get_resources_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/get_resources_spec.rb
@@ -28,7 +28,6 @@ describe 'get_resources' do
   context 'with targets' do
     let(:hostnames) { %w[a.b.com winrm://x.y.com pcp://foo] }
     let(:targets) { hostnames.map { |h| Bolt::Target.new(h) } }
-    let(:unknown_targets) { targets.reject { |target| target.protocol == 'pcp' } }
     let(:query_resources_task) { Bolt::Task.new(name: 'query_resources_task') }
 
     before(:each) do

--- a/lib/bolt_spec/plans.rb
+++ b/lib/bolt_spec/plans.rb
@@ -202,7 +202,7 @@ module BoltSpec
     end
 
     def allow_apply_prep
-      allow_task('apply_helpers::custom_facts').be_called_times(100)
+      allow_task('apply_helpers::custom_facts')
       nil
     end
 
@@ -212,7 +212,7 @@ module BoltSpec
     end
 
     def allow_get_resources
-      allow_task('apply_helpers::query_resources').be_called_times(100)
+      allow_task('apply_helpers::query_resources')
       nil
     end
 

--- a/lib/bolt_spec/plans/action_stubs.rb
+++ b/lib/bolt_spec/plans/action_stubs.rb
@@ -36,7 +36,7 @@ module BoltSpec
       def initialize(expect = false)
         @calls = 0
         @expect = expect
-        @expected_calls = 1
+        @expected_calls = nil
         # invocation spec
         @invocation = {}
         # return value
@@ -63,6 +63,7 @@ module BoltSpec
       # This changes the stub from an allow to an expect which will validate
       # that it has been called.
       def expect_call
+        @expected_calls = 1
         @expect = true
         self
       end


### PR DESCRIPTION
Remove unused code, and make `allow_*` truly unlimited in BoltSpec::Plans
unless overridden by `be_called_times`.