### PR TITLE
(maint) Fix typo in wrapping an existing script with task docs

### DIFF
--- a/pre-docs/writing_tasks.md
+++ b/pre-docs/writing_tasks.md
@@ -746,7 +746,7 @@ Given a script, `myscript.sh`, that accepts 2 positional args, `filename` and `v
    chmod +x $script_file
    commandline=("$script_file" "$PT_filename" "$PT_version")
    # If the stderr output of the script is important redirect it to stdout.
-   "${commandline[@]}" 2>&
+   "${commandline[@]}" 2>&1
    ```
 
 If you intend to use this task with PE and assign RBAC permissions for it make


### PR DESCRIPTION
It seems that in a revision the example wrapper task got a character truncated from the end. This commit updates with the character added back.