### PR TITLE
(BOLT-1056) Add warning about using shell one-liners

### DIFF
--- a/pre-docs/running_bolt_commands.md
+++ b/pre-docs/running_bolt_commands.md
@@ -38,6 +38,14 @@ bolt command run "netstat -an | grep 'tcp.*LISTEN'" --nodes web5.mydomain.edu, w
 
     **Note:** When connecting to Bolt hosts over WinRM that have not configured SSL for port 5986, passing the `--no-ssl` switch is required to connect to the default WinRM port 5985.
 
+## Running commands with redirection or pipes
+
+When you run one-line commands that include redirection or pipes, pass `bash`
+or another shell as the command. Using a shall ensures that the one-liner is
+run as a single command and that it works correctly with `run-as`. For example,
+instead of `bolt command run "echo foo > /root/foo" --run-as root`, use `bolt
+command run "bash -c 'echo foo > /root/foo'" --run-as root`.
+
 
 ## Run a script on remote nodes
 


### PR DESCRIPTION
@melamos This is really painful when users run into it. I'm not sure how to make it as discoverable as possible.