### PR TITLE
(BOLT-830) Add script extension metadata for bolt_shim script task

### DIFF
--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -110,7 +110,8 @@ module Bolt
         content = Base64.encode64(content)
         params = {
           'content' => content,
-          'arguments' => arguments
+          'arguments' => arguments,
+          'name' => Pathname(script).basename.to_s
         }
         callback ||= proc {}
         results = run_task_job(targets, BOLT_SCRIPT_TASK, params, options, &callback)

--- a/spec/bolt/transport/orch_spec.rb
+++ b/spec/bolt/transport/orch_spec.rb
@@ -473,7 +473,7 @@ describe Bolt::Transport::Orch, orchestrator: true do
 
       {
         task: 'bolt_shim::script',
-        params: { 'content' => content, 'arguments' => args }
+        params: { 'content' => content, 'arguments' => args, 'name' => 'success.sh' }
       }
     }
 


### PR DESCRIPTION
The bolt_shim::script task now expects the script extension to be provided when the target is has a windows OS. See https://github.com/puppetlabs/puppetlabs-bolt_shim/pull/8 for corresponding bolt_shim module PR.