### PR TITLE
(BOLT-1175) Support running plans from YAML plans

### DIFF
--- a/lib/bolt/pal/yaml_plan/evaluator.rb
+++ b/lib/bolt/pal/yaml_plan/evaluator.rb
@@ -11,7 +11,7 @@ module Bolt
           @evaluator = Puppet::Pops::Parser::EvaluatingParser.new
         end
 
-        STEP_KEYS = %w[task command eval script source].freeze
+        STEP_KEYS = %w[task command eval script source plan].freeze
 
         def dispatch_step(scope, step)
           step = evaluate_code_blocks(scope, step)
@@ -26,6 +26,8 @@ module Bolt
             task_step(scope, step)
           when 'command'
             command_step(scope, step)
+          when 'plan'
+            plan_step(scope, step)
           when 'script'
             script_step(scope, step)
           when 'source'
@@ -52,7 +54,17 @@ module Bolt
                  else
                    [task, target, params]
                  end
+
           scope.call_function('run_task', args)
+        end
+
+        def plan_step(scope, step)
+          plan = step['plan']
+          parameters = step['parameters'] || {}
+
+          args = [plan, parameters]
+
+          scope.call_function('run_plan', args)
         end
 
         def script_step(scope, step)

--- a/spec/bolt/pal/yaml_plan/evaluator_spec.rb
+++ b/spec/bolt/pal/yaml_plan/evaluator_spec.rb
@@ -241,6 +241,35 @@ describe Bolt::PAL::YamlPlan::Evaluator do
     end
   end
 
+  describe "#plan_step" do
+    let(:step) do
+      { 'plan' => 'testplan',
+        'parameters' => { 'message' => 'hello',
+                          'count' => 5 } }
+    end
+
+    it 'passes parameters to the plan' do
+      expect(scope).to receive(:call_function).with('run_plan', ['testplan', { 'message' => 'hello', 'count' => 5 }])
+
+      subject.plan_step(scope, step)
+    end
+
+    it 'succeeds if no parameters are specified' do
+      step.delete('parameters')
+
+      expect(scope).to receive(:call_function).with('run_plan', ['testplan', {}])
+
+      subject.plan_step(scope, step)
+    end
+    it 'succeeds if nil parameters are specified' do
+      step['parameters'] = nil
+
+      expect(scope).to receive(:call_function).with('run_plan', ['testplan', {}])
+
+      subject.plan_step(scope, step)
+    end
+  end
+
   describe "#command_step" do
     let(:step) do
       { 'command' => 'hostname -f',

--- a/spec/fixtures/modules/yaml/plans/define_foo.yaml
+++ b/spec/fixtures/modules/yaml/plans/define_foo.yaml
@@ -1,0 +1,3 @@
+steps:
+  - name: foo
+    eval: "hello world"

--- a/spec/fixtures/modules/yaml/plans/delegate.yaml
+++ b/spec/fixtures/modules/yaml/plans/delegate.yaml
@@ -1,0 +1,11 @@
+parameters:
+  nodes:
+    type: TargetSpec
+
+steps:
+  - name: run_plan
+    plan: yaml::task
+    parameters:
+      nodes: $nodes
+
+return: $run_plan

--- a/spec/fixtures/modules/yaml/plans/plan_isolated_from_subplan.yaml
+++ b/spec/fixtures/modules/yaml/plans/plan_isolated_from_subplan.yaml
@@ -1,0 +1,4 @@
+steps:
+  - plan: yaml::define_foo
+
+return: $foo

--- a/spec/fixtures/modules/yaml/plans/plan_with_isolated_subplan.yaml
+++ b/spec/fixtures/modules/yaml/plans/plan_with_isolated_subplan.yaml
@@ -1,0 +1,9 @@
+parameters:
+  message:
+    type: String
+
+steps:
+  - name: undefined_var
+    plan: yaml::undefined_var
+
+return: $undefined_var

--- a/spec/fixtures/modules/yaml/plans/undefined_var.yaml
+++ b/spec/fixtures/modules/yaml/plans/undefined_var.yaml
@@ -1,0 +1,2 @@
+steps: []
+return: $message

--- a/spec/integration/yaml_plan_spec.rb
+++ b/spec/integration/yaml_plan_spec.rb
@@ -60,6 +60,26 @@ describe "running YAML plans", ssh: true do
     expect(result.first['result']['_output']).to match(/Uploaded .*test.sh/)
   end
 
+  it 'runs another plan' do
+    result = run_plan('yaml::delegate', nodes: target)
+
+    expect(result.first['node']).to eq(target)
+    expect(result.first['status']).to eq('success')
+    expect(result.first['result']).to eq('_output' => "hello world\n")
+  end
+
+  it 'does not expose its own variables to a sub-plan' do
+    result = run_plan('yaml::plan_with_isolated_subplan', message: 'hello world')
+
+    expect(result['msg']).to match(/Unknown variable/)
+  end
+
+  it 'does not leak variables back into the calling plan' do
+    result = run_plan('yaml::plan_isolated_from_subplan')
+
+    expect(result['msg']).to match(/Unknown variable/)
+  end
+
   it 'passes information between steps' do
     result = run_plan('yaml::param_passing')
 


### PR DESCRIPTION
This adds a `plan` step which can be used to run another plan.

This also fixes an issue with scope leaking between plan invocations.
Previously, we were running plans in the scope in which they were called,
causing variables in the surrounding scope to be visible to the plan. We now
run plans from the scope in which they're defined, which is global scope. That
causes every plan invocation to have a fresh scope without any stray variables
polluting it.