### PR TITLE
(BOLT-1358) Fix local_windows transport calling profile

### DIFF
--- a/acceptance/config/gem/options.rb
+++ b/acceptance/config/gem/options.rb
@@ -6,6 +6,7 @@
     'setup/gem/pre-suite/020_install.rb',
     'setup/common/pre-suite/030_set_password.rb',
     'setup/common/pre-suite/031_add_local_nix_user.rb',
+    'setup/common/pre-suite/032_configure_windows_profile.rb',
     'setup/common/pre-suite/050_build_bolt_inventory.rb',
     'setup/common/pre-suite/071_install_modules.rb'
   ],

--- a/acceptance/config/git/options.rb
+++ b/acceptance/config/git/options.rb
@@ -7,6 +7,7 @@
     'setup/git/pre-suite/020_install.rb',
     'setup/common/pre-suite/030_set_password.rb',
     'setup/common/pre-suite/031_add_local_nix_user.rb',
+    'setup/common/pre-suite/032_configure_windows_profile.rb',
     'setup/common/pre-suite/050_build_bolt_inventory.rb',
     'setup/common/pre-suite/071_install_modules.rb'
   ],

--- a/acceptance/config/package/options.rb
+++ b/acceptance/config/package/options.rb
@@ -5,6 +5,7 @@
     'setup/package/pre-suite/020_install.rb',
     'setup/common/pre-suite/030_set_password.rb',
     'setup/common/pre-suite/031_add_local_nix_user.rb',
+    'setup/common/pre-suite/032_configure_windows_profile.rb',
     'setup/common/pre-suite/050_build_bolt_inventory.rb'
   ],
   load_path: './lib/acceptance'

--- a/acceptance/lib/acceptance/bolt_setup_helper.rb
+++ b/acceptance/lib/acceptance/bolt_setup_helper.rb
@@ -46,6 +46,10 @@ module Acceptance
       ENV['LOCAL_USER'] || 'local_user'
     end
 
+    def profile_tracker
+      ENV['PROFILE_TRACKER'] || "C:/ProfileDir/profile_tracker.txt"
+    end
+
     def local_user_homedir
       case bolt['platform']
       when /osx/

--- a/acceptance/setup/common/pre-suite/032_configure_windows_profile.rb
+++ b/acceptance/setup/common/pre-suite/032_configure_windows_profile.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'bolt_setup_helper'
+
+test_name "Configure Windows Profile" do
+  extend Acceptance::BoltSetupHelper
+
+  step "Configure a Windows Profile that contains will write to a file every time it is loaded" do
+    if bolt['platform'] =~ /windows/
+      execute_powershell_script_on(bolt, <<-PS)
+$profileTracker = #{profile_tracker.inspect}
+$BaseDir = Split-Path $profileTracker
+if (!(Test-Path -Path $BaseDir ))
+{ New-Item -Type Directory -Path $BaseDir -Force }
+if (!(Test-Path -Path $PROFILE.AllUsersAllHosts))
+{ New-Item -Type File -Path $PROFILE.AllUsersAllHosts -Force }
+$ProfileCode = [string]::Format('"Profile Loaded" | Out-File {0} -Append', $profileTracker)
+Set-Content -Path $PROFILE.AllUsersAllHosts -value $ProfileCode
+PS
+
+      result = execute_powershell_script_on(bolt, <<-PS)
+Type $PROFILE.AllUsersAllHosts
+PS
+      assert_match(result.stdout.strip, "\"Profile Loaded\" | Out-File #{profile_tracker} -Append")
+    end
+  end
+end

--- a/acceptance/tests/script_local.rb
+++ b/acceptance/tests/script_local.rb
@@ -6,39 +6,60 @@ test_name "bolt script run should execute script on localhost via local transpor
   extend Acceptance::BoltCommandHelper
   extend Acceptance::BoltSetupHelper
 
-  skip_test('no applicable nodes to test on') if bolt['platform'] =~ /windows/
+  if bolt['platform'] =~ /windows/
+    script = "test_local.ps1"
 
-  script = "test_local.sh"
+    step "create powershell script on bolt controller" do
+      create_remote_file(bolt, script, <<-FILE)
+      Write-Host "Dont Load Profile"
+      FILE
+    end
 
-  step "create script on bolt controller" do
-    create_remote_file(bolt, script, <<-FILE)
-    #!/bin/sh
-    echo "$* there $(whoami)"
-    FILE
-  end
+    step "execute powershell script via local transport without loading powershell profile" do
+      bolt_command = "bolt script run #{script}"
+      flags = { '--nodes' => 'localhost' }
 
-  step "execute `bolt script run` on localhost" do
-    bolt_command = "bolt script run #{script} hello"
+      inspect_profile_tracker = "\"if (Test-Path -Path #{profile_tracker.inspect}) " \
+                                "{ Get-Content -Path #{profile_tracker.inspect} }\""
+      profile_pre = on(bolt, powershell(inspect_profile_tracker))
+      result = bolt_command_on(bolt, bolt_command, flags)
+      assert_match(/Dont Load Profile/, result.stdout, 'failed to run powershell script')
+      profile_post = on(bolt, powershell(inspect_profile_tracker))
+      assert_equal(profile_pre.stdout, profile_post.stdout, 'Profile was loaded')
+    end
+  else
+    script = "test_local.sh"
 
-    flags = { '--nodes' => 'localhost' }
+    step "create script on bolt controller" do
+      create_remote_file(bolt, script, <<-FILE)
+      #!/bin/sh
+      echo "$* there $(whoami)"
+      FILE
+    end
 
-    result = bolt_command_on(bolt, bolt_command, flags)
-    message = "Unexpected output from the command:\n#{result.cmd}"
-    assert_match(/hello there root/, result.stdout, message)
-  end
+    step "execute `bolt script run` on localhost" do
+      bolt_command = "bolt script run #{script} hello"
 
-  step "execute `bolt script run` on localhost with run-as" do
-    # make sure local_user is allowed to run script
-    local_owned_script = "#{local_user_homedir}/test_local.sh"
-    on(bolt, "cp #{script} #{local_owned_script}")
-    on(bolt, "chown -R local_user #{local_owned_script}")
+      flags = { '--nodes' => 'localhost' }
 
-    bolt_command = "bolt script run #{local_owned_script} hello"
+      result = bolt_command_on(bolt, bolt_command, flags)
+      message = "Unexpected output from the command:\n#{result.cmd}"
+      assert_match(/hello there root/, result.stdout, message)
+    end
 
-    flags = { '--nodes' => 'localhost', '--run-as' => "'#{local_user}'" }
+    step "execute `bolt script run` on localhost with run-as" do
+      # make sure local_user is allowed to run script
+      local_owned_script = "#{local_user_homedir}/test_local.sh"
+      on(bolt, "cp #{script} #{local_owned_script}")
+      on(bolt, "chown -R local_user #{local_owned_script}")
 
-    result = bolt_command_on(bolt, bolt_command, flags)
-    message = "Unexpected output from the command:\n#{result.cmd}"
-    assert_match(/hello there #{local_user}/, result.stdout, message)
+      bolt_command = "bolt script run #{local_owned_script} hello"
+
+      flags = { '--nodes' => 'localhost', '--run-as' => "'#{local_user}'" }
+
+      result = bolt_command_on(bolt, bolt_command, flags)
+      message = "Unexpected output from the command:\n#{result.cmd}"
+      assert_match(/hello there #{local_user}/, result.stdout, message)
+    end
   end
 end

--- a/acceptance/tests/task_local.rb
+++ b/acceptance/tests/task_local.rb
@@ -5,49 +5,72 @@ require 'bolt_command_helper'
 test_name "bolt task run should execute tasks on localhost via local transport" do
   extend Acceptance::BoltCommandHelper
   extend Acceptance::BoltSetupHelper
-
-  skip_test('no applicable nodes to test on') if bolt['platform'] =~ /windows/
-
   dir = bolt.tmpdir('local_task')
 
-  step "create task on bolt controller" do
-    on(bolt, "mkdir -p #{dir}/modules/test/tasks")
-    create_remote_file(bolt, "#{dir}/modules/test/tasks/whoami_nix", <<-FILE)
-    #!/bin/sh
-    echo "$PT_greetings from $(whoami)"
-    FILE
-    # TODO: Use input_method: both (default) once bug BOLT-1283 is fixed
-    conf = { 'input_method' => 'environment' }
-    create_remote_file(bolt, "#{dir}/modules/test/tasks/whoami_nix.json", conf.to_json)
-  end
+  if bolt['platform'] =~ /windows/
+    step "create task on bolt controller" do
+      on(bolt, "mkdir -p #{dir}/modules/test/tasks")
+      create_remote_file(bolt, "#{dir}/modules/test/tasks/test_profile.ps1", <<-FILE)
+      Write-Host 'Dont Load Profile'
+      FILE
+    end
 
-  step "execute `bolt task run` on localhost via local transport" do
-    bolt_command = "bolt task run test::whoami_nix greetings=hello"
-    flags = {
-      '--nodes' => 'localhost',
-      '--modulepath' => "#{dir}/modules"
-    }
+    step "execute `bolt task run` via local transport and ensure profile not loaded" do
+      bolt_command = "bolt task run test::test_profile"
 
-    result = bolt_command_on(bolt, bolt_command, flags)
-    message = "Unexpected output from the command:\n#{result.cmd}"
-    regex = /hello from root/
-    assert_match(regex, result.stdout, message)
-  end
+      flags = {
+        '--nodes' => 'localhost',
+        '--modulepath' => "#{dir}/modules"
+      }
 
-  step "execute `bolt task run` on localhost via local transport with run-as" do
-    on(bolt, "cp -r #{dir}/modules #{local_user_homedir}")
-    on(bolt, "chown -R #{local_user} #{local_user_homedir}/modules")
+      inspect_profile_tracker = "\"if (Test-Path -Path #{profile_tracker.inspect}) " \
+                                "{ Get-Content -Path #{profile_tracker.inspect} }\""
+      profile_pre = on(bolt, powershell(inspect_profile_tracker))
+      result = bolt_command_on(bolt, bolt_command, flags)
+      assert_match(/Dont Load Profile/, result.stdout, 'failed to run powershell task')
+      profile_post = on(bolt, powershell(inspect_profile_tracker))
+      assert_equal(profile_pre.stdout, profile_post.stdout, 'Profile was loaded')
+    end
+  else
+    step "create task on bolt controller" do
+      on(bolt, "mkdir -p #{dir}/modules/test/tasks")
+      create_remote_file(bolt, "#{dir}/modules/test/tasks/whoami_nix", <<-FILE)
+      #!/bin/sh
+      echo "$PT_greetings from $(whoami)"
+      FILE
+      # TODO: Use input_method: both (default) once bug BOLT-1283 is fixed
+      conf = { 'input_method' => 'environment' }
+      create_remote_file(bolt, "#{dir}/modules/test/tasks/whoami_nix.json", conf.to_json)
+    end
 
-    bolt_command = "bolt task run test::whoami_nix greetings=hello"
-    flags = {
-      '--nodes' => 'localhost',
-      '--modulepath' => "#{local_user_homedir}/modules",
-      '--run-as' => "'#{local_user}'"
-    }
+    step "execute `bolt task run` on localhost via local transport" do
+      bolt_command = "bolt task run test::whoami_nix greetings=hello"
+      flags = {
+        '--nodes' => 'localhost',
+        '--modulepath' => "#{dir}/modules"
+      }
 
-    result = bolt_command_on(bolt, bolt_command, flags)
-    message = "Unexpected output from the command:\n#{result.cmd}"
-    regex = /hello from #{local_user}/
-    assert_match(regex, result.stdout, message)
+      result = bolt_command_on(bolt, bolt_command, flags)
+      message = "Unexpected output from the command:\n#{result.cmd}"
+      regex = /hello from root/
+      assert_match(regex, result.stdout, message)
+    end
+
+    step "execute `bolt task run` on localhost via local transport with run-as" do
+      on(bolt, "cp -r #{dir}/modules #{local_user_homedir}")
+      on(bolt, "chown -R #{local_user} #{local_user_homedir}/modules")
+
+      bolt_command = "bolt task run test::whoami_nix greetings=hello"
+      flags = {
+        '--nodes' => 'localhost',
+        '--modulepath' => "#{local_user_homedir}/modules",
+        '--run-as' => "'#{local_user}'"
+      }
+
+      result = bolt_command_on(bolt, bolt_command, flags)
+      message = "Unexpected output from the command:\n#{result.cmd}"
+      regex = /hello from #{local_user}/
+      assert_match(regex, result.stdout, message)
+    end
   end
 end

--- a/lib/bolt/transport/powershell.rb
+++ b/lib/bolt/transport/powershell.rb
@@ -4,9 +4,9 @@ module Bolt
   module Transport
     module Powershell
       class << self
-        PS_ARGS = %w[
-          -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass
-        ].freeze
+        def ps_args
+          %w[-NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass]
+        end
 
         def powershell_file?(path)
           Pathname(path).extname.casecmp('.ps1').zero?
@@ -22,7 +22,7 @@ module Bolt
           when '.ps1'
             [
               'powershell.exe',
-              [*PS_ARGS, '-File', "\"#{path}\""]
+              [*ps_args, '-File', "\"#{path}\""]
             ]
           when '.pp'
             [


### PR DESCRIPTION
Previous to this commit the local_windows transport would call the powershell
profile if the default value for the 'interpreter' variable was ever used. in
this scenario the default interpreter needs to include PS_ARGS defined in the
powershell transport.

This commit adds PS_ARGS to the default of interpreter