### PR TITLE
(BOLT-1050) Do not override _run_as in plans with config

### DIFF
--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -95,15 +95,6 @@ module Bolt
         interpreters[Pathname(executable).extname] if interpreters
       end
 
-      def reject_transport_options(target, options)
-        if target.options['run-as']
-          options.reject { |k, _v| k == '_run_as' }
-        else
-          options
-        end
-      end
-      private :reject_transport_options
-
       # Transform a parameter map to an environment variable map, with parameter names prefixed
       # with 'PT_' and values transformed to JSON unless they're strings.
       def envify_params(params)
@@ -135,7 +126,7 @@ module Bolt
         target = targets.first
         with_events(target, callback) do
           @logger.debug { "Running task run '#{task}' on #{target.uri}" }
-          run_task(target, task, arguments, reject_transport_options(target, options))
+          run_task(target, task, arguments, options)
         end
       end
 
@@ -149,7 +140,7 @@ module Bolt
         target = targets.first
         with_events(target, callback) do
           @logger.debug("Running command '#{command}' on #{target.uri}")
-          run_command(target, command, reject_transport_options(target, options))
+          run_command(target, command, options)
         end
       end
 
@@ -163,7 +154,7 @@ module Bolt
         target = targets.first
         with_events(target, callback) do
           @logger.debug { "Running script '#{script}' on #{target.uri}" }
-          run_script(target, script, arguments, reject_transport_options(target, options))
+          run_script(target, script, arguments, options)
         end
       end
 
@@ -177,7 +168,7 @@ module Bolt
         target = targets.first
         with_events(target, callback) do
           @logger.debug { "Uploading: '#{source}' to #{destination} on #{target.uri}" }
-          upload(target, source, destination, reject_transport_options(target, options))
+          upload(target, source, destination, options)
         end
       end
 

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -55,22 +55,6 @@ describe "Bolt::Executor" do
       executor.run_command(targets, command)
     end
 
-    context 'nodes with run_as' do
-      let(:targets) {
-        [Bolt::Target.new("target1", 'run-as' => 'foo'),
-         Bolt::Target.new("target2", 'run-as' => 'foo')]
-      }
-
-      it 'does not pass _run_as' do
-        executor.run_as = 'foo'
-        node_results.each do |target, result|
-          expect(ssh).to receive(:run_command).with(target, command, {}).and_return(result)
-        end
-
-        executor.run_command(targets, command)
-      end
-    end
-
     it "yields each result" do
       node_results.each do |target, result|
         expect(ssh).to receive(:run_command).with(target, command, {}).and_return(result)
@@ -120,25 +104,6 @@ describe "Bolt::Executor" do
       results = executor.run_script(targets, script, [])
       results.each do |result|
         expect(result).to be_instance_of(Bolt::Result)
-      end
-    end
-
-    context 'nodes with run_as' do
-      let(:targets) {
-        [Bolt::Target.new("target1", 'run-as' => 'foo'),
-         Bolt::Target.new("target2", 'run-as' => 'foo')]
-      }
-
-      it 'does not pass _run_as' do
-        executor.run_as = 'foo'
-        node_results.each do |target, result|
-          expect(ssh).to receive(:run_script).with(target, script, [], {}).and_return(result)
-        end
-
-        results = executor.run_script(targets, script, [])
-        results.each do |result|
-          expect(result).to be_instance_of(Bolt::Result)
-        end
       end
     end
 
@@ -201,31 +166,6 @@ describe "Bolt::Executor" do
       results = executor.run_task(targets, mock_task(task), task_arguments, task_options)
       results.each do |result|
         expect(result).to be_instance_of(Bolt::Result)
-      end
-    end
-
-    context 'nodes with run_as' do
-      let(:targets) {
-        [Bolt::Target.new("target1", 'run-as' => 'foo'),
-         Bolt::Target.new("target2")]
-      }
-
-      it 'does not pass _run_as for nodes that specify run_as' do
-        executor.run_as = 'bar'
-        expect(ssh)
-          .to receive(:run_task)
-          .with(targets[0], task_type(task), task_arguments, task_options)
-          .and_return(node_results[targets[0]])
-
-        expect(ssh)
-          .to receive(:run_task)
-          .with(targets[1], task_type(task), task_arguments, { '_run_as' => 'bar' }.merge(task_options))
-          .and_return(node_results[targets[1]])
-
-        results = executor.run_task(targets, mock_task(task), task_arguments, task_options)
-        results.each do |result|
-          expect(result).to be_instance_of(Bolt::Result)
-        end
       end
     end
 

--- a/spec/fixtures/run_as/test/plans/run_as_user.pp
+++ b/spec/fixtures/run_as/test/plans/run_as_user.pp
@@ -2,5 +2,6 @@ plan test::run_as_user(String $target, String $user) {
   run_command('whoami', $target, _run_as => $user)
   upload_file('test/id.sh', "/home/${user}/id.sh", $target, _run_as => $user)
   run_script('test/id.sh', $target, _run_as => $user)
+  run_task('test::id', $target, _run_as => $user)
   return run_plan(test::whoami, target => $target, _run_as => $user)
 }


### PR DESCRIPTION
Previously when the `run-as` option was set (config, inventory, CLI) any run_* function that specified the `_run_as` option would be overriden. This led to confusing behavior for users. This commit removes overriding `_run_as` with `run-as`.