### PR TITLE
(BOLT-1264) Document puppetdb inventory plugin config

### DIFF
--- a/pre-docs/inventory_file_generating.md
+++ b/pre-docs/inventory_file_generating.md
@@ -53,7 +53,7 @@ $ bolt-inventory-pdb pdb.yaml -o myfile.yaml --token-file ~/mytoken --cacert /et
 
 ## File format
 
-The `bolt-inventory-pdb` tool generates an inventory file from a source yaml file. This file has the same format as the inventory file except instead of nodes keys it has query keys. The query should be a PuppetDB query in either [Puppet Query Language \(PQL\)](https://puppet.com/docs/puppetdb/5.2/api/query/v4/pql.html) or AST syntax. When `bolt-inventory-pdb` runs it makes queries against PuppetDB and creates a nodes item for each group. This is an example of a file that adds all nodes to the top-level group, creates a Windows group configured to use the WinRM transport and a basil group for nodes with basil in the certname.
+The `bolt-inventory-pdb` tool generates an inventory file from a source yaml file. This file has the same format as the inventory file except instead of nodes keys it has query keys. The query should be a PuppetDB query in either [Puppet Query Language \(PQL\)](https://puppet.com/docs/puppetdb/latest/api/query/v4/pql.html) or [PuppetDB AST](https://puppet.com/docs/puppetdb/latest/api/query/v4/ast.html) syntax. When `bolt-inventory-pdb` runs it makes queries against PuppetDB and creates a nodes item for each group. This is an example of a file that adds all nodes to the top-level group, creates a Windows group configured to use the WinRM transport and a basil group for nodes with basil in the certname.
 
 ```
 query: "nodes[certname] {}"


### PR DESCRIPTION
This allows user who are using the PuppetDB inventory plugin to set config
values based on facts gathered from PuppetDB. This adds documentation including an example on how the feature works.