### PR TITLE
(maint) Update bundle command for installing from Gem

### DIFF
--- a/acceptance/setup/gem/pre-suite/020_install.rb
+++ b/acceptance/setup/gem/pre-suite/020_install.rb
@@ -6,7 +6,7 @@ test_name "Install Bolt gem" do
   extend Acceptance::BoltSetupHelper
 
   step "Install Bolt gem" do
-    install_command = "gem install bolt --source #{gem_source} --no-ri --no-rdoc"
+    install_command = "gem install bolt --source #{gem_source} --no-document"
     install_command += " -v '#{gem_version}'" unless gem_version.empty?
     case bolt['platform']
     when /windows/

--- a/acceptance/setup/git/pre-suite/020_install.rb
+++ b/acceptance/setup/git/pre-suite/020_install.rb
@@ -47,7 +47,7 @@ test_name "Install Bolt via git" do
   end
 
   step "Install custom gem" do
-    install_command = "cd bolt; gem install bolt-#{version}.gem --no-ri --no-rdoc"
+    install_command = "cd bolt; gem install bolt-#{version}.gem --no-document"
     case bolt['platform']
     when /windows/
       execute_powershell_script_on(bolt, install_command)


### PR DESCRIPTION
The `--no-ri` and `--no-doc` flags have been deprecated for bundler. (https://github.com/rubygems/rubygems/commit/0d22d6025ce2653ec9fb20a4e0745c79bda677da) user `--no-document` instead.