### PR TITLE
(BOLT-1039) expose proxyjump option from bolt config.

### DIFF
--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -9,7 +9,8 @@ module Bolt
   module Transport
     class SSH < Base
       def self.options
-        %w[port user password sudo-password private-key host-key-check connect-timeout tmpdir run-as tty run-as-command]
+        %w[port user password sudo-password private-key host-key-check
+           connect-timeout tmpdir run-as tty run-as-command proxyjump]
       end
 
       def provided_features

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -5,6 +5,7 @@ require 'shellwords'
 require 'bolt/node/errors'
 require 'bolt/node/output'
 require 'bolt/util'
+require 'net/ssh/proxy/jump'
 
 module Bolt
   module Transport
@@ -115,6 +116,8 @@ module Bolt
                                         Net::SSH::Verifiers::Null.new
                                       end
           options[:timeout] = target.options['connect-timeout'] if target.options['connect-timeout']
+
+          options[:proxy] = Net::SSH::Proxy::Jump.new(target.options['proxyjump']) if target.options['proxyjump']
 
           if @load_config
             # Mirroring:

--- a/pre-docs/bolt_configuration_options.md
+++ b/pre-docs/bolt_configuration_options.md
@@ -44,6 +44,8 @@ ssh:
 
 `password`: Login password.
 
+`proxyjump`: A jump host to proxy ssh connections through and an optional user to connect as for example `jump.example.com` or `user1@jump.example.com`.
+
 `run-as`: A different user to run commands as after login.
 
 `sudo-password`: Password to use when changing users via `run-as`.

--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -67,6 +67,18 @@ describe Bolt::Transport::SSH do
   end
 
   context "when connecting", ssh: true do
+    it "passes proxyjump options" do
+      allow(Net::SSH)
+        .to receive(:start)
+        .with(anything,
+              anything,
+              hash_including(
+                proxy: instance_of(Net::SSH::Proxy::Jump)
+              ))
+      target = make_target(conf: mk_config(proxyjump: 'jump.example.com'))
+      ssh.with_connection(target) {}
+    end
+
     it "performs secure host key verification by default" do
       allow(Net::SSH)
         .to receive(:start)


### PR DESCRIPTION

inventory

```
    nodes:
      - ma4wbg4k9352e3q.delivery.puppetlabs.net
    config:
      ssh:
        proxyjump: u0tfqlau5siznqy.delivery.puppetlabs.net
        host-key-check: false
```

usage

```
clavelin:bolt adreyer$ bundle exec bolt command run hostname -n ma4wbg4k9352e3q.delivery.puppetlabs.net
Started on ma4wbg4k9352e3q.delivery.puppetlabs.net...
Warning: Permanently added 'u0tfqlau5siznqy.delivery.puppetlabs.net,10.16.115.130' (ECDSA) to the list of known hosts.
Finished on ma4wbg4k9352e3q.delivery.puppetlabs.net:
  STDOUT:
    ma4wbg4k9352e3q
```