### PR TITLE
(BOLT-1325) Add out::message function to print a message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
 - bundle exec rubocop
 - |
   status=0
-  for i in 'boltlib' 'ctrl' 'file' 'system'; do
+  for i in 'boltlib' 'ctrl' 'file' 'out' 'system'; do
     pushd bolt-modules/$i
     if ! bundle exec rake spec; then
       status=1

--- a/Rakefile
+++ b/Rakefile
@@ -58,6 +58,7 @@ task :docs do
                          yard_args: ['bolt-modules/boltlib',
                                      'bolt-modules/ctrl',
                                      'bolt-modules/file',
+                                     'bolt-modules/out',
                                      'bolt-modules/system'])
   json = JSON.parse(File.read(tmpfile))
   funcs = json.delete('puppet_functions')

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,7 @@ for:
       - bundle exec rake appveyor
       - ps: |
           $test_fail = 0
-          $mods = ("boltlib", "ctrl", "file", "system")
+          $mods = ("boltlib", "ctrl", "file", "out", "system")
           Get-ChildItem bolt-modules -Directory -Include $mods | foreach {
             cd $_.FullName;
             $test_output = bundle exec rake spec

--- a/bolt-modules/out/Rakefile
+++ b/bolt-modules/out/Rakefile
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'puppetlabs_spec_helper/rake_tasks'

--- a/bolt-modules/out/lib/puppet/functions/out/message.rb
+++ b/bolt-modules/out/lib/puppet/functions/out/message.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Output a message for the user.
+#
+# This will print a message to stdout when using the human output format.
+#
+# **NOTE:** Not available in apply block
+Puppet::Functions.create_function(:'out::message') do
+  # Output a message.
+  # @param message The message to output.
+  # @example Print a message
+  #   out::message('Something went wrong')
+  dispatch :output_message do
+    param 'String', :message
+    return_type 'Undef'
+  end
+
+  def output_message(message)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'out::message')
+    end
+
+    executor = Puppet.lookup(:bolt_executor)
+    executor.publish_event(type: :message, message: message)
+
+    nil
+  end
+end

--- a/bolt-modules/out/spec/functions/out/message_spec.rb
+++ b/bolt-modules/out/spec/functions/out/message_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/executor'
+require 'bolt/target'
+
+describe 'out::message' do
+  let(:executor) { Bolt::Executor.new }
+  let(:events) { [] }
+  let(:outputter) { stub('outputter') }
+
+  around(:each) do |example|
+    executor.subscribe(outputter)
+
+    Puppet[:tasks] = true
+    Puppet.override(bolt_executor: executor) do
+      example.run
+    end
+  end
+
+  it "sends a message event to the executor" do
+    outputter.expects(:handle_event).with(type: :message, message: 'hello world')
+    is_expected.to run.with_params('hello world')
+    executor.shutdown
+  end
+end

--- a/bolt-modules/out/spec/spec_helper.rb
+++ b/bolt-modules/out/spec/spec_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'puppet_pal'
+require 'bolt/pal'
+
+# Ensure tasks are enabled when rspec-puppet sets up an environment
+# so we get task loaders.
+Puppet[:tasks] = true
+Bolt::PAL.load_puppet
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -56,6 +56,8 @@ module Bolt
           @disable_depth -= 1
         when :disable_default_output
           @disable_depth += 1
+        when :message
+          print_message_event(event)
         end
       end
 
@@ -334,6 +336,10 @@ module Bolt
         end
       end
 
+      def print_message_event(event)
+        print_message(event[:message])
+      end
+
       def fatal_error(err)
         @stream.puts(colorize(:red, err.message))
         if err.is_a? Bolt::RunFailure
@@ -346,10 +352,10 @@ module Bolt
           end
         end
       end
-    end
 
-    def print_message(message)
-      @stream.puts(message)
+      def print_message(message)
+        @stream.puts(message)
+      end
     end
   end
 end

--- a/pre-docs/plan_functions.md
+++ b/pre-docs/plan_functions.md
@@ -338,6 +338,29 @@ get_targets('localhost')
 ```
 
 
+## out::message
+
+Output a message for the user.
+
+This will print a message to stdout when using the human output format.
+
+**NOTE:** Not available in apply block
+
+
+```
+out::message(String $message)
+```
+
+*Returns:* `Undef` 
+
+* **message** `String` The message to output.
+
+**Example:** Print a message
+```
+out::message('Something went wrong')
+```
+
+
 ## puppetdb_fact
 
 Collects facts based on a list of certnames.

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -285,4 +285,9 @@ plans/plans/plans/plans
     outputter.fatal_error(Bolt::CLIError.new("oops"))
     expect(output.string).to eq("oops\n")
   end
+
+  it "handles message events" do
+    outputter.print_message_event(message: "hello world")
+    expect(output.string).to eq("hello world\n")
+  end
 end


### PR DESCRIPTION
Previously, plans used the built-in Puppet logging functions
(info/notice/etc) to print output for the user. This doesn't work well
now that the default log level for the console is warn. It also doesn't
match our expected semantics around when logging should be used vs. when
the outputter should be used.

We have a new out::message function that can be used to send output to
the user via the outputter. This function takes a message and directs it
to the console if using the human outputter. Currently, the message is
ignored when using the JSON outputter.