### PR TITLE
(BOLT-1151) Load and show YAML plans

### DIFF
--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -81,6 +81,7 @@ module Bolt
 
       require 'bolt/pal/logging'
       require 'bolt/pal/issues'
+      require 'bolt/pal/yaml_plan_evaluator'
 
       # Now that puppet is loaded we can include puppet mixins in data types
       Bolt::ResultSet.include_iterable
@@ -103,7 +104,9 @@ module Bolt
         pal.with_script_compiler do |compiler|
           alias_types(compiler)
           begin
-            yield compiler
+            Puppet.override(yaml_plan_instantiator: Bolt::PAL::YamlPlanEvaluator) do
+              yield compiler
+            end
           rescue Bolt::Error => err
             err
           rescue Puppet::PreformattedError => err

--- a/lib/bolt/pal/yaml_plan_evaluator.rb
+++ b/lib/bolt/pal/yaml_plan_evaluator.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module Bolt
+  class PAL
+    class YamlPlanEvaluator
+      # For compatibility with the Puppet evaluator
+      def evaluate_block_with_bindings(closure_scope, args_hash, plan_body) end
+
+      # As an "evaluator", this object is occasionally called on to evaluate
+      # values that are assumed to be bits of AST (as they would if this were a
+      # normal Puppet plan). This includes parameter types/values. Since those
+      # things are already "evaluated" in this case, we just return them
+      # unmodified.
+      def evaluate(expr, _scope)
+        expr
+      end
+
+      def self.create(loader, typed_name, source_ref, yaml_string)
+        body = YAML.safe_load(yaml_string, [Symbol], [], true, source_ref)
+        unless body.is_a?(Hash)
+          type = body.class.name
+          raise ArgumentError, "The data loaded from #{source_ref} does not contain an object - its type is #{type}"
+        end
+
+        plan_definition = PlanWrapper.new(typed_name, body)
+
+        created = create_function_class(plan_definition)
+        closure_scope = nil
+
+        created.new(closure_scope, loader.private_loader)
+      end
+
+      def self.create_function_class(plan_definition)
+        Puppet::Functions.create_function(plan_definition.name, Puppet::Functions::PuppetFunction) do
+          closure = Puppet::Pops::Evaluator::Closure::Named.new(plan_definition.name,
+                                                                YamlPlanEvaluator.new,
+                                                                plan_definition)
+          init_dispatch(closure)
+        end
+      end
+
+      class PlanWrapper
+        Parameter = Struct.new(:name, :value, :type_expr) do
+          def captures_rest
+            false
+          end
+        end
+
+        attr_reader :name, :body
+
+        def initialize(name, body)
+          @name = name
+          @body = body
+        end
+
+        def parameters
+          @parameters ||= @body.fetch('parameters', {}).map do |name, definition|
+            type = Puppet::Pops::Types::TypeParser.singleton.parse(definition['type']) if definition.key?('type')
+            Parameter.new(name, definition['default'], type)
+          end
+        end
+
+        def return_type
+          Puppet::Pops::Types::TypeParser.singleton.parse('Boltlib::PlanResult')
+        end
+        # XXX maybe something about location
+      end
+    end
+  end
+end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1079,7 +1079,8 @@ bar
             ['sample'],
             ['sample::single_task'],
             ['sample::three_tasks'],
-            ['sample::two_tasks']
+            ['sample::two_tasks'],
+            ['sample::yaml']
           ].each do |plan|
             expect(plan_list).to include(plan)
           end
@@ -1113,6 +1114,34 @@ bar
               },
               "param_optional" => {
                 "type" => "Optional[String]"
+              },
+              "param_with_default_value" => {
+                "type" => "String",
+                "default_value" => nil
+              }
+            }
+          )
+        end
+
+        it "shows an individual yaml plan data" do
+          plan_name = 'sample::yaml'
+          options = {
+            subcommand: 'plan',
+            action: 'show',
+            object: plan_name
+          }
+          cli.execute(options)
+          json = JSON.parse(output.string)
+          expect(json).to eq(
+            "name" => "sample::yaml",
+            "module_dir" => File.absolute_path(File.join(__dir__, "..", "fixtures", "modules", "sample")),
+            "parameters" => {
+              "nodes" => {
+                "type" => "TargetSpec"
+              },
+              "param_optional" => {
+                "type" => "Optional[String]",
+                "default_value" => nil
               },
               "param_with_default_value" => {
                 "type" => "String",

--- a/spec/fixtures/modules/sample/plans/yaml.yaml
+++ b/spec/fixtures/modules/sample/plans/yaml.yaml
@@ -1,0 +1,16 @@
+---
+parameters:
+  nodes:
+    type: TargetSpec
+  param_optional:
+    type: Optional[String]
+    default: undef
+  param_with_default_value:
+    type: String
+    default: 'hello'
+
+steps:
+  - task: sample::echo
+    target: $nodes
+  - command: echo hello world
+    target: $nodes


### PR DESCRIPTION
This allows `bolt plan show` and `bolt plan show <plan>` to find and
display YAML plans. We create a new YamlPlanEvaluator class and pass it
to Puppet via the context (as yaml_plan_instantiator), which then calls
back into Bolt whenever a YAML plan is loaded. This allows the logic for
listing and finding plans to live in Puppet, but for all of the logic
about how to run them to live in Bolt.

The execution of YAML plans follows a similar model as Puppet plans: we
create a Puppet function which, when invoked, will run the plan. We
use a PlanWrapper class to encapsulate the plan data and make it behave
like a Puppet PlanDefinition object. This commit also includes an empty
definition of the `evaluate_block_with_bindings` method, which allows
our YamlPlanEvaluator to function as though it were a regular Puppet
evaluator.