### PR TITLE
(BOLT-1150) Bump puppet dependency to 6.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,11 +21,6 @@ gem "puppetlabs_spec_helper",
     git: 'https://github.com/puppetlabs/puppetlabs_spec_helper.git',
     ref: '96a633ebf1a1e88062bf726d4271a3251baf082e'
 
-# Required to use YAML plans in development
-gem 'puppet',
-    git: 'https://github.com/puppetlabs/puppet.git',
-    ref: '1d1faaf94566fa93d59cc4587ee941c7aa478867'
-
 group(:test) do
   gem "beaker-hostgenerator"
   gem "gettext-setup", '~> 0.28', require: false

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-scp", "~> 1.2"
   spec.add_dependency "net-ssh", ">= 4.0"
   spec.add_dependency "orchestrator_client", "~> 0.4"
-  spec.add_dependency "puppet", [">= 6.0.1", "< 7"]
+  spec.add_dependency "puppet", [">= 6.4.0", "< 7"]
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "r10k", "~> 3.1"
   spec.add_dependency "ruby_smb", "~> 1.0"


### PR DESCRIPTION
This is the version that contains YAML plan loading.