### PR TITLE
(BOLT-1264) Set config from PuppetDB facts

### DIFF
--- a/lib/bolt/plugin/puppetdb.rb
+++ b/lib/bolt/plugin/puppetdb.rb
@@ -3,8 +3,19 @@
 module Bolt
   class Plugin
     class Puppetdb
+      class FactLookupError < Bolt::Error
+        def initialize(fact, err = nil)
+          m = String.new("Fact lookup '#{fact}' contains an invalid factname")
+          m << ": #{err}" unless err.nil?
+          super(m, 'bolt.plugin/fact-lookup-error')
+        end
+      end
+
+      TARGET_OPTS = %w[uri name config].freeze
+
       def initialize(pdb_client)
         @puppetdb_client = pdb_client
+        @logger = Logging.logger[self]
       end
 
       def name
@@ -15,9 +26,61 @@ module Bolt
         ['lookup_targets']
       end
 
+      def warn_missing_fact(certname, fact)
+        @logger.warn("Could not find fact #{fact} for node #{certname}")
+      end
+
+      def fact_path(raw_fact)
+        fact_path = raw_fact.split(".")
+        if fact_path[0] == 'facts'
+          fact_path.drop(1)
+        elsif fact_path == ['certname']
+          fact_path
+        else
+          raise FactLookupError.new(raw_fact, "fact lookups must start with 'facts.'")
+        end
+      end
+
       def lookup_targets(opts)
-        nodes = @puppetdb_client.query_certnames(opts['query'])
-        nodes.map { |certname| { 'uri' => certname } }
+        targets = @puppetdb_client.query_certnames(opts['query'])
+        facts = []
+
+        target_opts = opts.select { |k, _| TARGET_OPTS.include?(k) }
+        Bolt::Util.walk_vals(target_opts) do |value|
+          # This is done in parts instead of in place so that we only need to
+          # make one puppetDB query
+          if value.is_a?(String)
+            facts << fact_path(value)
+          end
+          value
+        end
+
+        facts.uniq!
+        # Returns {'mycertname' => [{'path' => ['nested', 'fact'], 'value' => val'}], ... }
+        fact_values = @puppetdb_client.fact_values(targets, facts)
+
+        targets.map do |certname|
+          target_data = fact_values[certname]
+          target = resolve_facts(target_opts, certname, target_data) || {}
+          target['uri'] = certname unless target['uri'] || target['name']
+
+          target
+        end
+      end
+
+      def resolve_facts(config, certname, target_data)
+        Bolt::Util.walk_vals(config) do |value|
+          if value.is_a?(String)
+            data = target_data&.detect { |d| d['path'] == fact_path(value) }
+            warn_missing_fact(certname, value) if data.nil?
+            # If there's no fact data this will be nil
+            data&.fetch('value', nil)
+          elsif value.is_a?(Array) || value.is_a?(Hash)
+            value
+          else
+            raise FactLookupError.new(value, "fact lookups must be a string")
+          end
+        end
       end
     end
   end

--- a/lib/bolt/puppetdb/client.rb
+++ b/lib/bolt/puppetdb/client.rb
@@ -42,6 +42,22 @@ module Bolt
         end
       end
 
+      def fact_values(certnames = [], facts = [])
+        return {} if certnames.empty? || facts.empty?
+
+        certnames.uniq!
+        name_query = certnames.map { |c| ["=", "certname", c] }
+        name_query.insert(0, "or")
+
+        facts_query = facts.map { |f| ["=", "path", f] }
+        facts_query.insert(0, "or")
+
+        query = ['and', name_query, facts_query]
+        result = make_query(query, 'fact-contents')
+        result.map! { |h| h.delete_if { |k, _v| %w[environment name].include?(k) } }
+        result.group_by { |c| c['certname'] }
+      end
+
       def make_query(query, path = nil)
         body = JSON.generate(query: query)
         url = "#{uri}/pdb/query/v4"

--- a/spec/bolt/plugin/puppetdb_spec.rb
+++ b/spec/bolt/plugin/puppetdb_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/plugin/puppetdb'
+
+describe Bolt::Plugin::Puppetdb do
+  let(:config) do
+    Bolt::PuppetDB::Config.new('server_urls' => 'https://localhost:8081',
+                               'cacert' => '/path/to/cacert',
+                               'token' => 'token')
+  end
+  let(:pdb_client) { Bolt::PuppetDB::Client.new(config) }
+  let(:plugin) { Bolt::Plugin::Puppetdb.new(pdb_client) }
+  let(:opts) do
+  end
+
+  it 'has a hook for lookup_targets' do
+    expect(plugin.hooks).to eq(['lookup_targets'])
+  end
+
+  context "#fact_path" do
+    it "converts a valid dot-notation fact to an array" do
+      expect(plugin.fact_path("facts.straw.berries")).to eq(%w[straw berries])
+    end
+
+    it "errors when fact is not prepended with 'facts'" do
+      expect { plugin.fact_path("strawberries") }
+        .to raise_error(Bolt::Plugin::Puppetdb::FactLookupError,
+                        /must start with 'facts.'/)
+    end
+
+    it "allows for 'certname'" do
+      expect(plugin.fact_path("certname")).to eq(['certname'])
+    end
+  end
+
+  context "#lookup_targets" do
+    let(:certname) { 'therealslimcertname' }
+    let(:name_fact) { 'thefakeslimcertname' }
+    let(:values_hash) do
+      { certname => [{
+        'path' => ['name_fact'],
+        'value' => name_fact
+      }] }
+    end
+    before(:each) do
+      allow(pdb_client).to receive(:query_certnames).and_return([certname])
+      allow(pdb_client).to receive(:fact_values).and_return(values_hash)
+    end
+
+    it "sets uri to certname if uri and name are not configured" do
+      expect(plugin.lookup_targets('query' => ""))
+        .to eq([{ "uri" => certname }])
+    end
+
+    context "with a name configured" do
+      let(:opts) do
+        { "query" => '',
+          "name" => 'facts.name_fact' }
+      end
+
+      it "sets the uri to the specified name" do
+        expect(plugin.lookup_targets(opts))
+          .to eq([{ "name" => "thefakeslimcertname" }])
+      end
+    end
+  end
+
+  context "#resolve_facts" do
+    context "with invalid fact values" do
+      let(:certname) { 'shady' }
+      let(:config) { { 'name' => 1 } }
+      let(:data) do
+        { certname => [{
+          'path' => [1],
+          'value' => 'the loneliest number'
+        }] }
+      end
+
+      it "raises an error" do
+        expect { plugin.resolve_facts(config, certname, data) }
+          .to raise_error(Bolt::Plugin::Puppetdb::FactLookupError, /be a string/)
+      end
+    end
+
+    context "with no fact_values" do
+      it "returns an empty hash" do
+        expect(plugin.resolve_facts({}, 'shady', nil)).to eq({})
+      end
+    end
+  end
+end

--- a/spec/lib/bolt_spec/conn.rb
+++ b/spec/lib/bolt_spec/conn.rb
@@ -8,6 +8,8 @@ module BoltSpec
       default_host = 'localhost'
       default_user = 'bolt'
       default_password = 'bolt'
+      default_second_user = 'test'
+      default_second_pw = 'test'
       default_key = Dir["spec/fixtures/keys/id_rsa"][0]
       default_port = 0
 
@@ -31,7 +33,10 @@ module BoltSpec
         user: ENV["BOLT_#{tu}_USER"] || default_user,
         password: ENV["BOLT_#{tu}_PASSWORD"] || default_password,
         port: (ENV["BOLT_#{tu}_PORT"] || default_port).to_i,
-        key: ENV["BOLT_#{tu}_KEY"] || default_key
+        key: ENV["BOLT_#{tu}_KEY"] || default_key,
+        second_user: ENV["BOLT_#{tu}_SECOND_USER"] || default_second_user,
+        second_pw: ENV["BOLT_#{tu}_SECOND_PW"] || default_second_pw,
+        system_user: `whoami`.strip
       }
     end
 


### PR DESCRIPTION
This allows user who are using the PuppetDB inventory plugin to set config
values based on facts gathered from PuppetDB. It works by collecting a list
of facts and a list of certnames that we need those facts for, then makes a
single puppetdb query to the `fact-contents` endpoint for the facts. It then
iterates back through the config to fill in the right values for the right
nodes.