### PR TITLE
(maint) Unskip resolved device spec test

### DIFF
--- a/spec/integration/device_spec.rb
+++ b/spec/integration/device_spec.rb
@@ -68,7 +68,6 @@ describe "devices" do
       end
 
       it 'runs a plan that collects facts' do
-        pending "puppet-resource_api 1.8.3 has incorrect validation that causes these tests to fail"
         with_tempfile_containing('inventory', YAML.dump(device_inventory), '.yaml') do |inv|
           results = run_cli_json(%W[plan run device_test::facts --nodes device_targets
                                     --modulepath #{modulepath} --inventoryfile #{inv.path}])


### PR DESCRIPTION
This commit removes the rspec pending designation as a fix for this test appears to have been released with puppet 6.5