### PR TITLE
(BOLT-1133) Add slack channel info to documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Bolt Community Slack Channel 
 
-Join the `#bolt` channel in the [puppet community slack instance](https://slack.puppet.com/) where Bolt developers and community members who use and contribute to Bolt discuss the tool. Another channel of interest is the `#office-hours` where once a week a Bolt developer leads a Q&A session about using Bolt.
+Join the `#bolt` channel in the [Puppet community Slack](https://slack.puppet.com/) where Bolt developers and community members who use and contribute to Bolt discuss the tool. Another channel of interest is the `#office-hours` where once a week a Bolt developer leads a Q&A session about using Bolt.
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Additionally the Bolt project includes:
     * [Writing Plans](https://puppet.com/docs/bolt/latest/writing_plans.html)
 * [Applying Manifest Blocks in Plans](https://puppet.com/docs/bolt/latest/applying_manifest_blocks.html)
 
+## Getting Help
+
+* [#bolt on Slack](https://slack.puppet.com/) - Join the Bolt developers and community
+
 ## Kudos
 
 Thank you to [Marcin Bunsch](https://github.com/marcinbunsch) for allowing Puppet to use the `bolt` gem name.

--- a/pre-docs/bolt.md
+++ b/pre-docs/bolt.md
@@ -71,6 +71,10 @@ Bolt is an open source task runner that automates the manual work that you do to
 
  -   **Share and contribute**
 
+[Join us on Slack](https://slack.puppet.com/) - Join the `#bolt` channel in the [Puppet community Slack](https://slack.puppet.com/)
+
+[Follow us on Twitter](https://twitter.com/puppetize/)
+
 [Engage with the Puppet community](https://puppet.com/community) - Share what you know and get help from other users and employees.
 
 [Puppet Forge](https://forge.puppet.com) - Find modules you can use, and contribute modules you've made to the community.

--- a/pre-docs/bolt_installing.md
+++ b/pre-docs/bolt_installing.md
@@ -283,3 +283,7 @@ To disable the collection of analytics data add the following line to `~/.puppe
 ```
 disabled: true
 ```
+
+## Have Questions?
+
+Get in touch! We're in `#bolt` on the [Puppet community Slack](https://slack.puppet.com/).


### PR DESCRIPTION
This adds our Slack channel info to the README, the main `bolt` documentation page, and the `installing Bolt` page. Also adds Puppet's twitter to the `bolt` docs page, and updates verbage of the CONTRIBUTING doc for consistency.