### PR TITLE
(BOLT-938) Handle connect timeout error for puppetdb client failover

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "winrm-fs", "~> 1.3"
 
   # there is a bug in puppetlabs_spec_helper for modules without fixtures
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler", ">= 1.14"
   spec.add_development_dependency "puppetlabs_spec_helper", "~> 2.6"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/bolt/puppetdb/client.rb
+++ b/lib/bolt/puppetdb/client.rb
@@ -50,10 +50,8 @@ module Bolt
 
         begin
           response = http_client.post(url, body: body, header: headers)
-        rescue SocketError, OpenSSL::SSL::SSLError, SystemCallError, Net::ProtocolError, IOError => err
-          raise Bolt::PuppetDBFailoverError, "Failed to query PuppetDB: #{err}"
         rescue StandardError => err
-          raise Bolt::PuppetDBError, "Failed to query PuppetDB: #{err}"
+          raise Bolt::PuppetDBFailoverError, "Failed to query PuppetDB: #{err}"
         end
 
         if response.code != 200

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -159,7 +159,7 @@ describe "passes parsed AST to the apply_catalog task" do
           error = result['details']['result_set'][0]['result']['_error']
           expect(error['kind']).to eq('bolt/apply-error')
           expect(error['msg']).to match(/Apply failed to compile for #{uri}/)
-          expect(@log_output.readlines).to include(/Failed to query PuppetDB: /)
+          expect(@log_output.readlines).to include(/Failed to connect to all PuppetDB server_urls/)
         end
       end
 
@@ -170,7 +170,7 @@ describe "passes parsed AST to the apply_catalog task" do
           error = result['details']['result_set'][0]['result']['_error']
           expect(error['kind']).to eq('bolt/apply-error')
           expect(error['msg']).to match(/Apply failed to compile for #{uri}/)
-          expect(@log_output.readlines).to include(/Failed to query PuppetDB: /)
+          expect(@log_output.readlines).to include(/Failed to connect to all PuppetDB server_urls/)
         end
       end
     end


### PR DESCRIPTION
This commit adds `HTTPClient::ConnectTimeoutError` to the list of handled exceptions for rolling with a puppetdb failover. Previously this would raise a PuppetDBerror and not result in checking for other acceptable puppetdb connections.