### PR TITLE
(BOLT-1403) Make bolt-server specs less task-specific

### DIFF
--- a/spec/bolt_server/app_integration_spec.rb
+++ b/spec/bolt_server/app_integration_spec.rb
@@ -22,9 +22,9 @@ describe "BoltServer::TransportApp", puppetserver: true do
     let(:path) { '/ssh/run_task' }
 
     it 'runs an echo task with a password' do
-      body = build_request('sample::echo',
-                           conn_target('ssh', include_password: true),
-                           "message": "Hello!")
+      body = build_task_request('sample::echo',
+                                conn_target('ssh', include_password: true),
+                                "message": "Hello!")
 
       post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
       expect(last_response).to be_ok
@@ -38,9 +38,9 @@ describe "BoltServer::TransportApp", puppetserver: true do
       private_key = ENV['BOLT_SSH_KEY'] || Dir["spec/fixtures/keys/id_rsa"][0]
       private_key_content = File.read(private_key)
       target = conn_target('ssh', options: { 'private-key-content' => private_key_content })
-      body = build_request('sample::echo',
-                           target,
-                           "message": "Hello!")
+      body = build_task_request('sample::echo',
+                                target,
+                                "message": "Hello!")
 
       post path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json'
       expect(last_response).to be_ok
@@ -51,8 +51,8 @@ describe "BoltServer::TransportApp", puppetserver: true do
     end
 
     it 'runs a shareable task' do
-      body = build_request('shareable',
-                           conn_target('ssh', include_password: true))
+      body = build_task_request('shareable',
+                                conn_target('ssh', include_password: true))
 
       post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
       expect(last_response).to be_ok

--- a/spec/bolt_server/transport_app_spec.rb
+++ b/spec/bolt_server/transport_app_spec.rb
@@ -38,288 +38,259 @@ describe "BoltServer::TransportApp" do
     expect(last_response.status).to eq(200)
   end
 
-  context 'with ssh target', ssh: true do
-    let(:target) { conn_info('ssh') }
-    let(:path) { '/ssh/run_task' }
-    let(:echo_task) {
-      {
-        'name': 'sample::echo',
-        'metadata': {
-          'description': 'Echo a message',
-          'parameters': { 'message': 'Default message' }
-        },
-        files: [{
-          filename: "echo.sh",
-          sha256: "foo",
-          uri: { path: 'foo', params: { environment: 'foo' } }
-        }]
-      }
-    }
-
-    it 'errors if both password and private-key-content are present' do
-      body = {
-        'task': echo_task,
-        'target': {
-          'password': 'foo',
-          'private-key-content': 'content'
-        },
-        'parameters': { "message": "Hello!" }
-      }
-
-      post path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json'
-      expect(last_response).not_to be_ok
-      expect(last_response.status).to eq(400)
-      result = JSON.parse(last_response.body)
-      regex = %r{The property '#/target' of type object matched more than one of the required schemas}
-      expect(result['details'].join).to match(regex)
-    end
-
-    it 'fails if no authorization is present' do
-      body = {
-        'task': echo_task,
-        'target': {
-          'hostname': target[:host],
-          'user': target[:user],
-          'port': target[:port],
-          'host-key-check': false
-        },
-        'parameters': { "message": "Hello!" }
-      }
-
-      post path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json'
-      expect(last_response).not_to be_ok
-      expect(last_response.status).to eq(400)
-      result = last_response.body
-      expect(result).to match(%r{The property '#/target' of type object did not match any of the required schemas})
-    end
-
-    it 'runs an echo task' do
-      body = {
-        'task': echo_task,
-        'target': {
-          'hostname': target[:host],
-          'user': target[:user],
-          'password': target[:password],
-          'port': target[:port],
-          'host-key-check': false
-        },
-        'parameters': { "message": "Hello!" }
-      }
-      post path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json'
-      expect(last_response).to be_ok
-      expect(last_response.status).to eq(200)
-      result = JSON.parse(last_response.body)
-      expect(result).to include('status' => 'success')
-      expect(result['result']['_output']).to match(/got passed the message: Hello!/)
-    end
-
-    it 'runs an echo task using a private key' do
-      private_key = ENV['BOLT_SSH_KEY'] || Dir["spec/fixtures/keys/id_rsa"][0]
-      private_key_content = File.read(private_key)
-      body = {
-        'task': echo_task,
-        'target': {
-          'hostname': target[:host],
-          'user': target[:user],
-          'private-key-content': private_key_content,
-          'port': target[:port],
-          'host-key-check': false
-        },
-        'parameters': { "message": "Hello!" }
-      }
-      post path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json'
-      expect(last_response).to be_ok
-      expect(last_response.status).to eq(200)
-      result = JSON.parse(last_response.body)
-      expect(result).to include('status' => 'success')
-      expect(result['result']['_output']).to match(/got passed the message: Hello!/)
-    end
-
-    context 'with Bolt::Error that contains a stack trace' do
-      let(:error_result) do
-        ex = RuntimeError.new("oops")
-        ex.set_backtrace('/path/to/bolt/code.rb:42')
-        Bolt::Result.from_exception(conn_target('ssh'), ex)
-      end
-
-      it 'scrubs stack trace from result' do
-        allow_any_instance_of(Bolt::Executor).to receive(:batch_execute).and_return(Bolt::ResultSet.new([error_result]))
-        body = {
-          'task': echo_task,
-          'target': {
-            'hostname': target[:host],
-            'user': target[:user],
-            'password': target[:password],
-            'port': target[:port],
-            'host-key-check': false
-          },
-          'parameters': { "message": "Hello!" }
-        }
-
-        post path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json'
-        expect(last_response).to be_ok
-        expect(last_response.status).to eq(200)
-        result = JSON.parse(last_response.body)
-        expect(result).to include('status' => 'failure')
-        expect(result['result']['_error']).to include('msg' => 'oops', 'details' => { 'class' => 'RuntimeError' })
-        expect(result['result']['_error']).not_to include('stack_trace')
-      end
-    end
-  end
-
-  context 'with winrm target', winrm: true do
-    let(:target) { conn_info('winrm') }
-    let(:path) { '/winrm/run_task' }
-    let(:echo_task) {
-      {
-        name: 'sample::wininput',
-        metadata: {
-          description: 'Echo a message',
-          input_method: 'stdin'
-        },
-        files: [{
-          filename: "wininput.ps1",
-          sha256: "foo",
-          uri: { path: 'foo', params: { environment: 'foo' } }
-        }]
-
-      }
-    }
-
-    it 'fails if no authorization is present' do
-      body = {
-        'task': echo_task,
-        'target': {
-          'hostname': target[:host],
-          'user': target[:user],
-          'port': target[:port]
-        }
-      }
-
-      post path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json'
-      expect(last_response).not_to be_ok
-      expect(last_response.status).to eq(400)
-      result = last_response.body
-      expect(result).to match(%r{The property '#/target' did not contain a required property of 'password'})
-    end
-
-    it 'fails if either port or connect-timeout is a string' do
-      body = {
-        'task': echo_task,
-        'target': {
-          'hostname': target[:host],
-          'user': target[:user],
-          'password': target[:password],
-          'port': "port",
-          'connect-timeout': "timeout"
-        },
-        'parameters': { "input": "Hello!" }
-      }
-
-      post path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json'
-      expect(last_response).not_to be_ok
-      expect(last_response.status).to eq(400)
-      result = last_response.body
-
-      expect(result).to match(%r{The property '#/target/port' of type string did not match the following type: integer})
-      expect(result)
-        .to match(%r{The property '#/target/connect-timeout' of type string did not match the following type: integer})
-    end
-
-    it 'runs an echo task' do
-      body = {
-        'task': echo_task,
-        'target': {
-          'hostname': target[:host],
-          'user': target[:user],
-          'password': target[:password],
-          'port': target[:port]
-        },
-        'parameters': { "input": "Hello!" }
-      }
-      post path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json'
-      expect(last_response).to be_ok
-      expect(last_response.status).to eq(200)
-      result = JSON.parse(last_response.body)
-      expect(result).to include('status' => 'success')
-      expect(result['result']['_output']).to match(/INPUT.*Hello!/)
-    end
-
-    context 'with Bolt::Error that contains a stack trace' do
-      let(:error_result) do
-        ex = RuntimeError.new("oops")
-        ex.set_backtrace('/path/to/bolt/code.rb:42')
-        Bolt::Result.from_exception(conn_target('winrm'), ex)
-      end
-
-      it 'scrubs stack trace from result' do
-        allow_any_instance_of(Bolt::Executor).to receive(:batch_execute).and_return(Bolt::ResultSet.new([error_result]))
-        body = {
-          'task': echo_task,
-          'target': {
-            'hostname': target[:host],
-            'user': target[:user],
-            'password': target[:password],
-            'port': target[:port]
-          },
-          'parameters': { "input": "Hello!" }
-        }
-
-        post path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json'
-        expect(last_response).to be_ok
-        expect(last_response.status).to eq(200)
-        result = JSON.parse(last_response.body)
-        expect(result).to include('status' => 'failure')
-        expect(result['result']['_error']).to include('msg' => 'oops', 'details' => { 'class' => 'RuntimeError' })
-        expect(result['result']['_error']).not_to include('stack_trace')
-      end
-    end
-  end
-
   context 'when raising errors' do
-    let(:target) { conn_info('ssh') }
-    let(:echo_task) {
-      {
-        'name': 'echo',
-        'metadata': {
-          'description': 'Echo a message',
-          'parameters': { 'message': 'Default message' }
-        },
-        'file': {
-          'file_content': Base64.encode64("#!/usr/bin/env bash\necho $PT_message"),
-          'filename': "echo.sh"
-        }
-      }
-    }
-
     it 'returns non-html 404 when the endpoint is not found' do
-      body = {
-        'task': echo_task,
-        'target': {
-          'hostname': target[:host],
-          'user': target[:user],
-          'password': target[:password],
-          'port': target[:port],
-          'host-key-check': false
-        },
-        'parameters': { "message": "Hello!" }
-      }
-
-      post '/ssh/run_tasksss', JSON.generate(body), 'CONTENT_TYPE' => 'text/json'
+      post '/ssh/run_tasksss', JSON.generate({}), 'CONTENT_TYPE' => 'text/json'
       expect(last_response).not_to be_ok
       expect(last_response.status).to eq(404)
-      r = JSON.parse(last_response.body)
-      expect(r['msg']).to eq("Could not find route /ssh/run_tasksss")
-      expect(r['kind']).to eq("boltserver/not-found")
+      result = JSON.parse(last_response.body)
+      expect(result['msg']).to eq("Could not find route /ssh/run_tasksss")
+      expect(result['kind']).to eq("boltserver/not-found")
     end
 
     it 'returns non-html 500 when the request times out' do
       get '/500_error'
       expect(last_response).not_to be_ok
       expect(last_response.status).to eq(500)
-      r = JSON.parse(last_response.body)
-      expect(r['msg']).to eq('500: Unknown error: Unexpected error')
-      expect(r['kind']).to eq('boltserver/server-error')
+      result = JSON.parse(last_response.body)
+      expect(result['msg']).to eq('500: Unknown error: Unexpected error')
+      expect(result['kind']).to eq('boltserver/server-error')
+    end
+  end
+
+  describe 'transport routes' do
+    let(:action) { 'run_task' }
+    let(:result) { double(Bolt::Result, status_hash: { status: 'test_status' }) }
+
+    before(:each) do
+      allow_any_instance_of(BoltServer::TransportApp)
+        .to receive(action.to_sym).and_return(
+          Bolt::ResultSet.new([result])
+        )
+    end
+
+    describe '/ssh/*' do
+      let(:path) { "/ssh/#{action}" }
+      let(:target) { conn_info('ssh') }
+
+      it 'returns a non-html 404 if the action does not exist' do
+        post('/ssh/not_an_action', JSON.generate({}), 'CONTENT_TYPE' => 'text/json')
+
+        expect(last_response).not_to be_ok
+        expect(last_response.status).to eq(404)
+
+        result = JSON.parse(last_response.body)
+        expect(result['kind']).to eq('boltserver/not-found')
+      end
+
+      it 'errors if both password and private-key-content are present' do
+        body = { target: {
+          password: 'password',
+          'private-key-content': 'private-key-content'
+        } }
+
+        post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
+
+        expect(last_response).not_to be_ok
+        expect(last_response.status).to eq(400)
+
+        result = JSON.parse(last_response.body)
+        regex = %r{The property '#/target' of type object matched more than one of the required schemas}
+        expect(result['details'].join).to match(regex)
+      end
+
+      it 'fails if no authorization is present' do
+        body = { target: {
+          hostname: target[:host],
+          user: target[:user],
+          port: target[:port],
+          'host-key-check': false
+        } }
+
+        post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
+
+        expect(last_response).not_to be_ok
+        expect(last_response.status).to eq(400)
+
+        result = last_response.body
+        expect(result).to match(%r{The property '#/target' of type object did not match any of the required schemas})
+      end
+
+      it 'performs the action when using a password and scrubs any stack traces' do
+        body = { 'target': {
+          'hostname': target[:host],
+          'user': target[:user],
+          'password': target[:password],
+          'port': target[:port],
+          'host-key-check': false
+        } }
+
+        expect_any_instance_of(BoltServer::TransportApp)
+          .to receive(:scrub_stack_trace).with(result.status_hash).and_return({})
+
+        post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
+
+        expect(last_response).to be_ok
+        expect(last_response.status).to eq(200)
+      end
+
+      it 'performs an action when using a private key and scrubs any stack traces' do
+        private_key = ENV['BOLT_SSH_KEY'] || Dir["spec/fixtures/keys/id_rsa"][0]
+        private_key_content = File.read(private_key)
+
+        body = { 'target': {
+          'hostname': target[:host],
+          'user': target[:user],
+          'private-key-content': private_key_content,
+          'port': target[:port],
+          'host-key-check': false
+        } }
+
+        expect_any_instance_of(BoltServer::TransportApp)
+          .to receive(:scrub_stack_trace).with(result.status_hash).and_return({})
+
+        post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
+
+        expect(last_response).to be_ok
+        expect(last_response.status).to eq(200)
+      end
+    end
+
+    describe '/winrm/*' do
+      let(:path) { "/winrm/#{action}" }
+      let(:target) { conn_info('winrm') }
+
+      it 'returns a non-html 404 if the action does not exist' do
+        post('/winrm/not_an_action', JSON.generate({}), 'CONTENT_TYPE' => 'text/json')
+
+        expect(last_response).not_to be_ok
+        expect(last_response.status).to eq(404)
+
+        result = JSON.parse(last_response.body)
+        expect(result['kind']).to eq('boltserver/not-found')
+      end
+
+      it 'fails if no authorization is present' do
+        body = { target: {
+          hostname: target[:host],
+          user: target[:user],
+          port: target[:port]
+        } }
+
+        post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
+
+        expect(last_response).not_to be_ok
+        expect(last_response.status).to eq(400)
+
+        result = last_response.body
+        expect(result).to match(%r{The property '#/target' did not contain a required property of 'password'})
+      end
+
+      it 'fails if either port or connect-timeout is a string' do
+        body = { target: {
+          hostname: target[:host],
+          uaser: target[:user],
+          password: target[:password],
+          port: 'port',
+          'connect-timeout': 'timeout'
+        } }
+
+        post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
+
+        expect(last_response).not_to be_ok
+        expect(last_response.status).to eq(400)
+
+        result = last_response.body
+        [
+          %r{The property '#/target/port' of type string did not match the following type: integer},
+          %r{The property '#/target/connect-timeout' of type string did not match the following type: integer}
+        ].each do |re|
+          expect(result).to match(re)
+        end
+      end
+
+      it 'performs the action and scrubs any stack traces from the result' do
+        body = { target: {
+          hostname: target[:host],
+          user: target[:user],
+          password: target[:password],
+          port: target[:port]
+        } }
+
+        expect_any_instance_of(BoltServer::TransportApp)
+          .to receive(:scrub_stack_trace).with(result.status_hash).and_return({})
+
+        post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
+
+        expect(last_response).to be_ok
+        expect(last_response.status).to eq(200)
+      end
+    end
+  end
+
+  describe 'action endpoint' do
+    # Helper to set the transport on a body hash, and then post
+    # to an action endpoint (/ssh/<action> or /winrm/<action>)
+    def post_over_transport(transport, action, body_defaults = {})
+      path = "/#{transport}/#{action}"
+
+      target = conn_info(transport)
+      body = body_defaults.merge(target: {
+                                   hostname: target[:host],
+                                   user: target[:user],
+                                   password: target[:password],
+                                   port: target[:port]
+                                 })
+
+      post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
+    end
+
+    describe 'run_task' do
+      it 'runs a simple echo task over SSH', :ssh do
+        example_task = {
+          task: { name: 'sample::echo',
+                  metadata: {
+                    description: 'Echo a message',
+                    parameters: { message: 'Default message' }
+                  },
+                  files: [{ filename: "echo.sh", sha256: "foo",
+                            uri: { path: 'foo', params: { environment: 'foo' } } }] },
+          parameters: { message: "Hello!" }
+        }
+
+        post_over_transport('ssh', 'run_task', example_task)
+
+        expect(last_response).to be_ok
+        expect(last_response.status).to eq(200)
+
+        result = JSON.parse(last_response.body)
+        expect(result).to include('status' => 'success')
+        expect(result['result']['_output']).to match(/got passed the message: Hello!/)
+      end
+
+      it "runs a simple echo task over WinRM", :winrm do
+        example_task = {
+          task: {
+            name: 'sample::wininput',
+            metadata: {
+              description: 'Echo a message',
+              input_method: 'stdin'
+            },
+            files: [{ filename: 'wininput.ps1', sha256: 'foo',
+                      uri: { path: 'foo', params: { environment: 'foo' } } }]
+          },
+          parameters: { input: 'Hello!' }
+        }
+
+        post_over_transport('winrm', 'run_task', example_task)
+
+        expect(last_response).to be_ok
+        expect(last_response.status).to eq(200)
+
+        result = JSON.parse(last_response.body)
+        expect(result).to include('status' => 'success')
+        expect(result['result']['_output']).to match(/INPUT.*Hello!/)
+      end
     end
   end
 end

--- a/spec/lib/bolt_spec/bolt_server.rb
+++ b/spec/lib/bolt_spec/bolt_server.rb
@@ -80,7 +80,7 @@ module BoltSpec
       JSON.parse(resp.body)
     end
 
-    def build_request(task_name, target, params = {})
+    def build_task_request(task_name, target, params = {})
       {
         'task' => get_task_data(task_name),
         'target' => target2request(target),


### PR DESCRIPTION
Refactors transport_app_spec tests in a way that should allow for easier
additions of other actions (like run_command, upload_file, run_script)
to the bolt server API alongside run_task.

app_integration_spec tests remain the same, except for a renamed helper
method.