### PR TITLE
(BOLT-1131) Update error handling for functions not allowed in apply

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/add_facts.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/add_facts.rb
@@ -17,9 +17,8 @@ Puppet::Functions.create_function(:add_facts) do
 
   def add_facts(target, facts)
     unless Puppet[:tasks]
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, operation: 'add_facts'
-      )
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'add_facts')
     end
 
     inventory = Puppet.lookup(:bolt_inventory) { nil }

--- a/bolt-modules/boltlib/lib/puppet/functions/add_facts.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/add_facts.rb
@@ -3,6 +3,8 @@
 require 'bolt/error'
 
 # Deep merges a hash of facts with the existing facts on a target.
+#
+# **NOTE:** Not available in apply block
 Puppet::Functions.create_function(:add_facts) do
   # @param target A target.
   # @param facts A hash of fact names to values that may include structured facts.

--- a/bolt-modules/boltlib/lib/puppet/functions/add_to_group.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/add_to_group.rb
@@ -20,6 +20,11 @@ Puppet::Functions.create_function(:add_to_group) do
   end
 
   def add_to_group(targets, group)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'add_to_group')
+    end
+
     inventory = Puppet.lookup(:bolt_inventory) { nil }
 
     unless inventory && Puppet.features.bolt?

--- a/bolt-modules/boltlib/lib/puppet/functions/add_to_group.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/add_to_group.rb
@@ -3,6 +3,8 @@
 require 'bolt/error'
 
 # Adds a target to specified inventory group.
+#
+# **NOTE:** Not available in apply block
 Puppet::Functions.create_function(:add_to_group) do
   # @param targets A pattern or array of patterns identifying a set of targets.
   # @param group The name of the group to add targets to.

--- a/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
@@ -39,9 +39,15 @@ Puppet::Functions.create_function(:apply_prep) do
   end
 
   def apply_prep(target_spec)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'apply_prep')
+    end
+
     applicator = Puppet.lookup(:apply_executor) { nil }
     executor = Puppet.lookup(:bolt_executor) { nil }
     inventory = Puppet.lookup(:bolt_inventory) { nil }
+
     unless applicator && executor && inventory && Puppet.features.bolt?
       raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
         Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('apply_prep')

--- a/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
@@ -10,6 +10,8 @@ require 'bolt/task'
 #
 # If no agent is detected on the target using the 'puppet_agent::version' task, it's installed
 # using 'puppet_agent::install' and the puppet service is stopped/disabled using the 'service' task.
+#
+# **NOTE:** Not available in apply block
 Puppet::Functions.create_function(:apply_prep) do
   # @param targets A pattern or array of patterns identifying a set of targets.
   # @example Prepare targets by name.

--- a/bolt-modules/boltlib/lib/puppet/functions/fail_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/fail_plan.rb
@@ -6,6 +6,8 @@ require 'bolt/error'
 #
 # Plan authors should call this function when their plan is not successful. The
 # error may then be caught by another plans run_plan function or in bolt itself
+#
+# **NOTE:** Not available in apply block
 Puppet::Functions.create_function(:fail_plan) do
   # Fail a plan, generating an exception from the parameters.
   # @param msg An error message.

--- a/bolt-modules/boltlib/lib/puppet/functions/fail_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/fail_plan.rb
@@ -32,6 +32,11 @@ Puppet::Functions.create_function(:fail_plan) do
   end
 
   def from_args(msg, kind = nil, details = nil, issue_code = nil)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'fail_plan')
+    end
+
     executor = Puppet.lookup(:bolt_executor) { nil }
     executor&.report_function_call('fail_plan')
 

--- a/bolt-modules/boltlib/lib/puppet/functions/get_resources.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/get_resources.rb
@@ -32,6 +32,11 @@ Puppet::Functions.create_function(:get_resources) do
   end
 
   def get_resources(target_spec, resources)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'get_resources')
+    end
+
     applicator = Puppet.lookup(:apply_executor) { nil }
     executor = Puppet.lookup(:bolt_executor) { nil }
     inventory = Puppet.lookup(:bolt_inventory) { nil }

--- a/bolt-modules/boltlib/lib/puppet/functions/get_resources.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/get_resources.rb
@@ -7,6 +7,8 @@ require 'bolt/task'
 #
 # Requires the Puppet Agent be installed on the target, which can be accomplished with apply_prep
 # or by directly running the puppet_agent::install task.
+#
+# **NOTE:** Not available in apply block
 Puppet::Functions.create_function(:get_resources) do
   # @param targets A pattern or array of patterns identifying a set of targets.
   # @param resources A resource type or instance, or an array of such.

--- a/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
@@ -4,6 +4,8 @@ require 'bolt/error'
 
 # Runs a command on the given set of targets and returns the result from each command execution.
 # This function does nothing if the list of targets is empty.
+#
+# **NOTE:** Not available in apply block
 Puppet::Functions.create_function(:run_command) do
   # Run a command.
   # @param command A command to run on target.

--- a/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
@@ -40,15 +40,13 @@ Puppet::Functions.create_function(:run_command) do
   end
 
   def run_command_with_description(command, targets, description = nil, options = nil)
-    options ||= {}
-    options = options.merge('_description' => description) if description
-
     unless Puppet[:tasks]
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, operation: 'run_command'
-      )
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'run_command')
     end
 
+    options ||= {}
+    options = options.merge('_description' => description) if description
     executor = Puppet.lookup(:bolt_executor) { nil }
     inventory = Puppet.lookup(:bolt_inventory) { nil }
     unless executor && inventory && Puppet.features.bolt?

--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -18,9 +18,8 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
 
   def run_plan(scope, plan_name, named_args = {})
     unless Puppet[:tasks]
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, operation: 'run_plan'
-      )
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'run_plan')
     end
 
     executor = Puppet.lookup(:bolt_executor) { nil }

--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -3,6 +3,8 @@
 require 'bolt/error'
 
 # Runs the `plan` referenced by its name. A plan is autoloaded from `<moduleroot>/plans`.
+#
+# **NOTE:** Not available in apply block
 Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction) do
   # @param plan_name The plan to run.
   # @param named_args Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.

--- a/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
@@ -2,6 +2,8 @@
 
 # Uploads the given script to the given set of targets and returns the result of having each target execute the script.
 # This function does nothing if the list of targets is empty.
+#
+# **NOTE:** Not available in apply block
 Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFunction) do
   # Run a script.
   # @param script Path to a script to run on target. May be an absolute path or a modulename/filename selector for a

--- a/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
@@ -46,15 +46,13 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
   end
 
   def run_script_with_description(scope, script, targets, description = nil, options = nil)
-    options ||= {}
-    options = options.merge('_description' => description) if description
-
     unless Puppet[:tasks]
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, operation: 'run_script'
-      )
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'run_script')
     end
 
+    options ||= {}
+    options = options.merge('_description' => description) if description
     executor = Puppet.lookup(:bolt_executor) { nil }
     inventory = Puppet.lookup(:bolt_inventory) { nil }
     unless executor && inventory && Puppet.features.bolt?

--- a/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
@@ -67,13 +67,12 @@ Puppet::Functions.create_function(:run_task) do
   end
 
   def run_task_raw(task_name, targets, description = nil, task_args = nil, &block)
-    task_args ||= {}
     unless Puppet[:tasks]
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, operation: 'run_task'
-      )
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'run_task')
     end
 
+    task_args ||= {}
     executor = Puppet.lookup(:bolt_executor) { nil }
     inventory = Puppet.lookup(:bolt_inventory) { nil }
     unless executor && inventory && Puppet.features.bolt?

--- a/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
@@ -6,6 +6,8 @@ require 'bolt/task'
 
 # Runs a given instance of a `Task` on the given set of targets and returns the result from each.
 # This function does nothing if the list of targets is empty.
+#
+# **NOTE:** Not available in apply block
 Puppet::Functions.create_function(:run_task) do
   # Run a task.
   # @param task_name The task to run.

--- a/bolt-modules/boltlib/lib/puppet/functions/set_feature.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_feature.rb
@@ -9,6 +9,8 @@ require 'bolt/error'
 # - powershell
 # - shell
 # - puppet-agent
+#
+# **NOTE:** Not available in apply block
 Puppet::Functions.create_function(:set_feature) do
   # @param target The Target object to add features to. See {get_targets}.
   # @param feature The string identifying the feature.

--- a/bolt-modules/boltlib/lib/puppet/functions/set_feature.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_feature.rb
@@ -13,7 +13,7 @@ Puppet::Functions.create_function(:set_feature) do
   # @param target The Target object to add features to. See {get_targets}.
   # @param feature The string identifying the feature.
   # @param value Whether the feature is supported.
-  # @return [Undef]
+  # @return The target with the updated feature
   # @example Add the puppet-agent feature to a target
   #   set_feature($target, 'puppet-agent', true)
   dispatch :set_feature do
@@ -24,9 +24,8 @@ Puppet::Functions.create_function(:set_feature) do
 
   def set_feature(target, feature, value = true)
     unless Puppet[:tasks]
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, operation: 'set_feature'
-      )
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'set_feature')
     end
 
     inventory = Puppet.lookup(:bolt_inventory) { nil }

--- a/bolt-modules/boltlib/lib/puppet/functions/set_var.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_var.rb
@@ -3,6 +3,8 @@
 require 'bolt/error'
 
 # Sets a variable { key => value } for a target.
+#
+# **NOTE:** Not available in apply block
 Puppet::Functions.create_function(:set_var) do
   # @param target The Target object to set the variable for. See {get_targets}.
   # @param key The key for the variable.

--- a/bolt-modules/boltlib/lib/puppet/functions/set_var.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_var.rb
@@ -18,9 +18,8 @@ Puppet::Functions.create_function(:set_var) do
 
   def set_var(target, key, value)
     unless Puppet[:tasks]
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, operation: 'set_var'
-      )
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'set_var')
     end
 
     inventory = Puppet.lookup(:bolt_inventory) { nil }

--- a/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
@@ -50,15 +50,13 @@ Puppet::Functions.create_function(:upload_file, Puppet::Functions::InternalFunct
   end
 
   def upload_file_with_description(scope, source, destination, targets, description = nil, options = nil)
-    options ||= {}
-    options = options.merge('_description' => description) if description
-
     unless Puppet[:tasks]
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, operation: 'upload_file'
-      )
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'upload_file')
     end
 
+    options ||= {}
+    options = options.merge('_description' => description) if description
     executor = Puppet.lookup(:bolt_executor) { nil }
     inventory = Puppet.lookup(:bolt_inventory) { nil }
     unless executor && inventory && Puppet.features.bolt?

--- a/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
@@ -4,6 +4,8 @@ require 'bolt/error'
 
 # Uploads the given file or directory to the given set of targets and returns the result from each upload.
 # This function does nothing if the list of targets is empty.
+#
+# **NOTE:** Not available in apply block
 Puppet::Functions.create_function(:upload_file, Puppet::Functions::InternalFunction) do
   # Upload a file.
   # @param source A source path, either an absolute path or a modulename/filename selector for a file in

--- a/bolt-modules/boltlib/lib/puppet/functions/wait_until_available.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/wait_until_available.rb
@@ -17,14 +17,13 @@ Puppet::Functions.create_function(:wait_until_available) do
   end
 
   def wait_until_available(targets, options = nil)
-    options ||= {}
-
     unless Puppet[:tasks]
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, operation: 'wait_until_available'
-      )
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING,
+                              action: 'wait_until_available')
     end
 
+    options ||= {}
     executor = Puppet.lookup(:bolt_executor) { nil }
     inventory = Puppet.lookup(:bolt_inventory) { nil }
     unless executor && inventory && Puppet.features.bolt?

--- a/bolt-modules/boltlib/lib/puppet/functions/wait_until_available.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/wait_until_available.rb
@@ -3,6 +3,8 @@
 require 'bolt/util'
 
 # Wait until all targets accept connections.
+#
+# **NOTE:** Not available in apply block
 Puppet::Functions.create_function(:wait_until_available) do
   # Wait until targets are available.
   # @param targets A pattern identifying zero or more targets. See {get_targets} for accepted patterns.

--- a/bolt-modules/boltlib/lib/puppet/functions/without_default_logging.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/without_default_logging.rb
@@ -20,6 +20,12 @@ Puppet::Functions.create_function(:without_default_logging) do
   end
 
   def without_default_logging
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING,
+                              action: 'without_default_logging')
+    end
+
     executor = Puppet.lookup(:bolt_executor) { nil }
     executor.report_function_call('without_default_logging')
 

--- a/bolt-modules/boltlib/lib/puppet/functions/without_default_logging.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/without_default_logging.rb
@@ -5,6 +5,8 @@
 # Messages for actions within this block will be logged at `info` level instead
 # of `notice`, so they will not be seen normally but # will still be present
 # when `verbose` logging is requested.
+#
+# **NOTE:** Not available in apply block
 Puppet::Functions.create_function(:without_default_logging) do
   # @param block The block where action logging is suppressed.
   # @return [Undef]

--- a/bolt-modules/boltlib/spec/functions/add_facts_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/add_facts_spec.rb
@@ -9,9 +9,10 @@ describe 'add_facts' do
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { mock('inventory') }
   let(:target) { Bolt::Target.new('example') }
+  let(:tasks_enabled) { true }
 
   around(:each) do |example|
-    Puppet[:tasks] = true
+    Puppet[:tasks] = tasks_enabled
     Puppet.features.stubs(:bolt?).returns(true)
 
     Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
@@ -36,5 +37,13 @@ describe 'add_facts' do
     inventory.expects(:add_facts).returns({})
 
     is_expected.to run.with_params(target, {})
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+    it 'fails and reports that add_facts is not available' do
+      is_expected.to run.with_params(target, {})
+                        .and_raise_error(/Plan language function 'add_facts' cannot be used/)
+    end
   end
 end

--- a/bolt-modules/boltlib/spec/functions/add_to_group_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/add_to_group_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+describe 'add_to_group' do
+  include PuppetlabsSpec::Fixtures
+  let(:executor) { Bolt::Executor.new }
+  let(:inventory) { Bolt::Inventory.new({}) }
+  let(:target) { Bolt::Target.new('example') }
+  let(:group) { 'all' }
+  let(:tasks_enabled) { true }
+
+  around(:each) do |example|
+    Puppet[:tasks] = tasks_enabled
+    Puppet.features.stubs(:bolt?).returns(true)
+
+    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
+      example.run
+    end
+  end
+
+  it 'should add a target to group' do
+    is_expected.to run.with_params(target, group)
+    expect(inventory.get_targets('all')[0].name).to eq('example')
+  end
+
+  it 'errors when passed invalid data types' do
+    is_expected.to run.with_params(target, 1)
+                      .and_raise_error(ArgumentError,
+                                       "'add_to_group' parameter 'group' expects a String value, got Integer")
+  end
+
+  it 'reports the call to analytics' do
+    executor.expects(:report_function_call).with('add_to_group')
+    is_expected.to run.with_params(target, group)
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+    it 'fails and reports that add_to_group is not available' do
+      is_expected.to run.with_params(target, group)
+                        .and_raise_error(/Plan language function 'add_to_group' cannot be used/)
+    end
+  end
+end

--- a/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
@@ -13,9 +13,10 @@ describe 'apply_prep' do
   let(:applicator) { mock('Bolt::Applicator') }
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { Bolt::Inventory.new({}) }
+  let(:tasks_enabled) { true }
 
   around(:each) do |example|
-    Puppet[:tasks] = true
+    Puppet[:tasks] = tasks_enabled
     Puppet.features.stubs(:bolt?).returns(true)
 
     executor.stubs(:noop).returns(false)
@@ -184,6 +185,14 @@ describe 'apply_prep' do
         expect(inventory.features(target)).to include('puppet-agent')
         expect(inventory.facts(target)).to eq(fact)
       end
+    end
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+    it 'fails and reports that apply_prep is not available' do
+      is_expected.to run.with_params('foo')
+                        .and_raise_error(/Plan language function 'apply_prep' cannot be used/)
     end
   end
 end

--- a/bolt-modules/boltlib/spec/functions/fail_plan_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/fail_plan_spec.rb
@@ -6,6 +6,11 @@ require 'bolt/error'
 
 describe 'fail_plan' do
   include PuppetlabsSpec::Fixtures
+  let(:tasks_enabled) { true }
+
+  before(:each) do
+    Puppet[:tasks] = tasks_enabled
+  end
 
   it 'raises an error from arguments' do
     is_expected.to run.with_params('oops').and_raise_error(Bolt::PlanFailure)
@@ -22,6 +27,14 @@ describe 'fail_plan' do
 
     Puppet.override(bolt_executor: executor) do
       is_expected.to run.with_params('foo').and_raise_error(Bolt::PlanFailure)
+    end
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+    it 'fails and reports that fail_plan is not available' do
+      is_expected.to run.with_params('foo')
+                        .and_raise_error(/Plan language function 'fail_plan' cannot be used/)
     end
   end
 end

--- a/bolt-modules/boltlib/spec/functions/get_resources_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/get_resources_spec.rb
@@ -13,9 +13,10 @@ describe 'get_resources' do
   let(:applicator) { mock('Bolt::Applicator') }
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { Bolt::Inventory.new({}) }
+  let(:tasks_enabled) { true }
 
   around(:each) do |example|
-    Puppet[:tasks] = true
+    Puppet[:tasks] = tasks_enabled
     Puppet.features.stubs(:bolt?).returns(true)
 
     executor.stubs(:noop).returns(false)
@@ -79,6 +80,14 @@ describe 'get_resources' do
       is_expected.to run.with_params(hostnames, 'not a type[hello there]').and_raise_error(
         Bolt::Error, "not a type[hello there] is not a valid resource type or type instance name"
       )
+    end
+
+    context 'without tasks enabled' do
+      let(:tasks_enabled) { false }
+      it 'fails and reports that get_resources is not available' do
+        is_expected.to run.with_params(hostnames, 'file')
+                          .and_raise_error(/Plan language function 'get_resources' cannot be used/)
+      end
     end
   end
 end

--- a/bolt-modules/boltlib/spec/functions/run_command_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_command_spec.rb
@@ -151,10 +151,9 @@ describe 'run_command' do
 
   context 'without tasks enabled' do
     let(:tasks_enabled) { false }
-
     it 'fails and reports that run_command is not available' do
       is_expected.to run.with_params('echo hello', [])
-                        .and_raise_error(/The task operation 'run_command' is not available/)
+                        .and_raise_error(/Plan language function 'run_command' cannot be used/)
     end
   end
 end

--- a/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
@@ -7,9 +7,10 @@ require 'bolt/executor'
 describe 'run_plan' do
   include PuppetlabsSpec::Fixtures
   let(:executor) { Bolt::Executor.new }
+  let(:tasks_enabled) { true }
 
   around(:each) do |example|
-    Puppet[:tasks] = true
+    Puppet[:tasks] = tasks_enabled
     Puppet.features.stubs(:bolt?).returns(true)
     executor.stubs(:noop).returns(false)
 
@@ -86,6 +87,14 @@ describe 'run_plan' do
 
     it 'returns undef for plans without explicit return' do
       is_expected.to run.with_params('test::no_return').and_return(nil)
+    end
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+    it 'fails and reports that run_plan is not available' do
+      is_expected.to run.with_params('test::run_me')
+                        .and_raise_error(/Plan language function 'run_plan' cannot be used/)
     end
   end
 end

--- a/bolt-modules/boltlib/spec/functions/run_script_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_script_spec.rb
@@ -180,7 +180,8 @@ describe 'run_script' do
 
     it 'fails and reports that run_script is not available' do
       is_expected.to run
-        .with_params('test/uploads/nonesuch.sh', []).and_raise_error(/The task operation 'run_script' is not available/)
+        .with_params('test/uploads/nonesuch.sh', [])
+        .and_raise_error(/Plan language function 'run_script' cannot be used/)
     end
   end
 end

--- a/bolt-modules/boltlib/spec/functions/run_task_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_spec.rb
@@ -28,9 +28,10 @@ describe 'run_task' do
   include PuppetlabsSpec::Fixtures
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { mock('Bolt::Inventory') }
+  let(:tasks_enabled) { true }
 
   around(:each) do |example|
-    Puppet[:tasks] = true
+    Puppet[:tasks] = tasks_enabled
     Puppet.features.stubs(:bolt?).returns(true)
 
     executor.stubs(:noop).returns(false)
@@ -125,6 +126,15 @@ describe 'run_task' do
 
       is_expected.to run.with_params('Test::Echo', hostname, default_args.merge('_bolt_api_call' => true))
                         .and_return(result_set)
+    end
+
+    context 'without tasks enabled' do
+      let(:tasks_enabled) { false }
+
+      it 'fails and reports that run_task is not available' do
+        is_expected.to run
+          .with_params('Test::Echo', hostname).and_raise_error(/Plan language function 'run_task' cannot be used/)
+      end
     end
 
     context 'with description' do

--- a/bolt-modules/boltlib/spec/functions/set_feature_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/set_feature_spec.rb
@@ -4,12 +4,13 @@ require 'spec_helper'
 require 'bolt/executor'
 require 'bolt/target'
 
-describe 'set_var' do
+describe 'set_feature' do
   include PuppetlabsSpec::Fixtures
   let(:executor) { Bolt::Executor.new }
   let(:inventory) { mock('inventory') }
   let(:target) { Bolt::Target.new('example') }
   let(:tasks_enabled) { true }
+  let(:feature) { 'feature' }
 
   around(:each) do |example|
     Puppet[:tasks] = tasks_enabled
@@ -21,29 +22,29 @@ describe 'set_var' do
   end
 
   it 'should set a variable on a target' do
-    inventory.expects(:set_var).with(target, 'a', 'b').returns(nil)
-    is_expected.to run.with_params(target, 'a', 'b').and_return(nil)
+    inventory.expects(:set_feature).with(target, feature, true).returns(target)
+    is_expected.to run.with_params(target, feature, true).and_return(target)
   end
 
   it 'errors when passed invalid data types' do
     is_expected.to run.with_params(target, 1, 'one')
                       .and_raise_error(ArgumentError,
-                                       "'set_var' parameter 'key' expects a String value, got Integer")
+                                       "'set_feature' parameter 'feature' expects a String value, got Integer")
   end
 
   it 'reports the call to analytics' do
-    executor.expects(:report_function_call).with('set_var')
-    inventory.expects(:set_var).with(target, 'a', 'b').returns(nil)
+    executor.expects(:report_function_call).with('set_feature')
+    inventory.expects(:set_feature).with(target, feature, true).returns(target)
 
-    is_expected.to run.with_params(target, 'a', 'b').and_return(nil)
+    is_expected.to run.with_params(target, feature, true).and_return(target)
   end
 
   context 'without tasks enabled' do
     let(:tasks_enabled) { false }
 
-    it 'fails and reports that set_var is not available' do
+    it 'fails and reports that set_feature is not available' do
       is_expected.to run
-        .with_params(target, 'a', 'b').and_raise_error(/Plan language function 'set_var' cannot be used/)
+        .with_params(target, feature, true).and_raise_error(/Plan language function 'set_feature' cannot be used/)
     end
   end
 end

--- a/bolt-modules/boltlib/spec/functions/upload_file_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/upload_file_spec.rb
@@ -179,7 +179,7 @@ describe 'upload_file' do
 
     it 'fails and reports that upload_file is not available' do
       is_expected.to run.with_params('test/uploads/nonesuch.html', '/some/place', [])
-                        .and_raise_error(/The task operation 'upload_file' is not available/)
+                        .and_raise_error(/Plan language function 'upload_file' cannot be used/)
     end
   end
 end

--- a/bolt-modules/boltlib/spec/functions/wait_until_available_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/wait_until_available_spec.rb
@@ -54,4 +54,13 @@ describe 'wait_until_available' do
                         .and_raise_error(/The 'bolt' library is required to wait until targets are available/)
     end
   end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+
+    it 'fails and reports that wait_until_available is not available' do
+      is_expected.to run
+        .with_params(target).and_raise_error(/Plan language function 'wait_until_available' cannot be used/)
+    end
+  end
 end

--- a/bolt-modules/boltlib/spec/spec_helper.rb
+++ b/bolt-modules/boltlib/spec/spec_helper.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 require 'puppet_pal'
+require 'bolt/pal'
 
 # Ensure tasks are enabled when rspec-puppet sets up an environment
 # so we get task loaders.
 Puppet[:tasks] = true
+Bolt::PAL.load_puppet
 require 'puppetlabs_spec_helper/module_spec_helper'

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -80,6 +80,7 @@ module Bolt
       end
 
       require 'bolt/pal/logging'
+      require 'bolt/pal/issues'
 
       # Now that puppet is loaded we can include puppet mixins in data types
       Bolt::ResultSet.include_iterable

--- a/lib/bolt/pal/issues.rb
+++ b/lib/bolt/pal/issues.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Bolt
+  class PAL
+    module Issues
+      # Create issue using Issues api
+      PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING =
+        Puppet::Pops::Issues.issue :PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, :action do
+          "Plan language function '#{action}' cannot be used from declarative manifest code or apply blocks"
+        end
+    end
+  end
+end

--- a/pre-docs/plan_functions.md
+++ b/pre-docs/plan_functions.md
@@ -5,6 +5,8 @@
 
 Deep merges a hash of facts with the existing facts on a target.
 
+**NOTE:** Not available in apply block
+
 
 ```
 add_facts(Target $target, Hash $facts)
@@ -24,6 +26,8 @@ add_facts($target, { 'os' => { 'family' => 'windows', 'name' => 'windows' } })
 ## add_to_group
 
 Adds a target to specified inventory group.
+
+**NOTE:** Not available in apply block
 
 
 ```
@@ -63,6 +67,8 @@ property of its transport (PCP) or by explicitly setting it as a feature in Bolt
 
 If no agent is detected on the target using the 'puppet_agent::version' task, it's installed
 using 'puppet_agent::install' and the puppet service is stopped/disabled using the 'service' task.
+
+**NOTE:** Not available in apply block
 
 
 ```
@@ -144,6 +150,8 @@ Raises a Bolt::PlanFailure exception to signal to callers that the plan failed.
 
 Plan authors should call this function when their plan is not successful. The
 error may then be caught by another plans run_plan function or in bolt itself
+
+**NOTE:** Not available in apply block
 
 
 ### Fail a plan, generating an exception from the parameters.
@@ -230,6 +238,8 @@ The results are returned as a list of hashes representing each resource.
 
 Requires the Puppet Agent be installed on the target, which can be accomplished with apply_prep
 or by directly running the puppet_agent::install task.
+
+**NOTE:** Not available in apply block
 
 
 ```
@@ -330,6 +340,8 @@ puppetdb_query('nodes[certname] {}')
 Runs a command on the given set of targets and returns the result from each command execution.
 This function does nothing if the list of targets is empty.
 
+**NOTE:** Not available in apply block
+
 
 ### Run a command.
 
@@ -371,6 +383,8 @@ run_command('hostname', $targets, 'Get hostname')
 
 Runs the `plan` referenced by its name. A plan is autoloaded from `<moduleroot>/plans`.
 
+**NOTE:** Not available in apply block
+
 
 ```
 run_plan(String $plan_name, Optional[Hash] $named_args)
@@ -391,6 +405,8 @@ run_plan('canary', 'command' => 'false', 'nodes' => $targets, '_catch_errors' =>
 
 Uploads the given script to the given set of targets and returns the result of having each target execute the script.
 This function does nothing if the list of targets is empty.
+
+**NOTE:** Not available in apply block
 
 
 ### Run a script.
@@ -441,6 +457,8 @@ run_script('/var/tmp/myscript', $targets, 'Downloading my application')
 
 Runs a given instance of a `Task` on the given set of targets and returns the result from each.
 This function does nothing if the list of targets is empty.
+
+**NOTE:** Not available in apply block
 
 
 ### Run a task.
@@ -504,12 +522,14 @@ Currently supported features are
 - shell
 - puppet-agent
 
+**NOTE:** Not available in apply block
+
 
 ```
 set_feature(Target $target, String $feature, Optional[Boolean] $value)
 ```
 
-*Returns:* `Undef` 
+*Returns:* `Any` The target with the updated feature
 
 * **target** `Target` The Target object to add features to. See [`get_targets`](#get_targets).
 * **feature** `String` The string identifying the feature.
@@ -524,6 +544,8 @@ set_feature($target, 'puppet-agent', true)
 ## set_var
 
 Sets a variable { key => value } for a target.
+
+**NOTE:** Not available in apply block
 
 
 ```
@@ -565,6 +587,8 @@ system::env('USER')
 
 Uploads the given file or directory to the given set of targets and returns the result from each upload.
 This function does nothing if the list of targets is empty.
+
+**NOTE:** Not available in apply block
 
 
 ### Upload a file.
@@ -638,6 +662,8 @@ $target.vars
 
 Wait until all targets accept connections.
 
+**NOTE:** Not available in apply block
+
 
 ```
 wait_until_available(Boltlib::TargetSpec $targets, Optional[Hash[String[1], Any]] $options)
@@ -661,6 +687,8 @@ Define a block where default logging is suppressed.
 Messages for actions within this block will be logged at `info` level instead
 of `notice`, so they will not be seen normally but # will still be present
 when `verbose` logging is requested.
+
+**NOTE:** Not available in apply block
 
 
 ```

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -142,7 +142,7 @@ describe "passes parsed AST to the apply_catalog task" do
       expect(error['kind']).to eq('bolt/apply-error')
       expect(error['msg']).to match(/Apply failed to compile for #{uri}/)
       expect(@log_output.readlines)
-        .to include(/The task operation 'run_task' is not available when compiling a catalog/)
+        .to include(/Plan language function 'run_task' cannot be used from declarative manifest code/)
     end
 
     context 'with puppetdb stubbed' do


### PR DESCRIPTION
Previously when a function like `apply_prep` was attempted to be called from a plan a cryptic error message was raised that referenced 'The bolt library is required...'. This commit ensures that plan functions that are not meant to be called in an apply block raise an appropriate puppet error/issue. Also plan functions that had previously been guarded by raising a `TASK_OPERATION_NOT_SUPPORTED_WHEN_COMPILING` issue have been replaced to use issues defined in a new Bolt::PAL::Issues module. This module is intended follow the pattern for extending puppet by requiring in the Bolt::PAL.load_puppet method.