### PR TITLE
(BOLT-1445, BOLT-1455) Update log level docs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - 'acceptance/vendor/**/*'
     - 'modules/**/*'
     - 'docs/**/*'
+    - 'site-modules/**/*'
 
 # Checks for if and unless statements that would fit on one line if written as a
 # modifier if/unless.

--- a/bolt-modules/out/lib/puppet/functions/out/message.rb
+++ b/bolt-modules/out/lib/puppet/functions/out/message.rb
@@ -2,7 +2,8 @@
 
 # Output a message for the user.
 #
-# This will print a message to stdout when using the human output format.
+# This will print a message to stdout when using the human output format,
+# and print to stderr when using the json output format
 #
 # **NOTE:** Not available in apply block
 Puppet::Functions.create_function(:'out::message') do

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -42,6 +42,10 @@ By default, Bolt tries to connect over the standard SSH port 22. If you need to 
 
 Make sure you've specified the `winrm` protocol for the target. You can either include it in the name of the target (`winrm://hostname.example.com`), pass `--transport winrm` on the CLI, or set the transport in your Bolt config or inventory. By default, Bolt will try to connect over SSH.
 
+## Puppet log functions are not logging to the console
+
+The default log level for the console is `warn`. When a `notice` function is used in a plan, it will not be printed to the console. When you have messages you want to be printed to the console regardless of log level you should use the `out::message` plan function. The [`out::message`](../pre-docs/plan_functions.md#outmessage) function is not available for use in an apply block and only accepts string values. If you need to send a message that is not a String value or is in an apply block you can use the `warning` Puppet log function. The `notice` Puppet log function could be used when you only wish to see the output in the console when executing your plan with the `--debug` flag which will set the console log level to `debug` for that run. See the docs for configuring the [Bolt's log level](https://puppet.com/docs/bolt/latest/bolt_configuration_options.html#log-file-configuration-options) for more information about how to configure the log levels.
+
 ## I still need help
 
 Visit the **#bolt** channel in the [Puppet Community Slack](https://slack.puppet.com) and you will find a whole community of people waiting to help!

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -44,7 +44,11 @@ Make sure you've specified the `winrm` protocol for the target. You can either i
 
 ## Puppet log functions are not logging to the console
 
-The default log level for the console is `warn`. When a `notice` function is used in a plan, it will not be printed to the console. When you have messages you want to be printed to the console regardless of log level you should use the `out::message` plan function. The [`out::message`](../pre-docs/plan_functions.md#outmessage) function is not available for use in an apply block and only accepts string values. If you need to send a message that is not a String value or is in an apply block you can use the `warning` Puppet log function. The `notice` Puppet log function could be used when you only wish to see the output in the console when executing your plan with the `--debug` flag which will set the console log level to `debug` for that run. See the docs for configuring the [Bolt's log level](https://puppet.com/docs/bolt/latest/bolt_configuration_options.html#log-file-configuration-options) for more information about how to configure the log levels.
+The default log level for the console is `warn`. When a `notice` function is used in a plan, it will not be printed to the console. When you have messages you want to be printed to the console regardless of log level you should use the `out::message` plan function. The [`out::message`](../pre-docs/plan_functions.md#outmessage) function is not available for use in an apply block and only accepts string values.
+
+If you need to send a message that is not a String value or is in an apply block you can use the `warning` Puppet log function. The `notice` Puppet log function could be used when you only wish to see the output in the console when executing your plan with the `--debug` flag which will set the console log level to `debug` for that run.
+
+See the docs for configuring the [Bolt's log level](https://puppet.com/docs/bolt/latest/bolt_configuration_options.html#log-file-configuration-options) for more information about how to configure the log levels.
 
 ## I still need help
 

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -421,7 +421,7 @@ module Bolt
       plan_context[:description] = options[:description] if options[:description]
 
       executor = Bolt::Executor.new(config.concurrency, @analytics, options[:noop])
-      executor.subscribe(outputter) if options.fetch(:format, 'human') == 'human'
+      executor.subscribe(outputter)
       executor.subscribe(log_outputter)
       executor.start_plan(plan_context)
       result = pal.run_plan(plan_name, plan_arguments, executor, inventory, puppetdb_client)

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -421,7 +421,12 @@ module Bolt
       plan_context[:description] = options[:description] if options[:description]
 
       executor = Bolt::Executor.new(config.concurrency, @analytics, options[:noop])
-      executor.subscribe(outputter)
+      if options.fetch(:format, 'human') == 'human'
+        executor.subscribe(outputter)
+      else
+        # Only subscribe to out::message events for JSON outputter
+        executor.subscribe(outputter, [:message])
+      end
       executor.subscribe(log_outputter)
       executor.start_plan(plan_context)
       result = pal.run_plan(plan_name, plan_arguments, executor, inventory, puppetdb_client)

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -21,6 +21,8 @@ module Bolt
         case event[:type]
         when :node_result
           print_result(event[:result])
+        when :message
+          print_message_event(event)
         end
       end
 
@@ -106,7 +108,13 @@ module Bolt
         @stream.puts '}' if @object_open
       end
 
-      def print_message(message); end
+      def print_message_event(event)
+        print_message(event[:message])
+      end
+
+      def print_message(message)
+        $stderr.puts(message)
+      end
     end
   end
 end

--- a/pre-docs/plan_functions.md
+++ b/pre-docs/plan_functions.md
@@ -380,7 +380,8 @@ get_targets('localhost')
 
 Output a message for the user.
 
-This will print a message to stdout when using the human output format.
+This will print a message to stdout when using the human output format,
+and print to stderr when using the json output format
 
 **NOTE:** Not available in apply block
 

--- a/pre-docs/writing_plans.md
+++ b/pre-docs/writing_plans.md
@@ -496,7 +496,7 @@ plan run_with_facts(TargetSpec $nodes) {
 
 ### Collect general data from PuppetDB
 
-You can use the `puppetdb_query` function in plans to make direct queries to PuppetDB. For example you can discover nodes from PuppetDB and then run tasks on them. You'll have to configure the [puppetdb client](bolt_connect_puppetdb.md)before running it. You can learn how to [structure pql queries here](https://puppet.com/docs/puppetdb/latest/api/query/tutorial-pql.html), and find [pql reference and examples here](https://puppet.com/docs/puppetdb/latest/api/query/v4/pql.html)
+You can use the `puppetdb_query` function in plans to make direct queries to PuppetDB. For example you can discover nodes from PuppetDB and then run tasks on them. You'll have to configure the [puppetdb client](bolt_connect_puppetdb.md) before running it. You can learn how to [structure pql queries here](https://puppet.com/docs/puppetdb/latest/api/query/tutorial-pql.html), and find [pql reference and examples here](https://puppet.com/docs/puppetdb/latest/api/query/v4/pql.html)
 
 ```
 plan pdb_discover {

--- a/spec/fixtures/modules/output/plans/init.pp
+++ b/spec/fixtures/modules/output/plans/init.pp
@@ -1,0 +1,3 @@
+plan output() {
+  out::message("Outputting a message")
+}

--- a/spec/integration/output_spec.rb
+++ b/spec/integration/output_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/integration'
+
+describe "when sending an out::message event" do
+  include BoltSpec::Integration
+
+  let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
+  let(:config_flags) { %W[--modulepath #{modulepath}] }
+
+  it "prints to stdout when format is human" do
+    output = run_cli(%w[plan run output] + config_flags, outputter: Bolt::Outputter::Human)
+    expect(output).to include("Outputting a message")
+  end
+
+  it "prints to stderr when format is json" do
+    expect {
+      run_cli(%w[plan run output --format json] + config_flags)
+    }.to output("Outputting a message\n").to_stderr
+  end
+end


### PR DESCRIPTION
This commit updates the log level documentation in the writing plan docs to include updated information about how to log messages from plan execution. It also adds a section to the common debugging page with some prescriptive recommendations for handling plan logging.