### PR TITLE
(BOLT-1129) Add metadata.json files to bundled modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,12 @@ Gemfile.local
 
 acceptance/hosts.yaml
 
+## Generated metadata.json for internal modules
+bolt-modules/*/metadata.json
+modules/aggregate/metadata.json
+modules/canary/metadata.json
+modules/puppetdb_fact/metadata.json
+
 modules/apply
 modules/facts
 modules/package

--- a/bolt-modules/boltlib/metadata.erb
+++ b/bolt-modules/boltlib/metadata.erb
@@ -1,0 +1,12 @@
+{
+  "name": "puppetlabs-boltlib",
+  "version": "<%= bolt_version %>",
+  "author": "Puppet",
+  "summary": "Bolt Plan Language Module",
+  "license": "Apache-2.0",
+  "source": "https://github.com/puppetlabs/bolt",
+  "project_page": "https://puppet.com/docs/bolt/1.x/bolt.html",
+  "issues_url": "http://tickets.puppetlabs.com/browse/BOLT",
+  "dependencies": [
+  ]
+}

--- a/bolt-modules/ctrl/metadata.erb
+++ b/bolt-modules/ctrl/metadata.erb
@@ -1,0 +1,12 @@
+{
+  "name": "puppetlabs-ctrl",
+  "version": "<%= bolt_version %>",
+  "author": "Puppet",
+  "summary": "Bolt Plan Language Module",
+  "license": "Apache-2.0",
+  "source": "https://github.com/puppetlabs/bolt",
+  "project_page": "https://puppet.com/docs/bolt/1.x/bolt.html",
+  "issues_url": "http://tickets.puppetlabs.com/browse/BOLT",
+  "dependencies": [
+  ]
+}

--- a/bolt-modules/file/metadata.erb
+++ b/bolt-modules/file/metadata.erb
@@ -1,0 +1,12 @@
+{
+  "name": "puppetlabs-file",
+  "version": "<%= bolt_version %>",
+  "author": "Puppet",
+  "summary": "Bolt Plan Language Module",
+  "license": "Apache-2.0",
+  "source": "https://github.com/puppetlabs/bolt",
+  "project_page": "https://puppet.com/docs/bolt/1.x/bolt.html",
+  "issues_url": "http://tickets.puppetlabs.com/browse/BOLT",
+  "dependencies": [
+  ]
+}

--- a/bolt-modules/system/metadata.erb
+++ b/bolt-modules/system/metadata.erb
@@ -1,0 +1,12 @@
+{
+  "name": "puppetlabs-system",
+  "version": "<%= bolt_version %>",
+  "author": "Puppet",
+  "summary": "Bolt Plan Language Module",
+  "license": "Apache-2.0",
+  "source": "https://github.com/puppetlabs/bolt",
+  "project_page": "https://puppet.com/docs/bolt/1.x/bolt.html",
+  "issues_url": "http://tickets.puppetlabs.com/browse/BOLT",
+  "dependencies": [
+  ]
+}

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
                        Dir['lib/**/*.rb'] +
                        Dir['lib/**/*.json'] +
                        Dir['libexec/*'] +
+                       Dir['bolt-modules/*/metadata.json'] +
                        Dir['bolt-modules/*/lib/**/*.rb'] +
                        Dir['bolt-modules/*/types/**/*.pp'] +
                        Dir['modules/*/files/**/*'] +

--- a/modules/aggregate/metadata.erb
+++ b/modules/aggregate/metadata.erb
@@ -1,0 +1,12 @@
+{
+  "name": "puppetlabs-aggregate",
+  "version": "<%= bolt_version %>",
+  "author": "Puppet",
+  "summary": "Bolt Packaged Module",
+  "license": "Apache-2.0",
+  "source": "https://github.com/puppetlabs/bolt",
+  "project_page": "https://puppet.com/docs/bolt/1.x/bolt.html",
+  "issues_url": "http://tickets.puppetlabs.com/browse/BOLT",
+  "dependencies": [
+  ]
+}

--- a/modules/canary/metadata.erb
+++ b/modules/canary/metadata.erb
@@ -1,0 +1,12 @@
+{
+  "name": "puppetlabs-canary",
+  "version": "<%= bolt_version %>",
+  "author": "Puppet",
+  "summary": "Bolt Packaged Module",
+  "license": "Apache-2.0",
+  "source": "https://github.com/puppetlabs/bolt",
+  "project_page": "https://puppet.com/docs/bolt/1.x/bolt.html",
+  "issues_url": "http://tickets.puppetlabs.com/browse/BOLT",
+  "dependencies": [
+  ]
+}

--- a/modules/puppetdb_fact/metadata.erb
+++ b/modules/puppetdb_fact/metadata.erb
@@ -1,0 +1,12 @@
+{
+  "name": "puppetlabs-puppetdb_fact",
+  "version": "<%= bolt_version %>",
+  "author": "Puppet",
+  "summary": "Bolt Packaged Module",
+  "license": "Apache-2.0",
+  "source": "https://github.com/puppetlabs/bolt",
+  "project_page": "https://puppet.com/docs/bolt/1.x/bolt.html",
+  "issues_url": "http://tickets.puppetlabs.com/browse/BOLT",
+  "dependencies": [
+  ]
+}


### PR DESCRIPTION
This change set updates the Bolt gemspec to include `metadata.json` in gem packages. Templates for generating `metadata.json` files have been added to internal modules such as boltlib. The Rakefile has also been updated with logic for rendering these templates whenever they change, or the Bolt version number is updated. Template rendering has also been added as a dependency of the `rake build` task.