### PR TITLE
(BOLT-153) Windows SMB file transfer support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ To exclude tests that rely on Vagrant, run:
 
 Windows includes additional tests that require a full Windows Server VM to run; we run them in AppVeyor. If you need to run the tests locally set `APPVEYOR_AGENTS=true`, re-run `vagrant up` to create a `Windows Server 2016 Core` VM, and run tests with
 
-    $ BOLT_WINRM_PORT=35985 BOLT_WINRM_USER=vagrant BOLT_WINRM_PASSWORD=vagrant bundle exec rake integration:appveyor_agents
+    $ BOLT_WINRM_PORT=35985 BOLT_WINRM_SMB_PORT=3445 BOLT_WINRM_USER=vagrant BOLT_WINRM_PASSWORD=vagrant bundle exec rake integration:appveyor_agents
 
 ### `rubocop` on Windows
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,7 @@ windows_provision = <<SCRIPT
 ($user = New-LocalUser -Name bolt -Password (ConvertTo-SecureString -String bolt -Force -AsPlainText)) | Format-List
 # add the bolt user to the 'Remote Management Users' group
 Add-LocalGroupMember -Group 'Remote Management Users' -Member $user
+Add-LocalGroupMember -Group 'Administrators' -Member $user
 
 # import the certificate to be used for the winrm-ssl
 ($cert = Import-PfxCertificate -FilePath C:\\cert.pfx -CertStoreLocation cert:\\LocalMachine\\My -Password (ConvertTo-SecureString -String bolt -Force -AsPlainText)) | Format-List
@@ -39,6 +40,7 @@ Vagrant.configure('2') do |config|
     windows.vm.network :forwarded_port, guest: 22, host: 2222, id: 'ssh', disabled: true
     windows.vm.network :forwarded_port, guest: 5985, host: 25985, host_ip: '127.0.0.1', id: 'winrm'
     windows.vm.network :forwarded_port, guest: 5986, host: 25986, host_ip: '127.0.0.1', id: 'winrm-ssl'
+    windows.vm.network :forwarded_port, guest: 445, host: 2445, host_ip: '127.0.0.1', id: 'smb'
     windows.vm.provision 'file', source: 'resources/cert.pfx', destination: 'C:\cert.pfx'
     windows.vm.provision 'shell', privileged: true, inline: windows_provision
     windows.vm.provider 'virtualbox' do |vb|
@@ -52,6 +54,7 @@ Vagrant.configure('2') do |config|
       windows.vm.guest = :windows
       windows.vm.communicator = "winrm"
       windows.vm.network :forwarded_port, guest: 5985, host: 35985, host_ip: '127.0.0.1', id: 'winrm'
+      windows.vm.network :forwarded_port, guest: 445, host: 3445, host_ip: '127.0.0.1', id: 'smb'
       windows.vm.provision 'shell', privileged: true, inline: 'slmgr /rearm'
       windows.vm.provider "virtualbox" do |vb|
         vb.gui = false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ environment:
   BOLT_WINRM_HOST: localhost
   BOLT_WINRM_PORT: 5985
   BOLT_WINRM_SSL_PORT: 5986
+  BOLT_WINRM_SMB_PORT: 445
   RUBY_VERSION: 25
 
 install:
@@ -98,7 +99,7 @@ for:
           RUBY_VERSION: 23
         - configuration: Agentfull
           RUBY_VERSION: 24
-    
+
     environment:
       APPVEYOR_AGENTS: true
 

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "puppet", [">= 6.0.1", "< 7"]
   spec.add_dependency "puppet-resource_api"
   spec.add_dependency "r10k", "~> 2.6"
+  spec.add_dependency "ruby_smb", "~> 1.0"
   spec.add_dependency "terminal-table", "~> 1.8"
   spec.add_dependency "winrm", "~> 2.0"
   spec.add_dependency "winrm-fs", "~> 1.3"

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -36,7 +36,7 @@ module Bolt
 
     TRANSPORT_OPTIONS = %i[password run-as sudo-password extensions
                            private-key tty tmpdir user connect-timeout
-                           cacert token-file service-url interpreters].freeze
+                           cacert token-file service-url interpreters file-protocol].freeze
 
     def self.default
       new(Bolt::Boltdir.new('.'), {})

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -36,7 +36,7 @@ module Bolt
 
     TRANSPORT_OPTIONS = %i[password run-as sudo-password extensions
                            private-key tty tmpdir user connect-timeout
-                           cacert token-file service-url interpreters file-protocol].freeze
+                           cacert token-file service-url interpreters file-protocol smb-port].freeze
 
     def self.default
       new(Bolt::Boltdir.new('.'), {})

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -8,7 +8,10 @@ module Bolt
   module Transport
     class WinRM < Base
       def self.options
-        %w[port user password connect-timeout ssl ssl-verify tmpdir cacert extensions interpreters file-protocol]
+        %w[
+          port user password connect-timeout ssl ssl-verify tmpdir cacert
+          extensions interpreters file-protocol smb-port
+        ]
       end
 
       def self.default_options

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -8,14 +8,15 @@ module Bolt
   module Transport
     class WinRM < Base
       def self.options
-        %w[port user password connect-timeout ssl ssl-verify tmpdir cacert extensions interpreters]
+        %w[port user password connect-timeout ssl ssl-verify tmpdir cacert extensions interpreters file-protocol]
       end
 
       def self.default_options
         {
           'connect-timeout' => 10,
           'ssl' => true,
-          'ssl-verify' => true
+          'ssl-verify' => true,
+          'file-protocol' => 'winrm'
         }
       end
 
@@ -32,6 +33,10 @@ module Bolt
         ssl_flag = options['ssl']
         unless !!ssl_flag == ssl_flag
           raise Bolt::ValidationError, 'ssl option must be a Boolean true or false'
+        end
+
+        if ssl_flag && (options['file-protocol'] == 'smb')
+          raise Bolt::ValidationError, 'SMB file transfers are not allowed with SSL enabled'
         end
 
         ssl_verify_flag = options['ssl-verify']

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -266,7 +266,7 @@ module Bolt
           # It's lame that TCPSocket doesn't take a connect timeout
           # Using Timeout.timeout is bad, but is done elsewhere...
           Timeout.timeout(target.options['connect-timeout']) do
-            TCPSocket.new(target.host, SMB_PORT)
+            TCPSocket.new(target.host, target.options['smb-port'] || SMB_PORT)
           end
         rescue Errno::ECONNREFUSED => e
           # handle this to prevent obscuring error message as SMB problem

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -2,6 +2,7 @@
 
 require 'bolt/node/errors'
 require 'bolt/node/output'
+require 'ruby_smb'
 
 module Bolt
   module Transport
@@ -93,6 +94,7 @@ module Bolt
 
         def disconnect
           @session&.close
+          @client&.disconnect!
           @logger.debug { "Closed session" }
         end
 
@@ -141,8 +143,55 @@ module Bolt
         end
 
         def write_remote_file(source, destination)
+          if target.options['file-protocol'] == 'smb'
+            write_remote_file_smb(source, destination)
+          else
+            write_remote_file_winrm(source, destination)
+          end
+        end
+
+        def write_remote_file_winrm(source, destination)
           fs = ::WinRM::FS::FileManager.new(@connection)
           fs.upload(source, destination)
+        rescue StandardError => e
+          raise Bolt::Node::FileError.new(e.message, 'WRITE_ERROR')
+        end
+
+        def write_remote_file_smb(source, destination)
+          win_dest = destination.tr('/', '\\')
+          if (md = win_dest.match(/^([a-z]):\\(.*)/i))
+            # if drive, use admin share for that drive, so path is '\\host\C$'
+            path = "\\\\#{@target.host}\\#{md[1]}$"
+            dest = md[2]
+          elsif (md = win_dest.match(/^(\\\\[^\\]+\\[^\\]+)\\(.*)/))
+            # if unc, path is '\\host\share'
+            path = md[1]
+            dest = md[2]
+          else
+            raise ArgumentError, "Unknown destination '#{destination}'"
+          end
+
+          client = smb_client_login
+          tree = client.tree_connect(path)
+          begin
+            file = tree.open_file(filename: dest, write: true, disposition: ::RubySMB::Dispositions::FILE_OVERWRITE_IF)
+            begin
+              # `file` doesn't derive from IO, so can't use IO.copy_stream
+              File.open(source, 'rb') do |f|
+                pos = 0
+                while (buf = f.read(8 * 1024 * 1024))
+                  file.write(data: buf, offset: pos)
+                  pos += buf.length
+                end
+              end
+            ensure
+              file.close
+            end
+          ensure
+            tree.disconnect!
+          end
+        rescue ::RubySMB::Error::UnexpectedStatusCode => e
+          raise Bolt::Node::FileError.new("SMB Error: #{e.message}", 'WRITE_ERROR')
         rescue StandardError => e
           raise Bolt::Node::FileError.new(e.message, 'WRITE_ERROR')
         end
@@ -183,6 +232,53 @@ module Bolt
           remote_path = "#{dir}\\#{filename}"
           write_remote_file(content, remote_path)
           remote_path
+        end
+
+        private
+
+        def smb_client_login
+          return @client if @client
+
+          dispatcher = RubySMB::Dispatcher::Socket.new(smb_socket_connect)
+          @client = RubySMB::Client.new(dispatcher, smb1: false, smb2: true, username: @user, password: target.password)
+          status = @client.login
+          case status
+          when WindowsError::NTStatus::STATUS_SUCCESS
+            @logger.debug { "Connected to #{@client.dns_host_name}" }
+          when WindowsError::NTStatus::STATUS_LOGON_FAILURE
+            raise Bolt::Node::ConnectError.new(
+              "SMB authentication failed for #{target.host}",
+              'AUTH_ERROR'
+            )
+          else
+            raise Bolt::Node::ConnectError.new(
+              "Failed to connect to #{target.host} using SMB: #{status.description}",
+              'CONNECT_ERROR'
+            )
+          end
+
+          @client
+        end
+
+        SMB_PORT = 445
+
+        def smb_socket_connect
+          # It's lame that TCPSocket doesn't take a connect timeout
+          # Using Timeout.timeout is bad, but is done elsewhere...
+          Timeout.timeout(target.options['connect-timeout']) do
+            TCPSocket.new(target.host, SMB_PORT)
+          end
+        rescue Errno::ECONNREFUSED => e
+          # handle this to prevent obscuring error message as SMB problem
+          raise Bolt::Node::ConnectError.new(
+            "Failed to connect to #{target.host} using SMB: #{e.message}",
+            'CONNECT_ERROR'
+          )
+        rescue Timeout::Error
+          raise Bolt::Node::ConnectError.new(
+            "Timeout after #{target.options['connect-timeout']} seconds connecting to #{target.host}",
+            'CONNECT_ERROR'
+          )
         end
       end
     end

--- a/pre-docs/bolt_configuration_options.md
+++ b/pre-docs/bolt_configuration_options.md
@@ -89,6 +89,8 @@ interpreters:
 
 *The smb file-protocol is experimental and is currently unsupported in conjunction with SSL given only SMB2 is currently implemented*
 
+`smb-port`: With `file-protocol` set to `smb`, this is the port to establish a connection on. Default is `445`.
+
 ## PCP transport configuration options
 
 `service-url`: The URL of the orchestrator API.

--- a/pre-docs/bolt_configuration_options.md
+++ b/pre-docs/bolt_configuration_options.md
@@ -85,6 +85,10 @@ interpreters:
 
 `password`: Login password. Required.
 
+`file-protocol`: Which file transfer protocol to use. Either `winrm` or `smb`. Using `smb` is recommended for large file transfers. Default is `winrm`.
+
+*The smb file-protocol is experimental and is currently unsupported in conjunction with SSL given only SMB2 is currently implemented*
+
 ## PCP transport configuration options
 
 `service-url`: The URL of the orchestrator API.

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -52,7 +52,7 @@ describe Bolt::Applicator do
           transport: 'ssh',
           transports: {
             ssh: { 'connect-timeout' => 10, 'host-key-check' => true, tty: false },
-            winrm: { 'connect-timeout' => 10, ssl: true, 'ssl-verify' => true },
+            winrm: { 'connect-timeout' => 10, ssl: true, 'ssl-verify' => true, 'file-protocol' => 'winrm' },
             pcp: {
               'task-environment' => 'production'
             },

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -573,7 +573,8 @@ describe Bolt::Inventory do
           'extensions' => ".py",
           'password' => 'youwinrm',
           'port' => '12345winrm',
-          'user' => 'mewinrm'
+          'user' => 'mewinrm',
+          'file-protocol' => 'winrm'
         )
       end
 

--- a/spec/bolt/transport/winrm_spec.rb
+++ b/spec/bolt/transport/winrm_spec.rb
@@ -31,6 +31,7 @@ describe Bolt::Transport::WinRM do
   let(:host) { conn_info('winrm')[:host] }
   let(:port) { conn_info('winrm')[:port] }
   let(:ssl_port) { ENV['BOLT_WINRM_SSL_PORT'] || 25986 }
+  let(:smb_port) { ENV['BOLT_WINRM_SMB_PORT'] || 2445 }
   let(:user) { conn_info('winrm')[:user] }
   let(:password) { conn_info('winrm')[:password] }
   let(:command) { "echo $env:UserName" }
@@ -232,7 +233,7 @@ PS
 
     %w[winrm smb].each do |protocol|
       it "can upload a file to a host using #{protocol}", winrm: true do
-        conf = mk_config(ssl: false, user: user, password: password, 'file-protocol': protocol)
+        conf = mk_config(ssl: false, user: user, password: password, 'file-protocol': protocol, 'smb-port': smb_port)
         target = make_target(conf: conf)
         contents = SecureRandom.uuid
         remote_path = "C:\\Windows\\Temp\\upload-test-#{protocol}"
@@ -256,7 +257,7 @@ PS
     # test should be refactored to supply an SSL flag for winrm + smb and remove other SSL test
     it "will fail to upload a file with SMB with a host that requires SSL", winrm: true do
       expect {
-        mk_config(ssl: true, user: user, password: password, 'file-protocol': 'smb')
+        mk_config(ssl: true, user: user, password: password, 'file-protocol': 'smb', 'smb-port': smb_port)
       }.to raise_error(Bolt::ValidationError)
     end
 


### PR DESCRIPTION
Updated version of #856 - adds / addresses a small number of new things

- Fixes `Vagrantfile` to port forward 445 to 2445 of host (else there is no way to test locally)
- Errors when SSL is specified in conjunction with SMB (as encryption is not yet available)
- Removes SMB1 support
- Uses `WindowsError::NTStatus` status objects rather than embedding Win32 error codes
- Improves error handling / messages when SMB port gets a connection refused error
- Adds smb-port configuration option (defaults to port 445)
- Adds tests against SMB transfers
- Adds recursive directory copy over SMB

From original PR courtesy @joshcooper:

WinRM sucks for file transfer because it base64 encodes the payload,
compresses it as a zip file, transfers the contents via Powershell in
SOAP/XML messages, and decompresses on the remote side.

This commit allows bolt to upload files using SMB using the Rapid7 gem.
If anyone understands SMB, it's Rapid7/metasploit. The WinRM connection
lazily generates an SMBClient if a file is uploaded. The connection
will only login once, but connect to and disconnect from the share for
each uploaded file.

Before this commit transferring a 75MB jre takes 58.7 seconds to a local
Windows VM. With this commit it takes 6.2 seconds.

By default, WinRM connections continue to use WinRM for file transfers.
To enable SMB, add the following to the inventory file:

    winrm:
      file-protocol: smb

When uploading a file, the destination path should be specified as
either a drive letter or UNC path. If a drive letter is given, then bolt
will use the administrative share, usually `\\<host>\C$`. Note this
requires administrative privileges. To upload a file as a non-admin
user, enter the share as a UNC path. If bolt is running on a Windows
host:

    PS C:\> bolt file upload C:\path\to\file \\host\share\path\to\filebolt file upload C:\path\to\file \\host\share\path\to\file

If bolt is running on a non-Windows host, backslashes in the destination
path need to be escaped:

    $ bolt file upload /path/to/file \\\\host\\share\\path\\to\\file

Or forward slashes can be used (for drive letter or UNC paths):

    $ bolt file upload /path/to/file C:/path/to/file