### PR TITLE
(maint) Pin to compatible puppetdb docker image

### DIFF
--- a/spec/Dockerfile.puppetdb
+++ b/spec/Dockerfile.puppetdb
@@ -1,4 +1,4 @@
-FROM puppet/puppetdb
+FROM puppet/puppetdb:6.0.1
 
 ARG hostname="bolt-puppetdb"
 


### PR DESCRIPTION
The puppetdb docker image has had a major update that changes the way we use in for testin bolt. This commit pins to a compatible version while we sort out how to update tests to be compatible with new image.