### PR TITLE
updated travis.yml to push bolt to dockerhub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
     - REGISTRY_HOST=pcr-internal.puppet.net
     - DOCKER_REGISTRY=pe-and-platform
     - BOLT_SUDO_USER=true
+    - DOCKERHUB_USER=Puppet
+    - DOCKERHUB_REPO=bolt
     - secure: Gk8LaACXYEVpv5LIWEMOuH3sJP4CzB2aSvE1BUcfDWkI+Hdgr2by3w/nGbKpyVD+v2H8r0zXyVrbCJ/qzx2gCRxqKJ2GKJEsrStT+8z3BXRRRzwkThIBVyWKk9b9bTt8AE0G94I3BE4gJyIPfbX5XxnKcg7nJZGOmubZpUPQX+2SXSfy9EbtY9iismwK7LGtWv6l90cK2eSLZGvdsSKPo7cylOldXfdYIyeBtvsIL1juBaiINX52Zgt371+nX53fDSYOKdIDLuhNqX3zpNOuIJ9DUj4E7IJA7+XhHy77zL98VjHtPo5H4fmKyZ2k+xbYqOydc5OPGguKequsnyDo5npktDrkbswnjWMXNDu+wImAd+IwHG2lTamsAnOGQ+E6g2oK0R5fUL26XJ3lBnTRrsLDnlrvqYqFxt3MCR+o5+DnTirSVQJfrRVsIKTucWHlYLTOUWkVDrLavJqIbWHytEbMf/BXUcovlQzSgfu5/Y1GkUJBnthtbiZfTImmBLcrqKDD4PnDmvC1v9Z5KR78MYu7lFTe5C4STj2aR6bwvqjiPKm6kYG5etOFEyRJ+CbqD2QsdF2N6Ww/RFWovqVqQIWuGdhumDUTdmQAiiPxl12M0+kIH6NugpBD3gt4RT0sni/T+booDw6b3Ts4WJ8FW1/LPWdy7gVo9yOCL4FhjOw=
 before_script:
 - docker-compose -f spec/docker-compose.yml up -d --build
@@ -57,12 +59,18 @@ script:
 after_script:
 - docker-compose -f spec/docker-compose.yml logs
 deploy:
-  provider: script
-  on:
-    repo: puppetlabs/bolt
-    # deploy the master branch or tag pushes
-    condition: $TRAVIS_BRANCH == "master" || -n $TRAVIS_TAG
-  script: bash scripts/deploy.sh
+  - provider: script
+    on:
+      repo: puppetlabs/bolt
+      # deploy the master branch or tag pushes
+      condition: $TRAVIS_BRANCH == "master" || -n $TRAVIS_TAG
+    script: bash scripts/deploy.sh
+  - provider: script
+    on:
+      repo: puppetlabs/bolt
+      # deploy the master branch or tag pushes
+      condition: $TRAVIS_BRANCH == "master" || -n $TRAVIS_TAG
+    script: bash scripts/push-bolt-to-dockerhub.sh
 notifications:
   email: false
   hipchat:

--- a/docker/bolt.dockerfile
+++ b/docker/bolt.dockerfile
@@ -1,0 +1,42 @@
+FROM alpine:3.5
+
+MAINTAINER Gareth Rushgrove "gareth@puppet.com"
+
+LABEL org.label-schema.vendor="Puppet" \
+      org.label-schema.url="https://github.com/puppetlabs/bolt" \
+      org.label-schema.name="Bolt" \
+      org.label-schema.license="Apache-2.0" \
+      org.label-schema.schema-version="1.0" \
+      com.puppet.dockerfile="/Dockerfile"
+
+RUN apk add --update --no-cache \
+      build-base \
+      libffi-dev \
+      ca-certificates \
+      ruby \
+      ruby-io-console \
+      ruby-irb \
+      ruby-rdoc \
+      ruby-dev \
+      git && \
+      gem install bundler
+
+RUN addgroup -S bolt && adduser -S -g bolt bolt
+
+# As of https://github.com/moby/moby/pull/34263 Docker supports
+# setting ownership on Copy, but it's only available since the
+# 17.09 edge release of Moby. We'll wait until it's in the
+# main release
+# COPY --chown=bolt:bolt . /usr/src/bolt
+COPY . /usr/src/bolt
+RUN chown bolt:bolt /usr/src/bolt
+WORKDIR /usr/src/bolt
+
+USER bolt
+
+RUN bundle install --path .bundle
+
+ENTRYPOINT ["bundle", "exec", "bolt"]
+CMD ["--help" ]
+
+COPY docker/bolt.dockerfile /Dockerfile

--- a/scripts/push-bolt-to-dockerhub.sh
+++ b/scripts/push-bolt-to-dockerhub.sh
@@ -1,0 +1,17 @@
+#!bin/bash
+
+# Make sure this happens before set -x
+echo "${DOCKERHUB_PASS}" | docker login -u "${DOCKERHUB_USER}" --password-stdin
+
+set -x
+set -e
+
+if [ ! -z "${TRAVIS_TAG}" ]; then
+    docker build -t ${DOCKERHUB_USER}/${DOCKERHUB_REPO}:${TRAVIS_TAG} -f docker/bolt.dockerfile .
+fi
+
+# build image
+docker build -t ${DOCKERHUB_USER}/${DOCKERHUB_REPO} -f docker/bolt.dockerfile .
+# login to dockerhub
+# push image
+docker push ${DOCKERHUB_USER}/${DOCKERHUB_REPO}


### PR DESCRIPTION
Building a bolt image based on the Dockerfile in [https://github.com/puppetlabs/tasks-playground/tree/master/docker-image](https://github.com/puppetlabs/tasks-playground/tree/master/docker-image) and publishing it to the official Puppet dockerhub repo.

Publishing to Dockerhub only takes place when: 
- master is updated tag it as latest
- a tag is set. e.g. v1.21.0 it will tag bolt as v1.21.0 and latest.

**TODO**: DOCKERHUB_PASS as secure variable in .travis.yml or in travis as secure environment variable (don't print your password to stdout ;) )