### PR TITLE
(maint) Test bolt compatibility with ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: bundler
 services:
 - docker
 rvm:
-- 2.5
+- 2.6
 env:
   global:
     - REGISTRY_HOST=pcr-internal.puppet.net

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "CFPropertyList", "~> 2.2"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "docker-api", "~> 1.34"
+  spec.add_dependency "ffi", "~> 1.10"
   spec.add_dependency "logging", "~> 2.2"
   spec.add_dependency "minitar", "~> 0.6"
   spec.add_dependency "net-scp", "~> 1.2"


### PR DESCRIPTION
The latest version of the `ffi` gem adds support for ffi on windows.