### PR TITLE
(BOLT-1201) Use old Psych.parse signature if needed

### DIFF
--- a/lib/bolt/pal/yaml_plan/loader.rb
+++ b/lib/bolt/pal/yaml_plan/loader.rb
@@ -43,7 +43,13 @@ module Bolt
         end
 
         def self.parse_plan(yaml_string, source_ref)
-          parse_tree = Psych.parse(yaml_string, filename: source_ref)
+          # This passes the filename as the second arg for compatibility with Psych used with ruby < 2.6
+          # This can be removed when we remove support for ruby 2.5
+          parse_tree = if Psych.method(:parse).parameters.include?('legacy_filename')
+                         Psych.parse(yaml_string, filename: source_ref)
+                       else
+                         Psych.parse(yaml_string, source_ref)
+                       end
           PuppetVisitor.create_visitor.accept(parse_tree)
         end
 


### PR DESCRIPTION
**What this changes** This checks the `Psych.parse` signature available in the installed ruby stdlib to see if `legacy_filename` is available. If it is, we can assume passing filename using the keyword parameter. If not, use the old Psych.parse signature and just pass a filename

**Why** So that we can successfully load plans on ruby < 2.6