### PR TITLE
(maint) Fix typos in puppet strings docs for catch_errors

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/catch_errors.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/catch_errors.rb
@@ -8,8 +8,8 @@
 Puppet::Functions.create_function(:catch_errors) do
   # @param error_types An array of error types to catch
   # @param block The block of steps to catch errors on
-  # @return Undef If an error is raised in the block then the error will be
-  # returned, otherwise the result will be returned
+  # @return If an error is raised in the block then the error will be returned,
+  #         otherwise the result will be returned
   # @example Catch errors for a block
   #   catch_errors() || {
   #     run_command("whoami", $nodes)
@@ -26,6 +26,7 @@ Puppet::Functions.create_function(:catch_errors) do
   dispatch :catch_errors do
     optional_param 'Array[String[1]]', :error_types
     block_param 'Callable[0, 0]', :block
+    return_type 'Any'
   end
 
   def catch_errors(error_types = nil)

--- a/pre-docs/plan_functions.md
+++ b/pre-docs/plan_functions.md
@@ -98,7 +98,8 @@ error kinds to catch.
 catch_errors(Optional[Array[String[1]]] $error_types, Callable[0, 0] &$block)
 ```
 
-*Returns:* `Any` Undef If an error is raised in the block then the error will be
+*Returns:* `Any` If an error is raised in the block then the error will be returned,
+otherwise the result will be returned
 
 * **error_types** `Optional[Array[String[1]]]` An array of error types to catch
 * **&block** `Callable[0, 0]` The block of steps to catch errors on

--- a/pre-docs/writing_plans.md
+++ b/pre-docs/writing_plans.md
@@ -189,7 +189,7 @@ fail_plan($errorobject)
 
 ### Catching Errors in a Plan
 
-Bolt includes a `catch_errors` function which executes a block of code and returns the error if an error is raised or the result of the block if no errors are raised. When you call `run_plan` with `_catch_errors`, use a `catch_errors` block, or call the `error` method on a result, you may get an error.
+Bolt includes a `catch_errors` function which executes a block of code and returns the error if an error is raised or the result of the block if no errors are raised. You may get an `Error` object returned if you call a function with `_catch_errors`, use a `catch_errors` block, or call the `Error` function.
 
 The `Error` data type includes:
 


### PR DESCRIPTION
A newline in the `@return` docstring cut off the string when compiled in CI, and the return type for `catch_errors` was not specified. This also rewords the `Catching Errors` section of the docs for clarity.