### PR TITLE
(BOLT-1472) Setup Kerberos in Container Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ addons:
   # Ensure Travis resolves itself as the Samba KDC hosted in Docker
   hosts:
     - samba-ad.bolt.test
+    - omiserver.bolt.test
 before_install:
 # Kerberos client for use with the Samba KDC in Docker
 - sudo apt-get install -yq krb5-user

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,23 @@ env:
     - DOCKER_REGISTRY=pe-and-platform
     - BOLT_SUDO_USER=true
     - secure: Gk8LaACXYEVpv5LIWEMOuH3sJP4CzB2aSvE1BUcfDWkI+Hdgr2by3w/nGbKpyVD+v2H8r0zXyVrbCJ/qzx2gCRxqKJ2GKJEsrStT+8z3BXRRRzwkThIBVyWKk9b9bTt8AE0G94I3BE4gJyIPfbX5XxnKcg7nJZGOmubZpUPQX+2SXSfy9EbtY9iismwK7LGtWv6l90cK2eSLZGvdsSKPo7cylOldXfdYIyeBtvsIL1juBaiINX52Zgt371+nX53fDSYOKdIDLuhNqX3zpNOuIJ9DUj4E7IJA7+XhHy77zL98VjHtPo5H4fmKyZ2k+xbYqOydc5OPGguKequsnyDo5npktDrkbswnjWMXNDu+wImAd+IwHG2lTamsAnOGQ+E6g2oK0R5fUL26XJ3lBnTRrsLDnlrvqYqFxt3MCR+o5+DnTirSVQJfrRVsIKTucWHlYLTOUWkVDrLavJqIbWHytEbMf/BXUcovlQzSgfu5/Y1GkUJBnthtbiZfTImmBLcrqKDD4PnDmvC1v9Z5KR78MYu7lFTe5C4STj2aR6bwvqjiPKm6kYG5etOFEyRJ+CbqD2QsdF2N6Ww/RFWovqVqQIWuGdhumDUTdmQAiiPxl12M0+kIH6NugpBD3gt4RT0sni/T+booDw6b3Ts4WJ8FW1/LPWdy7gVo9yOCL4FhjOw=
+    # specify explicitly, even though docker-compose.yml has same defaults
+    - KRB5_REALM=BOLT.TEST
+    - KRB5_KDC=samba-ad.bolt.test
+    - SMB_ADMIN_PASSWORD=B0ltrules!
+    - KRB5_CONFIG=/tmp/krb5.conf
+addons:
+  # Ensure Travis resolves itself as the Samba KDC hosted in Docker
+  hosts:
+    - samba-ad.bolt.test
+before_install:
+# Kerberos client for use with the Samba KDC in Docker
+- sudo apt-get install -yq krb5-user
+# Build / start Samba before other containers, since its fast
+- docker-compose -f spec/docker-compose.yml up -d --build samba-ad
+
 before_script:
+- $TRAVIS_BUILD_DIR/spec/fixtures/samba-ad/kerberos-client-config.sh
 - docker-compose -f spec/docker-compose.yml up -d --build
 - eval `ssh-agent`
 - cat Gemfile.lock

--- a/developer-docs/kerberos.md
+++ b/developer-docs/kerberos.md
@@ -81,6 +81,8 @@ winrm:
 
 In Bolt testing atop Docker containers, [Samba server](https://www.samba.org/) is setup on Linux to approximate an Active Directory setup, which also includes DNS and LDAP support. Given Kerberos has very strict requirements around computer identity (via DNS), Docker user-defined networks with custom DNS and subnets are easier to setup than running in an arbitrary network environment. This lends itself well to an automated and reproducable ephemeral Kerberos environment.
 
+[OMI Server](https://github.com/microsoft/omi) requires the additional Active Directory-like features beyond just a KDC to enable Kerberos based authentication. OMI provides a PowerShell WinRM endpoint on Linux that is intended to behave like the equivalent Windows endpoint.
+
 This environment is intended to support multiple environments:
 
 * [TravisCI automated testing](#travisCI-automated-testing)
@@ -88,15 +90,15 @@ This environment is intended to support multiple environments:
 
 #### Container Setup
 
-The current `spec/docker-compose.yml` supports a number of containers, many of which are intended to be built when started. For Kerberos, build / start just the relevant container:
+The current `spec/docker-compose.yml` supports a number of containers, many of which are intended to be built when started. For Kerberos, build / start just the relevant containers:
 
-`docker-compose -f spec/docker-compose.yml up -d --build samba-ad`
+`docker-compose -f spec/docker-compose.yml up -d --build samba-ad omiserver`
 
 ##### Samba AD (KDC)
 
-A Kerberos server is provided by running an Alpine container with Samba as an Active Directory domain controller. The Kerberos realm is `BOLT.TEST`, Active Directory domain is `BOLT.TEST` (short name `BOLT`) and DNS suffix is `bolt.test`
+A Kerberos server is provided by running an Alpine container with Samba as an [Active Directory domain controller](https://wiki.samba.org/index.php/Setting_up_Samba_as_an_Active_Directory_Domain_Controller). The Kerberos realm is `BOLT.TEST`, Active Directory domain is `BOLT.TEST` (short name `BOLT`) and DNS suffix is `bolt.test`
 
-This container provides DNS and LDAP support, and a variety of [other services](https://wiki.samba.org/index.php/Samba_AD_DC_Port_Usage) including:
+This container provides DNS and LDAP support, but does not contain NTP as that is already provided in a Docker environment. It also hosts a variety of [other services](https://wiki.samba.org/index.php/Samba_AD_DC_Port_Usage) including:
 
 ###### External Ports / Services
 
@@ -125,8 +127,40 @@ To access the shell, use `/bin/sh` like:
 
 Useful tooling on the instance for managing Active Directory includes:
 
-* [`samba-tool`](https://www.samba.org/samba/docs/current/man-html/samba-tool.8.html) - primary Samba admin tool 
+* [`samba-tool`](https://www.samba.org/samba/docs/current/man-html/samba-tool.8.html) - primary Samba admin tool
 * [`net`](https://www.samba.org/samba/docs/current/man-html/net.8.html) - designed to work like the `net` tool on Windows
+
+##### OMI Server
+
+An Ubuntu container running OMI server and listening on both the HTTP and HTTPS WinRM endpoints is intended to simulate a Windows host in a non-Windows environment.
+
+On startup, the container is automatically domain joined to the Samba active directory and is reachable inside the UDN as `omiserver.bolt.test`. As with the Samba container, add an entry to `/etc/hosts` to be able to access it via DNS name from the Docker host environment.
+
+On startup, the Docker entrypoint script waits for the domain to be resolved via DNS and accessible before attempting to perform a domain join with `realm join` followed by `net ads join` (after configuring local Kerberos and Samba clients). The [`sssd`](https://docs.pagure.org/SSSD.sssd/) service is setup to use the [`ad provider`](https://docs.pagure.org/SSSD.sssd/users/ad_provider.html) so that it may look up domain accounts locally.
+
+The container performs a basic validation using `getent passwd administrator@BOLT.TEST` to verify the system is properly configured and domain joined. It then uses the `omicli` tool and the PowerShell cmdlet `Invoke-Command` to vet that the `bolt:bolt` account can authenticate properly.
+
+At this stage, OMI server is not yet configured to use Kerberos authentication, so that connectivity is not verified.
+
+###### External Ports
+
+* 45985 (tcp) - WinRM HTTP (internally 5985)
+* 45986 (tcp) - WinRM HTTPS (internally 5986)
+
+###### Interactive Shell Access
+
+To access the shell, use `/bin/bash` like:
+
+> docker-compose -f spec/docker-compose.yml exec omiserver /bin/bash
+
+Useful tooling on the instance includes:
+
+* [`host`](https://linux.die.net/man/1/host) - DNS lookup utility
+* [`klist`](https://web.mit.edu/kerberos/krb5-devel/doc/user/user_commands/klist.html) - check Kerberos tickets
+* [`realm`](https://www.systutorials.com/docs/linux/man/8-realm/) - manages enrollment in Kerberos realms and Active Directory domains
+* [`net`](https://www.samba.org/samba/docs/current/man-html/net.8.html) - designed to work like the `net` tool on Windows
+* [`pwsh`](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-linux?view=powershell-6) - PowerShell 6
+* [`omicli`](https://github.com/microsoft/omi/blob/master/Unix/cli/examples.txt) - client tool used to verify basic OMI server functionality
 
 #### TravisCI automated testing
 
@@ -136,7 +170,7 @@ At present, Travis setup will:
 * Install the Kerberos client package
 * Configure the Kerberos client with the approriate server (`samba-ad.bolt.test`) for the realm `BOLT.TEST`
 
-Automated tests (in `spec/bolt/transport/winrm_spec.rb`) simplify verify that the correct TGT can be acquired from the Samba AD using `kinit` using the domain administrator account `Administrator@BOLT.TEST`.
+Automated tests (in `spec/bolt/transport/winrm_spec.rb`) verify that the correct TGT (ticket granting ticket) can be acquired from the Samba AD using `kinit` using the domain administrator account `Administrator@BOLT.TEST`.
 
 Previously added tests are still marked pending until other infrastructure within Docker is configured to use Kerberos.
 

--- a/spec/Dockerfile.omiserver
+++ b/spec/Dockerfile.omiserver
@@ -86,6 +86,7 @@ ADD fixtures/omiserver/domain-join.sh /
 ADD fixtures/omiserver/realmd.conf.tmpl /
 ADD fixtures/omiserver/smb.conf.tmpl /
 ADD fixtures/omiserver/sssd.conf.tmpl /
+ADD fixtures/omiserver/omi-enable-kerberos-auth.sh /
 ADD fixtures/omiserver/verify-omi-authentication.sh /
 ADD fixtures/omiserver/verify-pwsh-authentication.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/spec/Dockerfile.omiserver
+++ b/spec/Dockerfile.omiserver
@@ -3,6 +3,8 @@
 FROM ubuntu:18.04
 
 ARG BOLT_PASSWORD=bolt
+# NOTE: Only designed to be set at build time, not at run time!
+ENV BOLT_PASSWORD=${BOLT_PASSWORD}
 
 RUN useradd bolt \
  && echo "bolt:${BOLT_PASSWORD}" | chpasswd
@@ -58,4 +60,6 @@ RUN touch /etc/opt/omi/creds/ntlm \
 EXPOSE 5985 5986
 
 ADD fixtures/omiserver/docker-entrypoint.sh /
+ADD fixtures/omiserver/verify-omi-authentication.sh /
+ADD fixtures/omiserver/verify-pwsh-authentication.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/spec/Dockerfile.omiserver
+++ b/spec/Dockerfile.omiserver
@@ -5,12 +5,20 @@ FROM ubuntu:18.04
 ARG BOLT_PASSWORD=bolt
 # NOTE: Only designed to be set at build time, not at run time!
 ENV BOLT_PASSWORD=${BOLT_PASSWORD}
+ENV KRB5_REALM=
+ENV KRB5_KDC=
+ENV KRB5_ADMINSERVER=
+ENV SMB_ADMIN=Administrator
+ENV SMB_ADMIN_PASSWORD=
 
 RUN useradd bolt \
  && echo "bolt:${BOLT_PASSWORD}" | chpasswd
 
 # install Microsoft package repo for access to omi and powershell packages
-# gss-ntlmssp is for OMI server, remaining packages are for .NET Core / PowerShell
+# gss-ntlmssp is for OMI server NTLM + Kerb support
+# ntp, realmd, sssd, samba-*, adcli are for working with Active Directory
+# krb5-config, krb5-user are Kerberos libraries
+# remaining packages are for .NET Core / PowerShell
 # PSRP deb provides OMI "plugin" for PowerShell
 RUN export DEBIAN_FRONTEND=noninteractive \
  && apt-get update -y \
@@ -19,8 +27,20 @@ RUN export DEBIAN_FRONTEND=noninteractive \
  && dpkg -i packages-microsoft-prod.deb \
  && apt-get update -y \
  && apt-get install -y \
+    gettext-base \
     gss-ntlmssp \
     libgssapi-krb5-2 \
+    ntp \
+    krb5-config \
+    krb5-user \
+    realmd \
+    sssd \
+    sssd-tools \
+    samba-common \
+    samba-dsdb-modules \
+    samba-common-bin \
+    samba-libs \
+    adcli \
     omi \
     powershell \
  && wget https://github.com/PowerShell/psl-omi-provider/releases/download/v1.4.2-2/psrp-1.4.2-2.universal.x64.deb \
@@ -60,6 +80,12 @@ RUN touch /etc/opt/omi/creds/ntlm \
 EXPOSE 5985 5986
 
 ADD fixtures/omiserver/docker-entrypoint.sh /
+ADD fixtures/samba-ad/kerberos-client-config.sh /
+ADD fixtures/samba-ad/krb5.conf.tmpl /
+ADD fixtures/omiserver/domain-join.sh /
+ADD fixtures/omiserver/realmd.conf.tmpl /
+ADD fixtures/omiserver/smb.conf.tmpl /
+ADD fixtures/omiserver/sssd.conf.tmpl /
 ADD fixtures/omiserver/verify-omi-authentication.sh /
 ADD fixtures/omiserver/verify-pwsh-authentication.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/spec/Dockerfile.samba-ad
+++ b/spec/Dockerfile.samba-ad
@@ -1,0 +1,17 @@
+FROM alpine:latest
+
+RUN apk add --no-cache supervisor tini gettext samba-dc
+
+ADD fixtures/samba-ad/docker-entrypoint.sh /
+ADD fixtures/samba-ad/samba-ad-config.sh /
+ADD fixtures/samba-ad/smb.conf.tmpl /
+ADD fixtures/samba-ad/kerberos-client-config.sh /
+ADD fixtures/samba-ad/krb5.conf.tmpl /
+ADD fixtures/samba-ad/supervisord.conf /etc/supervisord.conf
+
+VOLUME /var/lib/krb5kdc
+
+EXPOSE 464 88
+
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["/docker-entrypoint.sh"]

--- a/spec/bolt/transport/winrm_spec.rb
+++ b/spec/bolt/transport/winrm_spec.rb
@@ -210,7 +210,11 @@ PS
       skip('Windows Active Directory tickets are different') if Bolt::Util.windows?
 
       @kerb_user = 'Administrator'
-      @kerb_realm = 'BOLT.TEST'
+      @kerb_realm = ENV['KRB5_REALM'] || 'BOLT.TEST'
+      @smb_admin_pass = ENV['SMB_ADMIN_PASSWORD'] || 'B0ltrules!'
+
+      # this will renew any stale tickets when testing locally
+      `echo #{@smb_admin_pass} | kinit Administrator@#{@kerb_realm}`
     end
 
     let(:omi_http_kerb_target) do
@@ -221,6 +225,12 @@ PS
     let(:omi_https_kerb_target) do
       conf = mk_config(ssl: true, realm: @kerb_realm, 'ssl-verify': false)
       make_target(host_: 'omiserver.bolt.test', port_: 45986, conf: conf)
+    end
+
+    # verifies the local setup has already acquired the right Kerberos ticket
+    it "has acquired a ticket granting ticket from the Samba AD / KDC" do
+      esc_realm = Regexp.escape(@kerb_realm)
+      expect(`klist`).to match(%r{krbtgt\/#{esc_realm}@#{esc_realm}})
     end
 
     it "executes a command on a host over HTTP" do

--- a/spec/bolt/transport/winrm_spec.rb
+++ b/spec/bolt/transport/winrm_spec.rb
@@ -234,12 +234,12 @@ PS
     end
 
     it "executes a command on a host over HTTP" do
-      pending("Not yet implemented")
+      pending("WinRM gem and OMI server have a protocol negotiation bug")
       expect(winrm.run_command(omi_http_kerb_target, command)['stdout']).to eq("#{@kerb_user}\r\n")
     end
 
     it "executes a command on a host over HTTPS" do
-      pending("Not yet implemented")
+      pending("WinRM gem and OMI server have a protocol negotiation bug")
       expect(winrm.run_command(omi_https_kerb_target, command)['stdout']).to eq("#{@kerb_user}\r\n")
     end
   end

--- a/spec/docker-compose.yml
+++ b/spec/docker-compose.yml
@@ -50,6 +50,11 @@ services:
 
   omiserver:
     hostname: omiserver
+    domainname: bolt.test
+    # must use Samba AD for DNS
+    dns:
+      - 172.22.0.100
+      - 8.8.8.8
     build:
       context: .
       dockerfile: Dockerfile.omiserver
@@ -58,6 +63,16 @@ services:
     ports:
       - "45985:5985"
       - "45986:5986"
+    environment:
+      KRB5_REALM: ${KRB5_REALM:-BOLT.TEST}
+      KRB5_KDC: ${KRB5_KDC:-samba-ad.bolt.test}
+      SMB_DOMAIN: ${SMB_DOMAIN:-BOLT}
+      SMB_ADMIN: Administrator
+      SMB_ADMIN_PASSWORD: ${SMB_ADMIN_PASSWORD:-B0ltrules!}
+    depends_on:
+      - samba-ad
+    networks:
+      BOLT.TEST:
 
   samba-ad:
     hostname: samba-ad
@@ -86,6 +101,8 @@ services:
     networks:
       BOLT.TEST:
         ipv4_address: 172.22.0.100
+        aliases:
+          - samba-ad.bolt.test
 
 networks:
   BOLT.TEST:

--- a/spec/docker-compose.yml
+++ b/spec/docker-compose.yml
@@ -58,3 +58,38 @@ services:
     ports:
       - "45985:5985"
       - "45986:5986"
+
+  samba-ad:
+    hostname: samba-ad
+    domainname: bolt.test
+    # must use itself for DNS
+    dns:
+      - 172.22.0.100
+      - 8.8.8.8
+    build:
+      context: .
+      dockerfile: Dockerfile.samba-ad
+    restart: always
+    # SYS_ADMIN necessary for samba-tool domain provision
+    # otherwise set_nt_acl_no_snum: fset_nt_acl returned NT_STATUS_ACCESS_DENIED
+    cap_add:
+      - SYS_ADMIN
+    ports:
+      - "88:88"
+      - "464:464"
+    environment:
+      KRB5_REALM: ${KRB5_REALM:-BOLT.TEST}
+      KRB5_KDC: ${KRB5_KDC:-localhost}
+      KRB5_ADMINSERVER: ${KRB5_ADMINSERVER}
+      SMB_DOMAIN: ${SMB_DOMAIN:-BOLT}
+      SMB_ADMIN_PASSWORD: ${SMB_ADMIN_PASSWORD:-B0ltrules!}
+    networks:
+      BOLT.TEST:
+        ipv4_address: 172.22.0.100
+
+networks:
+  BOLT.TEST:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.22.0.0/16

--- a/spec/fixtures/omiserver/docker-entrypoint.sh
+++ b/spec/fixtures/omiserver/docker-entrypoint.sh
@@ -4,6 +4,9 @@ set -e
 /opt/omi/bin/omiserver --version
 pwsh --version
 
+./kerberos-client-config.sh
+./domain-join.sh
+
 cat << EOF
 
 ************************************************************

--- a/spec/fixtures/omiserver/docker-entrypoint.sh
+++ b/spec/fixtures/omiserver/docker-entrypoint.sh
@@ -19,6 +19,7 @@ EOF
 # there is a race here which may cause the log to not be created yet
 sync
 
+./omi-enable-kerberos-auth.sh
 ./verify-omi-authentication.sh
 ./verify-pwsh-authentication.sh
 

--- a/spec/fixtures/omiserver/docker-entrypoint.sh
+++ b/spec/fixtures/omiserver/docker-entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 /opt/omi/bin/omiserver --version
 pwsh --version
@@ -14,6 +15,9 @@ EOF
 /opt/omi/bin/omiserver -d
 # there is a race here which may cause the log to not be created yet
 sync
+
+./verify-omi-authentication.sh
+./verify-pwsh-authentication.sh
 
 cat << EOF
 

--- a/spec/fixtures/omiserver/domain-join.sh
+++ b/spec/fixtures/omiserver/domain-join.sh
@@ -1,0 +1,224 @@
+#!/bin/sh
+set -e
+
+if [ -z ${KRB5_REALM} ]; then
+    echo "No KRB5_REALM Provided. Exiting ..."
+    exit 1
+fi
+
+if [ -z ${SMB_DOMAIN} ]; then
+    echo "No SMB_DOMAIN Provided. Exiting ..."
+    exit 1
+fi
+
+if [ -z ${SMB_ADMIN} ]; then
+    echo "No SMB_ADMIN Provided. Exiting ..."
+    exit 1
+fi
+
+if [ -z ${SMB_ADMIN_PASSWORD} ]; then
+    echo "No SMB_ADMIN_PASSWORD Provided. Exiting ..."
+    exit 1
+fi
+
+# since we're in Docker, it shouldn't be necessary to sync NTP
+
+cat << EOF
+
+************************************************************
+Checking realm DNS
+************************************************************
+
+EOF
+
+export KRB5_REALM_LOWER=$(echo "${KRB5_REALM}" | tr '[:upper:]' '[:lower:]')
+LDAP_DNS="_ldap._tcp.${KRB5_REALM_LOWER}"
+until host -t SRV -v ${LDAP_DNS}
+do
+    echo "Waiting for ${LDAP_DNS} to resolve... exit status: $?"
+    sleep 1s
+done
+# show that DNS record exists
+host -t SRV -v ${LDAP_DNS}
+
+cat << EOF
+
+************************************************************
+Initializing Kerberos client
+************************************************************
+
+EOF
+
+# wait for the DC to be listening
+until echo "${SMB_ADMIN_PASSWORD}" | KRB5_TRACE=/dev/stdout kinit "${SMB_ADMIN}"
+do
+    echo "Waiting to retrieve ticket granting ticket from domain controller... exit status: $?"
+    sleep 1s
+done
+# show the ticket granting ticket
+KRB5_TRACE=/dev/stdout klist
+
+cat << EOF
+
+************************************************************
+GNU Name Sevice Switch Configuration
+************************************************************
+
+EOF
+# this should include `sss` for passwd, group, shadow, services, netgroup, sudoers
+cat /etc/nsswitch.conf
+
+cat << EOF
+
+************************************************************
+Creating realmd.conf
+************************************************************
+
+EOF
+
+envsubst < realmd.conf.tmpl | tee /etc/realmd.conf
+
+cat << EOF
+
+************************************************************
+Creating /etc/samba/smb.conf
+************************************************************
+
+EOF
+
+cp /etc/samba/smb.conf /etc/samba/smb.conf.bak
+envsubst < smb.conf.tmpl | tee /etc/samba/smb.conf
+
+cat << EOF
+
+************************************************************
+Joining domain ${KRB5_REALM_LOWER} as ${SMB_ADMIN} using realm
+************************************************************
+
+EOF
+
+# waiting for: realm: Already joined to this domain
+until echo "${SMB_ADMIN_PASSWORD}" |
+  realm --verbose join "${KRB5_REALM_LOWER}" -U ${SMB_ADMIN} --install=/ 2>&1 |
+  tee join.txt |
+  grep -q "Already joined to this domain"
+do
+    # When successful:
+    # omiserver_1      | Joining domain bolt.test with realm command
+    # omiserver_1      |  * Resolving: _ldap._tcp.bolt.test
+    # omiserver_1      |  * Performing LDAP DSE lookup on: 172.22.0.100
+    # omiserver_1      |  * Successfully discovered: bolt.test
+    # omiserver_1      | realm: Already joined to this domain
+
+    # omiserver_1      | Server time: Tue, 18 Jun 2019 22:47:17 UTC
+
+    # When unsuccesful:
+    # omiserver_1      | Joining domain bolt.test with realm command
+    # omiserver_1      |  * Resolving: _ldap._tcp.bolt.test
+    # omiserver_1      |  * Performing LDAP DSE lookup on: 172.22.0.100
+    # omiserver_1      |  ! Can't contact LDAP server
+    # omiserver_1      | realm: Cannot join this realm
+    # omiserver_1      | Failed to get server's current time!
+
+    # omiserver_1      | Server time: Thu, 01 Jan 1970 00:00:00 UTC
+
+    cat join.txt
+    echo "Waiting for successful domain join...\n"
+    sleep 1s
+done
+cat join.txt
+
+cat << EOF
+
+************************************************************
+net ads join ${SMB_ADMIN}%${SMB_ADMIN_PASSWORD}
+************************************************************
+
+EOF
+
+# https://wiki.samba.org/index.php/Setting_up_Samba_as_a_Domain_Member#Joining_the_Domain
+# DO NOT use `samba-tool domain join` per documentation
+net ads join --user ${SMB_ADMIN}%${SMB_ADMIN_PASSWORD}
+
+cat << EOF
+
+************************************************************
+Creating sssd.conf / setting permissions / ownership
+************************************************************
+
+EOF
+
+envsubst < sssd.conf.tmpl | tee /etc/sssd/sssd.conf
+
+# sssd service won't start without perms of 0600 and correct owner
+chmod 0600 /etc/sssd/sssd.conf
+chown root:root /etc/sssd/sssd.conf
+ls -rtaFl /etc/sssd/sssd.conf
+
+cat << EOF
+
+************************************************************
+PAM config
+************************************************************
+
+EOF
+
+ls -rtaFl /etc/pam.d/common-*
+grep -E 'sss|mkhomedir' /etc/pam.d/common-*
+
+cat << EOF
+
+************************************************************
+Starting sssd service
+************************************************************
+
+EOF
+
+service sssd start
+
+# emit information about domain join
+cat << EOF
+
+************************************************************
+Verifying realm ${KRB5_REALM_LOWER}
+************************************************************
+
+EOF
+realm --verbose discover "${KRB5_REALM_LOWER}" --install=/
+
+cat << EOF
+
+************************************************************
+net ads info
+************************************************************
+
+EOF
+
+net ads info
+
+cat << EOF
+
+************************************************************
+Verifying sssd service
+************************************************************
+
+EOF
+
+service sssd status
+ps aux | grep sssd
+
+cat << EOF
+
+************************************************************
+Verifying ${SMB_ADMIN}@${KRB5_REALM} user can be looked up
+************************************************************
+
+EOF
+
+getent passwd ${SMB_ADMIN}@${KRB5_REALM}
+getent passwd ${SMB_DOMAIN}\\${SMB_ADMIN}
+# should produce something like:
+# administrator:*:1219600500:1219600513:Administrator:/home/administrator@BOLT.TEST:
+# dump all the sssd log files
+sync
+cat /var/log/sssd/*

--- a/spec/fixtures/omiserver/omi-enable-kerberos-auth.sh
+++ b/spec/fixtures/omiserver/omi-enable-kerberos-auth.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+set -e
+
+if [ -z ${SMB_ADMIN} ]; then
+    echo "No SMB_ADMIN Provided. Exiting ..."
+    exit 1
+fi
+
+if [ -z ${SMB_ADMIN_PASSWORD} ]; then
+    echo "No SMB_ADMIN_PASSWORD Provided. Exiting ..."
+    exit 1
+fi
+
+# it's important to restart the sssd service after updating the keytab
+# (originally generated as part of the `realm join`)
+cat << EOF
+
+************************************************************
+Updating Kerberos keytab file for ${SMB_ADMIN}
+************************************************************
+
+EOF
+
+echo "${SMB_ADMIN_PASSWORD}" | net ads keytab add HTTP -U ${SMB_ADMIN}
+
+cp /etc/krb5.keytab /etc/opt/omi/creds/omi.keytab
+chown omi:omi /etc/opt/omi/creds/omi.keytab
+# dumps the contents of the keyfile
+klist -Kke
+
+# WinRM gem requests the HTTP SPN when connecting
+# https://github.com/WinRb/WinRM/blob/2a9a2ff55c5bbd903a019d63b1d134ac32ead4c7/lib/winrm/http/transport.rb#L299
+cat << EOF
+
+************************************************************
+Verifying HTTP SPN in Active Directory (Samba)
+************************************************************
+
+EOF
+
+net ads dn --kerberos 'CN=OMISERVER,CN=Computers,DC=bolt,DC=test' servicePrincipalName
+
+net ads dn --kerberos 'CN=OMISERVER,CN=Computers,DC=bolt,DC=test' servicePrincipalName \
+  | grep 'HTTP/omiserver.bolt.test'
+
+# NOTE: similar information can be acquired with tools available on the DC:
+# samba-tool spn list OMISERVER$
+# samba-tool computer list
+# samba-tool computer show OMISERVER$
+# Adding new SPNs takes the form:
+# samba-tool spn add HTTP/OMISERVER@BOLT.TEST OMISERVER$
+
+cat << EOF
+
+************************************************************
+Restarting sssd service
+************************************************************
+
+EOF
+
+service sssd restart
+service sssd status
+# dump all the sssd log files
+cat /var/log/sssd/*

--- a/spec/fixtures/omiserver/realmd.conf.tmpl
+++ b/spec/fixtures/omiserver/realmd.conf.tmpl
@@ -1,0 +1,17 @@
+[users]
+default-home = /home/%D/%U
+default-shell = /bin/bash
+
+[active-directory]
+default-client = sssd
+os-name = Ubuntu Desktop Linux
+os-version = 16.04
+
+[service]
+automatic-install = no
+
+[${KRB5_REALM_LOWER}]
+fully-qualified-names = no
+automatic-id-mapping = yes
+user-principal = yes
+manage-system = no

--- a/spec/fixtures/omiserver/smb.conf.tmpl
+++ b/spec/fixtures/omiserver/smb.conf.tmpl
@@ -1,0 +1,20 @@
+[global]
+workgroup = ${SMB_DOMAIN}
+security = ads
+realm = ${KRB5_REALM_LOWER}
+server role = member server
+kerberos method = secrets and keytab
+
+# defaults from Ubuntu smb.conf
+server string = %h server (Samba, Ubuntu)
+log file = /var/log/samba/log.%m
+max log size = 1000
+syslog = 0
+panic action = /usr/share/samba/panic-action %d
+passdb backend = tdbsam
+obey pam restrictions = yes
+unix password sync = yes
+passwd program = /usr/bin/passwd %u
+passwd chat = *Enter\snew\s*\spassword:* %n\n *Retype\snew\s*\spassword:* %n\n *password\supdated\ssuccessfully* .
+pam password change = yes
+map to guest = bad user

--- a/spec/fixtures/omiserver/sssd.conf.tmpl
+++ b/spec/fixtures/omiserver/sssd.conf.tmpl
@@ -1,0 +1,14 @@
+# https://linux.die.net/man/5/sssd-ad
+[sssd]
+services = nss, pam
+config_file_version = 2
+domains = ${KRB5_REALM}
+
+[nss]
+debug_level = 3
+
+[domain/${KRB5_REALM}]
+id_provider = ad
+access_provider = ad
+fallback_homedir = /home/%u@%d
+debug_level = 3

--- a/spec/fixtures/omiserver/verify-omi-authentication.sh
+++ b/spec/fixtures/omiserver/verify-omi-authentication.sh
@@ -6,6 +6,21 @@ if [ -z ${BOLT_PASSWORD} ]; then
     exit 1
 fi
 
+if [ -z ${KRB5_REALM} ]; then
+    echo "No KRB5_REALM Provided. Exiting ..."
+    exit 1
+fi
+
+if [ -z ${SMB_ADMIN} ]; then
+    echo "No SMB_ADMIN Provided. Exiting ..."
+    exit 1
+fi
+
+if [ -z ${SMB_ADMIN_PASSWORD} ]; then
+    echo "No SMB_ADMIN_PASSWORD Provided. Exiting ..."
+    exit 1
+fi
+
 cat << EOF
 
 ************************************************************
@@ -36,3 +51,24 @@ Verifying HTTPS SPNEGO auth bolt:${BOLT_PASSWORD} with omicli
 EOF
 
 /opt/omi/bin/omicli --hostname omiserver -u bolt -p ${BOLT_PASSWORD} id --auth NegoWithCreds --encryption https
+
+# oddly, password must be supplied here to verify the creds??
+cat << EOF
+
+************************************************************
+Verifying HTTP Kerberos auth Administrator@${KRB5_REALM} ${SMB_ADMIN_PASSWORD} with omicli
+************************************************************
+
+EOF
+
+/opt/omi/bin/omicli --hostname omiserver --auth Kerberos -u Administrator@${KRB5_REALM} -p "${SMB_ADMIN_PASSWORD}" id --encryption http
+
+cat << EOF
+
+************************************************************
+Verifying HTTPS Kerberos auth Administrator@${KRB5_REALM} ${SMB_ADMIN_PASSWORD} with omicli
+************************************************************
+
+EOF
+
+/opt/omi/bin/omicli --hostname omiserver --auth Kerberos -u Administrator@${KRB5_REALM} -p "${SMB_ADMIN_PASSWORD}" id --encryption https

--- a/spec/fixtures/omiserver/verify-omi-authentication.sh
+++ b/spec/fixtures/omiserver/verify-omi-authentication.sh
@@ -15,3 +15,24 @@ Verifying HTTPS Basic auth bolt:${BOLT_PASSWORD} with omicli
 EOF
 
 /opt/omi/bin/omicli --hostname omiserver -u bolt -p ${BOLT_PASSWORD} id --auth Basic --encryption https
+
+cat << EOF
+
+************************************************************
+Verifying HTTP SPNEGO auth bolt:${BOLT_PASSWORD} with omicli
+************************************************************
+
+EOF
+
+/opt/omi/bin/omicli --hostname omiserver -u bolt -p ${BOLT_PASSWORD} id --auth NegoWithCreds --encryption http
+
+
+cat << EOF
+
+************************************************************
+Verifying HTTPS SPNEGO auth bolt:${BOLT_PASSWORD} with omicli
+************************************************************
+
+EOF
+
+/opt/omi/bin/omicli --hostname omiserver -u bolt -p ${BOLT_PASSWORD} id --auth NegoWithCreds --encryption https

--- a/spec/fixtures/omiserver/verify-omi-authentication.sh
+++ b/spec/fixtures/omiserver/verify-omi-authentication.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+if [ -z ${BOLT_PASSWORD} ]; then
+    echo "No BOLT_PASSWORD Provided. Exiting ..."
+    exit 1
+fi
+
+cat << EOF
+
+************************************************************
+Verifying HTTPS Basic auth bolt:${BOLT_PASSWORD} with omicli
+************************************************************
+
+EOF
+
+/opt/omi/bin/omicli --hostname omiserver -u bolt -p ${BOLT_PASSWORD} id --auth Basic --encryption https

--- a/spec/fixtures/omiserver/verify-pwsh-authentication.sh
+++ b/spec/fixtures/omiserver/verify-pwsh-authentication.sh
@@ -6,6 +6,21 @@ if [ -z ${BOLT_PASSWORD} ]; then
     exit 1
 fi
 
+if [ -z ${KRB5_REALM} ]; then
+    echo "No KRB5_REALM Provided. Exiting ..."
+    exit 1
+fi
+
+if [ -z ${SMB_ADMIN} ]; then
+    echo "No SMB_ADMIN Provided. Exiting ..."
+    exit 1
+fi
+
+if [ -z ${SMB_ADMIN_PASSWORD} ]; then
+    echo "No SMB_ADMIN_PASSWORD Provided. Exiting ..."
+    exit 1
+fi
+
 cat << EOF
 
 ************************************************************
@@ -48,6 +63,36 @@ EOF
 
 AUTH='-Authentication Negotiate'
 PS="Invoke-Command -ComputerName omiserver $COMMAND $AUTH $SSL $CREDS"
+/usr/bin/pwsh -Command ''$PS'' | tee /tmp/psversion.txt
+
+cat /tmp/psversion.txt | grep ^OS.*Linux
+
+cat << EOF
+
+************************************************************
+Verifying HTTP Kerberos auth Administrator@${KRB5_REALM} ${SMB_ADMIN_PASSWORD} with pwsh
+************************************************************
+
+EOF
+
+AUTH='-Authentication Kerberos'
+KRB_PASS='(ConvertTo-SecureString $ENV:SMB_ADMIN_PASSWORD -AsPlainText -Force)'
+KRB_CREDS="-Credential (New-Object System.Management.Automation.PSCredential(\"\${ENV:SMB_ADMIN}@\${ENV:KRB5_REALM}\", $KRB_PASS))"
+PS="Invoke-Command -ComputerName omiserver $COMMAND $AUTH $KRB_CREDS"
+/usr/bin/pwsh -Command ''$PS'' | tee /tmp/psversion.txt
+
+cat /tmp/psversion.txt | grep ^OS.*Linux
+
+cat << EOF
+
+************************************************************
+Verifying HTTPS Kerberos auth Administrator@${KRB5_REALM} ${SMB_ADMIN_PASSWORD} with pwsh
+************************************************************
+
+EOF
+
+AUTH='-Authentication Kerberos'
+PS="Invoke-Command -ComputerName omiserver $COMMAND $AUTH $SSL $KRB_CREDS"
 /usr/bin/pwsh -Command ''$PS'' | tee /tmp/psversion.txt
 
 cat /tmp/psversion.txt | grep ^OS.*Linux

--- a/spec/fixtures/omiserver/verify-pwsh-authentication.sh
+++ b/spec/fixtures/omiserver/verify-pwsh-authentication.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+
+if [ -z ${BOLT_PASSWORD} ]; then
+    echo "No BOLT_PASSWORD Provided. Exiting ..."
+    exit 1
+fi
+
+cat << EOF
+
+************************************************************
+Verifying HTTPS Basic auth bolt:${BOLT_PASSWORD} with pwsh
+************************************************************
+
+EOF
+
+COMMAND='-Command { $PSVersionTable }'
+AUTH='-Authentication Basic'
+SSL='-UseSSL -SessionOption (New-PSSessionOption -SkipCACheck -SkipCNCheck)'
+PASS='(ConvertTo-SecureString $ENV:BOLT_PASSWORD -AsPlainText -Force)'
+CREDS="-Credential (New-Object System.Management.Automation.PSCredential('bolt', $PASS))"
+PS="Invoke-Command -ComputerName omiserver $COMMAND $AUTH $SSL $CREDS"
+/usr/bin/pwsh -Command ''$PS'' | tee /tmp/psversion.txt
+
+cat /tmp/psversion.txt | grep ^OS.*Linux

--- a/spec/fixtures/omiserver/verify-pwsh-authentication.sh
+++ b/spec/fixtures/omiserver/verify-pwsh-authentication.sh
@@ -23,3 +23,31 @@ PS="Invoke-Command -ComputerName omiserver $COMMAND $AUTH $SSL $CREDS"
 /usr/bin/pwsh -Command ''$PS'' | tee /tmp/psversion.txt
 
 cat /tmp/psversion.txt | grep ^OS.*Linux
+
+cat << EOF
+
+************************************************************
+Verifying HTTP SPNEGO auth bolt:${BOLT_PASSWORD} with pwsh
+************************************************************
+
+EOF
+
+AUTH='-Authentication Negotiate'
+PS="Invoke-Command -ComputerName omiserver $COMMAND $AUTH $CREDS"
+/usr/bin/pwsh -Command ''$PS'' | tee /tmp/psversion.txt
+
+cat /tmp/psversion.txt | grep ^OS.*Linux
+
+cat << EOF
+
+************************************************************
+Verifying HTTPS SPNEGO auth bolt:${BOLT_PASSWORD} with pwsh
+************************************************************
+
+EOF
+
+AUTH='-Authentication Negotiate'
+PS="Invoke-Command -ComputerName omiserver $COMMAND $AUTH $SSL $CREDS"
+/usr/bin/pwsh -Command ''$PS'' | tee /tmp/psversion.txt
+
+cat /tmp/psversion.txt | grep ^OS.*Linux

--- a/spec/fixtures/samba-ad/docker-entrypoint.sh
+++ b/spec/fixtures/samba-ad/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+./samba-ad-config.sh
+./kerberos-client-config.sh
+
+/usr/bin/supervisord -c /etc/supervisord.conf

--- a/spec/fixtures/samba-ad/kerberos-client-config.sh
+++ b/spec/fixtures/samba-ad/kerberos-client-config.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -e
+
+cat << EOF
+
+************************************************************
+Configuring Krb5 Client
+************************************************************
+
+EOF
+
+if [ -z ${KRB5_REALM} ]; then
+    echo "No KRB5_REALM Provided. Exiting ..."
+    exit 1
+fi
+
+if [ -z ${KRB5_KDC} ]; then
+    echo "No KRB5_KDC Provided. Exiting ..."
+    exit 1
+fi
+
+if [ -z ${KRB5_ADMINSERVER} ]; then
+    echo "KRB5_ADMINSERVER not provided. Using KRB5_KDC value ${KRB5_KDC}"
+    export KRB5_ADMINSERVER=${KRB5_KDC}
+fi
+
+if [ -z ${KRB5_CONFIG} ]; then
+    echo "KRB5_CONFIG not provided. Using /etc/krb5.conf"
+    export KRB5_CONFIG=/etc/krb5.conf
+fi
+
+cat << EOF
+
+************************************************************
+Creating Krb5 Client Configuration ${KRB5_CONFIG}
+************************************************************
+
+EOF
+
+export KRB5_REALM_LOWER=$(echo "${KRB5_REALM}" | tr '[:upper:]' '[:lower:]')
+TEMPLATE_PATH=$(dirname "$(readlink -f "$0")")
+envsubst < ${TEMPLATE_PATH}/krb5.conf.tmpl | tee ${KRB5_CONFIG}

--- a/spec/fixtures/samba-ad/krb5.conf.tmpl
+++ b/spec/fixtures/samba-ad/krb5.conf.tmpl
@@ -1,0 +1,18 @@
+[libdefaults]
+dns_lookup_kdc = true
+dns_lookup_realm = false
+ticket_lifetime = 24h
+renew_lifetime = 7d
+forwardable = true
+rdns = false
+default_realm = ${KRB5_REALM}
+
+[realms]
+${KRB5_REALM} = {
+    kdc = ${KRB5_KDC}
+    admin_server = ${KRB5_ADMINSERVER}
+}
+
+[domain_realm]
+${KRB5_REALM_LOWER} = ${KRB5_REALM}
+.${KRB5_REALM_LOWER} = ${KRB5_REALM}

--- a/spec/fixtures/samba-ad/krb5.osx.conf
+++ b/spec/fixtures/samba-ad/krb5.osx.conf
@@ -1,0 +1,9 @@
+[realms]
+BOLT.TEST = {
+  kdc = tcp/samba-ad.bolt.test
+  admin_server = tcp/samba-ad.bolt.test
+}
+
+[domain_realm]
+bolt.test = BOLT.TEST
+.bolt.test = BOLT.TEST

--- a/spec/fixtures/samba-ad/samba-ad-config.sh
+++ b/spec/fixtures/samba-ad/samba-ad-config.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+set -e
+
+cat << EOF
+
+************************************************************
+Configuring Samba
+************************************************************
+
+EOF
+
+if [ -z ${KRB5_REALM} ]; then
+    echo "No KRB5_REALM Provided. Exiting ..."
+    exit 1
+fi
+
+if [ -z ${SMB_DOMAIN} ]; then
+    echo "No SMB_DOMAIN Provided. Exiting ..."
+    exit 1
+fi
+
+if [ -z ${SMB_ADMIN_PASSWORD} ]; then
+    echo "No SMB_ADMIN_PASSWORD Provided. Exiting ..."
+    exit 1
+fi
+
+cat << EOF
+
+************************************************************
+Tool Versions
+************************************************************
+
+EOF
+
+echo "samba-tool version: $(samba-tool --version)"
+echo "net ads version: $(net ads --version)"
+
+cat << EOF
+
+************************************************************
+Provisioning Domain
+************************************************************
+
+EOF
+
+echo "Creating Samba SMB Configuration"
+
+export KRB5_REALM_LOWER=$(echo "${KRB5_REALM}" | tr '[:upper:]' '[:lower:]')
+envsubst < smb.conf.tmpl | tee /etc/samba/smb.conf
+
+# https://wiki.samba.org/index.php/Setting_up_Samba_as_an_Active_Directory_Domain_Controller#Parameter_Explanation
+# https://www.samba.org/samba/docs/current/man-html/samba-tool.8.html
+samba-tool domain provision \
+    --use-rfc2307 \
+    --realm=${KRB5_REALM} \
+    --domain=${SMB_DOMAIN} \
+    --server-role=dc \
+    --adminpass=${SMB_ADMIN_PASSWORD} \
+    --dns-backend=SAMBA_INTERNAL
+
+  # DNS forwarder IP address (write 'none' to disable forwarding) [127.0.0.11]:
+  # --host-name=HOSTNAME  set hostname
+  # --host-ip=IPADDRESS   set IPv4 ipaddress
+  # --host-ip6=IP6ADDRESS
+  #                       set IPv6 ipaddress
+  # --site=SITENAME       set site name
+  # --krbtgtpass=PASSWORD
+  #                       choose krbtgt password (otherwise random)
+  # --machinepass=PASSWORD
+  #                       choose machine password (otherwise random)
+  # --dnspass=PASSWORD    choose dns password (otherwise random)
+  # --ldapadminpass=PASSWORD
+  #                       choose password to set between Samba and its LDAP
+  #                       backend (otherwise random)
+  # Samba Common Options:
+  #   -s FILE, --configfile=FILE
+  #                       Configuration file
+  #   -d DEBUGLEVEL, --debuglevel=DEBUGLEVEL
+  #                       debug level
+  #   --option=OPTION     set smb.conf option from command line
+
+cat << EOF
+
+************************************************************
+Confirming Samba Kerberos library (Heimdal vs MIT)
+************************************************************
+
+EOF
+
+smbd -b | grep HEIMDAL
+smbd -b | grep HAVE_LIBKADM5SRV_MIT

--- a/spec/fixtures/samba-ad/smb.conf.tmpl
+++ b/spec/fixtures/samba-ad/smb.conf.tmpl
@@ -1,0 +1,18 @@
+[global]
+        server role = domain controller
+        workgroup = ${SMB_DOMAIN}
+        realm = ${KRB5_REALM_LOWER}
+        netbios name = SAMBA-AD
+        passdb backend = samba4
+        idmap_ldb:use rfc2307 = yes
+        # NOTE: requests are first forwarded to Docker
+        # then docker-compose config forwards to DNS server in user-defined network
+        dns forwarder = 127.0.0.11
+
+[netlogon]
+        path = /var/lib/samba/sysvol/example.com/scripts
+        read only = No
+
+[sysvol]
+        path = /var/lib/samba/sysvol
+        read only = No

--- a/spec/fixtures/samba-ad/supervisord.conf
+++ b/spec/fixtures/samba-ad/supervisord.conf
@@ -1,0 +1,21 @@
+[inet_http_server]
+port = 9001
+username = bolt
+password = bolt
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl = http://127.0.0.1:9001
+
+[program:samba]
+command   = /usr/sbin/samba -i
+
+[supervisord]
+logfile   = /tmp/supervisord.log   ; supervisord log file
+loglevel  = error                  ; info, debug, warn, trace
+nodaemon  = true
+user      = root
+pidfile   = /tmp/supervisord.pid   ; pidfile location
+directory = /tmp


### PR DESCRIPTION
* builds on ~~#996~~
* blocked by ~~#1087~~
* follow-on dev PR setup at #1093 

 - Ensure that Basic auth with credentials can be used over HTTP(S)
   against the OMI server setup

   This basically verifies that the NTLM authentication file is properly
   setup for use with OMI server and contains bolt:$BOLT_PASSWORD
   where $BOLT_PASSWORD is setup during container build

 - These checks are performed with both omicli *and* pwsh. The scripts
   are separated so that the pwsh tests can be performed from another
   container used for development

 - The current docker-compose hostname: omiserver is sufficient for the
   container to correctly self-identify

 - This establishes an Active Directory server in the Docker compose
   stack, which is one of the easier ways on Linux to establish a KDC
   (Key Distribution Center). While originally inspired by a simpler
   KDC setup at gcavalcante8808/docker-krb5-server
   it became necessary to setup full AD to be able to interoperate with
   OMI server.

   Samba implements not just the AD on Linux, but also sets up DNS SRV
   records for critical addresses like _ldap._tcp.bolt.test

   The compose stack is configured with a new BOLT.TEST network so that
   strict control over the subnet can be setup to give the Samba DNS a
   static IP address, which is critically necessary for it behave
   correctly. Since Kerberos relies heavily on network identity / DNS
   names, it's important to configure the network properly. It's also
   necessary to add the kernel capability SYS_ADMIN through Compose.

 - Samba is setup to own the realm BOLT.TEST and the short name BOLT,
   the provisioning of which happens in samba-ad-config.sh

   The smb.conf in use is instructed to use the Docker DNS of 127.0.0.11
   which is configured in docker-compose.yml to redirect back to the
   address of the Samba container.

   DNS -> 127.0.0.11 -> 172.22.0.100

 - Setup TravisCI to register samba-ad.bolt.test as an entry in
   /etc/hosts so that Bolt may acquire a ticket for the realm BOLT.TEST.
   It's also necessary to specify the correct krb5.conf settings via the
   KRB5_CONFIG env var, pointing it to /tmp/krb5.conf which is generated
   by helper script kerberos-client-config.sh

 - kerberos-client-config.sh takes a few environment variables:

   KRB5_REALM - realm name, typically BOLT.TEST
   KRB5_KDC - KDC DNS name, typically samba-ad.bolt.test
   KRB5_ADMINSERVER (optional) - KDC Admin DNS name, same as above
   KRB5_CONFIG (optional) - path to config, default to /etc/krb5.conf

   The script is currently used in Travis to dynamically produce the
   necessary config file, but will also be used in the future to
   produce the same file for OMI server

 - Add a single test under the :kerberos tag that performs a regex
   match against the `klist` output to make sure that a single ticket
   has been acquired, so that the test may be run in TravisCI and
   locally on OSX dev environments.

   NOTE: OSX can only acquire tickets, and will not be able to
   participate in future testing because of its Kerberos library.

   NOTE: Windows has a very different klist command line tool with
   wildly different output, and Windows is not tested in this PR

 - To configure Docker on OSX to communicate with the Samba KDC to
   acquire tickets requires several setup steps.

   * Adding an entry to /etc/hosts like:

     127.0.0.1 samba-ad.bolt.test

   * export KRB5_CONF=$(pwd)/spec/fixtures/kdc/krb5.osx.conf, the
     contents of which are setup to match sensible defaults:

     [realms]
     BOLT.TEST = {
       kdc = tcp/samba-ad.bolt.test
       admin_server = tcp/samba-ad.bolt.test
     }

     [domain_realm]
     bolt.test = BOLT.TEST
     .bolt.test = BOLT.TEST

     Alternatively, those settings may be more permanently added to
     /etc/krb5.conf if desired

   * NOTE: tcp/ is necessary Kerberos will try to use UDP by default
     which is not available to OSX Docker by default

 - To acquire the ticket granting ticket, use the command:

    KRB5_TRACE=/dev/stdout kinit Administrator@BOLT.TEST

    The current password is "B0ltrules!" as specified in docker-compose
    with the variable SMB_ADMIN_PASSWORD. KRB5_TRACE is not necessary
    but provides additional debug output that can be useful

    To destroy the ticket, use the command:

    kdestroy --credential=krbtgt/BOLT.TEST@BOLT.TEST

 - Install additional packages to support joining to the running Samba
   domain controller - time synchronization, Kerberos client libraries
   and various Samba tools

 - For the omiserver container to join the Samba domain, it must be on
   the same network, responding to the same DNS. Configure the Docker
   network accordingly to ensure that the containers are on the same
   subnet, and that the DNS alias samba-ad.bolt.test DNS resolves properly.

 - This does a basic domain join, configuring user lookup with sssd,
   which includes the following steps from the OMI server container:

   * Verify DNS resolution works for _ldap._tcp.bolt.test
   * Grab the Kerberos TGT (ticket granting ticket) for the domain
     Administrator account
   * Emit the nsswitch.conf for debug purposes
   * Configure realmd service with the specified domain and updating
     the smb.conf with config values for:
     - workgroup
     - realm
     - kerberos method = secrets and keytabs
   * Execute a realm join
   * Execute a net ads join
     - theoretically only one join should be necessary
   * Configure sssd with the given domain / realm
   * Emit relevant sssd info from /etc/pam.d config files
   * Start the sssd service
   * Verify realm discovered properly
   * Use `net ads info` to emit domain information
   * Verify sssd service running
   * Verify domain admin lookup succeeds with getent passwd

 - This has the added side effect of enabling OMI server SPNEGO based
   authentication to work properly, which is demonstrated by using both
   omicli *and* pwsh remoting

 - Now that there is a Samba server available to issue Kerberos tickets,
   configure OMI to use it, also adding the HTTP service SPN

 - Setup is based on instructions from OMI documentation at
   Microsoft/omi:Unix/doc/setup-kerberos-omi.md@master#ubuntu-linux-1604-lts-and-1404-lts-1610-yakkety-and-1704-zesty

 - Unfortunately, there is a bug in the winrm gem preventing it from
   properly interoperating with OMI server when Kerberos authentication
   is enabled. Therefore tests are still marked as pending.

   This will be fixed in tickets.puppetlabs.com/browse/BOLT-1476