### PR TITLE
 (BOLT-1052) Add run-as option to local transport 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,3 +81,10 @@ Metrics/ParameterLists:
 
 Metrics/PerceivedComplexity:
   Enabled: false
+
+Performance/UnfreezeString:
+  Enabled: false
+
+Lint/HandleExceptions:
+  Exclude:
+    - lib/bolt/transport/local/shell.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,21 @@ env:
   global:
     - REGISTRY_HOST=pcr-internal.puppet.net
     - DOCKER_REGISTRY=pe-and-platform
+    - BOLT_SUDO_USER=true
     - secure: Gk8LaACXYEVpv5LIWEMOuH3sJP4CzB2aSvE1BUcfDWkI+Hdgr2by3w/nGbKpyVD+v2H8r0zXyVrbCJ/qzx2gCRxqKJ2GKJEsrStT+8z3BXRRRzwkThIBVyWKk9b9bTt8AE0G94I3BE4gJyIPfbX5XxnKcg7nJZGOmubZpUPQX+2SXSfy9EbtY9iismwK7LGtWv6l90cK2eSLZGvdsSKPo7cylOldXfdYIyeBtvsIL1juBaiINX52Zgt371+nX53fDSYOKdIDLuhNqX3zpNOuIJ9DUj4E7IJA7+XhHy77zL98VjHtPo5H4fmKyZ2k+xbYqOydc5OPGguKequsnyDo5npktDrkbswnjWMXNDu+wImAd+IwHG2lTamsAnOGQ+E6g2oK0R5fUL26XJ3lBnTRrsLDnlrvqYqFxt3MCR+o5+DnTirSVQJfrRVsIKTucWHlYLTOUWkVDrLavJqIbWHytEbMf/BXUcovlQzSgfu5/Y1GkUJBnthtbiZfTImmBLcrqKDD4PnDmvC1v9Z5KR78MYu7lFTe5C4STj2aR6bwvqjiPKm6kYG5etOFEyRJ+CbqD2QsdF2N6Ww/RFWovqVqQIWuGdhumDUTdmQAiiPxl12M0+kIH6NugpBD3gt4RT0sni/T+booDw6b3Ts4WJ8FW1/LPWdy7gVo9yOCL4FhjOw=
 before_script:
 - docker-compose -f spec/docker-compose.yml up -d --build
 - eval `ssh-agent`
 - cat Gemfile.lock
 - bundle exec r10k puppetfile install
+  # Add users to test sudo on localhost
+- sudo groupadd bolt
+- sudo useradd -g bolt bolt
+- echo 'bolt:bolt' | sudo chpasswd
+- echo 'travis:travis' | sudo chpasswd
+  # Undo travis sudoers config
+- sudo sh -c "echo 'Defaults authenticate' >> /etc/sudoers"
+- sudo sh -c "echo 'travis  ALL=(ALL) PASSWD:ALL' >> /etc/sudoers"
 script:
 - bundle exec rake travisci
 - bundle exec rubocop

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -8,15 +8,17 @@ require 'bolt/transport/ssh'
 require 'bolt/transport/winrm'
 require 'bolt/transport/orch'
 require 'bolt/transport/local'
+require 'bolt/transport/local_windows'
 require 'bolt/transport/docker'
 require 'bolt/transport/remote'
+require 'bolt/util'
 
 module Bolt
   TRANSPORTS = {
     ssh: Bolt::Transport::SSH,
     winrm: Bolt::Transport::WinRM,
     pcp: Bolt::Transport::Orch,
-    local: Bolt::Transport::Local,
+    local: Bolt::Util.windows? ? Bolt::Transport::LocalWindows : Bolt::Transport::Local,
     docker: Bolt::Transport::Docker,
     remote: Bolt::Transport::Remote
   }.freeze

--- a/lib/bolt/transport/local.rb
+++ b/lib/bolt/transport/local.rb
@@ -1,17 +1,10 @@
 # frozen_string_literal: true
 
-require 'json'
-require 'fileutils'
-require 'tmpdir'
-require 'bolt/transport/base'
-require 'bolt/transport/powershell'
-require 'bolt/util'
-
 module Bolt
   module Transport
-    class Local < Base
+    class Local < Sudoable
       def self.options
-        %w[tmpdir interpreters]
+        %w[tmpdir interpreters sudo-password run-as run-as-command]
       end
 
       def self.default_options
@@ -21,176 +14,17 @@ module Bolt
       end
 
       def provided_features
-        if Bolt::Util.windows?
-          ['powershell']
-        else
-          ['shell']
-        end
+        ['shell']
       end
 
-      def default_input_method(executable)
-        input_method ||= Powershell.powershell_file?(executable) ? 'powershell' : 'both'
-        input_method
+      def self.validate(options)
+        logger = Logging.logger[self]
+        validate_sudo_options(options, logger)
       end
 
-      def self.validate(_options); end
-
-      def initialize
-        super
-        @conn = Shell.new
-      end
-
-      def in_tmpdir(base)
-        args = base ? [nil, base] : []
-        dir = begin
-                Dir.mktmpdir(*args)
-              rescue StandardError => e
-                raise Bolt::Node::FileError.new("Could not make tempdir: #{e.message}", 'TEMPDIR_ERROR')
-              end
-
-        yield dir
-      ensure
-        FileUtils.remove_entry dir if dir
-      end
-      private :in_tmpdir
-
-      def copy_file(source, destination)
-        FileUtils.cp_r(source, destination, remove_destination: true)
-      rescue StandardError => e
-        raise Bolt::Node::FileError.new(e.message, 'WRITE_ERROR')
-      end
-
-      def with_tmpscript(script, base)
-        in_tmpdir(base) do |dir|
-          dest = File.join(dir, File.basename(script))
-          copy_file(script, dest)
-          File.chmod(0o750, dest)
-          yield dest, dir
-        end
-      end
-      private :with_tmpscript
-
-      def upload(target, source, destination, _options = {})
-        copy_file(source, destination)
-        Bolt::Result.for_upload(target, source, destination)
-      end
-
-      def run_command(target, command, _options = {})
-        in_tmpdir(target.options['tmpdir']) do |dir|
-          output = @conn.execute(command, dir: dir)
-          Bolt::Result.for_command(target,
-                                   output.stdout.string,
-                                   output.stderr.string,
-                                   output.exit_code,
-                                   'command', command)
-        end
-      end
-
-      def run_script(target, script, arguments, _options = {})
-        with_tmpscript(File.absolute_path(script), target.options['tmpdir']) do |file, dir|
-          logger.debug "Running '#{file}' with #{arguments}"
-
-          # unpack any Sensitive data AFTER we log
-          arguments = unwrap_sensitive_args(arguments)
-          if Bolt::Util.windows?
-            if Powershell.powershell_file?(file)
-              command = Powershell.run_script(arguments, file)
-              output = @conn.execute(command, dir: dir, env: "powershell.exe")
-            else
-              path, args = *Powershell.process_from_extension(file)
-              args += Powershell.escape_arguments(arguments)
-              command = args.unshift(path).join(' ')
-              output = @conn.execute(command, dir: dir)
-            end
-          else
-            if arguments.empty?
-              # We will always provide separated arguments, so work-around Open3's handling of a single
-              # argument as the entire command string for script paths containing spaces.
-              arguments = ['']
-            end
-            output = @conn.execute(file, *arguments, dir: dir)
-          end
-          Bolt::Result.for_command(target,
-                                   output.stdout.string,
-                                   output.stderr.string,
-                                   output.exit_code,
-                                   'script', script)
-        end
-      end
-
-      def run_task(target, task, arguments, _options = {})
-        implementation = select_implementation(target, task)
-        executable = implementation['path']
-        input_method = implementation['input_method']
-        extra_files = implementation['files']
-
-        in_tmpdir(target.options['tmpdir']) do |dir|
-          if extra_files.empty?
-            script = File.join(dir, File.basename(executable))
-          else
-            arguments['_installdir'] = dir
-            script_dest = File.join(dir, task.tasks_dir)
-            FileUtils.mkdir_p([script_dest] + extra_files.map { |file| File.join(dir, File.dirname(file['name'])) })
-
-            script = File.join(script_dest, File.basename(executable))
-            extra_files.each do |file|
-              dest = File.join(dir, file['name'])
-              copy_file(file['path'], dest)
-              File.chmod(0o750, dest)
-            end
-          end
-
-          copy_file(executable, script)
-          File.chmod(0o750, script)
-
-          interpreter = select_interpreter(script, target.options['interpreters'])
-          interpreter_debug = interpreter ? " using '#{interpreter}' interpreter" : nil
-          # log the arguments with sensitive data redacted, do NOT log unwrapped_arguments
-          logger.debug("Running '#{script}' with #{arguments}#{interpreter_debug}")
-          unwrapped_arguments = unwrap_sensitive_args(arguments)
-
-          stdin = STDIN_METHODS.include?(input_method) ? JSON.dump(unwrapped_arguments) : nil
-
-          if Bolt::Util.windows?
-            # WINDOWS
-            if ENVIRONMENT_METHODS.include?(input_method)
-              environment_params = envify_params(unwrapped_arguments).each_with_object([]) do |(arg, val), list|
-                list << Powershell.set_env(arg, val)
-              end
-              environment_params = environment_params.join("\n") + "\n"
-            else
-              environment_params = ""
-            end
-
-            if Powershell.powershell_file?(script) && stdin.nil?
-              command = Powershell.run_ps_task(arguments, script, input_method)
-              command = environment_params + Powershell.shell_init + command
-              interpreter ||= 'powershell.exe'
-              output =
-                if input_method == 'powershell'
-                  @conn.execute(command, dir: dir, interpreter: interpreter)
-                else
-                  @conn.execute(command, dir: dir, stdin: stdin, interpreter: interpreter)
-                end
-            end
-            unless output
-              if interpreter
-                env = ENVIRONMENT_METHODS.include?(input_method) ? envify_params(unwrapped_arguments) : nil
-                output = @conn.execute(script, stdin: stdin, env: env, dir: dir, interpreter: interpreter)
-              else
-                path, args = *Powershell.process_from_extension(script)
-                command = args.unshift(path).join(' ')
-                command = environment_params + Powershell.shell_init + command
-                output = @conn.execute(command, dir: dir, stdin: stdin, interpreter: 'powershell.exe')
-              end
-            end
-          else
-            # POSIX
-            env = ENVIRONMENT_METHODS.include?(input_method) ? envify_params(unwrapped_arguments) : nil
-            output = @conn.execute(script, stdin: stdin, env: env, dir: dir, interpreter: interpreter)
-          end
-          Bolt::Result.for_task(target, output.stdout.string, output.stderr.string, output.exit_code, task.name)
-        end
+      def with_connection(target, *_args)
+        conn = Shell.new(target)
+        yield conn
       end
 
       def connected?(_targets)

--- a/lib/bolt/transport/local/shell.rb
+++ b/lib/bolt/transport/local/shell.rb
@@ -1,26 +1,206 @@
 # frozen_string_literal: true
 
 require 'open3'
+require 'fileutils'
 require 'bolt/node/output'
+require 'bolt/util'
 
 module Bolt
   module Transport
-    class Local
-      class Shell
-        def execute(*command, options)
-          command.unshift(options[:interpreter]) if options[:interpreter]
-          command = [options[:env]] + command if options[:env]
+    class Local < Sudoable
+      class Shell < Sudoable::Connection
+        attr_accessor :user, :logger, :target
+        attr_writer :run_as
 
-          if options[:stdin]
-            stdout, stderr, rc = Open3.capture3(*command, stdin_data: options[:stdin], chdir: options[:dir])
+        CHUNK_SIZE = 4096
+
+        def initialize(target)
+          @target = target
+          # The familiar problem: Etc.getlogin is broken on osx
+          @user = ENV['USER'] || Etc.getlogin
+          @run_as = target.options['run-as']
+          @logger = Logging.logger[self]
+        end
+
+        # If prompted for sudo password, send password to stdin and return an
+        # empty string. Otherwise, check for sudo errors and raise Bolt error.
+        # If error is not sudo-related, return the stderr string to be added to
+        # node output
+        def handle_sudo(stdin, err, pid)
+          if err.include?(Sudoable.sudo_prompt)
+            # A wild sudo prompt has appeared!
+            if @target.options['sudo-password']
+              # Hopefully no one's sudo-password is > 64kb
+              stdin.write("#{@target.options['sudo-password']}\n")
+              ''
+            else
+              raise Bolt::Node::EscalateError.new(
+                "Sudo password for user #{@user} was not provided for localhost",
+                'NO_PASSWORD'
+              )
+            end
           else
-            stdout, stderr, rc = Open3.capture3(*command, chdir: options[:dir])
+            handle_sudo_errors(err, pid)
+          end
+        end
+
+        def handle_sudo_errors(err, pid)
+          if err =~ /^#{@user} is not in the sudoers file\./
+            @logger.debug { err }
+            raise Bolt::Node::EscalateError.new(
+              "User #{@user} does not have sudo permission on localhost",
+              'SUDO_DENIED'
+            )
+          elsif err =~ /^Sorry, try again\./
+            @logger.debug { err }
+            # CODEREVIEW can we kill a sudo process without sudo password?
+            Process.kill('TERM', pid)
+            raise Bolt::Node::EscalateError.new(
+              "Sudo password for user #{@user} not recognized on localhost",
+              'BAD_PASSWORD'
+            )
+          else
+            # No need to raise an error - just return the string
+            err
+          end
+        end
+
+        def copy_file(source, dest)
+          if source.is_a?(StringIO)
+            File.open("tempfile", "w") { |f| f.write(source.read) }
+            execute(['mv', 'tempfile', dest])
+          else
+            # Mimic the behavior of `cp --remove-destination`
+            # since the flag isn't supported on MacOS
+            result = execute(['rm', '-rf', dest])
+            if result.exit_code != 0
+              message = "Could not remove existing file #{dest}: #{result.stderr.string}"
+              raise Bolt::Node::FileError.new(message, 'REMOVE_ERROR')
+            end
+
+            result = execute(['cp', '-r', source, dest])
+            if result.exit_code != 0
+              message = "Could not copy file to #{dest}: #{result.stderr.string}"
+              raise Bolt::Node::FileError.new(message, 'COPY_ERROR')
+            end
+          end
+        end
+
+        def with_tmpscript(script)
+          with_tempdir do |dir|
+            dest = File.join(dir.to_s, File.basename(script))
+            copy_file(script, dest)
+            yield dest, dir
+          end
+        end
+
+        # See if there's a sudo prompt in the output
+        # If not, return the output
+        def check_sudo(out, inp, pid)
+          buffer = out.readpartial(CHUNK_SIZE)
+          # Split on newlines, including the newline
+          lines = buffer.split(/(?<=[\n])/)
+          # handle_sudo will return the line if it is not a sudo prompt or error
+          lines.map! { |line| handle_sudo(inp, line, pid) }
+          lines.join("")
+        end
+
+        def execute(command, sudoable: true, **options)
+          run_as = options[:run_as] || self.run_as
+          escalate = sudoable && run_as && @user != run_as
+          use_sudo = escalate && @target.options['run-as-command'].nil?
+
+          if options[:interpreter]
+            if command.is_a?(Array)
+              command.unshift(options[:interpreter])
+            else
+              command = [options[:interpreter], command]
+            end
           end
 
+          command_str = command.is_a?(String) ? command : Shellwords.shelljoin(command)
+
+          if escalate
+            if use_sudo
+              sudo_flags = ["sudo", "-k", "-S", "-u", run_as, "-p", Sudoable.sudo_prompt]
+              sudo_flags += ["-E"] if options[:environment]
+              sudo_str = Shellwords.shelljoin(sudo_flags)
+              command_str = "#{sudo_str} #{command_str}"
+            else
+              run_as_str = Shellwords.shelljoin(@target.options['run-as-command'] + [run_as])
+              command_str = "#{run_as_str} #{command_str}"
+            end
+          end
+
+          command_arr = options[:environment].nil? ? [command_str] : [options[:environment], command_str]
+
+          # Prepare the variables!
           result_output = Bolt::Node::Output.new
-          result_output.stdout << stdout unless stdout.nil?
-          result_output.stderr << stderr unless stderr.nil?
-          result_output.exit_code = rc.exitstatus
+          in_buffer = options[:stdin] || ''
+          # Chunks of this size will be read in one iteration
+          index = 0
+          timeout = 0.1
+
+          inp, out, err, t = Open3.popen3(*command_arr)
+          read_streams = { out => String.new,
+                           err => String.new }
+          write_stream = in_buffer.empty? ? [] : [inp]
+
+          # See if there's a sudo prompt
+          if use_sudo
+            ready_read = select([err], nil, nil, timeout * 5)
+            read_streams[err] << check_sudo(err, inp, t.pid) if ready_read
+          end
+
+          # True while the thread is running or waiting for IO input
+          while t.alive?
+            # See if we can read from out or err, or write to in
+            ready_read, ready_write, = select(read_streams.keys, write_stream, nil, timeout)
+
+            # Read from out and err
+            ready_read&.each do |stream|
+              begin
+                # Check for sudo prompt
+                read_streams[stream] << if use_sudo
+                                          check_sudo(stream, inp, t.pid)
+                                        else
+                                          stream.readpartial(CHUNK_SIZE)
+                                        end
+              rescue EOFError
+              end
+            end
+
+            # select will either return an empty array if there are no
+            # writable streams or nil if no IO object is available before the
+            # timeout is reached.
+            writable = if ready_write.respond_to?(:empty?)
+                         !ready_write.empty?
+                       else
+                         !ready_write.nil?
+                       end
+
+            if writable && index < in_buffer.length
+              to_print = in_buffer[index..-1]
+              written = inp.write_nonblock to_print
+              index += written
+            end
+
+            if index >= in_buffer.length && !write_stream.empty?
+              inp.close
+              write_stream = []
+            end
+          end
+          # Read any remaining data in the pipe. Do not wait for
+          # EOF in case the pipe is inherited by a child process.
+          read_streams.each do |stream, _|
+            begin
+              loop { read_streams[stream] << stream.read_nonblock(CHUNK_SIZE) }
+            rescue Errno::EAGAIN, EOFError
+            end
+          end
+          result_output.stdout << read_streams[out]
+          result_output.stderr << read_streams[err]
+          result_output.exit_code = t.value.exitstatus
           result_output
         end
       end

--- a/lib/bolt/transport/local_windows.rb
+++ b/lib/bolt/transport/local_windows.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'fileutils'
+require 'open3'
+require 'tmpdir'
+require 'bolt/node/output'
+require 'bolt/transport/base'
+require 'bolt/transport/powershell'
+require 'bolt/util'
+
+module Bolt
+  module Transport
+    class LocalWindows < Base
+      def self.options
+        %w[tmpdir interpreters run-as run-as-command sudo-password]
+      end
+
+      def self.default_options
+        {
+          'interpreters' => { '.rb' => RbConfig.ruby }
+        }
+      end
+
+      def provided_features
+        ['powershell']
+      end
+
+      def default_input_method(executable)
+        input_method ||= Powershell.powershell_file?(executable) ? 'powershell' : 'both'
+        input_method
+      end
+
+      def self.validate(options)
+        logger = Logging.logger[self]
+        if options['sudo-password'] || options['run-as'] || options['run-as-command'] || options['_run_as']
+          logger.warn("run-as is not supported for Windows hosts using the local transport")
+        end
+      end
+
+      def in_tmpdir(base)
+        args = base ? [nil, base] : []
+        dir = begin
+                Dir.mktmpdir(*args)
+              rescue StandardError => e
+                raise Bolt::Node::FileError.new("Could not make tempdir: #{e.message}", 'TEMPDIR_ERROR')
+              end
+
+        yield dir
+      ensure
+        FileUtils.remove_entry dir if dir
+      end
+      private :in_tmpdir
+
+      def copy_file(source, destination)
+        FileUtils.cp_r(source, destination, remove_destination: true)
+      rescue StandardError => e
+        raise Bolt::Node::FileError.new(e.message, 'WRITE_ERROR')
+      end
+
+      def with_tmpscript(script, base)
+        in_tmpdir(base) do |dir|
+          dest = File.join(dir, File.basename(script))
+          copy_file(script, dest)
+          File.chmod(0o750, dest)
+          yield dest, dir
+        end
+      end
+      private :with_tmpscript
+
+      def execute(*command, options)
+        command.unshift(options[:interpreter]) if options[:interpreter]
+        command = [options[:env]] + command if options[:env]
+
+        if options[:stdin]
+          stdout, stderr, rc = Open3.capture3(*command, stdin_data: options[:stdin], chdir: options[:dir])
+        else
+          stdout, stderr, rc = Open3.capture3(*command, chdir: options[:dir])
+        end
+
+        result_output = Bolt::Node::Output.new
+        result_output.stdout << stdout unless stdout.nil?
+        result_output.stderr << stderr unless stderr.nil?
+        result_output.exit_code = rc.exitstatus
+        result_output
+      end
+
+      def upload(target, source, destination, options = {})
+        self.class.validate(options)
+        copy_file(source, destination)
+        Bolt::Result.for_upload(target, source, destination)
+      end
+
+      def run_command(target, command, options = {})
+        self.class.validate(options)
+        in_tmpdir(target.options['tmpdir']) do |dir|
+          output = execute(command, dir: dir)
+          Bolt::Result.for_command(target,
+                                   output.stdout.string,
+                                   output.stderr.string,
+                                   output.exit_code,
+                                   'command', command)
+        end
+      end
+
+      def run_script(target, script, arguments, options = {})
+        self.class.validate(options)
+        with_tmpscript(File.absolute_path(script), target.options['tmpdir']) do |file, dir|
+          logger.debug "Running '#{file}' with #{arguments}"
+
+          # unpack any Sensitive data AFTER we log
+          arguments = unwrap_sensitive_args(arguments)
+          if Powershell.powershell_file?(file)
+            command = Powershell.run_script(arguments, file)
+            output = execute(command, dir: dir, env: "powershell.exe")
+          else
+            path, args = *Powershell.process_from_extension(file)
+            args += Powershell.escape_arguments(arguments)
+            command = args.unshift(path).join(' ')
+            output = execute(command, dir: dir)
+          end
+          Bolt::Result.for_command(target,
+                                   output.stdout.string,
+                                   output.stderr.string,
+                                   output.exit_code,
+                                   'script', script)
+        end
+      end
+
+      def run_task(target, task, arguments, options = {})
+        self.class.validate(options)
+        implementation = select_implementation(target, task)
+        executable = implementation['path']
+        input_method = implementation['input_method']
+        extra_files = implementation['files']
+
+        in_tmpdir(target.options['tmpdir']) do |dir|
+          if extra_files.empty?
+            script = File.join(dir, File.basename(executable))
+          else
+            arguments['_installdir'] = dir
+            script_dest = File.join(dir, task.tasks_dir)
+            FileUtils.mkdir_p([script_dest] + extra_files.map { |file| File.join(dir, File.dirname(file['name'])) })
+
+            script = File.join(script_dest, File.basename(executable))
+            extra_files.each do |file|
+              dest = File.join(dir, file['name'])
+              copy_file(file['path'], dest)
+              File.chmod(0o750, dest)
+            end
+          end
+
+          copy_file(executable, script)
+          File.chmod(0o750, script)
+
+          interpreter = select_interpreter(script, target.options['interpreters'])
+          interpreter_debug = interpreter ? " using '#{interpreter}' interpreter" : nil
+          # log the arguments with sensitive data redacted, do NOT log unwrapped_arguments
+          logger.debug("Running '#{script}' with #{arguments}#{interpreter_debug}")
+          unwrapped_arguments = unwrap_sensitive_args(arguments)
+
+          stdin = STDIN_METHODS.include?(input_method) ? JSON.dump(unwrapped_arguments) : nil
+          if ENVIRONMENT_METHODS.include?(input_method)
+            environment_params = envify_params(unwrapped_arguments).each_with_object([]) do |(arg, val), list|
+              list << Powershell.set_env(arg, val)
+            end
+            environment_params = environment_params.join("\n") + "\n"
+          else
+            environment_params = ""
+          end
+
+          if Powershell.powershell_file?(script) && stdin.nil?
+            command = Powershell.run_ps_task(arguments, script, input_method)
+            command = environment_params + Powershell.shell_init + command
+            interpreter ||= 'powershell.exe'
+            output =
+              if input_method == 'powershell'
+                execute(command, dir: dir, interpreter: interpreter)
+              else
+                execute(command, dir: dir, stdin: stdin, interpreter: interpreter)
+              end
+          end
+          unless output
+            if interpreter
+              env = ENVIRONMENT_METHODS.include?(input_method) ? envify_params(unwrapped_arguments) : nil
+              output = execute(script, stdin: stdin, env: env, dir: dir, interpreter: interpreter)
+            else
+              path, args = *Powershell.process_from_extension(script)
+              command = args.unshift(path).join(' ')
+              command = environment_params + Powershell.shell_init + command
+              output = execute(command, dir: dir, stdin: stdin, interpreter: 'powershell.exe')
+            end
+          end
+          Bolt::Result.for_task(target,
+                                output.stdout.string,
+                                output.stderr.string,
+                                output.exit_code,
+                                task.name)
+        end
+      end
+
+      def connected?(_targets)
+        true
+      end
+    end
+  end
+end
+
+require 'bolt/transport/local/shell'

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 require 'bolt/node/errors'
-require 'bolt/transport/base'
+require 'bolt/transport/sudoable'
 require 'json'
 require 'shellwords'
 
 module Bolt
   module Transport
-    class SSH < Base
+    class SSH < Sudoable
       def self.options
         %w[port user password sudo-password private-key host-key-check
            connect-timeout tmpdir run-as tty run-as-command proxyjump interpreters]
@@ -27,11 +27,7 @@ module Bolt
 
       def self.validate(options)
         logger = Logging.logger[self]
-
-        if options['sudo-password'] && options['run-as'].nil?
-          logger.warn("--sudo-password will not be used without specifying a " \
-                       "user to escalate to with --run-as")
-        end
+        validate_sudo_options(options, logger)
 
         host_key = options['host-key-check']
         unless !!host_key == host_key
@@ -49,11 +45,6 @@ module Bolt
         unless timeout_value.is_a?(Integer) || timeout_value.nil?
           error_msg = "connect-timeout value must be an Integer, received #{timeout_value}:#{timeout_value.class}"
           raise Bolt::ValidationError, error_msg
-        end
-
-        run_as_cmd = options['run-as-command']
-        if run_as_cmd && (!run_as_cmd.is_a?(Array) || run_as_cmd.any? { |n| !n.is_a?(String) })
-          raise Bolt::ValidationError, "run-as-command must be an Array of Strings, received #{run_as_cmd}"
         end
       end
 
@@ -81,138 +72,6 @@ module Bolt
           conn&.disconnect
         rescue StandardError => ex
           logger.info("Failed to close connection to #{target.uri} : #{ex.message}")
-        end
-      end
-
-      def upload(target, source, destination, options = {})
-        with_connection(target) do |conn|
-          conn.running_as(options['_run_as']) do
-            conn.with_remote_tempdir do |dir|
-              basename = File.basename(destination)
-              tmpfile = "#{dir}/#{basename}"
-              conn.write_remote_file(source, tmpfile)
-              # pass over file ownership if we're using run-as to be a different user
-              dir.chown(conn.run_as)
-              result = conn.execute(['mv', tmpfile, destination], sudoable: true)
-              if result.exit_code != 0
-                message = "Could not move temporary file '#{tmpfile}' to #{destination}: #{result.stderr.string}"
-                raise Bolt::Node::FileError.new(message, 'MV_ERROR')
-              end
-            end
-            Bolt::Result.for_upload(target, source, destination)
-          end
-        end
-      end
-
-      def run_command(target, command, options = {})
-        with_connection(target) do |conn|
-          conn.running_as(options['_run_as']) do
-            output = conn.execute(command, sudoable: true)
-            Bolt::Result.for_command(target,
-                                     output.stdout.string,
-                                     output.stderr.string,
-                                     output.exit_code,
-                                     'command', command)
-          end
-        end
-      end
-
-      def run_script(target, script, arguments, options = {})
-        # unpack any Sensitive data
-        arguments = unwrap_sensitive_args(arguments)
-
-        with_connection(target) do |conn|
-          conn.running_as(options['_run_as']) do
-            conn.with_remote_tempdir do |dir|
-              remote_path = conn.write_remote_executable(dir, script)
-              dir.chown(conn.run_as)
-              output = conn.execute([remote_path, *arguments], sudoable: true)
-              Bolt::Result.for_command(target,
-                                       output.stdout.string,
-                                       output.stderr.string,
-                                       output.exit_code,
-                                       'script', script)
-            end
-          end
-        end
-      end
-
-      def run_task(target, task, arguments, options = {})
-        implementation = select_implementation(target, task)
-        executable = implementation['path']
-        input_method = implementation['input_method']
-        extra_files = implementation['files']
-
-        # unpack any Sensitive data
-        arguments = unwrap_sensitive_args(arguments)
-        with_connection(target, options.fetch('_load_config', true)) do |conn|
-          conn.running_as(options['_run_as']) do
-            stdin, output = nil
-            command = []
-            execute_options = {}
-            execute_options[:interpreter] = select_interpreter(executable, target.options['interpreters'])
-
-            conn.with_remote_tempdir do |dir|
-              if extra_files.empty?
-                task_dir = dir
-              else
-                # TODO: optimize upload of directories
-                arguments['_installdir'] = dir.to_s
-                task_dir = File.join(dir.to_s, task.tasks_dir)
-                dir.mkdirs([task.tasks_dir] + extra_files.map { |file| File.dirname(file['name']) })
-                extra_files.each do |file|
-                  conn.write_remote_file(file['path'], File.join(dir.to_s, file['name']))
-                end
-              end
-
-              remote_task_path = conn.write_remote_executable(task_dir, executable)
-
-              if STDIN_METHODS.include?(input_method)
-                stdin = JSON.dump(arguments)
-              end
-
-              if ENVIRONMENT_METHODS.include?(input_method)
-                execute_options[:environment] = envify_params(arguments)
-              end
-
-              if conn.run_as && stdin
-                # Inject interpreter in to wrapper script and remove from execute options
-                wrapper = make_wrapper_stringio(remote_task_path, stdin, execute_options[:interpreter])
-                execute_options.delete(:interpreter)
-                remote_wrapper_path = conn.write_remote_executable(dir, wrapper, 'wrapper.sh')
-                command << remote_wrapper_path
-              else
-                command << remote_task_path
-                execute_options[:stdin] = stdin
-              end
-              dir.chown(conn.run_as)
-
-              execute_options[:sudoable] = true if conn.run_as
-              output = conn.execute(command, execute_options)
-            end
-            Bolt::Result.for_task(target, output.stdout.string,
-                                  output.stderr.string,
-                                  output.exit_code,
-                                  task.name)
-          end
-        end
-      end
-
-      def make_wrapper_stringio(task_path, stdin, interpreter = nil)
-        if interpreter
-          StringIO.new(<<-SCRIPT)
-#!/bin/sh
-'#{interpreter}' '#{task_path}' <<'EOF'
-#{stdin}
-EOF
-SCRIPT
-        else
-          StringIO.new(<<-SCRIPT)
-#!/bin/sh
-'#{task_path}' <<'EOF'
-#{stdin}
-EOF
-SCRIPT
         end
       end
 

--- a/lib/bolt/transport/sudoable.rb
+++ b/lib/bolt/transport/sudoable.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require 'shellwords'
+require 'bolt/transport/base'
+
+module Bolt
+  module Transport
+    class Sudoable < Base
+      def self.validate_sudo_options(options, logger)
+        if options['sudo-password'] && options['run-as'].nil?
+          logger.warn("--sudo-password will not be used without specifying a " \
+                      "user to escalate to with --run-as")
+        end
+
+        run_as_cmd = options['run-as-command']
+        if run_as_cmd && (!run_as_cmd.is_a?(Array) || run_as_cmd.any? { |n| !n.is_a?(String) })
+          raise Bolt::ValidationError, "run-as-command must be an Array of Strings, received #{run_as_cmd}"
+        end
+      end
+
+      def self.sudo_prompt
+        '[sudo] Bolt needs to run as another user, password: '
+      end
+
+      def run_command(target, command, options = {})
+        with_connection(target) do |conn|
+          conn.running_as(options['_run_as']) do
+            output = conn.execute(command, sudoable: true)
+            Bolt::Result.for_command(target,
+                                     output.stdout.string,
+                                     output.stderr.string,
+                                     output.exit_code,
+                                     'command', command)
+          end
+        end
+      end
+
+      def upload(target, source, destination, options = {})
+        with_connection(target) do |conn|
+          conn.running_as(options['_run_as']) do
+            conn.with_tempdir do |dir|
+              basename = File.basename(destination)
+              tmpfile = File.join(dir.to_s, basename)
+              conn.copy_file(source, tmpfile)
+              # pass over file ownership if we're using run-as to be a different user
+              dir.chown(conn.run_as)
+              result = conn.execute(['mv', tmpfile, destination], sudoable: true)
+              if result.exit_code != 0
+                message = "Could not move temporary file '#{tmpfile}' to #{destination}: #{result.stderr.string}"
+                raise Bolt::Node::FileError.new(message, 'MV_ERROR')
+              end
+            end
+            Bolt::Result.for_upload(target, source, destination)
+          end
+        end
+      end
+
+      def run_script(target, script, arguments, options = {})
+        # unpack any Sensitive data
+        arguments = unwrap_sensitive_args(arguments)
+
+        with_connection(target) do |conn|
+          conn.running_as(options['_run_as']) do
+            conn.with_tempdir do |dir|
+              path = conn.write_executable(dir.to_s, script)
+              dir.chown(conn.run_as)
+              output = conn.execute([path, *arguments], sudoable: true)
+              Bolt::Result.for_command(target,
+                                       output.stdout.string,
+                                       output.stderr.string,
+                                       output.exit_code,
+                                       'script', script)
+            end
+          end
+        end
+      end
+
+      def run_task(target, task, arguments, options = {})
+        implementation = select_implementation(target, task)
+        executable = implementation['path']
+        input_method = implementation['input_method']
+        extra_files = implementation['files']
+
+        with_connection(target, options.fetch('_load_config', true)) do |conn|
+          conn.running_as(options['_run_as']) do
+            stdin, output = nil
+            command = []
+            execute_options = {}
+            execute_options[:interpreter] = select_interpreter(executable, target.options['interpreters'])
+            interpreter_debug = if execute_options[:interpreter]
+                                  " using '#{execute_options[:interpreter]}' interpreter"
+                                end
+            # log the arguments with sensitive data redacted, do NOT log unwrapped_arguments
+            logger.debug("Running '#{executable}' with #{arguments}#{interpreter_debug}")
+            # unpack any Sensitive data
+            arguments = unwrap_sensitive_args(arguments)
+
+            conn.with_tempdir do |dir|
+              if extra_files.empty?
+                task_dir = dir
+              else
+                # TODO: optimize upload of directories
+                arguments['_installdir'] = dir.to_s
+                task_dir = File.join(dir.to_s, task.tasks_dir)
+                dir.mkdirs([task.tasks_dir] + extra_files.map { |file| File.dirname(file['name']) })
+                extra_files.each do |file|
+                  conn.copy_file(file['path'], File.join(dir.to_s, file['name']))
+                end
+              end
+
+              remote_task_path = conn.write_executable(task_dir, executable)
+
+              if STDIN_METHODS.include?(input_method)
+                stdin = JSON.dump(arguments)
+              end
+
+              if ENVIRONMENT_METHODS.include?(input_method)
+                execute_options[:environment] = envify_params(arguments)
+              end
+
+              if conn.run_as && stdin
+                # Inject interpreter in to wrapper script and remove from execute options
+                wrapper = make_wrapper_stringio(remote_task_path, stdin, execute_options[:interpreter])
+                execute_options.delete(:interpreter)
+                remote_wrapper_path = conn.write_executable(dir, wrapper, 'wrapper.sh')
+                command << remote_wrapper_path
+              else
+                command << remote_task_path
+                execute_options[:stdin] = stdin
+              end
+              dir.chown(conn.run_as)
+
+              execute_options[:sudoable] = true if conn.run_as
+              output = conn.execute(command, execute_options)
+            end
+            Bolt::Result.for_task(target, output.stdout.string,
+                                  output.stderr.string,
+                                  output.exit_code,
+                                  task.name)
+          end
+        end
+      end
+
+      def make_wrapper_stringio(task_path, stdin, interpreter = nil)
+        if interpreter
+          StringIO.new(<<~SCRIPT)
+            #!/bin/sh
+            '#{interpreter}' '#{task_path}' <<'EOF'
+            #{stdin}
+            EOF
+            SCRIPT
+        else
+          StringIO.new(<<~SCRIPT)
+            #!/bin/sh
+            '#{task_path}' <<'EOF'
+            #{stdin}
+            EOF
+            SCRIPT
+        end
+      end
+    end
+  end
+end

--- a/lib/bolt/transport/sudoable/connection.rb
+++ b/lib/bolt/transport/sudoable/connection.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'bolt/transport/sudoable/tmpdir'
+
+module Bolt
+  module Transport
+    class Sudoable < Base
+      class Connection
+        attr_accessor :target
+        def initialize(target)
+          @target = target
+          @run_as = nil
+          @logger = Logging.logger[@target.host]
+        end
+
+        # This method allows the @run_as variable to be used as a per-operation
+        # override for the user to run as. When @run_as is unset, the user
+        # specified on the target will be used.
+        def run_as
+          @run_as || target.options['run-as']
+        end
+
+        # Run as the specified user for the duration of the block.
+        def running_as(user)
+          @run_as = user
+          yield
+        ensure
+          @run_as = nil
+        end
+
+        def make_executable(path)
+          result = execute(['chmod', 'u+x', path])
+          if result.exit_code != 0
+            message = "Could not make file '#{path}' executable: #{result.stderr.string}"
+            raise Bolt::Node::FileError.new(message, 'CHMOD_ERROR')
+          end
+        end
+
+        def make_tempdir
+          tmpdir = @target.options.fetch('tmpdir', '/tmp')
+          tmppath = "#{tmpdir}/#{SecureRandom.uuid}"
+          command = ['mkdir', '-m', 700, tmppath]
+
+          result = execute(command)
+          if result.exit_code != 0
+            raise Bolt::Node::FileError.new("Could not make tempdir: #{result.stderr.string}", 'TEMPDIR_ERROR')
+          end
+          path = tmppath || result.stdout.string.chomp
+          Sudoable::Tmpdir.new(self, path)
+        end
+
+        def write_executable(dir, file, filename = nil)
+          filename ||= File.basename(file)
+          remote_path = File.join(dir.to_s, filename)
+          copy_file(file, remote_path)
+          make_executable(remote_path)
+          remote_path
+        end
+
+        # A helper to create and delete a tempdir on the remote system. Yields the
+        # directory name.
+        def with_tempdir
+          dir = make_tempdir
+          yield dir
+        ensure
+          dir&.delete
+        end
+
+        def execute(*_args)
+          message = "#{self.class.name} must implement #{method} to execute commands"
+          raise NotImplementedError, message
+        end
+      end
+    end
+  end
+end

--- a/lib/bolt/transport/sudoable/tmpdir.rb
+++ b/lib/bolt/transport/sudoable/tmpdir.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Bolt
+  module Transport
+    class Sudoable < Base
+      class Tmpdir
+        def initialize(node, path)
+          @conn = node
+          @owner = node.user
+          @path = path
+          @logger = node.logger
+        end
+
+        def to_s
+          @path
+        end
+
+        def mkdirs(subdirs)
+          abs_subdirs = subdirs.map { |subdir| File.join(@path, subdir) }
+          result = @conn.execute(['mkdir', '-p'] + abs_subdirs)
+          if result.exit_code != 0
+            message = "Could not create subdirectories in '#{@path}': #{result.stderr.string}"
+            raise Bolt::Node::FileError.new(message, 'MKDIR_ERROR')
+          end
+        end
+
+        def chown(owner)
+          return if owner.nil? || owner == @owner
+
+          result = @conn.execute(['id', '-g', owner])
+          if result.exit_code != 0
+            message = "Could not identify group of user #{owner}: #{result.stderr.string}"
+            raise Bolt::Node::FileError.new(message, 'ID_ERROR')
+          end
+          group = result.stdout.string.chomp
+
+          # Chown can only be run by root.
+          result = @conn.execute(['chown', '-R', "#{owner}:#{group}", @path], sudoable: true, run_as: 'root')
+          if result.exit_code != 0
+            message = "Could not change owner of '#{@path}' to #{owner}: #{result.stderr.string}"
+            raise Bolt::Node::FileError.new(message, 'CHOWN_ERROR')
+          end
+
+          # File ownership successfully changed, record the new owner.
+          @owner = owner
+        end
+
+        def delete
+          result = @conn.execute(['rm', '-rf', @path], sudoable: true, run_as: @owner)
+          if result.exit_code != 0
+            @logger.warn("Failed to clean up tempdir '#{@path}': #{result.stderr.string}")
+          end
+          # For testing
+          result.stderr.string
+        end
+      end
+    end
+  end
+end

--- a/pre-docs/bolt_configuration_options.md
+++ b/pre-docs/bolt_configuration_options.md
@@ -107,6 +107,11 @@ interpreters:
 ## Local transport configuration options
 
 `tmpdir`: The directory to copy and execute temporary files.
+`run-as`: A different user to run commands as after login.
+
+`run-as-command`: The command to elevate permissions. Bolt appends the user and command strings to the configured run as a command before running it on the target. This command must not require an interactive password prompt, and the `sudo-password` option is ignored when `run-as-command` is specified. The run-as command must be specified as an array.
+
+`sudo-password`: Password to use when changing users via `run-as`.
 
 ## Docker transport configuration options
 

--- a/spec/bolt/transport/local_spec.rb
+++ b/spec/bolt/transport/local_spec.rb
@@ -4,13 +4,18 @@ require 'spec_helper'
 require 'bolt/transport/local'
 require 'bolt/target'
 require 'bolt/inventory'
+require 'bolt/util'
 require 'bolt_spec/transport'
+require 'bolt_spec/conn'
 
 require_relative 'shared_examples'
 
 describe Bolt::Transport::Local do
   include BoltSpec::Transport
 
+  let(:host_and_port) { "localhost" }
+  let(:user) { 'travis' }
+  let(:password) { 'travis' }
   let(:transport) { :local }
   let(:os_context) { Bolt::Util.windows? ? windows_context : posix_context }
   let(:target) { Bolt::Target.new('local://localhost', transport_conf) }
@@ -29,10 +34,169 @@ describe Bolt::Transport::Local do
 
   include_examples 'transport api'
 
+  context 'running as another user', sudo: true do
+    include_examples 'with sudo'
+
+    context "overriding with '_run_as'" do
+      let(:config) {
+        mk_config('sudo-password' => password, 'run-as' => 'root')
+      }
+      let(:target) { make_target }
+
+      it "can override run_as for command via an option" do
+        expect(runner.run_command(target, 'whoami', '_run_as' => user)['stdout']).to eq("#{user}\n")
+      end
+
+      it "can override run_as for script via an option" do
+        contents = "#!/bin/sh\nwhoami"
+        with_tempfile_containing('script test', contents) do |file|
+          expect(runner.run_script(target, file.path, [], '_run_as' => user)['stdout']).to eq("#{user}\n")
+        end
+      end
+
+      it "can override run_as for task via an option" do
+        contents = "#!/bin/sh\nwhoami"
+        with_task_containing('tasks_test', contents, 'environment') do |task|
+          expect(runner.run_task(target, task, {}, '_run_as' => user).message).to eq("#{user}\n")
+        end
+      end
+
+      it "can override run_as for file upload via an option" do
+        contents = "upload file test as root content"
+        dest = '/tmp/root-file-upload-test'
+        with_tempfile_containing('tasks test upload as root', contents) do |file|
+          expect(runner.upload(target, file.path, dest, '_run_as' => user).message).to match(/Uploaded/)
+          expect(runner.run_command(target, "cat #{dest}", '_run_as' => user)['stdout']).to eq(contents)
+          expect(runner.run_command(target, "stat -c %U #{dest}", '_run_as' => user)['stdout'].chomp).to eq(user)
+          expect(runner.run_command(target, "stat -c %G #{dest}", '_run_as' => user)['stdout'].chomp).to eq(user)
+        end
+
+        runner.run_command(target, "rm #{dest}", sudoable: true, run_as: user)
+      end
+    end
+
+    context "as user with no password" do
+      let(:config) {
+        mk_config('run-as' => 'root')
+      }
+      let(:target) { make_target }
+
+      it "returns a failed result when a temporary directory is created" do
+        contents = "#!/bin/sh\nwhoami"
+        with_tempfile_containing('script test', contents) do |file|
+          expect {
+            runner.run_script(target, file.path, [])
+          }.to raise_error(Bolt::Node::EscalateError,
+                           "Sudo password for user #{user} was not provided for #{host_and_port}")
+        end
+      end
+    end
+  end
+
+  context 'with large input and output' do
+    let(:file_size) { 1011 }
+    let(:str) { (0...1024).map { rand(65..90).chr }.join }
+    let(:arguments) { { 'input' => str * file_size } }
+    let(:ruby_task) do
+      <<~TASK
+      #!/usr/bin/env ruby
+      input = STDIN.read
+      STDERR.print input
+      STDOUT.print input
+      TASK
+    end
+
+    it "runs with large input and captures large output" do
+      with_task_containing('big_kahuna', ruby_task, 'stdin', '.rb') do |task|
+        result = runner.run_task(target, task, arguments).value
+        expect(result['input'].bytesize).to eq(file_size * 1024)
+        # Ensure the strings are the same
+        expect(result['input'][-1024..-1]).to eq(str)
+      end
+    end
+
+    context 'with run-as', sudo: true do
+      let(:config) {
+        mk_config('sudo-password' => password, 'run-as' => 'root')
+      }
+      let(:target) { make_target }
+
+      it "runs with large input and output" do
+        with_task_containing('big_kahuna', ruby_task, 'stdin', '.rb') do |task|
+          result = runner.run_task(target, task, arguments).value
+          expect(result['input'].bytesize).to eq(file_size * 1024)
+          expect(result['input'][-1024..-1]).to eq(str)
+        end
+      end
+    end
+
+    context 'with slow input' do
+      let(:file_size) { 100 }
+      let(:ruby_task) do
+        <<~TASK
+        #!/usr/bin/env ruby
+        while true
+          begin
+            input = STDIN.readpartial(1024)
+            sleep(0.2)
+            STDERR.print input
+            STDOUT.print input
+          rescue EOFError
+            break
+          end
+        end
+        TASK
+      end
+
+      it "runs with large input and captures large output" do
+        with_task_containing('slow_and_steady', ruby_task, 'stdin', '.rb') do |task|
+          result = runner.run_task(target, task, arguments).value
+          expect(result['input'].bytesize).to eq(file_size * 1024)
+          # Ensure the strings are the same
+          expect(result['input'][-1024..-1]).to eq(str)
+        end
+      end
+    end
+  end
+
+  context 'on windows hosts', windows: true do
+    context 'with run-as configured' do
+      let(:config) { mk_config('run-as' => 'root') }
+      let(:target) { make_target }
+
+      it "warns when trying to use run-as" do
+        runner.run_command(target, os_context[:stdout_command][0])
+        logs = @log_output.readlines
+        expect(logs).to include(/WARN  Bolt::Transport::LocalWindows : run-as is not supported/)
+      end
+    end
+
+    context 'with empty config' do
+      let(:config) { mk_config({}) }
+      let(:target) { make_target }
+
+      it "warns when trying to use _run_as" do
+        runner.run_command(target, os_context[:stdout_command][0], '_run_as' => user)
+        logs = @log_output.readlines
+        expect(logs).to include(/WARN  Bolt::Transport::LocalWindows : run-as is not supported/)
+      end
+    end
+  end
+
   context 'file errors' do
     before(:each) do
-      allow(FileUtils).to receive(:cp_r).and_raise('no write')
-      allow(Dir).to receive(:mktmpdir).with(no_args).and_raise('no tmpdir')
+      allow_any_instance_of(Bolt::Transport::Local).to receive(:upload).and_raise(
+        Bolt::Node::FileError.new("no write", "WRITE_ERROR")
+      )
+      allow_any_instance_of(Bolt::Transport::LocalWindows).to receive(:upload).and_raise(
+        Bolt::Node::FileError.new("no write", "WRITE_ERROR")
+      )
+      allow_any_instance_of(Bolt::Transport::LocalWindows).to receive(:in_tmpdir).and_raise(
+        Bolt::Node::FileError.new("no write", "WRITE_ERROR")
+      )
+      allow_any_instance_of(Bolt::Transport::Local::Shell).to receive(:with_tempdir).and_raise(
+        Bolt::Node::FileError.new("no tmpdir", "TEMDIR_ERROR")
+      )
     end
 
     include_examples 'transport failures'

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -348,7 +348,10 @@ describe 'running with an inventory file', reset_puppet_settings: true do
         after(:each) { `rm -rf #{tmpdir}` }
 
         it 'uses tmpdir' do
-          expect(run_one_node(run_command)['stdout'].strip).to match(/#{Regexp.escape(tmpdir)}/)
+          with_tempfile_containing('script', 'echo "`dirname $0`"', '.sh') do |f|
+            run_script = ['script', 'run', f.path, '--nodes', target] + config_flags
+            expect(run_one_node(run_script)['stdout'].strip).to match(/#{Regexp.escape(tmpdir)}/)
+          end
         end
       end
 
@@ -371,7 +374,10 @@ describe 'running with an inventory file', reset_puppet_settings: true do
         after(:each) { `rm -rf #{tmpdir}` }
 
         it 'uses tmpdir' do
-          expect(run_one_node(run_command)['stdout'].strip).to match(/#{Regexp.escape(tmpdir)}/)
+          with_tempfile_containing('script', 'echo "`dirname $0`"', '.sh') do |f|
+            run_script = ['script', 'run', f.path, '--nodes', target] + config_flags
+            expect(run_one_node(run_script)['stdout'].strip).to match(/#{Regexp.escape(tmpdir)}/)
+          end
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,7 @@ RSpec.configure do |config|
 
   config.filter_run_excluding appveyor_agents: true unless ENV['APPVEYOR_AGENTS']
   config.filter_run_excluding windows: true unless ENV['BOLT_WINDOWS']
+  config.filter_run_excluding sudo: true unless ENV['BOLT_SUDO_USER']
 
   # rspec-mocks config
   config.mock_with :rspec do |mocks|


### PR DESCRIPTION
This adds support for `run-as`, `sudo-password`, and `run-as-command` to the local transport. These can be configured in the config file, by command line options, or in the inventory file, and should behave exactly like the same options for SSH.

I ended up keeping the SSH and local functionality mostly separate in order to take advantage of `popen3` and other system libraries for the local transport. I also pulled most of SSH's `sudo` tests into the shared examples so that local can use them.