### PR TITLE
(BOLT-1324) Fix port collision for local test setup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,18 +15,20 @@ RSpec::Core::RakeTask.new(:spec)
 desc "Run RSpec tests that don't require VM fixtures or a particular shell"
 RSpec::Core::RakeTask.new(:unit) do |t|
   t.rspec_opts = '--tag ~ssh --tag ~docker --tag ~bash --tag ~winrm ' \
-                 '--tag ~appveyor_agents --tag ~puppetserver --tag ~puppetdb'
+                 '--tag ~appveyor_agents --tag ~puppetserver --tag ~puppetdb ' \
+                 '--tag ~omi'
 end
 
 desc "Run RSpec tests for AppVeyor that don't require SSH, Bash, Appveyor Puppet Agents, or orchestrator"
 RSpec::Core::RakeTask.new(:appveyor) do |t|
   t.rspec_opts = '--tag ~ssh --tag ~docker --tag ~bash --tag ~appveyor_agents ' \
-         '--tag ~orchestrator --tag ~puppetserver --tag ~puppetdb'
+         '--tag ~orchestrator --tag ~puppetserver --tag ~puppetdb --tag ~omi'
 end
 
 desc "Run RSpec tests for TravisCI that don't require WinRM"
 RSpec::Core::RakeTask.new(:travisci) do |t|
-  t.rspec_opts = '--tag ~winrm --tag ~appveyor_agents --tag ~puppetserver --tag ~puppetdb --tag ~windows'
+  t.rspec_opts = '--tag ~winrm --tag ~appveyor_agents --tag ~puppetserver --tag ~puppetdb ' \
+  '--tag ~omi --tag ~windows'
 end
 
 desc "Run RSpec tests that require slow to start puppet containers"
@@ -141,6 +143,11 @@ namespace :integration do
   desc 'Run tests that require Puppet Agents configured with Appveyor'
   RSpec::Core::RakeTask.new(:appveyor_agents) do |t|
     t.rspec_opts = '--tag appveyor_agents'
+  end
+
+  desc 'Run tests that require OMI docker container'
+  RSpec::Core::RakeTask.new(:omi) do |t|
+    t.rspec_opts = '--tag omi'
   end
 
   task ssh: :update_submodules

--- a/spec/bolt/transport/winrm_spec.rb
+++ b/spec/bolt/transport/winrm_spec.rb
@@ -144,14 +144,16 @@ PS
   end
 
   context "connecting over SSL", winrm: true, omi: true do
+    # In order to run vagrant and docker targets simultaniously for local dev, use 2498{5,6} to avoid port conflict
+    let(:omi_target) { make_target(port_: 24986, conf: ssl_config) }
     let(:target) { make_target(port_: ssl_port, conf: ssl_config) }
 
     it "can test whether the target is available" do
-      expect(winrm.connected?(target)).to eq(true)
+      expect(winrm.connected?(omi_target)).to eq(true)
     end
 
     it "executes a command on a host" do
-      expect(winrm.run_command(target, command)['stdout']).to eq("#{user}\r\n")
+      expect(winrm.run_command(omi_target, command)['stdout']).to eq("#{user}\r\n")
     end
 
     # winrm gem doesn't fully support OMI server, so disable this test
@@ -178,7 +180,27 @@ PS
       target.options.delete('cacert')
       target.options['ssl-verify'] = false
 
-      expect(winrm.run_command(target, command)['stdout']).to eq("#{user}\r\n")
+      expect(winrm.run_command(omi_target, command)['stdout']).to eq("#{user}\r\n")
+    end
+  end
+
+  context "connecting over SSL to OMI container ", omi: true do
+    # In order to run vagrant and docker targets simultaniously for local dev, use 2498{5,6} to avoid port conflict
+    let(:omi_target) { make_target(port_: 24986, conf: ssl_config) }
+
+    it "can test whether the target is available" do
+      expect(winrm.connected?(omi_target)).to eq(true)
+    end
+
+    it "executes a command on a host" do
+      expect(winrm.run_command(omi_target, command)['stdout']).to eq("#{user}\r\n")
+    end
+
+    it "skips verification with ssl-verify: false" do
+      target.options.delete('cacert')
+      target.options['ssl-verify'] = false
+
+      expect(winrm.run_command(omi_target, command)['stdout']).to eq("#{user}\r\n")
     end
   end
 

--- a/spec/docker-compose.yml
+++ b/spec/docker-compose.yml
@@ -56,5 +56,5 @@ services:
       args:
         BOLT_PASSWORD: bolt
     ports:
-      - "25985:5985"
-      - "25986:5986"
+      - "24985:5985"
+      - "24986:5986"


### PR DESCRIPTION
When the OMI docker container was introduced, it was configured to map local port 2598{5,6} to 598{5,6}. This is the same port used the vagrant windows nano image. While this is not a problem in Travis or Appveyor, it prevents local testing using both the windows nano vagrant image and the docker OMI container. This commit removes the port conflict.