### PR TITLE
(BOLT-1194) Allow description key in yaml plan params

### DIFF
--- a/lib/bolt/pal/yaml_plan.rb
+++ b/lib/bolt/pal/yaml_plan.rb
@@ -4,7 +4,7 @@ module Bolt
   class PAL
     class YamlPlan
       PLAN_KEYS = Set['parameters', 'steps', 'return', 'version']
-      PARAMETER_KEYS = Set['type', 'default']
+      PARAMETER_KEYS = Set['type', 'default', 'description']
       COMMON_STEP_KEYS = %w[name description target].freeze
       STEP_KEYS = {
         'command' => {


### PR DESCRIPTION
The original implementation of the yaml plan validation did not allow the `description` key to be declared for YAML plan parameters. This commit adds that as an allowable key.