### PR TITLE
(BOLT-1119) Fix error when using ssh transport on windows controller

### DIFF
--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -76,7 +76,7 @@ module Bolt
           @transport_logger = transport_logger
         end
 
-        PAGEANT_NAME = "Pageant\0".encode(Encoding::UTF_16LE).freeze
+        PAGEANT_NAME = "Pageant\0".encode(Encoding::UTF_16LE)
 
         def connect
           options = {


### PR DESCRIPTION
Acceptance tests were failing because "cannot modify frozen string" using ssh transport from a windows bolt controller. This commit does not freeze the PAGEANT_NAME string.