### PR TITLE
(maint) Specify bolt_server spec helper default port as integer

### DIFF
--- a/spec/lib/bolt_spec/bolt_server.rb
+++ b/spec/lib/bolt_spec/bolt_server.rb
@@ -39,7 +39,7 @@ module BoltSpec
         elsif target.options['private-key']
           req['private-key-content'] = File.read(target.options['private-key'])
         end
-        req['port'] ||= '22'
+        req['port'] ||= 22
         req['user'] ||= 'root'
       when 'winrm'
         req['ssl'] = false


### PR DESCRIPTION
Previously the target2request method would set the port for an ssh target as the string '22'. The transport app schema requires this value to be an integer. This commit updates the method to set the default ssh port to the integer value.