### PR TITLE
(BOLT-1209) Refactor AppVeyor commands to PowerShell script / verify WinRM connection in PowerShell

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,6 +42,8 @@ for:
           type Gemfile.lock
           . .\ci.ps1
           Install-Puppetfile
+          $ENV:BOLT_WINRM_PASSWORD = New-RandomPassword
+          New-LocalAdmin -UserName $ENV:BOLT_WINRM_USER -Password $ENV:BOLT_WINRM_PASSWORD
           Set-WinRMHostConfiguration
 
     test_script:
@@ -94,6 +96,8 @@ for:
           type Gemfile.lock
           . .\ci.ps1
           Install-Puppetfile
+          $ENV:BOLT_WINRM_PASSWORD = New-RandomPassword
+          New-LocalAdmin -UserName $ENV:BOLT_WINRM_USER -Password $ENV:BOLT_WINRM_PASSWORD
           Set-WinRMHostConfiguration
           Set-ActiveRubyFromPuppet
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,26 +40,9 @@ for:
           gem -v
           bundle -v
           type Gemfile.lock
-          $CACertFile = Join-Path -Path $ENV:AppData -ChildPath 'RubyCACert.pem'
-
-          If (-Not (Test-Path -Path $CACertFile)) {
-            "Downloading CA Cert bundle.."
-              [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-                Invoke-WebRequest -Uri 'https://curl.haxx.se/ca/cacert.pem' -UseBasicParsing -OutFile $CACertFile | Out-Null
-              }
-
-              "Setting CA Certificate store set to $CACertFile.."
-          $ENV:SSL_CERT_FILE = $CACertFile
-          [System.Environment]::SetEnvironmentVariable('SSL_CERT_FILE',$CACertFile, [System.EnvironmentVariableTarget]::Machine)
-          bundle exec r10k puppetfile install
-          Add-Type -AssemblyName System.Web
-          $ENV:BOLT_WINRM_PASSWORD = "&aA4" + [System.Web.Security.Membership]::GeneratePassword(10, 3)
-          ($user = New-LocalUser -Name $ENV:BOLT_WINRM_USER -Password (ConvertTo-SecureString -String $ENV:BOLT_WINRM_PASSWORD -Force -AsPlainText)) | Format-List
-          Add-LocalGroupMember -Group 'Remote Management Users' -Member $user
-          Add-LocalGroupMember -Group Administrators -Member $user
-          # configure WinRM to use resources/cert.pfx for SSL
-          ($cert = Import-PfxCertificate -FilePath resources/cert.pfx -CertStoreLocation cert:\\LocalMachine\\My -Password (ConvertTo-SecureString -String bolt -Force -AsPlainText)) | Format-List
-          New-WSManInstance -ResourceURI winrm/config/Listener -SelectorSet @{Address='*';Transport='HTTPS'} -ValueSet @{Hostname='localhost';CertificateThumbprint=$cert.Thumbprint} | Format-List
+          . .\ci.ps1
+          Install-Puppetfile
+          Set-WinRMHostConfiguration
 
     test_script:
       - bundle exec rake appveyor
@@ -109,30 +92,13 @@ for:
           gem -v
           bundle -v
           type Gemfile.lock
-          $CACertFile = Join-Path -Path $ENV:AppData -ChildPath 'RubyCACert.pem'
-
-          If (-Not (Test-Path -Path $CACertFile)) {
-            "Downloading CA Cert bundle.."
-              [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-                Invoke-WebRequest -Uri 'https://curl.haxx.se/ca/cacert.pem' -UseBasicParsing -OutFile $CACertFile | Out-Null
-              }
-
-              "Setting CA Certificate store set to $CACertFile.."
-          $ENV:SSL_CERT_FILE = $CACertFile
-          [System.Environment]::SetEnvironmentVariable('SSL_CERT_FILE',$CACertFile, [System.EnvironmentVariableTarget]::Machine)
-          bundle exec r10k puppetfile install
-          Add-Type -AssemblyName System.Web
-          $ENV:BOLT_WINRM_PASSWORD = "&aA4" + [System.Web.Security.Membership]::GeneratePassword(10, 3)
-          ($user = New-LocalUser -Name $ENV:BOLT_WINRM_USER -Password (ConvertTo-SecureString -String $ENV:BOLT_WINRM_PASSWORD -Force -AsPlainText)) | Format-List
-          Add-LocalGroupMember -Group 'Remote Management Users' -Member $user
-          Add-LocalGroupMember -Group Administrators -Member $user
+          . .\ci.ps1
+          Install-Puppetfile
+          Set-WinRMHostConfiguration
           # Make sure Puppet Ruby take precedence over system ruby (pup 5/6)
           $puppet_five_ruby = "C:\Program Files\Puppet Labs\Puppet\sys\ruby\bin"
           $puppet_six_ruby = "C:\Program Files\Puppet Labs\Puppet\puppet\bin"
           [System.Environment]::SetEnvironmentVariable("Path","$puppet_five_ruby;$puppet_six_ruby;" + $ENV:Path, [System.EnvironmentVariableTarget]::Machine)
-          # configure WinRM to use resources/cert.pfx for SSL
-          ($cert = Import-PfxCertificate -FilePath resources/cert.pfx -CertStoreLocation cert:\\LocalMachine\\My -Password (ConvertTo-SecureString -String bolt -Force -AsPlainText)) | Format-List
-          New-WSManInstance -ResourceURI winrm/config/Listener -SelectorSet @{Address='*';Transport='HTTPS'} -ValueSet @{Hostname='localhost';CertificateThumbprint=$cert.Thumbprint} | Format-List
 
     test_script:
       - bundle exec rake integration:appveyor_agents

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,8 +43,10 @@ for:
           . .\ci.ps1
           Install-Puppetfile
           $ENV:BOLT_WINRM_PASSWORD = New-RandomPassword
-          New-LocalAdmin -UserName $ENV:BOLT_WINRM_USER -Password $ENV:BOLT_WINRM_PASSWORD
+          $user = @{ UserName = $ENV:BOLT_WINRM_USER; Password = $ENV:BOLT_WINRM_PASSWORD }
+          New-LocalAdmin @user
           Set-WinRMHostConfiguration
+          Test-WinRMConfiguration @user | Out-Null
 
     test_script:
       - bundle exec rake appveyor
@@ -97,9 +99,11 @@ for:
           . .\ci.ps1
           Install-Puppetfile
           $ENV:BOLT_WINRM_PASSWORD = New-RandomPassword
-          New-LocalAdmin -UserName $ENV:BOLT_WINRM_USER -Password $ENV:BOLT_WINRM_PASSWORD
+          $user = @{ UserName = $ENV:BOLT_WINRM_USER; Password = $ENV:BOLT_WINRM_PASSWORD }
+          New-LocalAdmin @user
           Set-WinRMHostConfiguration
           Set-ActiveRubyFromPuppet
+          Test-WinRMConfiguration @user | Out-Null
 
     test_script:
       - bundle exec rake integration:appveyor_agents

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -95,10 +95,7 @@ for:
           . .\ci.ps1
           Install-Puppetfile
           Set-WinRMHostConfiguration
-          # Make sure Puppet Ruby take precedence over system ruby (pup 5/6)
-          $puppet_five_ruby = "C:\Program Files\Puppet Labs\Puppet\sys\ruby\bin"
-          $puppet_six_ruby = "C:\Program Files\Puppet Labs\Puppet\puppet\bin"
-          [System.Environment]::SetEnvironmentVariable("Path","$puppet_five_ruby;$puppet_six_ruby;" + $ENV:Path, [System.EnvironmentVariableTarget]::Machine)
+          Set-ActiveRubyFromPuppet
 
     test_script:
       - bundle exec rake integration:appveyor_agents

--- a/ci.ps1
+++ b/ci.ps1
@@ -21,13 +21,21 @@ function Install-Puppetfile
   bundle exec r10k puppetfile install
 }
 
-function Set-WinRMHostConfiguration
+function New-RandomPassword
 {
   Add-Type -AssemblyName System.Web
-  $ENV:BOLT_WINRM_PASSWORD = "&aA4" + [System.Web.Security.Membership]::GeneratePassword(10, 3)
-  ($user = New-LocalUser -Name $ENV:BOLT_WINRM_USER -Password (ConvertTo-SecureString -String $ENV:BOLT_WINRM_PASSWORD -Force -AsPlainText)) | Format-List
+  "&aA4" + [System.Web.Security.Membership]::GeneratePassword(10, 3)
+}
+
+function New-LocalAdmin($userName, $password)
+{
+  ($user = New-LocalUser -Name $userName -Password (ConvertTo-SecureString -String $password -Force -AsPlainText)) | Format-List
   Add-LocalGroupMember -Group 'Remote Management Users' -Member $user
   Add-LocalGroupMember -Group Administrators -Member $user
+}
+
+function Set-WinRMHostConfiguration
+{
   # configure WinRM to use resources/cert.pfx for SSL
   ($cert = Import-PfxCertificate -FilePath resources/cert.pfx -CertStoreLocation cert:\\LocalMachine\\My -Password (ConvertTo-SecureString -String bolt -Force -AsPlainText)) | Format-List
   New-WSManInstance -ResourceURI winrm/config/Listener -SelectorSet @{Address='*';Transport='HTTPS'} -ValueSet @{Hostname='localhost';CertificateThumbprint=$cert.Thumbprint} | Format-List

--- a/ci.ps1
+++ b/ci.ps1
@@ -32,3 +32,11 @@ function Set-WinRMHostConfiguration
   ($cert = Import-PfxCertificate -FilePath resources/cert.pfx -CertStoreLocation cert:\\LocalMachine\\My -Password (ConvertTo-SecureString -String bolt -Force -AsPlainText)) | Format-List
   New-WSManInstance -ResourceURI winrm/config/Listener -SelectorSet @{Address='*';Transport='HTTPS'} -ValueSet @{Hostname='localhost';CertificateThumbprint=$cert.Thumbprint} | Format-List
 }
+
+function Set-ActiveRubyFromPuppet
+{
+  # Make sure Puppet Ruby take precedence over system ruby (pup 5/6)
+  $puppet_five_ruby = "C:\Program Files\Puppet Labs\Puppet\sys\ruby\bin"
+  $puppet_six_ruby = "C:\Program Files\Puppet Labs\Puppet\puppet\bin"
+  [System.Environment]::SetEnvironmentVariable("Path","$puppet_five_ruby;$puppet_six_ruby;" + $ENV:Path, [System.EnvironmentVariableTarget]::Machine)
+}

--- a/ci.ps1
+++ b/ci.ps1
@@ -33,10 +33,15 @@ function Set-WinRMHostConfiguration
   New-WSManInstance -ResourceURI winrm/config/Listener -SelectorSet @{Address='*';Transport='HTTPS'} -ValueSet @{Hostname='localhost';CertificateThumbprint=$cert.Thumbprint} | Format-List
 }
 
+# Ensure Puppet Ruby 5 / 6 takes precedence over system Ruby
 function Set-ActiveRubyFromPuppet
 {
-  # Make sure Puppet Ruby take precedence over system ruby (pup 5/6)
-  $puppet_five_ruby = "C:\Program Files\Puppet Labs\Puppet\sys\ruby\bin"
-  $puppet_six_ruby = "C:\Program Files\Puppet Labs\Puppet\puppet\bin"
-  [System.Environment]::SetEnvironmentVariable("Path","$puppet_five_ruby;$puppet_six_ruby;" + $ENV:Path, [System.EnvironmentVariableTarget]::Machine)
+  # https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md
+  $path = @(
+    "${ENV:ProgramFiles}\Puppet Labs\Puppet\sys\ruby\bin",
+    "${ENV:ProgramFiles}\Puppet Labs\Puppet\puppet\bin",
+    $ENV:Path
+  ) -join ';'
+
+  [System.Environment]::SetEnvironmentVariable('Path', $path, [System.EnvironmentVariableTarget]::Machine)
 }

--- a/ci.ps1
+++ b/ci.ps1
@@ -29,7 +29,13 @@ function New-RandomPassword
 
 function New-LocalAdmin($userName, $password)
 {
-  ($user = New-LocalUser -Name $userName -Password (ConvertTo-SecureString -String $password -Force -AsPlainText)) | Format-List
+  $userArgs = @{
+    Name     = $userName
+    Password = (ConvertTo-SecureString -String $password -Force -AsPlainText)
+  }
+
+  $user = New-LocalUser @userArgs
+  $user | Format-List
   Add-LocalGroupMember -Group 'Remote Management Users' -Member $user
   Add-LocalGroupMember -Group Administrators -Member $user
 }

--- a/ci.ps1
+++ b/ci.ps1
@@ -6,12 +6,12 @@ function Set-CACert
   $CACertFile = Join-Path -Path $ENV:AppData -ChildPath 'RubyCACert.pem'
 
   If (-Not (Test-Path -Path $CACertFile)) {
-    "Downloading CA Cert bundle.."
+    Write-Information "Downloading CA Cert bundle.."
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     Invoke-WebRequest -Uri 'https://curl.haxx.se/ca/cacert.pem' -UseBasicParsing -OutFile $CACertFile | Out-Null
   }
 
-  "Setting CA Certificate store set to $CACertFile.."
+  Write-Information "Setting CA Certificate store set to $CACertFile.."
   $ENV:SSL_CERT_FILE = $CACertFile
   [System.Environment]::SetEnvironmentVariable('SSL_CERT_FILE', $CACertFile, [System.EnvironmentVariableTarget]::Machine)
 }
@@ -36,7 +36,7 @@ function New-LocalAdmin($userName, $password)
   }
 
   $user = New-LocalUser @userArgs
-  $user | Format-List
+  Write-Information ($user | Format-List | Out-String)
   Add-LocalGroupMember -Group 'Remote Management Users' -Member $user
   Add-LocalGroupMember -Group Administrators -Member $user
 }
@@ -59,14 +59,15 @@ function Grant-WinRMHttpsAccess($certThumbprint)
     SelectorSet = @{ Address = '*'; Transport = 'HTTPS' }
     ValueSet    = @{ Hostname = 'localhost'; CertificateThumbprint = $certThumbprint }
   }
-  New-WSManInstance @winRMArgs | Format-List
+  $instance = New-WSManInstance @winRMArgs
+  Write-Information ($instance | Format-List | Out-String)
 }
 
 function Set-WinRMHostConfiguration
 {
   # configure WinRM to use resources/cert.pfx for SSL
   $cert = Install-Certificate -Path 'resources/cert.pfx' -Password 'bolt'
-  $cert | Format-List
+  Write-Information ($cert | Format-List | Out-String)
   Grant-WinRMHttpsAccess -CertThumbprint $cert.Thumbprint
 }
 

--- a/ci.ps1
+++ b/ci.ps1
@@ -1,0 +1,34 @@
+$ErrorActionPreference = 'Stop'
+
+function Set-CACert
+{
+  $CACertFile = Join-Path -Path $ENV:AppData -ChildPath 'RubyCACert.pem'
+
+  If (-Not (Test-Path -Path $CACertFile)) {
+    "Downloading CA Cert bundle.."
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Invoke-WebRequest -Uri 'https://curl.haxx.se/ca/cacert.pem' -UseBasicParsing -OutFile $CACertFile | Out-Null
+  }
+
+  "Setting CA Certificate store set to $CACertFile.."
+  $ENV:SSL_CERT_FILE = $CACertFile
+  [System.Environment]::SetEnvironmentVariable('SSL_CERT_FILE', $CACertFile, [System.EnvironmentVariableTarget]::Machine)
+}
+
+function Install-Puppetfile
+{
+  Set-CACert
+  bundle exec r10k puppetfile install
+}
+
+function Set-WinRMHostConfiguration
+{
+  Add-Type -AssemblyName System.Web
+  $ENV:BOLT_WINRM_PASSWORD = "&aA4" + [System.Web.Security.Membership]::GeneratePassword(10, 3)
+  ($user = New-LocalUser -Name $ENV:BOLT_WINRM_USER -Password (ConvertTo-SecureString -String $ENV:BOLT_WINRM_PASSWORD -Force -AsPlainText)) | Format-List
+  Add-LocalGroupMember -Group 'Remote Management Users' -Member $user
+  Add-LocalGroupMember -Group Administrators -Member $user
+  # configure WinRM to use resources/cert.pfx for SSL
+  ($cert = Import-PfxCertificate -FilePath resources/cert.pfx -CertStoreLocation cert:\\LocalMachine\\My -Password (ConvertTo-SecureString -String bolt -Force -AsPlainText)) | Format-List
+  New-WSManInstance -ResourceURI winrm/config/Listener -SelectorSet @{Address='*';Transport='HTTPS'} -ValueSet @{Hostname='localhost';CertificateThumbprint=$cert.Thumbprint} | Format-List
+}

--- a/ci.ps1
+++ b/ci.ps1
@@ -28,7 +28,17 @@ function Set-CACert
 function Install-Puppetfile
 {
   Set-CACert
-  bundle exec r10k puppetfile install
+
+  # Forge connections may fail intermittently
+  $retryArgs = @{
+    SuccessMessage = 'Succeeded in installing Puppetfile'
+    FailMessage    = 'Failed to install required modules from Forge'
+    Retries        = 10
+    Timeout        = 2
+    Script         = { bundle exec r10k puppetfile install }
+  }
+
+  Invoke-ScriptBlockWithRetry @retryArgs
 }
 
 function New-RandomPassword


### PR DESCRIPTION
 - There's a bunch of redundant and hard to read code in appveyor.yml
   that is moved verbatim to a separate file ci.ps1, then is refactored

 - Break it into reusable functions (that can also be used in local dev):

   * Set-CACert - Sets `SSL_CERT_FILE` environment variable to the latest CA bundel from curl.haxx.se
   * Install-Puppetfile - Installs the CA bundle, sets env var and installs the Puppetfile
   * New-RandomPassword - generates random password
   * New-LocalAdmin - creates a new user with name / password and adds them to RDP group
   * Install-Certificate - installs a cert in the machine store given its password
   * Grant-WinRMHttpsAccess - enables winrm SSL access given a cert thumbprint
   * Set-WinRMHostConfiguration - CI helper that wraps up installing the bolt cert and configuring winrm to use it
   * Set-ActiveRubyFromPuppet - ensures Puppets Ruby is earlier in `PATH` than System Ruby

- Logic in `appveyor.yml` now runs through some very high level functions that are more descriptive

- Adds new function `Test-WinRMConfiguration` - uses the `New-PSSession` cmdlet to establish a WinRM SSL connection back to `localhost` given a set of credentials. By default waits 15 times at 1 second intervals before throwing a terminating error.

- Retries acquiring CA bundle from curl.haxx.se

- Retries installing the `Puppetfile`


The hope here is that if WinRM needs some time to become available, the pre-suite checks should verify that / fail fast if necessary.