### PR TITLE
(maint) Docs typo: http -> https

### DIFF
--- a/pre-docs/bolt_configuration_options.md
+++ b/pre-docs/bolt_configuration_options.md
@@ -84,7 +84,7 @@ interpreters:
 
 `smb-port`: With `file-protocol` set to `smb`, this is the port to establish a connection on. Default is `445`.
 
-`ssl`: When `true`, Bolt will use normal http connections for WinRM. Default is `true`.
+`ssl`: When `true`, Bolt will use secure https connections for WinRM. Default is `true`.
 
 `ssl-verify`: When true, verifies the targets certificate matches the `cacert`. Default is `true`.
 


### PR DESCRIPTION
**What this changes** Corrects "ssl: When true, Bolt will use normal http connections for WinRM. Default is true" to "ssl: When true, Bolt will use https connections for WinRM. Default is true"