### PR TITLE
(BOLT-1341) Support Terraform statefile version 4

### DIFF
--- a/lib/bolt/plugin/terraform.rb
+++ b/lib/bolt/plugin/terraform.rb
@@ -24,29 +24,20 @@ module Bolt
       def lookup_targets(opts)
         state = load_statefile(opts)
 
-        resources = state.fetch('modules', {}).flat_map do |mod|
-          mod.fetch('resources', {}).map do |name, resource|
-            [name, resource.dig('primary', 'attributes')]
-          end
-        end
+        resources = extract_resources(state)
 
         regex = Regexp.new(opts['resource_type'])
 
         resources.select do |name, _resource|
           name.match?(regex)
         end.map do |name, resource|
-          unless resource.key?(opts['uri'])
-            warn_missing_property(name, opts['uri'])
-            next
-          end
+          uri = lookup(name, resource, opts['uri'])
+          next unless uri
 
-          target = { 'uri' => resource[opts['uri']] }
+          target = { 'uri' => uri }
           if opts.key?('name')
-            if resource.key?(opts['name'])
-              target['name'] = resource[opts['name']]
-            else
-              warn_missing_property(name, opts['name'])
-            end
+            real_name = lookup(name, resource, opts['name'])
+            target['name'] = real_name if real_name
           end
           if opts.key?('config')
             target['config'] = resolve_config(name, resource, opts['config'])
@@ -65,15 +56,57 @@ module Bolt
         raise Bolt::FileError.new("Could not load Terraform state file #{filename}: #{e}", filename)
       end
 
+      # Format the list of resources into a list of [name, attribute map]
+      # pairs. This method handles both version 4 and earlier statefiles, doing
+      # the appropriate munging based on the shape of the data.
+      def extract_resources(state)
+        if state['version'] >= 4
+          state.fetch('resources', []).flat_map do |resource_set|
+            prefix = "#{resource_set['type']}.#{resource_set['name']}"
+            resource_set['instances'].map do |resource|
+              instance_name = prefix
+              instance_name += ".#{resource['index_key']}" if resource['index_key']
+
+              [instance_name, resource['attributes']]
+            end
+          end
+        else
+          state.fetch('modules', {}).flat_map do |mod|
+            mod.fetch('resources', {}).map do |name, resource|
+              [name, resource.dig('primary', 'attributes')]
+            end
+          end
+        end
+      end
+
+      # Look up a nested value from the resource attributes. The key is of the
+      # form `foo.bar.0.baz`. For terraform statefile version 3, this will
+      # exactly correspond to a key in the resource. In version 4, it will
+      # correspond to a nested hash entry at {foo: {bar: [{baz: <value>}]}}
+      # For simplicity's sake, we just check both.
+      def lookup(name, resource, path)
+        segments = path.split('.').map do |segment|
+          begin
+            Integer(segment)
+          rescue ArgumentError
+            segment
+          end
+        end
+
+        value = resource[path] || resource.dig(*segments)
+        unless value
+          warn_missing_property(name, path)
+        end
+        value
+      end
+
+      # Walk the "template" config mapping provided in the plugin config and
+      # replace all values with the corresponding value from the resource
+      # parameters.
       def resolve_config(name, resource, config_template)
         Bolt::Util.walk_vals(config_template) do |value|
           if value.is_a?(String)
-            if resource.key?(value)
-              resource[value]
-            else
-              warn_missing_property(name, value)
-              nil
-            end
+            lookup(name, resource, value)
           else
             value
           end

--- a/lib/bolt/plugin/terraform.rb
+++ b/lib/bolt/plugin/terraform.rb
@@ -31,10 +31,12 @@ module Bolt
         resources.select do |name, _resource|
           name.match?(regex)
         end.map do |name, resource|
-          uri = lookup(name, resource, opts['uri'])
-          next unless uri
+          target = {}
 
-          target = { 'uri' => uri }
+          if opts.key?('uri')
+            uri = lookup(name, resource, opts['uri'])
+            target['uri'] = uri if uri
+          end
           if opts.key?('name')
             real_name = lookup(name, resource, opts['name'])
             target['name'] = real_name if real_name

--- a/pre-docs/inventory_version2.md
+++ b/pre-docs/inventory_version2.md
@@ -156,10 +156,12 @@ The Terraform plugin accepts several fields:
 
 `dir`: The directory from which to load Terraform state  
 `resource_type`: The Terraform resources to match, as a regular expression  
-`uri`: The property of the Terraform resource to use as the target URI  
+`uri`: The property of the Terraform resource to use as the target URI (optional)  
 `statefile`: The name of the Terraform state file to load within `dir` (optional, defaults to `terraform.tfstate`)  
 `name`: The property of the Terraform resource to use as the target name (optional)  
 `config`: A Bolt config map where each value is the Terraform property to use for that config setting
+
+One of `uri` or `name` is required. If only `uri` is set, then the value of `uri` will be used as the `name`.
 
 ```
 groups:
@@ -175,7 +177,9 @@ groups:
         uri: public_ip
 ```
 
-The resource and property names correspond to the output of `terraform show`. 
+Multiple resources with the same name are identified <resource>.0, <resource>.1, etc.
+
+The path to nested properties must be separated with `.`: for example, `network_interface.0.access_config.0.nat_ip`.
 
 For example, the following truncated output creates two targets, named `34.83.150.52` and `34.83.16.240`. These targets are created by matching the resources `google_compute_instance.web.0` and `google_compute_instance.web.1`. The `uri` for each target is the value of their `network_interface.0.access_config.0.nat_ip` property, which corresponds to the externally routable IP address in Google Cloud.
 

--- a/spec/bolt/plugin/terraform_spec.rb
+++ b/spec/bolt/plugin/terraform_spec.rb
@@ -54,6 +54,14 @@ describe Bolt::Plugin::Terraform do
                                          { 'uri' => ip1, 'name' => 'test-instance-1' })
     end
 
+    it 'sets only name if uri is not specified' do
+      opts.delete('uri')
+      targets = subject.lookup_targets(opts.merge('name' => 'id'))
+
+      expect(targets).to contain_exactly({ 'name' => 'test-instance-0' },
+                                         { 'name' => 'test-instance-1' })
+    end
+
     it 'builds a config map from the inventory' do
       config_template = { 'ssh' => { 'user' => 'metadata.sshUser' } }
       targets = subject.lookup_targets(opts.merge('config' => config_template))

--- a/spec/bolt/plugin/terraform_spec.rb
+++ b/spec/bolt/plugin/terraform_spec.rb
@@ -6,9 +6,8 @@ require 'bolt/plugin/terraform'
 # rubocop:disable Style/BracesAroundHashParameters
 describe Bolt::Plugin::Terraform do
   let(:terraform_dir) { File.expand_path(File.join(__dir__, '../../fixtures/terraform')) }
-  let(:resource_type) { 'google_compute_instance' }
+  let(:resource_type) { 'google_compute_instance.*' }
   let(:uri) { 'network_interface.0.access_config.0.nat_ip' }
-  let(:opts) { { 'dir' => terraform_dir, 'resource_type' => resource_type, 'uri' => uri } }
 
   it 'has a hook for lookup_targets' do
     expect(subject.hooks).to eq(['lookup_targets'])
@@ -28,43 +27,68 @@ describe Bolt::Plugin::Terraform do
     expect(state).to eq(JSON.parse(File.read(statefile)))
   end
 
-  it 'matches resources that start with the given type' do
-    targets = subject.lookup_targets(opts)
+  shared_examples('loading terraform targets') do
+    let(:opts) do
+      { 'dir' => terraform_dir,
+        'statefile' => statefile,
+        'resource_type' => resource_type,
+        'uri' => uri }
+    end
 
-    expect(targets).to contain_exactly({ 'uri' => '34.83.150.52' }, { 'uri' => '34.83.16.240' })
+    it 'matches resources that start with the given type' do
+      targets = subject.lookup_targets(opts)
+
+      expect(targets).to contain_exactly({ 'uri' => ip0 }, { 'uri' => ip1 })
+    end
+
+    it 'can filter resources by regex' do
+      targets = subject.lookup_targets(opts.merge('resource_type' => 'google_compute_instance.example.\d+'))
+
+      expect(targets).to contain_exactly({ 'uri' => ip0 }, { 'uri' => ip1 })
+    end
+
+    it 'maps inventory to name' do
+      targets = subject.lookup_targets(opts.merge('name' => 'id'))
+
+      expect(targets).to contain_exactly({ 'uri' => ip0, 'name' => 'test-instance-0' },
+                                         { 'uri' => ip1, 'name' => 'test-instance-1' })
+    end
+
+    it 'builds a config map from the inventory' do
+      config_template = { 'ssh' => { 'user' => 'metadata.sshUser' } }
+      targets = subject.lookup_targets(opts.merge('config' => config_template))
+
+      config = { 'ssh' => { 'user' => 'someone' } }
+      expect(targets).to contain_exactly({ 'uri' => ip0, 'config' => config },
+                                         { 'uri' => ip1, 'config' => config })
+    end
+
+    it 'returns nothing if there are no matching resources' do
+      targets = subject.lookup_targets(opts.merge('resource_type' => 'aws_instance'))
+
+      expect(targets).to be_empty
+    end
+
+    it 'fails if the state file does not exist' do
+      expect { subject.lookup_targets(opts.merge('statefile' => 'nonexistent.tfstate')) }
+        .to raise_error(Bolt::Error, /Could not load Terraform state file nonexistent.tfstate/)
+    end
   end
 
-  it 'can filter resources by regex' do
-    targets = subject.lookup_targets(opts.merge('resource_type' => 'google_compute_instance.example.\d+'))
+  describe "using a terrform version 3 state file" do
+    let(:statefile) { 'terraform3.tfstate' }
+    let(:ip0) { '34.83.150.52' }
+    let(:ip1) { '34.83.16.240' }
 
-    expect(targets).to contain_exactly({ 'uri' => '34.83.150.52' }, { 'uri' => '34.83.16.240' })
+    include_examples 'loading terraform targets'
   end
 
-  it 'maps inventory to name' do
-    targets = subject.lookup_targets(opts.merge('name' => 'id'))
+  describe "using a terraform version 4 state file" do
+    let(:statefile) { 'terraform.tfstate' }
+    let(:ip0) { '34.83.160.116' }
+    let(:ip1) { '35.230.3.44' }
 
-    expect(targets).to contain_exactly({ 'uri' => '34.83.150.52', 'name' => 'test-instance-0' },
-                                       { 'uri' => '34.83.16.240', 'name' => 'test-instance-1' })
-  end
-
-  it 'builds a config map from the inventory' do
-    config_template = { 'ssh' => { 'user' => 'metadata.sshUser' } }
-    targets = subject.lookup_targets(opts.merge('config' => config_template))
-
-    config = { 'ssh' => { 'user' => 'someone' } }
-    expect(targets).to contain_exactly({ 'uri' => '34.83.150.52', 'config' => config },
-                                       { 'uri' => '34.83.16.240', 'config' => config })
-  end
-
-  it 'returns nothing if there are no matching resources' do
-    targets = subject.lookup_targets(opts.merge('resource_type' => 'aws_instance'))
-
-    expect(targets).to be_empty
-  end
-
-  it 'fails if the state file does not exist' do
-    expect { subject.lookup_targets(opts.merge('statefile' => 'nonexistent.tfstate')) }
-      .to raise_error(Bolt::Error, /Could not load Terraform state file nonexistent.tfstate/)
+    include_examples 'loading terraform targets'
   end
 end
 # rubocop:enable Style/BracesAroundHashParameters

--- a/spec/fixtures/terraform/terraform.tfstate
+++ b/spec/fixtures/terraform/terraform.tfstate
@@ -1,175 +1,204 @@
 {
-    "version": 3,
-    "terraform_version": "0.11.13",
-    "serial": 20,
-    "lineage": "7fe841b8-d733-9b8c-f6b4-6d485cd3059a",
-    "modules": [
+  "version": 4,
+  "terraform_version": "0.12.0",
+  "serial": 31,
+  "lineage": "7fe841b8-d733-9b8c-f6b4-6d485cd3059a",
+  "outputs": {
+    "web": {
+      "value": {
+        "hostname": [
+          "test-instance-0",
+          "test-instance-1"
+        ],
+        "ip": [
+          "34.83.160.116",
+          "35.230.3.44"
+        ]
+      },
+      "type": [
+        "object",
         {
-            "path": [
-                "root"
-            ],
-            "outputs": {
-                "web": {
-                    "sensitive": false,
-                    "type": "map",
-                    "value": {
-                        "hostname": [
-                            "test-instance-0",
-                            "test-instance-1"
-                        ],
-                        "ip": [
-                            "34.83.150.52",
-                            "34.83.16.240"
-                        ]
-                    }
-                }
-            },
-            "resources": {
-                "google_compute_instance.example.0": {
-                    "type": "google_compute_instance",
-                    "depends_on": [],
-                    "primary": {
-                        "id": "test-instance-0",
-                        "attributes": {
-                            "attached_disk.#": "0",
-                            "boot_disk.#": "1",
-                            "boot_disk.0.auto_delete": "true",
-                            "boot_disk.0.device_name": "persistent-disk-0",
-                            "boot_disk.0.disk_encryption_key_raw": "",
-                            "boot_disk.0.disk_encryption_key_sha256": "",
-                            "boot_disk.0.initialize_params.#": "1",
-                            "boot_disk.0.initialize_params.0.image": "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-7-v20190423",
-                            "boot_disk.0.initialize_params.0.size": "10",
-                            "boot_disk.0.initialize_params.0.type": "pd-standard",
-                            "boot_disk.0.source": "https://www.googleapis.com/compute/v1/projects/example/zones/us-west1-a/disks/test-instance-0",
-                            "can_ip_forward": "false",
-                            "cpu_platform": "Intel Broadwell",
-                            "deletion_protection": "false",
-                            "guest_accelerator.#": "0",
-                            "hostname": "",
-                            "id": "test-instance-0",
-                            "instance_id": "8946822406274313149",
-                            "label_fingerprint": "42WmSpB8rSM=",
-                            "labels.%": "0",
-                            "machine_type": "f1-micro",
-                            "metadata.%": "1",
-                            "metadata.sshUser": "someone",
-                            "metadata_fingerprint": "_augjlko69Y=",
-                            "metadata_startup_script": "",
-                            "min_cpu_platform": "",
-                            "name": "test-instance-0",
-                            "network_interface.#": "1",
-                            "network_interface.0.access_config.#": "1",
-                            "network_interface.0.access_config.0.assigned_nat_ip": "",
-                            "network_interface.0.access_config.0.nat_ip": "34.83.150.52",
-                            "network_interface.0.access_config.0.network_tier": "PREMIUM",
-                            "network_interface.0.access_config.0.public_ptr_domain_name": "",
-                            "network_interface.0.address": "",
-                            "network_interface.0.alias_ip_range.#": "0",
-                            "network_interface.0.name": "nic0",
-                            "network_interface.0.network": "https://www.googleapis.com/compute/v1/projects/example/global/networks/default",
-                            "network_interface.0.network_ip": "10.138.0.22",
-                            "network_interface.0.subnetwork": "https://www.googleapis.com/compute/v1/projects/example/regions/us-west1/subnetworks/default",
-                            "network_interface.0.subnetwork_project": "example",
-                            "project": "example",
-                            "scheduling.#": "1",
-                            "scheduling.0.automatic_restart": "true",
-                            "scheduling.0.on_host_maintenance": "MIGRATE",
-                            "scheduling.0.preemptible": "false",
-                            "scratch_disk.#": "0",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/example/zones/us-west1-a/instances/test-instance-0",
-                            "service_account.#": "0",
-                            "tags.#": "0",
-                            "tags_fingerprint": "42WmSpB8rSM=",
-                            "zone": "us-west1-a"
-                        },
-                        "meta": {
-                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
-                                "create": 360000000000,
-                                "delete": 360000000000,
-                                "update": 360000000000
-                            },
-                            "schema_version": "6"
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                },
-                "google_compute_instance.example.1": {
-                    "type": "google_compute_instance",
-                    "depends_on": [],
-                    "primary": {
-                        "id": "test-instance-1",
-                        "attributes": {
-                            "attached_disk.#": "0",
-                            "boot_disk.#": "1",
-                            "boot_disk.0.auto_delete": "true",
-                            "boot_disk.0.device_name": "persistent-disk-0",
-                            "boot_disk.0.disk_encryption_key_raw": "",
-                            "boot_disk.0.disk_encryption_key_sha256": "",
-                            "boot_disk.0.initialize_params.#": "1",
-                            "boot_disk.0.initialize_params.0.image": "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-7-v20190423",
-                            "boot_disk.0.initialize_params.0.size": "10",
-                            "boot_disk.0.initialize_params.0.type": "pd-standard",
-                            "boot_disk.0.source": "https://www.googleapis.com/compute/v1/projects/example/zones/us-west1-a/disks/test-instance-1",
-                            "can_ip_forward": "false",
-                            "cpu_platform": "Intel Broadwell",
-                            "deletion_protection": "false",
-                            "guest_accelerator.#": "0",
-                            "hostname": "",
-                            "id": "test-instance-1",
-                            "instance_id": "257748381260868542",
-                            "label_fingerprint": "42WmSpB8rSM=",
-                            "labels.%": "0",
-                            "machine_type": "f1-micro",
-                            "metadata.%": "1",
-                            "metadata.sshUser": "someone",
-                            "metadata_fingerprint": "_augjlko69Y=",
-                            "metadata_startup_script": "",
-                            "min_cpu_platform": "",
-                            "name": "test-instance-1",
-                            "network_interface.#": "1",
-                            "network_interface.0.access_config.#": "1",
-                            "network_interface.0.access_config.0.assigned_nat_ip": "",
-                            "network_interface.0.access_config.0.nat_ip": "34.83.16.240",
-                            "network_interface.0.access_config.0.network_tier": "PREMIUM",
-                            "network_interface.0.access_config.0.public_ptr_domain_name": "",
-                            "network_interface.0.address": "",
-                            "network_interface.0.alias_ip_range.#": "0",
-                            "network_interface.0.name": "nic0",
-                            "network_interface.0.network": "https://www.googleapis.com/compute/v1/projects/example/global/networks/default",
-                            "network_interface.0.network_ip": "10.138.0.21",
-                            "network_interface.0.subnetwork": "https://www.googleapis.com/compute/v1/projects/example/regions/us-west1/subnetworks/default",
-                            "network_interface.0.subnetwork_project": "example",
-                            "project": "example",
-                            "scheduling.#": "1",
-                            "scheduling.0.automatic_restart": "true",
-                            "scheduling.0.on_host_maintenance": "MIGRATE",
-                            "scheduling.0.preemptible": "false",
-                            "scratch_disk.#": "0",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/example/zones/us-west1-a/instances/test-instance-1",
-                            "service_account.#": "0",
-                            "tags.#": "0",
-                            "tags_fingerprint": "42WmSpB8rSM=",
-                            "zone": "us-west1-a"
-                        },
-                        "meta": {
-                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
-                                "create": 360000000000,
-                                "delete": 360000000000,
-                                "update": 360000000000
-                            },
-                            "schema_version": "6"
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.google"
-                }
-            },
-            "depends_on": []
+          "hostname": [
+            "tuple",
+            [
+              "string",
+              "string"
+            ]
+          ],
+          "ip": [
+            "tuple",
+            [
+              "string",
+              "string"
+            ]
+          ]
         }
-    ]
+      ]
+    }
+  },
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "google_compute_instance",
+      "name": "example",
+      "each": "list",
+      "provider": "provider.google",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 6,
+          "attributes": {
+            "allow_stopping_for_update": null,
+            "attached_disk": [],
+            "boot_disk": [
+              {
+                "auto_delete": true,
+                "device_name": "persistent-disk-0",
+                "disk_encryption_key_raw": "",
+                "disk_encryption_key_sha256": "",
+                "initialize_params": [
+                  {
+                    "image": "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-7-v20190517",
+                    "size": 10,
+                    "type": "pd-standard"
+                  }
+                ],
+                "source": "https://www.googleapis.com/compute/v1/projects/example/zones/us-west1-a/disks/test-instance-0"
+              }
+            ],
+            "can_ip_forward": false,
+            "cpu_platform": "Intel Broadwell",
+            "deletion_protection": false,
+            "description": null,
+            "disk": [],
+            "guest_accelerator": [],
+            "hostname": "",
+            "id": "test-instance-0",
+            "instance_id": "4870046101813452651",
+            "label_fingerprint": "42WmSpB8rSM=",
+            "labels": null,
+            "machine_type": "f1-micro",
+            "metadata": {
+              "sshUser": "someone"
+            },
+            "metadata_fingerprint": "_augjlko69Y=",
+            "metadata_startup_script": "",
+            "min_cpu_platform": "",
+            "name": "test-instance-0",
+            "network_interface": [
+              {
+                "access_config": [
+                  {
+                    "assigned_nat_ip": "",
+                    "nat_ip": "34.83.160.116",
+                    "network_tier": "PREMIUM",
+                    "public_ptr_domain_name": ""
+                  }
+                ],
+                "address": "",
+                "alias_ip_range": [],
+                "name": "nic0",
+                "network": "https://www.googleapis.com/compute/v1/projects/example/global/networks/default",
+                "network_ip": "10.138.0.26",
+                "subnetwork": "https://www.googleapis.com/compute/v1/projects/example/regions/us-west1/subnetworks/default",
+                "subnetwork_project": "example"
+              }
+            ],
+            "project": "example",
+            "scheduling": [
+              {
+                "automatic_restart": true,
+                "on_host_maintenance": "MIGRATE",
+                "preemptible": false
+              }
+            ],
+            "scratch_disk": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/example/zones/us-west1-a/instances/test-instance-0",
+            "service_account": [],
+            "tags": null,
+            "tags_fingerprint": "42WmSpB8rSM=",
+            "timeouts": null,
+            "zone": "us-west1-a"
+          }
+        },
+        {
+          "index_key": 1,
+          "schema_version": 6,
+          "attributes": {
+            "allow_stopping_for_update": null,
+            "attached_disk": [],
+            "boot_disk": [
+              {
+                "auto_delete": true,
+                "device_name": "persistent-disk-0",
+                "disk_encryption_key_raw": "",
+                "disk_encryption_key_sha256": "",
+                "initialize_params": [
+                  {
+                    "image": "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-7-v20190517",
+                    "size": 10,
+                    "type": "pd-standard"
+                  }
+                ],
+                "source": "https://www.googleapis.com/compute/v1/projects/example/zones/us-west1-a/disks/test-instance-1"
+              }
+            ],
+            "can_ip_forward": false,
+            "cpu_platform": "Intel Broadwell",
+            "deletion_protection": false,
+            "description": null,
+            "disk": [],
+            "guest_accelerator": [],
+            "hostname": "",
+            "id": "test-instance-1",
+            "instance_id": "1607667099291738032",
+            "label_fingerprint": "42WmSpB8rSM=",
+            "labels": null,
+            "machine_type": "f1-micro",
+            "metadata": {
+              "sshUser": "someone"
+            },
+            "metadata_fingerprint": "_augjlko69Y=",
+            "metadata_startup_script": "",
+            "min_cpu_platform": "",
+            "name": "test-instance-1",
+            "network_interface": [
+              {
+                "access_config": [
+                  {
+                    "assigned_nat_ip": "",
+                    "nat_ip": "35.230.3.44",
+                    "network_tier": "PREMIUM",
+                    "public_ptr_domain_name": ""
+                  }
+                ],
+                "address": "",
+                "alias_ip_range": [],
+                "name": "nic0",
+                "network": "https://www.googleapis.com/compute/v1/projects/example/global/networks/default",
+                "network_ip": "10.138.0.25",
+                "subnetwork": "https://www.googleapis.com/compute/v1/projects/example/regions/us-west1/subnetworks/default",
+                "subnetwork_project": "example"
+              }
+            ],
+            "project": "example",
+            "scheduling": [
+              {
+                "automatic_restart": true,
+                "on_host_maintenance": "MIGRATE",
+                "preemptible": false
+              }
+            ],
+            "scratch_disk": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/example/zones/us-west1-a/instances/test-instance-1",
+            "service_account": [],
+            "tags": null,
+            "tags_fingerprint": "42WmSpB8rSM=",
+            "timeouts": null,
+            "zone": "us-west1-a"
+          }
+        }
+      ]
+    }
+  ]
 }
-

--- a/spec/fixtures/terraform/terraform3.tfstate
+++ b/spec/fixtures/terraform/terraform3.tfstate
@@ -1,0 +1,175 @@
+{
+    "version": 3,
+    "terraform_version": "0.11.13",
+    "serial": 20,
+    "lineage": "7fe841b8-d733-9b8c-f6b4-6d485cd3059a",
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {
+                "web": {
+                    "sensitive": false,
+                    "type": "map",
+                    "value": {
+                        "hostname": [
+                            "test-instance-0",
+                            "test-instance-1"
+                        ],
+                        "ip": [
+                            "34.83.150.52",
+                            "34.83.16.240"
+                        ]
+                    }
+                }
+            },
+            "resources": {
+                "google_compute_instance.example.0": {
+                    "type": "google_compute_instance",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "test-instance-0",
+                        "attributes": {
+                            "attached_disk.#": "0",
+                            "boot_disk.#": "1",
+                            "boot_disk.0.auto_delete": "true",
+                            "boot_disk.0.device_name": "persistent-disk-0",
+                            "boot_disk.0.disk_encryption_key_raw": "",
+                            "boot_disk.0.disk_encryption_key_sha256": "",
+                            "boot_disk.0.initialize_params.#": "1",
+                            "boot_disk.0.initialize_params.0.image": "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-7-v20190423",
+                            "boot_disk.0.initialize_params.0.size": "10",
+                            "boot_disk.0.initialize_params.0.type": "pd-standard",
+                            "boot_disk.0.source": "https://www.googleapis.com/compute/v1/projects/example/zones/us-west1-a/disks/test-instance-0",
+                            "can_ip_forward": "false",
+                            "cpu_platform": "Intel Broadwell",
+                            "deletion_protection": "false",
+                            "guest_accelerator.#": "0",
+                            "hostname": "",
+                            "id": "test-instance-0",
+                            "instance_id": "8946822406274313149",
+                            "label_fingerprint": "42WmSpB8rSM=",
+                            "labels.%": "0",
+                            "machine_type": "f1-micro",
+                            "metadata.%": "1",
+                            "metadata.sshUser": "someone",
+                            "metadata_fingerprint": "_augjlko69Y=",
+                            "metadata_startup_script": "",
+                            "min_cpu_platform": "",
+                            "name": "test-instance-0",
+                            "network_interface.#": "1",
+                            "network_interface.0.access_config.#": "1",
+                            "network_interface.0.access_config.0.assigned_nat_ip": "",
+                            "network_interface.0.access_config.0.nat_ip": "34.83.150.52",
+                            "network_interface.0.access_config.0.network_tier": "PREMIUM",
+                            "network_interface.0.access_config.0.public_ptr_domain_name": "",
+                            "network_interface.0.address": "",
+                            "network_interface.0.alias_ip_range.#": "0",
+                            "network_interface.0.name": "nic0",
+                            "network_interface.0.network": "https://www.googleapis.com/compute/v1/projects/example/global/networks/default",
+                            "network_interface.0.network_ip": "10.138.0.22",
+                            "network_interface.0.subnetwork": "https://www.googleapis.com/compute/v1/projects/example/regions/us-west1/subnetworks/default",
+                            "network_interface.0.subnetwork_project": "example",
+                            "project": "example",
+                            "scheduling.#": "1",
+                            "scheduling.0.automatic_restart": "true",
+                            "scheduling.0.on_host_maintenance": "MIGRATE",
+                            "scheduling.0.preemptible": "false",
+                            "scratch_disk.#": "0",
+                            "self_link": "https://www.googleapis.com/compute/v1/projects/example/zones/us-west1-a/instances/test-instance-0",
+                            "service_account.#": "0",
+                            "tags.#": "0",
+                            "tags_fingerprint": "42WmSpB8rSM=",
+                            "zone": "us-west1-a"
+                        },
+                        "meta": {
+                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
+                                "create": 360000000000,
+                                "delete": 360000000000,
+                                "update": 360000000000
+                            },
+                            "schema_version": "6"
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.google"
+                },
+                "google_compute_instance.example.1": {
+                    "type": "google_compute_instance",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "test-instance-1",
+                        "attributes": {
+                            "attached_disk.#": "0",
+                            "boot_disk.#": "1",
+                            "boot_disk.0.auto_delete": "true",
+                            "boot_disk.0.device_name": "persistent-disk-0",
+                            "boot_disk.0.disk_encryption_key_raw": "",
+                            "boot_disk.0.disk_encryption_key_sha256": "",
+                            "boot_disk.0.initialize_params.#": "1",
+                            "boot_disk.0.initialize_params.0.image": "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-7-v20190423",
+                            "boot_disk.0.initialize_params.0.size": "10",
+                            "boot_disk.0.initialize_params.0.type": "pd-standard",
+                            "boot_disk.0.source": "https://www.googleapis.com/compute/v1/projects/example/zones/us-west1-a/disks/test-instance-1",
+                            "can_ip_forward": "false",
+                            "cpu_platform": "Intel Broadwell",
+                            "deletion_protection": "false",
+                            "guest_accelerator.#": "0",
+                            "hostname": "",
+                            "id": "test-instance-1",
+                            "instance_id": "257748381260868542",
+                            "label_fingerprint": "42WmSpB8rSM=",
+                            "labels.%": "0",
+                            "machine_type": "f1-micro",
+                            "metadata.%": "1",
+                            "metadata.sshUser": "someone",
+                            "metadata_fingerprint": "_augjlko69Y=",
+                            "metadata_startup_script": "",
+                            "min_cpu_platform": "",
+                            "name": "test-instance-1",
+                            "network_interface.#": "1",
+                            "network_interface.0.access_config.#": "1",
+                            "network_interface.0.access_config.0.assigned_nat_ip": "",
+                            "network_interface.0.access_config.0.nat_ip": "34.83.16.240",
+                            "network_interface.0.access_config.0.network_tier": "PREMIUM",
+                            "network_interface.0.access_config.0.public_ptr_domain_name": "",
+                            "network_interface.0.address": "",
+                            "network_interface.0.alias_ip_range.#": "0",
+                            "network_interface.0.name": "nic0",
+                            "network_interface.0.network": "https://www.googleapis.com/compute/v1/projects/example/global/networks/default",
+                            "network_interface.0.network_ip": "10.138.0.21",
+                            "network_interface.0.subnetwork": "https://www.googleapis.com/compute/v1/projects/example/regions/us-west1/subnetworks/default",
+                            "network_interface.0.subnetwork_project": "example",
+                            "project": "example",
+                            "scheduling.#": "1",
+                            "scheduling.0.automatic_restart": "true",
+                            "scheduling.0.on_host_maintenance": "MIGRATE",
+                            "scheduling.0.preemptible": "false",
+                            "scratch_disk.#": "0",
+                            "self_link": "https://www.googleapis.com/compute/v1/projects/example/zones/us-west1-a/instances/test-instance-1",
+                            "service_account.#": "0",
+                            "tags.#": "0",
+                            "tags_fingerprint": "42WmSpB8rSM=",
+                            "zone": "us-west1-a"
+                        },
+                        "meta": {
+                            "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0": {
+                                "create": 360000000000,
+                                "delete": 360000000000,
+                                "update": 360000000000
+                            },
+                            "schema_version": "6"
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.google"
+                }
+            },
+            "depends_on": []
+        }
+    ]
+}
+


### PR DESCRIPTION
Terraform 0.12 introduced version 4 of the statefile format, which is
significantly different from the previous version. In particular, resources are
organized differently, named differently, and their parameters are broken into
nested hashes and arrays instead of alays being a flat hash.

This adds support for the new statefile format by checking the "version" field
and determining how to process the resources. We still accept exactly the same
options in the plugin and the user doesn't need to be aware of which format
their statefile is in.

We do some standardization of the resources into a list, but keep their
parameters in whatever form they came from the statefile. Then at lookup time,
we check for both the dotted form of the key as well as doing the nested
lookup. Only one of those should match at a time, so this prevents us from
having to keep track of which format the data is in.