### PR TITLE
(BOLT-1119) Improve Bolt startup time (on Windows)

### DIFF
--- a/lib/bolt/analytics.rb
+++ b/lib/bolt/analytics.rb
@@ -62,6 +62,10 @@ module Bolt
       attr_reader :user_id
 
       def initialize(user_id)
+        # lazy-load expensive gem code
+        require 'concurrent/configuration'
+        require 'concurrent/future'
+
         @logger = Logging.logger[self]
         @http = HTTPClient.new
         @user_id = user_id

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'base64'
-require 'concurrent'
 require 'find'
 require 'json'
 require 'logging'
@@ -15,6 +14,9 @@ require 'bolt/util/puppet_log_level'
 module Bolt
   class Applicator
     def initialize(inventory, executor, modulepath, plugin_dirs, pdb_client, hiera_config, max_compiles)
+      # lazy-load expensive gem code
+      require 'concurrent'
+
       @inventory = inventory
       @executor = executor
       @modulepath = modulepath

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -2,7 +2,8 @@
 
 require 'yaml'
 require 'logging'
-require 'concurrent'
+# limit the loaded portion of concurrent as its expensive
+require 'concurrent/utility/processor_counter'
 require 'pathname'
 require 'bolt/boltdir'
 require 'bolt/transport/ssh'

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -3,7 +3,6 @@
 # Used for $ERROR_INFO. This *must* be capitalized!
 require 'English'
 require 'json'
-require 'concurrent'
 require 'logging'
 require 'set'
 require 'bolt/analytics'
@@ -25,6 +24,10 @@ module Bolt
                    noop = nil,
                    bundled_content: nil,
                    load_config: true)
+
+      # lazy-load expensive gem code
+      require 'concurrent'
+
       @analytics = analytics
       @bundled_content = bundled_content
       @logger = Logging.logger[self]

--- a/lib/bolt/notifier.rb
+++ b/lib/bolt/notifier.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
-require 'concurrent'
-
 module Bolt
   class Notifier
-    def initialize(executor = Concurrent::SingleThreadExecutor.new)
-      @executor = executor
+    def initialize(executor = nil)
+      # lazy-load expensive gem code
+      require 'concurrent'
+
+      @executor = executor || Concurrent::SingleThreadExecutor.new
     end
 
     def notify(callback, event)

--- a/lib/bolt/transport/docker/connection.rb
+++ b/lib/bolt/transport/docker/connection.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'docker'
 require 'logging'
 require 'bolt/node/errors'
 
@@ -9,6 +8,9 @@ module Bolt
     class Docker < Base
       class Connection
         def initialize(target)
+          # lazy-load expensive gem code
+          require 'docker'
+
           @target = target
           @logger = Logging.logger[target.host]
         end

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'base64'
-require 'concurrent'
 require 'find'
 require 'json'
 require 'minitar'

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -4,7 +4,6 @@ require 'base64'
 require 'find'
 require 'json'
 require 'minitar'
-require 'orchestrator_client'
 require 'pathname'
 require 'zlib'
 require 'bolt/transport/base'
@@ -39,6 +38,9 @@ module Bolt
       def self.validate(options); end
 
       def initialize(*args)
+        # lazy-load expensive gem code
+        require 'orchestrator_client'
+
         @connections = {}
         super
       end

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -2,7 +2,6 @@
 
 require 'bolt/node/errors'
 require 'bolt/node/output'
-require 'ruby_smb'
 
 module Bolt
   module Transport
@@ -158,6 +157,9 @@ module Bolt
         end
 
         def write_remote_file_smb(source, destination)
+          # lazy-load expensive gem code
+          require 'ruby_smb'
+
           win_dest = destination.tr('/', '\\')
           if (md = win_dest.match(/^([a-z]):\\(.*)/i))
             # if drive, use admin share for that drive, so path is '\\host\C$'

--- a/lib/bolt_server/file_cache.rb
+++ b/lib/bolt_server/file_cache.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require 'concurrent/atomic/read_write_lock'
+require 'concurrent/executor/single_thread_executor'
+require 'concurrent/promise'
+require 'concurrent/timer_task'
 require 'digest'
 require 'fileutils'
 require 'net/http'
@@ -20,15 +24,11 @@ module BoltServer
     PURGE_TTL = 7 * PURGE_INTERVAL
 
     def initialize(config,
-                   executor: nil,
+                   executor: Concurrent::SingleThreadExecutor.new,
                    purge_interval: PURGE_INTERVAL,
                    purge_timeout: PURGE_TIMEOUT,
                    purge_ttl: PURGE_TTL)
-
-      # lazy-load expensive gem code
-      require 'concurrent'
-
-      @executor = executor || Concurrent::SingleThreadExecutor.new
+      @executor = executor
       @cache_dir = config['cache-dir']
       @config = config
       @logger = Logging.logger[self]

--- a/lib/bolt_server/file_cache.rb
+++ b/lib/bolt_server/file_cache.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'concurrent'
 require 'digest'
 require 'fileutils'
 require 'net/http'
@@ -21,11 +20,15 @@ module BoltServer
     PURGE_TTL = 7 * PURGE_INTERVAL
 
     def initialize(config,
-                   executor: Concurrent::SingleThreadExecutor.new,
+                   executor: nil,
                    purge_interval: PURGE_INTERVAL,
                    purge_timeout: PURGE_TIMEOUT,
                    purge_ttl: PURGE_TTL)
-      @executor = executor
+
+      # lazy-load expensive gem code
+      require 'concurrent'
+
+      @executor = executor || Concurrent::SingleThreadExecutor.new
       @cache_dir = config['cache-dir']
       @config = config
       @logger = Logging.logger[self]

--- a/lib/plan_executor/app.rb
+++ b/lib/plan_executor/app.rb
@@ -9,7 +9,6 @@ require 'bolt/puppetdb'
 require 'bolt/version'
 require 'plan_executor/applicator'
 require 'plan_executor/executor'
-require 'concurrent'
 require 'json'
 require 'json-schema'
 
@@ -28,6 +27,9 @@ module PlanExecutor
     end
 
     def initialize(config)
+      # lazy-load expensive gem code
+      require 'concurrent'
+
       @http_client = create_http(config)
 
       # Use an empty inventory until we figure out where this data comes from.

--- a/spec/fixtures/scripts/bolt_cli_loader.rb
+++ b/spec/fixtures/scripts/bolt_cli_loader.rb
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# effectively the same as bolt/exe/bolt, but with gem output
+
+require 'bolt'
+require 'bolt/cli'
+
+def suppress_outputs
+  null_io = !!File::ALT_SEPARATOR ? 'NUL' : '/dev/null'
+  out = $stdout.clone
+  err = $stderr.clone
+  $stderr.reopen(null_io, 'w')
+  $stdout.reopen(null_io, 'w')
+  yield
+ensure
+  $stdout.reopen(out)
+  $stderr.reopen(err)
+end
+
+cli = Bolt::CLI.new(['--help'])
+begin
+  # hide Bolt output produced by executing cli
+  suppress_outputs { cli.execute(cli.parse) }
+# eat the CLIExit exception
+rescue Bolt::CLIExit
+  nil
+ensure
+  # emit loaded code files, typically .rb and .so
+  puts $LOADED_FEATURES.sort
+end

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe "when loading bolt for CLI invocation" do
+  context 'and calling help' do
+    def cli_loaded_features
+      cli_loader = File.join(__dir__, '..', 'fixtures', 'scripts', 'bolt_cli_loader.rb')
+      `bundle exec ruby #{cli_loader}`.split("\n")
+    end
+
+    let(:loaded_features) { cli_loaded_features }
+
+    [
+      'docker-api',
+      'excon'
+    ].each do |gem_name|
+      it "does not load #{gem_name} gem code" do
+        gem_path = Regexp.escape(Gem.loaded_specs[gem_name].full_gem_path)
+        any_gem_source_code = a_string_matching(gem_path)
+        fail_msg = "loaded unexpected #{gem_name} gem code from #{gem_path}"
+        expect(loaded_features).not_to include(any_gem_source_code), fail_msg
+      end
+    end
+  end
+end

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -21,7 +21,11 @@ describe "when loading bolt for CLI invocation" do
       'rubyntlm',
       'windows_error',
       # FFI + dependencies
-      'ffi'
+      'ffi',
+      # orchestrator client + dependencies
+      'orchestrator_client',
+      'faraday',
+      'multipart-post'
     ].each do |gem_name|
       it "does not load #{gem_name} gem code" do
         gem_path = Regexp.escape(Gem.loaded_specs[gem_name].full_gem_path)

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -12,8 +12,14 @@ describe "when loading bolt for CLI invocation" do
     let(:loaded_features) { cli_loaded_features }
 
     [
+      # docker-api + dependencies
       'docker-api',
-      'excon'
+      'excon',
+      # ruby_smb + dependencies
+      'ruby_smb',
+      'bindata',
+      'rubyntlm',
+      'windows_error'
     ].each do |gem_name|
       it "does not load #{gem_name} gem code" do
         gem_path = Regexp.escape(Gem.loaded_specs[gem_name].full_gem_path)

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -19,7 +19,9 @@ describe "when loading bolt for CLI invocation" do
       'ruby_smb',
       'bindata',
       'rubyntlm',
-      'windows_error'
+      'windows_error',
+      # FFI + dependencies
+      'ffi'
     ].each do |gem_name|
       it "does not load #{gem_name} gem code" do
         gem_path = Regexp.escape(Gem.loaded_specs[gem_name].full_gem_path)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,9 @@ require 'logging'
 require 'rspec/logging_helper'
 # Make sure puppet is required for the 'reset puppet settings' context
 require 'puppet_pal'
+# HACK: must be loaded prior to spec libs that implement stub to prevent
+# RubySMB::Dcerpc::Request from shadowing 'stub' through BinData::DSLMixin::DSLFieldValidator
+require 'ruby_smb'
 
 ENV['RACK_ENV'] = 'test'
 $LOAD_PATH.unshift File.join(__dir__, 'lib')


### PR DESCRIPTION
Refactors code loads so that gem code that isn't needed for commands like `help` will never be loaded

In a Windows 10 VM test environment, this PR will:

* Cut run time from 4.4 seconds to 2.6 seconds (times vary depending on disk IO - in pathological cases the difference can be much more extreme)
* Reduces the amount of code Ruby loads from 845 files down to 395 files


Things to still improve

- [x] Integration test for `bolt --help` showing certain libraries are not loaded / defined (to prevent accidental regressions)

Moving further exploration / improvements to #906