### PR TITLE
(maint) Ensure testing deferred in apply has compatible agent version

### DIFF
--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -160,11 +160,12 @@ describe "apply" do
 
     context "with a puppet_agent installed" do
       before(:all) do
-        # TODO: Extract into test helper if needed in more files
-        uri = conn_uri('ssh')
-        inventory_data = conn_inventory
-        config_data = root_config
-        run_task('puppet_agent::install', uri, {}, config: config_data, inventory: inventory_data)
+        # Deferred must use puppet >= 6
+        target = conn_uri('ssh')
+        install(target, inventory: conn_inventory)
+        result = run_task('puppet_agent::version', target, {}, config: root_config, inventory: conn_inventory)
+        major_version = result.first['result']['version'].split('.').first.to_i
+        expect(major_version).to be >= 6
       end
 
       context "apply() function" do

--- a/spec/lib/bolt_spec/puppet_agent.rb
+++ b/spec/lib/bolt_spec/puppet_agent.rb
@@ -23,7 +23,7 @@ module BoltSpec
       run_command(uninstall, target, config: config, inventory: inventory)
     end
 
-    def install(target, collection: 'puppet6', inventory: nil)
+    def install(target, collection: nil, inventory: nil)
       config = {
         'ssh' => {
           'run-as' => 'root',
@@ -35,10 +35,10 @@ module BoltSpec
         }
       }
       inventory ||= {}
-      result = run_task('puppet_agent::install', target,
-                        { 'collection' => collection },
-                        config: config,
-                        inventory: inventory)
+      # Task will get latest collection without collection specified
+      task_params = collection ? { 'collection' => collection } : {}
+
+      result = run_task('puppet_agent::install', target, task_params, config: config, inventory: inventory)
 
       expect(result.count).to eq(1)
       expect(result[0]).to include('status' => 'success')


### PR DESCRIPTION
For the second time in two weeks a puppet 5 agent was installed for "latest". The test failure message for using an apply with the `deferred` feature does not make it obvious that an incompatible agent is used. This commit updates the test to use the generalized `BoltSpec::PuppetAgent` install method and ensure a `deferred` compatible agent is installed. It also modifies the install method such that it will default to install the latest collection and optionally install from a specified collection.