### PR TITLE
(BOLT-1274) Raise validation error when inventory config is invalid

### DIFF
--- a/lib/bolt/inventory/group.rb
+++ b/lib/bolt/inventory/group.rb
@@ -62,6 +62,11 @@ module Bolt
             msg = "Found unexpected key(s) #{unexpected_keys.join(', ')} in node #{node['name']}"
             @logger.warn(msg)
           end
+
+          unless node['config'].nil? || node['config'].is_a?(Hash)
+            raise ValidationError.new("Invalid configuration for node: #{node['name']}", @name)
+          end
+
           config_keys = node['config']&.keys || []
           unless (unexpected_keys = config_keys - CONFIG_KEYS).empty?
             msg = "Found unexpected key(s) #{unexpected_keys.join(', ')} in config for node #{node['name']}"

--- a/lib/bolt/inventory/group2.rb
+++ b/lib/bolt/inventory/group2.rb
@@ -102,6 +102,11 @@ module Bolt
           msg = "Found unexpected key(s) #{unexpected_keys.join(', ')} in target #{target['name']}"
           @logger.warn(msg)
         end
+
+        unless target['config'].nil? || target['config'].is_a?(Hash)
+          raise ValidationError.new("Invalid configuration for target: #{target['name']}", @name)
+        end
+
         config_keys = target['config']&.keys || []
         unless (unexpected_keys = config_keys - CONFIG_KEYS).empty?
           msg = "Found unexpected key(s) #{unexpected_keys.join(', ')} in config for target #{target['name']}"

--- a/spec/bolt/inventory/group2_spec.rb
+++ b/spec/bolt/inventory/group2_spec.rb
@@ -438,6 +438,24 @@ describe Bolt::Inventory::Group2 do
     end
   end
 
+  context 'where a config value is not a hash' do
+    let(:data) do
+      {
+        'name' => 'group1',
+        'groups' => [
+          {
+            'name' => 'foo1',
+            'targets' => [{ 'name' => 'foo1', 'config' => 'foo' }]
+          }
+        ]
+      }
+    end
+
+    it 'raises an error' do
+      expect { group.validate }.to raise_error(Bolt::Inventory::ValidationError, /Invalid configuration for target/)
+    end
+  end
+
   context 'with nested groups' do
     context 'when one group contains a child group' do
       let(:data) do

--- a/spec/bolt/inventory/group_spec.rb
+++ b/spec/bolt/inventory/group_spec.rb
@@ -436,6 +436,24 @@ describe Bolt::Inventory::Group do
     end
   end
 
+  context 'where a config value is not a hash' do
+    let(:data) do
+      {
+        'name' => 'group1',
+        'groups' => [
+          {
+            'name' => 'foo1',
+            'nodes' => [{ 'name' => 'foo1', 'config' => 'foo' }]
+          }
+        ]
+      }
+    end
+
+    it 'raises an error' do
+      expect { group.validate }.to raise_error(Bolt::Inventory::ValidationError, /Invalid configuration for node/)
+    end
+  end
+
   context 'with nested groups' do
     context 'when one group contains a child group' do
       let(:data) do


### PR DESCRIPTION
Previously if the config set in inventory was either not defined, or was not a hash a stack trace would be raised when trying to access `target['options']&.keys`. This commit adds a validation step to ensure there is either no config set or that if it is set that it is a hash. The net effect is to raise a validation error pointing to the offending key instead of a stack trace.