### PR TITLE
(maint) Pin ffi to 1.9.25 for macos git-based acceptance tests

### DIFF
--- a/acceptance/setup/common/pre-suite/010_install_ruby.rb
+++ b/acceptance/setup/common/pre-suite/010_install_ruby.rb
@@ -47,6 +47,8 @@ PS
       result = on(bolt, 'ruby --version')
     when /osx/
       # ruby dev tools should be already installed
+      # Pin ffi to 1.9.25 to avoid incompatability with 1.11.1
+      on(bolt, 'gem install ffi --no-document -v 1.9.25')
       result = on(bolt, 'ruby --version')
     else
       fail_test("#{bolt['platform']} not currently a supported bolt controller")


### PR DESCRIPTION
The newest version of the ffi gem (1.11.1) is not installable on macos with native ruby version. In order to support git based testing on macos for 10.13, pin to 1.9.25.