### PR TITLE
(maint) Set load-config directly on targets

### DIFF
--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -22,8 +22,7 @@ module Bolt
     def initialize(concurrency = 1,
                    analytics = Bolt::Analytics::NoopClient.new,
                    noop = nil,
-                   bundled_content: nil,
-                   load_config: true)
+                   bundled_content: nil)
 
       # lazy-load expensive gem code
       require 'concurrent'
@@ -31,7 +30,6 @@ module Bolt
       @analytics = analytics
       @bundled_content = bundled_content
       @logger = Logging.logger[self]
-      @load_config = load_config
 
       @transports = Bolt::TRANSPORTS.each_with_object({}) do |(key, val), coll|
         coll[key.to_s] = if key == :remote
@@ -263,7 +261,6 @@ module Bolt
       log_action(description, targets) do
         notify = proc { |event| @notifier.notify(callback, event) if callback }
         options = { '_run_as' => run_as }.merge(options) if run_as
-        options = options.merge('_load_config' => @load_config)
         arguments['_task'] = task.name
 
         results = batch_execute(targets) do |transport, batch|

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -17,7 +17,8 @@ module Bolt
         {
           'connect-timeout' => 10,
           'host-key-check' => true,
-          'tty' => false
+          'tty' => false,
+          'load-config' => true
         }
       end
 
@@ -72,8 +73,8 @@ module Bolt
         @transport_logger.level = :warn
       end
 
-      def with_connection(target, load_config = true)
-        conn = Connection.new(target, @transport_logger, load_config)
+      def with_connection(target)
+        conn = Connection.new(target, @transport_logger)
         conn.connect
         yield conn
       ensure
@@ -145,7 +146,7 @@ module Bolt
 
         # unpack any Sensitive data
         arguments = unwrap_sensitive_args(arguments)
-        with_connection(target, options.fetch('_load_config', true)) do |conn|
+        with_connection(target) do |conn|
           conn.running_as(options['_run_as']) do
             stdin, output = nil
             command = []

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -63,15 +63,15 @@ module Bolt
         attr_reader :logger, :user, :target
         attr_writer :run_as
 
-        def initialize(target, transport_logger, load_config = true)
+        def initialize(target, transport_logger)
           # lazy-load expensive gem code
           require 'net/ssh'
           require 'net/ssh/proxy/jump'
 
           @target = target
-          @load_config = load_config
+          @load_config = target.options['load-config']
 
-          ssh_user = load_config ? Net::SSH::Config.for(target.host)[:user] : nil
+          ssh_user = @load_config ? Net::SSH::Config.for(target.host)[:user] : nil
           @user = @target.user || ssh_user || Etc.getlogin
           @run_as = nil
 

--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -25,7 +25,7 @@ module BoltServer
                                        Addressable::URI.parse("file:task"))
       JSON::Validator.add_schema(shared_schema)
 
-      @executor = Bolt::Executor.new(0, load_config: false)
+      @executor = Bolt::Executor.new(0)
 
       @file_cache = BoltServer::FileCache.new(@config).setup
 
@@ -79,6 +79,7 @@ module BoltServer
         opts['private-key'] = { 'key-data' => opts['private-key-content'] }
         opts.delete('private-key-content')
       end
+      opts['load-config'] = false
 
       target = [Bolt::Target.new(body['target']['hostname'], opts)]
 

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -51,7 +51,7 @@ describe Bolt::Applicator do
         config: {
           transport: 'ssh',
           transports: {
-            ssh: { 'connect-timeout' => 10, 'host-key-check' => true, tty: false },
+            ssh: { 'connect-timeout' => 10, 'host-key-check' => true, tty: false, 'load-config' => true },
             winrm: { 'connect-timeout' => 10, ssl: true, 'ssl-verify' => true, 'file-protocol' => 'winrm' },
             pcp: {
               'task-environment' => 'production'

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -84,7 +84,8 @@ describe Bolt::Inventory do
     {
       'connect-timeout' => 10,
       'tty' => false,
-      'host-key-check' => true
+      'host-key-check' => true,
+      'load-config' => true
     }
   }
 
@@ -548,6 +549,7 @@ describe Bolt::Inventory do
         expect(target.options).to eq(
           'connect-timeout' => 3,
           'tty' => true,
+          'load-config' => true,
           'host-key-check' => false,
           'private-key' => "anything",
           'tmpdir' => "/ssh",

--- a/spec/bolt/transport/remote_spec.rb
+++ b/spec/bolt/transport/remote_spec.rb
@@ -16,7 +16,7 @@ describe Bolt::Transport::Remote do
                                         } }],
                                     'config' => { "transport" => "remote" })
 
-    executor = Bolt::Executor.new(load_config: false)
+    executor = Bolt::Executor.new
     remote_transport = executor.transports['remote'].value
     target = inventory.get_targets("node2").first
 

--- a/spec/bolt/transport/shared_examples.rb
+++ b/spec/bolt/transport/shared_examples.rb
@@ -405,7 +405,7 @@ QUOTED
     end
 
     let(:remote_runner) do
-      executor = Bolt::Executor.new(load_config: false)
+      executor = Bolt::Executor.new
       executor.transports[transport.to_s] = Concurrent::Delay.new { runner }
       executor.transports['remote'].value
     end

--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -184,7 +184,8 @@ describe Bolt::Transport::SSH do
       allow(Etc).to receive(:getlogin).and_return('bolt')
       expect(Net::SSH::Config).not_to receive(:for)
 
-      config_user = ssh.with_connection(make_target(conf: no_user_config), false, &:user)
+      transport_conf['load-config'] = false
+      config_user = ssh.with_connection(make_target(conf: no_user_config), &:user)
       expect(config_user).to be('bolt')
     end
   end

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -232,7 +232,8 @@ describe "passes parsed AST to the apply_catalog task" do
           expect(notify[0]['title']).to eq("Num Targets: 3")
           expect(notify[1]['title']).to eq("Target 1 Facts: {operatingsystem => Ubuntu, added => fact}")
           expect(notify[2]['title']).to eq("Target 1 Vars: {environment => production, features => [puppet-agent]}")
-          res = "Target 0 Config: {connect-timeout => 11, host-key-check => false, tty => false, password => bolt}"
+          res = "Target 0 Config: {connect-timeout => 11, host-key-check => false, " \
+                "tty => false, load-config => true, password => bolt}"
           expect(notify[3]['title']).to eq(res)
           expect(notify[4]['title']).to eq("Target 1 Password: secret")
         end


### PR DESCRIPTION
Previously, we were passing through the `load_config` setting from the
executor to the SSH transport, to disable loading SSH config when
running via bolt-server. This complicates the signature of
Executor#initialize and it's an unncessarily roundabout path for that
option.

We now set `load-config` directly on the target objects via a default on
the transport and override it explicitly in bolt-server. This ensures
the target carries that setting with it.

This does _not_ allow `load-config` to be set in the Bolt config or
inventory file.