### PR TITLE
(BOLT-1262) Do not let file upload hang with sudoable

### DIFF
--- a/lib/bolt/transport/sudoable.rb
+++ b/lib/bolt/transport/sudoable.rb
@@ -44,7 +44,7 @@ module Bolt
               conn.copy_file(source, tmpfile)
               # pass over file ownership if we're using run-as to be a different user
               dir.chown(conn.run_as)
-              result = conn.execute(['mv', tmpfile, destination], sudoable: true)
+              result = conn.execute(['mv', '-f', tmpfile, destination], sudoable: true)
               if result.exit_code != 0
                 message = "Could not move temporary file '#{tmpfile}' to #{destination}: #{result.stderr.string}"
                 raise Bolt::Node::FileError.new(message, 'MV_ERROR')


### PR DESCRIPTION
In the case where a user specified with `run-as` tried to upload a file to a destination owned by a user with different privilages an command prompt is raised which causes the command to hang indefinitely. By adding the `-f` flag to the `mv` command an appropriate permission error is raised and the operation does not hang.