### PR TITLE
(BOLT-1197) Add $nodes run_plan() positional arg 2

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -6,6 +6,7 @@ require 'bolt/error'
 #
 # **NOTE:** Not available in apply block
 Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction) do
+  # Run a plan
   # @param plan_name The plan to run.
   # @param named_args Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.
   # @return [PlanResult] The result of running the plan. Undef if plan does not explicitly return results.
@@ -18,6 +19,13 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
     return_type 'Boltlib::PlanResult'
   end
 
+  # Run a plan, specifying $nodes as a positional argument.
+  # @param plan_name The plan to run.
+  # @param named_args Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.
+  # @param targets A pattern identifying zero or more targets. See {get_targets} for accepted patterns.
+  # @return [PlanResult] The result of running the plan. Undef if plan does not explicitly return results.
+  # @example Run a plan
+  #   run_plan('canary', $nodes, 'command' => 'false')
   dispatch :run_plan_with_targetspec do
     scope_param
     param 'String', :plan_name
@@ -29,8 +37,8 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
   def run_plan_with_targetspec(scope, plan_name, targets, named_args = {})
     unless named_args['nodes'].nil?
       raise ArgumentError,
-            "A plan's \"nodes\" parameter may be specified as the second positional argument to " \
-            "run_plan(), but in that case \"nodes\" must not be specified in the named arguments " \
+            "A plan's 'nodes' parameter may be specified as the second positional argument to " \
+            "run_plan(), but in that case 'nodes' must not be specified in the named arguments " \
             "hash."
     end
     run_plan(scope, plan_name, named_args.merge('nodes' => targets))

--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -18,6 +18,24 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
     return_type 'Boltlib::PlanResult'
   end
 
+  dispatch :run_plan_with_targetspec do
+    scope_param
+    param 'String', :plan_name
+    param 'Boltlib::TargetSpec', :targets
+    optional_param 'Hash', :named_args
+    return_type 'Boltlib::PlanResult'
+  end
+
+  def run_plan_with_targetspec(scope, plan_name, targets, named_args = {})
+    unless named_args['nodes'].nil?
+      raise ArgumentError,
+            "A plan's \"nodes\" parameter may be specified as the second positional argument to " \
+            "run_plan(), but in that case \"nodes\" must not be specified in the named arguments " \
+            "hash."
+    end
+    run_plan(scope, plan_name, named_args.merge('nodes' => targets))
+  end
+
   def run_plan(scope, plan_name, named_args = {})
     unless Puppet[:tasks]
       raise Puppet::ParseErrorWithIssue

--- a/bolt-modules/boltlib/spec/fixtures/modules/test/plans/run_me_nodes.pp
+++ b/bolt-modules/boltlib/spec/fixtures/modules/test/plans/run_me_nodes.pp
@@ -1,0 +1,6 @@
+plan test::run_me_nodes(
+  BoltLib::TargetSpec $nodes,
+  Optional[Integer]   $x = undef,
+) {
+  return $nodes
+}

--- a/bolt-modules/boltlib/spec/fixtures/modules/test/plans/run_me_nodes.pp
+++ b/bolt-modules/boltlib/spec/fixtures/modules/test/plans/run_me_nodes.pp
@@ -1,6 +1,5 @@
 plan test::run_me_nodes(
   BoltLib::TargetSpec $nodes,
-  Optional[Integer]   $x = undef,
 ) {
   return $nodes
 }

--- a/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
@@ -48,6 +48,10 @@ describe 'run_plan' do
 
         is_expected.to run.with_params('test::run_me', '_run_as' => 'bar').and_return('worked2')
       end
+
+      it 'run_plan(name, nodes, hash) where nodes is the "nodes" parameter to the plan' do
+        is_expected.to run.with_params('test::run_me_nodes', 'node1,node2').and_return('node1,node2')
+      end
     end
 
     it 'reports the function call to analytics' do
@@ -77,6 +81,11 @@ describe 'run_plan' do
       it 'failing with type mismatch error if given args does not match parameters' do
         is_expected.to run.with_params('test::run_me_int', 'x' => 'should not work')
                           .and_raise_error(/expects an Integer value/)
+      end
+
+      it 'fails with argument error if given nodes positional argument and nodes named argument' do
+        is_expected.to run.with_params('test::run_me_nodes', 'node1', 'nodes' => 'node2')
+                          .and_raise_error(ArgumentError)
       end
     end
 

--- a/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
@@ -83,9 +83,14 @@ describe 'run_plan' do
                           .and_raise_error(/expects an Integer value/)
       end
 
-      it 'fails with argument error if given nodes positional argument and nodes named argument' do
+      it 'failing with argument error if given nodes positional argument and nodes named argument' do
         is_expected.to run.with_params('test::run_me_nodes', 'node1', 'nodes' => 'node2')
                           .and_raise_error(ArgumentError)
+      end
+
+      it 'failing with parse error if given nodes positional argument for plan without nodes parameter' do
+        is_expected.to run.with_params('test::run_me', 'node1')
+                          .and_raise_error(Puppet::ParseError)
       end
     end
 

--- a/pre-docs/plan_functions.md
+++ b/pre-docs/plan_functions.md
@@ -492,7 +492,7 @@ Runs the `plan` referenced by its name. A plan is autoloaded from `<moduleroot>/
 **NOTE:** Not available in apply block
 
 
-### 
+### Run a plan
 
 ```
 run_plan(String $plan_name, Optional[Hash] $named_args)
@@ -508,18 +508,22 @@ run_plan(String $plan_name, Optional[Hash] $named_args)
 run_plan('canary', 'command' => 'false', 'nodes' => $targets, '_catch_errors' => true)
 ```
 
-### 
+### Run a plan, specifying $nodes as a positional argument.
 
 ```
 run_plan(String $plan_name, Boltlib::TargetSpec $targets, Optional[Hash] $named_args)
 ```
 
-*Returns:* `Boltlib::PlanResult` 
+*Returns:* `Boltlib::PlanResult` The result of running the plan. Undef if plan does not explicitly return results.
 
-* **plan_name** `String` 
-* **targets** `Boltlib::TargetSpec` 
-* **named_args** `Optional[Hash]` 
+* **plan_name** `String` The plan to run.
+* **named_args** `Optional[Hash]` Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.
+* **targets** `Boltlib::TargetSpec` A pattern identifying zero or more targets. See [`get_targets`](#get_targets) for accepted patterns.
 
+**Example:** Run a plan
+```
+run_plan('canary', $nodes, 'command' => 'false')
+```
 
 
 ## run_script

--- a/pre-docs/plan_functions.md
+++ b/pre-docs/plan_functions.md
@@ -492,6 +492,8 @@ Runs the `plan` referenced by its name. A plan is autoloaded from `<moduleroot>/
 **NOTE:** Not available in apply block
 
 
+### 
+
 ```
 run_plan(String $plan_name, Optional[Hash] $named_args)
 ```
@@ -505,6 +507,19 @@ run_plan(String $plan_name, Optional[Hash] $named_args)
 ```
 run_plan('canary', 'command' => 'false', 'nodes' => $targets, '_catch_errors' => true)
 ```
+
+### 
+
+```
+run_plan(String $plan_name, Boltlib::TargetSpec $targets, Optional[Hash] $named_args)
+```
+
+*Returns:* `Boltlib::PlanResult` 
+
+* **plan_name** `String` 
+* **targets** `Boltlib::TargetSpec` 
+* **named_args** `Optional[Hash]` 
+
 
 
 ## run_script


### PR DESCRIPTION
To provide consistency of special treatment for a plan parameter named
$nodes, allow the run_plan() function to be invoked with $nodes as the
second positional argument, so that it can be used the same way
run_task() is. E.g.

    run_task('util::hello', $targets,
      message => 'hello, beautiful world!',
    )

    run_plan('reboot', $targets,
      message => 'what a great day to reboot!',
    )

This matches the way run_task() works when a nodes/targets argument is
defined.

Previously, a plan needed to be invoked as follows, which resulted in
inconsistency in how to run "actions" against "targets", in tasks vs.
plans.

    # OLD WAY; NO LONGER NECESSARY (but still works)
    run_task('util::hello', $targets,
      message => 'hello, beautiful world!',
    )

    run_plan('reboot',
      nodes   => $targets,
      message => 'what a great day to reboot',
    )