### PR TITLE
(BOLT-1318) Warn when case-insensitive modulepath exists

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -366,7 +366,8 @@ Available options are:
         @options[:'compile-concurrency'] = concurrency
       end
       define('-m', '--modulepath MODULES',
-             "List of directories containing modules, separated by '#{File::PATH_SEPARATOR}'") do |modulepath|
+             "List of directories containing modules, separated by '#{File::PATH_SEPARATOR}'",
+             'Directories are case-sensitive') do |modulepath|
         # When specified from the CLI, modulepath entries are relative to pwd
         @options[:modulepath] = modulepath.split(File::PATH_SEPARATOR).map do |moduledir|
           File.expand_path(moduledir)

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -117,6 +117,9 @@ module Bolt
 
       Bolt::Logger.configure(config.log, config.color)
 
+      # Logger must be configured before checking path case, otherwise warnings will not display
+      @config.check_path_case('modulepath', @config.modulepath)
+
       # After validation, initialize inventory and targets. Errors here are better to catch early.
       # After this step
       # options[:target_args] will contain a string/array version of the targetting options this is passed to plans

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -286,5 +286,27 @@ module Bolt
         impl.validate(@transports[transport])
       end
     end
+
+    # Check if there is a case-insensitive match to the path
+    def check_path_case(type, paths)
+      return if paths.nil?
+      matches = matching_paths(paths)
+
+      if matches.any?
+        msg = "WARNING: Bolt is case sensitive when specifying a #{type}. Did you mean:\n"
+        matches.each { |path| msg += "         #{path}\n" }
+        @logger.warn msg
+      end
+    end
+
+    def matching_paths(paths)
+      [*paths].map { |p| Dir.glob([p, casefold(p)]) }.flatten.uniq.reject { |p| [*paths].include?(p) }
+    end
+
+    def casefold(path)
+      path.chars.map do |l|
+        l =~ /[A-Za-z]/ ? "[#{l.upcase}#{l.downcase}]" : l
+      end.join
+    end
   end
 end

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -96,6 +96,12 @@ describe Bolt::Config do
   end
 
   describe "validate" do
+    it "returns suggested paths when path case is incorrect" do
+      modules = File.expand_path('modules')
+      config = Bolt::Config.new(boltdir, 'modulepath' => modules.upcase)
+      expect(config.matching_paths(config.modulepath)).to include(modules)
+    end
+
     it "does not accept invalid log levels" do
       config = {
         'log' => {


### PR DESCRIPTION
This commit adds a warning that displays when a specified modulepath does not exist but a case-insensitive version does. The case-insensitive version of the modulepath is displayed with the warning. Previously, if the modulepath's case was incorrect then Bolt would not be able to locate the modules.

The reason for this change is that some Bolt users may be expecting case-insensitivity when specifying a modulepath, but not know that Bolt is case-sensitive.