### PR TITLE
(BOLT-1119) Ensure Win32API require case correct

### DIFF
--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -126,7 +126,7 @@ module Bolt
                 options[:use_agent] = false
               end
             elsif Bolt::Util.windows?
-              require 'win32api'
+              require 'Win32API' # case matters in this require!
               # https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-findwindoww
               @find_window ||= Win32API.new('user32', 'FindWindowW', %w[P P], 'L')
               if @find_window.call(nil, PAGEANT_NAME).to_i == 0


### PR DESCRIPTION
 - To properly load alongside Puppet, the require for Win32API must
   use the same case as Puppet.

   From the Puppet code:

	 require 'Win32API' # case matters in this require!

 - Without this change, Bolt will stream a number of warnings like:

	C:/PROGRA~1/PUPPET~1/Bolt/lib/ruby/2.5.0/win32api.rb:10: warning: already initialized constant Win32API::DLL
	C:/PROGRA~1/PUPPET~1/Bolt/lib/ruby/2.5.0/Win32API.rb:10: warning: previous definition of DLL was here
	C:/PROGRA~1/PUPPET~1/Bolt/lib/ruby/2.5.0/win32api.rb:11: warning: already initialized constant Win32API::TYPEMAP
	C:/PROGRA~1/PUPPET~1/Bolt/lib/ruby/2.5.0/Win32API.rb:11: warning: previous definition of TYPEMAP was here
	C:/PROGRA~1/PUPPET~1/Bolt/lib/ruby/2.5.0/win32api.rb:12: warning: already initialized constant Win32API::POINTER_TYPE
	C:/PROGRA~1/PUPPET~1/Bolt/lib/ruby/2.5.0/Win32API.rb:12: warning: previous definition of POINTER_TYPE was here
	C:/PROGRA~1/PUPPET~1/Bolt/lib/ruby/2.5.0/win32api.rb:14: warning: already initialized constant Win32API::WIN32_TYPES
	C:/PROGRA~1/PUPPET~1/Bolt/lib/ruby/2.5.0/Win32API.rb:14: warning: previous definition of WIN32_TYPES was here
	C:/PROGRA~1/PUPPET~1/Bolt/lib/ruby/2.5.0/win32api.rb:15: warning: already initialized constant Win32API::DL_TYPES
	C:/PROGRA~1/PUPPET~1/Bolt/lib/ruby/2.5.0/Win32API.rb:15: warning: previous definition of DL_TYPES was here