### PR TITLE
(BOLT-817) Support array of directories for modulepath

### DIFF
--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -146,7 +146,12 @@ module Bolt
       # Expand paths relative to the Boltdir. Any settings that came from the
       # CLI will already be absolute, so the expand will be skipped.
       if data.key?('modulepath')
-        @modulepath = data['modulepath'].split(File::PATH_SEPARATOR).map do |moduledir|
+        moduledirs = if data['modulepath'].is_a?(String)
+                       data['modulepath'].split(File::PATH_SEPARATOR)
+                     else
+                       data['modulepath']
+                     end
+        @modulepath = moduledirs.map do |moduledir|
           File.expand_path(moduledir, @boltdir.path)
         end
       end

--- a/pre-docs/bolt_configuration_options.md
+++ b/pre-docs/bolt_configuration_options.md
@@ -20,7 +20,7 @@ ssh:
 
 `format`: The format to use when printing results. Options are `human` and `json`. Default is `human`.
 
-`modulepath`: The module path for loading tasks and plan code. This is a list of directories separated by the OS specific file path separator. The default path for modules is `modules:site` inside the `Boltdir`.
+`modulepath`: The module path for loading tasks and plan code. This is either an array of directories or a string containing a list of directories separated by the OS specific PATH separator. The default path for modules is `modules:site` inside the `Boltdir`.
 
 `inventoryfile`: The path to a structured data inventory file used to refer to groups of nodes on the commandline and from plans. The default path for the inventory file is `inventory.yaml` inside the `Boltdir`.
 

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -27,6 +27,12 @@ describe Bolt::Config do
       config = Bolt::Config.new(boltdir, 'modulepath' => module_dirs.join(File::PATH_SEPARATOR))
       expect(config.modulepath).to eq(module_dirs.map { |dir| (boltdir.path + dir).to_s })
     end
+
+    it "accepts an array for modulepath" do
+      module_dirs = %w[site modules]
+      config = Bolt::Config.new(boltdir, 'modulepath' => module_dirs)
+      expect(config.modulepath).to eq(module_dirs.map { |dir| (boltdir.path + dir).to_s })
+    end
   end
 
   describe "deep_clone" do


### PR DESCRIPTION
This allows the `modulepath` setting in `bolt.yaml` to be specified as an
array of module directories in addition to the previous behavior of a
PATH-like string. Because the PATH separator varies by platform, this
allows users to write a single `bolt.yaml` that will work on both *nix
and Windows systems.