### PR TITLE
(BOLT-1109) Support puppetdb lookups in inventory2

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -19,6 +19,7 @@ require 'bolt/rerun'
 require 'bolt/logger'
 require 'bolt/outputter'
 require 'bolt/puppetdb'
+require 'bolt/plugin'
 require 'bolt/pal'
 require 'bolt/target'
 require 'bolt/version'
@@ -46,7 +47,7 @@ module Bolt
 
     # Only call after @config has been initialized.
     def inventory
-      @inventory ||= Bolt::Inventory.from_config(config)
+      @inventory ||= Bolt::Inventory.from_config(config, plugins)
     end
     private :inventory
 
@@ -219,6 +220,10 @@ module Bolt
       return @puppetdb_client if @puppetdb_client
       puppetdb_config = Bolt::PuppetDB::Config.load_config(nil, config.puppetdb)
       @puppetdb_client = Bolt::PuppetDB::Client.new(puppetdb_config)
+    end
+
+    def plugins
+      @plugins ||= Bolt::Plugin.setup(config, puppetdb_client)
     end
 
     def query_puppetdb_nodes(query)

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -43,7 +43,7 @@ module Bolt
       end
     end
 
-    def self.from_config(config)
+    def self.from_config(config, plugins = nil)
       if ENV.include?(ENVIRONMENT_VAR)
         begin
           data = YAML.safe_load(ENV[ENVIRONMENT_VAR])
@@ -54,18 +54,18 @@ module Bolt
         data = Bolt::Util.read_config_file(config.inventoryfile, config.default_inventoryfile, 'inventory')
       end
 
-      inventory = create_version(data, config)
+      inventory = create_version(data, config, plugins)
       inventory.validate
       inventory
     end
 
-    def self.create_version(data, config)
+    def self.create_version(data, config, plugins)
       version = (data || {}).delete('version') { 1 }
       case version
       when 1
         new(data, config)
       when 2
-        Bolt::Inventory::Inventory2.new(data, config)
+        Bolt::Inventory::Inventory2.new(data, config, plugins: plugins)
       else
         raise ValidationError, "Unsupported version #{version} specified in inventory"
       end

--- a/lib/bolt/inventory/inventory2.rb
+++ b/lib/bolt/inventory/inventory2.rb
@@ -12,7 +12,7 @@ module Bolt
         end
       end
 
-      def initialize(data, config = nil, target_vars: {}, target_facts: {}, target_features: {})
+      def initialize(data, config = nil, plugins: nil, target_vars: {}, target_facts: {}, target_features: {})
         @logger = Logging.logger[self]
         # Config is saved to add config options to targets
         @config = config || Bolt::Config.default
@@ -23,6 +23,7 @@ module Bolt
         @target_facts = target_facts
         @target_features = target_features
 
+        @groups.lookup_targets(plugins)
         @groups.resolve_aliases(@groups.target_aliases, @groups.target_names)
         collect_groups
       end

--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'bolt/plugin/puppetdb'
+
+module Bolt
+  class Plugin
+    def self.setup(config, pdb_client)
+      plugins = new(config)
+      plugins.add_plugin(Bolt::Plugin::Puppetdb.new(pdb_client))
+      plugins
+    end
+
+    def initialize(_config)
+      @plugins = {}
+    end
+
+    def add_plugin(plugin)
+      @plugins[plugin.name] = plugin
+    end
+
+    def for_hook(hook)
+      @plugins.filter { |_n, plug| plug.hooks.include? hook }
+    end
+
+    def by_name(plugin_name)
+      @plugins[plugin_name]
+    end
+  end
+end

--- a/lib/bolt/plugin/puppetdb.rb
+++ b/lib/bolt/plugin/puppetdb.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Bolt
+  class Plugin
+    class Puppetdb
+      def initialize(pdb_client)
+        @puppetdb_client = pdb_client
+      end
+
+      def name
+        'puppetdb'
+      end
+
+      def hooks
+        ['lookup_targets']
+      end
+
+      def lookup_targets(opts)
+        nodes = @puppetdb_client.query_certnames(opts['query'])
+        nodes.map { |certname| { 'uri' => certname } }
+      end
+    end
+  end
+end

--- a/pre-docs/inventory_version2.md
+++ b/pre-docs/inventory_version2.md
@@ -59,6 +59,41 @@ targets:
     uri: 192.168.100.179
 ```
 
+### `target-lookups` and dynamic puppetdb queries
+
+`target-lookups` is a new key at the group level that allows you to dynamically
+lookup the targets in the node. The lookup method is eventually expected to be
+pluggable but for now Bolt only ships a single builtin plugin `puppetdb` that
+can use a puppetdb query to populate the targets.
+
+```
+groups:
+  - name: windows
+    target-lookups:
+      - plugin: puppetdb
+        query: "inventory[certname] { facts.osfamily = 'windows' }"
+    config:
+      transport: winrm
+  - name: redhat
+    target-lookups:
+      - plugin: puppetdb
+        query: "inventory[certname] { facts.osfamily = 'RedHat' }"
+    config:
+      transport: ssh
+```
+
+`target-lookups` contains an array of target lookup objects. Each
+`target-lookup` entry must include a `plugin` key that defines which plugin
+should be used for the lookup. The rest of the keys are specific to the plugin
+being used.
+
+For the puppetdb plugin The query field is a string containing a pql query or an array containing a
+query in the puppetdb ast syntax.
+
+Make sure you have [configured puppetdb](./bolt_connect_puppetdb.md)
+
+
+
 ## Inventory config
 
 You can only set transport configuration in the inventory file. This means using a top level `transport` value to assign a transport to the target and all values in the section named for the transport (`ssh`, `winrm`, `remote`, etc.). You can set config on targets or groups in the inventory file. Bolt performs a depth first search of targets, followed by a search of groups, and uses the first value it finds. Nested hashes are merged.

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -230,6 +230,7 @@ describe "Bolt::CLI" do
       it "expands tilde to a user directory when --nodes starts with @" do
         expect(File).to receive(:read).with(File.join(Dir.home, 'nodes.txt')).and_return("foo\nbar\n")
         cli = Bolt::CLI.new(%w[command run --nodes @~/nodes.txt])
+        allow(cli).to receive(:puppetdb_client)
         result = cli.parse
         expect(result[:targets]).to eq(targets)
       end

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 require 'bolt_spec/config'
 require 'bolt/inventory'
+require 'bolt/plugin'
 require 'yaml'
 
 describe Bolt::Inventory do
@@ -18,6 +19,8 @@ describe Bolt::Inventory do
     expect(targets[0].name).to eq(name)
     targets[0]
   end
+
+  let(:plugins) { Bolt::Plugin.new(config) }
 
   let(:data) {
     {
@@ -133,7 +136,7 @@ describe Bolt::Inventory do
   end
 
   context 'with an empty config' do
-    let(:inventory) { Bolt::Inventory.from_config(config) }
+    let(:inventory) { Bolt::Inventory.from_config(config, plugins) }
     let(:target) { inventory.get_targets('nonode')[0] }
 
     it 'should accept an empty file' do
@@ -150,7 +153,7 @@ describe Bolt::Inventory do
   end
 
   context 'with BOLT_INVENTORY set' do
-    let(:inventory) { Bolt::Inventory.from_config(config) }
+    let(:inventory) { Bolt::Inventory.from_config(config, plugins) }
     let(:target) { inventory.get_targets('node1')[0] }
 
     before(:each) do
@@ -175,7 +178,8 @@ describe Bolt::Inventory do
                                          'winrm' => {
                                            'ssl' => false,
                                            'ssl-verify' => false
-                                         }))
+                                         }),
+                                  plugins)
     }
     let(:target) { inventory.get_targets('nonode')[0] }
 
@@ -194,7 +198,7 @@ describe Bolt::Inventory do
 
   describe 'get_targets' do
     context 'empty inventory' do
-      let(:inventory) { Bolt::Inventory.from_config(config) }
+      let(:inventory) { Bolt::Inventory.from_config(config, plugins) }
 
       it 'should parse a single target URI' do
         name = 'nonode'
@@ -669,17 +673,17 @@ describe Bolt::Inventory do
 
   describe :create_version do
     it 'creates a version1 inventory by default' do
-      inv = Bolt::Inventory.create_version({}, config)
+      inv = Bolt::Inventory.create_version({}, config, plugins)
       expect(inv.class).to eq(Bolt::Inventory)
     end
 
     it 'creates a version1 inventlory when specified' do
-      inv = Bolt::Inventory.create_version({ 'version' => 1 }, config)
+      inv = Bolt::Inventory.create_version({ 'version' => 1 }, config, plugins)
       expect(inv.class).to eq(Bolt::Inventory)
     end
 
     it 'creates a version2 inventory when specified' do
-      inv = Bolt::Inventory.create_version({ 'version' => 2 }, config)
+      inv = Bolt::Inventory.create_version({ 'version' => 2 }, config, plugins)
       expect(inv.class).to eq(Bolt::Inventory::Inventory2)
     end
   end

--- a/spec/lib/bolt_spec/integration.rb
+++ b/spec/lib/bolt_spec/integration.rb
@@ -1,18 +1,20 @@
 # frozen_string_literal: true
 
 require 'bolt/cli'
+require 'bolt_spec/puppetdb'
 
 module BoltSpec
   module Integration
+    include BoltSpec::PuppetDB
+
     def run_cli(arguments, rescue_exec: false, outputter: Bolt::Outputter::JSON)
       cli = Bolt::CLI.new(arguments)
 
       # prevent tests from reading users config
       allow(Bolt::Boltdir).to receive(:find_boltdir).and_return(Bolt::Boltdir.new(Dir.mktmpdir))
-      puppetdb_config = Bolt::PuppetDB::Config.new('server_urls' => 'https://puppetdb.example.com',
-                                                   'cacert' => '/path/to/cacert')
-      puppetdb_client = Bolt::PuppetDB::Client.new(puppetdb_config)
-      allow(cli).to receive(:puppetdb_client).and_return(puppetdb_client)
+
+      allow(cli).to receive(:puppetdb_client).and_return(pdb_client)
+
       output =  StringIO.new
       outputter = outputter.new(false, false, output)
       allow(cli).to receive(:outputter).and_return(outputter)


### PR DESCRIPTION
This adds a primative plugin concept to Bolt. Currenlty this is closely
tailored to the needs of the 'puppetdb' plugin which is a bit magic
since it uses prexisting puppetdb configuration.

The key parts of the plugin framework are `self.setup` which returns a new
plugin library with plugins loaded and `by_name` which allows us to
fetch the puppetdb plugin. We should expect to refactor basically
everything else around how we load plugins as we develop more hooks and
external plugins.

This is currently based on the BOLT-1232 PR since it also needs to add pre-docs