### PR TITLE
(BOLT-843) Support retrying on failed nodes.

### DIFF
--- a/lib/bolt/boltdir.rb
+++ b/lib/bolt/boltdir.rb
@@ -6,7 +6,7 @@ module Bolt
   class Boltdir
     BOLTDIR_NAME = 'Boltdir'
 
-    attr_reader :path, :config_file, :inventory_file, :modulepath, :hiera_config, :puppetfile
+    attr_reader :path, :config_file, :inventory_file, :modulepath, :hiera_config, :puppetfile, :rerunfile
 
     def self.default_boltdir
       Boltdir.new(File.join('~', '.puppetlabs', 'bolt'))
@@ -36,6 +36,7 @@ module Bolt
       @modulepath = [(@path + 'modules').to_s, (@path + 'site-modules').to_s, (@path + 'site').to_s]
       @hiera_config = @path + 'hiera.yaml'
       @puppetfile = @path + 'Puppetfile'
+      @rerunfile = @path + '.rerun.json'
     end
 
     def to_s

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -31,8 +31,8 @@ module Bolt
   end
 
   class Config
-    attr_accessor :concurrency, :format, :trace, :log, :puppetdb, :color,
-                  :transport, :transports, :inventoryfile, :compile_concurrency
+    attr_accessor :concurrency, :format, :trace, :log, :puppetdb, :color, :save_rerun,
+                  :transport, :transports, :inventoryfile, :compile_concurrency, :boltdir
     attr_writer :modulepath
 
     TRANSPORT_OPTIONS = %i[password run-as sudo-password extensions
@@ -65,6 +65,7 @@ module Bolt
       @format = 'human'
       @puppetdb = {}
       @color = true
+      @save_rerun = true
 
       # add an entry for the default console logger
       @log = { 'console' => {} }
@@ -147,6 +148,8 @@ module Bolt
       @hiera_config = File.expand_path(data['hiera-config'], @boltdir.path) if data.key?('hiera-config')
       @compile_concurrency = data['compile-concurrency'] if data.key?('compile-concurrency')
 
+      @save_rerun = data['save-rerun'] if data.key?('save-rerun')
+
       %w[concurrency format puppetdb color transport].each do |key|
         send("#{key}=", data[key]) if data.key?(key)
       end
@@ -167,6 +170,8 @@ module Bolt
       %i[concurrency transport format trace modulepath inventoryfile color].each do |key|
         send("#{key}=", options[key]) if options.key?(key)
       end
+
+      @save_rerun = options[:'save-rerun'] if options.key?(:'save-rerun')
 
       if options[:debug]
         @log['console'][:level] = :debug
@@ -213,6 +218,10 @@ module Bolt
 
     def default_inventoryfile
       [@boltdir.inventory_file]
+    end
+
+    def rerunfile
+      @boltdir.rerunfile
     end
 
     def hiera_config

--- a/lib/bolt/rerun.rb
+++ b/lib/bolt/rerun.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'logging'
+
+module Bolt
+  class Rerun
+    def initialize(path, save_failures)
+      @path = path
+      @save_failures = save_failures
+      @logger = Logging.logger[self]
+    end
+
+    def data
+      @data ||= JSON.parse(File.read(@path))
+      unless @data.is_a?(Array) && @data.all? { |r| r['target'] && r['status'] }
+        raise Bolt::FileError.new("Missing data in rerun file: #{@path}", @path)
+      end
+      @data
+    rescue JSON::ParserError
+      raise Bolt::FileError.new("Could not parse rerun file: #{@path}", @path)
+    rescue IOError, SystemCallError
+      raise Bolt::FileError.new("Could not read rerun file: #{@path}", @path)
+    end
+
+    def get_targets(filter)
+      filtered = case filter
+                 when 'all'
+                   data
+                 when 'failure'
+                   data.select { |result| result['status'] == 'failure' }
+                 when 'success'
+                   data.select { |result| result['status'] == 'success' }
+                 else
+                   raise Bolt::CLIError, "Unexpected option #{filter} for '--retry'"
+                 end
+      filtered.map { |result| result['target'] }
+    end
+
+    def update(result_set)
+      unless @save_failures == false
+        if result_set.is_a?(Bolt::PlanResult)
+          result_set = result_set.value
+          result_set = result_set.result_set if result_set.is_a?(Bolt::RunFailure)
+        end
+
+        if result_set.is_a?(Bolt::ResultSet)
+          data = result_set.map { |res| res.status_hash.select { |k, _| %i[target status].include? k } }
+          File.write(@path, data.to_json)
+        else
+          FileUtils.rm(@path)
+        end
+      end
+    rescue StandardError => e
+      @logger.warn("Failed to save failure to #{@path}: #{e.message}")
+    end
+  end
+end

--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -91,7 +91,9 @@ module Bolt
     end
 
     def status_hash
+      # DEPRECATION: node in status hashes is deprecated and should be removed in 2.0
       { node: @target.name,
+        target: @target.name,
         type: type,
         object: object,
         status: ok? ? 'success' : 'failure',

--- a/pre-docs/bolt_command_reference.md
+++ b/pre-docs/bolt_command_reference.md
@@ -4,7 +4,7 @@ Review the subcommands, actions, and options that are available for Bolt.
 
 ## Common Bolt commands
 
-Bolt commands use the syntax: `bolt <subcommand> <action> [options]` 
+Bolt commands use the syntax: `bolt <subcommand> <action> [options]`
 
 |Command|Description|Arguments|
 |-------|-----------|---------|
@@ -14,7 +14,7 @@ Bolt commands use the syntax: `bolt <subcommand> <action> [options]`
 | `bolt plan run` | Runs a task plan. | - The plan name, in the format `modulename::planname`.<br>- The nodes on which to run the plan.
 | `bolt apply` | Applies a Puppet manifest file. | - The path to the manifest file.<br>- The nodes on which to run the plan.
 | `bolt file upload` | Uploads a local file to a remote node. | - The path to the source file.<br>- The path to the remote location.<br>- The nodes on which to upload the file.
-| `bolt task show` | Lists all the tasks on the modulepath that have not been marked `private`. Will note whether a task supports no-operation mode. | - Adding a specific task name displays details and parameters for the task.<br>- Optionally, the name of a task you want details for: `bolt task show <TASK NAME>` 
+| `bolt task show` | Lists all the tasks on the modulepath that have not been marked `private`. Will note whether a task supports no-operation mode. | - Adding a specific task name displays details and parameters for the task.<br>- Optionally, the name of a task you want details for: `bolt task show <TASK NAME>`
 | `bolt plan show` | Lists the plans that are installed on the current module path. | - Adding a specific plan name displays details and parameters for the plan.
 
 ## Command options
@@ -33,9 +33,10 @@ Options are optional unless marked as required. 
 
  |
 | `--query` `, -q` |Query PuppetDB to determine the targets.|
+|`--rerun`| use the `.rerun.json` file to choose the targets. Requires a single filter options: all, failure, or success.
 | `--noop` |Execute a task that supports it in no-operation mode.|
 | `--description` |Add a description to the run. Used in logging and submitted to Orchestrator with the PCP transport.|
-| `--params` | Parameters, passed as a JSON object on the command line, or as a JSON parameter file, prefaced with `@` like `@params.json`. For Windows PowerShell,  add single quotation marks to define the file: `'@params.json'` 
+| `--params` | Parameters, passed as a JSON object on the command line, or as a JSON parameter file, prefaced with `@` like `@params.json`. For Windows PowerShell,  add single quotation marks to define the file: `'@params.json'`
 
  |
 
@@ -78,6 +79,7 @@ Options are optional unless marked as required. 
 | `--configfile` |Specify where to load config from \(default: `bolt.yaml` inside the `Boltdir`\).|
 | `--boltdir` |Specify what Boltdir to load config from \(default: autodiscovered from current working dir\).|
 | `--inventoryfile`, `-i` |Specify where to load inventory from \(default: `inventory.yaml` inside the `Boltdir`\).|
+| `--save-rerun, --no-save-rerun` | Specify whether bolt should update the `.rerun.json` file (default: save-rerun). |
 
 ## Transport options
 

--- a/pre-docs/bolt_configuration_options.md
+++ b/pre-docs/bolt_configuration_options.md
@@ -27,7 +27,7 @@ ssh:
 
 `hiera-config`: Specify the path to your Hiera config. The default path for the Hiera config file is `hiera.yaml` inside the Bolt project directory.
 
-`interpreters`: A map of an extension name to the absolute path of an executable, enabling you to override the shebang defined in a task executable. The extension can optionally be specified with the '.' character ('.py' and 'py' both map to a task executable `task.py`) and the extension is case sensitive. The transports that support interpreter configuration are `docker`, `local`, `ssh`, and `winrm`. The local transport defaults to using the ruby interpreter that is running Bolt. For example: 
+`interpreters`: A map of an extension name to the absolute path of an executable, enabling you to override the shebang defined in a task executable. The extension can optionally be specified with the '.' character ('.py' and 'py' both map to a task executable `task.py`) and the extension is case sensitive. The transports that support interpreter configuration are `docker`, `local`, `ssh`, and `winrm`. The local transport defaults to using the ruby interpreter that is running Bolt. For example:
 
 ```
 interpreters:
@@ -40,6 +40,9 @@ interpreters:
 
 `transport`: Specify the default transport to use when the transport for a target is not specified in the url or inventory. The valid options for transport are `docker`, `local`, `pcp`, `ssh`, and `winrm`.
 
+`save-rerun`: Whether bolt should update `.rerun.json` in the Bolt project
+directory. If your target names include passwords you should set this to false
+to avoid writing them to disk.
 
 ## SSH transport configuration options
 
@@ -61,7 +64,7 @@ interpreters:
 
 `sudo-password`: Password to use when changing users via `run-as`.
 
-`tmpdir`: The directory to upload and execute temporary files on the target. 
+`tmpdir`: The directory to upload and execute temporary files on the target.
 
 `user`: Login user. Default is `root`.
 

--- a/pre-docs/bolt_options.md
+++ b/pre-docs/bolt_options.md
@@ -21,7 +21,7 @@ When targeting systems with the `--nodes` flag, you can specify the transport ei
 -   To generate a node list with brace expansion, specify the node list with an equals sign \(`=`\), such as `--nodes=web{1,2}`.
 
     ```
-     bolt command run --nodes={web{5,6,7},elasticsearch{1,2,3}.subdomain}.mydomain.edu  
+     bolt command run --nodes={web{5,6,7},elasticsearch{1,2,3}.subdomain}.mydomain.edu
     ```
 
     This command runs Bolt on the following hosts:
@@ -83,7 +83,7 @@ To specify nodes from an inventory file, reference nodes by node name, a glob ma
 -   To match all the nodes that start with elasticsearch in the inventory file example:
 
 ```
---nodes 'elasticsearch*' 
+--nodes 'elasticsearch*'
 ```
 
 
@@ -107,6 +107,32 @@ groups:
 
 
 [Inventory file](inventory_file.md)
+
+### Rerunning based on the last result
+
+After every execution Bolt will write information about the result of that run to a
+`.rerun.json` file inside the Bolt project directory. That file can then be
+used to specify nodes for future bolt commands.
+
+To attempt to retry the action target the nodes on which the previous action
+failed with `--rerun failure`. If you want to continue targeting these nodes
+pass `--no-save-rerun` to prevent bolt from updating the file.
+
+```
+bolt command run false --nodes all
+bolt command run whoami --rerun failure --no-save-rerun
+```
+
+If one command is dependant on the success of a previous command you can target
+the successful nodes with `--rerun success`.
+
+```
+bolt task run package action=install name=httpd --nodes all
+bolt task run server action=restart name=httpd --rerun success
+```
+
+*note*: When a plan does not return a `ResultSet` object bolt cannot save
+information for reruns and `.rerun.json` will be deleted.
 
 ### Set a default transport
 

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -247,24 +247,6 @@ bar
           cli.parse
         }.to raise_error(Bolt::CLIError, /Targets must be specified/)
       end
-
-      it 'does not list nodes in plan --help' do
-        cli = Bolt::CLI.new(%w[plan --help])
-        expect {
-          expect {
-            cli.parse
-          }.to raise_error(Bolt::CLIExit)
-        }.not_to output(/--nodes/).to_stdout
-      end
-
-      it 'does not list nodes in help plan' do
-        cli = Bolt::CLI.new(%w[help plan])
-        expect {
-          expect {
-            cli.parse
-          }.to raise_error(Bolt::CLIExit)
-        }.not_to output(/--nodes/).to_stdout
-      end
     end
 
     describe "query" do
@@ -669,7 +651,7 @@ bar
         expect {
           cli = Bolt::CLI.new(%w[plan run foo --query nodes{} --nodes bar])
           cli.parse
-        }.to raise_error(Bolt::CLIError, /'--nodes' or '--query'/)
+        }.to raise_error(Bolt::CLIError, /Only one of '--nodes'/)
       end
 
       it "fails with --noop" do
@@ -1530,6 +1512,7 @@ bar
           cli.execute(options)
           expect(JSON.parse(output.string)).to eq(
             [{ 'node' => 'foo',
+               'target' => 'foo',
                'status' => 'success',
                'type' => 'task',
                'object' => 'some_task',
@@ -1560,6 +1543,7 @@ bar
           cli.execute(options)
           expect(JSON.parse(output.string)).to eq(
             [{ 'node' => 'foo',
+               'target' => 'foo',
                'status' => 'success',
                'type' => 'task',
                'object' => 'some_task',
@@ -1596,6 +1580,7 @@ bar
             [
               {
                 'node' => 'foo',
+                'target' => 'foo',
                 'status' => 'failure',
                 'type' => 'task',
                 'object' => 'some_task',

--- a/spec/bolt/rerun_spec.rb
+++ b/spec/bolt/rerun_spec.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/files'
+require 'bolt_spec/task'
+require 'bolt/cli'
+require 'bolt/util'
+
+# This is primarily a test of the cli but cli_spec is over 2k lines so I'm
+# keeping this separate.
+describe 'rerun' do
+  include BoltSpec::Files
+
+  around(:each) do |example|
+    Dir.mktmpdir do |boltdir|
+      @boltdir = Bolt::Boltdir.new(boltdir)
+      example.run
+    end
+  end
+
+  let(:executor) { double('executor', noop: false, analytics: Bolt::Analytics::NoopClient.new) }
+  let(:pal) { double('pal') }
+
+  let(:target_spec) { %w[node1 node2] }
+  let(:targets) { target_spec.map { |uri| Bolt::Target.new(uri) } }
+  let(:result_vals) { [{}, { '_error' => {} }] }
+
+  let(:result_set) do
+    results = targets.zip(result_vals).map do |t, r|
+      Bolt::Result.new(t, value: r)
+    end
+    Bolt::ResultSet.new(results)
+  end
+
+  let(:failure_array) do
+    result_set.map do |r|
+      r = r.status_hash
+      { 'target' => r[:target], 'status' => r[:status] }
+    end
+  end
+
+  let(:output) { StringIO.new }
+
+  before(:each) do
+    allow(Bolt::Boltdir).to receive(:find_boltdir).and_return(@boltdir)
+    allow(Bolt::Executor).to receive(:new).and_return(executor)
+    allow_any_instance_of(Bolt::CLI).to receive(:pal).and_return(pal)
+
+    # Don't allow tests to override the captured log config
+    allow(Bolt::Logger).to receive(:configure)
+    allow_any_instance_of(Bolt::CLI).to receive(:warn)
+    outputter = Bolt::Outputter::JSON.new(false, false, output)
+    allow_any_instance_of(Bolt::CLI).to receive(:outputter).and_return(outputter)
+  end
+
+  def write_rerun(data)
+    File.write(File.join(@boltdir.path, '.rerun.json'), data.to_json)
+  end
+
+  def read_rerun
+    JSON.parse(File.read(File.join(@boltdir.path, '.rerun.json')))
+  end
+
+  def run_cli(args)
+    cli = Bolt::CLI.new(args)
+    cli.execute(cli.parse)
+  end
+
+  it 'fails when there is no rerun file' do
+    expect do
+      run_cli(['command', 'run', 'whoami', '--rerun', 'all'])
+    end.to raise_error(Bolt::FileError, /Could not read rerun/)
+  end
+
+  it 'fails with an unparsable rerun file' do
+    File.write(File.join(@boltdir.path, '.rerun.json'), 'not"json:')
+    expect do
+      run_cli(['command', 'run', 'whoami', '--rerun', 'all'])
+    end.to raise_error(Bolt::FileError, /Could not parse rerun/)
+  end
+
+  it 'fails with invalid data in the rerun file' do
+    write_rerun([{}])
+    expect do
+      run_cli(['command', 'run', 'whoami', '--rerun', 'all'])
+    end.to raise_error(Bolt::FileError, /Missing data in rerun/)
+  end
+
+  context 'with a rerun file' do
+    before(:each) { write_rerun(failure_array) }
+
+    it 'runs a command with all targets' do
+      expect(executor).to receive(:run_command)
+        .with(targets, 'whoami', kind_of(Hash))
+        .and_return(result_set)
+      run_cli(['command', 'run', 'whoami', '--rerun', 'all'])
+    end
+
+    it 'runs a command with failed targets' do
+      expect(executor).to receive(:run_command)
+        .with([targets[1]], 'whoami', kind_of(Hash))
+        .and_return(result_set)
+      run_cli(['command', 'run', 'whoami', '--rerun', 'failure'])
+    end
+
+    it 'runs a command with success targets' do
+      expect(executor).to receive(:run_command)
+        .with([targets[0]], 'whoami', kind_of(Hash))
+        .and_return(result_set)
+      run_cli(['command', 'run', 'whoami', '--rerun', 'success'])
+    end
+
+    it 'fails with an unhandled filter' do
+      expect do
+        run_cli(['command', 'run', 'whoami', '--rerun', 'invalid'])
+      end.to raise_error(/Unexpected option/)
+    end
+  end
+
+  context 'with an empty rerun file' do
+    before(:each) do
+      write_rerun(['original result'])
+
+      allow(executor).to receive(:start_plan)
+      allow(executor).to receive(:finish_plan)
+      allow(pal).to receive(:parse_params)
+      allow(pal).to receive(:parse_manifest)
+    end
+
+    let(:success_set) { Bolt::ResultSet.new([result_set.results[0], result_set.results[0]]) }
+
+    it 'updates the file when a command fails' do
+      allow(executor).to receive(:run_command)
+        .with(targets, 'whoami', kind_of(Hash))
+        .and_return(result_set)
+      run_cli(['command', 'run', 'whoami', '--nodes', target_spec.join(',')])
+
+      expect(read_rerun).to eq(failure_array)
+    end
+
+    it 'does not update the file with --no-save-rerun' do
+      allow(executor).to receive(:run_command)
+        .with(targets, 'whoami', kind_of(Hash))
+        .and_return(result_set)
+      run_cli(['command', 'run', 'whoami', '--no-tty', '--no-save-rerun', '--nodes', target_spec.join(',')])
+
+      expect(read_rerun).to eq(['original result'])
+    end
+
+    it 'does not update the file with save-rerun: false' do
+      File.write(@boltdir.config_file, { 'save-rerun' => false }.to_yaml)
+
+      allow(executor).to receive(:run_command)
+        .with(targets, 'whoami', kind_of(Hash))
+        .and_return(result_set)
+      run_cli(['command', 'run', 'whoami', '--nodes', target_spec.join(',')])
+
+      expect(read_rerun).to eq(['original result'])
+    end
+
+    it 'updates the file when a plan returns a failing ResultSet' do
+      expect(pal).to receive(:run_plan).and_return(Bolt::PlanResult.new(result_set, 'failure'))
+      run_cli(%w[plan run whoami])
+
+      expect(read_rerun).to eq(failure_array)
+    end
+
+    it 'updates the file when a plan raises a RunFailure' do
+      pr = Bolt::PlanResult.new(Bolt::RunFailure.new(result_set, 'failure'), 'command')
+      expect(pal).to receive(:run_plan).and_return(pr)
+      run_cli(%w[plan run whoami])
+
+      expect(read_rerun).to eq(failure_array)
+    end
+
+    it 'deletes the the file when a plan fails with nil' do
+      expect(pal).to receive(:run_plan)
+        .and_return(Bolt::PlanResult.new(nil, 'failure'))
+      run_cli(%w[plan run whoami])
+
+      expect(File.exist?(File.join(@boltdir.path, '.rerun.json'))).to eq(false)
+    end
+
+    it 'updates the file when apply fails' do
+      allow(pal).to receive(:in_plan_compiler)
+      allow(pal).to receive(:with_bolt_executor)
+        .and_return(Bolt::ResultSet.new([Bolt::ApplyResult.new(targets[0], error: { 'kind' => 'oops' })]))
+      run_cli(['apply', '--nodes', 'node1', '-e', 'include foo'])
+      expect(read_rerun).to eq([{ "status" => "failure", "target" => "node1" }])
+    end
+
+    it 'updates the file when apply succeeds' do
+      allow(pal).to receive(:in_plan_compiler)
+      allow(pal).to receive(:with_bolt_executor)
+        .and_return(Bolt::ResultSet.new([Bolt::ApplyResult.new(targets[0], report: {})]))
+      run_cli(['apply', '--nodes', 'node1', '-e', 'include foo'])
+      expect(read_rerun).to eq([{ "status" => "success", "target" => "node1" }])
+    end
+  end
+end

--- a/spec/bolt/result_set_spec.rb
+++ b/spec/bolt/result_set_spec.rb
@@ -24,11 +24,13 @@ describe Bolt::Result do
 
   it 'is creates the correct json' do
     expected = [{ "node" => "node1",
+                  "target" => "node1",
                   "type" => nil,
                   "object" => nil,
                   "status" => "success",
                   "result" => { "key" => "val1" } },
                 { "node" => "node1",
+                  "target" => "node1",
                   "type" => nil,
                   "object" => nil,
                   "status" => "failure",

--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'net/ssh'
+require 'net/ssh/proxy/jump'
 require 'bolt_spec/conn'
 require 'bolt_spec/errors'
 require 'bolt_spec/transport'

--- a/spec/integration/target_spec.rb
+++ b/spec/integration/target_spec.rb
@@ -25,6 +25,7 @@ describe "when running a plan that creates targets", ssh: true do
         [
           {
             'node' => uri,
+            'target' => uri,
             'type' => 'task',
             'object' => 'results',
             'status' => 'success',


### PR DESCRIPTION
Bolt will now write a <boltdir>/.last_result.json file whenever a
command fails. Users can use this file to target nodes from the last
failure with the `--retry` flag.

In order to avoid spreading `nodes` to a new file this also adds a
`target` key to the status hash of Results.

This still needs predocs.