### PR TITLE
(BOLT-1022) Allows hyphens in aliases and group names

### DIFF
--- a/lib/bolt/inventory/group.rb
+++ b/lib/bolt/inventory/group.rb
@@ -8,7 +8,7 @@ module Bolt
       attr_accessor :name, :nodes, :aliases, :name_or_alias, :groups, :config, :rest, :facts, :vars, :features
 
       # Regex used to validate group names and target aliases.
-      NAME_REGEX = /\A[a-z0-9_]+\Z/.freeze
+      NAME_REGEX = /\A[a-z0-9_][a-z0-9_-]*\Z/.freeze
 
       def initialize(data)
         @logger = Logging.logger[self]

--- a/spec/bolt/inventory/group_spec.rb
+++ b/spec/bolt/inventory/group_spec.rb
@@ -727,6 +727,31 @@ describe Bolt::Inventory::Group do
       it { expect { group }.to raise_error(/Invalid alias not a valid alias/) }
     end
 
+    context 'validating alias names' do
+      let(:data) do
+        {
+          'name' => 'root',
+          'nodes' => [
+            { 'name' => 'node1', 'alias' => @alias }
+          ]
+        }
+      end
+
+      %w[alias1 _alias1 1alias 1_alias_ alias-1 a 1].each do |alias_name|
+        it "accepts '#{alias_name}'" do
+          @alias = alias_name
+          expect(group.node_aliases).to eq(alias_name => 'node1')
+        end
+      end
+
+      %w[-alias1 alias/1 alias.1 - Alias1 ALIAS_1].each do |alias_name|
+        it "rejects '#{alias_name}'" do
+          @alias = alias_name
+          expect { group }.to raise_error(/Invalid alias/)
+        end
+      end
+    end
+
     context 'conflicting alias' do
       let(:data) do
         {


### PR DESCRIPTION
This allows valid hostnames like prod-master-1 to be used as aliases,
without having to translate the hyphens to underscores. This does not
allow an alias to _begin_ with a hyphen.