### PR TITLE
(BOLT-1356) Add docstrings for canary plan

### DIFF
--- a/modules/canary/plans/init.pp
+++ b/modules/canary/plans/init.pp
@@ -1,3 +1,30 @@
+# @summary
+#   Run a task, command or script on canary nodes before running it on all nodes.
+#
+# This plan accepts a action and a $nodes parameter. The action can be the name
+# of a task, a script or a command to run. It will run the action on a canary
+# group of nodes and only continue to the rest of the nodes if it succeeds on
+# all canaries. This returns a ResultSet object with a Result for every node.
+# Any skipped nodes will have a 'canary/skipped-node' error kind.
+#
+# @param task
+#  The name of the task to run. Mutually exclusive with command and script.
+# @param command
+#   The command to run. Mutually exclusive with task and script.
+# @param script
+#   The script to run. Mutually exclusive with task and command.
+# @param nodes
+#   The target to run on.
+# @param params
+#   The parameters to use for the task.
+# @param canary_size
+#   How many targets to use in the canary group.
+#
+# @return ResultSet a merged resultset from running the action on all targets
+#
+# @example Run a command
+#   run_plan(canary, command => 'whoami', nodes => $mynodes)
+
 plan canary(
   Optional[String[0]] $task = undef,
   Optional[String[0]] $command = undef,


### PR DESCRIPTION
This adds docstrings for the canary plan to help with strings
development. Currenlty it appears as those strings only handles the
@param statements