### PR TITLE
(maint) Update puppet_agent module to 2.1.2

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -7,7 +7,7 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '0.6.0'
 mod 'puppetlabs-facts', '0.5.1'
-mod 'puppetlabs-puppet_agent', '2.1.1'
+mod 'puppetlabs-puppet_agent', '2.1.2'
 
 # Core types and providers for Puppet 6
 mod 'puppetlabs-augeas_core', '1.0.4'

--- a/acceptance/setup/common/pre-suite/071_install_modules.rb
+++ b/acceptance/setup/common/pre-suite/071_install_modules.rb
@@ -9,7 +9,7 @@ test_name "Install modules" do
   create_remote_file(bolt, "#{default_boltdir}/Puppetfile", <<-PUPPETFILE)
 mod 'puppetlabs-facts', '0.5.1'
 mod 'puppetlabs-service', '0.6.0'
-mod 'puppetlabs-puppet_agent', '2.1.1'
+mod 'puppetlabs-puppet_agent', '2.1.2'
 PUPPETFILE
 
   bolt_command_on(bolt, 'bolt puppetfile install')


### PR DESCRIPTION
The location of public release packages will change on May 14.
As such, the following changes aim to prepare for the changeover
to ensure there are no breakages with downstream dependencies.