### PR TITLE
(BOLT-1076) Bump orchestrator_client gem

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "minitar", "~> 0.6"
   spec.add_dependency "net-scp", "~> 1.2"
   spec.add_dependency "net-ssh", ">= 4.0"
-  spec.add_dependency "orchestrator_client", "~> 0.3.1"
+  spec.add_dependency "orchestrator_client", "~> 0.4"
   spec.add_dependency "puppet", [">= 6.0.1", "< 7"]
   spec.add_dependency "puppet-resource_api"
   spec.add_dependency "r10k", "~> 3.1"

--- a/spec/bolt/transport/orch_spec.rb
+++ b/spec/bolt/transport/orch_spec.rb
@@ -46,13 +46,16 @@ describe Bolt::Transport::Orch, orchestrator: true do
 
   describe "when orchestrator_client-ruby is used" do
     it "bolt sets User-Agent header option to Bolt/${version}" do
-      config = {
-        'service-url' => 'foo',
-        'cacert' => 'bar'
-      }
-      allow(OrchestratorClient).to receive(:new).and_call_original
-      c = Bolt::Transport::Orch::Connection.new(config, nil, orch.logger)
-      expect(c.instance_variable_get(:@client).config.config["User-Agent"]).to eq("Bolt/#{Bolt::VERSION}")
+      with_tempfile_containing('token', 'faketoken') do |conf|
+        config = {
+          'service-url' => 'https://foo.bar:8143',
+          'cacert' => 'bar',
+          'token-file' => conf.path
+        }
+        allow(OrchestratorClient).to receive(:new).and_call_original
+        c = Bolt::Transport::Orch::Connection.new(config, nil, orch.logger)
+        expect(c.instance_variable_get(:@client).config.config["User-Agent"]).to eq("Bolt/#{Bolt::VERSION}")
+      end
     end
   end
 


### PR DESCRIPTION
The 0.4.2 version of orchestrator_client adds persistent HTTP connections for linux clients as well as validation and helpful error messages for token-file config.