### PR TITLE
(BOLT-1423) Ensure ssh session is closed after disconnect-timeout

### DIFF
--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -37,7 +37,7 @@ module Bolt
     attr_writer :modulepath
 
     TRANSPORT_OPTIONS = %i[password run-as sudo-password extensions
-                           private-key tty tmpdir user connect-timeout
+                           private-key tty tmpdir user connect-timeout disconnect-timeout
                            cacert token-file service-url interpreters file-protocol smb-port realm].freeze
 
     PUPPETFILE_OPTIONS = %w[proxy forge].freeze

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -10,7 +10,7 @@ module Bolt
     class SSH < Sudoable
       def self.options
         %w[host port user password sudo-password private-key host-key-check
-           connect-timeout tmpdir run-as tty run-as-command proxyjump interpreters]
+           connect-timeout disconnect-timeout tmpdir run-as tty run-as-command proxyjump interpreters]
       end
 
       def self.default_options
@@ -18,7 +18,8 @@ module Bolt
           'connect-timeout' => 10,
           'host-key-check' => true,
           'tty' => false,
-          'load-config' => true
+          'load-config' => true,
+          'disconnect-timeout' => 5
         }
       end
 
@@ -42,10 +43,12 @@ module Bolt
           end
         end
 
-        timeout_value = options['connect-timeout']
-        unless timeout_value.is_a?(Integer) || timeout_value.nil?
-          error_msg = "connect-timeout value must be an Integer, received #{timeout_value}:#{timeout_value.class}"
-          raise Bolt::ValidationError, error_msg
+        %w[connect-timeout disconnect-timeout].each do |timeout|
+          timeout_value = options[timeout]
+          unless timeout_value.is_a?(Integer) || timeout_value.nil?
+            error_msg = "#{timeout} value must be an Integer, received #{timeout_value}:#{timeout_value.class}"
+            raise Bolt::ValidationError, error_msg
+          end
         end
       end
 

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -130,7 +130,11 @@ module Bolt
 
         def disconnect
           if @session && !@session.closed?
-            @session.close
+            begin
+              Timeout.timeout(@target.options['disconnect-timeout']) { @session.close }
+            rescue Timeout::Error
+              @session.shutdown!
+            end
             @logger.debug { "Closed session" }
           end
         end

--- a/lib/bolt_server/schemas/partials/target-ssh.json
+++ b/lib/bolt_server/schemas/partials/target-ssh.json
@@ -28,6 +28,10 @@
       "type": "integer",
       "description": "How long Bolt should wait when establishing connections"
     },
+    "disconnect-timeout": {
+      "type": "integer",
+      "description": "How long Bolt should wait before forcing a disconnect"
+    },
     "run-as-command": {
       "type": "array",
       "description": "Command elevate permissions",

--- a/pre-docs/bolt_configuration_options.md
+++ b/pre-docs/bolt_configuration_options.md
@@ -54,6 +54,8 @@ to avoid writing them to disk.
 
 `connect-timeout`: How long Bolt should wait when establishing connections.
 
+`disconnect-timeout`: How long Bolt should wait to force-close an ssh connection.
+
 `host-key-check`: Whether to perform host key validation when connecting over SSH. Default is `true`.
 
 `password`: Login password.

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -51,7 +51,13 @@ describe Bolt::Applicator do
         config: {
           transport: 'ssh',
           transports: {
-            ssh: { 'connect-timeout' => 10, 'host-key-check' => true, tty: false, 'load-config' => true },
+            ssh: {
+              'connect-timeout' => 10,
+              'host-key-check' => true,
+              'tty' => false,
+              'load-config' => true,
+              'disconnect-timeout' => 5
+            },
             winrm: { 'connect-timeout' => 10, ssl: true, 'ssl-verify' => true, 'file-protocol' => 'winrm' },
             pcp: {
               'task-environment' => 'production'

--- a/spec/bolt/inventory/inventory2_spec.rb
+++ b/spec/bolt/inventory/inventory2_spec.rb
@@ -165,6 +165,7 @@ describe Bolt::Inventory::Inventory2 do
     let(:ssh_target_option_defaults) {
       {
         'connect-timeout' => 10,
+        'disconnect-timeout' => 5,
         'tty' => false,
         'host-key-check' => true
       }
@@ -469,6 +470,19 @@ describe Bolt::Inventory::Inventory2 do
           end
         end
 
+        context 'disconnect-timeout' do
+          let(:data) {
+            {
+              'targets' => ['target'],
+              'config' => { 'ssh' => { 'disconnect-timeout' => '10' } }
+            }
+          }
+
+          it 'fails validation' do
+            expect { inventory.get_targets('target') }.to raise_error(Bolt::ValidationError)
+          end
+        end
+
         context 'ssl' do
           let(:data) {
             {
@@ -620,6 +634,7 @@ describe Bolt::Inventory::Inventory2 do
           expect(target.port).to eq('12345ssh')
           expect(target.options).to eq(
             'connect-timeout' => 3,
+            'disconnect-timeout' => 5,
             'tty' => true,
             'host-key-check' => false,
             'private-key' => "anything",

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -86,6 +86,7 @@ describe Bolt::Inventory do
   let(:ssh_target_option_defaults) {
     {
       'connect-timeout' => 10,
+      'disconnect-timeout' => 5,
       'tty' => false,
       'host-key-check' => true,
       'load-config' => true
@@ -401,6 +402,19 @@ describe Bolt::Inventory do
         end
       end
 
+      context 'disconnect-timeout' do
+        let(:data) {
+          {
+            'nodes' => ['node'],
+            'config' => { 'ssh' => { 'disconnect-timeout' => '10' } }
+          }
+        }
+
+        it 'fails validation' do
+          expect { inventory.get_targets('node') }.to raise_error(Bolt::ValidationError)
+        end
+      end
+
       context 'ssl' do
         let(:data) {
           {
@@ -552,6 +566,7 @@ describe Bolt::Inventory do
         expect(target.port).to eq('12345ssh')
         expect(target.options).to eq(
           'connect-timeout' => 3,
+          'disconnect-timeout' => 5,
           'tty' => true,
           'load-config' => true,
           'host-key-check' => false,

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -258,7 +258,7 @@ describe "passes parsed AST to the apply_catalog task" do
           expect(notify[1]['title']).to eq("Target 1 Facts: {operatingsystem => Ubuntu, added => fact}")
           expect(notify[2]['title']).to eq("Target 1 Vars: {environment => production, features => [puppet-agent]}")
           res = "Target 0 Config: {connect-timeout => 11, host-key-check => false, " \
-                "tty => false, load-config => true, password => bolt}"
+                "tty => false, load-config => true, disconnect-timeout => 5, password => bolt}"
           expect(notify[3]['title']).to eq(res)
           expect(notify[4]['title']).to eq("Target 1 Password: secret")
         end


### PR DESCRIPTION
In certain ssh configurations the socket.close method for net-ssh https://github.com/net-ssh/net-ssh/blob/dd13dd44d68b7fa82d4ca9a3bbe18e30c855f1d2/lib/net/ssh/transport/session.rb#L130 can hang. This commit implements the use of a fallback method defined in the net-ssh session class called `shutdown!` after a configurable timeout period to avoid hanging indefinitely when net-ssh cannot close a socket.