### PR TITLE
(maint) Track puppet_agent module by tag instead of commit

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -7,9 +7,7 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '0.5.0'
 mod 'puppetlabs-facts', '0.5.0'
-mod 'puppet_agent',
-    git: 'https://github.com/puppetlabs/puppetlabs-puppet_agent',
-    ref: '4194511678422231e67c50793440bb37e5e747fc'
+mod 'puppetlabs-puppet_agent', '2.0.1'
 
 # Core types and providers for Puppet 6
 mod 'puppetlabs-augeas_core', '1.0.3'

--- a/acceptance/setup/common/pre-suite/071_install_modules.rb
+++ b/acceptance/setup/common/pre-suite/071_install_modules.rb
@@ -9,9 +9,7 @@ test_name "Install modules" do
   create_remote_file(bolt, "#{default_boltdir}/Puppetfile", <<-PUPPETFILE)
 mod 'puppetlabs-facts', '0.5.0'
 mod 'puppetlabs-service', '0.5.0'
-mod 'puppet_agent',
-    git: 'https://github.com/puppetlabs/puppetlabs-puppet_agent',
-    ref: '4194511678422231e67c50793440bb37e5e747fc'
+mod 'puppetlabs-puppet_agent', '2.0.1'
 PUPPETFILE
 
   bolt_command_on(bolt, 'bolt puppetfile install')


### PR DESCRIPTION
The puppet_agent module has reached a 2.x release that includes task content! This allows us to download from puppet forge by version instead of github reference.