### PR TITLE
(BOLT-1398) Add inventory show command

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -28,6 +28,9 @@ module Bolt
       when 'file'
         { flags: ACTION_OPTS + %w[tmpdir],
           banner: FILE_HELP }
+      when 'inventory'
+        { flags: OPTIONS[:inventory] + OPTIONS[:global] + %w[format inventoryfile boltdir configfile],
+          banner: INVENTORY_HELP }
       when 'plan'
         case action
         when 'convert'
@@ -110,6 +113,7 @@ Available subcommands:
   bolt secret createkeys           Create new encryption keys
   bolt secret encrypt <plaintext>  Encrypt a value
   bolt secret decrypt <encrypted>  Decrypt a value
+  bolt inventory show              Show the list of targets an action would run on
 
 Run `bolt <subcommand> --help` to view specific examples.
 
@@ -263,8 +267,18 @@ Available options are:
         createkeys               Create new encryption keys
         encrypt                  Encrypt a value
         decrypt                  Decrypt a value
+
       Available options are:
     SECRET_HELP
+
+    INVENTORY_HELP = <<~INVENTORY_HELP
+      Usage: bolt inventory <action>
+
+      Available actions are:
+        show                     Show the list of targets an action would run on
+
+      Available options are:
+    INVENTORY_HELP
 
     def initialize(options)
       super()

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -35,6 +35,7 @@ module Bolt
                  'file' => %w[upload],
                  'puppetfile' => %w[install show-modules],
                  'secret' => %w[encrypt decrypt createkeys],
+                 'inventory' => %w[show],
                  'apply' => %w[] }.freeze
 
     attr_reader :config, :options
@@ -296,6 +297,8 @@ module Bolt
           else
             list_plans
           end
+        elsif options[:subcommand] == 'inventory'
+          list_targets
         end
         return 0
       elsif options[:action] == 'show-modules'
@@ -391,6 +394,11 @@ module Bolt
 
     def list_plans
       outputter.print_plans(pal.list_plans, pal.list_modulepath)
+    end
+
+    def list_targets
+      update_targets(options)
+      outputter.print_targets(options)
     end
 
     def run_plan(plan_name, plan_arguments, nodes, options)

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -311,6 +311,13 @@ module Bolt
         end
       end
 
+      def print_targets(options)
+        targets = options[:targets].map(&:name)
+        count = "#{targets.count} target#{'s' unless targets.count == 1}"
+        @stream.puts targets.join("\n")
+        @stream.puts colorize(:green, count)
+      end
+
       # @param [Bolt::ResultSet] apply_result A ResultSet object representing the result of a `bolt apply`
       def print_apply_result(apply_result, elapsed_time)
         print_summary(apply_result, elapsed_time)

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -87,6 +87,13 @@ module Bolt
                        "moduledir": moduledir }.to_json)
       end
 
+      def print_targets(options)
+        targets = options[:targets].map(&:name)
+        count = targets.count
+        @stream.puts({ "targets": targets,
+                       "count": count }.to_json)
+      end
+
       def fatal_error(err)
         @stream.puts "],\n" if @items_open
         @stream.puts '"_error": ' if @object_open

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -171,6 +171,15 @@ describe "Bolt::CLI" do
           }.to output(/Available actions are:.*install.*show-modules/m).to_stdout
         end
 
+        it 'accepts inventory' do
+          cli = Bolt::CLI.new(%w[help inventory])
+          expect {
+            expect {
+              cli.parse
+            }.to raise_error(Bolt::CLIExit)
+          }.to output(/Available actions are:.*show/m).to_stdout
+        end
+
         it 'excludes invalid subcommand flags' do
           cli = Bolt::CLI.new(%w[help puppetfile])
           expect {
@@ -2168,11 +2177,17 @@ describe "Bolt::CLI" do
   describe 'inventoryfile' do
     let(:inventorydir) { File.join(__dir__, '..', 'fixtures', 'configs') }
 
-    it 'raises an error if a inventory file is specified and invalid' do
+    it 'raises an error if an inventory file is specified and invalid' do
       cli = Bolt::CLI.new(%W[command run uptime --inventoryfile #{File.join(inventorydir, 'invalid.yml')} --nodes foo])
       expect {
         cli.parse
       }.to raise_error(Bolt::Error, /Could not parse/)
+    end
+
+    it 'lists targets the action would run on' do
+      cli = Bolt::CLI.new(%w[inventory show -t localhost])
+      expect_any_instance_of(Bolt::Outputter::Human).to receive(:print_targets)
+      cli.execute(cli.parse)
     end
 
     context 'with BOLT_INVENTORY set' do

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -54,6 +54,8 @@ describe 'running with an inventory file', reset_puppet_settings: true do
 
   let(:run_plan) { ['plan', 'run', 'inventory', "command=#{shell_cmd}", "host=#{target}"] + config_flags }
 
+  let(:show_inventory) { ['inventory', 'show', '--nodes', target] + config_flags }
+
   around(:each) do |example|
     with_tempfile_containing('inventory', inventory.to_json, '.yml') do |f|
       @inventoryfile = f.path
@@ -382,6 +384,12 @@ describe 'running with an inventory file', reset_puppet_settings: true do
           end
         end
       end
+    end
+  end
+
+  context 'when showing inventory' do
+    it 'lists targets an action would run on' do
+      expect(run_cli_json(show_inventory)['targets'][0]).to include(target)
     end
   end
 end


### PR DESCRIPTION
This adds support for an `inventory show` command that lists target names for targets which match the targetting option and are in the inventory.