### PR TITLE
(maint) Fix inventory add_to_group integration test

### DIFF
--- a/spec/fixtures/modules/add_group/plans/init.pp
+++ b/spec/fixtures/modules/add_group/plans/init.pp
@@ -5,26 +5,29 @@ plan add_group (TargetSpec $nodes) {
     "user" => 'bolt',
     'password' => 'bolt'
   )
-  $t = get_targets('add_me')
+
   # Add new facts/var, specifically one that is novel, the other that should override existing.
   $new_target.add_facts({'plan_context' => 'keep', 'override_parent' => 'keep'})
   $new_target.set_var('plan_context','keep')
   $new_target.set_var('override_parent', 'keep')
   # Add from Target object
   $new_target.add_to_group('add_me')
-  # Add from string
+  # When a Target already exists in a group, do nothing (bar_1 defined in bar)
   add_to_group('bar_1', 'bar')
   # Add to default "all" group
   add_to_group('add_to_all', 'all')
   $add_me_targets = get_targets('add_me')
 
-  $result = { 'addme_group' => $add_me_targets,
-        'existing_facts' => $add_me_targets[0].facts,
-			  'existing_vars' => $add_me_targets[0].vars,
-        'added_facts' => $add_me_targets[1].facts,
-			  'added_vars' => $add_me_targets[1].vars,
-			  'target_from_string' => get_targets('bar'),
-			  'target_to_all_group' => get_targets('all')}
+  $result = { 
+    'addme_group' => $add_me_targets,
+    'existing_facts' => $add_me_targets[0].facts,
+    'existing_vars' => $add_me_targets[0].vars,
+    'added_facts' => $add_me_targets[1].facts,
+    'added_vars' => $add_me_targets[1].vars,
+    'target_not_overwritten' => get_targets('bar')[0].vars['bar_1_var'],
+    'target_not_duplicated' => get_targets('bar'),
+    'target_to_all_group' => get_targets('all')
+  }
 
   return $result
 }

--- a/spec/integration/inventory2_spec.rb
+++ b/spec/integration/inventory2_spec.rb
@@ -240,7 +240,12 @@ describe 'running with an inventory file', reset_puppet_settings: true do
           },
           {
             name: 'bar',
-            targets: [],
+            targets: [
+              {
+                uri: 'bar_1',
+                vars: { bar_1_var: 'dont_overwrite' }
+              }
+            ],
             config: {
               transport: 'local'
             },
@@ -282,7 +287,8 @@ describe 'running with an inventory file', reset_puppet_settings: true do
       expect(result['existing_vars']).to eq(expected_hash_pre)
       expect(result['added_facts']).to eq(expected_hash_post)
       expect(result['added_vars']).to eq(expected_hash_post)
-      expect(result['target_from_string']).to eq(["Target('bar_1', {})"])
+      expect(result['target_not_overwritten']).to eq("dont_overwrite")
+      expect(result['target_not_duplicated']).to eq(["Target('bar_1', {})"])
       expect(result['target_to_all_group']).to include("Target('add_to_all', {})")
     end
 

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -205,7 +205,8 @@ describe 'running with an inventory file', reset_puppet_settings: true do
             name: 'bar',
             nodes: [
               {
-                name: 'bar_1'
+                name: 'bar_1',
+                vars: { bar_1_var: 'dont_overwrite' }
               }
             ],
             config: {
@@ -246,7 +247,8 @@ describe 'running with an inventory file', reset_puppet_settings: true do
       expect(result['existing_vars']).to eq(expected_hash_pre)
       expect(result['added_facts']).to eq(expected_hash_post)
       expect(result['added_vars']).to eq(expected_hash_post)
-      expect(result['target_from_string']).to eq(["Target('bar_1', {})"])
+      expect(result['target_not_overwritten']).to eq("dont_overwrite")
+      expect(result['target_not_duplicated']).to eq(["Target('bar_1', {})"])
       expect(result['target_to_all_group']).to include("Target('add_to_all', {})")
     end
 


### PR DESCRIPTION
Previously the test to verify that `add_to_group` does not overwrite existing targets in inventory was mislabled and did not actually test the functionality. This commit adds more descriptive names. It updates the tests such that when a target exists in inventory and has an associated var, adding a target with the same name from a plan using the `add_to_group` function does not overwrite or try to duplicate the target.