### PR TITLE
(BOLT-830) Send file basename to bolt_shim script task

### DIFF
--- a/lib/plan_executor/orch_client.rb
+++ b/lib/plan_executor/orch_client.rb
@@ -124,7 +124,8 @@ module PlanExecutor
       content = Base64.encode64(content)
       params = {
         'content' => content,
-        'arguments' => arguments
+        'arguments' => arguments,
+        'name' => Pathname(script).basename.to_s
       }
       callback ||= proc {}
       results = run_task_job(targets, BOLT_SCRIPT_TASK, params, options, &callback)


### PR DESCRIPTION
In order to support powershell tasks on windows targets the bolt_shim module expects the script basename to be included for the `script` task.