### PR TITLE
(BOLT-1085) Pass nil through to environment variables

### DIFF
--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -108,7 +108,7 @@ module Bolt
       # with 'PT_' and values transformed to JSON unless they're strings.
       def envify_params(params)
         params.each_with_object({}) do |(k, v), h|
-          v = v.to_json unless v.is_a?(String)
+          v = v.to_json unless v.is_a?(String) || v.nil?
           h["PT_#{k}"] = v
         end
       end


### PR DESCRIPTION
Previously parameters with the value `nil` would be converted to the string `null` when "envifying" parameters. This commit prevents this conversion.