### PR TITLE
(BOLT-1403) Separate bolt-server JSON schemas for targets

### DIFF
--- a/lib/bolt_server/schemas/ssh-run_task.json
+++ b/lib/bolt_server/schemas/ssh-run_task.json
@@ -4,71 +4,7 @@
   "description": "POST ssh/run_task request schema",
   "type": "object",
   "properties": {
-    "target": {
-      "type": "object",
-      "description": "Target information to run task on",
-      "properties": {
-        "hostname": {
-          "type": "string",
-          "description": "Target identifier"
-        },
-        "user": {
-          "type": "string",
-          "description": "Login user"
-        },
-        "password": {
-          "type": "string",
-          "description": "Password for SSH transport authentication"
-        },
-        "private-key-content": {
-          "type": "string",
-          "description": "Contents of private key for SSH"
-        },
-        "port": {
-          "type": "integer",
-          "description": "Connection port"
-        },
-        "connect-timeout": {
-          "type": "integer",
-          "description": "How long Bolt should wait when establishing connections"
-        },
-        "run-as-command": {
-          "type": "array",
-          "description": "Command elevate permissions",
-          "items": { "type": "string" }
-        },
-        "run-as": {
-          "type": "string",
-          "description": "A different user to run commands as after login"
-        },
-        "tmpdir": {
-          "type": "string",
-          "description": "The directory to upload and execute temporary files on the target"
-        },
-        "tty": {
-          "type": "boolean",
-          "description": "Should bolt use pseudo tty to meet sudoer restrictions"
-        },
-        "host-key-check": {
-          "type": "boolean",
-          "description": "Whether to perform host key validation when connecting over SSH"
-        },
-        "sudo-password": {
-          "type": "string",
-          "description": "Password to use when changing users via run-as"
-        },
-        "interpreters": {
-          "type": "object",
-          "description": "Map of file extensions to remote executable"
-        }
-      },
-      "oneOf": [
-        { "required": ["password"] },
-        { "required": ["private-key-content"] }
-      ],
-      "required": ["hostname", "user"],
-      "additionalProperties": false
-    },
+    "target": { "$ref": "file:target-ssh" },
     "task": { "$ref": "file:task"},
     "parameters": {
       "type": "object",

--- a/lib/bolt_server/schemas/target-ssh.json
+++ b/lib/bolt_server/schemas/target-ssh.json
@@ -1,0 +1,80 @@
+{
+  "id": "file:target-ssh",
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "Target information about where to run a bolt action over SSH",
+  "type": "object",
+  "properties": {
+    "hostname": {
+      "type": "string",
+      "description": "Target identifier"
+    },
+    "user": {
+      "type": "string",
+      "description": "Login user"
+    },
+    "password": {
+      "type": "string",
+      "description": "Password for SSH transport authentication"
+    },
+    "private-key-content": {
+      "type": "string",
+      "description": "Contents of private key for SSH"
+    },
+    "port": {
+      "type": "integer",
+      "description": "Connection port"
+    },
+    "connect-timeout": {
+      "type": "integer",
+      "description": "How long Bolt should wait when establishing connections"
+    },
+    "run-as-command": {
+      "type": "array",
+      "description": "Command elevate permissions",
+      "items": {
+        "type": "string"
+      }
+    },
+    "run-as": {
+      "type": "string",
+      "description": "A different user to run commands as after login"
+    },
+    "tmpdir": {
+      "type": "string",
+      "description": "The directory to upload and execute temporary files on the target"
+    },
+    "tty": {
+      "type": "boolean",
+      "description": "Should bolt use pseudo tty to meet sudoer restrictions"
+    },
+    "host-key-check": {
+      "type": "boolean",
+      "description": "Whether to perform host key validation when connecting over SSH"
+    },
+    "sudo-password": {
+      "type": "string",
+      "description": "Password to use when changing users via run-as"
+    },
+    "interpreters": {
+      "type": "object",
+      "description": "Map of file extensions to remote executable"
+    }
+  },
+  "oneOf": [
+    {
+      "required": [
+        "password"
+      ]
+    },
+    {
+      "required": [
+        "private-key-content"
+      ]
+    }
+  ],
+  "required": [
+    "hostname",
+    "user"
+  ],
+  "additionalProperties": false
+}

--- a/lib/bolt_server/schemas/target-winrm.json
+++ b/lib/bolt_server/schemas/target-winrm.json
@@ -1,0 +1,63 @@
+{
+  "id": "file:target-winrm",
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "Target information about where to run a bolt action over WinRM",
+  "type": "object",
+  "properties": {
+    "hostname": {
+      "type": "string",
+      "description": "Target identifier"
+    },
+    "user": {
+      "type": "string",
+      "description": "Login user"
+    },
+    "password": {
+      "type": "string",
+      "description": "Password for SSH transport authentication"
+    },
+    "port": {
+      "type": "integer",
+      "description": "Connection port"
+    },
+    "connect-timeout": {
+      "type": "integer",
+      "description": "How long Bolt should wait when establishing connections"
+    },
+    "tmpdir": {
+      "type": "string",
+      "description": "The directory to upload and execute temporary files on the target"
+    },
+    "ssl": {
+      "type": "boolean",
+      "description": "When true, Bolt will use https connections for WinRM"
+    },
+    "ssl-verify": {
+      "type": "boolean",
+      "description": "When true, verifies the targets certificate matches the cacert"
+    },
+    "cacert": {
+      "type": "string",
+      "description": "The path to the CA certificate"
+    },
+    "extensions": {
+      "type": "array",
+      "description": "List of file extensions that are accepted for scripts or tasks"
+    },
+    "interpreters": {
+      "type": "object",
+      "description": "Map of file extensions to remote executable"
+    },
+    "file-protocol": {
+      "type": "string",
+      "enum": ["winrm", "smb"],
+      "description": "Protocol for file transfer, WinRM or SMB"
+    },
+    "smb-port": {
+      "type": "integer",
+      "description": "Port for SMB protocol"
+    }
+  },
+  "required": ["hostname", "user", "password"],
+  "additionalProperties": false
+}

--- a/lib/bolt_server/schemas/winrm-run_task.json
+++ b/lib/bolt_server/schemas/winrm-run_task.json
@@ -4,69 +4,8 @@
   "description": "POST winrm/run_task request schema",
   "type": "object",
   "properties": {
-    "target": {
-      "type": "object",
-      "description": "Target information to run task on",
-      "properties": {
-        "hostname": {
-          "type": "string",
-          "description": "Target identifier"
-        },
-        "user": {
-          "type": "string",
-          "description": "Login user"
-        },
-        "password": {
-          "type": "string",
-          "description": "Password for SSH transport authentication"
-        },
-        "port": {
-          "type": "integer",
-          "description": "Connection port"
-        },
-        "connect-timeout": {
-          "type": "integer",
-          "description": "How long Bolt should wait when establishing connections"
-        },
-        "tmpdir": {
-          "type": "string",
-          "description": "The directory to upload and execute temporary files on the target"
-        },
-        "ssl": {
-          "type": "boolean",
-          "description": "When true, Bolt will use https connections for WinRM"
-        },
-        "ssl-verify": {
-          "type": "boolean",
-          "description": "When true, verifies the targets certificate matches the cacert"
-        },
-        "cacert": {
-          "type": "string",
-          "description": "The path to the CA certificate"
-        },
-        "extensions": {
-          "type": "array",
-          "description": "List of file extensions that are accepted for scripts or tasks"
-        },
-        "interpreters": {
-          "type": "object",
-          "description": "Map of file extensions to remote executable"
-        },
-        "file-protocol": {
-          "type": "string",
-          "enum": ["winrm", "smb"],
-          "description": "Protocol for file transfer, WinRM or SMB"
-        },
-        "smb-port": {
-          "type": "integer",
-          "description": "Port for SMB protocol"
-        }
-      },
-
-      "required": ["hostname", "user", "password"],
-      "additionalProperties": false
-    },
-    "task": { "$ref": "file:task"},
+    "target": { "$ref":  "file:target-winrm" },
+    "task": { "$ref": "file:task" },
     "parameters": {
       "type": "object",
       "description": "JSON formatted parameters to be provided to task"


### PR DESCRIPTION
Splits the SSH and WinRM target JSON schemas into their own dedicated
files, so that other bolt-server request schemas besides the existing
task schema can reuse them.

This is intended to support the future addition of new endpoints in bolt-server that allow for running commands and scripts and uploading files, in addition to running tasks. 