### PR TITLE
(BOLT-1337) Make ResultSet.filter return ResultSet

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/datatypes/resultset.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/resultset.rb
@@ -9,7 +9,7 @@ Puppet::DataTypes.create_type('ResultSet') do
       count => Callable[[], Integer],
       empty => Callable[[], Boolean],
       error_set => Callable[[], ResultSet],
-      filter => Callable[[Callable], ResultSet],
+      filter_set => Callable[[Callable], ResultSet],
       find => Callable[[String[1]], Optional[Variant[Result, ApplyResult]]],
       first => Callable[[], Optional[Variant[Result, ApplyResult]]],
       names => Callable[[], Array[String[1]]],

--- a/bolt-modules/boltlib/lib/puppet/datatypes/resultset.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/resultset.rb
@@ -9,6 +9,7 @@ Puppet::DataTypes.create_type('ResultSet') do
       count => Callable[[], Integer],
       empty => Callable[[], Boolean],
       error_set => Callable[[], ResultSet],
+      filter => Callable[[Callable], ResultSet],
       find => Callable[[String[1]], Optional[Variant[Result, ApplyResult]]],
       first => Callable[[], Optional[Variant[Result, ApplyResult]]],
       names => Callable[[], Array[String[1]]],

--- a/lib/bolt/result_set.rb
+++ b/lib/bolt/result_set.rb
@@ -30,6 +30,11 @@ module Bolt
       self
     end
 
+    def filter
+      filtered = @results.select { |r| yield r }
+      self.class.new(filtered)
+    end
+
     def result_hash
       @result_hash ||= @results.each_with_object({}) do |result, acc|
         acc[result.target.name] = result

--- a/lib/bolt/result_set.rb
+++ b/lib/bolt/result_set.rb
@@ -30,7 +30,7 @@ module Bolt
       self
     end
 
-    def filter
+    def filter_set
       filtered = @results.select { |r| yield r }
       self.class.new(filtered)
     end

--- a/pre-docs/writing_plans.md
+++ b/pre-docs/writing_plans.md
@@ -278,6 +278,7 @@ A `ResultSet` has the following methods:
 -   `error_set()`: A `ResultSet`containing only the results of failed nodes.
 
 -   `ok_set()`: A `ResultSet` containing only the successful results.
+-   `filter_set(block)`: Filters a `ResultSet` with the given block and returns a `ResultSet` object (where [Puppet's filter function](https://puppet.com/docs/puppet/6.4/function.html#filter) returns an array or hash)
 
 -   `targets()`: An array of all the `Target` objects from every `Result`in the set.
 
@@ -349,6 +350,13 @@ Similarly you can iterate over the array of hashes returned by calling `to_data`
 ```
 $r = run_command('whoami', 'localhost,local://0.0.0.0')
 $r.to_data.each |$result_hash| { notice($result_hash['result']['stdout']) }
+```
+
+You can also use `filter_set` to filter a ResultSet and apply a ResultSet function such as `targets` to the output:
+```
+$filtered = $result.filter_set |$r| {
+  $r['tag'] == "you're it"
+}.targets
 ```
 
 ## Passing sensitive data to tasks

--- a/spec/bolt/result_set_spec.rb
+++ b/spec/bolt/result_set_spec.rb
@@ -44,7 +44,7 @@ describe Bolt::Result do
     expect(result_set.to_data).to eq(expected)
   end
 
-  it 'returns a ResultSet when filtered' do
-    expect(result_set.filter { |r| r['node'] == 'node1' }).to be_a(Bolt::ResultSet)
+  it 'filter_set returns a ResultSet' do
+    expect(result_set.filter_set { |r| r['node'] == 'node1' }).to be_a(Bolt::ResultSet)
   end
 end

--- a/spec/bolt/result_set_spec.rb
+++ b/spec/bolt/result_set_spec.rb
@@ -43,4 +43,8 @@ describe Bolt::Result do
   it 'to_data exposes resultset as array of hashes' do
     expect(result_set.to_data).to eq(expected)
   end
+
+  it 'returns a ResultSet when filtered' do
+    expect(result_set.filter { |r| r['node'] == 'node1' }).to be_a(Bolt::ResultSet)
+  end
 end

--- a/spec/fixtures/modules/results/plans/test_methods.pp
+++ b/spec/fixtures/modules/results/plans/test_methods.pp
@@ -10,6 +10,11 @@ plan results::test_methods(
 
   # Test to_s works
   $str = "result ${result}"
+  # Test filter_set works
+  $filtered = $result.filter_set |$r| {
+    $r['tag'] == "you're it"
+  }.targets
+  notice("Filtered set: ${$filtered}")
   # return ok
   return $result.ok
 }

--- a/spec/fixtures/modules/results/tasks/init.sh
+++ b/spec/fixtures/modules/results/tasks/init.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-echo "hi"
-
 if [ ! -z "$PT_fail" ]; then
   exit 1
+else
+  echo "{\"tag\": \"you're it\"}"
 fi

--- a/spec/integration/result_set_spec.rb
+++ b/spec/integration/result_set_spec.rb
@@ -34,10 +34,25 @@ describe "when running a plan that manipulates an execution result", ssh: true d
       expect(output.strip).to eq('false')
     end
 
+    context 'filters result sets' do
+      it 'includes target when filter is true' do
+        params = { target: uri }.to_json
+        run_cli(['plan', 'run', 'results::test_methods', "--params", params] + config_flags)
+        expect(@log_output.readlines)
+          .to include("NOTICE  Puppet : Filtered set: [Target('ssh://bolt:bolt@localhost:20022', {})]\n")
+      end
+
+      it 'excludes target when filter is false' do
+        params = { target: uri, fail: true }.to_json
+        run_cli(['plan', 'run', 'results::test_methods', "--params", params] + config_flags)
+        expect(@log_output.readlines).to include("NOTICE  Puppet : Filtered set: []\n")
+      end
+    end
+
     it 'exposes errrors for results' do
       params = { target: uri }.to_json
       output = run_cli(['plan', 'run', 'results::test_error', "--params", params] + config_flags)
-      expect(output.strip).to eq('"The task failed with exit code 1"')
+      expect(output.strip).to eq('"The task failed with exit code 1:\n"')
     end
   end
 end

--- a/spec/integration/ssh_spec.rb
+++ b/spec/integration/ssh_spec.rb
@@ -55,7 +55,7 @@ describe "when runnning over the ssh transport", ssh: true do
     it 'reports errors when task fails', :reset_puppet_settings do
       result = run_failed_node(%w[task run results fail=true] + config_flags)
       expect(result['_error']['kind']).to eq('puppetlabs.tasks/task-error')
-      expect(result['_error']['msg']).to eq('The task failed with exit code 1')
+      expect(result['_error']['msg']).to eq("The task failed with exit code 1:\n")
     end
 
     it 'passes noop to a task that supports noop', :reset_puppet_settings do

--- a/spec/integration/target_spec.rb
+++ b/spec/integration/target_spec.rb
@@ -30,7 +30,7 @@ describe "when running a plan that creates targets", ssh: true do
             'object' => 'results',
             'status' => 'success',
             'result' => {
-              '_output' => "hi\n"
+              "tag" => "you're it"
             }
           }
         ]


### PR DESCRIPTION
This should be possible/easy:

    $reboot_targets = $patch_results.ok_set.filter_set |$result| {
      $result['reboot_flag'] == true
    }.targets

This commit makes it work by adding a `.filter_set` method which acts the same as `.filter`, but returns a ResultSet datatype.

The existing `.filter` method was insufficient because it returned a Tuple, not a ResultSet.