### PR TITLE
(BOLT-1040) Skip puppet-agent dependent tests for osx-10.14

### DIFF
--- a/acceptance/tests/apply_plan_ssh.rb
+++ b/acceptance/tests/apply_plan_ssh.rb
@@ -7,10 +7,10 @@ test_name "bolt plan run should apply manifest block on remote hosts via ssh" do
   extend Acceptance::BoltCommandHelper
 
   ssh_nodes = select_hosts(roles: ['ssh'])
-  osx11 = select_hosts(platform: [/osx-10.11/])
+  skip_targets = select_hosts(platform: [/osx-10.11/, /osx-10.14/])
   targets = "ssh_nodes"
-  if osx11.any?
-    ssh_nodes -= osx11
+  if skip_targets.any?
+    ssh_nodes -= skip_targets
     targets = ssh_nodes.each_with_object([]) { |node, acc| acc.push(node[:vmhostname]) }.join(",")
   end
 

--- a/acceptance/tests/bolt_apply.rb
+++ b/acceptance/tests/bolt_apply.rb
@@ -11,7 +11,7 @@ test_name "bolt apply should apply manifest block on remote hosts via ssh and wi
   targets = ssh_nodes + winrm_nodes
 
   # Puppet 6 doesn't support OSX 10.11, so skip those hosts if present
-  targets -= select_hosts(platform: [/osx-10.11/])
+  targets -= select_hosts(platform: [/osx-10.11/, /osx-10.14/])
 
   skip_test('no applicable nodes to test on') if targets.empty?
 


### PR DESCRIPTION
Puppet agent is not yet available for osx 10.14. Previously we skipped agent dependent tests for osx 10.11 for a similar reason. This can be reverted once puppet agent is available on osx 10.14.