### PR TITLE
(WIP)(maint) Query remote WinRM host for path separator

### DIFF
--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -55,6 +55,7 @@ module Bolt
         begin
           conn&.disconnect
         rescue StandardError => ex
+          require 'pry'; binding.pry
           logger.info("Failed to close connection to #{target.uri} : #{ex.message}")
         end
       end
@@ -80,6 +81,7 @@ module Bolt
           conn.with_remote_tempdir do |dir|
             remote_path = conn.write_remote_executable(dir, script)
             if Powershell.powershell_file?(remote_path)
+              require 'pry'; binding.pry
               output = conn.execute(Powershell.run_script(arguments, remote_path))
             else
               path, args = *Powershell.process_from_extension(remote_path)

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -51,7 +51,7 @@ module Bolt
             @connection.logger = @transport_logger
 
             @session = @connection.shell(:powershell)
-            @session.run('$PSVersionTable.PSVersion')
+            @separator = @session.run('[System.IO.Path]::DirectorySeparatorChar').stdout.strip
             @logger.debug { "Opened session" }
           end
         rescue Timeout::Error
@@ -172,14 +172,14 @@ module Bolt
         def write_remote_executable(dir, file, filename = nil)
           filename ||= File.basename(file)
           validate_extensions(File.extname(filename))
-          remote_path = "#{dir}\\#{filename}"
+          remote_path = "#{dir}#{@separator}#{filename}"
           write_remote_file(file, remote_path)
           remote_path
         end
 
         def write_executable_from_content(dir, content, filename)
           validate_extensions(File.extname(filename))
-          remote_path = "#{dir}\\#{filename}"
+          remote_path = "#{dir}#{@separator}#{filename}"
           write_remote_file(content, remote_path)
           remote_path
         end

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -91,6 +91,8 @@ module Bolt
         end
 
         def disconnect
+          # TODO: think the actual failure here is with closing the session
+          require 'pry'; binding.pry
           @session&.close
           @logger.debug { "Closed session" }
         end
@@ -143,6 +145,7 @@ module Bolt
           fs = ::WinRM::FS::FileManager.new(@connection)
           fs.upload(source, destination)
         rescue StandardError => e
+          require 'pry'; binding.pry
           raise Bolt::Node::FileError.new(e.message, 'WRITE_ERROR')
         end
 


### PR DESCRIPTION
 - When running Bolt over WinRM against Linux hosts, a temp file path to write
   scripts is created that hardcodes a path like:

   dir\\filename

 - This path is not friendly to Linux based hosts.

   Instead, query for the separator when initializing a Bolt WinRM connection
   using PowerShells [System.IO.Path]::DirectorySeparatorChar and save it
   locally. When constructing / joining remote paths, use this value.