### PR TITLE
(BOLT-836) Support lookup() in plans outside of apply blocks

### DIFF
--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -172,6 +172,7 @@ module Bolt
         Puppet.settings.send(:clear_everything_for_tests)
         Puppet.initialize_settings(cli)
         Puppet::GettextConfig.create_default_text_domain
+        Puppet.settings[:hiera_config] = @hiera_config
         self.class.configure_logging
         yield
       end


### PR DESCRIPTION
Makes simple lookups work from Bolt's hiera config. The inputs to lookup - certname, environment, facts, etc - may not be correct.