### PR TITLE
(maint) Speed up PuppetDB tests which timed out

### DIFF
--- a/spec/bolt/puppetdb/client_spec.rb
+++ b/spec/bolt/puppetdb/client_spec.rb
@@ -108,15 +108,15 @@ describe Bolt::PuppetDB::Client do
 
     it 'should fail after all servers fail' do
       conf = pdb_conf
-      conf['server_urls'] = ['https://bad_host1.dne.com', 'https://bad_host2.dne.com']
+      conf['server_urls'] = ['https://bad1.example.com', 'https://bad2.example.com']
       client = Bolt::PuppetDB::Client.new(Bolt::PuppetDB::Config.new(conf))
-      msg = "Failed to connect to all PuppetDB server_urls: https://bad_host1.dne.com, https://bad_host2.dne.com."
+      msg = "Failed to connect to all PuppetDB server_urls: https://bad1.example.com, https://bad2.example.com."
       expect { client.facts_for_node(%w[node1 node2]) }.to raise_error(Bolt::PuppetDBError, msg)
     end
 
     it 'should failover if the first server fails' do
       conf = pdb_conf
-      conf['server_urls'] = ['https://bad_host.dne.com', pdb_conf['server_urls']]
+      conf['server_urls'] = ['https://bad.example.com', pdb_conf['server_urls']]
       client = Bolt::PuppetDB::Client.new(Bolt::PuppetDB::Config.new(conf))
       facts = client.facts_for_node(%w[node1 node2])
       expect(facts).to eq(facts_hash)


### PR DESCRIPTION
Previously, these tests were using bad_host{1,2}.dne.com as their
example "bad" hosts. However, those hosts happen to actually resolve to
servers somewhere, which blackhole our connections, causing them to
block for 60 seconds before finally timing out. Since we attempt three
total connections to these hosts, that adds 180 unnecessary seconds to
the test runtime. In general, it's also bad practice for our tests to
attempt to connect to random machines on the internet.

We now use example.com, which is specifically intended for this kind of
use case and simply fails to resolve. This causes the tests to fail fast
and cuts off three minutes from their runtime.