### PR TITLE
(BOLT-1154) Remove unnecessary guard conditions in plan functions

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/add_facts.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/add_facts.rb
@@ -23,9 +23,9 @@ Puppet::Functions.create_function(:add_facts) do
         .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'add_facts')
     end
 
-    inventory = Puppet.lookup(:bolt_inventory) { nil }
-    executor = Puppet.lookup(:bolt_executor) { nil }
-    executor&.report_function_call('add_facts')
+    inventory = Puppet.lookup(:bolt_inventory)
+    executor = Puppet.lookup(:bolt_executor)
+    executor.report_function_call('add_facts')
 
     inventory.add_facts(target, facts)
   end

--- a/bolt-modules/boltlib/lib/puppet/functions/add_facts.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/add_facts.rb
@@ -24,13 +24,6 @@ Puppet::Functions.create_function(:add_facts) do
     end
 
     inventory = Puppet.lookup(:bolt_inventory) { nil }
-
-    unless inventory
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('add facts')
-      )
-    end
-
     executor = Puppet.lookup(:bolt_executor) { nil }
     executor&.report_function_call('add_facts')
 

--- a/bolt-modules/boltlib/lib/puppet/functions/add_to_group.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/add_to_group.rb
@@ -27,10 +27,9 @@ Puppet::Functions.create_function(:add_to_group) do
         .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'add_to_group')
     end
 
-    inventory = Puppet.lookup(:bolt_inventory) { nil }
-
-    executor = Puppet.lookup(:bolt_executor) { nil }
-    executor&.report_function_call('add_to_group')
+    inventory = Puppet.lookup(:bolt_inventory)
+    executor = Puppet.lookup(:bolt_executor)
+    executor.report_function_call('add_to_group')
 
     inventory.add_to_group(inventory.get_targets(targets), group)
   end

--- a/bolt-modules/boltlib/lib/puppet/functions/add_to_group.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/add_to_group.rb
@@ -29,12 +29,6 @@ Puppet::Functions.create_function(:add_to_group) do
 
     inventory = Puppet.lookup(:bolt_inventory) { nil }
 
-    unless inventory && Puppet.features.bolt?
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('process targets through inventory')
-      )
-    end
-
     executor = Puppet.lookup(:bolt_executor) { nil }
     executor&.report_function_call('add_to_group')
 

--- a/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
@@ -50,12 +50,6 @@ Puppet::Functions.create_function(:apply_prep) do
     executor = Puppet.lookup(:bolt_executor) { nil }
     inventory = Puppet.lookup(:bolt_inventory) { nil }
 
-    unless applicator && executor && inventory && Puppet.features.bolt?
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('apply_prep')
-      )
-    end
-
     executor.report_function_call('apply_prep')
 
     targets = inventory.get_targets(target_spec)

--- a/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
@@ -46,9 +46,9 @@ Puppet::Functions.create_function(:apply_prep) do
         .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'apply_prep')
     end
 
-    applicator = Puppet.lookup(:apply_executor) { nil }
-    executor = Puppet.lookup(:bolt_executor) { nil }
-    inventory = Puppet.lookup(:bolt_inventory) { nil }
+    applicator = Puppet.lookup(:apply_executor)
+    executor = Puppet.lookup(:bolt_executor)
+    inventory = Puppet.lookup(:bolt_inventory)
 
     executor.report_function_call('apply_prep')
 

--- a/bolt-modules/boltlib/lib/puppet/functions/facts.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/facts.rb
@@ -14,14 +14,8 @@ Puppet::Functions.create_function(:facts) do
   end
 
   def facts(target)
-    inventory = Puppet.lookup(:bolt_inventory) { nil }
-
-    unless inventory
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('get facts for a target')
-      )
-    end
-
+    inventory = Puppet.lookup(:bolt_inventory)
+    # Bolt executor not expected when invoked from apply block
     executor = Puppet.lookup(:bolt_executor) { nil }
     executor&.report_function_call('facts')
 

--- a/bolt-modules/boltlib/lib/puppet/functions/fail_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/fail_plan.rb
@@ -39,8 +39,8 @@ Puppet::Functions.create_function(:fail_plan) do
         .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'fail_plan')
     end
 
-    executor = Puppet.lookup(:bolt_executor) { nil }
-    executor&.report_function_call('fail_plan')
+    executor = Puppet.lookup(:bolt_executor)
+    executor.report_function_call('fail_plan')
 
     raise Bolt::PlanFailure.new(msg, kind || 'bolt/plan-failure', details, issue_code)
   end

--- a/bolt-modules/boltlib/lib/puppet/functions/get_resources.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/get_resources.rb
@@ -42,11 +42,6 @@ Puppet::Functions.create_function(:get_resources) do
     applicator = Puppet.lookup(:apply_executor) { nil }
     executor = Puppet.lookup(:bolt_executor) { nil }
     inventory = Puppet.lookup(:bolt_inventory) { nil }
-    unless applicator && executor && inventory && Puppet.features.bolt?
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('get_resources')
-      )
-    end
 
     resources = [resources].flatten
     resources.each do |resource|

--- a/bolt-modules/boltlib/lib/puppet/functions/get_resources.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/get_resources.rb
@@ -39,9 +39,9 @@ Puppet::Functions.create_function(:get_resources) do
         .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'get_resources')
     end
 
-    applicator = Puppet.lookup(:apply_executor) { nil }
-    executor = Puppet.lookup(:bolt_executor) { nil }
-    inventory = Puppet.lookup(:bolt_inventory) { nil }
+    applicator = Puppet.lookup(:apply_executor)
+    executor = Puppet.lookup(:bolt_executor)
+    inventory = Puppet.lookup(:bolt_inventory)
 
     resources = [resources].flatten
     resources.each do |resource|

--- a/bolt-modules/boltlib/lib/puppet/functions/get_targets.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/get_targets.rb
@@ -24,7 +24,7 @@ Puppet::Functions.create_function(:get_targets) do
   def get_targets(names)
     inventory = Puppet.lookup(:bolt_inventory) { nil }
 
-    unless inventory && Puppet.features.bolt?
+    unless inventory
       raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
         Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('process targets through inventory')
       )

--- a/bolt-modules/boltlib/lib/puppet/functions/get_targets.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/get_targets.rb
@@ -22,14 +22,8 @@ Puppet::Functions.create_function(:get_targets) do
   end
 
   def get_targets(names)
-    inventory = Puppet.lookup(:bolt_inventory) { nil }
-
-    unless inventory
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('process targets through inventory')
-      )
-    end
-
+    inventory = Puppet.lookup(:bolt_inventory)
+    # Bolt executor not expected when invoked from apply block
     executor = Puppet.lookup(:bolt_executor) { nil }
     executor&.report_function_call('get_targets')
 

--- a/bolt-modules/boltlib/lib/puppet/functions/puppetdb_fact.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/puppetdb_fact.rb
@@ -17,13 +17,8 @@ Puppet::Functions.create_function(:puppetdb_fact) do
   end
 
   def puppetdb_fact(certnames)
-    puppetdb_client = Puppet.lookup(:bolt_pdb_client) { nil }
-    unless puppetdb_client
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('query facts from puppetdb')
-      )
-    end
-
+    puppetdb_client = Puppet.lookup(:bolt_pdb_client)
+    # Bolt executor not expected when invoked from apply block
     executor = Puppet.lookup(:bolt_executor) { nil }
     executor&.report_function_call('puppetdb_fact')
 

--- a/bolt-modules/boltlib/lib/puppet/functions/puppetdb_query.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/puppetdb_query.rb
@@ -19,13 +19,8 @@ Puppet::Functions.create_function(:puppetdb_query) do
   # The query type could be more specific ASTQuery = Array[Variant[String, ASTQuery]]
 
   def make_query(query)
-    puppetdb_client = Puppet.lookup(:bolt_pdb_client) { nil }
-    unless puppetdb_client
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('query facts from puppetdb')
-      )
-    end
-
+    puppetdb_client = Puppet.lookup(:bolt_pdb_client)
+    # Bolt executor not expected when invoked from apply block
     executor = Puppet.lookup(:bolt_executor) { nil }
     executor&.report_function_call('puppetdb_query')
 

--- a/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
@@ -49,8 +49,8 @@ Puppet::Functions.create_function(:run_command) do
 
     options ||= {}
     options = options.merge('_description' => description) if description
-    executor = Puppet.lookup(:bolt_executor) { nil }
-    inventory = Puppet.lookup(:bolt_inventory) { nil }
+    executor = Puppet.lookup(:bolt_executor)
+    inventory = Puppet.lookup(:bolt_inventory)
 
     executor.report_function_call('run_command')
 

--- a/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
@@ -51,11 +51,6 @@ Puppet::Functions.create_function(:run_command) do
     options = options.merge('_description' => description) if description
     executor = Puppet.lookup(:bolt_executor) { nil }
     inventory = Puppet.lookup(:bolt_inventory) { nil }
-    unless executor && inventory && Puppet.features.bolt?
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('run a command')
-      )
-    end
 
     executor.report_function_call('run_command')
 

--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -24,7 +24,7 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
         .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'run_plan')
     end
 
-    executor = Puppet.lookup(:bolt_executor) { nil }
+    executor = Puppet.lookup(:bolt_executor)
 
     # Bolt calls this function internally to trigger plans from the CLI. We
     # don't want to count those invocations.

--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -25,11 +25,6 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
     end
 
     executor = Puppet.lookup(:bolt_executor) { nil }
-    unless executor && Puppet.features.bolt?
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('run a plan')
-      )
-    end
 
     # Bolt calls this function internally to trigger plans from the CLI. We
     # don't want to count those invocations.

--- a/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
@@ -55,8 +55,8 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
 
     options ||= {}
     options = options.merge('_description' => description) if description
-    executor = Puppet.lookup(:bolt_executor) { nil }
-    inventory = Puppet.lookup(:bolt_inventory) { nil }
+    executor = Puppet.lookup(:bolt_executor)
+    inventory = Puppet.lookup(:bolt_inventory)
 
     executor.report_function_call('run_script')
 

--- a/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
@@ -57,11 +57,6 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
     options = options.merge('_description' => description) if description
     executor = Puppet.lookup(:bolt_executor) { nil }
     inventory = Puppet.lookup(:bolt_inventory) { nil }
-    unless executor && inventory && Puppet.features.bolt?
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('run a script')
-      )
-    end
 
     executor.report_function_call('run_script')
 

--- a/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
@@ -77,11 +77,6 @@ Puppet::Functions.create_function(:run_task) do
     task_args ||= {}
     executor = Puppet.lookup(:bolt_executor) { nil }
     inventory = Puppet.lookup(:bolt_inventory) { nil }
-    unless executor && inventory && Puppet.features.bolt?
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('run a task')
-      )
-    end
 
     # Bolt calls this function internally to trigger tasks from the CLI. We
     # don't want to count those invocations.

--- a/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
@@ -75,8 +75,8 @@ Puppet::Functions.create_function(:run_task) do
     end
 
     task_args ||= {}
-    executor = Puppet.lookup(:bolt_executor) { nil }
-    inventory = Puppet.lookup(:bolt_inventory) { nil }
+    executor = Puppet.lookup(:bolt_executor)
+    inventory = Puppet.lookup(:bolt_inventory)
 
     # Bolt calls this function internally to trigger tasks from the CLI. We
     # don't want to count those invocations.

--- a/bolt-modules/boltlib/lib/puppet/functions/set_feature.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_feature.rb
@@ -30,10 +30,9 @@ Puppet::Functions.create_function(:set_feature) do
         .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'set_feature')
     end
 
-    inventory = Puppet.lookup(:bolt_inventory) { nil }
-
-    executor = Puppet.lookup(:bolt_executor) { nil }
-    executor&.report_function_call('set_feature')
+    inventory = Puppet.lookup(:bolt_inventory)
+    executor = Puppet.lookup(:bolt_executor)
+    executor.report_function_call('set_feature')
 
     inventory.set_feature(target, feature, value)
 

--- a/bolt-modules/boltlib/lib/puppet/functions/set_feature.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_feature.rb
@@ -32,12 +32,6 @@ Puppet::Functions.create_function(:set_feature) do
 
     inventory = Puppet.lookup(:bolt_inventory) { nil }
 
-    unless inventory
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('set feature')
-      )
-    end
-
     executor = Puppet.lookup(:bolt_executor) { nil }
     executor&.report_function_call('set_feature')
 

--- a/bolt-modules/boltlib/lib/puppet/functions/set_var.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_var.rb
@@ -26,12 +26,6 @@ Puppet::Functions.create_function(:set_var) do
 
     inventory = Puppet.lookup(:bolt_inventory) { nil }
 
-    unless inventory
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('set a var on a target')
-      )
-    end
-
     executor = Puppet.lookup(:bolt_executor) { nil }
     executor&.report_function_call('set_var')
 

--- a/bolt-modules/boltlib/lib/puppet/functions/set_var.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_var.rb
@@ -24,10 +24,9 @@ Puppet::Functions.create_function(:set_var) do
         .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'set_var')
     end
 
-    inventory = Puppet.lookup(:bolt_inventory) { nil }
-
-    executor = Puppet.lookup(:bolt_executor) { nil }
-    executor&.report_function_call('set_var')
+    inventory = Puppet.lookup(:bolt_inventory)
+    executor = Puppet.lookup(:bolt_executor)
+    executor.report_function_call('set_var')
 
     inventory.set_var(target, key, value)
   end

--- a/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
@@ -61,11 +61,6 @@ Puppet::Functions.create_function(:upload_file, Puppet::Functions::InternalFunct
     options = options.merge('_description' => description) if description
     executor = Puppet.lookup(:bolt_executor) { nil }
     inventory = Puppet.lookup(:bolt_inventory) { nil }
-    unless executor && inventory && Puppet.features.bolt?
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('do file uploads')
-      )
-    end
 
     executor.report_function_call('upload_file')
 

--- a/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
@@ -59,8 +59,8 @@ Puppet::Functions.create_function(:upload_file, Puppet::Functions::InternalFunct
 
     options ||= {}
     options = options.merge('_description' => description) if description
-    executor = Puppet.lookup(:bolt_executor) { nil }
-    inventory = Puppet.lookup(:bolt_inventory) { nil }
+    executor = Puppet.lookup(:bolt_executor)
+    inventory = Puppet.lookup(:bolt_inventory)
 
     executor.report_function_call('upload_file')
 

--- a/bolt-modules/boltlib/lib/puppet/functions/vars.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/vars.rb
@@ -18,14 +18,8 @@ Puppet::Functions.create_function(:vars) do
   end
 
   def vars(target)
-    inventory = Puppet.lookup(:bolt_inventory) { nil }
-
-    unless inventory
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('get vars')
-      )
-    end
-
+    inventory = Puppet.lookup(:bolt_inventory)
+    # Bolt executor not expected when invoked from apply block
     executor = Puppet.lookup(:bolt_executor) { nil }
     executor&.report_function_call('vars')
 

--- a/bolt-modules/boltlib/lib/puppet/functions/wait_until_available.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/wait_until_available.rb
@@ -26,13 +26,8 @@ Puppet::Functions.create_function(:wait_until_available) do
     end
 
     options ||= {}
-    executor = Puppet.lookup(:bolt_executor) { nil }
-    inventory = Puppet.lookup(:bolt_inventory) { nil }
-    unless executor && inventory && Puppet.features.bolt?
-      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
-        Puppet::Pops::Issues::TASK_MISSING_BOLT, action: _('wait until targets are available')
-      )
-    end
+    executor = Puppet.lookup(:bolt_executor)
+    inventory = Puppet.lookup(:bolt_inventory)
 
     executor.report_function_call('wait_until_available')
 

--- a/bolt-modules/boltlib/lib/puppet/functions/without_default_logging.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/without_default_logging.rb
@@ -28,7 +28,7 @@ Puppet::Functions.create_function(:without_default_logging) do
                               action: 'without_default_logging')
     end
 
-    executor = Puppet.lookup(:bolt_executor) { nil }
+    executor = Puppet.lookup(:bolt_executor)
     executor.report_function_call('without_default_logging')
 
     executor.without_default_logging do

--- a/bolt-modules/boltlib/spec/functions/add_facts_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/add_facts_spec.rb
@@ -13,8 +13,6 @@ describe 'add_facts' do
 
   around(:each) do |example|
     Puppet[:tasks] = tasks_enabled
-    Puppet.features.stubs(:bolt?).returns(true)
-
     Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
       example.run
     end

--- a/bolt-modules/boltlib/spec/functions/add_to_group_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/add_to_group_spec.rb
@@ -10,8 +10,6 @@ describe 'add_to_group' do
 
   around(:each) do |example|
     Puppet[:tasks] = tasks_enabled
-    Puppet.features.stubs(:bolt?).returns(true)
-
     Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
       example.run
     end

--- a/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
@@ -17,8 +17,6 @@ describe 'apply_prep' do
 
   around(:each) do |example|
     Puppet[:tasks] = tasks_enabled
-    Puppet.features.stubs(:bolt?).returns(true)
-
     executor.stubs(:noop).returns(false)
 
     Puppet.override(bolt_executor: executor, bolt_inventory: inventory, apply_executor: applicator) do

--- a/bolt-modules/boltlib/spec/functions/facts_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/facts_spec.rb
@@ -14,8 +14,6 @@ describe 'facts' do
 
   around(:each) do |example|
     Puppet[:tasks] = true
-    Puppet.features.stubs(:bolt?).returns(true)
-
     Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
       example.run
     end

--- a/bolt-modules/boltlib/spec/functions/fail_plan_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/fail_plan_spec.rb
@@ -7,9 +7,13 @@ require 'bolt/error'
 describe 'fail_plan' do
   include PuppetlabsSpec::Fixtures
   let(:tasks_enabled) { true }
+  let(:executor) { Bolt::Executor.new }
 
-  before(:each) do
+  around(:each) do |example|
     Puppet[:tasks] = tasks_enabled
+    Puppet.override(bolt_executor: executor) do
+      example.run
+    end
   end
 
   it 'raises an error from arguments' do

--- a/bolt-modules/boltlib/spec/functions/get_resources_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/get_resources_spec.rb
@@ -17,8 +17,6 @@ describe 'get_resources' do
 
   around(:each) do |example|
     Puppet[:tasks] = tasks_enabled
-    Puppet.features.stubs(:bolt?).returns(true)
-
     executor.stubs(:noop).returns(false)
 
     Puppet.override(bolt_executor: executor, bolt_inventory: inventory, apply_executor: applicator) do

--- a/bolt-modules/boltlib/spec/functions/get_targets_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/get_targets_spec.rb
@@ -19,9 +19,6 @@ describe 'get_targets' do
   context 'it calls inventory get_targets' do
     let(:hostname) { 'test.example.com' }
     let(:target) { Bolt::Target.new(hostname) }
-    before(:each) do
-      Puppet.features.stubs(:bolt?).returns(true)
-    end
 
     it 'with given host' do
       inventory.expects(:get_targets).with(hostname).returns([target])

--- a/bolt-modules/boltlib/spec/functions/get_targets_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/get_targets_spec.rb
@@ -64,12 +64,4 @@ describe 'get_targets' do
       is_expected.to run.with_params(hostname).and_return([target])
     end
   end
-
-  context 'without bolt feature present' do
-    it 'fails and reports that bolt library is required' do
-      Puppet.features.stubs(:bolt?).returns(false)
-      is_expected.to run.with_params('echo hello')
-                        .and_raise_error(/The 'bolt' library is required to process targets through inventory/)
-    end
-  end
 end

--- a/bolt-modules/boltlib/spec/functions/puppetdb_fact.rb
+++ b/bolt-modules/boltlib/spec/functions/puppetdb_fact.rb
@@ -9,8 +9,6 @@ describe 'puppetdb_fact' do
 
   around(:each) do |example|
     Puppet[:tasks] = true
-    Puppet.features.stubs(:bolt?).returns(true)
-
     Puppet.override(bolt_pdb_client: pdb_client) do
       example.run
     end

--- a/bolt-modules/boltlib/spec/functions/puppetdb_query.rb
+++ b/bolt-modules/boltlib/spec/functions/puppetdb_query.rb
@@ -9,8 +9,6 @@ describe 'puppetdb_query' do
 
   around(:each) do |example|
     Puppet[:tasks] = true
-    Puppet.features.stubs(:bolt?).returns(true)
-
     Puppet.override(bolt_pdb_client: pdb_client) do
       example.run
     end

--- a/bolt-modules/boltlib/spec/functions/run_command_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_command_spec.rb
@@ -141,14 +141,6 @@ describe 'run_command' do
     end
   end
 
-  context 'without bolt feature present' do
-    it 'fails and reports that bolt library is required' do
-      Puppet.features.stubs(:bolt?).returns(false)
-      is_expected.to run.with_params('echo hello', [])
-                        .and_raise_error(/The 'bolt' library is required to run a command/)
-    end
-  end
-
   context 'without tasks enabled' do
     let(:tasks_enabled) { false }
     it 'fails and reports that run_command is not available' do

--- a/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
@@ -11,7 +11,6 @@ describe 'run_plan' do
 
   around(:each) do |example|
     Puppet[:tasks] = tasks_enabled
-    Puppet.features.stubs(:bolt?).returns(true)
     executor.stubs(:noop).returns(false)
 
     Puppet.override(bolt_executor: executor) do

--- a/bolt-modules/boltlib/spec/functions/run_script_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_script_spec.rb
@@ -167,14 +167,6 @@ describe 'run_script' do
     end
   end
 
-  context 'without bolt feature present' do
-    it 'fails and reports that bolt library is required' do
-      Puppet.features.stubs(:bolt?).returns(false)
-      is_expected.to run
-        .with_params('test/uploads/nonesuch.sh', []).and_raise_error(/The 'bolt' library is required to run a script/)
-    end
-  end
-
   context 'without tasks enabled' do
     let(:tasks_enabled) { false }
 

--- a/bolt-modules/boltlib/spec/functions/run_task_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_spec.rb
@@ -32,8 +32,6 @@ describe 'run_task' do
 
   around(:each) do |example|
     Puppet[:tasks] = tasks_enabled
-    Puppet.features.stubs(:bolt?).returns(true)
-
     executor.stubs(:noop).returns(false)
 
     Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do

--- a/bolt-modules/boltlib/spec/functions/set_feature_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/set_feature_spec.rb
@@ -14,8 +14,6 @@ describe 'set_feature' do
 
   around(:each) do |example|
     Puppet[:tasks] = tasks_enabled
-    Puppet.features.stubs(:bolt?).returns(true)
-
     Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
       example.run
     end

--- a/bolt-modules/boltlib/spec/functions/set_var_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/set_var_spec.rb
@@ -13,8 +13,6 @@ describe 'set_var' do
 
   around(:each) do |example|
     Puppet[:tasks] = tasks_enabled
-    Puppet.features.stubs(:bolt?).returns(true)
-
     Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
       example.run
     end

--- a/bolt-modules/boltlib/spec/functions/upload_file_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/upload_file_spec.rb
@@ -166,14 +166,6 @@ describe 'upload_file' do
     end
   end
 
-  context 'without bolt feature present' do
-    it 'fails and reports that bolt library is required' do
-      Puppet.features.stubs(:bolt?).returns(false)
-      is_expected.to run.with_params('test/uploads/nonesuch.html', '/some/place', [])
-                        .and_raise_error(/The 'bolt' library is required to do file uploads/)
-    end
-  end
-
   context 'without tasks enabled' do
     let(:tasks_enabled) { false }
 

--- a/bolt-modules/boltlib/spec/functions/vars_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/vars_spec.rb
@@ -14,8 +14,6 @@ describe 'vars' do
 
   around(:each) do |example|
     Puppet[:tasks] = true
-    Puppet.features.stubs(:bolt?).returns(true)
-
     Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
       example.run
     end

--- a/bolt-modules/boltlib/spec/functions/wait_until_available_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/wait_until_available_spec.rb
@@ -47,14 +47,6 @@ describe 'wait_until_available' do
     end
   end
 
-  context 'without bolt feature present' do
-    it 'fails and reports that bolt library is required' do
-      Puppet.features.stubs(:bolt?).returns(false)
-      is_expected.to run.with_params('echo hello')
-                        .and_raise_error(/The 'bolt' library is required to wait until targets are available/)
-    end
-  end
-
   context 'without tasks enabled' do
     let(:tasks_enabled) { false }
 

--- a/lib/bolt/catalog.rb
+++ b/lib/bolt/catalog.rb
@@ -65,7 +65,6 @@ module Bolt
       target = request['target']
       pdb_client = Bolt::PuppetDB::Client.new(Bolt::PuppetDB::Config.new(request['pdb_config']))
       options = request['puppet_config'] || {}
-
       with_puppet_settings(request['hiera_config']) do
         Puppet[:rich_data] = true
         Puppet[:node_name_value] = target['name']

--- a/spec/pal/facts_spec.rb
+++ b/spec/pal/facts_spec.rb
@@ -24,6 +24,9 @@ describe 'Facts functions' do
   let(:inv) { Bolt::Inventory.new(data) }
   let(:pal) { Bolt::PAL.new(modulepath, nil) }
 
+  let(:analytics) { Bolt::Analytics::NoopClient.new }
+  let(:executor) { Bolt::Executor.new(1, analytics) }
+
   let(:target) { "$t = get_targets(#{node})[0]\n" }
   let(:facts) { "facts($t)\n" }
   let(:add_facts) { "add_facts($t, {'hot' => 'tamales', 'dark' => 'chocolate'})\n" }
@@ -34,13 +37,13 @@ describe 'Facts functions' do
   end
 
   it 'should set facts for a target' do
-    output = peval(target + add_facts + facts, pal, nil, inv)
+    output = peval(target + add_facts + facts, pal, executor, inv)
     expect(output).to eq('hot' => 'tamales', 'dark' => 'chocolate')
   end
 
   it 'should be consistent between target instances' do
     t2 = "$t2 = get_targets(#{node})[0]\nfacts($t2)\n"
-    output = peval(target + add_facts + t2 + facts, pal, nil, inv)
+    output = peval(target + add_facts + t2 + facts, pal, executor, inv)
     expect(output).to eq('hot' => 'tamales', 'dark' => 'chocolate')
   end
 
@@ -52,13 +55,13 @@ describe 'Facts functions' do
 
   it 'should be consistent when modified on a separate instance' do
     t2 = "$t2 = get_targets(#{node})[0]\n"
-    output = peval(target + t2 + add_facts + "facts($t2)", pal, nil, inv)
+    output = peval(target + t2 + add_facts + "facts($t2)", pal, executor, inv)
     expect(output).to eq('hot' => 'tamales', 'dark' => 'chocolate')
   end
 
   it 'should not mutate previously assigned facts' do
     assignx = "$x = facts($t)\n"
-    output = peval(target + assignx + add_facts + "$x", pal, nil, inv)
+    output = peval(target + assignx + add_facts + "$x", pal, executor, inv)
     expect(output).to eq('hot' => 'chocolate')
   end
 end

--- a/spec/pal/features_spec.rb
+++ b/spec/pal/features_spec.rb
@@ -13,6 +13,9 @@ describe 'set_features function' do
   before(:all) { Bolt::PAL.load_puppet }
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
+  let(:analytics) { Bolt::Analytics::NoopClient.new }
+  let(:executor) { Bolt::Executor.new(1, analytics) }
+
   let(:data) {
     {
       'nodes' => %w[example],
@@ -24,7 +27,7 @@ describe 'set_features function' do
   let(:target) { inventory.get_targets('example')[0] }
 
   it 'adds the feature to the target' do
-    peval(<<-CODE, pal, nil, inventory)
+    peval(<<-CODE, pal, executor, inventory)
     $t = get_targets('example')[0]
     $t.set_feature('shell')
     CODE
@@ -32,7 +35,7 @@ describe 'set_features function' do
   end
 
   it 'only adds the feature once' do
-    peval(<<-CODE, pal, nil, inventory)
+    peval(<<-CODE, pal, executor, inventory)
     $t = get_targets('example')[0]
     $t.set_feature('shell').set_feature('shell')
     CODE
@@ -40,14 +43,14 @@ describe 'set_features function' do
   end
 
   it 'deletes the feature if false is passed' do
-    peval(<<-CODE, pal, nil, inventory)
+    peval(<<-CODE, pal, executor, inventory)
     $t = get_targets('example')[0]
     $t.set_feature('shell')
     CODE
 
     expect(inventory.features(target).to_a).to eq(['shell'])
 
-    peval(<<-CODE, pal, nil, inventory)
+    peval(<<-CODE, pal, executor, inventory)
     $t = get_targets('example')[0]
     $t.set_feature('shell', false)
     CODE
@@ -56,7 +59,7 @@ describe 'set_features function' do
   end
 
   it "does nothing if false is passed for a feature that isn't present" do
-    peval(<<-CODE, pal, nil, inventory)
+    peval(<<-CODE, pal, executor, inventory)
     $t = get_targets('example')[0]
     $t.set_feature('shell', false)
     CODE
@@ -65,7 +68,7 @@ describe 'set_features function' do
   end
 
   it 'sets separate features for different nodes' do
-    peval(<<-CODE, pal, nil, inventory)
+    peval(<<-CODE, pal, executor, inventory)
     $targets = get_targets('example1,example2')
     $targets[0].set_feature('shell')
     $targets[1].set_feature('powershell')

--- a/spec/pal/vars_spec.rb
+++ b/spec/pal/vars_spec.rb
@@ -22,43 +22,46 @@ describe 'Vars function' do
   let(:inventory) { Bolt::Inventory.new(data) }
   let(:pal) { Bolt::PAL.new(modulepath, nil) }
 
+  let(:analytics) { Bolt::Analytics::NoopClient.new }
+  let(:executor) { Bolt::Executor.new(1, analytics) }
+
   let(:target) { "$t = get_targets('example')[0]\n" }
   let(:vars) { "$t.vars\n" }
   let(:set_donuts) { "$t.set_var('donuts', 'coffee')\n" }
   let(:set_pb) { "$t.set_var('pb', 'banana')\n" }
 
   it 'should get vars on a target' do
-    output = peval(target + vars, pal, nil, inventory)
+    output = peval(target + vars, pal, executor, inventory)
     expect(output).to eq('pb' => 'jelly', 'mac' => 'cheese')
   end
 
   it 'should set vars on a target' do
-    output = peval(target + set_donuts + vars, pal, nil, inventory)
+    output = peval(target + set_donuts + vars, pal, executor, inventory)
     expect(output).to eq('pb' => 'jelly', 'mac' => 'cheese', 'donuts' => 'coffee')
   end
 
   it 'should be consistent between target instances' do
     t2 = "$t2 = get_targets('example')[0]\n$t2.vars\n"
-    output = peval(target + set_pb + set_donuts + t2, pal, nil, inventory)
+    output = peval(target + set_pb + set_donuts + t2, pal, executor, inventory)
     expect(output).to eq('pb' => 'banana', 'mac' => 'cheese', 'donuts' => 'coffee')
   end
 
   it 'should be consistent when modified on a separate instance' do
     t2 = "$t2 = get_targets('example')[0]"
-    output = peval(target + t2 + set_donuts + '$t2.vars', pal, nil, inventory)
+    output = peval(target + t2 + set_donuts + '$t2.vars', pal, executor, inventory)
     expect(output).to eq('pb' => 'jelly', 'mac' => 'cheese', 'donuts' => 'coffee')
   end
 
   it 'set_var should override data from inventory file' do
     set_pb = "$t.set_var('pb', 'jam')\n"
-    output = peval(target + set_pb + vars, pal, nil, inventory)
+    output = peval(target + set_pb + vars, pal, executor, inventory)
     expect(output).to eq('pb' => 'jam', 'mac' => 'cheese')
   end
 
   it 'should not mutate previously assigned values' do
     set_pb = "$t.set_var('pb', 'jam')\n"
     assign1 = "$x = $t.vars['pb']\n"
-    output = peval(target + assign1 + set_pb + "$x", pal, nil, inventory)
+    output = peval(target + assign1 + set_pb + "$x", pal, executor, inventory)
     expect(output).to eq('jelly')
   end
 end


### PR DESCRIPTION
BOLT-1131 introduced a guard condition that prevents select plan functions from bein executed in an apply block. Specifically if `Puppet[:tasks]` is not truthy then an error is raised. This commit removes redundant conditionals to ensure the plan functions are runnable by the plan.