### PR TITLE
(BOLT-1243) Error with helpful message when no CLI command given

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -204,6 +204,10 @@ module Bolt
       if options[:subcommand] == 'apply' && (!options[:object] && !options[:code])
         raise Bolt::CLIError, "a manifest file or --execute is required"
       end
+
+      if options[:subcommand] == 'command' && (!options[:object] || options[:object].empty?)
+        raise Bolt::CLIError, "Must specify a command to run"
+      end
     end
 
     def handle_parser_errors


### PR DESCRIPTION
Previously an missing command argument would result in a stack trace. This commit validates that a command is given when invoking `bolt command run` on the CLI is a string with at least one character. Note this validation is modeled after the plan function `run_command` which validates the command argument is of type `String[1]`.