### PR TITLE
(BOLT-1299) Properly detect multi-line evals

### DIFF
--- a/lib/bolt/pal/yaml_plan/step.rb
+++ b/lib/bolt/pal/yaml_plan/step.rb
@@ -77,7 +77,7 @@ module Bolt
             # We have to do a little extra parsing here, since we only need
             # with() for eval blocks
             code = Bolt::Util.to_code(body['eval'])
-            if @name && code.include?("\n")
+            if @name && code.lines.count > 1
               # A little indented niceness
               indented = code.gsub(/\n/, "\n    ").chomp("  ")
               result << "with() || {\n    #{indented}}"


### PR DESCRIPTION
Previously, we were looking for a newline character to decide that the
content of an eval was multiple lines and should be wrapped in `with()`.
However, single line strings created using the mutli-line syntax in YAML
(which is necessary to be interpreted as code blocks) end in a newline.
We now check for more precisely what we means, which is that the string
contains multiple lines, not just that it might end with a newline.