### PR TITLE
(BOLT-1073) Document how to init BoltSpec

### DIFF
--- a/lib/bolt_spec/plans.rb
+++ b/lib/bolt_spec/plans.rb
@@ -32,6 +32,11 @@ require 'bolt/pal'
 #
 # Configuration
 #
+#  To configure Puppet and Bolt at the beginning of tests, add the following
+#  line to your spec_helper.rb:
+#
+#  BoltSpec::Plans.init
+#
 #  By default the plan helpers use the modulepath set up for rspec-puppet and
 #  an otherwise empty bolt config and inventory. To create your own values for
 #  these override the modulepath, config, or inventory methods.


### PR DESCRIPTION
In order to load and configure Puppet, Bolt and the logger, users need
to call `BoltSpec::Plans.init` before any tests run. This commit
documents that fact alongside the rest of the BoltSpec inline
documentation.