### PR TITLE
(BOLT-1408) Add task plugin

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -136,7 +136,7 @@ module Bolt
 
       options
     rescue Bolt::Error => e
-      warn e.message
+      outputter.fatal_error(e)
       raise e
     end
 

--- a/lib/bolt/inventory/group2.rb
+++ b/lib/bolt/inventory/group2.rb
@@ -106,7 +106,11 @@ module Bolt
             end
             plugin.validate_inventory_config(value) if plugin.respond_to?(:validate_inventory_config)
             Concurrent::Delay.new do
-              plugin.inventory_config(value)
+              begin
+                plugin.inventory_config(value)
+              rescue StandardError => e
+                raise Bolt::Plugin::PluginError.new(e.message, plugin, "inventory_targets in #{@name}")
+              end
             end
           else
             value
@@ -203,7 +207,12 @@ module Bolt
           raise ValidationError.new("#{plugin.name} does not support inventory_targets.", @name)
         end
 
-        targets = plugin.inventory_targets(lookup)
+        begin
+          targets = plugin.inventory_targets(lookup)
+        rescue StandardError => e
+          raise Bolt::Plugin::PluginError.new(e.message, plugin, "inventory_targets in #{@name}")
+        end
+
         targets.each { |target| add_target(target) }
       end
 

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -240,10 +240,14 @@ module Bolt
       end
     end
 
-    def get_task_info(task_name)
-      task = in_bolt_compiler do |compiler|
+    def task_signature(task_name)
+      in_bolt_compiler do |compiler|
         compiler.task_signature(task_name)
       end
+    end
+
+    def get_task_info(task_name)
+      task = task_signature(task_name)
 
       if task.nil?
         raise Bolt::Error.new(Bolt::Error.unknown_task(task_name), 'bolt/unknown-task')

--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -4,15 +4,24 @@ require 'bolt/plugin/puppetdb'
 require 'bolt/plugin/terraform'
 require 'bolt/plugin/pkcs7'
 require 'bolt/plugin/prompt'
+require 'bolt/plugin/task'
 
 module Bolt
   class Plugin
+    class PluginError < Bolt::Error
+      def initialize(msg, plugin, hook)
+        mess = "Error executing plugin: #{plugin.name} from #{hook}: #{msg}"
+        super(mess, 'bolt/plugin-error')
+      end
+    end
+
     def self.setup(config, pdb_client)
       plugins = new(config)
       plugins.add_plugin(Bolt::Plugin::Puppetdb.new(pdb_client))
       plugins.add_plugin(Bolt::Plugin::Terraform.new)
       plugins.add_plugin(Bolt::Plugin::Prompt.new)
       plugins.add_plugin(Bolt::Plugin::Pkcs7.new(config.boltdir.path, config.plugins['pkcs7'] || {}))
+      plugins.add_plugin(Bolt::Plugin::Task.new(config))
       plugins
     end
 

--- a/lib/bolt/plugin/task.rb
+++ b/lib/bolt/plugin/task.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module Bolt
+  class Plugin
+    class Task
+      def hooks
+        %w[inventory_targets inventory_config]
+      end
+
+      def name
+        'task'
+      end
+
+      # This creates it's own PAL so we don't have to pass a promise around
+      #
+      def initialize(config)
+        @config = config
+      end
+
+      attr_reader :config
+
+      def pal
+        # Hiera config should not be used yet.
+        @pal ||= Bolt::PAL.new(config.modulepath, config.hiera_config)
+      end
+
+      def executor
+        # Analytics should be handled at a higher level so create a new executor.
+        @executor ||= Bolt::Executor.new
+      end
+
+      def inventory
+        @inventory ||= Bolt::Inventory.new({}, config)
+      end
+
+      def run_task(opts)
+        result = pal.run_task(opts['task'],
+                              'localhost',
+                              opts['parameters'] || {},
+                              executor,
+                              inventory).first
+
+        raise Bolt::Error.new(result.error_hash['msg'], result.error_hash['kind']) if result.error_hash
+        result
+      end
+
+      def validate_options(opts)
+        raise Bolt::ValidationError, "Task plugin requires that the 'task' is specified" unless opts['task']
+
+        task = pal.task_signature(opts['task'])
+
+        raise Bolt::ValidationError, "Could not find task #{opts['task']}" unless task
+
+        errors = []
+        unless task.runnable_with?(opts['parameters'] || {}) { |msg| errors << msg }
+          # This relies on runnable with printing a partial message before the first real error
+          raise Bolt::ValidationError, "Invalid parameters for #{errors.join("\n")}"
+        end
+      end
+      alias validate_inventory_config validate_options
+
+      def inventory_config(opts)
+        result = run_task(opts)
+
+        unless result.value.include?('config')
+          raise Bolt::ValidationError, "Task result did not return 'config': #{result.value}"
+        end
+
+        result['config']
+      end
+
+      def inventory_targets(opts)
+        raise Bolt::ValidationError, "Task plugin requires that the 'task' is specified" unless opts['task']
+
+        result = run_task(opts)
+
+        targets = result['targets']
+        unless targets.is_a?(Array)
+          raise Bolt::ValidationError, "Task result did not return a targets array: #{result.value}"
+        end
+
+        unless targets.all? { |t| t.is_a?(Hash) }
+          msg = "All targets returned by an inventory targets task must be hashes, got: #{targets}"
+          raise Bolt::ValidationError, msg
+        end
+
+        targets
+      end
+    end
+  end
+end

--- a/spec/fixtures/modules/identity/tasks/init.json
+++ b/spec/fixtures/modules/identity/tasks/init.json
@@ -1,0 +1,7 @@
+{
+  "input_method": "stdin",
+  "implementations": [
+    {"name": "win.ps1", "requirements": ["powershell"]},
+    {"name": "linux.sh", "requirements": ["shell"]}
+  ]
+}

--- a/spec/fixtures/modules/identity/tasks/linux.sh
+++ b/spec/fixtures/modules/identity/tasks/linux.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+cat

--- a/spec/fixtures/modules/identity/tasks/win.ps1
+++ b/spec/fixtures/modules/identity/tasks/win.ps1
@@ -1,0 +1,2 @@
+$line = [Console]::In.ReadLine()
+Write-Output "$line"

--- a/spec/integration/plugin/task_spec.rb
+++ b/spec/integration/plugin/task_spec.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/files'
+require 'bolt_spec/integration'
+
+describe 'using the task plugin' do
+  include BoltSpec::Files
+  include BoltSpec::Integration
+
+  def with_boltdir(config: nil, inventory: nil)
+    Dir.mktmpdir do |tmpdir|
+      File.write(File.join(tmpdir, 'bolt.yaml'), config.to_yaml) if config
+      File.write(File.join(tmpdir, 'inventory.yaml'), inventory.to_yaml) if inventory
+      yield tmpdir
+    end
+  end
+
+  let(:config) { { 'modulepath' => ['modules', File.join(__dir__, '../../fixtures/modules')] } }
+
+  let(:plan) do
+    <<~PLAN
+      plan passw() {
+        return(get_targets('node1')[0].password)
+      }
+    PLAN
+  end
+
+  context 'with a config lookup' do
+    let(:plugin) {
+      {
+        '_plugin' => 'task',
+        'task' => 'identity',
+        'parameters' => {
+          'config' => 'ssshhh'
+        }
+      }
+    }
+
+    let(:inventory) {
+      { 'version' => 2,
+        'targets' => [
+          { 'uri' => 'node1',
+            'config' => {
+              'ssh' => {
+                'user' => 'me',
+                'password' => plugin
+              }
+            } }
+        ] }
+    }
+
+    it 'supports a config lookup' do
+      with_boltdir(inventory: inventory, config: config) do |boltdir|
+        plan_dir = File.join(boltdir, 'modules', 'passw', 'plans')
+        FileUtils.mkdir_p(plan_dir)
+        File.write(File.join(plan_dir, 'init.pp'), plan)
+        output = run_cli(['plan', 'run', 'passw', '--boltdir', boltdir])
+
+        expect(output.strip).to eq('"ssshhh"')
+      end
+    end
+
+    context 'with bad parameters' do
+      let(:plugin) {
+        {
+          '_plugin' => 'task',
+          'task' => 'sample::params',
+          'parameters' => {
+            'config' => 'ssshhh'
+          }
+        }
+      }
+
+      it 'errors when the parameters dont match' do
+        with_boltdir(inventory: inventory, config: config) do |boltdir|
+          plan_dir = File.join(boltdir, 'modules', 'passw', 'plans')
+          FileUtils.mkdir_p(plan_dir)
+          File.write(File.join(plan_dir, 'init.pp'), plan)
+          result = run_cli_json(['plan', 'run', 'passw', '--boltdir', boltdir], rescue_exec: true)
+
+          expect(result).to include('kind' => "bolt/validation-error")
+          expect(result['msg']).to match(/Invalid parameters for Task sample::params:\n/)
+        end
+      end
+    end
+
+    context 'with a bad result' do
+      let(:plugin) {
+        {
+          '_plugin' => 'task',
+          'task' => 'identity',
+          'parameters' => {
+            'not_config' => 'ssshhh'
+          }
+        }
+      }
+
+      it 'errors when the result is unexpected' do
+        with_boltdir(inventory: inventory, config: config) do |boltdir|
+          plan_dir = File.join(boltdir, 'modules', 'passw', 'plans')
+          FileUtils.mkdir_p(plan_dir)
+          File.write(File.join(plan_dir, 'init.pp'), plan)
+          result = run_cli_json(['plan', 'run', 'passw', '--boltdir', boltdir], rescue_exec: true)
+
+          expect(result).to include('kind' => "bolt/plugin-error")
+          expect(result['msg']).to match(/Task result did not return 'config'/)
+        end
+      end
+    end
+  end
+
+  context 'with a target lookup' do
+    let(:plugin) {
+      {
+        '_plugin' => 'task',
+        'task' => 'identity',
+        'parameters' => {
+          'targets' => [
+            {
+              'uri' => 'node1',
+              'config' => {
+                'ssh' => {
+                  'user' => 'me',
+                  'password' => 'ssshhh'
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+
+    let(:inventory) {
+      { 'version' => 2,
+        'targets' => [plugin] }
+    }
+    it 'supports a target lookup' do
+      with_boltdir(inventory: inventory, config: config) do |boltdir|
+        plan_dir = File.join(boltdir, 'modules', 'passw', 'plans')
+        FileUtils.mkdir_p(plan_dir)
+        File.write(File.join(plan_dir, 'init.pp'), plan)
+        output = run_cli(['plan', 'run', 'passw', '--boltdir', boltdir])
+
+        expect(output.strip).to eq('"ssshhh"')
+      end
+    end
+
+    context 'with a bad lookup' do
+      let(:plugin) {
+        {
+          '_plugin' => 'task',
+          'task' => 'identity',
+          'parameters' => {
+            'not_targets' => []
+          }
+        }
+      }
+
+      it 'errors when the result is unexpected' do
+        with_boltdir(inventory: inventory, config: config) do |boltdir|
+          plan_dir = File.join(boltdir, 'modules', 'passw', 'plans')
+          FileUtils.mkdir_p(plan_dir)
+          File.write(File.join(plan_dir, 'init.pp'), plan)
+          result = run_cli_json(['plan', 'run', 'passw', '--boltdir', boltdir], rescue_exec: true)
+
+          expect(result).to include('kind' => "bolt/plugin-error")
+          expect(result['msg']).to match(/Task result did not return a targets array/)
+        end
+      end
+
+      it 'errors when targets are strings' do
+        inventory['targets'][0]['parameters']['targets'] = %w[foo bar]
+        with_boltdir(inventory: inventory, config: config) do |boltdir|
+          plan_dir = File.join(boltdir, 'modules', 'passw', 'plans')
+          FileUtils.mkdir_p(plan_dir)
+          File.write(File.join(plan_dir, 'init.pp'), plan)
+          result = run_cli_json(['plan', 'run', 'passw', '--boltdir', boltdir], rescue_exec: true)
+
+          expect(result).to include('kind' => "bolt/plugin-error")
+          expect(result['msg']).to match(/All targets returned/)
+        end
+      end
+
+      it 'errors when execution fails' do
+        inventory['targets'][0]['parameters']['bad-key'] = 10
+        with_boltdir(inventory: inventory, config: config) do |boltdir|
+          plan_dir = File.join(boltdir, 'modules', 'passw', 'plans')
+          FileUtils.mkdir_p(plan_dir)
+          File.write(File.join(plan_dir, 'init.pp'), plan)
+          result = run_cli_json(['plan', 'run', 'passw', '--boltdir', boltdir], rescue_exec: true)
+
+          expect(result).to include('kind' => "bolt/plugin-error")
+          expect(result['msg']).to match(/bad-key/)
+        end
+      end
+
+      it 'errors when the task fails' do
+        inventory['targets'][0]['task'] = 'error::fail'
+        with_boltdir(inventory: inventory, config: config) do |boltdir|
+          plan_dir = File.join(boltdir, 'modules', 'passw', 'plans')
+          FileUtils.mkdir_p(plan_dir)
+          File.write(File.join(plan_dir, 'init.pp'), plan)
+          result = run_cli_json(['plan', 'run', 'passw', '--boltdir', boltdir], rescue_exec: true)
+
+          expect(result).to include('kind' => "bolt/plugin-error")
+          expect(result['msg']).to match(/The task failed/)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/bolt_spec/integration.rb
+++ b/spec/lib/bolt_spec/integration.rb
@@ -20,16 +20,16 @@ module BoltSpec
       allow(cli).to receive(:outputter).and_return(outputter)
       allow(Bolt::Logger).to receive(:configure)
 
-      opts = cli.parse
-
       if rescue_exec
         begin
+          opts = cli.parse
           cli.execute(opts)
         # rubocop:disable HandleExceptions
         rescue Bolt::Error
         end
         # rubocop:enable HandleExceptions
       else
+        opts = cli.parse
         cli.execute(opts)
       end
       output.string
@@ -41,7 +41,8 @@ module BoltSpec
       begin
         result = JSON.parse(output, quirks_mode: true)
       rescue JSON::ParserError
-        expect(output.string).to eq("Output should be JSON")
+        output = output.string unless output.is_a?(String)
+        expect(output).to eq("Output should be JSON")
       end
       result
     end


### PR DESCRIPTION
This adds a task plugin that will run an arbitray task on localhost and
use the result. This currenlty supports the inventory_config and
inventory_target hooks.

Since this plugin is only used to bootstrap inventory at this point it
creates a one off Inventory instance to use. This approach may have to
be reconsidered if the task plugin is extended to post-inventory hooks
in the future. For simplicity it creates it's own PAL and Executor
instances too.