### PR TITLE
(BOLT-1316) Add catch_errors plan language function

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/catch_errors.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/catch_errors.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Catches errors in a given block and returns them. This will return the
+# output of the block if no errors are raised. Accepts an optional list of
+# error kinds to catch.
+#
+# **NOTE:** Not available in apply block
+Puppet::Functions.create_function(:catch_errors) do
+  # @param error_types An array of error types to catch
+  # @param block The block of steps to catch errors on
+  # @return Undef If an error is raised in the block then the error will be
+  # returned, otherwise the result will be returned
+  # @example Catch errors for a block
+  #   catch_errors() || {
+  #     run_command("whoami", $nodes)
+  #     run_command("adduser ryan", $nodes)
+  #   }
+  # @example Catch parse errors for a block of code
+  #   catch_errors(['bolt/parse-error']) || {
+  #    run_plan('canary', $nodes)
+  #    run_plan('other_plan)
+  #    apply($nodes) || {
+  #      notify { "Hello": }
+  #    }
+  #   }
+  dispatch :catch_errors do
+    optional_param 'Array[String[1]]', :error_types
+    block_param 'Callable[0, 0]', :block
+  end
+
+  def catch_errors(error_types = nil)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING,
+                              action: self.class.name)
+    end
+
+    executor = Puppet.lookup(:bolt_executor)
+    executor.report_function_call(self.class.name)
+
+    begin
+      yield
+    rescue Puppet::PreformattedError => e
+      if e.cause.is_a?(Bolt::Error)
+        if error_types.nil?
+          return e.cause.to_puppet_error
+        elsif error_types.include?(e.cause.to_h['kind'])
+          return e.cause.to_puppet_error
+        else
+          raise e
+        end
+      else
+        raise e
+      end
+    end
+  end
+end

--- a/bolt-modules/boltlib/spec/functions/catch_errors_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/catch_errors_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/executor'
+
+describe 'catch_errors' do
+  let(:executor) { Bolt::Executor.new }
+  let(:tasks_enabled) { true }
+
+  around(:each) do |example|
+    Puppet[:tasks] = tasks_enabled
+    Puppet.override(bolt_executor: executor) do
+      example.run
+    end
+  end
+
+  it 'reports the call to analytics' do
+    executor.expects(:report_function_call).with('catch_errors')
+    is_expected.to(run
+      .with_lambda { 'abcd' })
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+
+    it 'fails and reports that catch_errors is not available' do
+      is_expected.to run
+        .with_lambda { puts 'hi' }
+        .and_raise_error(/Plan language function 'catch_errors' cannot be used/)
+    end
+  end
+end

--- a/pre-docs/plan_functions.md
+++ b/pre-docs/plan_functions.md
@@ -85,6 +85,43 @@ apply_prep('target1,target2')
 ```
 
 
+## catch_errors
+
+Catches errors in a given block and returns them. This will return the
+output of the block if no errors are raised. Accepts an optional list of
+error kinds to catch.
+
+**NOTE:** Not available in apply block
+
+
+```
+catch_errors(Optional[Array[String[1]]] $error_types, Callable[0, 0] &$block)
+```
+
+*Returns:* `Any` Undef If an error is raised in the block then the error will be
+
+* **error_types** `Optional[Array[String[1]]]` An array of error types to catch
+* **&block** `Callable[0, 0]` The block of steps to catch errors on
+
+**Example:** Catch errors for a block
+```
+catch_errors() || {
+  run_command("whoami", $nodes)
+  run_command("adduser ryan", $nodes)
+}
+```
+**Example:** Catch parse errors for a block of code
+```
+catch_errors(['bolt/parse-error']) || {
+ run_plan('canary', $nodes)
+ run_plan('other_plan)
+ apply($nodes) || {
+   notify { "Hello": }
+ }
+}
+```
+
+
 ## ctrl::do_until
 
 Repeat the block until it returns a truthy value. Returns the value.

--- a/spec/fixtures/modules/catch_errors/plans/break.pp
+++ b/spec/fixtures/modules/catch_errors/plans/break.pp
@@ -1,0 +1,13 @@
+plan catch_errors::break(
+  TargetSpec $nodes,
+  Array $list
+) {
+  $list.each |$elem| {
+    catch_errors() || {
+      notice($elem)
+      break()
+      notice("Out of bounds")
+    }
+  }
+  return "Break the chain"
+}

--- a/spec/fixtures/modules/catch_errors/plans/init.pp
+++ b/spec/fixtures/modules/catch_errors/plans/init.pp
@@ -1,0 +1,14 @@
+plan catch_errors(
+  TargetSpec $nodes,
+  Boolean $fail = true
+) {
+  $errors = catch_errors() || {
+    if $fail {
+      run_task('error::fail', $nodes)
+    } else {
+      run_command("echo 'Unepic unfailure'", $nodes)
+    }
+  }
+  notice("Step 1")
+  return $errors
+}

--- a/spec/fixtures/modules/catch_errors/plans/return.pp
+++ b/spec/fixtures/modules/catch_errors/plans/return.pp
@@ -1,0 +1,7 @@
+plan catch_errors::return(TargetSpec $nodes) {
+  $message = catch_errors() || {
+    return "You can return a product for up to 30 days from the date you purchased it"
+    notice("Don't go here")
+  }
+  return "Never break the chain"
+}

--- a/spec/fixtures/modules/catch_errors/plans/typed.pp
+++ b/spec/fixtures/modules/catch_errors/plans/typed.pp
@@ -1,0 +1,17 @@
+plan catch_errors::typed(
+  TargetSpec $nodes,
+  Boolean $fail_task = false,
+  Boolean $fail_plan = false,
+  Array $errors = ['puppetlabs.tasks/task-error']
+) {
+  $typed = catch_errors($errors) || {
+    run_task('error::typed', $nodes, 'fail' => $fail_task)
+    if $fail_plan {
+      run_plan('basic::failure', nodes => $nodes)
+    }
+    return "Ran with out error"
+  }
+  notice("Step 2")
+  $hash = { 'error' => $typed, 'msg' => 'Success' }
+  return $hash
+}

--- a/spec/fixtures/modules/error/tasks/fail.json
+++ b/spec/fixtures/modules/error/tasks/fail.json
@@ -1,0 +1,12 @@
+{
+  "implementations": [
+    {
+      "name": "fail.sh",
+      "requirements": ["shell"]
+    },
+    {
+      "name": "fail.ps1",
+      "requirements": ["powershell"]
+    }
+  ]
+}

--- a/spec/fixtures/modules/error/tasks/fail.ps1
+++ b/spec/fixtures/modules/error/tasks/fail.ps1
@@ -1,0 +1,2 @@
+Write-Output "failing"
+exit 1

--- a/spec/fixtures/modules/error/tasks/typed.json
+++ b/spec/fixtures/modules/error/tasks/typed.json
@@ -1,0 +1,13 @@
+{
+  "implementations": [
+    {
+      "name": "typed.sh",
+      "requirements": ["shell"]
+    },
+    {
+      "name": "typed.ps1",
+      "requirements": ["powershell"],
+      "input_method": "environment"
+    }
+  ]
+}

--- a/spec/fixtures/modules/error/tasks/typed.ps1
+++ b/spec/fixtures/modules/error/tasks/typed.ps1
@@ -1,0 +1,5 @@
+If($env:PT_fail -eq 'true') {
+  exit 1
+} Else {
+  Write-Output "{`"tag`": `"you're it`"}"
+}

--- a/spec/fixtures/modules/error/tasks/typed.sh
+++ b/spec/fixtures/modules/error/tasks/typed.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [ "$PT_fail" = true ]; then
+  exit 1
+else
+  echo "{\"tag\": \"you're it\"}"
+fi

--- a/spec/integration/catch_errors_spec.rb
+++ b/spec/integration/catch_errors_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/config'
+require 'bolt_spec/conn'
+require 'bolt_spec/files'
+require 'bolt_spec/integration'
+require 'bolt/util'
+
+describe "catch_errors" do
+  include BoltSpec::Integration
+  include BoltSpec::Config
+  include BoltSpec::Conn
+
+  after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
+
+  let(:modulepath) { [fixture_path('modules'), fixture_path('apply')].join(File::PATH_SEPARATOR) }
+  let(:target) do
+    if Bolt::Util.windows?
+      conn_uri('winrm')
+    else
+      conn_uri('ssh', include_password: true)
+    end
+  end
+  let(:transport_flags) do
+    if Bolt::Util.windows?
+      ['--password', conn_info('winrm')[:password],
+       '--no-ssl',
+       '--no-ssl-verify']
+    else
+      ['--no-host-key-check']
+    end
+  end
+
+  let(:config_flags) {
+    ['--format', 'json',
+     '--configfile', fixture_path('configs', 'empty.yml'),
+     '--modulepath', modulepath,
+     '--nodes', target] + transport_flags
+  }
+  let(:plan) { "catch_errors" }
+
+  it 'catches an error and continues' do
+    run_cli(%w[plan run catch_errors] + config_flags)
+    output = @log_output.readlines
+    expect(output).to include("NOTICE  Puppet : Step 1\n")
+  end
+
+  it 'returns a ResultSet' do
+    result = run_cli_json(%W[plan run #{plan}] + config_flags)
+    error = result['details']['result_set'].first['result']['_error']
+    expect(error['kind']).to eq('puppetlabs.tasks/task-error')
+    expect(error['msg']).to match(/failed with exit code 1/)
+  end
+
+  it 'returns the output if there are no errors' do
+    params = { fail: false }.to_json
+    result = run_cli_json(%W[plan run #{plan} --params #{params}] + config_flags).first
+    expect(result['status']).to eq('success')
+    expect(result['result']['stdout'].strip).to eq("Unepic unfailure")
+  end
+
+  context "with typed errors" do
+    # Plan returns a hash { 'error' => error, 'msg' => "Success" }
+    let(:plan) { "catch_errors::typed" }
+
+    it 'returns the error if it matches the type' do
+      params = { fail_task: true,
+                 errors: ['bolt/run-failure'] }.to_json
+      result = run_cli_json(%W[plan run #{plan} --params #{params}] + config_flags)
+      expect(result['error']['kind']).to eq('bolt/run-failure')
+      expect(result['msg']).to eq("Success")
+      expect(result).not_to include('kind')
+
+      # Verify that the plan continued
+      output = @log_output.readlines
+      expect(output).to include("NOTICE  Puppet : Step 2\n")
+    end
+
+    it 'returns the error if it matches the second type in the array' do
+      params = { fail_plan: true,
+                 errors: ['bolt/run-failure',
+                          'bolt/apply-failure'] }.to_json
+      result = run_cli_json(%W[plan run #{plan} --params #{params}] + config_flags)
+      expect(result['error']['kind']).to eq('bolt/apply-failure')
+      expect(result).not_to include('kind')
+    end
+
+    it 'fails the plan if the error is not in the type list' do
+      params = { fail_task: true,
+                 errors: ['bolt/fake-error'] }.to_json
+      result = run_cli_json(%W[plan run #{plan} --params #{params}] + config_flags)
+
+      expect(result).to include('kind')
+      expect(result['msg']).to include("Plan aborted")
+    end
+  end
+
+  context "when breaking" do
+    let(:plan) { "catch_errors::break" }
+    it "breaks from enumeration" do
+      params = { list: %w[firstcomment b c] }
+      result = run_cli_json(%W[plan run #{plan} --params #{params.to_json}] +
+                            config_flags)
+      expect(result).to eq("Break the chain")
+      output = @log_output.readlines
+      expect(output).to include("NOTICE  Puppet : firstcomment\n")
+      expect(output).not_to include(/Out of bounds/)
+    end
+  end
+
+  context "when returning" do
+    let(:plan) { "catch_errors::return" }
+
+    it "returns from the plan" do
+      result = run_cli_json(%W[plan run #{plan}] + config_flags)
+      expect(result).to include("You can return a product for up to 30 days")
+      output = @log_output.readlines
+      expect(output).not_to include(/Don't go here/)
+    end
+  end
+end


### PR DESCRIPTION
This adds a new Bolt plan language function `catch_errors`, which accepts an optional Array of error kinds to catch and a block of Bolt plan code to catch errors for. If an error matching the kinds (or all kinds, if none are specified) is raised in the block it is returned from the block, otherwise the result of the block is returned.