### PR TITLE
(BOLT-997) Bump facts and puppet_agent modules for fix

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,7 +6,7 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '0.4.0'
-mod 'puppetlabs-facts', '0.4.1'
+mod 'puppetlabs-facts', '0.5.0'
 mod 'puppet_agent',
     git: 'https://github.com/puppetlabs/puppetlabs-puppet_agent',
     ref: '52b5b6abc2d10fb8827edead34ef8ebe4adf1e29'

--- a/Puppetfile
+++ b/Puppetfile
@@ -9,7 +9,7 @@ mod 'puppetlabs-service', '0.4.0'
 mod 'puppetlabs-facts', '0.5.0'
 mod 'puppet_agent',
     git: 'https://github.com/puppetlabs/puppetlabs-puppet_agent',
-    ref: '52b5b6abc2d10fb8827edead34ef8ebe4adf1e29'
+    ref: 'fb4092305740f7f9e04722bb4a076afe89ab3161'
 
 # Core types and providers for Puppet 6
 mod 'puppetlabs-augeas_core', '1.0.3'


### PR DESCRIPTION
Fix installing puppet_agent when facter is already installed on some
platforms where facter and the facts scripts differ.