### PR TITLE
(BOLT-1118) Add command to show available modules

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
                        Dir['libexec/*'] +
                        Dir['bolt-modules/*/lib/**/*.rb'] +
                        Dir['bolt-modules/*/types/**/*.pp'] +
+                       Dir['modules/*/metadata.json'] +
                        Dir['modules/*/files/**/*'] +
                        Dir['modules/*/lib/**/*.rb'] +
                        Dir['modules/*/locales/**/*'] +

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -32,6 +32,7 @@ Available subcommands:
   bolt plan run <plan> [params]    Run a Puppet task plan
   bolt apply <manifest>            Apply Puppet manifest code
   bolt puppetfile install          Install modules from a Puppetfile into a Boltdir
+  bolt puppetfile show-modules     List modules available to Bolt
 
 Run `bolt <subcommand> --help` to view specific examples.
 
@@ -101,6 +102,7 @@ Usage: bolt puppetfile <action> [options]
 
 Available actions are:
   install                          Install modules from a Puppetfile into a Boltdir
+  show-modules                     List modules available to Bolt
 
 Install modules into the local Boltdir
   bolt puppetfile install

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -30,7 +30,7 @@ module Bolt
                  'task' => %w[show run],
                  'plan' => %w[show run],
                  'file' => %w[upload],
-                 'puppetfile' => %w[install],
+                 'puppetfile' => %w[install show-modules],
                  'apply' => %w[] }.freeze
 
     attr_reader :config, :options
@@ -259,6 +259,9 @@ module Bolt
           end
         end
         return 0
+      elsif options[:action] == 'show-modules'
+        list_modules
+        return 0
       end
 
       message = 'There may be processes left executing on some nodes.'
@@ -398,6 +401,10 @@ module Bolt
       outputter.print_apply_result(results)
 
       results.ok ? 0 : 1
+    end
+
+    def list_modules
+      outputter.print_module_list(pal.list_modules)
     end
 
     def install_puppetfile(puppetfile, modulepath)

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -203,7 +203,12 @@ module Bolt
             @stream.puts('(no modules installed)')
           else
             module_info = modules.map do |m|
-              version = m[:version] || '???'
+              version = if m[:version].nil?
+                          m[:internal_module_group].nil? ? '(no metadata)' : '(built-in)'
+                        else
+                          m[:version]
+                        end
+
               [m[:name], version]
             end
 

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -191,6 +191,27 @@ module Bolt
                         "details and parameters for a specific plan.")
       end
 
+      def print_module_list(module_list)
+        module_list.each do |path, modules|
+          @stream.write(path)
+
+          if modules.empty?
+            @stream.write(" (no modules installed)\n")
+          else
+            @stream.write("\n")
+
+            module_info = modules.map do |m|
+              version = m[:version] || '???'
+              [m[:name], version]
+            end
+
+            print_table(module_info)
+          end
+
+          @stream.write("\n")
+        end
+      end
+
       # @param [Bolt::ResultSet] apply_result A ResultSet object representing the result of a `bolt apply`
       def print_apply_result(apply_result)
         apply_result.each { |result| print_result(result) }

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -193,13 +193,15 @@ module Bolt
 
       def print_module_list(module_list)
         module_list.each do |path, modules|
-          @stream.write(path)
+          if (mod = modules.find { |m| m[:internal_module_group] })
+            @stream.puts(mod[:internal_module_group])
+          else
+            @stream.puts(path)
+          end
 
           if modules.empty?
-            @stream.write(" (no modules installed)\n")
+            @stream.puts('(no modules installed)')
           else
-            @stream.write("\n")
-
             module_info = modules.map do |m|
               version = m[:version] || '???'
               [m[:name], version]

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -42,6 +42,7 @@ module Bolt
       def print_table(results)
         @stream.puts results.to_json
       end
+      alias print_module_list print_table
 
       def print_task_info(task)
         path = task['files'][0]['path'].chomp("/tasks/#{task['files'][0]['name']}")

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -286,17 +286,27 @@ module Bolt
 
     # Returns a mapping of all modules available to the Bolt compiler
     #
-    # @return [Hash{String => Array<Hash{Symbol => String,nil}>}] A hash that
-    #   associates each directory on the module path with an array containing
-    #   a hash of information for each module in that directory. Currently,
-    #   the name and version of each module is returned.
+    # @return [Hash{String => Array<Hash{Symbol => String,nil}>}]
+    #   A hash that associates each directory on the module path with an array
+    #   containing a hash of information for each module in that directory.
+    #   The information hash provides the name, version, and a string
+    #   indicating whether the module belongs to an internal module group.
     def list_modules
+      internal_module_groups = { BOLTLIB_PATH => 'Plan Language Modules',
+                                 MODULES_PATH => 'Packaged Modules' }
+
       in_bolt_compiler do
         # NOTE: Can replace map+to_h with transform_values when Ruby 2.4
         #       is the minimum supported version.
         Puppet.lookup(:current_environment).modules_by_path.map do |path, modules|
+          module_group = internal_module_groups[path]
+
           values = modules.map do |mod|
-            { name: (mod.forge_name || mod.name), version: mod.version }
+            mod_info = { name: (mod.forge_name || mod.name),
+                         version: mod.version }
+            mod_info[:internal_module_group] = module_group unless module_group.nil?
+
+            mod_info
           end
 
           [path, values]

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -284,6 +284,26 @@ module Bolt
       plan_info
     end
 
+    # Returns a mapping of all modules available to the Bolt compiler
+    #
+    # @return [Hash{String => Array<Hash{Symbol => String,nil}>}] A hash that
+    #   associates each directory on the module path with an array containing
+    #   a hash of information for each module in that directory. Currently,
+    #   the name and version of each module is returned.
+    def list_modules
+      in_bolt_compiler do
+        # NOTE: Can replace map+to_h with transform_values when Ruby 2.4
+        #       is the minimum supported version.
+        Puppet.lookup(:current_environment).modules_by_path.map do |path, modules|
+          values = modules.map do |mod|
+            { name: (mod.forge_name || mod.name), version: mod.version }
+          end
+
+          [path, values]
+        end.to_h
+      end
+    end
+
     def run_task(task_name, targets, params, executor, inventory, description = nil, &eventblock)
       in_task_compiler(executor, inventory) do |compiler|
         params = params.merge('_bolt_api_call' => true)


### PR DESCRIPTION
This commit adds a `bolt module show` command that lists out each module path
in the Bolt environment, followed by the modules available and their versions
in a manner similar to `puppet module list`.