### PR TITLE
(BOLT-1057) Standardize BoltSpec::Run helper method signatures

### DIFF
--- a/lib/bolt_spec/run.rb
+++ b/lib/bolt_spec/run.rb
@@ -11,36 +11,35 @@ require 'bolt/util'
 # This is intended to provide a relatively stable method of executing bolt in process from tests.
 module BoltSpec
   module Run
-    def run_task(task_name, targets, params = nil, config: nil, inventory: nil)
+    def run_task(task_name, targets, params, config: nil, inventory: nil)
       result = BoltRunner.with_runner(config, inventory) do |runner|
-        runner.run_task(task_name, targets, params || {})
+        runner.run_task(task_name, targets, params)
       end
       result = result.to_a
       Bolt::Util.walk_keys(result, &:to_s)
     end
 
-    def run_plan(plan_name, params = nil, config: nil, inventory: nil)
+    def run_plan(plan_name, params, config: nil, inventory: nil)
       # Users copying code from run_task may forget that targets is not a parameter for run plan
-      params ||= {}
       raise ArgumentError, "params must be a hash" unless params.is_a?(Hash)
 
       result = BoltRunner.with_runner(config, inventory) do |runner|
-        runner.run_plan(plan_name, params || {})
+        runner.run_plan(plan_name, params)
       end
 
       { "status" => result.status,
         "value" => JSON.parse(result.value.to_json) }
     end
 
-    def run_command(command, targets, params = nil, config: nil, inventory: nil)
+    def run_command(command, targets, options: {}, config: nil, inventory: nil)
       result = BoltRunner.with_runner(config, inventory) do |runner|
-        runner.run_command(command, targets, params)
+        runner.run_command(command, targets, options)
       end
       result = result.to_a
       Bolt::Util.walk_keys(result, &:to_s)
     end
 
-    def run_script(script, targets, arguments = nil, options = {}, config: nil, inventory: nil)
+    def run_script(script, targets, arguments, options: {}, config: nil, inventory: nil)
       result = BoltRunner.with_runner(config, inventory) do |runner|
         runner.run_script(script, targets, arguments, options)
       end
@@ -116,13 +115,13 @@ module BoltSpec
         pal.run_plan(plan_name, params, executor, inventory, puppetdb_client)
       end
 
-      def run_command(command, targets, params = nil)
+      def run_command(command, targets, options)
         executor = Bolt::Executor.new(config.concurrency, @analytics)
         targets = inventory.get_targets(targets)
-        executor.run_command(targets, command, params || {})
+        executor.run_command(targets, command, options)
       end
 
-      def run_script(script, targets, arguments = nil, options = {})
+      def run_script(script, targets, arguments, options = {})
         executor = Bolt::Executor.new(config.concurrency, @analytics)
         targets = inventory.get_targets(targets)
         executor.run_script(targets, script, arguments, options)

--- a/spec/bolt_spec/run_spec.rb
+++ b/spec/bolt_spec/run_spec.rb
@@ -24,7 +24,7 @@ describe "BoltSpec::Run", ssh: true do
 
   describe 'run_task' do
     it 'should run a task on a node' do
-      result = run_task('sample::echo', 'ssh', options)
+      result = run_task('sample::echo', 'ssh', {}, options)
       expect(result[0]['status']).to eq('success')
     end
 
@@ -43,7 +43,7 @@ describe "BoltSpec::Run", ssh: true do
     end
 
     it 'should accept _catch_errors' do
-      result = run_command('echo hello', 'non_existent_node', { '_catch_errors' => true }, options)
+      result = run_command('echo hello', 'non_existent_node', options: { '_catch_errors' => true }, **options)
 
       expect(result[0]['status']).to eq('failure')
       expect(result[0]['result']['_error']['kind']).to eq('puppetlabs.tasks/connect-error')
@@ -60,7 +60,7 @@ describe "BoltSpec::Run", ssh: true do
     end
 
     it 'should accept _catch_errors' do
-      result = run_script('missing.sh', 'non_existent_node', nil, { '_catch_errors' => true }, options)
+      result = run_script('missing.sh', 'non_existent_node', nil, options: { '_catch_errors' => true }, **options)
 
       expect(result[0]['status']).to eq('failure')
       expect(result[0]['result']['_error']['kind']).to eq('puppetlabs.tasks/connect-error')
@@ -92,10 +92,10 @@ describe "BoltSpec::Run", ssh: true do
     end
 
     before(:all) do
-      result = run_task('puppet_agent::version', 'ssh', inventory: conn_inventory, config: root_config)
+      result = run_task('puppet_agent::version', 'ssh', {}, inventory: conn_inventory, config: root_config)
       expect(result.first['status']).to eq('success')
       unless result.first['result']['version']
-        result = run_task('puppet_agent::install', 'ssh', inventory: conn_inventory, config: root_config)
+        result = run_task('puppet_agent::install', 'ssh', {}, inventory: conn_inventory, config: root_config)
       end
       expect(result.first['status']).to eq('success')
     end

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -66,7 +66,7 @@ describe "apply" do
         expect(result.count).to eq(1)
         expect(result[0]).to include('status' => 'success')
 
-        result = run_task('puppet_agent::version', 'puppet_5', inventory: agent_version_inventory)
+        result = run_task('puppet_agent::version', 'puppet_5', {}, inventory: agent_version_inventory)
         expect(result.count).to eq(1)
         expect(result[0]).to include('status' => 'success')
         expect(result[0]['result']['version']).to match(/^5/)
@@ -77,7 +77,7 @@ describe "apply" do
         expect(result.count).to eq(1)
         expect(result[0]).to include('status' => 'success')
 
-        result = run_task('puppet_agent::version', 'puppet_6', inventory: agent_version_inventory)
+        result = run_task('puppet_agent::version', 'puppet_6', {}, inventory: agent_version_inventory)
         expect(result.count).to eq(1)
         expect(result[0]).to include('status' => 'success')
         expect(result[0]['result']['version']).to match(/^6/)
@@ -167,7 +167,7 @@ describe "apply" do
         uri = conn_uri('ssh')
         inventory_data = conn_inventory
         config_data = root_config
-        run_task('puppet_agent::install', uri, config: config_data, inventory: inventory_data)
+        run_task('puppet_agent::install', uri, {}, config: config_data, inventory: inventory_data)
       end
 
       context "apply() function" do
@@ -272,7 +272,7 @@ describe "apply" do
         expect(result.count).to eq(1)
         expect(result[0]).to include('status' => 'success')
 
-        result = run_task('puppet_agent::version', conn_uri('winrm'), config: config)
+        result = run_task('puppet_agent::version', conn_uri('winrm'), {}, config: config)
         expect(result.count).to eq(1)
         expect(result[0]).to include('status' => 'success')
         expect(result[0]['result']['version']).to match(/^5/)
@@ -318,7 +318,7 @@ describe "apply" do
         expect(result.count).to eq(1)
         expect(result[0]['status']).to eq('success')
 
-        result = run_task('puppet_agent::version', conn_uri('winrm'), config: config)
+        result = run_task('puppet_agent::version', conn_uri('winrm'), {}, config: config)
         expect(result.count).to eq(1)
         expect(result[0]).to include('status' => 'success')
         expect(result[0]['result']['version']).to match(/^6/)


### PR DESCRIPTION
Previously, these methods had confusing and inconsistent signatures
using a mix of optional parameters and keyword arguments. In some cases,
the optional parameters were themselves expects to be hashes, which
conflicted with the keyword arguments. That caused confusing behavior
when invoking the functions with only some arguments, as a hash intended
to be a positional argument could be interpreted as an _invalid_ keyword
arguments hash, or vice versa.

These functions now always require their `params` (or equivalent)
argument, leading to slightly more verbose but always clear
invocations. The functions which previously expected an options hash in
addition to their keyword arguments now expect the options hash to
be provided as a keyword argument named `options`.