### PR TITLE
(BOLT-1185) Add plan examples to bolt docs

### DIFF
--- a/pre-docs/bolt.md
+++ b/pre-docs/bolt.md
@@ -40,6 +40,8 @@ Bolt is an open source task runner that automates the manual work that you do to
 
  [Applying manifest blocks](applying_manifest_blocks.md#) 
 
+ [Plan examples](writing_yaml_plans.md#example-plans)
+
 
  | -   **Learn the basics**
 

--- a/pre-docs/bolt_running_plans.md
+++ b/pre-docs/bolt_running_plans.md
@@ -22,6 +22,7 @@ Note that, like `--nodes`, you can pass a comma-separated list of node names, wi
 
 **Tip**: Bolt is packaged with a collection of modules that contain useful plans to support common workflows. For details, see [Packaged modules](bolt_installing_modules.md#packaged-modules).
 
+**Related information**: Check out some [plan examples](writing_yaml_plans.md#example-plans) to get an idea of some use cases for plans. 
 
 ## Passing structured data
 

--- a/pre-docs/writing_plans.md
+++ b/pre-docs/writing_plans.md
@@ -527,3 +527,38 @@ plan pdb_discover {
   run_task('my_task', $nodes)
 }
 ```
+### Example plans
+
+Check out some example plans for inspiration writing your own.
+
+#### Beginner plans
+
+These plans show very simple use cases such as running a task and manipulating the results.
+
+##### Facts plans 
+
+The [facts module](https://forge.puppet.com/puppetlabs/facts) contains tasks and plans to discover facts about target systems.
+
+The [facts plan](https://github.com/puppetlabs/puppetlabs-facts/blob/master/plans/init.pp) gathers facts using the facts task and sets the facts in inventory. 
+
+The [facts::info plan](https://github.com/puppetlabs/puppetlabs-facts/blob/master/plans/info.pp) utilizes the facts task to discover facts and map relevant fact values to targets.
+
+#### Intermediate plans
+
+These plans show more advanced features in the plan language. 
+
+##### Reboot plan
+
+The [reboot module](https://forge.puppet.com/puppetlabs/reboot) contains tasks and plans for managing system reboots.
+
+The [reboot plan](https://github.com/puppetlabs/puppetlabs-reboot/blob/master/plans/init.pp) restarts a target system and waits for it to become available again.
+
+#### Advanced plans
+
+These plans show advanced plan features such as applying puppet code blocks and using external modules.
+
+##### Using plans to deploy Nginx and HAProxy
+
+In the [Introducing Masterless Puppet with Bolt](https://puppet.com/blog/introducing-masterless-puppet-bolt) blog post plans are used to deploy a load balanced web server.
+
+The [profiles::nginx_install plan](https://github.com/puppetlabs/bolt/blob/master/docs/11-apply-manifest-code/Boltdir/site/profiles/plans/nginx_install.pp) shows an example of how to deploy an example from the blog post.


### PR DESCRIPTION
This commit adds links to some real world plan examples in the writing plans section of the docs.