### PR TITLE
(BOLT-1242) Don't check for sudo prompt when stderr is EOF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ before_script:
 - cat Gemfile.lock
 - bundle exec r10k puppetfile install
   # Add users to test sudo on localhost
-- sudo groupadd bolt
-- sudo useradd -g bolt bolt
-- echo 'bolt:bolt' | sudo chpasswd
 - echo 'travis:travis' | sudo chpasswd
   # Undo travis sudoers config
 - sudo sh -c "echo 'Defaults authenticate' >> /etc/sudoers"


### PR DESCRIPTION
**What this changes** If the readstream had reached EOF then select will still return the stream as available for reading, per http://man7.org/linux/man-pages/man2/select.2.html. We want to catch an EOF error if the stream can't be read and return an empty string to the node output.
**Why** This breaks when the user is not prompted for a password, for instance if the user doesn't have a password. Instead it should escalate the user and continue executing.