### PR TITLE
(BOLT-146) Add configuration option to set task interpreter

### DIFF
--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -38,30 +38,6 @@ module Bolt
                            private-key tty tmpdir user connect-timeout
                            cacert token-file service-url interpreters].freeze
 
-    # TODO: move these to the transport themselves
-    TRANSPORT_SPECIFIC_DEFAULTS = {
-      ssh: {
-        'connect-timeout' => 10,
-        'host-key-check' => true,
-        'tty' => false
-      },
-      winrm: {
-        'connect-timeout' => 10,
-        'ssl' => true,
-        'ssl-verify' => true
-      },
-      pcp: {
-        'task-environment' => 'production'
-      },
-      local: {
-        'interpreters' => { 'rb' => RbConfig.ruby }
-      },
-      docker: {},
-      remote: {
-        'run-on' => 'localhost'
-      }
-    }.freeze
-
     def self.default
       new(Bolt::Boltdir.new('.'), {})
     end
@@ -93,8 +69,9 @@ module Bolt
       @log = { 'console' => {} }
 
       @transports = {}
-      TRANSPORTS.each_key do |transport|
-        @transports[transport] = TRANSPORT_SPECIFIC_DEFAULTS[transport].dup
+
+      TRANSPORTS.each do |key, transport|
+        @transports[key] = transport.default_options
       end
 
       update_from_file(config_data)

--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -87,6 +87,10 @@ module Bolt
         impl
       end
 
+      def select_interpreter(executable, interpreters)
+        interpreters[Pathname(executable).extname] if interpreters
+      end
+
       def reject_transport_options(target, options)
         if target.options['run-as']
           options.reject { |k, _v| k == '_run_as' }

--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -48,6 +48,10 @@ module Bolt
               "self.options() or self.filter_options(unfiltered) must be implemented by the transport class"
       end
 
+      def self.default_options
+        {}
+      end
+
       def self.filter_options(unfiltered)
         unfiltered.select { |k| options.include?(k) }
       end

--- a/lib/bolt/transport/docker.rb
+++ b/lib/bolt/transport/docker.rb
@@ -8,7 +8,7 @@ module Bolt
   module Transport
     class Docker < Base
       def self.options
-        %w[service-url service-options tmpdir]
+        %w[service-url service-options tmpdir interpreters]
       end
 
       def provided_features
@@ -87,7 +87,7 @@ module Bolt
         arguments = unwrap_sensitive_args(arguments)
         with_connection(target) do |conn|
           execute_options = {}
-
+          execute_options[:interpreter] = select_interpreter(executable, target.options['interpreters'])
           conn.with_remote_tempdir do |dir|
             if extra_files.empty?
               task_dir = dir
@@ -112,7 +112,7 @@ module Bolt
             end
 
             stdout, stderr, exitcode = conn.execute(remote_task_path, execute_options)
-            Bolt::Result.for_task(target, stdout.join, stderr.join, exitcode)
+            Bolt::Result.for_task(target, stdout.join, stderr.join.force_encoding("UTF-8"), exitcode)
           end
         end
       end

--- a/lib/bolt/transport/docker.rb
+++ b/lib/bolt/transport/docker.rb
@@ -48,7 +48,7 @@ module Bolt
 
             _, stderr, exitcode = conn.execute('mv', tmpfile, destination, {})
             if exitcode != 0
-              message = "Could not move temporary file '#{tmpfile}' to #{destination}: #{stderr.join}"
+              message = "Could not move temporary file '#{tmpfile}' to #{destination}: #{stderr}"
               raise Bolt::Node::FileError.new(message, 'MV_ERROR')
             end
           end
@@ -59,7 +59,7 @@ module Bolt
       def run_command(target, command, _options = {})
         with_connection(target) do |conn|
           stdout, stderr, exitcode = conn.execute(*Shellwords.split(command), {})
-          Bolt::Result.for_command(target, stdout.join, stderr.join, exitcode)
+          Bolt::Result.for_command(target, stdout, stderr, exitcode)
         end
       end
 
@@ -71,7 +71,7 @@ module Bolt
           conn.with_remote_tempdir do |dir|
             remote_path = conn.write_remote_executable(dir, script)
             stdout, stderr, exitcode = conn.execute(remote_path, *arguments, {})
-            Bolt::Result.for_command(target, stdout.join, stderr.join, exitcode)
+            Bolt::Result.for_command(target, stdout, stderr, exitcode)
           end
         end
       end
@@ -112,7 +112,7 @@ module Bolt
             end
 
             stdout, stderr, exitcode = conn.execute(remote_task_path, execute_options)
-            Bolt::Result.for_task(target, stdout.join, stderr.join.force_encoding("UTF-8"), exitcode)
+            Bolt::Result.for_task(target, stdout, stderr, exitcode)
           end
         end
       end

--- a/lib/bolt/transport/docker/connection.rb
+++ b/lib/bolt/transport/docker/connection.rb
@@ -40,6 +40,8 @@ module Bolt
           else
             @logger.info { "Command failed with exit code #{result[2]}" }
           end
+          result[0] = result[0].join.force_encoding('UTF-8')
+          result[1] = result[1].join.force_encoding('UTF-8')
           result
         rescue StandardError
           @logger.debug { "Command aborted" }
@@ -63,7 +65,7 @@ module Bolt
         def mkdirs(dirs)
           _, stderr, exitcode = execute('mkdir', '-p', *dirs, {})
           if exitcode != 0
-            message = "Could not create directories: #{stderr.join}"
+            message = "Could not create directories: #{stderr}"
             raise Bolt::Node::FileError.new(message, 'MKDIR_ERROR')
           end
         end
@@ -74,7 +76,7 @@ module Bolt
 
           stdout, stderr, exitcode = execute('mkdir', '-m', '700', tmppath, {})
           if exitcode != 0
-            raise Bolt::Node::FileError.new("Could not make tempdir: #{stderr.join}", 'TEMPDIR_ERROR')
+            raise Bolt::Node::FileError.new("Could not make tempdir: #{stderr}", 'TEMPDIR_ERROR')
           end
           tmppath || stdout.first
         end
@@ -86,7 +88,7 @@ module Bolt
           if dir
             _, stderr, exitcode = execute('rm', '-rf', dir, {})
             if exitcode != 0
-              @logger.warn("Failed to clean up tempdir '#{dir}': #{stderr.join}")
+              @logger.warn("Failed to clean up tempdir '#{dir}': #{stderr}")
             end
           end
         end
@@ -102,7 +104,7 @@ module Bolt
         def make_executable(path)
           _, stderr, exitcode = execute('chmod', 'u+x', path, {})
           if exitcode != 0
-            message = "Could not make file '#{path}' executable: #{stderr.join}"
+            message = "Could not make file '#{path}' executable: #{stderr}"
             raise Bolt::Node::FileError.new(message, 'CHMOD_ERROR')
           end
         end

--- a/lib/bolt/transport/docker/connection.rb
+++ b/lib/bolt/transport/docker/connection.rb
@@ -27,6 +27,7 @@ module Bolt
         end
 
         def execute(*command, options)
+          command.unshift(options[:interpreter]) if options[:interpreter]
           if options[:environment]
             envs = options[:environment].map { |env, val| "#{env}=#{val}" }
             command = ['env'] + envs + command

--- a/lib/bolt/transport/local/shell.rb
+++ b/lib/bolt/transport/local/shell.rb
@@ -8,6 +8,7 @@ module Bolt
     class Local
       class Shell
         def execute(*command, options)
+          command.unshift(options[:interpreter]) if options[:interpreter]
           command = [options[:env]] + command if options[:env]
 
           if options[:stdin]

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -29,6 +29,10 @@ module Bolt
         %w[service-url cacert token-file task-environment]
       end
 
+      def self.default_options
+        { 'task-environment' => 'production' }
+      end
+
       def provided_features
         ['puppet-agent']
       end

--- a/lib/bolt/transport/remote.rb
+++ b/lib/bolt/transport/remote.rb
@@ -11,6 +11,10 @@ module Bolt
         unfiltered
       end
 
+      def self.default_options
+        { 'run-on' => 'localhost' }
+      end
+
       def self.validate(options)
         # This will fail when validating global config
         # unless options['device-type']

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -13,6 +13,14 @@ module Bolt
            connect-timeout tmpdir run-as tty run-as-command proxyjump interpreters]
       end
 
+      def self.default_options
+        {
+          'connect-timeout' => 10,
+          'host-key-check' => true,
+          'tty' => false
+        }
+      end
+
       def provided_features
         ['shell']
       end

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -10,7 +10,7 @@ module Bolt
     class SSH < Base
       def self.options
         %w[port user password sudo-password private-key host-key-check
-           connect-timeout tmpdir run-as tty run-as-command proxyjump]
+           connect-timeout tmpdir run-as tty run-as-command proxyjump interpreters]
       end
 
       def provided_features
@@ -169,6 +169,7 @@ module Bolt
               dir.chown(conn.run_as)
 
               execute_options[:sudoable] = true if conn.run_as
+              execute_options[:interpreter] = select_interpreter(executable, target.options['interpreters'])
               output = conn.execute(command, execute_options)
             end
             Bolt::Result.for_task(target, output.stdout.string,

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -227,6 +227,10 @@ module Bolt
           escalate = sudoable && run_as && @user != run_as
           use_sudo = escalate && @target.options['run-as-command'].nil?
 
+          if options[:interpreter]
+            command.is_a?(Array) ? command.unshift(options[:interpreter]) : [options[:interpreter], command]
+          end
+
           command_str = command.is_a?(String) ? command : Shellwords.shelljoin(command)
           if escalate
             if use_sudo

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -8,7 +8,7 @@ module Bolt
   module Transport
     class WinRM < Base
       def self.options
-        %w[port user password connect-timeout ssl ssl-verify tmpdir cacert extensions]
+        %w[port user password connect-timeout ssl ssl-verify tmpdir cacert extensions interpreters]
       end
 
       def provided_features
@@ -135,7 +135,13 @@ module Bolt
               if Powershell.powershell_file?(remote_task_path) && stdin.nil?
                 conn.execute(Powershell.run_ps_task(arguments, remote_task_path, input_method))
               else
-                path, args = *Powershell.process_from_extension(remote_task_path)
+                interpreter = select_interpreter(remote_task_path, target.options['interpreters'])
+                if interpreter
+                  path = interpreter
+                  args = [remote_task_path]
+                else
+                  path, args = *Powershell.process_from_extension(remote_task_path)
+                end
                 conn.execute_process(path, args, stdin)
               end
 

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -11,6 +11,14 @@ module Bolt
         %w[port user password connect-timeout ssl ssl-verify tmpdir cacert extensions interpreters]
       end
 
+      def self.default_options
+        {
+          'connect-timeout' => 10,
+          'ssl' => true,
+          'ssl-verify' => true
+        }
+      end
+
       def provided_features
         ['powershell']
       end

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -17,9 +17,9 @@ module Bolt
           default_port = target.options['ssl'] ? HTTPS_PORT : HTTP_PORT
           @port = @target.port || default_port
           @user = @target.user
-
-          # Accept a single entry or a list, ensure each is prefixed with '.'
+          # Build set of extensions from extensions config as well as interpreters
           extensions = [target.options['extensions'] || []].flatten.map { |ext| ext[0] != '.' ? '.' + ext : ext }
+          extensions += target.options['interpreters'].keys if target.options['interpreters']
           @extensions = DEFAULT_EXTENSIONS.to_set.merge(extensions)
 
           @logger = Logging.logger[@target.host]

--- a/pre-docs/bolt_configuration_options.md
+++ b/pre-docs/bolt_configuration_options.md
@@ -12,6 +12,9 @@ format: human
 ssh:
   host-key-check: false
   private-key: ~/.ssh/bolt_id
+  user: foo
+  interpreters:
+    rb: /home/foo/.rbenv/versions/2.5.1/bin/ruby
 ```
 
 ## Global configuration options
@@ -27,6 +30,14 @@ ssh:
 `color`: Whether to use colored output when printing messages to the console.
 
 `hiera-config`: Specify the path to your Hiera config. The default path for the Hiera config file is `hiera.yaml` inside the `Boltdir`.
+
+`interpreters`: A map of extension name to absolute path of an executable. This allows a user to override the shebang defined in a task executable. The extension can optionally be specified with the '.' character included ('.py' and 'py' will both map to a task executable `task.py`) and the extension sepcified is case sensitive. The transports that support interpreter configuration are `docker`, `local`, `ssh`, and `winrm`. The local transport will default to using the ruby interpreter that is running bolt.
+
+*Example Interpreter Configuration*
+```
+interpreters:
+  py: /usr/bin/python3
+```
 
 ## SSH transport configuration options
 
@@ -50,7 +61,7 @@ ssh:
 
 `sudo-password`: Password to use when changing users via `run-as`.
 
-`tmpdir`: The directory to upload and execute temporary files on the target.
+`tmpdir`: The directory to upload and execute temporary files on the target. 
 
 ## WinRM transport configuration options
 

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -49,14 +49,16 @@ describe Bolt::Applicator do
           target_features: {}
         },
         config: {
-          transport: "ssh",
+          transport: 'ssh',
           transports: {
-            ssh: { 'connect-timeout' => 10, "host-key-check" => true, tty: false },
-            winrm: { 'connect-timeout' => 10, ssl: true, "ssl-verify" => true },
+            ssh: { 'connect-timeout' => 10, 'host-key-check' => true, tty: false },
+            winrm: { 'connect-timeout' => 10, ssl: true, 'ssl-verify' => true },
             pcp: {
-              "task-environment" => "production"
+              'task-environment' => 'production'
             },
-            local: {},
+            local: {
+              'interpreters' => { '.rb' => RbConfig.ruby }
+            },
             docker: {},
             remote: { 'run-on': 'localhost' }
           }

--- a/spec/fixtures/modules/sample/tasks/bolt_ruby.json
+++ b/spec/fixtures/modules/sample/tasks/bolt_ruby.json
@@ -1,0 +1,9 @@
+{
+  "description": "Task with incompatable shebang to be overriden by interpreter config",
+  "parameters": {
+    "message": {
+      "description": "Test message",
+      "type": "Optional[String[1]]"
+    }
+  }
+}

--- a/spec/fixtures/modules/sample/tasks/bolt_ruby.rb
+++ b/spec/fixtures/modules/sample/tasks/bolt_ruby.rb
@@ -1,0 +1,7 @@
+#!/foo/ruby
+# frozen_string_literal: true
+
+require 'json'
+
+result = { 'env' => ENV['PT_message'], 'stdin' => JSON.parse(gets)['message'] }
+puts result.to_json

--- a/spec/fixtures/modules/sample/tasks/interpreter.json
+++ b/spec/fixtures/modules/sample/tasks/interpreter.json
@@ -1,0 +1,9 @@
+{
+  "description": "Task with incompatable shebang to be overriden by interpreter config",
+  "parameters": {
+    "message": {
+      "description": "Test message",
+      "type": "Optional[String[1]]"
+    }
+  }
+}

--- a/spec/fixtures/modules/sample/tasks/interpreter.py
+++ b/spec/fixtures/modules/sample/tasks/interpreter.py
@@ -1,0 +1,10 @@
+#!/foo/python
+
+import os
+import fileinput
+import json
+
+for line in fileinput.input():
+    input_data = json.loads(line)
+    if input_data['message']:
+    	print(json.dumps({'env': os.environ['PT_message'], 'stdin': input_data['message']}))

--- a/spec/integration/local_spec.rb
+++ b/spec/integration/local_spec.rb
@@ -16,6 +16,9 @@ describe "when running over the local transport" do
 
   context 'when using CLI options' do
     let(:echo) { "echo hi" }
+    let(:config_flags) {
+      %W[--nodes localhost --format json --modulepath #{modulepath}]
+    }
 
     it 'runs multiple commands' do
       result = run_nodes(%W[command run #{echo} --nodes #{uri} --format json])
@@ -25,6 +28,12 @@ describe "when running over the local transport" do
     it 'reports errors when command fails' do
       result = run_failed_nodes(%W[command run boop --nodes #{uri} --format json])
       expect(result[0]['_error']).to be
+    end
+
+    it 'runs a ruby task using bolt ruby', :reset_puppet_settings do
+      result = run_one_node(%w[task run sample::bolt_ruby message=somemessage] + config_flags)
+      expect(result['env']).to match(/somemessage/)
+      expect(result['stdin']).to match(/somemessage/)
     end
   end
 

--- a/spec/integration/winrm_spec.rb
+++ b/spec/integration/winrm_spec.rb
@@ -100,6 +100,23 @@ describe "when runnning over the winrm transport", winrm: true do
     }
     let(:uri) { (1..2).map { |i| "#{conn_uri('winrm')}?id=#{i}" }.join(',') }
     let(:config_flags) { %W[--nodes #{uri}] }
+    let(:single_target_conf) { %W[--nodes #{conn_uri('winrm')}] }
+    let(:interpreter_task) { 'sample::bolt_ruby' }
+    let(:interpreter_ext) do
+      { 'interpreters' => {
+        '.rb' => RbConfig.ruby
+      } }
+    end
+    let(:interpreter_no_ext) do
+      { 'interpreters' => {
+        'rb' => RbConfig.ruby
+      } }
+    end
+    let(:bad_interpreter) do
+      { 'interpreters' => {
+        'rb' => 'C:\dev\null'
+      } }
+    end
 
     it 'runs multiple commands' do
       with_tempfile_containing('conf', YAML.dump(config)) do |conf|
@@ -114,6 +131,36 @@ describe "when runnning over the winrm transport", winrm: true do
         results.each do |result|
           expect(result['_output'].strip).to match(/STDIN: {"messa/)
         end
+      end
+    end
+
+    it 'runs task with specified interpreter key rb', :reset_puppet_settings, windows: true do
+      winrm_conf = { 'winrm' => config['winrm'].merge(interpreter_no_ext) }
+      with_tempfile_containing('conf', YAML.dump(config.merge(winrm_conf))) do |conf|
+        result =
+          run_nodes(%W[task run #{interpreter_task} message=somemessage
+                       --configfile #{conf.path}] + config_flags)
+        expect(result.map { |r| r['env'].strip }).to eq(%w[somemessage somemessage])
+        expect(result.map { |r| r['stdin'].strip }).to eq(%w[somemessage somemessage])
+      end
+    end
+
+    it 'runs task with interpreter key .rb', :reset_puppet_settings, windows: true do
+      winrm_conf = { 'winrm' => config['winrm'].merge(interpreter_ext) }
+      with_tempfile_containing('conf', YAML.dump(config.merge(winrm_conf))) do |conf|
+        result = run_nodes(%W[task run #{interpreter_task} message=somemessage
+                              --configfile #{conf.path}] + config_flags)
+        expect(result.map { |r| r['env'].strip }).to eq(%w[somemessage somemessage])
+        expect(result.map { |r| r['stdin'].strip }).to eq(%w[somemessage somemessage])
+      end
+    end
+
+    it 'task fails with bad interpreter', :reset_puppet_settings, windows: true do
+      winrm_conf = { 'winrm' => config['winrm'].merge(bad_interpreter) }
+      with_tempfile_containing('conf', YAML.dump(config.merge(winrm_conf))) do |conf|
+        result = run_failed_node(%W[task run #{interpreter_task} message=somemessage
+                                    --configfile #{conf.path}] + single_target_conf)
+        expect(result['_error']['msg']).to match(/'C:\\dev\\null' is not recognized/)
       end
     end
   end


### PR DESCRIPTION
This commit adds a configuration option to the local transport to configure what interpreter to run a task with. If an interpreter is set for a task with a given extension then that will override the shebang in the task.