### PR TITLE
(maint) Remove redundant freeze

### DIFF
--- a/bolt-modules/system/lib/puppet/functions/system/env.rb
+++ b/bolt-modules/system/lib/puppet/functions/system/env.rb
@@ -11,6 +11,6 @@ Puppet::Functions.create_function(:'system::env') do
   end
 
   def env(name)
-    ENV[name].freeze
+    ENV[name]
   end
 end


### PR DESCRIPTION
Rubocop 0.66.0 now identifies that `ENV[]` will always return frozen
strings and therefore our freeze is redundant.