### PR TITLE
(BOLT-1259) Add acceptance tests for local transport

### DIFF
--- a/acceptance/config/gem/options.rb
+++ b/acceptance/config/gem/options.rb
@@ -5,6 +5,7 @@
     'setup/common/pre-suite/010_install_ruby.rb',
     'setup/gem/pre-suite/020_install.rb',
     'setup/common/pre-suite/030_set_password.rb',
+    'setup/common/pre-suite/031_add_local_nix_user.rb',
     'setup/common/pre-suite/050_build_bolt_inventory.rb',
     'setup/common/pre-suite/071_install_modules.rb'
   ],

--- a/acceptance/config/git/options.rb
+++ b/acceptance/config/git/options.rb
@@ -6,6 +6,7 @@
     'setup/git/pre-suite/010_install_git.rb',
     'setup/git/pre-suite/020_install.rb',
     'setup/common/pre-suite/030_set_password.rb',
+    'setup/common/pre-suite/031_add_local_nix_user.rb',
     'setup/common/pre-suite/050_build_bolt_inventory.rb',
     'setup/common/pre-suite/071_install_modules.rb'
   ],

--- a/acceptance/config/package/options.rb
+++ b/acceptance/config/package/options.rb
@@ -4,6 +4,7 @@
   pre_suite: [
     'setup/package/pre-suite/020_install.rb',
     'setup/common/pre-suite/030_set_password.rb',
+    'setup/common/pre-suite/031_add_local_nix_user.rb',
     'setup/common/pre-suite/050_build_bolt_inventory.rb'
   ],
   load_path: './lib/acceptance'

--- a/acceptance/lib/acceptance/bolt_setup_helper.rb
+++ b/acceptance/lib/acceptance/bolt_setup_helper.rb
@@ -41,5 +41,18 @@ module Acceptance
     def git_sha
       ENV['GIT_SHA'] || ''
     end
+
+    def local_user
+      ENV['LOCAL_USER'] || 'local_user'
+    end
+
+    def local_user_homedir
+      case bolt['platform']
+      when /osx/
+        "/Users/#{local_user}"
+      else
+        "/home/#{local_user}"
+      end
+    end
   end
 end

--- a/acceptance/setup/common/pre-suite/031_add_local_nix_user.rb
+++ b/acceptance/setup/common/pre-suite/031_add_local_nix_user.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'bolt_setup_helper'
+
+test_name "Configure a bolt users on *nix" do
+  extend Beaker::HostPrebuiltSteps
+  extend Acceptance::BoltSetupHelper
+
+  skip_test('No local user needed for windows') if bolt['platform'] =~ /windows/
+  step "Create a non-root user to test local transport run-as" do
+    # Use Bolt's puppet for package testing
+    result = on(bolt, 'stat /usr/local/bin/puppet', acceptable_exit_codes: [0, 1])
+    puppet_path = result.exit_code == 0 ? '/usr/local/bin/puppet' : '/opt/puppetlabs/bolt/bin/puppet'
+
+    case bolt['platform']
+    when /osx/
+      dir = bolt.tmpdir('osx_manifest')
+      # Use beaker to set osx user and ensure they have a homedir
+      bolt.user_present(local_user)
+      # The puppet user resource parameter 'managehome' is not supported for macOS.
+      # Note the logic to conditionally invoke createhomedir was most cleanly/reliably expressed
+      # in puppet code (also tried shell script and multiple remote commands)
+      create_remote_file(bolt, "#{dir}/osx_user.pp", <<~MANIFEST)
+      exec { "/usr/sbin/createhomedir -c -l -u #{local_user}":
+        unless => "/bin/test -d /Users/#{local_user}/Library",
+      }
+      MANIFEST
+
+      on(bolt, "#{puppet_path} apply #{dir}/osx_user.pp")
+    else
+      on(bolt, "#{puppet_path} resource user #{local_user} ensure=present managehome=true")
+    end
+  end
+
+  step "Disable requiretty for root user on el7" do
+    case bolt['platform']
+    when /el-7/
+      create_remote_file(bolt, "/etc/sudoers.d/root", <<~FILE)
+        Defaults:root !requiretty
+      FILE
+    end
+  end
+end

--- a/acceptance/tests/bolt_apply.rb
+++ b/acceptance/tests/bolt_apply.rb
@@ -28,7 +28,7 @@ test_name "bolt apply should apply manifest block on remote hosts via ssh and wi
 
     targets.each do |node|
       # Verify that node succeeded
-      host = node.hostname
+      host = node == 'localhost' ? 'localhost' : node.hostname
       result = json.find { |n| n['node'] == host }
       assert_equal('success', result['status'],
                    "The task did not succeed on #{host}")
@@ -46,6 +46,17 @@ test_name "bolt apply should apply manifest block on remote hosts via ssh and wi
 
     result = bolt_command_on(bolt, bolt_command, flags)
     check_result(result, targets)
+  end
+
+  step "execute `bolt apply -e <code>` with json output against localhost" do
+    # TODO: Execute with '--run-as local_user' when BOLT-1283 is fixed
+    bolt_command = "bolt apply -e \"notify { 'hello world': }\" --nodes localhost"
+    flags = {
+      '--format' => 'json'
+    }
+
+    result = bolt_command_on(bolt, bolt_command, flags)
+    check_result(result, ['localhost'])
   end
 
   step "execute `bolt apply <file.pp>` with json output" do

--- a/acceptance/tests/command_local.rb
+++ b/acceptance/tests/command_local.rb
@@ -27,7 +27,7 @@ test_name "bolt command run should execute command on localhost via local transp
 
     result = bolt_command_on(bolt, bolt_command, flags)
 
-    message = "command executed as non run-as user:\n#{result.cmd}"
+    message = "command did not execute as #{local_user}:\n#{result.cmd}"
     regex = /#{local_user}/
     assert_match(regex, result.stdout, message)
   end

--- a/acceptance/tests/command_local.rb
+++ b/acceptance/tests/command_local.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'bolt_command_helper'
+
+test_name "bolt command run should execute command on localhost via local transport" do
+  extend Acceptance::BoltCommandHelper
+  extend Acceptance::BoltSetupHelper
+
+  skip_test('no applicable nodes to test on') if bolt['platform'] =~ /windows/
+
+  step "execute `bolt command run` via local transport" do
+    command = 'echo """hello from $(hostname)"""'
+    bolt_command = "bolt command run '#{command}'"
+    flags = { '--nodes' => 'localhost' }
+
+    result = bolt_command_on(bolt, bolt_command, flags)
+
+    message = "Unexpected output from the command:\n#{result.cmd}"
+    regex = /hello from #{bolt.hostname.split('.')[0]}/
+    assert_match(regex, result.stdout, message)
+  end
+
+  step "execute `bolt command run` via local transport using run-as" do
+    command = 'whoami'
+    bolt_command = "bolt command run '#{command}'"
+    flags = { '--nodes' => 'localhost', '--run-as' => "'#{local_user}'" }
+
+    result = bolt_command_on(bolt, bolt_command, flags)
+
+    message = "command executed as non run-as user:\n#{result.cmd}"
+    regex = /#{local_user}/
+    assert_match(regex, result.stdout, message)
+  end
+end

--- a/acceptance/tests/file_local.rb
+++ b/acceptance/tests/file_local.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'bolt_command_helper'
+
+test_name "Bolt file upload should copy local file to remote hosts via ssh" do
+  extend Acceptance::BoltCommandHelper
+  extend Acceptance::BoltSetupHelper
+
+  skip_test('no applicable nodes to test on') if bolt['platform'] =~ /windows/
+
+  dir = bolt.tmpdir('local_file_upload')
+
+  step "create file on bolt controller" do
+    create_remote_file(bolt, "#{dir}/local_file.txt", <<-FILE)
+    When in the course of human events it becomes necessary for one people...
+    FILE
+  end
+
+  step "execute `bolt file upload` via local transport" do
+    source = dest = 'local_file.txt'
+    bolt_command = "bolt file upload #{dir}/#{source} /tmp/#{dest}"
+    flags = { '--nodes' => 'localhost' }
+    result = bolt_command_on(bolt, bolt_command, flags)
+
+    message = "Unexpected output from the command:\n#{result.cmd}"
+    assert_match(/Uploaded.*#{source}.*to.*#{dest}/, result.stdout, message)
+
+    command = "cat /tmp/local_file.txt"
+    on(bolt, command, accept_all_exit_codes: true) do |res|
+      assert_equal(res.exit_code, 0, 'cat was not successful')
+
+      file_contents_message = 'The expected file contents where not observed'
+      regex = /When in the course of human events/
+      assert_match(regex, res.stdout, file_contents_message)
+    end
+  end
+
+  step "execute `bolt file upload` via local transport with run-as" do
+    source = dest = 'local_file.txt'
+    on(bolt, "cp #{dir}/#{source} #{local_user_homedir}/#{source}")
+    on(bolt, "chown #{local_user} #{local_user_homedir}/#{source}")
+    # previous test has root-owned copy, local user cannot overwrite it
+    on(bolt, "rm -f /tmp/#{dest}")
+    bolt_command = "bolt file upload #{local_user_homedir}/#{source} /tmp/#{dest}"
+    flags = { '--nodes' => 'localhost', '--run-as' => "'#{local_user}'" }
+    result = bolt_command_on(bolt, bolt_command, flags)
+
+    message = "Unexpected output from the command:\n#{result.cmd}"
+    assert_match(/Uploaded.*#{source}.*to.*#{dest}/, result.stdout, message)
+
+    command = "cat /tmp/local_file.txt"
+    on(bolt, command, accept_all_exit_codes: true) do |res|
+      assert_equal(res.exit_code, 0, 'cat was not successful')
+
+      file_contents_message = 'The expected file contents where not observed'
+      regex = /When in the course of human events/
+      assert_match(regex, res.stdout, file_contents_message)
+    end
+
+    command = "ls -la /tmp/local_file.txt"
+    on(bolt, command, accept_all_exit_codes: true) do |res|
+      assert_equal(res.exit_code, 0, 'ls was not successful')
+
+      file_contents_message = "File not owned by #{local_user}"
+      regex = /#{local_user}/
+      assert_match(regex, res.stdout, file_contents_message)
+    end
+  end
+end

--- a/acceptance/tests/script_local.rb
+++ b/acceptance/tests/script_local.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'bolt_command_helper'
+
+test_name "bolt script run should execute script on localhost via local transport" do
+  extend Acceptance::BoltCommandHelper
+  extend Acceptance::BoltSetupHelper
+
+  skip_test('no applicable nodes to test on') if bolt['platform'] =~ /windows/
+
+  script = "test_local.sh"
+
+  step "create script on bolt controller" do
+    create_remote_file(bolt, script, <<-FILE)
+    #!/bin/sh
+    echo "$* there $(whoami)"
+    FILE
+  end
+
+  step "execute `bolt script run` on localhost" do
+    bolt_command = "bolt script run #{script} hello"
+
+    flags = { '--nodes' => 'localhost' }
+
+    result = bolt_command_on(bolt, bolt_command, flags)
+    message = "Unexpected output from the command:\n#{result.cmd}"
+    assert_match(/hello there root/, result.stdout, message)
+  end
+
+  step "execute `bolt script run` on localhost with run-as" do
+    # make sure local_user is allowed to run script
+    local_owned_script = "#{local_user_homedir}/test_local.sh"
+    on(bolt, "cp #{script} #{local_owned_script}")
+    on(bolt, "chown -R local_user #{local_owned_script}")
+
+    bolt_command = "bolt script run #{local_owned_script} hello"
+
+    flags = { '--nodes' => 'localhost', '--run-as' => "'#{local_user}'" }
+
+    result = bolt_command_on(bolt, bolt_command, flags)
+    message = "Unexpected output from the command:\n#{result.cmd}"
+    assert_match(/hello there #{local_user}/, result.stdout, message)
+  end
+end

--- a/acceptance/tests/task_local.rb
+++ b/acceptance/tests/task_local.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'bolt_command_helper'
+
+test_name "bolt task run should execute tasks on localhost via local transport" do
+  extend Acceptance::BoltCommandHelper
+  extend Acceptance::BoltSetupHelper
+
+  skip_test('no applicable nodes to test on') if bolt['platform'] =~ /windows/
+
+  dir = bolt.tmpdir('local_task')
+
+  step "create task on bolt controller" do
+    on(bolt, "mkdir -p #{dir}/modules/test/tasks")
+    create_remote_file(bolt, "#{dir}/modules/test/tasks/whoami_nix", <<-FILE)
+    #!/bin/sh
+    echo "$PT_greetings from $(whoami)"
+    FILE
+    # TODO: Use input_method: both (default) once bug BOLT-1283 is fixed
+    conf = { 'input_method' => 'environment' }
+    create_remote_file(bolt, "#{dir}/modules/test/tasks/whoami_nix.json", conf.to_json)
+  end
+
+  step "execute `bolt task run` on localhost via local transport" do
+    bolt_command = "bolt task run test::whoami_nix greetings=hello"
+    flags = {
+      '--nodes' => 'localhost',
+      '--modulepath' => "#{dir}/modules"
+    }
+
+    result = bolt_command_on(bolt, bolt_command, flags)
+    message = "Unexpected output from the command:\n#{result.cmd}"
+    regex = /hello from root/
+    assert_match(regex, result.stdout, message)
+  end
+
+  step "execute `bolt task run` on localhost via local transport with run-as" do
+    on(bolt, "cp -r #{dir}/modules #{local_user_homedir}")
+    on(bolt, "chown -R #{local_user} #{local_user_homedir}/modules")
+
+    bolt_command = "bolt task run test::whoami_nix greetings=hello"
+    flags = {
+      '--nodes' => 'localhost',
+      '--modulepath' => "#{local_user_homedir}/modules",
+      '--run-as' => "'#{local_user}'"
+    }
+
+    result = bolt_command_on(bolt, bolt_command, flags)
+    message = "Unexpected output from the command:\n#{result.cmd}"
+    regex = /hello from #{local_user}/
+    assert_match(regex, result.stdout, message)
+  end
+end


### PR DESCRIPTION
This commit adds acceptance tests for the local transport. These tests are intended to set a baseline for testing local transport on a variety of supported platforms that are not covered by integration tests. This first iteration tests the behaviour of run-as accross different platforms as well as using bolt's puppet to apply manifest code.