### PR TITLE
(maint) Update docs around `run_task` function

### DIFF
--- a/developer-docs/bolt-api-servers.md
+++ b/developer-docs/bolt-api-servers.md
@@ -166,7 +166,7 @@ The metadata object is optional, and contains metadata about the task being run.
     - `type`: String, *optional* - The type the parameter should accept.
 
 #### Files
-# TODO
+# TODO for BOLT-952
 
 ### Response
 If the task runs the response will have status 200.

--- a/pre-docs/plan_functions.md
+++ b/pre-docs/plan_functions.md
@@ -460,7 +460,7 @@ run_task(String[1] $task_name, Boltlib::TargetSpec $targets, Optional[Hash[Strin
 
 * **task_name** `String[1]` The task to run.
 * **targets** `Boltlib::TargetSpec` A pattern identifying zero or more targets. See [`get_targets`](#get_targets) for accepted patterns.
-* **task_args** `Optional[Hash[String[1], Any]]` Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.
+* **task_args** `Optional[Hash[String[1], Any]]` Arguments to the task. Can also include additional options: '_catch_errors', '_run_as'. Note: This is parameters for the task, not [configuration options](#bolt_configuration_options)
 
 **Example:** Run a task as root
 ```


### PR DESCRIPTION
**What this changes** This clarifies that `run_task` accepts a hash of task parameters, rather than configuration options. It also corrects that it runs a task, not a plan.
Additionally it adds a note about what changes need to be made for BOLT-952

**Why** The docs can be misread to accept config options.
Some of the work for BOLT-952 has been done, but it it's half-complete, so this clarifies what needs to change