### PR TITLE
(BOLT-1399) Return original parameter hash when erroring

### DIFF
--- a/lib/bolt_spec/plans/action_stubs/script_stub.rb
+++ b/lib/bolt_spec/plans/action_stubs/script_stub.rb
@@ -31,7 +31,7 @@ module BoltSpec
       end
 
       def parameters
-        @invocation[:arguments] + @invocation[:options] if @invocation.include[:arguments]
+        @invocation[:params]
       end
 
       def result_for(target, stdout: '', stderr: '')
@@ -41,6 +41,7 @@ module BoltSpec
       # Public methods
 
       def with_params(params)
+        @invocation[:params] = params
         @invocation[:arguments] = params['arguments']
         @invocation[:options] = params.select { |k, _v| k.start_with?('_') }
         self

--- a/lib/bolt_spec/plans/action_stubs/task_stub.rb
+++ b/lib/bolt_spec/plans/action_stubs/task_stub.rb
@@ -30,7 +30,7 @@ module BoltSpec
       end
 
       def parameters
-        @invocation[:arguments] + @invocation[:options] if @invocation.include?(:arguments)
+        @invocation[:params]
       end
 
       # Allow any data.
@@ -43,6 +43,7 @@ module BoltSpec
       # Restricts the stub to only match invocations with certain parameters.
       # All parameters must match exactly.
       def with_params(params)
+        @invocation[:params] = params
         @invocation[:arguments] = params.reject { |k, _v| k.start_with?('_') }
         @invocation[:options] = params.select { |k, _v| k.start_with?('_') }
         self

--- a/spec/bolt_spec/plan_spec.rb
+++ b/spec/bolt_spec/plan_spec.rb
@@ -35,6 +35,12 @@ shared_examples 'action tests' do
   it 'fails when not stubbed' do
     expect { run_plan(plan_name, 'nodes' => targets) }.to raise_error(RuntimeError, /Unexpected call to/)
   end
+
+  it 'prints expected parameters when erroring' do
+    params = Regexp.escape(expect_action.parameters.to_s)
+    expect_action.not_be_called
+    expect { run_plan(plan_name, 'nodes' => targets) }.to raise_error(RuntimeError, /#{params}/)
+  end
 end
 
 describe "BoltSpec::Plans" do


### PR DESCRIPTION
This commit returns the original hash of expected parameters for printing when a script or task stubs raise an error. Previously, the original hash of parameters was split into separate 'arguments' and 'options' hashes which were then incorrectly reassembled into a single hash whenever the stubs errored.