### PR TITLE
(BOLT-1205, BOLT-1200) Add default local config only for localhost

### DIFF
--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -177,6 +177,21 @@ module Bolt
     end
     private :groups_in
 
+    # TODO: Possibly refactor this once inventory v2 is more stable
+    def self.localhost_defaults(data)
+      defaults = {
+        'config' => {
+          'transport' => 'local',
+          'local' => { 'interpreters' => { '.rb' => RbConfig.ruby } }
+        },
+        'features' => ['puppet-agent']
+      }
+      data = Bolt::Util.deep_merge(defaults, data)
+      # If features is an empty array deep_merge won't add the puppet-agent
+      data['features'] << 'puppet-agent' if data['features'].empty?
+      data
+    end
+
     # Pass a target to get_targets for a public version of this
     # Should this reconfigure configured targets?
     def update_target(target)
@@ -188,10 +203,7 @@ module Bolt
         data['config'] = {}
       end
 
-      unless data['config']['transport']
-        data['config']['transport'] = 'local' if target.name == 'localhost'
-      end
-
+      data = self.class.localhost_defaults(data) if target.name == 'localhost'
       # These should only get set from the inventory if they have not yet
       # been instantiated
       set_vars_from_hash(target.name, data['vars']) unless @target_vars[target.name]

--- a/lib/bolt/inventory/inventory2.rb
+++ b/lib/bolt/inventory/inventory2.rb
@@ -122,10 +122,7 @@ module Bolt
           data['config'] = {}
         end
 
-        unless data['config']['transport']
-          data['config']['transport'] = 'local' if target.name == 'localhost'
-        end
-
+        data = Bolt::Inventory.localhost_defaults(data) if target.name == 'localhost'
         # These should only get set from the inventory if they have not yet
         # been instantiated
         set_vars_from_hash(target.name, data['vars']) unless @target_vars[target.name]

--- a/lib/bolt/task.rb
+++ b/lib/bolt/task.rb
@@ -72,9 +72,9 @@ module Bolt
 
     # Returns a hash of implementation name, path to executable, input method (if defined),
     # and any additional files (name and path)
-    def select_implementation(target, additional_features = [])
+    def select_implementation(target, provided_features = [])
       impl = if (impls = implementations)
-               available_features = target.features + additional_features
+               available_features = target.features + provided_features
                impl = impls.find do |imp|
                  remote_impl = imp['remote']
                  remote_impl = metadata['remote'] if remote_impl.nil?

--- a/lib/bolt/transport/local.rb
+++ b/lib/bolt/transport/local.rb
@@ -7,12 +7,6 @@ module Bolt
         %w[tmpdir interpreters sudo-password run-as run-as-command]
       end
 
-      def self.default_options
-        {
-          'interpreters' => { '.rb' => RbConfig.ruby }
-        }
-      end
-
       def provided_features
         ['shell']
       end

--- a/lib/bolt/transport/local_windows.rb
+++ b/lib/bolt/transport/local_windows.rb
@@ -16,12 +16,6 @@ module Bolt
         %w[tmpdir interpreters run-as run-as-command sudo-password]
       end
 
-      def self.default_options
-        {
-          'interpreters' => { '.rb' => RbConfig.ruby }
-        }
-      end
-
       def provided_features
         ['powershell']
       end

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -56,9 +56,7 @@ describe Bolt::Applicator do
             pcp: {
               'task-environment' => 'production'
             },
-            local: {
-              'interpreters' => { '.rb' => RbConfig.ruby }
-            },
+            local: {},
             docker: {},
             remote: { 'run-on': 'localhost' }
           }

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -595,6 +595,76 @@ describe Bolt::Inventory do
         )
       end
     end
+
+    context 'with localhost' do
+      context 'with no inventory' do
+        let(:inventory) { Bolt::Inventory.new({}) }
+
+        it 'adds magic config options' do
+          target = get_target(inventory, 'localhost')
+          expect(target.protocol).to eq('local')
+          expect(target.options['interpreters']).to include('.rb' => RbConfig.ruby)
+          expect(target.features).to include('puppet-agent')
+        end
+      end
+
+      context 'with no additional config' do
+        let(:data) {
+          { 'nodes' => ['localhost'] }
+        }
+
+        let(:inventory) { Bolt::Inventory.new(data) }
+
+        it 'adds magic config options' do
+          target = get_target(inventory, 'localhost')
+          expect(target.protocol).to eq('local')
+          expect(target.options['interpreters']).to include('.rb' => RbConfig.ruby)
+          expect(target.features).to include('puppet-agent')
+        end
+      end
+
+      context 'with config' do
+        let(:data) {
+          { 'name' => 'locomoco',
+            'nodes' => ['localhost'],
+            'config' => {
+              'transport' => 'local',
+              'local' => {
+                'interpreters' => { '.rb' => '/foo/ruby' }
+              }
+            } }
+        }
+        let(:inventory) { Bolt::Inventory.new(data) }
+
+        it 'does not override config options' do
+          target = get_target(inventory, 'localhost')
+          expect(target.protocol).to eq('local')
+          expect(target.options['interpreters']).to include('.rb' => '/foo/ruby')
+          expect(target.features).to include('puppet-agent')
+        end
+      end
+
+      context 'with non-local transport' do
+        let(:data) {
+          { 'nodes' => [{
+            'name' => 'localhost',
+            'config' => {
+              'transport' => 'ssh',
+              'ssh' => {
+                'interpreters' => { '.rb' => '/foo/ruby' }
+              }
+            }
+          }] }
+        }
+        let(:inventory) { Bolt::Inventory.new(data) }
+        it 'does not set magic config' do
+          target = get_target(inventory, 'localhost')
+          expect(target.protocol).to eq('ssh')
+          expect(target.options['interpreters']).to include('.rb' => '/foo/ruby')
+          expect(target.features).to include('puppet-agent')
+        end
+      end
+    end
   end
 
   describe :create_version do

--- a/spec/integration/local_spec.rb
+++ b/spec/integration/local_spec.rb
@@ -68,6 +68,8 @@ describe "when running over the local transport" do
     context 'with environment variables set' do
       before(:each) { ENV['test_var'] = "testing this" }
       after(:each) { ENV.delete('test_var') }
+      # Only works with localhost's default configuration
+      let(:uri) { 'localhost' }
 
       it 'exposes environment variables to the task' do
         result = run_one_node(%w[task run env_var::get_var] + config_flags)


### PR DESCRIPTION
This ensures that 'magic' local config only gets merged with the provided config when the hostname is localhost, regardless of the transport used. The 'magic' config options for localhost are to add the `puppet-agent` feature to the localhost target, and to set the default ruby interpreter to be Bolt's ruby.