### PR TITLE
(BOLT-1268) Only load inventory when necessary

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -261,11 +261,19 @@ module Bolt
         screen += '_object'
       end
 
-      @analytics.screen_view(screen,
-                             output_format: config.format,
-                             target_nodes: options.fetch(:targets, []).count,
-                             inventory_nodes: inventory.node_names.count,
-                             inventory_groups: inventory.group_names.count)
+      screen_view_fields = {
+        output_format: config.format
+      }
+
+      # Only include target and inventory info for commands that take a targets
+      # list. This avoids loading inventory for commands that don't need it.
+      if options.key?(:targets)
+        screen_view_fields.merge!(target_nodes: options[:targets].count,
+                                  inventory_nodes: inventory.node_names.count,
+                                  inventory_groups: inventory.group_names.count)
+      end
+
+      @analytics.screen_view(screen, screen_view_fields)
 
       if options[:action] == 'show'
         if options[:subcommand] == 'task'

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1045,6 +1045,17 @@ describe "Bolt::CLI" do
             }
           )
         end
+
+        it "does not load inventory" do
+          options = {
+            subcommand: 'task',
+            action: 'show'
+          }
+
+          expect(cli).not_to receive(:inventory)
+
+          cli.execute(options)
+        end
       end
 
       context "when available tasks include an error", :reset_puppet_settings do
@@ -1179,6 +1190,17 @@ describe "Bolt::CLI" do
               }
             }
           )
+        end
+
+        it "does not load inventory" do
+          options = {
+            subcommand: 'plan',
+            action: 'show'
+          }
+
+          expect(cli).not_to receive(:inventory)
+
+          cli.execute(options)
         end
       end
 


### PR DESCRIPTION
Previously, we loaded the inventory for all commands, regardless of
whether the command actually needed the inventory. This meant that an
invalid inventory would cause commands like `bolt task show` to fail,
even though they shouldn't care about the inventory whatsoever.

We were loading the inventory in order to figure out the number of nodes
and groups in use to include in the analytics report. We now only
include that information if the command is using targets.