### PR TITLE
(docs) Replace reference to task hands on lab to github.io site

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Bolt is a Ruby command-line tool for executing commands, scripts, and tasks on r
 * Scales to more than 1000 concurrent connections.
 * Supports industry standard protocols (SSH/SCP, WinRM/PSRP) and authentication methods (password, publickey).
 
-> For a step-by-step introduction to Bolt, see our [hands-on-lab](https://github.com/puppetlabs/tasks-hands-on-lab).
+> For a step-by-step introduction to Bolt, see our [hands-on-lab](https://puppetlabs.github.io/bolt/).
 
 Additionally the Bolt project includes:
 

--- a/pre-docs/bolt.md
+++ b/pre-docs/bolt.md
@@ -47,7 +47,7 @@ Bolt is an open source task runner that automates the manual work that you do to
 
  | -   **Learn the basics**
 
-[Hands-on lab](https://github.com/puppetlabs/tasks-hands-on-lab#puppet-tasks-hands-on-lab) - Using a GitHub repository with sample files and code examples, install and run Bolt in a safe environment.
+[Hands-on lab](https://puppetlabs.github.io/bolt/) - Using a GitHub repository with sample files and code examples, install and run Bolt in a safe environment.
 
 [Online training](https://learn.puppet.com/course/puppet-orchestration-bolt-and-tasks?_ga=2.158319738.1526297716.1533055277-261802629.1531434605) - Learn how to use Bolt to run a command, a script, and a task.
 

--- a/pre-docs/getting_started_with_bolt.md
+++ b/pre-docs/getting_started_with_bolt.md
@@ -4,7 +4,7 @@ Using hands-on exercises, discover how Bolt can help you manage your infrastruct
 
 ## Hands-on lab
 
-The Puppet Tasks Hands-on Lab is a GitHub repository that contains sample files, code examples, and exercises to help you configure Bolt and learn to use it in a safe environment. For more information, see the [puppetlabs/tasks-hands-on-lab repository](https://github.com/puppetlabs/tasks-hands-on-lab#puppet-tasks-hands-on-lab).
+For a step-by-step introduction to Bolt and to the Puppet Tasks ecosystem try out the [Bolt Hands On Lab](https://puppetlabs.github.io/bolt/).
 
 ## Online training
 

--- a/pre-docs/running_bolt_commands.md
+++ b/pre-docs/running_bolt_commands.md
@@ -23,11 +23,11 @@ bolt command run <COMMAND> --nodes winrm://<WINDOWS.NODE> --user <USERNAME> --pa
 -   To run a command that contains spaces or shell special characters, wrap the command in single quotation marks:
 
 ```
-bolt command run 'echo $HOME' --nodes web5.mydomain.edu, web6.mydomain.edu
+bolt command run 'echo $HOME' --nodes web5.mydomain.edu,web6.mydomain.edu
 ```
 
 ```
-bolt command run "netstat -an | grep 'tcp.*LISTEN'" --nodes web5.mydomain.edu, web6.mydomain.edu
+bolt command run "netstat -an | grep 'tcp.*LISTEN'" --nodes web5.mydomain.edu,web6.mydomain.edu
 ```
 
 -   To run a cross-platform command:
@@ -62,7 +62,7 @@ bolt script run <PATH/TO/SCRIPT> --nodes <NODE NAME>,<NODE NAME>,<NODE NAME>
 ```
 
 ```
-bolt script run ../myscript.sh --nodes web5.mydomain.edu, web6.mydomain.edu
+bolt script run ../myscript.sh --nodes web5.mydomain.edu,web6.mydomain.edu
 ```
 
 -   When executing on WinRM nodes, include the WinRM protocol in the nodes string:
@@ -111,7 +111,7 @@ bolt file upload <SOURCE> <DESTINATION> --nodes <NODE NAME>,<NODE NAME>
 ```
 
 ```
-bolt file upload my_file.txt /tmp/remote_file.txt --nodes web5.mydomain.edu, web6.mydomain.edu
+bolt file upload my_file.txt /tmp/remote_file.txt --nodes web5.mydomain.edu,web6.mydomain.edu
 ```
 
 


### PR DESCRIPTION
As part of bolt write the docs, make the https://puppetlabs.github.io/bolt/ more discoverable.