### PR TITLE
(BOLT-495) Set check_host_ip flag to false for net-ssh

### DIFF
--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -119,6 +119,11 @@ module Bolt
 
           options[:proxy] = Net::SSH::Proxy::Jump.new(target.options['proxyjump']) if target.options['proxyjump']
 
+          # This option was to address discrepency betwen net-ssh host-key-check and ssh(1)
+          # For the net-ssh 5.x series it defaults to true, in 6.x it will default to false, and will be removed in 7.x
+          # https://github.com/net-ssh/net-ssh/pull/663#issuecomment-469979931
+          options[:check_host_ip] = false if Net::SSH::VALID_OPTIONS.include?(:check_host_ip)
+
           if @load_config
             # Mirroring:
             # https://github.com/net-ssh/net-ssh/blob/master/lib/net/ssh/authentication/agent.rb#L80


### PR DESCRIPTION
The 5.2.0 release of net-ssh contains an update to behavior of host-key-check to be more consistent with that of ssh(1). Ssh(1) does not require both hostname and IP when performing host-key-check where net-ssh < 5.1.0 did. This was causing issues for users whereby they could ssh to their nodes with system ssh but not with the bolt ssh transport. The net-ssh maintainer agree to the following plan:

1.) 5.2.0 introduce check_host_ip: false flag, and set check_host_ip to false if CheckHostIP false in net-ssh configs
2.) 6.0 make check_host_ip: false the default and give deprecation warning for check_host_ip: true usage
3.) 7.0 remove check_host_ip

This commit ensures that the check_host_ip flag is set to false.