### PR TITLE
(FM-7656) Update puppet_agent module ref

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -9,7 +9,7 @@ mod 'puppetlabs-service', '0.5.0'
 mod 'puppetlabs-facts', '0.5.0'
 mod 'puppet_agent',
     git: 'https://github.com/puppetlabs/puppetlabs-puppet_agent',
-    ref: 'fb4092305740f7f9e04722bb4a076afe89ab3161'
+    ref: '4194511678422231e67c50793440bb37e5e747fc'
 
 # Core types and providers for Puppet 6
 mod 'puppetlabs-augeas_core', '1.0.3'

--- a/acceptance/setup/common/pre-suite/071_install_modules.rb
+++ b/acceptance/setup/common/pre-suite/071_install_modules.rb
@@ -11,7 +11,7 @@ mod 'puppetlabs-facts', '0.5.0'
 mod 'puppetlabs-service', '0.5.0'
 mod 'puppet_agent',
     git: 'https://github.com/puppetlabs/puppetlabs-puppet_agent',
-    ref: 'fb4092305740f7f9e04722bb4a076afe89ab3161'
+    ref: '4194511678422231e67c50793440bb37e5e747fc'
 PUPPETFILE
 
   bolt_command_on(bolt, 'bolt puppetfile install')


### PR DESCRIPTION
The powershell implementation for the puppet_agent::install task now downloads the msi over https instead of http.