### PR TITLE
(BOLT-126) Add WinRM Kerberos support

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -191,6 +191,9 @@ Usage: bolt apply <manifest.pp> [options]
       define('--[no-]ssl-verify', 'Verify remote host SSL certificate with WinRM') do |ssl_verify|
         @options[:'ssl-verify'] = ssl_verify
       end
+      define('--realm REALM', 'Kerberos realm for WinRM authentication') do |realm|
+        @options[:realm] = realm
+      end
 
       separator 'Escalation:'
       define('--run-as USER', 'User to run as using privilege escalation') do |user|

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -37,7 +37,7 @@ module Bolt
 
     TRANSPORT_OPTIONS = %i[password run-as sudo-password extensions
                            private-key tty tmpdir user connect-timeout
-                           cacert token-file service-url interpreters file-protocol smb-port].freeze
+                           cacert token-file service-url interpreters file-protocol smb-port realm].freeze
 
     def self.default
       new(Bolt::Boltdir.new('.'), {})

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -10,7 +10,7 @@ module Bolt
       def self.options
         %w[
           host port user password connect-timeout ssl ssl-verify tmpdir
-          cacert extensions interpreters file-protocol smb-port
+          cacert extensions interpreters file-protocol smb-port realm
         ]
       end
 


### PR DESCRIPTION
This is based on the work in #231, overhauled for the current version of Bolt.