### PR TITLE
(BOLT-1187) Accept a `return` expression for YAML plans

### DIFF
--- a/lib/bolt/pal/yaml_plan.rb
+++ b/lib/bolt/pal/yaml_plan.rb
@@ -9,7 +9,7 @@ module Bolt
         end
       end
 
-      attr_reader :name, :parameters, :steps
+      attr_reader :name, :parameters, :steps, :return
 
       def initialize(name, plan)
         # Top-level plan keys aren't allowed to be Puppet code, so force them
@@ -35,6 +35,8 @@ module Bolt
           stringified_step['name'] = stringify(stringified_step['name']) if stringified_step.key?('name')
           stringified_step
         end.freeze
+
+        @return = plan['return']
 
         validate
       end

--- a/lib/bolt/pal/yaml_plan/evaluator.rb
+++ b/lib/bolt/pal/yaml_plan/evaluator.rb
@@ -107,16 +107,17 @@ module Bolt
         # This is the method that Puppet calls to evaluate the plan. The name
         # makes more sense for .pp plans.
         def evaluate_block_with_bindings(closure_scope, args_hash, plan)
-          closure_scope.with_local_scope(args_hash) do |scope|
+          plan_result = closure_scope.with_local_scope(args_hash) do |scope|
             plan.steps.each do |step|
-              result = dispatch_step(scope, step)
+              step_result = dispatch_step(scope, step)
 
-              scope.setvar(step['name'], result) if step.key?('name')
+              scope.setvar(step['name'], step_result) if step.key?('name')
             end
+
+            evaluate_code_blocks(scope, plan.return)
           end
 
-          result = nil
-          throw :return, Puppet::Pops::Evaluator::Return.new(result, nil, nil)
+          throw :return, Puppet::Pops::Evaluator::Return.new(plan_result, nil, nil)
         end
 
         # Recursively evaluate any EvaluableString instances in the object.

--- a/lib/bolt/pal/yaml_plan/evaluator.rb
+++ b/lib/bolt/pal/yaml_plan/evaluator.rb
@@ -106,13 +106,9 @@ module Bolt
 
         # This is the method that Puppet calls to evaluate the plan. The name
         # makes more sense for .pp plans.
-        def evaluate_block_with_bindings(closure_scope, args_hash, steps)
-          unless steps.is_a?(Array)
-            raise Bolt::Error.new("Plan must specify an array of steps", "bolt/invalid-plan")
-          end
-
+        def evaluate_block_with_bindings(closure_scope, args_hash, plan)
           closure_scope.with_local_scope(args_hash) do |scope|
-            steps.each do |step|
+            plan.steps.each do |step|
               result = dispatch_step(scope, step)
 
               scope.setvar(step['name'], result) if step.key?('name')

--- a/spec/fixtures/modules/sample/plans/yaml.yaml
+++ b/spec/fixtures/modules/sample/plans/yaml.yaml
@@ -14,5 +14,8 @@ steps:
     target: $nodes
     parameters:
       message: hello world
-  - command: echo hello world
+  - name: echo_message
+    command: echo hello world
     target: $nodes
+
+return: $echo_message.first.value

--- a/spec/fixtures/modules/yaml/files/test.sh
+++ b/spec/fixtures/modules/yaml/files/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo $@

--- a/spec/fixtures/modules/yaml/plans/command.yaml
+++ b/spec/fixtures/modules/yaml/plans/command.yaml
@@ -1,0 +1,10 @@
+parameters:
+  nodes:
+    type: TargetSpec
+
+steps:
+  - name: run_command
+    command: echo hello world
+    target: $nodes
+
+return: $run_command

--- a/spec/fixtures/modules/yaml/plans/param_passing.yaml
+++ b/spec/fixtures/modules/yaml/plans/param_passing.yaml
@@ -1,0 +1,16 @@
+parameters:
+  n:
+    type: Integer
+    default: 12
+
+steps:
+  - name: doubled
+    eval: $n * 2
+  - name: tripled
+    eval: $n * 3
+  - name: quintupled
+    eval: $doubled + $tripled
+  - name: stringified
+    eval: "${quintupled}"
+
+return: [$doubled, $tripled, $quintupled, $stringified]

--- a/spec/fixtures/modules/yaml/plans/script.yaml
+++ b/spec/fixtures/modules/yaml/plans/script.yaml
@@ -1,0 +1,11 @@
+parameters:
+  nodes:
+    type: TargetSpec
+
+steps:
+  - name: run_script
+    script: 'yaml/test.sh'
+    target: $nodes
+    arguments: ["foo", "bar", "baz"]
+
+return: $run_script

--- a/spec/fixtures/modules/yaml/plans/task.yaml
+++ b/spec/fixtures/modules/yaml/plans/task.yaml
@@ -1,0 +1,12 @@
+parameters:
+  nodes:
+    type: TargetSpec
+
+steps:
+  - name: run_task
+    task: sample
+    target: $nodes
+    parameters:
+      message: "hello world"
+
+return: $run_task

--- a/spec/fixtures/modules/yaml/plans/upload.yaml
+++ b/spec/fixtures/modules/yaml/plans/upload.yaml
@@ -1,0 +1,15 @@
+parameters:
+  nodes:
+    type: TargetSpec
+
+steps:
+  - name: upload_file
+    source: 'yaml/test.sh'
+    destination: '/tmp/test_upload.sh'
+    target: $nodes
+    arguments: ["foo", "bar", "baz"]
+  - name: cleanup
+    eval: rm '/tmp/test_upload.sh'
+    target: $nodes
+
+return: $upload_file

--- a/spec/integration/plan_spec.rb
+++ b/spec/integration/plan_spec.rb
@@ -45,7 +45,7 @@ describe "When a plan succeeds" do
 
   it 'runs a yaml plan', ssh: true do
     result = run_cli(['plan', 'run', 'sample::yaml', '--nodes', target] + config_flags)
-    expect(JSON.parse(result)).to be_nil
+    expect(JSON.parse(result)).to eq('stdout' => "hello world\n", 'stderr' => '', 'exit_code' => 0)
 
     lines = @log_output.readlines
     expect(lines).to include(match(/Starting: task/))

--- a/spec/integration/yaml_plan_spec.rb
+++ b/spec/integration/yaml_plan_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/config'
+require 'bolt_spec/conn'
+require 'bolt_spec/files'
+require 'bolt_spec/integration'
+
+describe "running YAML plans", ssh: true do
+  include BoltSpec::Integration
+  include BoltSpec::Config
+  include BoltSpec::Conn
+
+  after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
+
+  let(:modulepath) { fixture_path('modules') }
+  let(:config_flags) {
+    ['--format', 'json',
+     '--configfile', fixture_path('configs', 'empty.yml'),
+     '--modulepath', modulepath,
+     '--no-host-key-check']
+  }
+  let(:target) { conn_uri('ssh', include_password: true) }
+
+  def run_plan(plan_name, params = {})
+    result = run_cli(['plan', 'run', plan_name, '--params', params.to_json] + config_flags,
+                     outputter: Bolt::Outputter::JSON)
+    JSON.parse(result)
+  end
+
+  it 'runs a command' do
+    result = run_plan('yaml::command', nodes: target)
+
+    expect(result.first['node']).to eq(target)
+    expect(result.first['status']).to eq('success')
+    expect(result.first['result']).to eq("stdout" => "hello world\n", "stderr" => "", "exit_code" => 0)
+  end
+
+  it 'runs a task' do
+    result = run_plan('yaml::task', nodes: target)
+
+    expect(result.first['node']).to eq(target)
+    expect(result.first['status']).to eq('success')
+    expect(result.first['result']).to eq('_output' => "hello world\n")
+  end
+
+  it 'runs a script' do
+    result = run_plan('yaml::script', nodes: target)
+
+    expect(result.first['node']).to eq(target)
+    expect(result.first['status']).to eq('success')
+    expect(result.first['result']['stdout']).to eq("foo bar baz\n")
+  end
+
+  it 'uploads a file' do
+    result = run_plan('yaml::upload', nodes: target)
+
+    expect(result.first['node']).to eq(target)
+    expect(result.first['status']).to eq('success')
+    expect(result.first['result']['_output']).to match(/Uploaded .*test.sh/)
+  end
+
+  it 'passes information between steps' do
+    result = run_plan('yaml::param_passing')
+
+    expect(result).to eq([24, 36, 60, "60"])
+  end
+end


### PR DESCRIPTION
Previously, YAML plans always returned `undef`. Now they accept a top-level
`return` key which can be either a value or an expression which will be
evaluated and returned after the plan finishes. Plans which don't specify a
`return` will still return `undef`.