### PR TITLE
(BOLT-1327) Support `proxy` setting for bolt puppetfile install

### DIFF
--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -32,12 +32,15 @@ module Bolt
 
   class Config
     attr_accessor :concurrency, :format, :trace, :log, :puppetdb, :color, :save_rerun,
-                  :transport, :transports, :inventoryfile, :compile_concurrency, :boltdir
+                  :transport, :transports, :inventoryfile, :compile_concurrency, :boltdir,
+                  :puppetfile_config
     attr_writer :modulepath
 
     TRANSPORT_OPTIONS = %i[password run-as sudo-password extensions
                            private-key tty tmpdir user connect-timeout
                            cacert token-file service-url interpreters file-protocol smb-port].freeze
+
+    PUPPETFILE_OPTIONS = %w[proxy].freeze
 
     def self.default
       new(Bolt::Boltdir.new('.'), {})
@@ -66,6 +69,7 @@ module Bolt
       @puppetdb = {}
       @color = true
       @save_rerun = true
+      @puppetfile_config = {}
 
       # add an entry for the default console logger
       @log = { 'console' => {} }
@@ -144,6 +148,10 @@ module Bolt
       end
 
       @inventoryfile = File.expand_path(data['inventoryfile'], @boltdir.path) if data.key?('inventoryfile')
+
+      if data.key?('puppetfile')
+        @puppetfile_config = data['puppetfile'].select { |k, _| PUPPETFILE_OPTIONS.include?(k) }
+      end
 
       @hiera_config = File.expand_path(data['hiera-config'], @boltdir.path) if data.key?('hiera-config')
       @compile_concurrency = data['compile-concurrency'] if data.key?('compile-concurrency')

--- a/pre-docs/bolt_configuration_options.md
+++ b/pre-docs/bolt_configuration_options.md
@@ -40,6 +40,8 @@ interpreters:
 
 `inventoryfile`: The path to a structured data inventory file used to refer to groups of nodes on the commandline and from plans. The default path for the inventory file is `inventory.yaml` inside the Bolt project directory.
 
+`puppetfile`: A map containing options for the `bolt puppetfile install` command. The only allowed key is `proxy` which specifies the HTTP proxy to use for Git and Puppet Forge operations.
+
 `modulepath`: The module path for loading tasks and plan code. This is either an array of directories or a string containing a list of directories separated by the OS specific PATH separator. The default path for modules is `modules:site-modules:site` inside the Bolt project directory.
 
 `transport`: Specify the default transport to use when the transport for a target is not specified in the url or inventory. The valid options for transport are `docker`, `local`, `pcp`, `ssh`, and `winrm`.

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1870,7 +1870,7 @@ describe "Bolt::CLI" do
         allow(puppetfile).to receive(:exist?).and_return(false)
 
         expect do
-          cli.install_puppetfile(puppetfile, modulepath)
+          cli.install_puppetfile({}, puppetfile, modulepath)
         end.to raise_error(Bolt::FileError, /Could not find a Puppetfile/)
       end
 
@@ -1880,13 +1880,13 @@ describe "Bolt::CLI" do
 
         allow(action_stub).to receive(:call).and_return(true)
 
-        cli.install_puppetfile(puppetfile, modulepath)
+        cli.install_puppetfile({}, puppetfile, modulepath)
       end
 
       it 'returns 0 and prints a result if successful' do
         allow(action_stub).to receive(:call).and_return(true)
 
-        expect(cli.install_puppetfile(puppetfile, modulepath)).to eq(0)
+        expect(cli.install_puppetfile({}, puppetfile, modulepath)).to eq(0)
 
         result = JSON.parse(output.string)
         expect(result['success']).to eq(true)
@@ -1897,7 +1897,7 @@ describe "Bolt::CLI" do
       it 'returns 1 and prints a result if unsuccessful' do
         allow(action_stub).to receive(:call).and_return(false)
 
-        expect(cli.install_puppetfile(puppetfile, modulepath)).to eq(1)
+        expect(cli.install_puppetfile({}, puppetfile, modulepath)).to eq(1)
 
         result = JSON.parse(output.string)
         expect(result['success']).to eq(false)
@@ -1909,7 +1909,7 @@ describe "Bolt::CLI" do
         allow(action_stub).to receive(:call).and_raise(R10K::Error.new('everything is terrible'))
 
         expect do
-          cli.install_puppetfile(puppetfile, modulepath)
+          cli.install_puppetfile({}, puppetfile, modulepath)
         end.to raise_error(Bolt::PuppetfileError, /everything is terrible/)
 
         expect(output.string).to be_empty


### PR DESCRIPTION
This exposes the r10k proxy setting in a new section of bolt.yaml called
`puppetfile`. This proxy will be used for Git HTTPS and Puppet Forge
operations.