### PR TITLE
(BOLT-1302) Enable apply acceptance tests for fedora 30

### DIFF
--- a/acceptance/tests/apply_plan_ssh.rb
+++ b/acceptance/tests/apply_plan_ssh.rb
@@ -7,7 +7,7 @@ test_name "bolt plan run should apply manifest block on remote hosts via ssh" do
   extend Acceptance::BoltCommandHelper
 
   ssh_nodes = select_hosts(roles: ['ssh'])
-  skip_targets = select_hosts(platform: [/osx-10.11/, /fedora-30/])
+  skip_targets = select_hosts(platform: [/osx-10.11/])
   targets = "ssh_nodes"
   if skip_targets.any?
     ssh_nodes -= skip_targets

--- a/acceptance/tests/bolt_apply.rb
+++ b/acceptance/tests/bolt_apply.rb
@@ -11,7 +11,7 @@ test_name "bolt apply should apply manifest block on remote hosts via ssh and wi
   targets = ssh_nodes + winrm_nodes
 
   # Puppet 6 doesn't support OSX 10.11, so skip those hosts if present
-  targets -= select_hosts(platform: [/osx-10.11/, /fedora-30/])
+  targets -= select_hosts(platform: [/osx-10.11/])
 
   skip_test('no applicable nodes to test on') if targets.empty?
 


### PR DESCRIPTION
With the release of puppet agent 6.5.0 for fedora 30 the puppet_agent::install task should have an agent to download which will allow apply acceptance tests to work on fedora 30.