### PR TITLE
(BOLT-1317) Add rake tasks for building gem for shipping pipeline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,10 @@ group(:development) do
   gem "puppet-strings", "~> 2.0"
 end
 
+group(:packaging) do
+  gem 'packaging', '~> 0.99.35'
+end
+
 local_gemfile = File.join(__dir__, 'Gemfile.local')
 if File.exist? local_gemfile
   eval_gemfile local_gemfile

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,10 @@ require "fileutils"
 require "json"
 require "erb"
 
+# Needed for Vanagon component ship job
+require 'packaging'
+Pkg::Util::RakeUtils.load_packaging_tasks
+
 desc "Run all RSpec tests"
 RSpec::Core::RakeTask.new(:spec)
 

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -54,6 +54,6 @@ Gem::Specification.new do |spec|
   # there is a bug in puppetlabs_spec_helper for modules without fixtures
   spec.add_development_dependency "bundler", ">= 1.14"
   spec.add_development_dependency "puppetlabs_spec_helper", "~> 2.7"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,0 +1,3 @@
+---
+build_gem: TRUE
+project: puppet-bolt


### PR DESCRIPTION
This commit adds the necessary rake tasks, gem dependency and build metadata to build and stage the bolt gem for the release pipeline. This allows the gem to be shipped to public repos with the same job that ships the bolt system packages.