### PR TITLE
(BOLT-1269) Add prompt plugin

### DIFF
--- a/lib/bolt/inventory/inventory2.rb
+++ b/lib/bolt/inventory/inventory2.rb
@@ -102,13 +102,13 @@ module Bolt
 
       def data_hash
         {
-          data: @data,
+          data: {},
           target_hash: {
-            target_vars: @target_vars,
-            target_facts: @target_facts,
-            target_features: @target_features
+            target_vars: {},
+            target_facts: {},
+            target_features: {}
           },
-          config: @config.transport_data_get
+          config: { transports: {} }
         }
       end
 

--- a/lib/bolt/inventory/inventory2.rb
+++ b/lib/bolt/inventory/inventory2.rb
@@ -16,13 +16,12 @@ module Bolt
         @logger = Logging.logger[self]
         # Config is saved to add config options to targets
         @config = config || Bolt::Config.default
-        @data = data ||= {}
-        @groups = Group2.new(data.merge('name' => 'all'))
+        @data = data || {}
+        @groups = Group2.new(@data.merge('name' => 'all'), plugins)
         @group_lookup = {}
         @target_vars = target_vars
         @target_facts = target_facts
         @target_features = target_features
-
         @groups.lookup_targets(plugins)
         @groups.resolve_aliases(@groups.target_aliases, @groups.target_names)
         collect_groups
@@ -121,6 +120,18 @@ module Bolt
       end
       private :groups_in
 
+      # Look for _plugins
+      def config_plugin(data)
+        Bolt::Util.walk_vals(data) do |val|
+          if val.is_a?(Concurrent::Delay)
+            val.value
+          else
+            val
+          end
+        end
+      end
+      private :config_plugin
+
       # Pass a target to get_targets for a public version of this
       # Should this reconfigure configured targets?
       def update_target(target)
@@ -138,6 +149,7 @@ module Bolt
         set_vars_from_hash(target.name, data['vars']) unless @target_vars[target.name]
         set_facts(target.name, data['facts']) unless @target_facts[target.name]
         data['features']&.each { |feature| set_feature(target, feature) } unless @target_features[target.name]
+        data['config'] = config_plugin(data['config'])
 
         # Use Config object to ensure config section is treated consistently with config file
         conf = @config.deep_clone

--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -2,6 +2,7 @@
 
 require 'bolt/plugin/puppetdb'
 require 'bolt/plugin/terraform'
+require 'bolt/plugin/prompt'
 
 module Bolt
   class Plugin
@@ -9,6 +10,7 @@ module Bolt
       plugins = new(config)
       plugins.add_plugin(Bolt::Plugin::Puppetdb.new(pdb_client))
       plugins.add_plugin(Bolt::Plugin::Terraform.new)
+      plugins.add_plugin(Bolt::Plugin::Prompt)
       plugins
     end
 

--- a/lib/bolt/plugin/prompt.rb
+++ b/lib/bolt/plugin/prompt.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'concurrent/delay'
+module Bolt
+  class Plugin
+    class Prompt
+      def initialize
+        # Might not need this
+        @logger = Logging.logger[self]
+      end
+
+      def self.name
+        'prompt'
+      end
+
+      def hooks
+        ['inventory_config_lookup']
+      end
+
+      def inventory_config_lookup(opts)
+        raise Bolt::ValidationError, "Prompt requires a 'message'" unless opts['message']
+        # Return a delay to only be evaluated when needed
+        Concurrent::Delay.new do
+          STDOUT.print "#{opts['message']}:"
+          value = STDIN.noecho(&:gets).chomp
+          STDOUT.puts
+          value
+        end
+      end
+    end
+  end
+end

--- a/spec/bolt/inventory/inventory2_spec.rb
+++ b/spec/bolt/inventory/inventory2_spec.rb
@@ -729,7 +729,7 @@ describe Bolt::Inventory::Inventory2 do
     end
   end
 
-  context 'with plugins' do
+  context 'with lookup_targets plugins' do
     let(:data) {
       {
         'version' => 2,

--- a/spec/bolt/plugin/prompt_spec.rb
+++ b/spec/bolt/plugin/prompt_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/plugin/prompt'
+require 'io/console'
+
+describe Bolt::Plugin::Prompt do
+  let(:prompt_data) { { '_plugin' => 'prompt', 'message' => 'Password Please' } }
+  let(:invalid_prompt_data) { { '_plugin' => 'prompt' } }
+  let(:password) { 'opensesame' }
+
+  it 'has a hook for inventory_config_lookup' do
+    expect(subject.hooks).to eq(['inventory_config_lookup'])
+  end
+
+  it 'returns concurrent delay when passed valid prompt data' do
+    delay = subject.inventory_config_lookup(prompt_data)
+
+    expect(delay).to be_instance_of(Concurrent::Delay)
+  end
+
+  it 'raises a validation error when no prompt message is provided' do
+    expect { subject.inventory_config_lookup(invalid_prompt_data) }.to raise_error(Bolt::ValidationError)
+  end
+
+  it 'concurrent delay prompts for data when executed' do
+    allow(STDIN).to receive(:noecho).and_return(password)
+    allow(STDOUT).to receive(:puts)
+
+    delay = subject.inventory_config_lookup(prompt_data)
+    expect(STDOUT).to receive(:print).with("#{prompt_data['message']}:")
+    expect(delay.value).to eq(password)
+  end
+end

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -26,8 +26,6 @@ describe "when loading bolt for CLI invocation" do
       'orchestrator_client',
       'faraday',
       'multipart-post',
-      # concurrent gem + dependencies
-      'concurrent-ruby',
       # httpclient + dependencies
       'httpclient',
       # locale + dependencies


### PR DESCRIPTION
This commit adds a prompt plugin. When data is loaded from inventory, values that the key '_plugin' points to will be used to look up available plugins by name. For the prompt plugin, a new instance of the prompt class is instantiated with the data in the same level of '_plugin' key in the hash. The `inventory_config_lookup` hook returns a concurrent delay which when executed prompts the user for a value.