### PR TITLE
(BOLT-1007) Create plan executor class for plan_executor service

### DIFF
--- a/lib/bolt/transport/api.rb
+++ b/lib/bolt/transport/api.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'bolt/transport/api/connection'
+
+# A copy of the orchestrator transport which uses the api connection class
+# in order to bypass calling 'start_plan'
+module Bolt
+  module Transport
+    class Api < Orch
+      def initialize(*args)
+        super
+      end
+
+      def get_connection(conn_opts)
+        key = Bolt::Transport::Api::Connection.get_key(conn_opts)
+        unless (conn = @connections[key])
+          @connections[key] = Bolt::Transport::Api::Connection.new(conn_opts, logger)
+          conn = @connections[key]
+        end
+        conn
+      end
+
+      def batches(targets)
+        targets.group_by { |target| Bolt::Transport::Api::Connection.get_key(target.options) }.values
+      end
+    end
+  end
+end

--- a/lib/bolt/transport/api/connection.rb
+++ b/lib/bolt/transport/api/connection.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# This is a copy of the orchestrator transport connection, but without the
+# 'start_plan' call in the init function which is handled by the orchestrator
+# client
+module Bolt
+  module Transport
+    class Api < Orch
+      class Connection
+        attr_reader :logger, :key
+
+        CONTEXT_KEYS = Set.new(%i[plan_name description params]).freeze
+
+        def self.get_key(opts)
+          [
+            opts['service-url'],
+            opts['task-environment'],
+            opts['token-file']
+          ].join('-')
+        end
+
+        def initialize(opts, logger)
+          @logger = logger
+          @key = self.class.get_key(opts)
+          client_keys = %w[service-url token-file cacert]
+          client_opts = client_keys.each_with_object({}) do |k, acc|
+            acc[k] = opts[k] if opts.include?(k)
+          end
+          client_opts['User-Agent'] = "Bolt/#{VERSION}"
+          logger.debug("Creating orchestrator client for #{client_opts}")
+
+          @client = OrchestratorClient.new(client_opts, true)
+          @environment = opts["task-environment"]
+        end
+
+        def finish_plan(plan_result)
+          if @plan_job
+            @client.command.plan_finish(
+              plan_job: @plan_job,
+              result: plan_result.value || '',
+              status: plan_result.status
+            )
+          end
+        end
+
+        def build_request(targets, task, arguments, description = nil)
+          body = { task: task.name,
+                   environment: @environment,
+                   noop: arguments['_noop'],
+                   params: arguments.reject { |k, _| k.start_with?('_') },
+                   scope: {
+                     nodes: targets.map(&:host)
+                   } }
+          body[:description] = description if description
+          body[:plan_job] = @plan_job if @plan_job
+          body
+        end
+
+        def run_task(targets, task, arguments, options)
+          body = build_request(targets, task, arguments, options['_description'])
+          @client.run_task(body)
+        end
+
+        def query_inventory(targets)
+          @client.post('inventory', nodes: targets.map(&:host))
+        end
+      end
+    end
+  end
+end

--- a/lib/plan_executor/app.rb
+++ b/lib/plan_executor/app.rb
@@ -8,6 +8,7 @@ require 'bolt/inventory'
 require 'bolt/pal'
 require 'bolt/puppetdb'
 require 'plan_executor/applicator'
+require 'plan_executor/executor'
 require 'concurrent'
 require 'json'
 require 'json-schema'
@@ -31,7 +32,7 @@ module PlanExecutor
       @worker = Concurrent::SingleThreadExecutor.new
 
       # Create a basic executor, leave concurrency up to Orchestrator.
-      @executor = executor || Bolt::Executor.new(0, load_config: false)
+      @executor = executor || PlanExecutor::Executor.new(0)
       # Use an empty inventory until we figure out where this data comes from.
       @inventory = Bolt::Inventory.new(nil)
       # TODO: what should max compiles be set to for apply?

--- a/lib/plan_executor/executor.rb
+++ b/lib/plan_executor/executor.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+# Used for $ERROR_INFO. This *must* be capitalized!
+require 'English'
+require 'json'
+require 'logging'
+require 'set'
+require 'bolt/result'
+require 'bolt/config'
+require 'bolt/transport/api'
+require 'bolt/notifier'
+require 'bolt/result_set'
+require 'bolt/puppetdb'
+
+module PlanExecutor
+  class Executor
+    attr_reader :noop, :transport
+
+    def initialize(noop = nil)
+      @logger = Logging.logger[self]
+      @plan_logging = false
+      @noop = noop
+      @logger.debug { "Started" }
+      @notifier = Bolt::Notifier.new
+      @transport = Bolt::Transport::Api.new
+    end
+
+    # This handles running the job, catching errors, and turning the result
+    # into a result set
+    def execute(targets)
+      result_array = begin
+                       yield
+                     rescue StandardError => e
+                       @logger.warn(e)
+                       # CODEREVIEW how should we fail if there's an error?
+                       Array(Bolt::Result.from_exception(targets[0], e))
+                     end
+      Bolt::ResultSet.new(result_array)
+    end
+
+    # TODO: Remove in favor of service logging
+    def log_action(description, targets)
+      # When running a plan, info messages like starting a task are promoted to notice.
+      log_method = @plan_logging ? :notice : :info
+      target_str = if targets.length > 5
+                     "#{targets.count} targets"
+                   else
+                     targets.map(&:uri).join(', ')
+                   end
+
+      @logger.send(log_method, "Starting: #{description} on #{target_str}")
+
+      start_time = Time.now
+      results = yield
+      duration = Time.now - start_time
+
+      failures = results.error_set.length
+      plural = failures == 1 ? '' : 's'
+
+      @logger.send(log_method, "Finished: #{description} with #{failures} failure#{plural} in #{duration.round(2)} sec")
+
+      results
+    end
+
+    def log_plan(plan_name)
+      log_method = @plan_logging ? :notice : :info
+      @logger.send(log_method, "Starting: plan #{plan_name}")
+      start_time = Time.now
+
+      results = nil
+      begin
+        results = yield
+      ensure
+        duration = Time.now - start_time
+        @logger.send(log_method, "Finished: plan #{plan_name} in #{duration.round(2)} sec")
+      end
+
+      results
+    end
+
+    def run_command(targets, command, options = {}, &callback)
+      description = options.fetch('_description', "command '#{command}'")
+      log_action(description, targets) do
+        notify = proc { |event| @notifier.notify(callback, event) if callback }
+
+        results = execute(targets) do
+          @transport.batch_command(targets, command, options, &notify)
+        end
+
+        @notifier.shutdown
+        results
+      end
+    end
+
+    def run_script(targets, script, arguments, options = {}, &callback)
+      description = options.fetch('_description', "script #{script}")
+      log_action(description, targets) do
+        notify = proc { |event| @notifier.notify(callback, event) if callback }
+
+        results = execute(targets) do
+          @transport.batch_script(targets, script, arguments, options, &notify)
+        end
+
+        @notifier.shutdown
+        results
+      end
+    end
+
+    def run_task(targets, task, arguments, options = {}, &callback)
+      description = options.fetch('_description', "task #{task.name}")
+      log_action(description, targets) do
+        notify = proc { |event| @notifier.notify(callback, event) if callback }
+
+        arguments['_task'] = task.name
+
+        results = execute(targets) do
+          @transport.batch_task(targets, task, arguments, options, &notify)
+        end
+
+        @notifier.shutdown
+        results
+      end
+    end
+
+    def upload_file(targets, source, destination, options = {}, &callback)
+      description = options.fetch('_description', "file upload from #{source} to #{destination}")
+      log_action(description, targets) do
+        notify = proc { |event| @notifier.notify(callback, event) if callback }
+
+        results = execute(targets) do
+          @transport.batch_upload(targets, source, destination, options, &notify)
+        end
+
+        @notifier.shutdown
+        results
+      end
+    end
+
+    class TimeoutError < RuntimeError; end
+
+    def wait_until_available(targets,
+                             description: 'wait until available',
+                             wait_time: 120,
+                             retry_interval: 1)
+      log_action(description, targets) do
+        begin
+          wait_until(wait_time, retry_interval) { @transport.batch_connected?(targets) }
+          targets.map { |target| Bolt::Result.new(target) }
+        rescue TimeoutError => e
+          targets.map { |target| Bolt::Result.from_exception(target, e) }
+        end
+      end
+    end
+
+    def wait_until(timeout, retry_interval)
+      start = wait_now
+      until yield
+        raise(TimeoutError, 'Timed out waiting for target') if (wait_now - start).to_i >= timeout
+        sleep(retry_interval)
+      end
+    end
+
+    # Plan context doesn't make sense for most transports but it is tightly
+    # coupled with the orchestrator transport since the transport behaves
+    # differently when a plan is running. In order to limit how much this
+    # pollutes the transport API we only handle the orchestrator transport here.
+    # Since we callt this function without resolving targets this will result
+    # in the orchestrator transport always being initialized during plan runs.
+    # For now that's ok.
+    #
+    # In the future if other transports need this or if we want a plan stack
+    # we'll need to refactor.
+    def start_plan(plan_context)
+      @transport.plan_context = plan_context
+      @plan_logging = true
+    end
+
+    def finish_plan(plan_result)
+      @transport.finish_plan(plan_result)
+    end
+
+    def without_default_logging
+      old_log = @plan_logging
+      @plan_logging = false
+      yield
+    ensure
+      @plan_logging = old_log
+    end
+
+    def report_bundled_content(mode, name); end
+
+    def report_function_call(function); end
+  end
+end

--- a/spec/bolt/transport/api_spec.rb
+++ b/spec/bolt/transport/api_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/task'
+require 'bolt/transport/api'
+require 'bolt/target'
+
+describe Bolt::Transport::Api do
+  include BoltSpec::Task
+
+  let(:results) do
+    [{ 'name' => 'localhost',
+       'state' => 'finished',
+       'result' => { '_output' => 'ok' } }]
+  end
+  let(:mock_client) { instance_double("OrchestratorClient", run_task: results) }
+  let(:mtask) { mock_task('foo', 'foo/tasks/init', 'input') }
+  let(:api) { Bolt::Transport::Api.new }
+
+  let(:targets) do
+    [Bolt::Target.new('pcp://node1').update_conf(Bolt::Config.default.transport_conf),
+     Bolt::Target.new('node2').update_conf(Bolt::Config.default.transport_conf)]
+  end
+
+  before(:each) do
+    allow(OrchestratorClient).to receive(:new).and_return(mock_client)
+  end
+
+  it "does not send start_plan command" do
+    plan_context = { plan_name: "foo", params: {} }
+    api.plan_context = plan_context
+
+    mock_command_api = instance_double("OrchestratorClient::Client")
+    allow(mock_client).to receive(:command)
+    expect(mock_command_api).not_to receive(:plan_start)
+
+    api.batch_task(targets, mtask, {})
+  end
+
+  describe '#get_connection' do
+    it 'returns API connection' do
+      expect(api.get_connection(targets.first.options))
+        .to be_a(Bolt::Transport::Api::Connection)
+    end
+  end
+
+  # Since we copy-pasted the orch connection file, this adds tests around
+  # conection to make sure the api connection stays up to date
+  describe 'batch_connected?' do
+    it 'returns true if all targets are connected' do
+      result = { 'items' => targets.map { |_| { 'connected' => true } } }
+      expect(mock_client).to receive(:post).with('inventory', nodes: targets.map(&:host)).and_return(result)
+      expect(api.batch_connected?(targets)).to eq(true)
+    end
+
+    it 'returns false if all targets are not connected' do
+      result = { 'items' => targets.map { |_| { 'connected' => false } } }
+      expect(mock_client).to receive(:post).with('inventory', nodes: targets.map(&:host)).and_return(result)
+      expect(api.batch_connected?(targets)).to eq(false)
+    end
+
+    it 'returns false if any targets are not connected' do
+      result = { 'items' => targets.map { |_| { 'connected' => true } } }
+      result['items'][0]['connected'] = false
+      expect(mock_client).to receive(:post).with('inventory', nodes: targets.map(&:host)).and_return(result)
+      expect(api.batch_connected?(targets)).to eq(false)
+    end
+  end
+end

--- a/spec/plan_executor/executor_spec.rb
+++ b/spec/plan_executor/executor_spec.rb
@@ -1,0 +1,249 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/task'
+require 'plan_executor/executor'
+require 'bolt/target'
+
+describe "PlanExecutor::Executor" do
+  include BoltSpec::Task
+
+  let(:executor) { PlanExecutor::Executor.new(1) }
+  let(:api) { executor.transport }
+  let(:command) { "hostname" }
+  let(:base_path) { File.expand_path(File.join(File.dirname(__FILE__), '..', '..')) }
+  let(:script) { File.join(base_path, 'spec', 'fixtures', 'scripts', 'success.sh') }
+  let(:dest) { '/tmp/upload' }
+  let(:task) { 'service::restart' }
+  let(:task_arguments) { { 'name' => 'apache' } }
+  let(:task_options) { {} }
+  let(:transport) { double('holodeck', initialize_transport: nil) }
+  let(:targets) { [Bolt::Target.new("target1"), Bolt::Target.new("target2")] }
+  let(:error) { Bolt::Error.new('failed', 'my-exception') }
+
+  let(:result) do
+    { 'exit_code' => 0, '_output' => 'ok' }
+  end
+
+  let(:node_result) { Bolt::Result.new(targets[0], value: result) }
+  let(:node_results) do
+    [Bolt::Result.new(targets[0], value: result),
+     Bolt::Result.new(targets[1], value: result)]
+  end
+
+  let(:client_results) {
+    [{ 'name' => 'target1',
+       'state' => 'finished',
+       'result' => result },
+     { 'name' => 'target2',
+       'state' => 'finished',
+       'results' => result }]
+  }
+
+  let(:mock_client) { instance_double("OrchestratorClient", run_task: client_results) }
+
+  def start_event(target)
+    { type: :node_start, target: target }
+  end
+
+  def success_event(result)
+    { type: :node_result, result: result }
+  end
+
+  before(:each) do
+    allow(OrchestratorClient).to receive(:new).and_return(mock_client)
+  end
+
+  context 'running a command' do
+    it 'executes on all nodes' do
+      expect(api).to receive(:batch_command)
+        .with(targets, command, {})
+        .and_return(node_results)
+
+      executor.run_command(targets, command, {})
+    end
+
+    it 'passes options' do
+      expect(api).to receive(:batch_command)
+        .with(targets, command, 'service_url' => 'abcde.com')
+        .and_return(node_results)
+
+      executor.run_command(targets, command, 'service_url' => 'abcde.com')
+    end
+
+    it "yields results" do
+      expect(mock_client).to receive(:run_task).and_return(client_results)
+
+      events = []
+      results = executor.run_command(targets, command) do |event|
+        events << event
+      end
+
+      results.each do |result|
+        expect(events).to include(success_event(result))
+        expect(events).to include(start_event(result.target))
+      end
+    end
+
+    it 'catches errors' do
+      expect(api).to receive(:batch_command)
+        .with(targets, command, {})
+        .and_raise(error)
+
+      executor.run_command(targets, command) do |result|
+        expect(result.error_hash['msg']).to eq('failed')
+        expect(result.error_hash['kind']).to eq('my-exception')
+      end
+    end
+  end
+
+  context 'executes running a script' do
+    it "on all nodes" do
+      expect(api).to receive(:batch_script)
+        .with(targets, script, [], {})
+        .and_return(node_results)
+
+      results = executor.run_script(targets, script, [], {})
+      results.each do |result|
+        expect(result).to be_instance_of(Bolt::Result)
+      end
+    end
+
+    it "yields each result" do
+      expect(mock_client).to receive(:run_task).and_return(client_results)
+
+      events = []
+      results = executor.run_script(targets, script, []) do |event|
+        events << event
+      end
+
+      results.each do |result|
+        expect(events).to include(success_event(result))
+        expect(events).to include(start_event(result.target))
+      end
+    end
+
+    it 'catches errors' do
+      expect(api)
+        .to receive(:batch_script)
+        .with(targets, script, [], {})
+        .and_raise(Bolt::Error, 'failed', 'my-exception')
+
+      executor.run_script(targets, script, []) do |result|
+        expect(result.error_hash['msg']).to eq('failed')
+        expect(result.error_hash['kind']).to eq('my-exception')
+      end
+    end
+  end
+
+  context 'running a task' do
+    it "executes on all nodes" do
+      expect(api)
+        .to receive(:batch_task)
+        .with(targets, task_type(task), task_arguments, task_options)
+        .and_return(node_results)
+
+      results = executor.run_task(targets, mock_task(task), task_arguments, task_options)
+      results.each do |result|
+        expect(result).to be_instance_of(Bolt::Result)
+        expect(result).to be_success
+      end
+    end
+
+    it "yields each result" do
+      expect(mock_client).to receive(:run_task).and_return(client_results)
+
+      events = []
+      results = executor.run_task(targets, mock_task(task), task_arguments, task_options) do |event|
+        events << event
+      end
+
+      results.each do |result|
+        expect(events).to include(success_event(result))
+        expect(events).to include(start_event(result.target))
+      end
+    end
+
+    it 'catches errors' do
+      expect(api)
+        .to receive(:batch_task)
+        .with(targets, task_type(task), task_arguments, task_options)
+        .and_raise(Bolt::Error, 'failed', 'my-exception')
+
+      executor.run_task(targets, mock_task(task), task_arguments, task_options) do |result|
+        expect(result.error_hash['msg']).to eq('failed')
+        expect(result.error_hash['kind']).to eq('my-exception')
+      end
+    end
+  end
+
+  context 'uploading a file' do
+    it "executes on all nodes" do
+      expect(api)
+        .to receive(:batch_upload)
+        .with(targets, script, dest, {})
+        .and_return(node_results)
+
+      results = executor.upload_file(targets, script, dest)
+      results.each do |result|
+        expect(result).to be_instance_of(Bolt::Result)
+      end
+    end
+
+    it "yields each result" do
+      expect(mock_client).to receive(:run_task).and_return(client_results)
+
+      events = []
+      results = executor.upload_file(targets, script, dest) do |event|
+        events << event
+      end
+
+      results.each do |result|
+        expect(events).to include(success_event(result))
+        expect(events).to include(start_event(result.target))
+      end
+    end
+
+    it 'catches errors' do
+      expect(api)
+        .to receive(:batch_upload)
+        .with(targets, script, dest, {})
+        .and_raise(Bolt::Error, 'failed', 'my-exception')
+
+      executor.upload_file(targets, script, dest) do |result|
+        expect(result.error_hash['msg']).to eq('failed')
+        expect(result.error_hash['kind']).to eq('my-exception')
+      end
+    end
+  end
+
+  it "returns and notifies an error result" do
+    expect(api)
+      .to receive(:get_connection)
+      .with(targets.first.options)
+      .and_raise(
+        Bolt::Node::ConnectError.new('Authentication failed', 'AUTH_ERROR')
+      )
+
+    notices = []
+    results = executor.run_command(targets, command) { |notice| notices << notice }
+
+    results.each do |result|
+      expect(result.error_hash['msg']).to eq('Authentication failed')
+      expect(result.error_hash['kind']).to eq('puppetlabs.tasks/connect-error')
+    end
+
+    expect(notices.count).to eq(4)
+    result_notices = notices.select { |notice| notice[:type] == :node_result }.map { |notice| notice[:result] }
+    expect(results).to eq(Bolt::ResultSet.new(result_notices))
+  end
+
+  it "returns an exception result if the connect raises an unhandled error" do
+    expect(api).to receive(:get_connection).and_raise("reset")
+
+    results = executor.run_command(targets, command)
+    results.each do |result|
+      expect(result.error_hash['kind']).to eq('puppetlabs.tasks/exception-error')
+    end
+  end
+end


### PR DESCRIPTION
This adds a new executor class for the `plan_executor` service, which bypasses logic around batching and queueing and exclusively uses the orchestrator transport. It also includes a new api transport class based on the orchestrator transport, which doesn't call `start_plan` as that's handled by the orchestrator.

Giving the plan executor service it's own executor greatly simplifies the logic around running jobs through the service.