### PR TITLE
(BOLT-1049) Update acceptance tests to service::init task

### DIFF
--- a/acceptance/files/example_apply/plans/puppet_status.pp
+++ b/acceptance/files/example_apply/plans/puppet_status.pp
@@ -1,0 +1,7 @@
+plan example_apply::puppet_status (TargetSpec $nodes) {
+  $targets = get_targets($nodes)
+  $targets.each |$target| {
+    set_feature($target, 'puppet-agent', true)
+  }
+  return run_task('service', $targets, 'action' => 'status', 'name' => 'puppet')
+}

--- a/acceptance/setup/common/pre-suite/071_install_modules.rb
+++ b/acceptance/setup/common/pre-suite/071_install_modules.rb
@@ -7,11 +7,11 @@ test_name "Install modules" do
 
   on(bolt, "mkdir -p #{default_boltdir}")
   create_remote_file(bolt, "#{default_boltdir}/Puppetfile", <<-PUPPETFILE)
-mod 'puppetlabs-facts', '0.2.0'
-mod 'puppetlabs-service', '0.3.1'
+mod 'puppetlabs-facts', '0.5.0'
+mod 'puppetlabs-service', '0.5.0'
 mod 'puppet_agent',
     git: 'https://github.com/puppetlabs/puppetlabs-puppet_agent',
-    ref: '319ce44a65e73bcf2712ad17be01f9636f0673c9'
+    ref: 'fb4092305740f7f9e04722bb4a076afe89ab3161'
 PUPPETFILE
 
   bolt_command_on(bolt, 'bolt puppetfile install')

--- a/acceptance/tests/apply_plan_ssh.rb
+++ b/acceptance/tests/apply_plan_ssh.rb
@@ -94,7 +94,7 @@ test_name "bolt plan run should apply manifest block on remote hosts via ssh" do
   end
 
   step "puppet service should be stopped" do
-    service_command = "bolt task run service action=status name=puppet -n #{targets}"
+    service_command = "bolt plan run example_apply::puppet_status -n #{targets}"
     result = bolt_command_on(bolt, service_command, flags)
 
     assert_equal(0, result.exit_code,
@@ -110,7 +110,7 @@ test_name "bolt plan run should apply manifest block on remote hosts via ssh" do
     ssh_nodes.each do |node|
       # Verify that node succeeded
       host = node.hostname
-      result = json['items'].select { |n| n['node'] == host }
+      result = json.select { |n| n['node'] == host }
       assert_equal('success', result[0]['status'],
                    "The task did not succeed on #{host}")
 

--- a/acceptance/tests/apply_plan_winrm.rb
+++ b/acceptance/tests/apply_plan_winrm.rb
@@ -90,8 +90,12 @@ test_name "bolt plan run should apply manifest block on remote hosts via winrm" 
   end
 
   step "puppet service should be stopped" do
-    service_command = 'bolt task run service action=status name=puppet -n winrm_nodes'
-    flags = { '--format' => 'json' }
+    service_command = 'bolt plan run example_apply::puppet_status -n winrm_nodes'
+    flags = {
+      '--modulepath' => modulepath(File.join(dir, 'modules')),
+      '--format' => 'json'
+    }
+
     result = bolt_command_on(bolt, service_command, flags)
 
     assert_equal(0, result.exit_code,
@@ -107,7 +111,7 @@ test_name "bolt plan run should apply manifest block on remote hosts via winrm" 
     winrm_nodes.each do |node|
       # Verify that node succeeded
       host = node.hostname
-      result = json['items'].select { |n| n['node'] == host }
+      result = json.select { |n| n['node'] == host }
       assert_equal('success', result[0]['status'],
                    "The task did not succeed on #{host}")
 


### PR DESCRIPTION
The most reliable way to query the status of puppet using the service task is the ruby implementation. This commit uses updated service, package, and puppet_agent modules for git based testing and updates the apply tests to use the service::init task by wrapping in a plan that sets the puppet-agent feature on target nodes.