### PR TITLE
(BOLT-1265) Add terraform target-lookup plugin

### DIFF
--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require 'bolt/plugin/puppetdb'
+require 'bolt/plugin/terraform'
 
 module Bolt
   class Plugin
     def self.setup(config, pdb_client)
       plugins = new(config)
       plugins.add_plugin(Bolt::Plugin::Puppetdb.new(pdb_client))
+      plugins.add_plugin(Bolt::Plugin::Terraform.new)
       plugins
     end
 

--- a/lib/bolt/plugin/terraform.rb
+++ b/lib/bolt/plugin/terraform.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Bolt
+  class Plugin
+    class Terraform
+      def name
+        'terraform'
+      end
+
+      def hooks
+        ['lookup_targets']
+      end
+
+      def lookup_targets(opts)
+        state = load_statefile(opts)
+
+        resources = state.fetch('modules', {}).flat_map do |mod|
+          mod.fetch('resources', {}).map do |name, resource|
+            [name, resource.dig('primary', 'attributes')]
+          end
+        end
+
+        regex = Regexp.new(opts['resource_type'])
+
+        resources.select do |name, _resource|
+          name.match?(regex)
+        end.map do |_name, resource|
+          target = { 'uri' => resource[opts['uri']] }
+          if opts.key?('name')
+            target['name'] = resource[opts['name']]
+          end
+          if opts.key?('config')
+            target['config'] = resolve_config(resource, opts['config'])
+          end
+          target
+        end
+      end
+
+      def load_statefile(opts)
+        dir = opts['dir']
+        filename = opts.fetch('statefile', 'terraform.tfstate')
+        statefile = File.expand_path(File.join(dir, filename))
+
+        JSON.parse(File.read(statefile))
+      rescue StandardError => e
+        raise Bolt::FileError.new("Could not load Terraform state file #{filename}: #{e}", filename)
+      end
+
+      def resolve_config(resource, config_template)
+        Bolt::Util.walk_vals(config_template) do |value|
+          if value.is_a?(String)
+            resource[value]
+          else
+            value
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/bolt/plugin/terraform_spec.rb
+++ b/spec/bolt/plugin/terraform_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/plugin/terraform'
+
+# rubocop:disable Style/BracesAroundHashParameters
+describe Bolt::Plugin::Terraform do
+  let(:terraform_dir) { File.expand_path(File.join(__dir__, '../../fixtures/terraform')) }
+  let(:resource_type) { 'google_compute_instance' }
+  let(:uri) { 'network_interface.0.access_config.0.nat_ip' }
+  let(:opts) { { 'dir' => terraform_dir, 'resource_type' => resource_type, 'uri' => uri } }
+
+  it 'has a hook for lookup_targets' do
+    expect(subject.hooks).to eq(['lookup_targets'])
+  end
+
+  it 'reads the terraform state file from the given directory' do
+    statefile = File.join(terraform_dir, 'terraform.tfstate')
+    state = subject.load_statefile('dir' => terraform_dir)
+
+    expect(state).to eq(JSON.parse(File.read(statefile)))
+  end
+
+  it 'accepts another name for the state file' do
+    statefile = File.join(terraform_dir, 'empty.tfstate')
+    state = subject.load_statefile('dir' => terraform_dir, 'statefile' => 'empty.tfstate')
+
+    expect(state).to eq(JSON.parse(File.read(statefile)))
+  end
+
+  it 'matches resources that start with the given type' do
+    targets = subject.lookup_targets(opts)
+
+    expect(targets).to contain_exactly({ 'uri' => '34.83.150.52' }, { 'uri' => '34.83.16.240' })
+  end
+
+  it 'can filter resources by regex' do
+    targets = subject.lookup_targets(opts.merge('resource_type' => 'google_compute_instance.example.\d+'))
+
+    expect(targets).to contain_exactly({ 'uri' => '34.83.150.52' }, { 'uri' => '34.83.16.240' })
+  end
+
+  it 'maps inventory to name' do
+    targets = subject.lookup_targets(opts.merge('name' => 'id'))
+
+    expect(targets).to contain_exactly({ 'uri' => '34.83.150.52', 'name' => 'test-instance-0' },
+                                       { 'uri' => '34.83.16.240', 'name' => 'test-instance-1' })
+  end
+
+  it 'builds a config map from the inventory' do
+    config_template = { 'ssh' => { 'user' => 'metadata.sshUser' } }
+    targets = subject.lookup_targets(opts.merge('config' => config_template))
+
+    config = { 'ssh' => { 'user' => 'someone' } }
+    expect(targets).to contain_exactly({ 'uri' => '34.83.150.52', 'config' => config },
+                                       { 'uri' => '34.83.16.240', 'config' => config })
+  end
+
+  it 'returns nothing if there are no matching resources' do
+    targets = subject.lookup_targets(opts.merge('resource_type' => 'aws_instance'))
+
+    expect(targets).to be_empty
+  end
+
+  it 'fails if the state file does not exist' do
+    expect { subject.lookup_targets(opts.merge('statefile' => 'nonexistent.tfstate')) }
+      .to raise_error(Bolt::Error, /Could not load Terraform state file nonexistent.tfstate/)
+  end
+end
+# rubocop:enable Style/BracesAroundHashParameters

--- a/spec/fixtures/terraform/empty.tfstate
+++ b/spec/fixtures/terraform/empty.tfstate
@@ -1,0 +1,16 @@
+{
+    "version": 3,
+    "terraform_version": "0.11.13",
+    "serial": 19,
+    "lineage": "7fe841b8-d733-9b8c-f6b4-6d485cd3059a",
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {},
+            "resources": {},
+            "depends_on": []
+        }
+    ]
+}

--- a/spec/fixtures/terraform/terraform.tfstate
+++ b/spec/fixtures/terraform/terraform.tfstate
@@ -1,0 +1,175 @@
+{
+    "version": 3,
+    "terraform_version": "0.11.13",
+    "serial": 20,
+    "lineage": "7fe841b8-d733-9b8c-f6b4-6d485cd3059a",
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {
+                "web": {
+                    "sensitive": false,
+                    "type": "map",
+                    "value": {
+                        "hostname": [
+                            "test-instance-0",
+                            "test-instance-1"
+                        ],
+                        "ip": [
+                            "34.83.150.52",
+                            "34.83.16.240"
+                        ]
+                    }
+                }
+            },
+            "resources": {
+                "google_compute_instance.example.0": {
+                    "type": "google_compute_instance",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "test-instance-0",
+                        "attributes": {
+                            "attached_disk.#": "0",
+                            "boot_disk.#": "1",
+                            "boot_disk.0.auto_delete": "true",
+                            "boot_disk.0.device_name": "persistent-disk-0",
+                            "boot_disk.0.disk_encryption_key_raw": "",
+                            "boot_disk.0.disk_encryption_key_sha256": "",
+                            "boot_disk.0.initialize_params.#": "1",
+                            "boot_disk.0.initialize_params.0.image": "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-7-v20190423",
+                            "boot_disk.0.initialize_params.0.size": "10",
+                            "boot_disk.0.initialize_params.0.type": "pd-standard",
+                            "boot_disk.0.source": "https://www.googleapis.com/compute/v1/projects/example/zones/us-west1-a/disks/test-instance-0",
+                            "can_ip_forward": "false",
+                            "cpu_platform": "Intel Broadwell",
+                            "deletion_protection": "false",
+                            "guest_accelerator.#": "0",
+                            "hostname": "",
+                            "id": "test-instance-0",
+                            "instance_id": "8946822406274313149",
+                            "label_fingerprint": "42WmSpB8rSM=",
+                            "labels.%": "0",
+                            "machine_type": "f1-micro",
+                            "metadata.%": "1",
+                            "metadata.sshUser": "someone",
+                            "metadata_fingerprint": "_augjlko69Y=",
+                            "metadata_startup_script": "",
+                            "min_cpu_platform": "",
+                            "name": "test-instance-0",
+                            "network_interface.#": "1",
+                            "network_interface.0.access_config.#": "1",
+                            "network_interface.0.access_config.0.assigned_nat_ip": "",
+                            "network_interface.0.access_config.0.nat_ip": "34.83.150.52",
+                            "network_interface.0.access_config.0.network_tier": "PREMIUM",
+                            "network_interface.0.access_config.0.public_ptr_domain_name": "",
+                            "network_interface.0.address": "",
+                            "network_interface.0.alias_ip_range.#": "0",
+                            "network_interface.0.name": "nic0",
+                            "network_interface.0.network": "https://www.googleapis.com/compute/v1/projects/example/global/networks/default",
+                            "network_interface.0.network_ip": "10.138.0.22",
+                            "network_interface.0.subnetwork": "https://www.googleapis.com/compute/v1/projects/example/regions/us-west1/subnetworks/default",
+                            "network_interface.0.subnetwork_project": "example",
+                            "project": "example",
+                            "scheduling.#": "1",
+                            "scheduling.0.automatic_restart": "true",
+                            "scheduling.0.on_host_maintenance": "MIGRATE",
+                            "scheduling.0.preemptible": "false",
+                            "scratch_disk.#": "0",
+                            "self_link": "https://www.googleapis.com/compute/v1/projects/example/zones/us-west1-a/instances/test-instance-0",
+                            "service_account.#": "0",
+                            "tags.#": "0",
+                            "tags_fingerprint": "42WmSpB8rSM=",
+                            "zone": "us-west1-a"
+                        },
+                        "meta": {
+                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
+                                "create": 360000000000,
+                                "delete": 360000000000,
+                                "update": 360000000000
+                            },
+                            "schema_version": "6"
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.google"
+                },
+                "google_compute_instance.example.1": {
+                    "type": "google_compute_instance",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "test-instance-1",
+                        "attributes": {
+                            "attached_disk.#": "0",
+                            "boot_disk.#": "1",
+                            "boot_disk.0.auto_delete": "true",
+                            "boot_disk.0.device_name": "persistent-disk-0",
+                            "boot_disk.0.disk_encryption_key_raw": "",
+                            "boot_disk.0.disk_encryption_key_sha256": "",
+                            "boot_disk.0.initialize_params.#": "1",
+                            "boot_disk.0.initialize_params.0.image": "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-7-v20190423",
+                            "boot_disk.0.initialize_params.0.size": "10",
+                            "boot_disk.0.initialize_params.0.type": "pd-standard",
+                            "boot_disk.0.source": "https://www.googleapis.com/compute/v1/projects/example/zones/us-west1-a/disks/test-instance-1",
+                            "can_ip_forward": "false",
+                            "cpu_platform": "Intel Broadwell",
+                            "deletion_protection": "false",
+                            "guest_accelerator.#": "0",
+                            "hostname": "",
+                            "id": "test-instance-1",
+                            "instance_id": "257748381260868542",
+                            "label_fingerprint": "42WmSpB8rSM=",
+                            "labels.%": "0",
+                            "machine_type": "f1-micro",
+                            "metadata.%": "1",
+                            "metadata.sshUser": "someone",
+                            "metadata_fingerprint": "_augjlko69Y=",
+                            "metadata_startup_script": "",
+                            "min_cpu_platform": "",
+                            "name": "test-instance-1",
+                            "network_interface.#": "1",
+                            "network_interface.0.access_config.#": "1",
+                            "network_interface.0.access_config.0.assigned_nat_ip": "",
+                            "network_interface.0.access_config.0.nat_ip": "34.83.16.240",
+                            "network_interface.0.access_config.0.network_tier": "PREMIUM",
+                            "network_interface.0.access_config.0.public_ptr_domain_name": "",
+                            "network_interface.0.address": "",
+                            "network_interface.0.alias_ip_range.#": "0",
+                            "network_interface.0.name": "nic0",
+                            "network_interface.0.network": "https://www.googleapis.com/compute/v1/projects/example/global/networks/default",
+                            "network_interface.0.network_ip": "10.138.0.21",
+                            "network_interface.0.subnetwork": "https://www.googleapis.com/compute/v1/projects/example/regions/us-west1/subnetworks/default",
+                            "network_interface.0.subnetwork_project": "example",
+                            "project": "example",
+                            "scheduling.#": "1",
+                            "scheduling.0.automatic_restart": "true",
+                            "scheduling.0.on_host_maintenance": "MIGRATE",
+                            "scheduling.0.preemptible": "false",
+                            "scratch_disk.#": "0",
+                            "self_link": "https://www.googleapis.com/compute/v1/projects/example/zones/us-west1-a/instances/test-instance-1",
+                            "service_account.#": "0",
+                            "tags.#": "0",
+                            "tags_fingerprint": "42WmSpB8rSM=",
+                            "zone": "us-west1-a"
+                        },
+                        "meta": {
+                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
+                                "create": 360000000000,
+                                "delete": 360000000000,
+                                "update": 360000000000
+                            },
+                            "schema_version": "6"
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.google"
+                }
+            },
+            "depends_on": []
+        }
+    ]
+}
+


### PR DESCRIPTION
This adds a plugin that can load terraform state and map resource
properties to target parameters. This allows a terraform project to be
used to dynamically determine the targets to use when running Bolt.