### PR TITLE
(discuss) experiment using fork instead of capture for compiling

### DIFF
--- a/libexec/bolt_catalog
+++ b/libexec/bolt_catalog
@@ -41,7 +41,7 @@ elsif command == "compile"
             else
               JSON.parse(STDIN.read)
             end
-  catalog = Bolt::Catalog.new.compile_catalog(request)
+  catalog = Bolt::Catalog.new.from_request(request)
   # This seems to be a string in ruby 2.3
   if catalog.is_a?(String)
     catalog = JSON.parse(catalog)

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -72,6 +72,7 @@ describe Bolt::Applicator do
   end
 
   it 'passes catalog input' do
+    expect(Process).to receive(:respond_to?).with(:fork).and_return(false)
     expect(Open3).to receive(:capture3)
       .with('ruby', /bolt_catalog/, 'compile', stdin_data: input.to_json)
       .and_return(['{}', '', double(:status, success?: true)])
@@ -84,6 +85,7 @@ describe Bolt::Applicator do
       { notice: 'Stuff happened' }
     ]
 
+    expect(Process).to receive(:respond_to?).with(:fork).and_return(false)
     expect(Open3).to receive(:capture3)
       .with('ruby', /bolt_catalog/, 'compile', stdin_data: input.to_json)
       .and_return(['{}', logs.map(&:to_json).join("\n"), double(:status, success?: true)])

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -119,9 +119,9 @@ describe "passes parsed AST to the apply_catalog task" do
 
     it 'fails immediately on a compile error' do
       result = run_cli_json(%w[plan run basic::catch_error catch=false] + config_flags)
-      expect(result['kind']).to eq('bolt/apply-failure')
+      expect(result).to include('kind' => 'bolt/apply-failure')
       error = result['details']['result_set'][0]['result']['_error']
-      expect(error['kind']).to eq('bolt/apply-error')
+      expect(error).to include('kind' => 'bolt/apply-error')
       expect(error['msg']).to match(/Apply failed to compile for #{uri}/)
       expect(@log_output.readlines)
         .to include(/stop the insanity/)


### PR DESCRIPTION
Initializing puppet for catalog compiles is very expensive. By calling
fork instead of capture we can still safely compile catalogs in their
own threads without having to reload puppet code. This also means we
won't have to serialize and deserialize the inventory. Unfortunately
fork is not available on windows so we cannot rely on this
functionality.


This doesn't currently work with the `bolt apply` commandline tool tests since the raw include statements don't work. It seems like the fork should be loading the code when parsing the AST but it isn't, I suspect there is some cache in puppet we need clear or it's an issue with a cache and our ad hoc environments.