### PR TITLE
(maint) Only wrap tmpdir-related errors in FileError

### DIFF
--- a/lib/bolt/transport/local.rb
+++ b/lib/bolt/transport/local.rb
@@ -36,11 +36,15 @@ module Bolt
 
       def in_tmpdir(base)
         args = base ? [nil, base] : []
-        Dir.mktmpdir(*args) do |dir|
-          yield dir
-        end
-      rescue StandardError => e
-        raise Bolt::Node::FileError.new("Could not make tempdir: #{e.message}", 'TEMPDIR_ERROR')
+        dir = begin
+                Dir.mktmpdir(*args)
+              rescue StandardError => e
+                raise Bolt::Node::FileError.new("Could not make tempdir: #{e.message}", 'TEMPDIR_ERROR')
+              end
+
+        yield dir
+      ensure
+        FileUtils.remove_entry dir if dir
       end
       private :in_tmpdir
 


### PR DESCRIPTION
Previously other errors from invoking a task or script would also be
caught and wrapped in FileError. We should only do that for errors we
know are related to creating the tmpdir.