### PR TITLE
(WIP)(BOLT-1052) Add run-as option to local transport

### DIFF
--- a/lib/bolt/transport/helpers.rb
+++ b/lib/bolt/transport/helpers.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'shellwords'
+
+def validate_sudo_options(options, logger)
+  if options['sudo-password'] && options['run-as'].nil?
+    logger.warn("--sudo-password will not be used without specifying a " \
+                "user to escalate to with --run-as")
+  end
+
+  run_as_cmd = options['run-as-command']
+  if run_as_cmd && (!run_as_cmd.is_a?(Array) || run_as_cmd.any? { |n| !n.is_a?(String) })
+    raise Bolt::ValidationError, "run-as-command must be an Array of Strings, received #{run_as_cmd}"
+  end
+end
+
+def sudo_prompt
+  '[sudo] Bolt needs to run as another user, password: '
+end
+
+def execute_prep(command,
+                 options,
+                 sudoable: false,
+                 run_as_command: nil,
+                 run_as: nil,
+                 conn_user: nil)
+
+  if options[:interpreter]
+    command.is_a?(Array) ? command.unshift(options[:interpreter]) : [options[:interpreter], command]
+  end
+
+  command_str = command.is_a?(String) ? command : Shellwords.shelljoin(command)
+
+  escalate = sudoable && run_as && conn_user != run_as
+  use_sudo = escalate && run_as_command.nil?
+  if escalate
+    if use_sudo
+      sudo_flags = ["sudo", "-S", "-u", run_as, "-p", sudo_prompt]
+      sudo_flags += ["-E"] if options[:environment]
+      sudo_str = Shellwords.shelljoin(sudo_flags)
+      command_str = "#{sudo_str} #{command_str}"
+    else
+      run_as_str = Shellwords.shelljoin(run_as_command + [run_as])
+      command_str = "#{run_as_str} #{command_str}"
+    end
+  end
+
+  command_str
+end

--- a/lib/bolt/transport/local.rb
+++ b/lib/bolt/transport/local.rb
@@ -11,7 +11,7 @@ module Bolt
   module Transport
     class Local < Base
       def self.options
-        %w[tmpdir interpreters]
+        %w[tmpdir interpreters sudo-password run-as run-as-command]
       end
 
       def self.default_options
@@ -33,7 +33,10 @@ module Bolt
         input_method
       end
 
-      def self.validate(_options); end
+      def self.validate(options)
+        logger = Logging.logger[self]
+        validate_sudo_options(options, logger)
+      end
 
       def initialize
         super
@@ -54,7 +57,27 @@ module Bolt
       end
       private :in_tmpdir
 
+      def chown(owner, filepaths)
+        # I kept this separate from SSH::Connection::RemoteTempdir
+        # to make use of fileutils
+        # The logic is similar though
+        return if owner.nil? || owner == Etc.getlogin
+        result = `id -g #{owner}`
+        if result.exit_code != 0
+          message = "Could not identify group of user #{owner}: #{result.stderr.string}"
+          raise Bolt::Node::FileError.new(message, 'ID_ERROR')
+        end
+        group = result.stdout.string.chomp
+
+        result = FileUtils.chown_R(owner, group, filepaths)
+        if result.exit_code != 0
+          message = "Could not change owner of '#{@path}' to #{owner}: #{result.stderr.string}"
+          raise Bolt::Node::FileError.new(message, 'CHOWN_ERROR')
+        end
+      end
+
       def copy_file(source, destination)
+        chown(@conn.run_as, source)
         FileUtils.cp_r(source, destination, remove_destination: true)
       rescue StandardError => e
         raise Bolt::Node::FileError.new(e.message, 'WRITE_ERROR')
@@ -70,118 +93,128 @@ module Bolt
       end
       private :with_tmpscript
 
-      def upload(target, source, destination, _options = {})
-        copy_file(source, destination)
-        Bolt::Result.for_upload(target, source, destination)
-      end
-
-      def run_command(target, command, _options = {})
-        in_tmpdir(target.options['tmpdir']) do |dir|
-          output = @conn.execute(command, dir: dir)
-          Bolt::Result.for_command(target, output.stdout.string, output.stderr.string, output.exit_code)
+      def upload(target, source, destination, options = {})
+        @conn.running_as(options['_run_as']) do
+          copy_file(source, destination)
+          Bolt::Result.for_upload(target, source, destination)
         end
       end
 
-      def run_script(target, script, arguments, _options = {})
-        with_tmpscript(File.absolute_path(script), target.options['tmpdir']) do |file, dir|
-          logger.debug "Running '#{file}' with #{arguments}"
-
-          # unpack any Sensitive data AFTER we log
-          arguments = unwrap_sensitive_args(arguments)
-          if Bolt::Util.windows?
-            if Powershell.powershell_file?(file)
-              command = Powershell.run_script(arguments, file)
-              output = @conn.execute(command, dir: dir, env: "powershell.exe")
-            else
-              path, args = *Powershell.process_from_extension(file)
-              args += Powershell.escape_arguments(arguments)
-              command = args.unshift(path).join(' ')
-              output = @conn.execute(command, dir: dir)
-            end
-          else
-            if arguments.empty?
-              # We will always provide separated arguments, so work-around Open3's handling of a single
-              # argument as the entire command string for script paths containing spaces.
-              arguments = ['']
-            end
-            output = @conn.execute(file, *arguments, dir: dir)
+      def run_command(target, command, options = {})
+        @conn.running_as(options['_run_as']) do
+          in_tmpdir(target.options['tmpdir']) do |dir|
+            options[:sudoable] = true if @conn.run_as
+            options[:dir] = dir
+            output = @conn.execute(command, target.options, options)
+            Bolt::Result.for_command(target, output.stdout.string, output.stderr.string, output.exit_code)
           end
-          Bolt::Result.for_command(target, output.stdout.string, output.stderr.string, output.exit_code)
         end
       end
 
-      def run_task(target, task, arguments, _options = {})
+      def run_script(target, script, arguments, options = {})
+        @conn.running_as(options['_run_as']) do
+          with_tmpscript(File.absolute_path(script), target.options['tmpdir']) do |file, dir|
+            logger.debug "Running '#{file}' with #{arguments}"
+
+            # unpack any Sensitive data AFTER we log
+            arguments = unwrap_sensitive_args(arguments)
+            if Bolt::Util.windows?
+              if Powershell.powershell_file?(file)
+                command = Powershell.run_script(arguments, file)
+                output = @conn.execute(command, target.options, dir: dir, env: "powershell.exe")
+              else
+                path, args = *Powershell.process_from_extension(file)
+                args += Powershell.escape_arguments(arguments)
+                command = args.unshift(path).join(' ')
+                output = @conn.execute(command, target.options, dir: dir)
+              end
+            else
+              if arguments.empty?
+                # We will always provide separated arguments, so work-around Open3's handling of a single
+                # argument as the entire command string for script paths containing spaces.
+                arguments = ['']
+              end
+              output = @conn.execute(file, target.options, *arguments, dir: dir)
+            end
+            Bolt::Result.for_command(target, output.stdout.string, output.stderr.string, output.exit_code)
+          end
+        end
+      end
+
+      def run_task(target, task, arguments, options = {})
         implementation = select_implementation(target, task)
         executable = implementation['path']
         input_method = implementation['input_method']
         extra_files = implementation['files']
 
-        in_tmpdir(target.options['tmpdir']) do |dir|
-          if extra_files.empty?
-            script = File.join(dir, File.basename(executable))
-          else
-            arguments['_installdir'] = dir
-            script_dest = File.join(dir, task.tasks_dir)
-            FileUtils.mkdir_p([script_dest] + extra_files.map { |file| File.join(dir, File.dirname(file['name'])) })
-
-            script = File.join(script_dest, File.basename(executable))
-            extra_files.each do |file|
-              dest = File.join(dir, file['name'])
-              copy_file(file['path'], dest)
-              File.chmod(0o750, dest)
-            end
-          end
-
-          copy_file(executable, script)
-          File.chmod(0o750, script)
-
-          interpreter = select_interpreter(script, target.options['interpreters'])
-          interpreter_debug = interpreter ? " using '#{interpreter}' interpreter" : nil
-          # log the arguments with sensitive data redacted, do NOT log unwrapped_arguments
-          logger.debug("Running '#{script}' with #{arguments}#{interpreter_debug}")
-          unwrapped_arguments = unwrap_sensitive_args(arguments)
-
-          stdin = STDIN_METHODS.include?(input_method) ? JSON.dump(unwrapped_arguments) : nil
-
-          if Bolt::Util.windows?
-            # WINDOWS
-            if ENVIRONMENT_METHODS.include?(input_method)
-              environment_params = envify_params(unwrapped_arguments).each_with_object([]) do |(arg, val), list|
-                list << Powershell.set_env(arg, val)
-              end
-              environment_params = environment_params.join("\n") + "\n"
+        @conn.running_as(options['_run_as']) do
+          in_tmpdir(target.options['tmpdir']) do |dir|
+            if extra_files.empty?
+              script = File.join(dir, File.basename(executable))
             else
-              environment_params = ""
-            end
+              arguments['_installdir'] = dir
+              script_dest = File.join(dir, task.tasks_dir)
+              FileUtils.mkdir_p([script_dest] + extra_files.map { |file| File.join(dir, File.dirname(file['name'])) })
 
-            if Powershell.powershell_file?(script) && stdin.nil?
-              command = Powershell.run_ps_task(arguments, script, input_method)
-              command = environment_params + Powershell.shell_init + command
-              interpreter ||= 'powershell.exe'
-              output =
-                if input_method == 'powershell'
-                  @conn.execute(command, dir: dir, interpreter: interpreter)
-                else
-                  @conn.execute(command, dir: dir, stdin: stdin, interpreter: interpreter)
-                end
-            end
-            unless output
-              if interpreter
-                env = ENVIRONMENT_METHODS.include?(input_method) ? envify_params(unwrapped_arguments) : nil
-                output = @conn.execute(script, stdin: stdin, env: env, dir: dir, interpreter: interpreter)
-              else
-                path, args = *Powershell.process_from_extension(script)
-                command = args.unshift(path).join(' ')
-                command = environment_params + Powershell.shell_init + command
-                output = @conn.execute(command, dir: dir, stdin: stdin, interpreter: 'powershell.exe')
+              script = File.join(script_dest, File.basename(executable))
+              extra_files.each do |file|
+                dest = File.join(dir, file['name'])
+                copy_file(file['path'], dest)
+                File.chmod(0o750, dest)
               end
             end
-          else
-            # POSIX
-            env = ENVIRONMENT_METHODS.include?(input_method) ? envify_params(unwrapped_arguments) : nil
-            output = @conn.execute(script, stdin: stdin, env: env, dir: dir, interpreter: interpreter)
+
+            copy_file(executable, script)
+            File.chmod(0o750, script)
+
+            interpreter = select_interpreter(script, target.options['interpreters'])
+            interpreter_debug = interpreter ? " using '#{interpreter}' interpreter" : nil
+            # log the arguments with sensitive data redacted, do NOT log unwrapped_arguments
+            logger.debug("Running '#{script}' with #{arguments}#{interpreter_debug}")
+            unwrapped_arguments = unwrap_sensitive_args(arguments)
+
+            stdin = STDIN_METHODS.include?(input_method) ? JSON.dump(unwrapped_arguments) : nil
+
+            if Bolt::Util.windows?
+              # WINDOWS
+              if ENVIRONMENT_METHODS.include?(input_method)
+                environment_params = envify_params(unwrapped_arguments).each_with_object([]) do |(arg, val), list|
+                  list << Powershell.set_env(arg, val)
+                end
+                environment_params = environment_params.join("\n") + "\n"
+              else
+                environment_params = ""
+              end
+
+              if Powershell.powershell_file?(script) && stdin.nil?
+                command = Powershell.run_ps_task(arguments, script, input_method)
+                command = environment_params + Powershell.shell_init + command
+                interpreter ||= 'powershell.exe'
+                output =
+                  if input_method == 'powershell'
+                    @conn.execute(command, target.options, dir: dir, interpreter: interpreter)
+                  else
+                    @conn.execute(command, target.options, dir: dir, stdin: stdin, interpreter: interpreter)
+                  end
+              end
+              unless output
+                if interpreter
+                  env = ENVIRONMENT_METHODS.include?(input_method) ? envify_params(unwrapped_arguments) : nil
+                  output = @conn.execute(script, target.options, stdin: stdin, env: env, dir: dir, interpreter: interpreter)
+                else
+                  path, args = *Powershell.process_from_extension(script)
+                  command = args.unshift(path).join(' ')
+                  command = environment_params + Powershell.shell_init + command
+                  output = @conn.execute(command, target.options, dir: dir, stdin: stdin, interpreter: 'powershell.exe')
+                end
+              end
+            else
+              # POSIX
+              env = ENVIRONMENT_METHODS.include?(input_method) ? envify_params(unwrapped_arguments) : nil
+              output = @conn.execute(script, target.options, stdin: stdin, environment: env, dir: dir, interpreter: interpreter)
+            end
+            Bolt::Result.for_task(target, output.stdout.string, output.stderr.string, output.exit_code)
           end
-          Bolt::Result.for_task(target, output.stdout.string, output.stderr.string, output.exit_code)
         end
       end
 

--- a/lib/bolt/transport/local/shell.rb
+++ b/lib/bolt/transport/local/shell.rb
@@ -2,19 +2,76 @@
 
 require 'open3'
 require 'bolt/node/output'
+require 'bolt/transport/helpers'
 
 module Bolt
   module Transport
     class Local
       class Shell
-        def execute(*command, options)
-          command.unshift(options[:interpreter]) if options[:interpreter]
-          command = [options[:env]] + command if options[:env]
+        attr_accessor :run_as
 
+        def initialize
+          @user = Etc.getlogin
+          @run_as = nil
+        end
+
+        # Run as the specified user for the duration of the block.
+        def running_as(user)
+          @run_as = user
+          yield
+        ensure
+          @run_as = nil
+        end
+
+        def handled_sudo(target, data)
+          # TODO
+#          if data.lines.include?(sudo_prompt)
+#            if target_options['sudo-password']
+#
+#          else
+#            # Cancel the sudo prompt to prevent later commands getting stuck
+#            raise Bolt::Node::EscalateError.new(
+#              "Sudo password for user #{@user} was not provided for #{target.uri}",
+#              'NO_PASSWORD'
+#            )
+#          end
+#        elsif data =~ /^#{@user} is not in the sudoers file\./
+#          @logger.debug { data }
+#          raise Bolt::Node::EscalateError.new(
+#            "User #{@user} does not have sudo permission on #{target.uri}",
+#            'SUDO_DENIED'
+#          )
+#        elsif data =~ /^Sorry, try again\./
+#          @logger.debug { data }
+#          raise Bolt::Node::EscalateError.new(
+#            "Sudo password for user #{@user} not recognized on #{target.uri}",
+#            'BAD_PASSWORD'
+#          )
+#        end
+#        false
+        end
+
+        def execute(*command, target_opts, options)
+          options[:sudoable] = true if options[:sudoable].nil?
+          run_as = options[:run_as] || @run_as || target_opts['run-as']
+
+          command_str = execute_prep(command,
+                                     options,
+                                     sudoable: options[:sudoable],
+                                     run_as_command: target_opts['run-as-command'],
+                                     run_as: run_as,
+                                     conn_user: @user)
+          command_arr = Shellwords.split(command_str)
+          command_arr = [options[:environment]] + command if options[:environment]
+
+          options[:environment] ||= {}
           if options[:stdin]
-            stdout, stderr, rc = Open3.capture3(*command, stdin_data: options[:stdin], chdir: options[:dir])
+            stdout, stderr, rc = Open3.capture3(*command_arr,
+                                                stdin_data: options[:stdin],
+                                                chdir: options[:dir])
           else
-            stdout, stderr, rc = Open3.capture3(*command, chdir: options[:dir])
+            stdout, stderr, rc = Open3.capture3(*command_arr,
+                                                chdir: options[:dir])
           end
 
           result_output = Bolt::Node::Output.new

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -2,6 +2,7 @@
 
 require 'bolt/node/errors'
 require 'bolt/transport/base'
+require 'bolt/transport/helpers'
 require 'json'
 require 'shellwords'
 
@@ -28,10 +29,7 @@ module Bolt
       def self.validate(options)
         logger = Logging.logger[self]
 
-        if options['sudo-password'] && options['run-as'].nil?
-          logger.warn("--sudo-password will not be used without specifying a " \
-                       "user to escalate to with --run-as")
-        end
+        validate_sudo_options(options, logger)
 
         host_key = options['host-key-check']
         unless !!host_key == host_key
@@ -49,11 +47,6 @@ module Bolt
         unless timeout_value.is_a?(Integer) || timeout_value.nil?
           error_msg = "connect-timeout value must be an Integer, received #{timeout_value}:#{timeout_value.class}"
           raise Bolt::ValidationError, error_msg
-        end
-
-        run_as_cmd = options['run-as-command']
-        if run_as_cmd && (!run_as_cmd.is_a?(Array) || run_as_cmd.any? { |n| !n.is_a?(String) })
-          raise Bolt::ValidationError, "run-as-command must be an Array of Strings, received #{run_as_cmd}"
         end
       end
 

--- a/pre-docs/bolt_configuration_options.md
+++ b/pre-docs/bolt_configuration_options.md
@@ -107,6 +107,11 @@ interpreters:
 ## Local transport configuration options
 
 `tmpdir`: The directory to copy and execute temporary files.
+`run-as`: A different user to run commands as after login.
+
+`run-as-command`: The command to elevate permissions. Bolt appends the user and command strings to the configured run as a command before running it on the target. This command must not require an interactive password prompt, and the `sudo-password` option is ignored when `run-as-command` is specified. The run-as command must be specified as an array.
+
+`sudo-password`: Password to use when changing users via `run-as`.
 
 ## Docker transport configuration options
 


### PR DESCRIPTION
This adds support for `run-as`, `sudo-password`, and `run-as-command` to the local transport. These can be configured in the config file, by command line options, or in the inventory file, and should behave exactly like the same options for SSH.