### PR TITLE
(maint) Explicitly reset message color with logging

### DIFF
--- a/lib/bolt/logger.rb
+++ b/lib/bolt/logger.rb
@@ -69,7 +69,7 @@ module Bolt
     def self.console_layout(color)
       color_scheme = :bolt if color
       Logging.layouts.pattern(
-        pattern: '%m\n',
+        pattern: '%m\e[0m\n',
         color_scheme: color_scheme
       )
     end


### PR DESCRIPTION
The logging library used by bolt allows setting a pattern to display messages. Bolt configures a newline to be appended to each message. For some terminals a newline will stop the reset character for colorization. The logging library appends the `clear` character to the log message *after* the newline has been appended. This commit updates the pattern to reset the terminal color before the newline. https://github.com/TwP/logging/blob/ef8b0f47e473b69dbccfea508fb5cf5d5f0ec2a6/lib/logging/color_scheme.rb#L193