### PR TITLE
(BOLT-1190) Don't leak scope to sub-plans

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -66,7 +66,9 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
         # If the plan does not throw :return by calling the return function it's result is
         # undef/nil
         result = catch(:return) do
-          func.class.dispatcher.dispatchers[0].call_by_name_with_scope(scope, params, true)
+          scope.with_global_scope do |global_scope|
+            func.class.dispatcher.dispatchers[0].call_by_name_with_scope(global_scope, params, true)
+          end
           nil
         end&.value
         # Validate the result is a PlanResult


### PR DESCRIPTION
Previously, we were running plans in the scope in which they were
called, causing variables in the surrounding scope to be visible to the
plan. We now run plans from the scope in which they're defined, which is
global scope. That causes every plan invocation to have a fresh scope
without any stray variables polluting it.