### PR TITLE
(BOLT-153) Support SMB file transfer

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "puppet", [">= 6.0.1", "< 7"]
   spec.add_dependency "puppet-resource_api"
   spec.add_dependency "r10k", "~> 2.6"
+  spec.add_dependency "ruby_smb", "~> 1.0"
   spec.add_dependency "terminal-table", "~> 1.8"
   spec.add_dependency "winrm", "~> 2.0"
   spec.add_dependency "winrm-fs", "~> 1.3"

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -48,7 +48,8 @@ module Bolt
       winrm: {
         'connect-timeout' => 10,
         'ssl' => true,
-        'ssl-verify' => true
+        'ssl-verify' => true,
+        'file-protocol' => 'winrm'
       },
       pcp: {
         'task-environment' => 'production'

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -8,7 +8,7 @@ module Bolt
   module Transport
     class WinRM < Base
       def self.options
-        %w[port user password connect-timeout ssl ssl-verify tmpdir cacert extensions]
+        %w[port user password connect-timeout ssl ssl-verify tmpdir cacert extensions file-protocol]
       end
 
       def provided_features

--- a/pre-docs/bolt_configuration_options.md
+++ b/pre-docs/bolt_configuration_options.md
@@ -72,6 +72,8 @@ ssh:
 
 `password`: Login password. Required.
 
+`file-protocol`: Which file transfer protocol to use. Either `winrm` or `smb`. Using `smb` is recommended for large file transfers. Default is `winrm`.
+
 ## PCP transport configuration options
 
 `service-url`: The URL of the orchestrator API.

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -52,7 +52,7 @@ describe Bolt::Applicator do
           transport: "ssh",
           transports: {
             ssh: { 'connect-timeout' => 10, "host-key-check" => true, tty: false },
-            winrm: { 'connect-timeout' => 10, ssl: true, "ssl-verify" => true },
+            winrm: { 'connect-timeout' => 10, ssl: true, "ssl-verify" => true, "file-protocol" => "winrm" },
             pcp: {
               "task-environment" => "production"
             },

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -573,7 +573,8 @@ describe Bolt::Inventory do
           'extensions' => ".py",
           'password' => 'youwinrm',
           'port' => '12345winrm',
-          'user' => 'mewinrm'
+          'user' => 'mewinrm',
+          'file-protocol' => 'winrm'
         )
       end
 


### PR DESCRIPTION
WinRM sucks for file transfer because it base64 encodes the payload,
compresses it as a zip file, transfers the contents via Powershell in
SOAP/XML messages, and decompresses on the remote side.

This commit allows bolt to upload files using SMB using the Rapid7 gem.
If anyone understands SMB, it's Rapid7/metasploit. The WinRM connection
lazily generates an SMBClient if a file is uploaded. The connection
will only login once, but connect to and disconnect from the share for
each uploaded file.

Before this commit transferring a 75MB jre takes 58.7 seconds to a local
Windows VM. With this commit it takes 6.2 seconds.

By default, WinRM connections continue to use WinRM for file transfers.
To enable SMB, add the following to the inventory file:

    winrm:
      file-protocol: smb

When uploading a file, the destination path should be specified as
either a drive letter or UNC path. If a drive letter is given, then bolt
will use the administrative share, usually `\\<host>\C$`. Note this
requires administrative privileges. To upload a file as a non-admin
user, enter the share as a UNC path. If bolt is running on a Windows
host:

    PS C:\> bolt file upload C:\path\to\file \\host\share\path\to\filebolt file upload C:\path\to\file \\host\share\path\to\file

If bolt is running on a non-Windows host, backslashes in the destination
path need to be escaped:

    $ bolt file upload /path/to/file \\\\host\\share\\path\\to\\file

Or forward slashes can be used (for drive letter or UNC paths):

    $ bolt file upload /path/to/file C:/path/to/file