### PR TITLE
(BOLT-1152) Run YAML plans

### DIFF
--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -28,7 +28,6 @@ module Bolt
       @analytics = analytics
       @bundled_content = bundled_content
       @logger = Logging.logger[self]
-      @plan_logging = false
       @load_config = load_config
 
       @transports = Bolt::TRANSPORTS.each_with_object({}) do |(key, val), coll|

--- a/lib/bolt/pal/yaml_plan_evaluator.rb
+++ b/lib/bolt/pal/yaml_plan_evaluator.rb
@@ -5,16 +5,108 @@ require 'yaml'
 module Bolt
   class PAL
     class YamlPlanEvaluator
-      # For compatibility with the Puppet evaluator
-      def evaluate_block_with_bindings(closure_scope, args_hash, plan_body) end
+      def initialize
+        @logger = Logging.logger[self]
+        @evaluator = Puppet::Pops::Parser::EvaluatingParser.new
+      end
 
-      # As an "evaluator", this object is occasionally called on to evaluate
-      # values that are assumed to be bits of AST (as they would if this were a
-      # normal Puppet plan). This includes parameter types/values. Since those
-      # things are already "evaluated" in this case, we just return them
-      # unmodified.
-      def evaluate(expr, _scope)
-        expr
+      STEP_KEYS = %w[task command].freeze
+
+      def dispatch_step(scope, step)
+        step_type, *extra_keys = STEP_KEYS.select { |key| step.key?(key) }
+        if !step_type || extra_keys.any?
+          unsupported_step(scope, step)
+        end
+
+        case step_type
+        when 'task'
+          task_step(scope, step)
+        when 'command'
+          command_step(scope, step)
+        else
+          # This shouldn't be able to happen since this case statement should
+          # match the STEP_KEYS list, but raise an error *just in case*,
+          # instead of silently skipping the step.
+          unsupported_step(scope, step)
+        end
+      end
+
+      def task_step(scope, step)
+        task = step['task']
+        target = step['target']
+        description = step['description']
+        params = step['parameters'] || {}
+        raise "Can't run a task without specifying a target" unless target
+
+        target = interpolate_variables(scope, target)
+        params = Bolt::Util.map_vals(params) { |param| interpolate_variables(scope, param) }
+
+        args = if description
+                 [task, target, description, params]
+               else
+                 [task, target, params]
+               end
+        scope.call_function('run_task', args)
+      end
+
+      def command_step(scope, step)
+        command = step['command']
+        target = step['target']
+        description = step['description']
+        raise "Can't run a command without specifying a target" unless target
+
+        target = interpolate_variables(scope, target)
+
+        args = [command, target]
+        args << description if description
+        scope.call_function('run_command', args)
+      end
+
+      def unsupported_step(_scope, step)
+        raise Bolt::Error.new("Unsupported plan step", "bolt/unsupported-step", step: step)
+      end
+
+      def evaluate_block_with_bindings(closure_scope, args_hash, plan_body)
+        unless plan_body['steps'].is_a?(Array)
+          raise Bolt::Error.new("Plan must specify an array of steps", "bolt/invalid-plan")
+        end
+
+        closure_scope.with_local_scope(args_hash) do |scope|
+          plan_body['steps'].each do |step|
+            dispatch_step(scope, step)
+          end
+        end
+
+        result = nil
+        throw :return, Puppet::Pops::Evaluator::Return.new(result, nil, nil)
+      end
+
+      # Evaluate strings which contain *exactly* a variable reference.
+      # Otherwise return the value unmodified.
+      def interpolate_variables(scope, value)
+        if value.is_a?(String)
+          # Try to parse the string as Puppet code. If it's invalid code,
+          # return the original string.
+          begin
+            parse_result = @evaluator.parse_string(value)
+          rescue Puppet::ParseError
+            return value
+          else
+            if parse_result.body.is_a?(Puppet::Pops::Model::VariableExpression)
+              # If we just evaluate the string, errors will reference "line 1", which is wrong
+              return scope.lookupvar(parse_result.body.expr.value)
+            end
+          end
+        end
+
+        value
+      end
+
+      # Occasionally the Closure will ask us to evaluate what it assumes are
+      # AST objects. Because we've sidestepped the AST, they aren't, so just
+      # return the values as already evaluated.
+      def evaluate(value, _scope)
+        value
       end
 
       def self.create(loader, typed_name, source_ref, yaml_string)
@@ -57,6 +149,7 @@ module Bolt
 
         def parameters
           @parameters ||= @body.fetch('parameters', {}).map do |name, definition|
+            definition ||= {}
             type = Puppet::Pops::Types::TypeParser.singleton.parse(definition['type']) if definition.key?('type')
             Parameter.new(name, definition['default'], type)
           end

--- a/spec/bolt/pal/yaml_plan_evaluator_spec.rb
+++ b/spec/bolt/pal/yaml_plan_evaluator_spec.rb
@@ -1,0 +1,352 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/pal'
+require 'bolt/pal/yaml_plan_evaluator'
+
+describe Bolt::PAL::YamlPlanEvaluator do
+  let(:plan_name) { Puppet::Pops::Loader::TypedName.new(:plan, 'test') }
+  let(:pal) { Bolt::PAL.new([], nil) }
+  # It doesn't really matter which loader or scope we use, but we need them, so take the
+  # static loader and global scope
+  let(:loader) { Puppet.lookup(:loaders).static_loader }
+  let(:scope) { Puppet.lookup(:global_scope) }
+
+  around :each do |example|
+    pal.in_bolt_compiler do
+      example.run
+    end
+  end
+
+  before :each do
+    # Make sure we don't accidentally call any run functions
+    allow(scope).to receive(:call_function)
+  end
+
+  def call_plan(plan, params = {})
+    # This is taken from the boltlib::run_plan function
+    catch(:return) {
+      plan.class.dispatcher.dispatchers[0].call_by_name_with_scope(scope, params, true)
+    }&.value
+  end
+
+  describe Bolt::PAL::YamlPlanEvaluator::PlanWrapper do
+    let(:plan) { described_class.new(plan_name, @plan_body) }
+
+    it 'parses parameter types' do
+      @plan_body = {
+        'parameters' => {
+          'nodes' => {
+            'type' => 'TargetSpec'
+          },
+          'package' => {
+            'type' => 'String'
+          },
+          'count' => {
+            'type' => 'Integer'
+          }
+        }
+      }
+
+      param_types = plan.parameters.inject({}) { |acc, param| acc.merge(param.name => param.type_expr) }
+
+      expect(param_types.keys).to contain_exactly('nodes', 'package', 'count')
+      expect(param_types['nodes'].name).to eq('TargetSpec')
+      expect(param_types['package']).to be_a(Puppet::Pops::Types::PStringType)
+      expect(param_types['count']).to be_a(Puppet::Pops::Types::PIntegerType)
+    end
+
+    it 'handles parameters without types' do
+      @plan_body = {
+        'parameters' => {
+          'empty' => {},
+          'nil' => nil
+        }
+      }
+
+      expect(plan.parameters.map(&:name)).to contain_exactly('empty', 'nil')
+      expect(plan.parameters.map(&:type_expr)).to eq([nil, nil])
+    end
+
+    it 'uses an empty parameter list if non are specified' do
+      @plan_body = {}
+
+      expect(plan.parameters).to eq([])
+    end
+  end
+
+  describe "::create" do
+    it 'fails if the plan is not a Hash' do
+      plan_body = '[]'
+
+      expect { described_class.create(loader, plan_name, 'test.yaml', plan_body) }.to raise_error(
+        ArgumentError, /test.yaml does not contain an object/
+      )
+    end
+
+    it 'returns a puppet function wrapper' do
+      plan_body = '{}'
+      plan = described_class.create(loader, plan_name, 'test.yaml', plan_body)
+      expect(plan).to be_a(Puppet::Functions::Function)
+    end
+  end
+
+  describe "evaluating a plan" do
+    it 'validates the parameters' do
+      plan_body = <<-YAML
+      parameters:
+        foo:
+          type: String
+        bar:
+          type: Integer
+
+      steps: []
+      YAML
+
+      plan = described_class.create(loader, plan_name, 'test.yaml', plan_body)
+
+      expect(call_plan(plan, 'foo' => 'hello', 'bar' => 5)).to eq(nil)
+      expect(call_plan(plan, 'foo' => '', 'bar' => 5)).to eq(nil)
+
+      expect { call_plan(plan, 'foo' => 'hello', 'bar' => 'five') }.to raise_error(
+        Puppet::ParseError, /parameter 'bar' expects an Integer value, got String/
+      )
+      expect { call_plan(plan, 'foo' => 'hello') }.to raise_error(
+        Puppet::ParseError, /expects a value for parameter 'bar'/
+      )
+      expect { call_plan(plan, 'foo' => 'hello', 'bar' => 5, 'baz' => true) }.to raise_error(
+        Puppet::ParseError, /has no parameter named 'baz'/
+      )
+    end
+
+    # a) empty array, b) nil, c) missing key
+    it 'does nothing if the steps list is empty' do
+      plan_body = <<-YAML
+      steps: []
+      YAML
+
+      plan = described_class.create(loader, plan_name, 'test.yaml', plan_body)
+
+      expect(scope).not_to receive(:call_function)
+
+      expect(call_plan(plan)).to eq(nil)
+    end
+
+    it 'fails if the steps list is not an array' do
+      plan_body = <<-YAML
+      steps: nil
+      YAML
+
+      plan = described_class.create(loader, plan_name, 'test.yaml', plan_body)
+
+      expect { call_plan(plan) }.to raise_error(Bolt::Error, /Plan must specify an array of steps/)
+    end
+
+    it 'fails if the steps list is not specified' do
+      plan_body = <<-YAML
+      parameters: {}
+      YAML
+
+      plan = described_class.create(loader, plan_name, 'test.yaml', plan_body)
+
+      expect { call_plan(plan) }.to raise_error(Bolt::Error, /Plan must specify an array of steps/)
+    end
+
+    it 'runs each step in order' do
+      plan_body = <<-YAML
+      parameters:
+        package:
+          type: String
+        nodes:
+          type: TargetSpec
+      steps:
+        - task: package
+          target: $nodes
+          parameters:
+            action: status
+            name: $package
+        - command: hostname -f
+          target: $nodes
+      YAML
+
+      plan = described_class.create(loader, plan_name, 'test.yaml', plan_body)
+
+      nodes = %w[foo.example.com bar.example.com]
+      params = { 'action' => 'status', 'name' => 'openssl' }
+      expect(scope).to receive(:call_function).with('run_task', ['package', nodes, params]).ordered
+      expect(scope).to receive(:call_function).with('run_command', ['hostname -f', nodes]).ordered
+
+      call_plan(plan, 'package' => 'openssl', 'nodes' => nodes)
+    end
+
+    # task+command
+    it 'fails if a step is ambiguous' do
+      plan_body = <<-YAML
+      steps:
+        - task: package
+          command: yum install package
+          target: ["foo.example.com"]
+      YAML
+
+      plan = described_class.create(loader, plan_name, 'test.yaml', plan_body)
+
+      expect { call_plan(plan) }.to raise_error(Bolt::Error, /Unsupported plan step/)
+    end
+
+    it 'fails for an unknown step' do
+      plan_body = <<-YAML
+      steps:
+        - package: openssl
+          target: ["foo.example.com"]
+      YAML
+
+      plan = described_class.create(loader, plan_name, 'test.yaml', plan_body)
+
+      expect { call_plan(plan) }.to raise_error(Bolt::Error, /Unsupported plan step/)
+    end
+  end
+
+  describe "#task_step" do
+    let(:step) do
+      { 'task' => 'package',
+        'target' => 'foo.example.com',
+        'parameters' => { 'action' => 'status',
+                          'name' => 'openssl' } }
+    end
+
+    it 'fails if no target is specified' do
+      step.delete('target')
+
+      expect { subject.task_step(scope, step) }.to raise_error(/Can't run a task without specifying a target/)
+    end
+
+    it 'succeeds if no parameters are specified' do
+      step.delete('parameters')
+
+      expect(scope).to receive(:call_function).with('run_task', ['package', 'foo.example.com', {}])
+      subject.task_step(scope, step)
+    end
+
+    it 'succeeds if nil parameters are specified' do
+      step['parameters'] = nil
+
+      expect(scope).to receive(:call_function).with('run_task', ['package', 'foo.example.com', {}])
+      subject.task_step(scope, step)
+    end
+
+    it 'accepts a variable for target' do
+      step['target'] = '$target'
+
+      scope.with_local_scope('target' => 'bar.example.com') do |local_scope|
+        args = ['package', 'bar.example.com', { 'action' => 'status', 'name' => 'openssl' }]
+        expect(local_scope).to receive(:call_function).with('run_task', args)
+
+        subject.task_step(local_scope, step)
+      end
+    end
+
+    it 'accepts a variable for parameter values' do
+      step['parameters'] = {
+        'name' => '$package',
+        'action' => 'status'
+      }
+
+      scope.with_local_scope('package' => 'vim') do |local_scope|
+        args = ['package', 'foo.example.com', { 'action' => 'status', 'name' => 'vim' }]
+        expect(local_scope).to receive(:call_function).with('run_task', args)
+
+        subject.task_step(local_scope, step)
+      end
+    end
+
+    it 'supports a description' do
+      step['description'] = 'run the thing'
+
+      args = ['package', 'foo.example.com', 'run the thing', { 'action' => 'status', 'name' => 'openssl' }]
+      expect(scope).to receive(:call_function).with('run_task', args)
+
+      subject.task_step(scope, step)
+    end
+  end
+
+  describe "#command_step" do
+    let(:step) do
+      { 'command' => 'hostname -f',
+        'target' => 'foo.example.com' }
+    end
+
+    it 'fails if no target is specified' do
+      step.delete('target')
+
+      expect { subject.command_step(scope, step) }.to raise_error(/Can't run a command without specifying a target/)
+    end
+
+    it 'accepts a variable for target' do
+      step['target'] = '$target'
+
+      scope.with_local_scope('target' => 'bar.example.com') do |local_scope|
+        expect(local_scope).to receive(:call_function).with('run_command', ['hostname -f', 'bar.example.com'])
+
+        subject.command_step(local_scope, step)
+      end
+    end
+
+    it 'supports a description' do
+      step['description'] = 'run the thing'
+
+      expect(scope).to receive(:call_function).with('run_command', ['hostname -f', 'foo.example.com', 'run the thing'])
+      subject.command_step(scope, step)
+    end
+  end
+
+  describe "#interpolate_variables" do
+    it 'returns non-String values unmodified' do
+      [
+        %w[a b c],
+        5,
+        true,
+        nil,
+        { 'a' => 1 },
+        %w[$a $b $c],
+        { '$a' => '$b' }
+      ].each do |value|
+        expect(subject.interpolate_variables(scope, value)).to eq(value)
+      end
+    end
+
+    it 'replaces exact variable matches with their value' do
+      scope.with_local_scope('message' => 'hello world') do |local_scope|
+        expect(subject.interpolate_variables(local_scope, '$message')).to eq('hello world')
+      end
+    end
+
+    it 'raises an error if an undefined variable is referenced' do
+      scope.with_local_scope('message' => 'hello world') do |local_scope|
+        expect { subject.interpolate_variables(local_scope, '$dressage') }.to raise_error(/Undefined variable/)
+      end
+    end
+
+    # This one seems like it should work, but `${message}` is actually invalid
+    # puppet code, because that form of variable reference needs to be inside a
+    # string literal.
+    it 'returns the string if it is wrapped in curly braces' do
+      expect(subject.interpolate_variables(scope, '${message}')).to eq('${message}')
+    end
+
+    it 'returns the string if it is not a variable reference' do
+      expect(subject.interpolate_variables(scope, 'foo')).to eq('foo')
+    end
+
+    it 'returns the string if it has an embedded variable reference' do
+      expect(subject.interpolate_variables(scope, 'foo$bar')).to eq('foo$bar')
+    end
+
+    it 'returns the string if it includes complex interpolation' do
+      expect(subject.interpolate_variables(scope, '${foo[0]}')).to eq('${foo[0]}')
+    end
+
+    it 'returns the string if it contains multiple variable interpolations' do
+      expect(subject.interpolate_variables(scope, '$foo$bar')).to eq('$foo$bar')
+    end
+  end
+end

--- a/spec/integration/plan_spec.rb
+++ b/spec/integration/plan_spec.rb
@@ -42,4 +42,13 @@ describe "When a plan succeeds" do
     expect(result).to match(/Successful on 1 node:/)
     expect(result).to match(/Ran on 1 node/)
   end
+
+  it 'runs a yaml plan', ssh: true do
+    result = run_cli(['plan', 'run', 'sample::yaml', '--nodes', target] + config_flags)
+    expect(JSON.parse(result)).to be_nil
+
+    lines = @log_output.readlines
+    expect(lines).to include(match(/Starting: task/))
+    expect(lines).to include(match(/Starting: command/))
+  end
 end


### PR DESCRIPTION
This implements support for running YAML plans containing task and command
steps only. Every other kind of step is unsupported.

Variable interpolation is supported for targets and for parameter values,
with only exact variable matches (like `$foo`) being supported. Any other
value will be treated as a literal.