### PR TITLE
(BOLT-1053) Update ruby_task_helper to 0.3.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -28,7 +28,7 @@ mod 'puppetlabs-package', '0.4.1'
 mod 'puppetlabs-puppet_conf', '0.3.0'
 mod 'puppetlabs-python_task_helper', '0.2.0'
 mod 'puppetlabs-reboot', '2.1.2'
-mod 'puppetlabs-ruby_task_helper', '0.2.0'
+mod 'puppetlabs-ruby_task_helper', '0.3.0'
 
 # If we don't list these modules explicitly, r10k will purge them
 mod 'canary', local: true


### PR DESCRIPTION
The 0.3.0 release includes a bug fix that symbolizes all parameter keys passed to the TaskHelper::task method by TaskHelper::run.