### PR TITLE
(BOLT-1343) Always link to project directory

### DIFF
--- a/pre-docs/applying_manifest_blocks.md
+++ b/pre-docs/applying_manifest_blocks.md
@@ -193,7 +193,7 @@ Create a manifest that sets up a web server with nginx, and run it as a plan.
 
 **Related information**
 
-
+[Bolt project directory](./bolt_project_directory.md)
 [NGINX](https://www.nginx.com/resources/glossary/nginx/)
 
 ## Create a sample manifest for IIS on Windows
@@ -278,6 +278,7 @@ Create a manifest that sets up a web server with IIS and run it as a plan.
 
 **Related information**
 
+[Bolt project directory](./bolt_project_directory.md)
 [IIS](https://www.iis.net)
 
 ## Using Puppet Device modules from an apply statement
@@ -306,6 +307,4 @@ nodes:
 When you set the `run-on` option with a device module the puppet-resource_api
 gem must installed with the puppet agent on the proxy target must be at least
 version 1.8.1.
-
-
 

--- a/pre-docs/bolt_configuration_options.md
+++ b/pre-docs/bolt_configuration_options.md
@@ -2,6 +2,10 @@
 
 Your Bolt configuration file can contain global and transport options.
 
+**Related Information**
+
+[Bolt project directory](./bolt_project_directory.md)
+
 ## Sample Bolt configuration file
 
 ```
@@ -40,8 +44,8 @@ interpreters:
 
 `transport`: Specify the default transport to use when the transport for a target is not specified in the url or inventory. The valid options for transport are `docker`, `local`, `pcp`, `ssh`, and `winrm`.
 
-`save-rerun`: Whether bolt should update `.rerun.json` in the Bolt project
-directory. If your target names include passwords you should set this to false
+`save-rerun`: Whether bolt should update `.rerun.json` in the [Bolt project
+directory]. If your target names include passwords you should set this to false
 to avoid writing them to disk.
 
 ## SSH transport configuration options

--- a/pre-docs/bolt_installing_modules.md
+++ b/pre-docs/bolt_installing_modules.md
@@ -54,7 +54,7 @@ For modules that require Ruby gems, see [Installing Gems with Bolt Packages](bol
 
 For more details about specifying modules in a Puppetfile, see the [Puppetfile documentation](https://puppet.com/docs/pe/2018.1/puppetfile.html).
 
-1.   Create a file named Puppetfile and store it in the [bolt project directory](./bolt_project_directory.md)
+1.   Create a file named Puppetfile and store it in the [Bolt project directory](./bolt_project_directory.md)
 2.   Open the Puppetfile in a text editor and add the modules and versions that you want to install. If the modules have dependencies, list those as well.
 
      ```

--- a/pre-docs/bolt_options.md
+++ b/pre-docs/bolt_options.md
@@ -154,9 +154,10 @@ To have Bolt securely prompt for a password, use the `--password` or `-p` flag w
 
 ## Rerunning commands based on the last result
 
-After every execution, Bolt writes information about the result of that run to a
-`.rerun.json` file inside the Bolt project directory. That file can then be
-used to specify nodes for future commands.
+After every execution, Bolt writes information about the result of that run
+to a `.rerun.json` file inside the Bolt project
+directory. That file can then be used to
+specify nodes for future commands.
 
 To attempt to retry a failed action on target nodes, use `--rerun failure`. To continue targeting those nodes,
 pass `--no-save-rerun` to prevent updating the file.
@@ -177,3 +178,5 @@ bolt task run server action=restart name=httpd --rerun success
 **Note**: When a plan does not return a `ResultSet` object, Bolt can't save
 information for reruns and `.rerun.json` is deleted.
 
+**Related Information**
+[Bolt project directory](./bolt_project_directory.md)

--- a/pre-docs/inventory_file.md
+++ b/pre-docs/inventory_file.md
@@ -3,7 +3,7 @@
 In Bolt, you can use an inventory file to store information about your nodes. For example, you can organize your nodes into groups or set up connection information for nodes or node groups.
 
 The inventory file is a yaml file stored by default at `inventory.yaml` inside
-the [bolt project directory](bolt_project_directory.md). At the top level it
+the [Bolt project directory](bolt_project_directory.md). At the top level it
 contains an array of nodes and groups. Each node can have a config, facts,
 vars, and features specific to that node. Each group can have an array of nodes
 and a config hash. node. Each group can have an array of nodes, an array of


### PR DESCRIPTION
This makes all instances (that I could find) of 'bolt project directory' a link to the project directory page, and standardizes capitalization.