### PR TITLE
(maint) Simplify Executor initialize signature

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,9 @@ Style/NumericLiterals:
 Style/NumericPredicate:
   Enabled: false
 
+Style/StderrPuts:
+  Enabled: false
+
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 

--- a/acceptance/files/example_apply/lib/puppet/type/warn.rb
+++ b/acceptance/files/example_apply/lib/puppet/type/warn.rb
@@ -13,7 +13,7 @@ Puppet::Type.newtype(:warn) do
       :absent
     end
 
-    def insync?(_is)
+    def insync?(_is_value)
       false
     end
 

--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -82,11 +82,11 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
         end
 
         result
-      rescue Puppet::PreformattedError => err
-        if named_args['_catch_errors'] && err.cause.is_a?(Bolt::Error)
-          result = err.cause.to_puppet_error
+      rescue Puppet::PreformattedError => e
+        if named_args['_catch_errors'] && e.cause.is_a?(Bolt::Error)
+          result = e.cause.to_puppet_error
         else
-          raise err
+          raise e
         end
       ensure
         if run_as

--- a/lib/bolt/analytics.rb
+++ b/lib/bolt/analytics.rb
@@ -60,6 +60,7 @@ module Bolt
 
     class Client
       attr_reader :user_id
+      attr_accessor :bundled_content
 
       def initialize(user_id)
         # lazy-load expensive gem code
@@ -73,6 +74,7 @@ module Bolt
         @user_id = user_id
         @executor = Concurrent.global_io_executor
         @os = compute_os
+        @bundled_content = []
       end
 
       def screen_view(screen, **kwargs)
@@ -164,8 +166,11 @@ module Bolt
     end
 
     class NoopClient
+      attr_accessor :bundled_content
+
       def initialize
         @logger = Logging.logger[self]
+        @bundled_content = []
       end
 
       def screen_view(screen, **_kwargs)

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -314,8 +314,8 @@ Usage: bolt apply <manifest.pp> [options]
     def parse_params(params)
       json = get_arg_input(params)
       JSON.parse(json)
-    rescue JSON::ParserError => err
-      raise Bolt::CLIError, "Unable to parse --params value as JSON: #{err}"
+    rescue JSON::ParserError => e
+      raise Bolt::CLIError, "Unable to parse --params value as JSON: #{e}"
     end
 
     def get_arg_input(value)
@@ -331,8 +331,8 @@ Usage: bolt apply <manifest.pp> [options]
 
     def read_arg_file(file)
       File.read(File.expand_path(file))
-    rescue StandardError => err
-      raise Bolt::FileError.new("Error attempting to read #{file}: #{err}", file)
+    rescue StandardError => e
+      raise Bolt::FileError.new("Error attempting to read #{file}: #{e}", file)
     end
   end
 end

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -21,14 +21,12 @@ module Bolt
     # https://makandracards.com/makandra/36011-ruby-do-not-mix-optional-and-keyword-arguments
     def initialize(concurrency = 1,
                    analytics = Bolt::Analytics::NoopClient.new,
-                   noop = false,
-                   bundled_content: nil)
+                   noop = false)
 
       # lazy-load expensive gem code
       require 'concurrent'
 
       @analytics = analytics
-      @bundled_content = bundled_content
       @logger = Logging.logger[self]
 
       @transports = Bolt::TRANSPORTS.each_with_object({}) do |(key, val), coll|
@@ -182,7 +180,7 @@ module Bolt
     end
 
     def report_bundled_content(mode, name)
-      if @bundled_content&.include?(name)
+      if @analytics.bundled_content&.include?(name)
         @analytics&.event('Bundled Content', mode, label: name)
       end
     end

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -21,7 +21,7 @@ module Bolt
     # https://makandracards.com/makandra/36011-ruby-do-not-mix-optional-and-keyword-arguments
     def initialize(concurrency = 1,
                    analytics = Bolt::Analytics::NoopClient.new,
-                   noop = nil,
+                   noop = false,
                    bundled_content: nil)
 
       # lazy-load expensive gem code

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -22,8 +22,7 @@ module Bolt
     def initialize(concurrency = 1,
                    analytics = Bolt::Analytics::NoopClient.new,
                    noop = nil,
-                   bundled_content: nil,
-                   load_config: true)
+                   bundled_content: nil)
 
       # lazy-load expensive gem code
       require 'concurrent'
@@ -31,7 +30,6 @@ module Bolt
       @analytics = analytics
       @bundled_content = bundled_content
       @logger = Logging.logger[self]
-      @load_config = load_config
 
       @transports = Bolt::TRANSPORTS.each_with_object({}) do |(key, val), coll|
         coll[key.to_s] = if key == :remote
@@ -263,7 +261,6 @@ module Bolt
       log_action(description, targets) do
         notify = proc { |event| @notifier.notify(callback, event) if callback }
         options = { '_run_as' => run_as }.merge(options) if run_as
-        options = options.merge('_load_config' => @load_config)
         arguments['_task'] = task.name
 
         results = batch_execute(targets) do |transport, batch|

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -108,12 +108,12 @@ module Bolt
             Puppet.override(yaml_plan_instantiator: Bolt::PAL::YamlPlan::Loader) do
               yield compiler
             end
-          rescue Bolt::Error => err
-            err
-          rescue Puppet::PreformattedError => err
-            PALError.from_preformatted_error(err)
-          rescue StandardError => err
-            PALError.from_preformatted_error(err)
+          rescue Bolt::Error => e
+            e
+          rescue Puppet::PreformattedError => e
+            PALError.from_preformatted_error(e)
+          rescue StandardError => e
+            PALError.from_preformatted_error(e)
           end
         end
       end

--- a/lib/bolt/puppetdb/client.rb
+++ b/lib/bolt/puppetdb/client.rb
@@ -49,8 +49,8 @@ module Bolt
 
         begin
           response = http_client.post(url, body: body, header: headers)
-        rescue StandardError => err
-          raise Bolt::PuppetDBFailoverError, "Failed to query PuppetDB: #{err}"
+        rescue StandardError => e
+          raise Bolt::PuppetDBFailoverError, "Failed to query PuppetDB: #{e}"
         end
 
         if response.code != 200
@@ -67,8 +67,8 @@ module Bolt
         rescue JSON::ParserError
           raise Bolt::PuppetDBError, "Unable to parse response as JSON: #{response.body}"
         end
-      rescue Bolt::PuppetDBFailoverError => err
-        @logger.error("Request to puppetdb at #{@current_url} failed with #{err}.")
+      rescue Bolt::PuppetDBFailoverError => e
+        @logger.error("Request to puppetdb at #{@current_url} failed with #{e}.")
         reject_url
         make_query(query, path)
       end

--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -69,8 +69,8 @@ module Bolt
 
         result = begin
                    yield
-                 rescue StandardError, NotImplementedError => ex
-                   Bolt::Result.from_exception(target, ex)
+                 rescue StandardError, NotImplementedError => e
+                   Bolt::Result.from_exception(target, e)
                  end
 
         callback&.call(type: :node_result, result: result)

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -17,7 +17,8 @@ module Bolt
         {
           'connect-timeout' => 10,
           'host-key-check' => true,
-          'tty' => false
+          'tty' => false,
+          'load-config' => true
         }
       end
 
@@ -63,8 +64,8 @@ module Bolt
         @transport_logger.level = :warn
       end
 
-      def with_connection(target, load_config = true)
-        conn = Connection.new(target, @transport_logger, load_config)
+      def with_connection(target)
+        conn = Connection.new(target, @transport_logger)
         conn.connect
         yield conn
       ensure

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -71,8 +71,8 @@ module Bolt
       ensure
         begin
           conn&.disconnect
-        rescue StandardError => ex
-          logger.info("Failed to close connection to #{target.uri} : #{ex.message}")
+        rescue StandardError => e
+          logger.info("Failed to close connection to #{target.uri} : #{e.message}")
         end
       end
 

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -14,15 +14,15 @@ module Bolt
         attr_reader :logger, :user, :target
         attr_writer :run_as
 
-        def initialize(target, transport_logger, load_config = true)
+        def initialize(target, transport_logger)
           # lazy-load expensive gem code
           require 'net/ssh'
           require 'net/ssh/proxy/jump'
 
           @target = target
-          @load_config = load_config
+          @load_config = target.options['load-config']
 
-          ssh_user = load_config ? Net::SSH::Config.for(target.host)[:user] : nil
+          ssh_user = @load_config ? Net::SSH::Config.for(target.host)[:user] : nil
           @user = @target.user || ssh_user || Etc.getlogin
           @run_as = nil
 

--- a/lib/bolt/transport/sudoable.rb
+++ b/lib/bolt/transport/sudoable.rb
@@ -81,7 +81,7 @@ module Bolt
         input_method = implementation['input_method']
         extra_files = implementation['files']
 
-        with_connection(target, options.fetch('_load_config', true)) do |conn|
+        with_connection(target) do |conn|
           conn.running_as(options['_run_as']) do
             stdin, output = nil
             command = []

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -70,8 +70,8 @@ module Bolt
       ensure
         begin
           conn&.disconnect
-        rescue StandardError => ex
-          logger.info("Failed to close connection to #{target.uri} : #{ex.message}")
+        rescue StandardError => e
+          logger.info("Failed to close connection to #{target.uri} : #{e.message}")
         end
       end
 

--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -25,7 +25,7 @@ module BoltServer
                                        Addressable::URI.parse("file:task"))
       JSON::Validator.add_schema(shared_schema)
 
-      @executor = Bolt::Executor.new(0, load_config: false)
+      @executor = Bolt::Executor.new(0)
 
       @file_cache = BoltServer::FileCache.new(@config).setup
 
@@ -79,6 +79,7 @@ module BoltServer
         opts['private-key'] = { 'key-data' => opts['private-key-content'] }
         opts.delete('private-key-content')
       end
+      opts['load-config'] = false
 
       target = [Bolt::Target.new(body['target']['hostname'], opts)]
 

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -51,7 +51,7 @@ describe Bolt::Applicator do
         config: {
           transport: 'ssh',
           transports: {
-            ssh: { 'connect-timeout' => 10, 'host-key-check' => true, tty: false },
+            ssh: { 'connect-timeout' => 10, 'host-key-check' => true, tty: false, 'load-config' => true },
             winrm: { 'connect-timeout' => 10, ssl: true, 'ssl-verify' => true, 'file-protocol' => 'winrm' },
             pcp: {
               'task-environment' => 'production'

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -701,36 +701,36 @@ bar
       it "does not calculate bundled content for a command" do
         cli = Bolt::CLI.new(%w[command run foo --nodes bar])
         cli.parse
-        expect(cli.bundled_content).to be_nil
+        expect(cli.bundled_content).to eq([])
       end
 
       it "does not calculate bundled content for a script" do
         cli = Bolt::CLI.new(%w[script run foo --nodes bar])
         cli.parse
-        expect(cli.bundled_content).to be_nil
+        expect(cli.bundled_content).to eq([])
       end
 
       it "does not calculate bundled content for a file" do
         cli = Bolt::CLI.new(%w[file upload /tmp /var foo --nodes bar])
         cli.parse
-        expect(cli.bundled_content).to be_nil
+        expect(cli.bundled_content).to eq([])
       end
 
       it "calculates bundled content for a task" do
         cli = Bolt::CLI.new(%w[task run foo --nodes bar])
         cli.parse
-        expect(cli.bundled_content).to be
+        expect(cli.bundled_content).not_to be_empty
       end
 
       it "calculates bundled content for a plan" do
         cli = Bolt::CLI.new(%w[plan run foo --nodes bar])
         cli.parse
-        expect(cli.bundled_content).to be
+        expect(cli.bundled_content).not_to be_empty
       end
     end
 
     describe "execute" do
-      let(:executor) { double('executor', noop: false, analytics: nil) }
+      let(:executor) { double('executor', noop: false, analytics: Bolt::Analytics::NoopClient.new) }
       let(:cli) { Bolt::CLI.new({}) }
       let(:targets) { [target] }
       let(:output) { StringIO.new }
@@ -1730,7 +1730,7 @@ bar
     end
 
     describe "execute with noop" do
-      let(:executor) { double('executor', noop: true, analytics: nil) }
+      let(:executor) { double('executor', noop: true, analytics: Bolt::Analytics::NoopClient.new) }
       let(:cli) { Bolt::CLI.new({}) }
       let(:targets) { [target] }
       let(:output) { StringIO.new }
@@ -1740,8 +1740,7 @@ bar
         allow(cli).to receive(:bundled_content).and_return(bundled_content)
         expect(Bolt::Executor).to receive(:new).with(Bolt::Config.default.concurrency,
                                                      anything,
-                                                     true,
-                                                     bundled_content: bundled_content).and_return(executor)
+                                                     true).and_return(executor)
         outputter = Bolt::Outputter::JSON.new(false, false, output)
         allow(cli).to receive(:outputter).and_return(outputter)
         allow(executor).to receive(:report_bundled_content)

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -479,7 +479,11 @@ describe "Bolt::Executor" do
     end
 
     context "#report_bundled_content" do
-      let(:executor) { Bolt::Executor.new(2, analytics, bundled_content: %w[canary facts]) }
+      let(:executor) { Bolt::Executor.new(2, analytics) }
+
+      before :each do
+        analytics.bundled_content = %w[canary facts]
+      end
 
       it 'reports an event when bundled plan is used' do
         expect(analytics).to receive(:event).with('Bundled Content', 'Plan', label: 'canary')

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -84,7 +84,8 @@ describe Bolt::Inventory do
     {
       'connect-timeout' => 10,
       'tty' => false,
-      'host-key-check' => true
+      'host-key-check' => true,
+      'load-config' => true
     }
   }
 
@@ -548,6 +549,7 @@ describe Bolt::Inventory do
         expect(target.options).to eq(
           'connect-timeout' => 3,
           'tty' => true,
+          'load-config' => true,
           'host-key-check' => false,
           'private-key' => "anything",
           'tmpdir' => "/ssh",

--- a/spec/bolt/transport/remote_spec.rb
+++ b/spec/bolt/transport/remote_spec.rb
@@ -16,7 +16,7 @@ describe Bolt::Transport::Remote do
                                         } }],
                                     'config' => { "transport" => "remote" })
 
-    executor = Bolt::Executor.new(load_config: false)
+    executor = Bolt::Executor.new
     remote_transport = executor.transports['remote'].value
     target = inventory.get_targets("node2").first
 

--- a/spec/bolt/transport/shared_examples.rb
+++ b/spec/bolt/transport/shared_examples.rb
@@ -415,7 +415,7 @@ QUOTED
     end
 
     let(:remote_runner) do
-      executor = Bolt::Executor.new(load_config: false)
+      executor = Bolt::Executor.new
       executor.transports[transport.to_s] = Concurrent::Delay.new { runner }
       executor.transports['remote'].value
     end

--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -186,7 +186,8 @@ describe Bolt::Transport::SSH do
       allow(Etc).to receive(:getlogin).and_return('bolt')
       expect(Net::SSH::Config).not_to receive(:for)
 
-      config_user = ssh.with_connection(make_target(conf: no_user_config), false, &:user)
+      transport_conf['load-config'] = false
+      config_user = ssh.with_connection(make_target(conf: no_user_config), &:user)
       expect(config_user).to be('bolt')
     end
   end

--- a/spec/fixtures/apply/basic/lib/puppet/type/warn.rb
+++ b/spec/fixtures/apply/basic/lib/puppet/type/warn.rb
@@ -13,7 +13,7 @@ Puppet::Type.newtype(:warn) do
       :absent
     end
 
-    def insync?(_is)
+    def insync?(_is_value)
       false
     end
 

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -232,7 +232,8 @@ describe "passes parsed AST to the apply_catalog task" do
           expect(notify[0]['title']).to eq("Num Targets: 3")
           expect(notify[1]['title']).to eq("Target 1 Facts: {operatingsystem => Ubuntu, added => fact}")
           expect(notify[2]['title']).to eq("Target 1 Vars: {environment => production, features => [puppet-agent]}")
-          res = "Target 0 Config: {connect-timeout => 11, host-key-check => false, tty => false, password => bolt}"
+          res = "Target 0 Config: {connect-timeout => 11, host-key-check => false, " \
+                "tty => false, load-config => true, password => bolt}"
           expect(notify[3]['title']).to eq(res)
           expect(notify[4]['title']).to eq("Target 1 Password: secret")
         end


### PR DESCRIPTION
The Executor currently takes both optional args and keyword args. It also takes
a couple of its arguments (`bundled_content` and `load_config`) purely so it
can pass them along to other parts of the system that need them.

This PR reworks the keyword args to be set more directly on the objects that
need them, rather than passing them through the Executor.

We now set `bundled_content` directly on the analytics client, since that's the only place it's needed.

We set `load-config` directly on Target objects via a default on the transport,
and override it explicitly in bolt-server. This carries the setting with the
Target, rather than leaking an implementation detail of the SSH transport into
the Executor. This specifically does _not_ allow `load-config` to be set in the
Bolt config or inventory file.