### PR TITLE
Added missing quote to puppetdb_query example

### DIFF
--- a/pre-docs/writing_plans.md
+++ b/pre-docs/writing_plans.md
@@ -467,7 +467,7 @@ You can use the `puppetdb_query` function in plans to make direct queries to Pu
 
 ```
 plan pdb_discover {
-  $result = puppetdb_query("inventory[certname] { app_role == 'web_server' })
+  $result = puppetdb_query("inventory[certname] { app_role == 'web_server' }")
   # extract the certnames into an array
   $names = $result.map |$r| { $r["certname"] }
   # wrap in url. You can skip this if the default transport is pcp


### PR DESCRIPTION
In the documentation for `puppetdb_query` i noticed the syntax highlighting was broken. After further inspection it appears a quote is missing in the example. This PR adds the missing quote.

![image](https://user-images.githubusercontent.com/3693851/50285338-f0b3db80-0429-11e9-9a2d-95cc8c6d623a.png)
