### PR TITLE
(BOLT-1125) Add more information about what was run to Results

### DIFF
--- a/lib/bolt/apply_result.rb
+++ b/lib/bolt/apply_result.rb
@@ -65,6 +65,7 @@ module Bolt
     def initialize(target, error: nil, report: nil)
       @target = target
       @value = {}
+      @type = 'apply'
       value['report'] = report if report
       value['_error'] = error if error
       value['_output'] = metrics_message if metrics_message

--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -5,7 +5,7 @@ require 'bolt/error'
 
 module Bolt
   class Result
-    attr_reader :target, :value
+    attr_reader :target, :value, :type, :object
 
     def self.from_exception(target, exception)
       @exception = exception
@@ -23,7 +23,7 @@ module Bolt
       Result.new(target, error: error)
     end
 
-    def self.for_command(target, stdout, stderr, exit_code)
+    def self.for_command(target, stdout, stderr, exit_code, type, command)
       value = {
         'stdout' => stdout,
         'stderr' => stderr,
@@ -37,10 +37,10 @@ module Bolt
           'details' => { 'exit_code' => exit_code }
         }
       end
-      new(target, value: value)
+      new(target, value: value, type: type, object: command)
     end
 
-    def self.for_task(target, stdout, stderr, exit_code)
+    def self.for_task(target, stdout, stderr, exit_code, task)
       begin
         value = JSON.parse(stdout)
         unless value.is_a? Hash
@@ -61,11 +61,11 @@ module Bolt
                             'msg' => msg,
                             'details' => { 'exit_code' => exit_code } }
       end
-      new(target, value: value)
+      new(target, value: value, type: 'task', object: task)
     end
 
     def self.for_upload(target, source, destination)
-      new(target, message: "Uploaded '#{source}' to '#{target.host}:#{destination}'")
+      new(target, message: "Uploaded '#{source}' to '#{target.host}:#{destination}'", type: 'upload', object: source)
     end
 
     # Satisfies the Puppet datatypes API
@@ -73,9 +73,11 @@ module Bolt
       new(target, value: value)
     end
 
-    def initialize(target, error: nil, message: nil, value: nil)
+    def initialize(target, error: nil, message: nil, value: nil, type: nil, object: nil)
       @target = target
       @value = value || {}
+      @type = type
+      @object = object
       @value_set = !value.nil?
       if error && !error.is_a?(Hash)
         raise "TODO: how did we get a string error"
@@ -90,12 +92,12 @@ module Bolt
 
     def status_hash
       { node: @target.name,
+        type: type,
+        object: object,
         status: ok? ? 'success' : 'failure',
         result: @value }
     end
 
-    # TODO: what to call this it's the value minus special keys
-    # This should be {} if a value was set otherwise it's nil
     def generic_value
       if @value_set
         value.reject { |k, _| %w[_error _output].include? k }
@@ -124,15 +126,11 @@ module Bolt
       to_json
     end
 
-    # TODO: remove in favor of ok?
-    def success?
-      ok?
-    end
-
     def ok?
       error_hash.nil?
     end
     alias ok ok?
+    alias success? ok?
 
     # This allows access to errors outside puppet compilation
     # it should be prefered over error in bolt code

--- a/lib/bolt/transport/docker.rb
+++ b/lib/bolt/transport/docker.rb
@@ -59,7 +59,7 @@ module Bolt
       def run_command(target, command, _options = {})
         with_connection(target) do |conn|
           stdout, stderr, exitcode = conn.execute(*Shellwords.split(command), {})
-          Bolt::Result.for_command(target, stdout, stderr, exitcode)
+          Bolt::Result.for_command(target, stdout, stderr, exitcode, 'command', command)
         end
       end
 
@@ -71,7 +71,7 @@ module Bolt
           conn.with_remote_tempdir do |dir|
             remote_path = conn.write_remote_executable(dir, script)
             stdout, stderr, exitcode = conn.execute(remote_path, *arguments, {})
-            Bolt::Result.for_command(target, stdout, stderr, exitcode)
+            Bolt::Result.for_command(target, stdout, stderr, exitcode, 'script', script)
           end
         end
       end
@@ -112,7 +112,7 @@ module Bolt
             end
 
             stdout, stderr, exitcode = conn.execute(remote_task_path, execute_options)
-            Bolt::Result.for_task(target, stdout, stderr, exitcode)
+            Bolt::Result.for_task(target, stdout, stderr, exitcode, task.name)
           end
         end
       end

--- a/lib/bolt/transport/local.rb
+++ b/lib/bolt/transport/local.rb
@@ -78,7 +78,11 @@ module Bolt
       def run_command(target, command, _options = {})
         in_tmpdir(target.options['tmpdir']) do |dir|
           output = @conn.execute(command, dir: dir)
-          Bolt::Result.for_command(target, output.stdout.string, output.stderr.string, output.exit_code)
+          Bolt::Result.for_command(target,
+                                   output.stdout.string,
+                                   output.stderr.string,
+                                   output.exit_code,
+                                   'command', command)
         end
       end
 
@@ -106,7 +110,11 @@ module Bolt
             end
             output = @conn.execute(file, *arguments, dir: dir)
           end
-          Bolt::Result.for_command(target, output.stdout.string, output.stderr.string, output.exit_code)
+          Bolt::Result.for_command(target,
+                                   output.stdout.string,
+                                   output.stderr.string,
+                                   output.exit_code,
+                                   'script', script)
         end
       end
 
@@ -181,7 +189,7 @@ module Bolt
             env = ENVIRONMENT_METHODS.include?(input_method) ? envify_params(unwrapped_arguments) : nil
             output = @conn.execute(script, stdin: stdin, env: env, dir: dir, interpreter: interpreter)
           end
-          Bolt::Result.for_task(target, output.stdout.string, output.stderr.string, output.exit_code)
+          Bolt::Result.for_task(target, output.stdout.string, output.stderr.string, output.exit_code, task.name)
         end
       end
 

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -108,7 +108,11 @@ module Bolt
         with_connection(target) do |conn|
           conn.running_as(options['_run_as']) do
             output = conn.execute(command, sudoable: true)
-            Bolt::Result.for_command(target, output.stdout.string, output.stderr.string, output.exit_code)
+            Bolt::Result.for_command(target,
+                                     output.stdout.string,
+                                     output.stderr.string,
+                                     output.exit_code,
+                                     'command', command)
           end
         end
       end
@@ -123,7 +127,11 @@ module Bolt
               remote_path = conn.write_remote_executable(dir, script)
               dir.chown(conn.run_as)
               output = conn.execute([remote_path, *arguments], sudoable: true)
-              Bolt::Result.for_command(target, output.stdout.string, output.stderr.string, output.exit_code)
+              Bolt::Result.for_command(target,
+                                       output.stdout.string,
+                                       output.stderr.string,
+                                       output.exit_code,
+                                       'script', script)
             end
           end
         end
@@ -184,7 +192,8 @@ module Bolt
             end
             Bolt::Result.for_task(target, output.stdout.string,
                                   output.stderr.string,
-                                  output.exit_code)
+                                  output.exit_code,
+                                  task.name)
           end
         end
       end

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -85,7 +85,11 @@ module Bolt
       def run_command(target, command, _options = {})
         with_connection(target) do |conn|
           output = conn.execute(command)
-          Bolt::Result.for_command(target, output.stdout.string, output.stderr.string, output.exit_code)
+          Bolt::Result.for_command(target,
+                                   output.stdout.string,
+                                   output.stderr.string,
+                                   output.exit_code,
+                                   'command', command)
         end
       end
 
@@ -102,7 +106,11 @@ module Bolt
               args += Powershell.escape_arguments(arguments)
               output = conn.execute_process(path, args)
             end
-            Bolt::Result.for_command(target, output.stdout.string, output.stderr.string, output.exit_code)
+            Bolt::Result.for_command(target,
+                                     output.stdout.string,
+                                     output.stderr.string,
+                                     output.exit_code,
+                                     'script', script)
           end
         end
       end
@@ -163,7 +171,8 @@ module Bolt
 
             Bolt::Result.for_task(target, output.stdout.string,
                                   output.stderr.string,
-                                  output.exit_code)
+                                  output.exit_code,
+                                  task.name)
           end
         end
       end

--- a/lib/bolt_spec/plans/action_stubs/command_stub.rb
+++ b/lib/bolt_spec/plans/action_stubs/command_stub.rb
@@ -29,7 +29,7 @@ module BoltSpec
       end
 
       def result_for(target, stdout: '', stderr: '')
-        Bolt::Result.for_command(target, stdout, stderr, 0)
+        Bolt::Result.for_command(target, stdout, stderr, 0, 'command', '')
       end
 
       # Public methods

--- a/lib/bolt_spec/plans/action_stubs/script_stub.rb
+++ b/lib/bolt_spec/plans/action_stubs/script_stub.rb
@@ -35,7 +35,7 @@ module BoltSpec
       end
 
       def result_for(target, stdout: '', stderr: '')
-        Bolt::Result.for_command(target, stdout, stderr, 0)
+        Bolt::Result.for_command(target, stdout, stderr, 0, 'script', '')
       end
 
       # Public methods

--- a/spec/bolt/apply_result_spec.rb
+++ b/spec/bolt/apply_result_spec.rb
@@ -7,17 +7,17 @@ require 'bolt/target'
 describe Bolt::ApplyResult do
   describe '#puppet_missing_error' do
     it 'returns the nil if no identifiable errors are found' do
-      result = Bolt::Result.for_task(:target, '', 'blah', 1)
+      result = Bolt::Result.for_task(:target, '', 'blah', 1, 'catalog')
       expect(Bolt::ApplyResult.puppet_missing_error(result)).to be_nil
     end
 
     it 'returns nil if no errors are present' do
-      result = Bolt::Result.for_task(:target, 'hello', '', 0)
+      result = Bolt::Result.for_task(:target, 'hello', '', 0, 'catalog')
       expect(Bolt::ApplyResult.puppet_missing_error(result)).to be_nil
     end
 
     it 'errors if /opt/puppetlabs/puppet/bin/ruby not found on Linux' do
-      orig_result = Bolt::Result.for_task(:target, '', 'blah', 127)
+      orig_result = Bolt::Result.for_task(:target, '', 'blah', 127, 'catalog')
       error = Bolt::ApplyResult.puppet_missing_error(orig_result)
       expect(error['kind']).to eq('bolt/apply-error')
       expect(error['msg'])
@@ -25,7 +25,7 @@ describe Bolt::ApplyResult do
     end
 
     it 'errors if /opt/puppetlabs/puppet/bin/ruby not found on macOS' do
-      orig_result = Bolt::Result.for_task(:target, '', 'blah', 126)
+      orig_result = Bolt::Result.for_task(:target, '', 'blah', 126, 'catalog')
       error = Bolt::ApplyResult.puppet_missing_error(orig_result)
       expect(error['kind']).to eq('bolt/apply-error')
       expect(error['msg'])
@@ -33,7 +33,7 @@ describe Bolt::ApplyResult do
     end
 
     it 'errors if Ruby cannot be found on Windows' do
-      orig_result = Bolt::Result.for_task(:target, '', "Could not find executable 'ruby.exe'", 1)
+      orig_result = Bolt::Result.for_task(:target, '', "Could not find executable 'ruby.exe'", 1, 'catalog')
       error = Bolt::ApplyResult.puppet_missing_error(orig_result)
       expect(error['kind']).to eq('bolt/apply-error')
       expect(error['msg'])
@@ -41,12 +41,21 @@ describe Bolt::ApplyResult do
     end
 
     it 'errors if Puppet cannot be found on Windows' do
-      orig_result = Bolt::Result.for_task(:target, '', 'cannot load such file -- puppet (LoadError)', 1)
+      orig_result = Bolt::Result.for_task(:target, '', 'cannot load such file -- puppet (LoadError)', 1, 'catalog')
       error = Bolt::ApplyResult.puppet_missing_error(orig_result)
       expect(error['kind']).to eq('bolt/apply-error')
       expect(error['msg'])
         .to eq('Found a Ruby without Puppet present, please install Puppet ' \
               "or remove Ruby from $env:Path to enable 'apply'")
+    end
+  end
+
+  describe 'type and object' do
+    it 'exposes apply as the type' do
+      result = Bolt::Result.for_task(:target, 'hello', '', 0, 'catalog')
+      result = Bolt::ApplyResult.new(result)
+      expect(result.type).to be('apply')
+      expect(result.object).to be(nil)
     end
   end
 end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1489,7 +1489,7 @@ bar
           expect(executor)
             .to receive(:run_task)
             .with(targets, task_t, { 'message' => 'hi there' }, kind_of(Hash))
-            .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'yes', '', 0)]))
+            .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'yes', '', 0, 'some_task')]))
 
           expect(executor).to receive(:start_plan)
           expect(executor).to receive(:log_plan)
@@ -1497,7 +1497,11 @@ bar
 
           cli.execute(options)
           expect(JSON.parse(output.string)).to eq(
-            [{ 'node' => 'foo', 'status' => 'success', 'result' => { '_output' => 'yes' } }]
+            [{ 'node' => 'foo',
+               'status' => 'success',
+               'type' => 'task',
+               'object' => 'some_task',
+               'result' => { '_output' => 'yes' } }]
           )
         end
 
@@ -1515,7 +1519,7 @@ bar
           expect(executor)
             .to receive(:run_task)
             .with(targets, task_t, { 'message' => 'hi there' }, kind_of(Hash))
-            .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'yes', '', 0)]))
+            .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'yes', '', 0, 'some_task')]))
 
           expect(executor).to receive(:start_plan)
           expect(executor).to receive(:log_plan)
@@ -1523,7 +1527,11 @@ bar
 
           cli.execute(options)
           expect(JSON.parse(output.string)).to eq(
-            [{ 'node' => 'foo', 'status' => 'success', 'result' => { '_output' => 'yes' } }]
+            [{ 'node' => 'foo',
+               'status' => 'success',
+               'type' => 'task',
+               'object' => 'some_task',
+               'result' => { '_output' => 'yes' } }]
           )
         end
 
@@ -1545,7 +1553,7 @@ bar
           expect(executor)
             .to receive(:run_task)
             .with(targets, task_t, { 'message' => 'hi there' }, kind_of(Hash))
-            .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'no', '', 1)]))
+            .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'no', '', 1, 'some_task')]))
 
           expect(executor).to receive(:start_plan)
           expect(executor).to receive(:log_plan)
@@ -1557,6 +1565,8 @@ bar
               {
                 'node' => 'foo',
                 'status' => 'failure',
+                'type' => 'task',
+                'object' => 'some_task',
                 'result' => {
                   "_output" => "no",
                   "_error" => {

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -217,7 +217,7 @@ plans/plans/plans/plans
   end
 
   it "prints CommandResults" do
-    outputter.print_result(Bolt::Result.for_command(target, "stout", "sterr", 2))
+    outputter.print_result(Bolt::Result.for_command(target, "stout", "sterr", 2, 'command', "executed"))
     lines = output.string
     expect(lines).to match(/STDOUT:\n    stout/)
     expect(lines).to match(/STDERR:\n    sterr/)
@@ -227,7 +227,7 @@ plans/plans/plans/plans
     result = { 'key' => 'val',
                '_error' => { 'msg' => 'oops' },
                '_output' => 'hello' }
-    outputter.print_result(Bolt::Result.for_task(target, result.to_json, "", 2))
+    outputter.print_result(Bolt::Result.for_task(target, result.to_json, "", 2, 'atask'))
     lines = output.string
     expect(lines).to match(/^  oops\n  hello$/)
     expect(lines).to match(/^    "key": "val"$/)

--- a/spec/bolt/result_set_spec.rb
+++ b/spec/bolt/result_set_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 require 'json'
 require 'bolt'
 require 'bolt/result'
+require 'bolt/target'
 
 describe Bolt::Result do
   let(:target1) { "node1" }
@@ -22,8 +23,16 @@ describe Bolt::Result do
   end
 
   it 'is creates the correct json' do
-    expected = '[{"node":"node1","status":"success","result":{"key":"val1"}},'\
-      '{"node":"node1","status":"failure","result":{"key":"val2","_error":{"kind":"bolt/oops"}}}]'
-    expect(result_set.to_json).to eq(expected)
+    expected = [{ "node" => "node1",
+                  "type" => nil,
+                  "object" => nil,
+                  "status" => "success",
+                  "result" => { "key" => "val1" } },
+                { "node" => "node1",
+                  "type" => nil,
+                  "object" => nil,
+                  "status" => "failure",
+                  "result" => { "key" => "val2", "_error" => { "kind" => "bolt/oops" } } }]
+    expect(JSON.parse(result_set.to_json)).to eq(expected)
   end
 end

--- a/spec/bolt/result_spec.rb
+++ b/spec/bolt/result_spec.rb
@@ -34,12 +34,12 @@ describe Bolt::Result do
 
   describe :for_command do
     it 'exposes value' do
-      result = Bolt::Result.for_command(target, "stout", "sterr", 0)
+      result = Bolt::Result.for_command(target, "stout", "sterr", 0, 'command', 'command')
       expect(result.value).to eq('stdout' => 'stout', 'stderr' => 'sterr', 'exit_code' => 0)
     end
 
     it 'creates errors' do
-      result = Bolt::Result.for_command(target, "stout", "sterr", 1)
+      result = Bolt::Result.for_command(target, "stout", "sterr", 1, 'command', 'command')
       expect(result.error_hash['kind']).to eq('puppetlabs.tasks/command-error')
     end
   end
@@ -47,27 +47,27 @@ describe Bolt::Result do
   describe :for_task do
     it 'parses json objects' do
       obj = { "key" => "val" }
-      result = Bolt::Result.for_task(target, obj.to_json, '', 0)
+      result = Bolt::Result.for_task(target, obj.to_json, '', 0, 'atask')
       expect(result.value).to eq(obj)
     end
 
     it 'doesnt include _ keys in generic_value' do
       obj = { "key" => "val" }
       special = { "_error" => {}, "_output" => "output" }
-      result = Bolt::Result.for_task(target, obj.merge(special).to_json, '', 0)
+      result = Bolt::Result.for_task(target, obj.merge(special).to_json, '', 0, 'atask')
       expect(result.generic_value).to eq(obj)
     end
 
     it "doesn't parse arrays" do
       stdout = '[1, 2, 3]'
-      result = Bolt::Result.for_task(target, stdout, '', 0)
+      result = Bolt::Result.for_task(target, stdout, '', 0, 'atask')
       expect(result.value).to eq('_output' => stdout)
     end
 
     it 'handles errors' do
       obj = { "key" => "val",
               "_error" => { "kind" => "error" } }
-      result = Bolt::Result.for_task(target, obj.to_json, '', 1)
+      result = Bolt::Result.for_task(target, obj.to_json, '', 1, 'atask')
       expect(result.value).to eq(obj)
       expect(result.error_hash).to eq(obj['_error'])
     end

--- a/spec/bolt/transport/orch_spec.rb
+++ b/spec/bolt/transport/orch_spec.rb
@@ -8,6 +8,7 @@ require 'bolt/transport/orch'
 require 'bolt/plan_result'
 require 'bolt/target'
 require 'open3'
+require 'orchestrator_client'
 
 describe Bolt::Transport::Orch, orchestrator: true do
   include BoltSpec::Files
@@ -121,7 +122,7 @@ describe Bolt::Transport::Orch, orchestrator: true do
     it "returns a result for every successful node" do
       results = [{ 'name' => 'node1', 'state' => 'finished', 'result' => { '_output' => 'hello' } },
                  { 'name' => 'node2', 'state' => 'finished', 'result' => { '_output' => 'goodbye' } }]
-      node_results = orch.process_run_results(targets, results)
+      node_results = orch.process_run_results(targets, results, 'thetask')
 
       expect(node_results[0]).to be_success
       expect(node_results[1]).to be_success
@@ -135,7 +136,7 @@ describe Bolt::Transport::Orch, orchestrator: true do
       it "returns failure for only the failed node" do
         results = [{ 'name' => 'node1', 'state' => 'finished', 'result' => { '_output' => 'hello' } },
                    { 'name' => 'node2', 'state' => 'failed', 'result' => { '_output' => 'goodbye' } }]
-        node_results = orch.process_run_results(targets, results)
+        node_results = orch.process_run_results(targets, results, 'thetask')
 
         expect(node_results[0]).to be_success
         expect(node_results[1]).not_to be_success
@@ -151,7 +152,7 @@ describe Bolt::Transport::Orch, orchestrator: true do
                                        'details' => {} } }
         results = [{ 'name' => 'node1', 'state' => 'finished', 'result' => { '_output' => 'hello' } },
                    { 'name' => 'node2', 'state' => 'failed', 'result' => error_result }]
-        node_results = orch.process_run_results(targets, results)
+        node_results = orch.process_run_results(targets, results, 'thetask')
 
         expect(node_results[0]).to be_success
         expect(node_results[1]).not_to be_success
@@ -163,7 +164,7 @@ describe Bolt::Transport::Orch, orchestrator: true do
         results = [{ 'name' => 'node1', 'state' => 'finished', 'result' => { '_output' => 'hello' } },
                    # XXX double-check that this is the correct result for a skipped node
                    { 'name' => 'node2', 'state' => 'skipped', 'result' => nil }]
-        node_results = orch.process_run_results(targets, results)
+        node_results = orch.process_run_results(targets, results, 'thetask')
 
         expect(node_results[0]).to be_success
         expect(node_results[1]).not_to be_success

--- a/spec/integration/target_spec.rb
+++ b/spec/integration/target_spec.rb
@@ -25,6 +25,8 @@ describe "when running a plan that creates targets", ssh: true do
         [
           {
             'node' => uri,
+            'type' => 'task',
+            'object' => 'results',
             'status' => 'success',
             'result' => {
               '_output' => "hi\n"


### PR DESCRIPTION
This adds type and object keys to the result object that display what
type is was(task/command...) and what the object or first argument to
the action was.