### PR TITLE
(maint) Fix typo in yaml plan docs

### DIFF
--- a/pre-docs/writing_yaml_plans.md
+++ b/pre-docs/writing_yaml_plans.md
@@ -193,7 +193,7 @@ parameters:
   frontends:
     type: TargetSpec
     description: "The frontend web servers"
-  frontends:
+  backends:
     type: TargetSpec
     description: "The backend application servers"
   version:


### PR DESCRIPTION
We defined 2 parameters `frontends`, based on the descriptions the second should be `backends`.