### PR TITLE
(BOLT-1302) Document installation for puppet-bolt on fedora 30

### DIFF
--- a/pre-docs/bolt_installing.md
+++ b/pre-docs/bolt_installing.md
@@ -185,21 +185,21 @@ The Puppet repository for the YUM package management system is [http://yum.puppe
     -   Enterprise Linux 6
 
         ```
-        sudo rpm -Uvh https://yum.puppet.com/puppet6/puppet6-release-el-6.noarch.rpm
+        sudo rpm -Uvh https://yum.puppet.com/puppet6-release-el-6.noarch.rpm
         sudo yum install puppet-bolt				
         ```
 
     -   Enterprise Linux 7
 
         ```
-        sudo rpm -Uvh https://yum.puppet.com/puppet6/puppet6-release-el-7.noarch.rpm
+        sudo rpm -Uvh https://yum.puppet.com/puppet6-release-el-7.noarch.rpm
         sudo yum install puppet-bolt
         ```
 
     -   Enterprise Linux 8
 
         ```
-        sudo rpm -Uvh https://yum.puppet.com/puppet6/puppet6-release-el-8.noarch.rpm
+        sudo rpm -Uvh https://yum.puppet.com/puppet6-release-el-8.noarch.rpm
         sudo yum install puppet-bolt
         ```
 
@@ -207,28 +207,28 @@ The Puppet repository for the YUM package management system is [http://yum.puppe
     -   SUSE Linux Enterprise Server 12
 
         ```
-        sudo rpm -Uvh https://yum.puppet.com/puppet6/puppet6-release-sles-12.noarch.rpm
+        sudo rpm -Uvh https://yum.puppet.com/puppet6-release-sles-12.noarch.rpm
         sudo zypper install puppet-bolt
         ```
 
     -   Fedora 28
 
         ```
-        sudo rpm -Uvh https://yum.puppet.com/puppet6/puppet6-release-fedora-28.noarch.rpm
+        sudo rpm -Uvh https://yum.puppet.com/puppet6-release-fedora-28.noarch.rpm
         sudo dnf install puppet-bolt
         ```
 
     -   Fedora 29
 
         ```
-        sudo rpm -Uvh https://yum.puppet.com/puppet6/puppet6-release-fedora-29.noarch.rpm
+        sudo rpm -Uvh https://yum.puppet.com/puppet6-release-fedora-29.noarch.rpm
         sudo dnf install puppet-bolt
         ```
 
     -   Fedora 30
 
         ```
-        sudo rpm -Uvh https://yum.puppet.com/puppet6/puppet6-release-fedora-30.noarch.rpm
+        sudo rpm -Uvh https://yum.puppet.com/puppet6-release-fedora-30.noarch.rpm
         sudo dnf install puppet-bolt
         ```
 

--- a/pre-docs/bolt_installing.md
+++ b/pre-docs/bolt_installing.md
@@ -225,6 +225,13 @@ The Puppet repository for the YUM package management system is [http://yum.puppe
         sudo dnf install puppet-bolt
         ```
 
+    -   Fedora 30
+
+        ```
+        sudo rpm -Uvh https://yum.puppet.com/puppet6/puppet6-release-fedora-30.noarch.rpm
+        sudo dnf install puppet-bolt
+        ```
+
 2.  Run a Bolt command and get started. 
 
     ```


### PR DESCRIPTION
This commit adds the installation instructions for installing bolt from the puppet 6 collection.