### PR TITLE
(BOLT-1204) Document installing bolt on el 8 platforms

### DIFF
--- a/pre-docs/bolt_installing.md
+++ b/pre-docs/bolt_installing.md
@@ -194,6 +194,14 @@ The Puppet repository for the YUM package management system is [http://yum.puppe
         sudo yum install puppet-bolt
         ```
 
+    -   Enterprise Linux 8
+
+        ```
+        sudo rpm -Uvh https://yum.puppet.com/puppet6/puppet6-release-el-8.noarch.rpm
+        sudo yum install puppet-bolt
+        ```
+
+
     -   SUSE Linux Enterprise Server 12
 
         ```


### PR DESCRIPTION
This commit documents installing puppet-bolt on el 8 platforms. Bolt is build and tested on redhat 8, this should also cover centos 8 when that is available.