### PR TITLE
(BOLT-756) Only try to load puppetdb.conf if exists

### DIFF
--- a/lib/bolt/puppetdb/config.rb
+++ b/lib/bolt/puppetdb/config.rb
@@ -36,7 +36,7 @@ module Bolt
           end
 
           begin
-            config = JSON.parse(File.read(filepath))
+            config = JSON.parse(File.read(filepath)) if filepath
           rescue StandardError => e
             Logging.logger[self].error("Could not load puppetdb.conf from #{filepath}: #{e.message}")
           end


### PR DESCRIPTION
Previously an error message would occur if no puppetdb.conf was found.