### PR TITLE
(website) Remove redundant "Introduction" link

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -30,9 +30,6 @@
             </a>
           </span>
           <ol>
-            <li>
-              <a href="{{ '/' | relative_url }}">Introduction</a>
-            </li>
             {% for lab in site.lab %}
               {% if lab.title %}
               <li><a href="{{ lab.url | remove: "/index.html" | relative_url }}">{{ lab.title }}</a></li>


### PR DESCRIPTION
We now link to the hands-on lab from the 'Bolt Hands-on Lab' heading, so
there's no need to have an extra "Introduction" entry in the navigation.
This also caused the numbered labs to not align with their index in the
navigation list, which is a minor annoyance.