### PR TITLE
(BOLT-1107) Use internal orchestrator API for running plan tasks

### DIFF
--- a/spec/plan_executor/app_spec.rb
+++ b/spec/plan_executor/app_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 require 'bolt_spec/conn'
 require 'plan_executor/app'
+require 'plan_executor/config'
 require 'json'
 require 'rack/test'
 
@@ -24,9 +25,12 @@ describe "PlanExecutor::App" do
 
   def app
     moduledir = File.join(__dir__, '..', 'fixtures', 'plan_executor')
+    ssldir = File.join(__dir__, '..', 'fixtures', 'ssl')
     config = PlanExecutor::Config.new('modulepath' => moduledir,
                                       'orchestrator-url' => 'abcde.com',
-                                      'ssl-ca-cert' => '/path/to/cert')
+                                      'ssl-cert' => File.join(ssldir, 'cert.pem'),
+                                      'ssl-key' => File.join(ssldir, 'key.pem'),
+                                      'ssl-ca-cert' => File.join(ssldir, 'ca.pem'))
     PlanExecutor::App.new(config)
   end
 

--- a/spec/plan_executor/orch_client_spec.rb
+++ b/spec/plan_executor/orch_client_spec.rb
@@ -14,62 +14,71 @@ describe PlanExecutor::OrchClient do
        'state' => 'finished',
        'result' => { '_output' => 'ok' } }]
   end
-  let(:mock_client) { instance_double("OrchestratorClient", run_task: results) }
-  let(:mock_command_api) { instance_double("OrchestratorClient::Client") }
+  let(:http_client) { double('http_client') }
   let(:mock_logger) { instance_double("Logging.logger") }
   let(:mtask) { mock_task('foo', 'foo/tasks/init', 'input') }
-  let(:api) { PlanExecutor::OrchClient.new('23', mock_client, mock_logger) }
+  let(:subject) { PlanExecutor::OrchClient.new('23', http_client, mock_logger) }
 
   let(:targets) do
     [Bolt::Target.new('pcp://node1').update_conf(Bolt::Config.default.transport_conf),
      Bolt::Target.new('node2').update_conf(Bolt::Config.default.transport_conf)]
   end
 
-  before(:each) do
-    allow(OrchestratorClient).to receive(:new).and_return(mock_client)
-    allow(mock_client).to receive(:config)
-      .and_return('service-url' => 'myorch.com')
-    # TODO: How do I avoid this?
-    allow(mock_logger).to receive(:debug)
+  def response(body, status = 200)
+    double('response', status: status, body: body)
   end
 
   describe '#send_request' do
+    let(:job_id) { 'https://example.com/orchestrator/v1/jobs/5' }
+    let(:job_nodes_id) { "#{job_id}/nodes" }
+    let(:job_created) { { 'job' => { 'id' => job_id } } }
+    let(:job_running) { { 'state' => 'running', 'nodes' => { 'id' => job_nodes_id } } }
+    let(:job_finished) { { 'state' => 'finished', 'nodes' => { 'id' => job_nodes_id } } }
+    let(:job_nodes) { { 'items' => results } }
+
     it "sends correct request" do
-      expect(mock_client).to receive(:run_task)
-        .with(hash_including(task: 'foo',
+      allow(http_client).to receive(:get).with(job_id).and_return(response(job_finished))
+      allow(http_client).to receive(:get).with(job_nodes_id).and_return(response(job_nodes))
+
+      expect(http_client).to receive(:post)
+        .with('internal/plan_task',
+              hash_including(task: 'foo',
                              scope: { nodes: targets.map(&:host) },
                              plan_job: '23'))
-      api.send_request(targets, mtask, {})
+        .and_return(response(job_created, 202))
+
+      subject.send_request(targets, mtask, {})
+    end
+
+    it "polls until the job finishes" do
+      allow(subject).to receive(:sleep)
+
+      expect(http_client).to receive(:post)
+        .with('internal/plan_task', anything)
+        .and_return(response(job_created, 202)).ordered
+      expect(http_client).to receive(:get).with(job_id).and_return(response(job_running)).ordered
+      expect(http_client).to receive(:get).with(job_id).and_return(response(job_running)).ordered
+      expect(http_client).to receive(:get).with(job_id).and_return(response(job_running)).ordered
+      expect(http_client).to receive(:get).with(job_id).and_return(response(job_finished)).ordered
+      expect(http_client).to receive(:get).with(job_nodes_id).and_return(response(job_nodes)).ordered
+
+      expect(subject.send_request(targets, mtask, {})).to eq(results)
+    end
+
+    it "fails if the job can't be started" do
+      allow(http_client).to receive(:post).and_return(response({ 'msg' => 'something went wrong' }, 400))
+
+      expect { subject.send_request(targets, mtask, {}) }.to raise_error(Bolt::Error, /something went wrong/)
     end
   end
 
   describe "#finish_plan" do
     it 'sends finish_plan to orchestrator' do
-      allow(mock_client).to receive(:command).and_return(mock_command_api)
+      expect(http_client).to receive(:post)
+        .with('internal/plan_finish', plan_job: '23', result: results, status: 'success')
+        .and_return(response({}, 202))
 
-      expect(mock_command_api).to receive(:plan_finish)
-        .with(plan_job: "23", result: results, status: 'success')
-
-      api.finish_plan(Bolt::PlanResult.new(results, 'success'))
-    end
-  end
-
-  describe "#run_task" do
-    let(:request) do
-      { task: 'foo',
-        environment: 'production',
-        noop: nil,
-        params: {},
-        plan_job: '23',
-        scope: {
-          nodes: targets.map(&:host)
-        } }
-    end
-    it 'runs a task' do
-      expect(mock_client).to receive(:run_task)
-        .with(request)
-
-      api.run_task(targets, mtask, {}, '')
+      expect(subject.finish_plan(Bolt::PlanResult.new(results, 'success'))).to eq({})
     end
   end
 end


### PR DESCRIPTION
Previously, the plan executor service used the public orchestrator API
to run plan tasks and submit plan results. This required it to follow
the same rules as a user running plans; specifically, it needed to
authenticated with an RBAC token and was only allowed to operate on
plans that were started by the same user for whom its RBAC token was
issued.

Now the service uses the internal API with certificate authentication to
connect as the API user and operate on plans with complete authority.
Because the public orchestrator-client library doesn't support features
we *need* like certificate authentication and the internal command API,
and it *does* have some automatic behavior around config loading that
we *don't* want, we now use a JSONClient (from the httpclient library)
directly to talk to the orchestrator service from the plan executor
instead.

We now create the http client during app startup time and pass it
through when creating an executor / orch client. That simplifies mocking
the http client in tests and also ensures that if we were to run
multiple plans at once, they would share a single http client.