### PR TITLE
(maint) Pin yard gem due to introduction of bug in puppet-strings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "puma", '>= 3.12.0'
 gem "rack", '>= 2.0.5'
 gem "rails-auth", '>= 2.1.4'
 gem "sinatra", '>= 2.0.4'
+gem "yard", "0.9.19"
 
 group(:test) do
   gem "beaker-hostgenerator"


### PR DESCRIPTION
This commit pins the yard gem to avoid unwanted behavior in puppet-strings rake task to generate plan function docs. For example with 0.9.20 `out::message` becomes `:'out::message'`.