### PR TITLE
(BOLT-1231) Switch V2 inventory to use 'targets' instead of 'nodes.

### DIFF
--- a/lib/bolt/inventory/group2.rb
+++ b/lib/bolt/inventory/group2.rb
@@ -5,7 +5,7 @@ require 'bolt/inventory/group'
 module Bolt
   class Inventory
     class Group2
-      attr_accessor :name, :nodes, :aliases, :name_or_alias, :groups, :config, :rest, :facts, :vars, :features
+      attr_accessor :name, :targets, :aliases, :name_or_alias, :groups, :config, :rest, :facts, :vars, :features
 
       # THESE are duplicates with the old groups for now.
       # Regex used to validate group names and target aliases.
@@ -13,7 +13,7 @@ module Bolt
 
       DATA_KEYS = %w[name config facts vars features].freeze
       NODE_KEYS = DATA_KEYS + %w[alias uri]
-      GROUP_KEYS = DATA_KEYS + %w[groups nodes]
+      GROUP_KEYS = DATA_KEYS + %w[groups targets]
       CONFIG_KEYS = Bolt::TRANSPORTS.keys.map(&:to_s) + ['transport']
 
       def initialize(data)
@@ -41,46 +41,46 @@ module Bolt
           @logger.warn(msg)
         end
 
-        nodes = fetch_value(data, 'nodes', Array)
+        targets = fetch_value(data, 'targets', Array)
         groups = fetch_value(data, 'groups', Array)
 
-        @nodes = {}
+        @targets = {}
         @aliases = {}
-        nodes.reject { |node| node.is_a?(String) }.each do |node|
-          unless node.is_a?(Hash)
-            raise ValidationError.new("Node entry must be a String or Hash, not #{node.class}", @name)
+        targets.reject { |target| target.is_a?(String) }.each do |target|
+          unless target.is_a?(Hash)
+            raise ValidationError.new("Node entry must be a String or Hash, not #{target.class}", @name)
           end
 
-          node['name'] ||= node['uri']
+          target['name'] ||= target['uri']
 
-          if node['name'].nil? || node['name'].empty?
-            raise ValidationError.new("No name or uri for node: #{node}", @name)
+          if target['name'].nil? || target['name'].empty?
+            raise ValidationError.new("No name or uri for target: #{target}", @name)
           end
 
-          if @nodes.include?(node['name'])
-            @logger.warn("Ignoring duplicate node in #{@name}: #{node}")
+          if @targets.include?(target['name'])
+            @logger.warn("Ignoring duplicate target in #{@name}: #{target}")
             next
           end
 
-          raise ValidationError.new("Node #{node} does not have a name", @name) unless node['name']
-          @nodes[node['name']] = node
+          raise ValidationError.new("Node #{target} does not have a name", @name) unless target['name']
+          @targets[target['name']] = target
 
-          unless (unexpected_keys = node.keys - NODE_KEYS).empty?
-            msg = "Found unexpected key(s) #{unexpected_keys.join(', ')} in node #{node['name']}"
+          unless (unexpected_keys = target.keys - NODE_KEYS).empty?
+            msg = "Found unexpected key(s) #{unexpected_keys.join(', ')} in target #{target['name']}"
             @logger.warn(msg)
           end
-          config_keys = node['config']&.keys || []
+          config_keys = target['config']&.keys || []
           unless (unexpected_keys = config_keys - CONFIG_KEYS).empty?
-            msg = "Found unexpected key(s) #{unexpected_keys.join(', ')} in config for node #{node['name']}"
+            msg = "Found unexpected key(s) #{unexpected_keys.join(', ')} in config for target #{target['name']}"
             @logger.warn(msg)
           end
 
-          next unless node.include?('alias')
+          next unless target.include?('alias')
 
-          aliases = node['alias']
+          aliases = target['alias']
           aliases = [aliases] if aliases.is_a?(String)
           unless aliases.is_a?(Array)
-            msg = "Alias entry on #{node['name']} must be a String or Array, not #{aliases.class}"
+            msg = "Alias entry on #{target['name']} must be a String or Array, not #{aliases.class}"
             raise ValidationError.new(msg, @name)
           end
 
@@ -88,26 +88,26 @@ module Bolt
             raise ValidationError.new("Invalid alias #{alia}", @name) unless alia =~ NAME_REGEX
 
             if (found = @aliases[alia])
-              raise ValidationError.new(alias_conflict(alia, found, node['name']), @name)
+              raise ValidationError.new(alias_conflict(alia, found, target['name']), @name)
             end
-            @aliases[alia] = node['name']
+            @aliases[alia] = target['name']
           end
         end
 
-        # If node is a string, it can refer to either a node name or alias. Which can't be determined
+        # If target is a string, it can refer to either a target name or alias. Which can't be determined
         # until all groups have been resolved, and requires a depth-first traversal to categorize them.
-        @name_or_alias = nodes.select { |node| node.is_a?(String) }
+        @name_or_alias = targets.select { |target| target.is_a?(String) }
 
         @groups = groups.map { |g| Group2.new(g) }
       end
 
-      def node_data(node_name)
-        if (data = @nodes[node_name])
+      def target_data(target_name)
+        if (data = @targets[target_name])
           { 'config' => data['config'] || {},
             'vars' => data['vars'] || {},
             'facts' => data['facts'] || {},
             'features' => data['features'] || [],
-            # This allows us to determine if a node was found?
+            # This allows us to determine if a target was found?
             'name' => data['name'] || nil,
             'uri' => data['uri'] || nil,
             # groups come from group_data
@@ -142,78 +142,78 @@ module Bolt
         value
       end
 
-      def resolve_aliases(aliases, node_names)
+      def resolve_aliases(aliases, target_names)
         @name_or_alias.each do |name_or_alias|
-          # If an alias is found, insert the name into this group. Otherwise use the name as a new node's uri.
-          if node_names.include?(name_or_alias)
-            @nodes[name_or_alias] = { 'name' => name_or_alias }
-          elsif (node_name = aliases[name_or_alias])
-            if @nodes.include?(node_name)
-              @logger.warn("Ignoring duplicate node in #{@name}: #{node_name}")
+          # If an alias is found, insert the name into this group. Otherwise use the name as a new target's uri.
+          if target_names.include?(name_or_alias)
+            @targets[name_or_alias] = { 'name' => name_or_alias }
+          elsif (target_name = aliases[name_or_alias])
+            if @targets.include?(target_name)
+              @logger.warn("Ignoring duplicate target in #{@name}: #{target_name}")
             else
-              @nodes[node_name] = { 'name' => node_name }
+              @targets[target_name] = { 'name' => target_name }
             end
           else
-            node_name = name_or_alias
+            target_name = name_or_alias
 
-            if @nodes.include?(node_name)
-              @logger.warn("Ignoring duplicate node in #{@name}: #{node_name}")
+            if @targets.include?(target_name)
+              @logger.warn("Ignoring duplicate target in #{@name}: #{target_name}")
             else
-              @nodes[node_name] = { 'uri' => node_name }
+              @targets[target_name] = { 'uri' => target_name }
             end
           end
         end
 
-        @groups.each { |g| g.resolve_aliases(aliases, node_names) }
+        @groups.each { |g| g.resolve_aliases(aliases, target_names) }
       end
 
-      private def alias_conflict(name, node1, node2)
-        "Alias #{name} refers to multiple targets: #{node1} and #{node2}"
+      private def alias_conflict(name, target1, target2)
+        "Alias #{name} refers to multiple targets: #{target1} and #{target2}"
       end
 
       private def group_alias_conflict(name)
         "Group #{name} conflicts with alias of the same name"
       end
 
-      private def group_node_conflict(name)
-        "Group #{name} conflicts with node of the same name"
+      private def group_target_conflict(name)
+        "Group #{name} conflicts with target of the same name"
       end
 
-      private def alias_node_conflict(name)
+      private def alias_target_conflict(name)
         "Node name #{name} conflicts with alias of the same name"
       end
 
-      def validate(used_names = Set.new, node_names = Set.new, aliased = {}, depth = 0)
+      def validate(used_names = Set.new, target_names = Set.new, aliased = {}, depth = 0)
         # Test if this group name conflicts with anything used before.
         raise ValidationError.new("Tried to redefine group #{@name}", @name) if used_names.include?(@name)
-        raise ValidationError.new(group_node_conflict(@name), @name) if node_names.include?(@name)
+        raise ValidationError.new(group_target_conflict(@name), @name) if target_names.include?(@name)
         raise ValidationError.new(group_alias_conflict(@name), @name) if aliased.include?(@name)
 
         used_names << @name
 
-        # Collect node names and aliases into a list used to validate that subgroups don't conflict.
-        # Used names validate that previously used group names don't conflict with new node names/aliases.
-        @nodes.each_key do |n|
-          # Require nodes to be parseable as a Target.
+        # Collect target names and aliases into a list used to validate that subgroups don't conflict.
+        # Used names validate that previously used group names don't conflict with new target names/aliases.
+        @targets.each_key do |n|
+          # Require targets to be parseable as a Target.
           begin
             Target.new(n)
           rescue Bolt::ParseError => e
             @logger.debug(e)
-            raise ValidationError.new("Invalid node name #{n}", @name)
+            raise ValidationError.new("Invalid target name #{n}", @name)
           end
 
-          raise ValidationError.new(group_node_conflict(n), @name) if used_names.include?(n)
+          raise ValidationError.new(group_target_conflict(n), @name) if used_names.include?(n)
           if aliased.include?(n)
-            raise ValidationError.new(alias_node_conflict(n), @name)
+            raise ValidationError.new(alias_target_conflict(n), @name)
           end
 
-          node_names << n
+          target_names << n
         end
 
         @aliases.each do |n, target|
           raise ValidationError.new(group_alias_conflict(n), @name) if used_names.include?(n)
-          if node_names.include?(n)
-            raise ValidationError.new(alias_node_conflict(n), @name)
+          if target_names.include?(n)
+            raise ValidationError.new(alias_target_conflict(n), @name)
           end
 
           if aliased.include?(n)
@@ -225,7 +225,7 @@ module Bolt
 
         @groups.each do |g|
           begin
-            g.validate(used_names, node_names, aliased, depth + 1)
+            g.validate(used_names, target_names, aliased, depth + 1)
           rescue ValidationError => e
             e.add_parent(@name)
             raise e
@@ -237,8 +237,8 @@ module Bolt
 
       # The data functions below expect and return nil or a hash of the schema
       # { 'config' => Hash , 'vars' => Hash, 'facts' => Hash, 'features' => Array, groups => Array }
-      def data_for(node_name)
-        data_merge(group_collect(node_name), node_collect(node_name))
+      def data_for(target_name)
+        data_merge(group_collect(target_name), target_collect(target_name))
       end
 
       def group_data
@@ -257,17 +257,17 @@ module Bolt
           'groups' => [] }
       end
 
-      # Returns all nodes contained within the group, which includes nodes from subgroups.
-      def node_names
-        @groups.inject(local_node_names) do |acc, g|
-          acc.merge(g.node_names)
+      # Returns all targets contained within the group, which includes targets from subgroups.
+      def target_names
+        @groups.inject(local_target_names) do |acc, g|
+          acc.merge(g.target_names)
         end
       end
 
-      # Returns a mapping of aliases to nodes contained within the group, which includes subgroups.
-      def node_aliases
+      # Returns a mapping of aliases to targets contained within the group, which includes subgroups.
+      def target_aliases
         @groups.inject(@aliases) do |acc, g|
-          acc.merge(g.node_aliases)
+          acc.merge(g.target_aliases)
         end
       end
 
@@ -278,25 +278,25 @@ module Bolt
         end
       end
 
-      def local_node_names
-        Set.new(@nodes.keys)
+      def local_target_names
+        Set.new(@targets.keys)
       end
-      private :local_node_names
+      private :local_target_names
 
-      def node_collect(node_name)
+      def target_collect(target_name)
         data = @groups.inject(nil) do |acc, g|
-          if (d = g.node_collect(node_name))
+          if (d = g.target_collect(target_name))
             data_merge(d, acc)
           else
             acc
           end
         end
-        data_merge(node_data(node_name), data)
+        data_merge(target_data(target_name), data)
       end
 
-      def group_collect(node_name)
+      def group_collect(target_name)
         data = @groups.inject(nil) do |acc, g|
-          if (d = g.data_for(node_name))
+          if (d = g.data_for(target_name))
             data_merge(d, acc)
           else
             acc
@@ -305,7 +305,7 @@ module Bolt
 
         if data
           data_merge(group_data, data)
-        elsif @nodes.include?(node_name)
+        elsif @targets.include?(target_name)
           group_data
         end
       end

--- a/spec/fixtures/modules/add_group/plans/init.pp
+++ b/spec/fixtures/modules/add_group/plans/init.pp
@@ -19,9 +19,9 @@ plan add_group (TargetSpec $nodes) {
   $add_me_targets = get_targets('add_me')
 
   $result = { 'addme_group' => $add_me_targets,
-			  'existing_facts' => $add_me_targets[0].facts,
+        'existing_facts' => $add_me_targets[0].facts,
 			  'existing_vars' => $add_me_targets[0].vars,
-			  'added_facts' => $add_me_targets[1].facts,
+        'added_facts' => $add_me_targets[1].facts,
 			  'added_vars' => $add_me_targets[1].vars,
 			  'target_from_string' => get_targets('bar'),
 			  'target_to_all_group' => get_targets('all')}


### PR DESCRIPTION
Moving forward bolt will standardize on calling targets targets instead
of nodes to avoid confusion about remote targets. This commit causes the
version 2 inventory file to look in `targets` instead of `nodes` for the
members of a group.