### PR TITLE
(maint) Pin postgres docker image to 9.6.13

### DIFF
--- a/spec/docker-compose.yml
+++ b/spec/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - "20024:22"
 
   postgres:
-    image: postgres:9.6
+    image: postgres:9.6.13
     environment:
       - POSTGRES_PASSWORD=puppetdb
       - POSTGRES_USER=puppetdb


### PR DESCRIPTION
Changes in 9.6.14 introduce erros in the migration scripts for puppetdb which is blocking CI. Unpin once resolved.