### PR TITLE
(BOLT-1171) Expose step results as variables

### DIFF
--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -250,7 +250,12 @@ module Bolt
 
     def list_plans
       in_bolt_compiler do |compiler|
-        compiler.list_plans.map { |plan| [plan.name] }.sort
+        errors = []
+        plans = compiler.list_plans(nil, errors).map { |plan| [plan.name] }.sort
+        errors.each do |error|
+          @logger.warn(error.details['original_error'])
+        end
+        plans
       end
     end
 

--- a/lib/bolt/pal/yaml_plan/evaluator.rb
+++ b/lib/bolt/pal/yaml_plan/evaluator.rb
@@ -113,7 +113,9 @@ module Bolt
 
           closure_scope.with_local_scope(args_hash) do |scope|
             steps.each do |step|
-              dispatch_step(scope, step)
+              result = dispatch_step(scope, step)
+
+              scope.setvar(step['name'], result) if step.key?('name')
             end
           end
 

--- a/lib/bolt/pal/yaml_plan/loader.rb
+++ b/lib/bolt/pal/yaml_plan/loader.rb
@@ -15,12 +15,13 @@ module Bolt
             new(scanner, class_loader)
           end
 
-          def visit_Psych_Nodes_Scalar(node) # rubocop:disable Naming/MethodName
+          def deserialize(node)
             if node.quoted
               case node.style
               when Psych::Nodes::Scalar::SINGLE_QUOTED
                 # Single-quoted strings are treated literally
-                node.transform
+                # @ss is a ScalarScanner, from the base ToRuby visitor class
+                node.value
               when Psych::Nodes::Scalar::DOUBLE_QUOTED
                 DoubleQuotedString.new(node.value)
               # | style string or > style string
@@ -28,10 +29,10 @@ module Bolt
                 CodeLiteral.new(node.value)
               # This one shouldn't be possible
               else
-                node.transform
+                @ss.tokenize(node.value)
               end
             else
-              value = node.transform
+              value = @ss.tokenize(node.value)
               if value.is_a?(String)
                 BareString.new(value)
               else

--- a/lib/bolt/pal/yaml_plan/loader.rb
+++ b/lib/bolt/pal/yaml_plan/loader.rb
@@ -54,7 +54,11 @@ module Bolt
             raise ArgumentError, "The data loaded from #{source_ref} does not contain an object - its type is #{type}"
           end
 
-          plan_definition = YamlPlan.new(typed_name, result).freeze
+          begin
+            plan_definition = YamlPlan.new(typed_name, result).freeze
+          rescue Bolt::Error => e
+            raise Puppet::ParseError.new(e.message, source_ref)
+          end
 
           created = create_function_class(plan_definition)
           closure_scope = nil

--- a/spec/bolt/pal/yaml_plan/evaluator_spec.rb
+++ b/spec/bolt/pal/yaml_plan/evaluator_spec.rb
@@ -325,4 +325,54 @@ describe Bolt::PAL::YamlPlan::Evaluator do
       expect(subject.eval_step(scope, step)). to eq(55)
     end
   end
+
+  describe "referring to previous steps" do
+    it "stores the result of a step in a variable" do
+      plan_body = <<-YAML
+      parameters:
+        input:
+          type: Integer
+
+      steps:
+        - name: foo
+          eval: $input + 5
+        - name: bar
+          command: "echo ${$foo*2}"
+          target: foo.example.com
+      YAML
+
+      plan = Bolt::PAL::YamlPlan::Loader.create(loader, plan_name, 'test.yaml', plan_body)
+
+      expect(scope).to receive(:call_function).with('run_command', ['echo 34', 'foo.example.com'])
+
+      call_plan(plan, 'input' => 12)
+    end
+
+    it "accepts a step without a name" do
+      plan_body = <<-YAML
+      steps:
+        - eval: >
+            5+6
+      YAML
+
+      plan = Bolt::PAL::YamlPlan::Loader.create(loader, plan_name, 'test.yaml', plan_body)
+
+      call_plan(plan)
+    end
+
+    it "can store and retrieve 'undef' results" do
+      plan_body = <<-YAML
+      steps:
+        - name: foo
+          eval: >
+            undef
+        - name: bar
+          eval: $foo
+      YAML
+
+      plan = Bolt::PAL::YamlPlan::Loader.create(loader, plan_name, 'test.yaml', plan_body)
+
+      call_plan(plan)
+    end
+  end
 end

--- a/spec/bolt/pal/yaml_plan/evaluator_spec.rb
+++ b/spec/bolt/pal/yaml_plan/evaluator_spec.rb
@@ -71,26 +71,6 @@ describe Bolt::PAL::YamlPlan::Evaluator do
       expect(call_plan(plan)).to eq(nil)
     end
 
-    it 'fails if the steps list is not an array' do
-      plan_body = <<-YAML
-      steps: null
-      YAML
-
-      plan = Bolt::PAL::YamlPlan::Loader.create(loader, plan_name, 'test.yaml', plan_body)
-
-      expect { call_plan(plan) }.to raise_error(Bolt::Error, /Plan must specify an array of steps/)
-    end
-
-    it 'fails if the steps list is not specified' do
-      plan_body = <<-YAML
-      parameters: {}
-      YAML
-
-      plan = Bolt::PAL::YamlPlan::Loader.create(loader, plan_name, 'test.yaml', plan_body)
-
-      expect { call_plan(plan) }.to raise_error(Bolt::Error, /Plan must specify an array of steps/)
-    end
-
     it 'runs each step in order' do
       plan_body = <<-YAML
       parameters:

--- a/spec/bolt/pal/yaml_plan/loader_spec.rb
+++ b/spec/bolt/pal/yaml_plan/loader_spec.rb
@@ -28,7 +28,10 @@ describe Bolt::PAL::YamlPlan::Loader do
     end
 
     it 'returns a puppet function wrapper' do
-      plan_body = '{}'
+      plan_body = <<-YAML
+      steps: []
+      YAML
+
       plan = described_class.create(loader, plan_name, 'test.yaml', plan_body)
       expect(plan).to be_a(Puppet::Functions::Function)
     end


### PR DESCRIPTION
Previously, there was no way for one step to rely on the result of another
step. Now we expose the result of each named step as a variable with the
same name as the step. This allows parameters for one step to be computed
by using the result of a previous step. The result for a step _without_ a
name will be discarded.

We also now validate that step names are legal variable names and that there
are no duplicate names between parameters and steps, as Puppet variables can
only be defined once.

This also includes a performance improvement to the YAML plan loader as well as
an improvement to how errors are displayed when listing plans.