### PR TITLE
(BOLT-1222) Add a 'resources' step for YAML plans

### DIFF
--- a/lib/bolt/pal/yaml_plan.rb
+++ b/lib/bolt/pal/yaml_plan.rb
@@ -48,19 +48,18 @@ module Bolt
           stringified_step = Bolt::Util.walk_keys(step) { |key| stringify(key) }
           stringified_step['name'] = stringify(stringified_step['name']) if stringified_step.key?('name')
 
-          step = Step.new(stringified_step, index + 1)
-          # Send object instead of just name so that step number is printed
-          duplicate_check(used_names, step)
+          step = Step.create(stringified_step, index + 1)
+          duplicate_check(used_names, stringified_step['name'], index + 1)
           used_names << stringified_step['name'] if stringified_step['name']
           step
         end.freeze
         @return = plan['return']
       end
 
-      def duplicate_check(used_names, step)
-        if used_names.include?(step.name)
-          error_message = "Duplicate step name or parameter detected: #{step.name.inspect}"
-          err = step.step_err_msg(error_message)
+      def duplicate_check(used_names, name, step_number)
+        if used_names.include?(name)
+          error_message = "Duplicate step name or parameter detected: #{name.inspect}"
+          err = Step.step_error(error_message, name, step_number)
           raise Bolt::Error.new(err, "bolt/invalid-plan")
         end
       end
@@ -101,6 +100,10 @@ module Bolt
         attr_reader :value
         def initialize(value)
           @value = value
+        end
+
+        def ==(other)
+          self.class == other.class && @value == other.value
         end
       end
 

--- a/lib/bolt/pal/yaml_plan/step.rb
+++ b/lib/bolt/pal/yaml_plan/step.rb
@@ -37,6 +37,10 @@ module Bolt
           'eval' => {
             'allowed_keys' => Set['eval', 'name', 'description'],
             'required_keys' => Set.new
+          },
+          'resources' => {
+            'allowed_keys' => Set['resources'].merge(COMMON_STEP_KEYS),
+            'required_keys' => Set['target']
           }
         }.freeze
 

--- a/lib/bolt/pal/yaml_plan/step.rb
+++ b/lib/bolt/pal/yaml_plan/step.rb
@@ -8,156 +8,89 @@ module Bolt
       class Step
         attr_reader :name, :type, :body, :target
 
+        def self.allowed_keys
+          Set['name', 'description', 'target']
+        end
+
         COMMON_STEP_KEYS = %w[name description target].freeze
-        STEP_KEYS = {
-          'command' => {
-            'allowed_keys' => Set['command'].merge(COMMON_STEP_KEYS),
-            'required_keys' => Set['target']
-          },
-          'script' => {
-            'allowed_keys' => Set['script', 'parameters', 'arguments'].merge(COMMON_STEP_KEYS),
-            'required_keys' => Set['target']
-          },
-          'task' => {
-            'allowed_keys' => Set['task', 'parameters'].merge(COMMON_STEP_KEYS),
-            'required_keys' => Set['target']
-          },
-          'plan' => {
-            'allowed_keys' => Set['plan', 'parameters'].merge(COMMON_STEP_KEYS),
-            'required_keys' => Set.new
-          },
-          'source' => {
-            'allowed_keys' => Set['source', 'destination'].merge(COMMON_STEP_KEYS),
-            'required_keys' => Set['target', 'source', 'destination']
-          },
-          'destination' => {
-            'allowed_keys' => Set['source', 'destination'].merge(COMMON_STEP_KEYS),
-            'required_keys' => Set['target', 'source', 'destination']
-          },
-          'eval' => {
-            'allowed_keys' => Set['eval', 'name', 'description'],
-            'required_keys' => Set.new
-          },
-          'resources' => {
-            'allowed_keys' => Set['resources'].merge(COMMON_STEP_KEYS),
-            'required_keys' => Set['target']
-          }
-        }.freeze
+        STEP_KEYS = %w[command script task plan source destination eval resources].freeze
 
-        def initialize(step_body, step_number)
-          @body = step_body
-          @name = @body['name']
-          # For error messages
-          @step_number = step_number
-          validate_step
-
-          @type = STEP_KEYS.keys.find { |key| @body.key?(key) }
-          @target = @body['target']
-        end
-
-        def transpile(plan_path)
-          result = String.new("  ")
-          result << "$#{@name} = " if @name
-
-          description = body.fetch('description', nil)
-          parameters = body.fetch('parameters', {})
-          if @type == 'script' && body.key?('arguments')
-            parameters['arguments'] = body['arguments']
-          end
-
-          case @type
-          when 'command', 'task', 'script', 'plan'
-            result << "run_#{@type}(#{Bolt::Util.to_code(body[@type])}"
-            result << ", #{Bolt::Util.to_code(@target)}" if @target
-            result << ", #{Bolt::Util.to_code(description)}" if description && type != 'plan'
-            result << ", #{Bolt::Util.to_code(parameters)}" unless parameters.empty?
-            result << ")"
-          when 'source'
-            result << "upload_file(#{Bolt::Util.to_code(body['source'])}, #{Bolt::Util.to_code(body['destination'])}"
-            result << ", #{Bolt::Util.to_code(@target)}" if @target
-            result << ", #{Bolt::Util.to_code(description)}" if description
-            result << ")"
-          when 'eval'
-            # We have to do a little extra parsing here, since we only need
-            # with() for eval blocks
-            code = Bolt::Util.to_code(body['eval'])
-            if @name && code.lines.count > 1
-              # A little indented niceness
-              indented = code.gsub(/\n/, "\n    ").chomp("  ")
-              result << "with() || {\n    #{indented}}"
-            else
-              result << code
-            end
+        def self.create(step_body, step_number)
+          type_keys = (STEP_KEYS & step_body.keys)
+          case type_keys.length
+          when 0
+            raise step_error("No valid action detected", step_body['name'], step_number)
+          when 1
+            type = type_keys.first
           else
-            # We should never get here
-            raise Bolt::YamlTranspiler::ConvertError.new("Can't convert unsupported step type #{@name}", plan_path)
+            if type_keys.to_set == Set['source', 'destination']
+              type = 'upload'
+            else
+              raise step_error("Multiple action keys detected: #{type_keys.inspect}", step_body['name'], step_number)
+            end
           end
-          result << "\n"
-          result
+
+          step_class = const_get("Bolt::PAL::YamlPlan::Step::#{type.capitalize}")
+          step_class.validate(step_body, step_number)
+          step_class.new(step_body)
         end
 
-        def validate_step
-          validate_step_keys
+        def initialize(step_body)
+          @name = step_body['name']
+          @description = step_body['description']
+          @target = step_body['target']
+          @body = step_body
+        end
+
+        def transpile
+          raise NotImplementedError, "Step #{@name} does not supported conversion to Puppet plan language"
+        end
+
+        def self.validate(body, step_number)
+          validate_step_keys(body, step_number)
 
           begin
-            @body.each { |k, v| validate_puppet_code(k, v) }
+            body.each { |k, v| validate_puppet_code(k, v) }
           rescue Bolt::Error => e
-            err = step_err_msg(e.msg)
-            raise Bolt::Error.new(err, 'bolt/invalid-plan')
+            raise step_error(e.msg, body['name'], step_number)
           end
 
           unless body.fetch('parameters', {}).is_a?(Hash)
             msg = "Parameters key must be a hash"
-            raise Bolt::Error.new(step_err_msg(msg), "bolt/invalid-plan")
+            raise step_error(msg, body['name'], step_number)
           end
 
-          if @name
-            unless @name.is_a?(String) && @name.match?(Bolt::PAL::YamlPlan::VAR_NAME_PATTERN)
-              error_message = "Invalid step name: #{@name.inspect}"
-              err = step_err_msg(error_message)
-              raise Bolt::Error.new(err, "bolt/invalid-plan")
+          if body.key?('name')
+            name = body['name']
+            unless name.is_a?(String) && name.match?(Bolt::PAL::YamlPlan::VAR_NAME_PATTERN)
+              error_message = "Invalid step name: #{name.inspect}"
+              raise step_error(error_message, body['name'], step_number)
             end
           end
         end
 
-        def validate_step_keys
-          step_keys = @body.keys.to_set
-          action = step_keys.intersection(STEP_KEYS.keys.to_set).to_a
-          unless action.count == 1
-            if action.count > 1
-              # Upload step is special in that it is identified by both `source` and `destination`
-              unless action.to_set == Set['source', 'destination']
-                error_message = "Multiple action keys detected: #{action.inspect}"
-                err = step_err_msg(error_message)
-                raise Bolt::Error.new(err, "bolt/invalid-plan")
-              end
-            else
-              error_message = "No valid action detected"
-              err = step_err_msg(error_message)
-              raise Bolt::Error.new(err, "bolt/invalid-plan")
-            end
-          end
+        def self.validate_step_keys(body, step_number)
+          step_type = name.split('::').last.downcase
 
           # For validated step action, ensure only valid keys
-          unless STEP_KEYS[action.first]['allowed_keys'].superset?(step_keys)
-            illegal_keys = step_keys - STEP_KEYS[action.first]['allowed_keys']
-            error_message = "The #{action.first.inspect} step does not support: #{illegal_keys.to_a.inspect} key(s)"
-            err = step_err_msg(error_message)
+          illegal_keys = body.keys.to_set - allowed_keys
+          if illegal_keys.any?
+            error_message = "The #{step_type.inspect} step does not support: #{illegal_keys.to_a.inspect} key(s)"
+            err = step_error(error_message, body['name'], step_number)
             raise Bolt::Error.new(err, "bolt/invalid-plan")
           end
 
           # Ensure all required keys are present
-          STEP_KEYS[action.first]['required_keys'].each do |k|
-            next if step_keys.include?(k)
-            missing_keys = STEP_KEYS[action.first]['required_keys'] - step_keys
-            error_message = "The #{action.first.inspect} step requires: #{missing_keys.to_a.inspect} key(s)"
-            err = step_err_msg(error_message)
+          missing_keys = required_keys - body.keys
+          if missing_keys.any?
+            error_message = "The #{step_type.inspect} step requires: #{missing_keys.to_a.inspect} key(s)"
+            err = step_error(error_message, body['name'], step_number)
             raise Bolt::Error.new(err, "bolt/invalid-plan")
           end
         end
 
         # Recursively ensure all puppet code can be parsed
-        def validate_puppet_code(step_key, value)
+        def self.validate_puppet_code(step_key, value)
           case value
           when Array
             value.map { |element| validate_puppet_code(step_key, element) }
@@ -184,16 +117,14 @@ module Bolt
           raise Bolt::Error.new("Error parsing #{step_key.inspect}: #{e.basic_message}", "bolt/invalid-plan")
         end
 
-        def step_err_msg(message)
-          if @name
-            "Parse error in step number #{@step_number} with name #{@name.inspect}: \n #{message}"
-          else
-            "Parse error in step number #{@step_number}: \n #{message}"
-          end
+        def self.step_error(message, name, step_number)
+          identifier = name ? name.inspect : "number #{step_number}"
+          error = "Parse error in step #{identifier}: \n #{message}"
+          Bolt::Error.new(error, 'bolt/invalid-plan')
         end
 
         # Parses the an evaluable string, optionally quote it before parsing
-        def parse_code_string(code, quote = false)
+        def self.parse_code_string(code, quote = false)
           if quote
             quoted = Puppet::Pops::Parser::EvaluatingParser.quote(code)
             Puppet::Pops::Parser::EvaluatingParser.new.parse_string(quoted)
@@ -201,7 +132,20 @@ module Bolt
             Puppet::Pops::Parser::EvaluatingParser.new.parse_string(code)
           end
         end
+
+        def function_call(function, args)
+          code_args = args.map { |arg| Bolt::Util.to_code(arg) }
+          "#{function}(#{code_args.join(', ')})"
+        end
       end
     end
   end
 end
+
+require 'bolt/pal/yaml_plan/step/command'
+require 'bolt/pal/yaml_plan/step/eval'
+require 'bolt/pal/yaml_plan/step/plan'
+require 'bolt/pal/yaml_plan/step/resources'
+require 'bolt/pal/yaml_plan/step/script'
+require 'bolt/pal/yaml_plan/step/task'
+require 'bolt/pal/yaml_plan/step/upload'

--- a/lib/bolt/pal/yaml_plan/step/command.rb
+++ b/lib/bolt/pal/yaml_plan/step/command.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Bolt
+  class PAL
+    class YamlPlan
+      class Step
+        class Command < Step
+          def self.allowed_keys
+            super + Set['command']
+          end
+
+          def self.required_keys
+            Set['target']
+          end
+
+          def initialize(step_body)
+            super
+            @command = step_body['command']
+          end
+
+          def transpile
+            code = String.new("  ")
+            code << "$#{@name} = " if @name
+
+            fn = 'run_command'
+            args = [@command, @target]
+            args << @description if @description
+
+            code << function_call(fn, args)
+
+            code << "\n"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bolt/pal/yaml_plan/step/eval.rb
+++ b/lib/bolt/pal/yaml_plan/step/eval.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Bolt
+  class PAL
+    class YamlPlan
+      class Step
+        class Eval < Step
+          def self.allowed_keys
+            super + Set['eval']
+          end
+
+          def self.required_keys
+            Set.new
+          end
+
+          def initialize(step_body)
+            super
+            @eval = step_body['eval']
+          end
+
+          def transpile
+            code = String.new("  ")
+            code << "$#{@name} = " if @name
+
+            code_body = Bolt::Util.to_code(@eval)
+
+            # If we're trying to assign the result of a multi-line eval to a name
+            # variable, we need to wrap it in `with()`.
+            if @name && code_body.lines.count > 1
+              indented = code_body.gsub(/\n/, "\n    ").chomp("  ")
+              code << "with() || {\n    #{indented}}"
+            else
+              code << code_body
+            end
+
+            code << "\n"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bolt/pal/yaml_plan/step/plan.rb
+++ b/lib/bolt/pal/yaml_plan/step/plan.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Bolt
+  class PAL
+    class YamlPlan
+      class Step
+        class Plan < Step
+          def self.allowed_keys
+            super + Set['plan', 'parameters']
+          end
+
+          def self.required_keys
+            Set.new
+          end
+
+          def initialize(step_body)
+            super
+            @plan = step_body['plan']
+            @parameters = step_body.fetch('parameters', {})
+          end
+
+          def transpile
+            code = String.new("  ")
+            code << "$#{@name} = " if @name
+
+            fn = 'run_plan'
+            args = [@plan]
+            args << @parameters unless @parameters.empty?
+
+            code << function_call(fn, args)
+
+            code << "\n"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bolt/pal/yaml_plan/step/resources.rb
+++ b/lib/bolt/pal/yaml_plan/step/resources.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Bolt
+  class PAL
+    class YamlPlan
+      class Step
+        class Resources < Step
+          def self.allowed_keys
+            super + Set['resources']
+          end
+
+          def self.required_keys
+            Set['target']
+          end
+
+          def initialize(step_body)
+            super
+            @resources = step_body['resources']
+            @normalized_resources = normalize_resources(@resources)
+          end
+
+          def self.validate(body, step_number)
+            super
+
+            body['resources'].each do |resource|
+              if resource['type'] || resource['title']
+                if !resource['type']
+                  err = "Resource declaration must include type key if title key is set"
+                  raise step_error(err, body['name'], step_number)
+                elsif !resource['title']
+                  err = "Resource declaration must include title key if type key is set"
+                  raise step_error(err, body['name'], step_number)
+                end
+              else
+                type_keys = (resource.keys - ['parameters'])
+                if type_keys.empty?
+                  err = "Resource declaration is missing a type"
+                  raise step_error(err, body['name'], step_number)
+                elsif type_keys.length > 1
+                  err = "Resource declaration has ambiguous type: could be #{type_keys.join(' or ')}"
+                  raise step_error(err, body['name'], step_number)
+                end
+              end
+            end
+          end
+
+          # What if this comes from a code block?
+          def normalize_resources(resources)
+            resources.map do |resource|
+              if resource['type'] && resource['title']
+                type = resource['type']
+                title = resource['title']
+              else
+                type, = (resource.keys - ['parameters'])
+                title = resource[type]
+              end
+
+              { 'type' => type, 'title' => title, 'parameters' => resource['parameters'] || {} }
+            end
+          end
+
+          def body
+            @body.merge('resources' => @normalized_resources)
+          end
+
+          def transpile
+            code = StringIO.new
+            code.print "  "
+            code.print "$#{@name} = " if @name
+
+            code.puts "apply(#{Bolt::Util.to_code(@target)}) {"
+
+            declarations = @normalized_resources.map do |resource|
+              type = resource['type'].is_a?(EvaluableString) ? resource['type'].value : resource['type']
+              title = Bolt::Util.to_code(resource['title'])
+              parameters = Bolt::Util.map_vals(resource['parameters']) do |val|
+                Bolt::Util.to_code(val)
+              end
+
+              resource_str = StringIO.new
+              if parameters.empty?
+                resource_str.puts "    #{type} { #{title}: }"
+              else
+                resource_str.puts "    #{type} { #{title}:"
+                parameters.each do |key, val|
+                  resource_str.puts "      #{key} => #{val},"
+                end
+                resource_str.puts "    }"
+              end
+              resource_str.string
+            end
+
+            code.puts declarations.join("    ->\n")
+
+            code.puts "  }\n"
+            code.string
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bolt/pal/yaml_plan/step/script.rb
+++ b/lib/bolt/pal/yaml_plan/step/script.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Bolt
+  class PAL
+    class YamlPlan
+      class Step
+        class Script < Step
+          def self.allowed_keys
+            super + Set['script', 'parameters', 'arguments']
+          end
+
+          def self.required_keys
+            Set['target']
+          end
+
+          def initialize(step_body)
+            super
+            @script = step_body['script']
+            @parameters = step_body.fetch('parameters', {})
+            @arguments = step_body.fetch('arguments', [])
+          end
+
+          def transpile
+            code = String.new("  ")
+            code << "$#{@name} = " if @name
+
+            options = @parameters.dup
+            options['arguments'] = @arguments unless @arguments.empty?
+
+            fn = 'run_script'
+            args = [@script, @target]
+            args << @description if @description
+            args << options unless options.empty?
+
+            code << function_call(fn, args)
+
+            code << "\n"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bolt/pal/yaml_plan/step/task.rb
+++ b/lib/bolt/pal/yaml_plan/step/task.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Bolt
+  class PAL
+    class YamlPlan
+      class Step
+        class Task < Step
+          def self.allowed_keys
+            super + Set['task', 'parameters']
+          end
+
+          def self.required_keys
+            Set['target']
+          end
+
+          def initialize(step_body)
+            super
+            @task = step_body['task']
+            @parameters = step_body.fetch('parameters', {})
+          end
+
+          def transpile
+            code = String.new("  ")
+            code << "$#{@name} = " if @name
+
+            fn = 'run_task'
+            args = [@task, @target]
+            args << @description if @description
+            args << @parameters unless @parameters.empty?
+
+            code << function_call(fn, args)
+
+            code << "\n"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bolt/pal/yaml_plan/step/upload.rb
+++ b/lib/bolt/pal/yaml_plan/step/upload.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Bolt
+  class PAL
+    class YamlPlan
+      class Step
+        class Upload < Step
+          def self.allowed_keys
+            super + Set['source', 'destination']
+          end
+
+          def self.required_keys
+            Set['target', 'source', 'destination']
+          end
+
+          def initialize(step_body)
+            super
+            @source = step_body['source']
+            @destination = step_body['destination']
+          end
+
+          def transpile
+            code = String.new("  ")
+            code << "$#{@name} = " if @name
+
+            fn = 'upload_file'
+            args = [@source, @destination, @target]
+            args << @description if @description
+
+            code << function_call(fn, args)
+
+            code << "\n"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bolt/pal/yaml_plan/transpiler.rb
+++ b/lib/bolt/pal/yaml_plan/transpiler.rb
@@ -37,8 +37,7 @@ module Bolt
           plan_string << ") {\n"
 
           plan_object.steps&.each do |step|
-            # This only needs the plan path for raising errors
-            plan_string << step.transpile(@plan_path)
+            plan_string << step.transpile
           end
 
           plan_string << "\n  return #{Bolt::Util.to_code(plan_object.return)}\n" if plan_object.return

--- a/pre-docs/writing_yaml_plans.md
+++ b/pre-docs/writing_yaml_plans.md
@@ -173,6 +173,39 @@ steps:
         - web3.example.com
 ```
 
+#### Resources step
+
+Use a `resources` step to apply a list of Puppet resources. A resource defines the _desired state_ for part of a target. Bolt will ensure each resource is in its desired state.
+
+Like the steps in a plan, if any resource in the list fails, the rest will be skipped.
+
+Resources steps use these fields:
+* `resources`: An array of resources to apply
+* `target`: A target or list of targets to apply the resources on
+
+Each resource is a YAML map with a type and title, and optionally a `parameters` key. The resource type and title can either be specified separately with the `type` and `title` keys, or can be specified in a single line by using the type name as a key with the title as its value.
+
+For example:
+
+```yaml
+steps:
+  - resources:
+    # This resource is type 'package' and title 'nginx'
+    - package: nginx
+      parameters:
+        ensure: latest
+    # This resource is type 'service' and title 'nginx'
+    - type: service
+      title: nginx
+      parameters:
+        ensure: running
+    target:
+      - web1.example.com
+      - web2.example.com
+      - web3.example.com
+    description: "Set up nginx on the webservers"
+```
+
 ### Parameters key
 
 Plans accept parameters with the `parameters` key. The value of `parameters` is a map, where each key is the name of a parameter and the value is a map describing the parameter.

--- a/spec/bolt/pal/yaml_plan_spec.rb
+++ b/spec/bolt/pal/yaml_plan_spec.rb
@@ -96,7 +96,7 @@ describe Bolt::PAL::YamlPlan do
 
         expect { plan }.to raise_error do |error|
           expect(error.kind).to eq('bolt/invalid-plan')
-          expect(error.message).to match(/Parse error in step number 1 with name \"foo\"/)
+          expect(error.message).to match(/Parse error in step \"foo\"/)
           expect(error.message).to match(/Duplicate step name or parameter detected: \"foo\"/)
         end
       end
@@ -123,7 +123,7 @@ describe Bolt::PAL::YamlPlan do
 
         expect { plan }.to raise_error do |error|
           expect(error.kind).to eq('bolt/invalid-plan')
-          expect(error.message).to match(/Parse error in step number 2 with name \"foo\"/)
+          expect(error.message).to match(/Parse error in step \"foo\"/)
           expect(error.message).to match(/Duplicate step name or parameter detected: \"foo\"/)
         end
       end
@@ -138,7 +138,7 @@ describe Bolt::PAL::YamlPlan do
 
         expect { plan }.to raise_error do |error|
           expect(error.kind).to eq('bolt/invalid-plan')
-          expect(error.message).to match(/Parse error in step number 1 with name \"foo-bar\"/)
+          expect(error.message).to match(/Parse error in step \"foo-bar\"/)
           expect(error.message).to match(/Invalid step name: \"foo-bar\"/)
         end
       end
@@ -154,7 +154,7 @@ describe Bolt::PAL::YamlPlan do
 
         expect { plan }.to raise_error do |error|
           expect(error.kind).to eq('bolt/invalid-plan')
-          expect(error.message).to match(/Parse error in step number 1 with name \"foo-bar\"/)
+          expect(error.message).to match(/Parse error in step \"foo-bar\"/)
           expect(error.message).to match(/Multiple action keys detected: \[\"task\", \"eval\"\]/)
         end
       end
@@ -186,7 +186,7 @@ describe Bolt::PAL::YamlPlan do
 
         expect { plan }.to raise_error do |error|
           expect(error.kind).to eq('bolt/invalid-plan')
-          expect(error.message).to match(/Parse error in step number 1 with name \"foo\"/)
+          expect(error.message).to match(/Parse error in step \"foo\"/)
           expect(error.message).to match(/The \"task\" step requires: \[\"target\"\] key\(s\)/)
         end
       end

--- a/spec/fixtures/modules/yaml/plans/conversion.yaml
+++ b/spec/fixtures/modules/yaml/plans/conversion.yaml
@@ -11,6 +11,14 @@ steps:
     target: $nodes
     parameters:
       message: $message
+  - eval: $nodes.apply_prep
+  - resources:
+    - package: nginx
+    - file: /etc/nginx/html/index.html
+      parameters:
+        content: "Hello world!"
+    - service: nginx
+    target: $nodes
   - name: eval_output
     eval: |
       # TODO: Can blocks handle comments?

--- a/spec/fixtures/modules/yaml/plans/empty_resources.yaml
+++ b/spec/fixtures/modules/yaml/plans/empty_resources.yaml
@@ -1,0 +1,13 @@
+parameters:
+  nodes:
+    type: TargetSpec
+
+steps:
+  - eval: $nodes.apply_prep
+  - name: apply_resources
+    target: $nodes
+    resources: []
+
+return: $apply_resources
+
+

--- a/spec/fixtures/modules/yaml/plans/resource_failure.yaml
+++ b/spec/fixtures/modules/yaml/plans/resource_failure.yaml
@@ -1,0 +1,18 @@
+parameters:
+  nodes:
+    type: TargetSpec
+
+steps:
+  - eval: $nodes.apply_prep
+  - name: apply_resources
+    target: $nodes
+    resources:
+      - notify: "hello world"
+      - file: "/tmp/foo/bar/baz"
+        parameters:
+          ensure: present
+      - notify: "goodbye"
+
+return: $apply_resources
+
+

--- a/spec/fixtures/modules/yaml/plans/resources.yaml
+++ b/spec/fixtures/modules/yaml/plans/resources.yaml
@@ -1,0 +1,14 @@
+parameters:
+  nodes:
+    type: TargetSpec
+
+steps:
+  - eval: $nodes.apply_prep
+  - name: apply_resources
+    target: $nodes
+    resources:
+      - notify: "hello world"
+      - notify: "goodbye"
+
+return: $apply_resources
+

--- a/spec/integration/transpiler_spec.rb
+++ b/spec/integration/transpiler_spec.rb
@@ -20,6 +20,16 @@ describe "transpiling YAML plans" do
     String $message = 'hello world'
   ) {
     $sample = run_task('sample', $nodes, {'message' => $message})
+    $nodes.apply_prep
+    apply($nodes) {
+      package { 'nginx': }
+      ->
+      file { '/etc/nginx/html/index.html':
+        content => "Hello world!",
+      }
+      ->
+      service { 'nginx': }
+    }
     $eval_output = with() || {
       # TODO: Can blocks handle comments?
       $list = $sample.targets.map |$t| {

--- a/spec/integration/yaml_plan_spec.rb
+++ b/spec/integration/yaml_plan_spec.rb
@@ -14,10 +14,13 @@ describe "running YAML plans", ssh: true do
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
   let(:modulepath) { fixture_path('modules') }
+  let(:password) { conn_info('ssh')[:password] }
   let(:config_flags) {
     ['--format', 'json',
      '--configfile', fixture_path('configs', 'empty.yml'),
      '--modulepath', modulepath,
+     '--run-as', 'root',
+     '--sudo-password', password,
      '--no-host-key-check']
   }
   let(:target) { conn_uri('ssh', include_password: true) }
@@ -66,6 +69,47 @@ describe "running YAML plans", ssh: true do
     expect(result.first['node']).to eq(target)
     expect(result.first['status']).to eq('success')
     expect(result.first['result']).to eq('_output' => "hello world\n")
+  end
+
+  it 'applies resources' do
+    result = run_plan('yaml::resources', nodes: target)
+
+    expect(result.first['node']).to eq(target)
+    expect(result.first['status']).to eq('success')
+
+    resources = result.first['result']['report']['resource_statuses']
+
+    expect(resources['Notify[hello world]']['changed']).to eq(true)
+    expect(resources['Notify[goodbye]']['changed']).to eq(true)
+  end
+
+  it 'skips remaining resources if one resource fails' do
+    result = run_plan('yaml::resource_failure', nodes: target)
+
+    expect(result['kind']).to eq('bolt/apply-failure')
+    node_result = result.dig('details', 'result_set').first
+    expect(node_result['node']).to eq(target)
+    expect(node_result['status']).to eq('failure')
+
+    expect(node_result.dig('result', '_error', 'kind')).to eq('bolt/resource-failure')
+
+    resources = node_result['result']['report']['resource_statuses']
+
+    # The file resource will fail so the second notify is skipped
+    expect(resources['Notify[hello world]']['changed']).to eq(true)
+    expect(resources['File[/tmp/foo/bar/baz]']['failed']).to eq(true)
+    expect(resources['Notify[goodbye]']['changed']).to eq(false)
+    expect(resources['Notify[goodbye]']['skipped']).to eq(true)
+  end
+
+  it 'applies an empty catalog if no resources are specified' do
+    result = run_plan('yaml::empty_resources', nodes: target)
+
+    expect(result.first['node']).to eq(target)
+    expect(result.first['status']).to eq('success')
+
+    resources = result.first['result']['report']['resource_statuses']
+    expect(resources).to be_empty
   end
 
   it 'does not expose its own variables to a sub-plan' do

--- a/spec/integration/yaml_plan_spec.rb
+++ b/spec/integration/yaml_plan_spec.rb
@@ -128,7 +128,7 @@ describe "running YAML plans", ssh: true do
     result = run_plan('yaml::bad_puppet')
 
     expect(result['kind']).to eq("bolt/invalid-plan")
-    expect(result['msg']).to match(/Parse error in step number 1 with name \"x_fail\":/)
+    expect(result['msg']).to match(/Parse error in step \"x_fail\":/)
   end
 
   it 'passes information between steps' do


### PR DESCRIPTION
This step accepts a list of resources and applies them similarly to the
`apply()` statement in Puppet language plans. A resource has a type,
title and parameters. As a shorthand, the type can be set as a key whose
value is the title, so long as the type name doesn't conflict with
another allowed key (type, title or parameters).

The resources step is applied by generating Puppet manifest code for
each resource, wrapping it an `apply()` statement so it is valid in
tasks mode, then parsing it and passing it to the Applicator.