### PR TITLE
(BOLT-1382) Fix batch err in wait_until_available

### DIFF
--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -292,7 +292,11 @@ module Bolt
               wait_until(wait_time, retry_interval) { transport.batch_connected?(batch) }
               batch.map { |target| Result.new(target) }
             rescue TimeoutError => e
-              batch.map { |target| Result.from_exception(target, e) }
+              available, unavailable = batch.partition { |target| transport.batch_connected?([target]) }
+              (
+                available.map { |target| Result.new(target) } +
+                unavailable.map { |target| Result.from_exception(target, e) }
+              )
             end
           end
         end


### PR DESCRIPTION
Previously, wait_until_available() would only check connectivity for a
batch at a time, and if any target in the batch was unavailable it would
report the whole batch as unavailable.

This commit modifies the error handling such that if a batch comes back
as having any unavailable targets in it, the results are partitioned so
that individual, target-by-target availability reporting is performed
correctly.