### PR TITLE
(BOLT-1108) Add site-modules to modulepath

### DIFF
--- a/lib/bolt/boltdir.rb
+++ b/lib/bolt/boltdir.rb
@@ -33,7 +33,7 @@ module Bolt
       @path = Pathname.new(path).expand_path
       @config_file = @path + 'bolt.yaml'
       @inventory_file = @path + 'inventory.yaml'
-      @modulepath = [(@path + 'modules').to_s, (@path + 'site').to_s]
+      @modulepath = [(@path + 'modules').to_s, (@path + 'site-modules').to_s, (@path + 'site').to_s]
       @hiera_config = @path + 'hiera.yaml'
       @puppetfile = @path + 'Puppetfile'
     end


### PR DESCRIPTION
Previously site specific modules were expected to be in the default `site` directory. This was just a convention and the name `site` doesn't clearly convey what it is for. This commit adds a new default `site-modules` directory to the modulepath. This makes it more clear to users that this is a directory that modules go in.