### PR TITLE
(maint) Only attempt delete .rerun.json if it exists

### DIFF
--- a/lib/bolt/rerun.rb
+++ b/lib/bolt/rerun.rb
@@ -47,12 +47,12 @@ module Bolt
         if result_set.is_a?(Bolt::ResultSet)
           data = result_set.map { |res| res.status_hash.select { |k, _| %i[target status].include? k } }
           File.write(@path, data.to_json)
-        else
+        elsif File.exist?(@path)
           FileUtils.rm(@path)
         end
       end
     rescue StandardError => e
-      @logger.warn("Failed to save failure to #{@path}: #{e.message}")
+      @logger.warn("Failed to save result to #{@path}: #{e.message}")
     end
   end
 end


### PR DESCRIPTION
Previously if there is no `.rerun.json` and a plan exits with non-ResultSet a warning is logged. This commit updates rerun logic to only attempt to delete the rerun file if it exists.