### PR TITLE
(BOLT-1074) Fix exit status return value for local transport

### DIFF
--- a/lib/bolt/transport/local/shell.rb
+++ b/lib/bolt/transport/local/shell.rb
@@ -19,7 +19,7 @@ module Bolt
           result_output = Bolt::Node::Output.new
           result_output.stdout << stdout unless stdout.nil?
           result_output.stderr << stderr unless stderr.nil?
-          result_output.exit_code = rc.to_i
+          result_output.exit_code = rc.exitstatus
           result_output
         end
       end

--- a/spec/bolt/transport/shared_examples.rb
+++ b/spec/bolt/transport/shared_examples.rb
@@ -95,9 +95,14 @@ shared_examples 'transport api' do
     end
 
     it "can return a non-zero exit status" do
-      # explicitly launch bash because Docker doesn't have bash as a default shell
-      # when you perform a: docker exec
-      result = runner.run_command(target, "/bin/bash -c 'exit 1'", '_catch_errors' => true).value
+      command = if target.protocol == 'docker'
+                  # explicitly launch bash for Docker transport because Docker doesn't have
+                  # a default shell when you perform: docker exec
+                  "/bin/bash -c 'exit 1'"
+                else
+                  "exit 1"
+                end
+      result = runner.run_command(target, command, '_catch_errors' => true).value
       expect(result['exit_code']).to eq(1)
     end
   end

--- a/spec/bolt/transport/shared_examples.rb
+++ b/spec/bolt/transport/shared_examples.rb
@@ -93,6 +93,13 @@ shared_examples 'transport api' do
       expect(result['stderr']).to eq('')
       expect(result['stdout']).to match(/hello " world/)
     end
+
+    it "can return a non-zero exit status" do
+      # explicitly launch bash because Docker doesn't have bash as a default shell
+      # when you perform a: docker exec
+      result = runner.run_command(target, "/bin/bash -c 'exit 1'", '_catch_errors' => true).value
+      expect(result['exit_code']).to eq(1)
+    end
   end
 
   context 'upload_file' do


### PR DESCRIPTION
Fixes the exit status return value for local transport. 

Based on the documentation for Process::Status https://ruby-doc.org/core-2.5.0/Process/Status.html :+1: 

```
Posix systems record information on processes using a 16-bit integer. The lower bits record the process status (stopped, exited, signaled) and the upper bits possibly contain additional information (for example the program's return code in the case of exited processes). Pre Ruby 1.8, these bits were exposed directly to the Ruby program. Ruby now encapsulates these in a Process::Status object. To maximize compatibility, however, these objects retain a bit-oriented interface. In the descriptions that follow, when we talk about the integer value of stat, we're referring to this 16 bit value.
```

To get the actual exit status we need to use the `.exitstatus` function.

Before:
```
$ bolt command run "exit 1" --nodes local://localhost
Started on localhost...
Failed on localhost:
  The command failed with exit code 256
Failed on 1 node: local://localhost
Ran on 1 node in 0.01 seconds
```

After:
```
$ bolt command run "exit 1" --nodes local://localhost
Started on localhost...
Failed on localhost:
  The command failed with exit code 1
Failed on 1 node: local://localhost
Ran on 1 node in 0.00 seconds
```