### PR TITLE
(maint) Temporarily pin cri gem so that r10k works for test setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,9 @@ gem "rack", '>= 2.0.5'
 gem "rails-auth", '>= 2.1.4'
 gem "sinatra", '>= 2.0.4'
 
+# Pin cri for now so r10k installs modules
+gem 'cri', '2.15.6'
+
 # Required to pick up plan specs in the rake spec task
 # TODO: move to test group?
 gem "puppetlabs_spec_helper",

--- a/lib/bolt/task.rb
+++ b/lib/bolt/task.rb
@@ -20,7 +20,6 @@ module Bolt
     :files,
     :metadata
   ) do
-
     attr_reader :remote
 
     def initialize(task, remote: false)


### PR DESCRIPTION
It appears that the new cri release (2.15.7) introduces a breaking change to r10k which is used to install modules for integration tests. This commit temporarily pins cri to a compatible version.