### PR TITLE
(BOLT-756) Don't error when puppetdb.conf can't be loaded.

### DIFF
--- a/spec/bolt/puppetdb/config_spec.rb
+++ b/spec/bolt/puppetdb/config_spec.rb
@@ -179,5 +179,13 @@ describe Bolt::PuppetDB::Config do
       expect(File).to receive(:exist?).with(Bolt::PuppetDB::Config::DEFAULT_CONFIG[:win_global])
       Bolt::PuppetDB::Config.load_config(nil, {})
     end
+
+    it "Does not error if puppetdb.conf fails to load" do
+      allow(Bolt::Util).to receive(:windows?).and_return(false)
+      expect(File).to receive(:exist?).with(Bolt::PuppetDB::Config::DEFAULT_CONFIG[:user]).and_return true
+      expect(File).to receive(:read).with(Bolt::PuppetDB::Config::DEFAULT_CONFIG[:user]).and_return 'bad"json'
+      expect(JSON).to receive(:parse).and_raise(JSON::ParserError.new("unexpected token"))
+      Bolt::PuppetDB::Config.load_config(nil, {})
+    end
   end
 end


### PR DESCRIPTION
Previously bolt would fail to run if it failed to read puppetdb.conf.
Now it will issue an error level log message but continue running.