### PR TITLE
(maint) Building for el 8 requires patches that landed in beaker 4

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -16,10 +16,12 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 3.10")
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 4")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.2")
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.0")
-gem 'beaker-puppet', *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 0.15')
+gem 'beaker-pe', *location_for(ENV['BEAKER_PE_VERSION'] || '~> 2')
+gem 'beaker-puppet', *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1')
+gem 'beaker-vmpooler', *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || '~> 1')
 gem 'rake', "~> 12.1"
 gem 'rototiller'
 

--- a/acceptance/setup/package/pre-suite/020_install.rb
+++ b/acceptance/setup/package/pre-suite/020_install.rb
@@ -2,6 +2,10 @@
 
 # Inspired by https://github.com/puppetlabs/pdk/blob/master/package-testing/pre/000_install_package.rb
 # Uses helpers from beaker-puppet to fetch build defaults
+require 'beaker-puppet'
+require 'beaker-pe'
+
+configure_type_defaults_on(hosts)
 
 test_name 'Install Bolt package' do
   if ENV['LOCAL_PKG']


### PR DESCRIPTION
It appears that most of the sticky points for staying on beaker 3 have been worked out. Adding the new platform requires a change to beaker that landed in the 4 series. This commit begins the attempt to migrate to beaker 4.