### PR TITLE
(BOLT-1193) Collect data about YAML plan usage

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -59,6 +59,11 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
       executor.run_as = run_as
     end
 
+    closure = func.class.dispatcher.dispatchers[0]
+    if closure.model.is_a?(Bolt::PAL::YamlPlan)
+      executor.report_yaml_plan(closure.model.body)
+    end
+
     # wrap plan execution in logging messages
     executor.log_plan(plan_name) do
       result = nil
@@ -67,7 +72,7 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
         # undef/nil
         result = catch(:return) do
           scope.with_global_scope do |global_scope|
-            func.class.dispatcher.dispatchers[0].call_by_name_with_scope(global_scope, params, true)
+            closure.call_by_name_with_scope(global_scope, params, true)
           end
           nil
         end&.value

--- a/lib/bolt/analytics.rb
+++ b/lib/bolt/analytics.rb
@@ -21,7 +21,9 @@ module Bolt
       target_nodes: :cd4,
       output_format: :cd5,
       statement_count: :cd6,
-      resource_mean: :cd7
+      resource_mean: :cd7,
+      plan_steps: :cd8,
+      return_type: :cd9
     }.freeze
 
     def self.build_client

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -201,6 +201,22 @@ module Bolt
       @analytics&.event('Apply', 'ast', data)
     end
 
+    def report_yaml_plan(plan)
+      steps = plan.steps.count
+      return_type = case plan.return
+                    when Bolt::PAL::YamlPlan::EvaluableString
+                      'expression'
+                    when nil
+                      nil
+                    else
+                      'value'
+                    end
+
+      @analytics&.event('Plan', 'yaml', plan_steps: steps, return_type: return_type)
+    rescue StandardError => e
+      @logger.debug { "Failed to submit analytics event: #{e.message}" }
+    end
+
     def with_node_logging(description, batch)
       @logger.info("#{description} on #{batch.map(&:uri)}")
       result = yield

--- a/lib/bolt/pal/yaml_plan/evaluator.rb
+++ b/lib/bolt/pal/yaml_plan/evaluator.rb
@@ -6,8 +6,9 @@ module Bolt
   class PAL
     class YamlPlan
       class Evaluator
-        def initialize
+        def initialize(analytics = Bolt::Analytics::NoopClient.new)
           @logger = Logging.logger[self]
+          @analytics = analytics
           @evaluator = Puppet::Pops::Parser::EvaluatingParser.new
         end
 

--- a/pre-docs/bolt_installing.md
+++ b/pre-docs/bolt_installing.md
@@ -257,6 +257,8 @@ Bolt collects data about how you use it. You can opt out of providing this data.
 - The output format selected \(human-readable, JSON\) 
 - The number of times Bolt tasks and plans are run \(This does not include user-defined tasks or plans.\)
 - Number of statements in an apply block, and how many resources that produces for each target.
+- Number of steps in a YAML plan
+- Return type (expression vs. value) of a YAML plan
 
 This data is associated with a random, non-identifiable user UUID.
 


### PR DESCRIPTION
We now submit a "Plan -> yaml" event when running a YAML plan, which
includes the number of steps in the plan and whether the return value of
the plan is a constant value or a Puppet expression.