### PR TITLE
(FM-7732) Track master branch of puppet_agent for update

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -7,7 +7,9 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '0.5.0'
 mod 'puppetlabs-facts', '0.5.0'
-mod 'puppetlabs-puppet_agent', '2.0.1'
+mod 'puppet_agent',
+    git: 'https://github.com/puppetlabs/puppetlabs-puppet_agent',
+    ref: '8b56966233536a4829d1ff533b720fe1bc1145b8'
 
 # Core types and providers for Puppet 6
 mod 'puppetlabs-augeas_core', '1.0.3'

--- a/acceptance/setup/common/pre-suite/071_install_modules.rb
+++ b/acceptance/setup/common/pre-suite/071_install_modules.rb
@@ -9,7 +9,9 @@ test_name "Install modules" do
   create_remote_file(bolt, "#{default_boltdir}/Puppetfile", <<-PUPPETFILE)
 mod 'puppetlabs-facts', '0.5.0'
 mod 'puppetlabs-service', '0.5.0'
-mod 'puppetlabs-puppet_agent', '2.0.1'
+mod 'puppet_agent',
+    git: 'https://github.com/puppetlabs/puppetlabs-puppet_agent',
+    ref: '8b56966233536a4829d1ff533b720fe1bc1145b8'
 PUPPETFILE
 
   bolt_command_on(bolt, 'bolt puppetfile install')


### PR DESCRIPTION
We would like to ship bolt with the update described in FM-7732. When the next release goes out has that update we will switch back to downloading from forge release.