### PR TITLE
(BOLT-146)(BOLT-153) Update bolt-server schemas

### DIFF
--- a/lib/bolt_server/schemas/ssh-run_task.json
+++ b/lib/bolt_server/schemas/ssh-run_task.json
@@ -56,6 +56,10 @@
         "sudo-password": {
           "type": "string",
           "description": "Password to use when changing users via run-as"
+        },
+        "interpreters": {
+          "type": "object",
+          "description": "Map of file extensions to remote executable"
         }
       },
       "oneOf": [

--- a/lib/bolt_server/schemas/winrm-run_task.json
+++ b/lib/bolt_server/schemas/winrm-run_task.json
@@ -48,6 +48,10 @@
           "type": "array",
           "description": "List of file extensions that are accepted for scripts or tasks"
         },
+        "interpreters": {
+          "type": "object",
+          "description": "Map of file extensions to remote executable"
+        },
         "file-protocol": {
           "type": "string",
           "enum": ["winrm", "smb"],
@@ -58,6 +62,7 @@
           "description": "Port for SMB protocol"
         }
       },
+
       "required": ["hostname", "user", "password"],
       "additionalProperties": false
     },

--- a/lib/bolt_server/schemas/winrm-run_task.json
+++ b/lib/bolt_server/schemas/winrm-run_task.json
@@ -47,6 +47,15 @@
         "extensions": {
           "type": "array",
           "description": "List of file extensions that are accepted for scripts or tasks"
+        },
+        "file-protocol": {
+          "type": "string",
+          "enum": ["winrm", "smb"],
+          "description": "Protocol for file transfer, WinRM or SMB"
+        },
+        "smb-port": {
+          "type": "integer",
+          "description": "Port for SMB protocol"
         }
       },
       "required": ["hostname", "user", "password"],


### PR DESCRIPTION
The `file-protocol`, `smb-port` options have been added to winrm transport. The `interpreters` option has been added to both winrm and ssh. This commit allows those configuration options in the {winrm,ssh}-run_task schemas. 