### PR TITLE
(BOLT-1223) Rename result type to result action, expose in plan

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/datatypes/applyresult.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/applyresult.rb
@@ -10,6 +10,8 @@ Puppet::DataTypes.create_type('ApplyResult') do
       error => Callable[[], Optional[Error]],
       ok => Callable[[], Boolean],
       message => Callable[[], Optional[String]],
+      action => Callable[[], String],
+      to_data => Callable[[], Hash],
     }
   PUPPET
 

--- a/bolt-modules/boltlib/lib/puppet/datatypes/result.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/result.rb
@@ -10,6 +10,7 @@ Puppet::DataTypes.create_type('Result') do
       error => Callable[[], Optional[Error]],
       message => Callable[[], Optional[String]],
       action => Callable[[], String],
+      to_data => Callable[[], Hash],
       ok => Callable[[], Boolean],
       '[]' => Callable[[String[1]], Data]
     }

--- a/bolt-modules/boltlib/lib/puppet/datatypes/result.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/result.rb
@@ -9,6 +9,7 @@ Puppet::DataTypes.create_type('Result') do
     functions => {
       error => Callable[[], Optional[Error]],
       message => Callable[[], Optional[String]],
+      action => Callable[[], String],
       ok => Callable[[], Boolean],
       '[]' => Callable[[String[1]], Data]
     }

--- a/bolt-modules/boltlib/lib/puppet/datatypes/resultset.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/resultset.rb
@@ -15,6 +15,7 @@ Puppet::DataTypes.create_type('ResultSet') do
       ok => Callable[[], Boolean],
       ok_set => Callable[[], ResultSet],
       targets => Callable[[], Array[Target]],
+      to_data => Callable[[], Array[Hash]],
     }
   PUPPET
 

--- a/lib/bolt/apply_result.rb
+++ b/lib/bolt/apply_result.rb
@@ -65,7 +65,7 @@ module Bolt
     def initialize(target, error: nil, report: nil)
       @target = target
       @value = {}
-      @type = 'apply'
+      @action = 'apply'
       value['report'] = report if report
       value['_error'] = error if error
       value['_output'] = metrics_message if metrics_message

--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -128,6 +128,10 @@ module Bolt
       to_json
     end
 
+    def to_data
+      Bolt::Util.walk_keys(status_hash, &:to_s)
+    end
+
     def ok?
       error_hash.nil?
     end

--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -5,7 +5,7 @@ require 'bolt/error'
 
 module Bolt
   class Result
-    attr_reader :target, :value, :type, :object
+    attr_reader :target, :value, :action, :object
 
     def self.from_exception(target, exception)
       @exception = exception
@@ -23,7 +23,7 @@ module Bolt
       Result.new(target, error: error)
     end
 
-    def self.for_command(target, stdout, stderr, exit_code, type, command)
+    def self.for_command(target, stdout, stderr, exit_code, action, command)
       value = {
         'stdout' => stdout,
         'stderr' => stderr,
@@ -37,7 +37,7 @@ module Bolt
           'details' => { 'exit_code' => exit_code }
         }
       end
-      new(target, value: value, type: type, object: command)
+      new(target, value: value, action: action, object: command)
     end
 
     def self.for_task(target, stdout, stderr, exit_code, task)
@@ -61,11 +61,11 @@ module Bolt
                             'msg' => msg,
                             'details' => { 'exit_code' => exit_code } }
       end
-      new(target, value: value, type: 'task', object: task)
+      new(target, value: value, action: 'task', object: task)
     end
 
     def self.for_upload(target, source, destination)
-      new(target, message: "Uploaded '#{source}' to '#{target.host}:#{destination}'", type: 'upload', object: source)
+      new(target, message: "Uploaded '#{source}' to '#{target.host}:#{destination}'", action: 'upload', object: source)
     end
 
     # Satisfies the Puppet datatypes API
@@ -73,10 +73,10 @@ module Bolt
       new(target, value: value)
     end
 
-    def initialize(target, error: nil, message: nil, value: nil, type: nil, object: nil)
+    def initialize(target, error: nil, message: nil, value: nil, action: nil, object: nil)
       @target = target
       @value = value || {}
-      @type = type
+      @action = action
       @object = object
       @value_set = !value.nil?
       if error && !error.is_a?(Hash)
@@ -94,7 +94,7 @@ module Bolt
       # DEPRECATION: node in status hashes is deprecated and should be removed in 2.0
       { node: @target.name,
         target: @target.name,
-        type: type,
+        action: action,
         object: object,
         status: ok? ? 'success' : 'failure',
         result: @value }

--- a/lib/bolt/result_set.rb
+++ b/lib/bolt/result_set.rb
@@ -90,6 +90,10 @@ module Bolt
       @results.map(&:status_hash).to_json(opts)
     end
 
+    def to_data
+      @results.map(&:to_data)
+    end
+
     def to_s
       to_json
     end

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -75,7 +75,7 @@ module Bolt
           # If it's finished or already has a proper error simply pass it to the
           # the result otherwise make sure an error is generated
           if state == 'finished' || (result && result['_error'])
-            Bolt::Result.new(target, value: result, type: 'task', object: task_name)
+            Bolt::Result.new(target, value: result, action: 'task', object: task_name)
           elsif state == 'skipped'
             Bolt::Result.new(
               target,
@@ -84,7 +84,7 @@ module Bolt
                 'msg' => "Node #{target.host} was skipped",
                 'details' => {}
               } },
-              type: 'task', object: task_name
+              action: 'task', object: task_name
             )
           else
             # Make a generic error with a unkown exit_code
@@ -230,7 +230,7 @@ module Bolt
       # run_task generates a result that makes sense for a generic task which
       # needs to be unwrapped to extract stdout/stderr/exitcode.
       #
-      def unwrap_bolt_result(target, result, type, obj)
+      def unwrap_bolt_result(target, result, action, obj)
         if result.error_hash
           # something went wrong return the failure
           return result
@@ -240,7 +240,7 @@ module Bolt
                                  result.value['stdout'],
                                  result.value['stderr'],
                                  result.value['exit_code'],
-                                 type, obj)
+                                 action, obj)
       end
     end
   end

--- a/pre-docs/writing_plans.md
+++ b/pre-docs/writing_plans.md
@@ -281,6 +281,8 @@ A `ResultSet` has the following methods:
 
 -   `ok():``Boolean` that is the same as `error_nodes.empty`.
 
+-   `to_data()`: An array of Hashes representing either `Result`s or `ApplyResults`
+
 
 A `Result` has the following methods:
 
@@ -296,6 +298,10 @@ A `Result` has the following methods:
 
 -   `[]`: Accesses the value hash directly.
 
+-   `to_data()`: Hash representation of `Result`.
+
+-   `action()`: String representation of result type (task, command, etc).
+
 
 An `ApplyResult` has the following methods:
 
@@ -307,6 +313,9 @@ An `ApplyResult` has the following methods:
 
 -   `ok()`: Returns `true` if the `Result` was successful.
 
+-   `to_data()`: Hash representation of `ApplyResult`.
+
+-   `action()`: String representation of result type (apply).
 
 An instance of `ResultSet` is `Iterable` as if it were an `Array[Variant[Result, ApplyResult]]` so that iterative functions such as `each`, `map`, `reduce`, or `filter` work directly on the ResultSet returning each result.
 
@@ -331,6 +340,13 @@ $r.each |$result| {
     notice("${node} errored with a message: ${result.error.message}")
   }
 }
+```
+
+Similarly you can iterate over the array of hashes returned by calling `to_data` on a `ResultSet` and access hash values. For example:
+
+```
+$r = run_command('whoami', 'localhost,local://0.0.0.0')
+$r.to_data.each |$result_hash| { notice($result_hash['result']['stdout']) }
 ```
 
 ## Passing sensitive data to tasks

--- a/spec/bolt/apply_result_spec.rb
+++ b/spec/bolt/apply_result_spec.rb
@@ -50,11 +50,11 @@ describe Bolt::ApplyResult do
     end
   end
 
-  describe 'type and object' do
-    it 'exposes apply as the type' do
+  describe 'action and object' do
+    it 'exposes apply as the action' do
       result = Bolt::Result.for_task(:target, 'hello', '', 0, 'catalog')
       result = Bolt::ApplyResult.new(result)
-      expect(result.type).to be('apply')
+      expect(result.action).to be('apply')
       expect(result.object).to be(nil)
     end
   end

--- a/spec/bolt/apply_result_spec.rb
+++ b/spec/bolt/apply_result_spec.rb
@@ -58,4 +58,26 @@ describe Bolt::ApplyResult do
       expect(result.object).to be(nil)
     end
   end
+
+  describe 'exposes methods for examining data' do
+    let(:example_target) { Bolt::Target.new('target') }
+    let(:task_result) { Bolt::Result.for_task(example_target, 'hello', '', 0, 'catalog') }
+    let(:apply_result) { Bolt::ApplyResult.from_task_result(task_result) }
+    let(:expected) {
+      { "node" => "target",
+        "target" => "target",
+        "action" => "apply",
+        "object" => nil,
+        "status" => "success",
+        "result" => { "report" => { "_output" => "hello" } } }
+    }
+
+    it 'with to_json' do
+      expect(JSON.parse(apply_result.to_json)).to eq(expected)
+    end
+
+    it 'with to_data' do
+      expect(apply_result.to_data).to eq(expected)
+    end
+  end
 end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1545,7 +1545,7 @@ describe "Bolt::CLI" do
             [{ 'node' => 'foo',
                'target' => 'foo',
                'status' => 'success',
-               'type' => 'task',
+               'action' => 'task',
                'object' => 'some_task',
                'result' => { '_output' => 'yes' } }]
           )
@@ -1576,7 +1576,7 @@ describe "Bolt::CLI" do
             [{ 'node' => 'foo',
                'target' => 'foo',
                'status' => 'success',
-               'type' => 'task',
+               'action' => 'task',
                'object' => 'some_task',
                'result' => { '_output' => 'yes' } }]
           )
@@ -1613,7 +1613,7 @@ describe "Bolt::CLI" do
                 'node' => 'foo',
                 'target' => 'foo',
                 'status' => 'failure',
-                'type' => 'task',
+                'action' => 'task',
                 'object' => 'some_task',
                 'result' => {
                   "_output" => "no",

--- a/spec/bolt/result_set_spec.rb
+++ b/spec/bolt/result_set_spec.rb
@@ -25,13 +25,13 @@ describe Bolt::Result do
   it 'is creates the correct json' do
     expected = [{ "node" => "node1",
                   "target" => "node1",
-                  "type" => nil,
+                  "action" => nil,
                   "object" => nil,
                   "status" => "success",
                   "result" => { "key" => "val1" } },
                 { "node" => "node1",
                   "target" => "node1",
-                  "type" => nil,
+                  "action" => nil,
                   "object" => nil,
                   "status" => "failure",
                   "result" => { "key" => "val2", "_error" => { "kind" => "bolt/oops" } } }]

--- a/spec/bolt/result_set_spec.rb
+++ b/spec/bolt/result_set_spec.rb
@@ -17,24 +17,30 @@ describe Bolt::Result do
                           Bolt::Result.new(Bolt::Target.new(target2), value: result_val2)
                         ])
   end
+  let(:expected) {
+    [{ "node" => "node1",
+       "target" => "node1",
+       "action" => nil,
+       "object" => nil,
+       "status" => "success",
+       "result" => { "key" => "val1" } },
+     { "node" => "node1",
+       "target" => "node1",
+       "action" => nil,
+       "object" => nil,
+       "status" => "failure",
+       "result" => { "key" => "val2", "_error" => { "kind" => "bolt/oops" } } }]
+  }
 
   it 'is enumerable' do
     expect(result_set.map { |r| r['key'] }).to eq(%w[val1 val2])
   end
 
-  it 'is creates the correct json' do
-    expected = [{ "node" => "node1",
-                  "target" => "node1",
-                  "action" => nil,
-                  "object" => nil,
-                  "status" => "success",
-                  "result" => { "key" => "val1" } },
-                { "node" => "node1",
-                  "target" => "node1",
-                  "action" => nil,
-                  "object" => nil,
-                  "status" => "failure",
-                  "result" => { "key" => "val2", "_error" => { "kind" => "bolt/oops" } } }]
+  it 'to_json creates the correct json' do
     expect(JSON.parse(result_set.to_json)).to eq(expected)
+  end
+
+  it 'to_data exposes resultset as array of hashes' do
+    expect(result_set.to_data).to eq(expected)
   end
 end

--- a/spec/bolt/transport/shared_examples.rb
+++ b/spec/bolt/transport/shared_examples.rb
@@ -91,7 +91,7 @@ shared_examples 'transport api' do
       command, expected = os_context[:stdout_command]
       result = runner.run_command(target, command)
       expect(result.value['stdout']).to match(expected)
-      expect(result.type).to eq('command')
+      expect(result.action).to eq('command')
       expect(result.object).to eq(command)
     end
 
@@ -127,7 +127,7 @@ shared_examples 'transport api' do
       with_tempfile_containing('upload-test', contents) do |file|
         result = runner.upload(target, file.path, remote_path)
         expect(result.message).to eq("Uploaded '#{file.path}' to '#{target.host}:#{remote_path}'")
-        expect(result.type).to eq('upload')
+        expect(result.action).to eq('upload')
         expect(result.object).to eq(file.path)
 
         expect(
@@ -166,7 +166,7 @@ shared_examples 'transport api' do
       with_tempfile_containing('script test', os_context[:echo_script]) do |file|
         result = runner.run_script(target, file.path, [])
         expect(result['stdout'].strip).to eq('')
-        expect(result.type).to eq('script')
+        expect(result.action).to eq('script')
         expect(result.object).to eq(file.path)
       end
     end

--- a/spec/integration/target_spec.rb
+++ b/spec/integration/target_spec.rb
@@ -26,7 +26,7 @@ describe "when running a plan that creates targets", ssh: true do
           {
             'node' => uri,
             'target' => uri,
-            'type' => 'task',
+            'action' => 'task',
             'object' => 'results',
             'status' => 'success',
             'result' => {


### PR DESCRIPTION
This commit renames the type attribute of a result object to action (BOLT-1125). It also exposes it as an action method for a result object in the plan language.