### PR TITLE
(GH-1060)  Add support for Windows Containers

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -11,7 +11,7 @@ env:
   BOLT_WINRM_SSL_PORT: 5986
   BOLT_WINRM_SMB_PORT: 445
   RUBY_VERSION: 25-x64
-  
+
 jobs:
 
   agentful:
@@ -93,7 +93,9 @@ jobs:
         run: bundle exec r10k puppetfile install
       - name: Pre-test setup
         shell: powershell
-        run: '& scripts\ci.ps1'
+        run: |
+          . scripts\ci.ps1
+          . scripts\windows_containers.ps1
       - name: Run tests
         shell: powershell
         run: bundle exec rake windows_ci

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ RSpec::Core::RakeTask.new(:spec)
 
 desc "Run RSpec tests that don't require VM fixtures or a particular shell"
 RSpec::Core::RakeTask.new(:unit) do |t|
-  t.rspec_opts = '--tag ~ssh --tag ~docker --tag ~bash --tag ~winrm ' \
+  t.rspec_opts = '--tag ~ssh --tag ~docker --tag ~docker_wcow --tag ~bash --tag ~winrm ' \
                  '--tag ~windows_agents --tag ~puppetserver --tag ~puppetdb ' \
                  '--tag ~omi --tag ~kerberos'
 end
@@ -33,7 +33,7 @@ end
 
 desc "Run RSpec tests for CI that don't require WinRM"
 RSpec::Core::RakeTask.new(:fast) do |t|
-  t.rspec_opts = '--tag ~winrm --tag ~windows_agents --tag ~puppetserver --tag ~puppetdb ' \
+  t.rspec_opts = '--tag ~winrm --tag ~docker_wcow --tag ~windows_agents --tag ~puppetserver --tag ~puppetdb ' \
   '--tag ~omi --tag ~windows --tag ~kerberos --tag ~expensive'
 end
 

--- a/lib/bolt/transport/docker.rb
+++ b/lib/bolt/transport/docker.rb
@@ -3,6 +3,7 @@
 require 'json'
 require 'shellwords'
 require 'bolt/transport/base'
+require 'bolt/util/windows/shellwords'
 
 module Bolt
   module Transport
@@ -54,7 +55,15 @@ module Bolt
               conn.write_remote_file(source, tmpfile)
             end
 
-            _, stderr, exitcode = conn.execute('mv', tmpfile, destination, {})
+            if conn.windows_container?
+              command = [
+                'cmd.exe', '/c', 'move', '/y', Bolt::Util.windows_path(tmpfile), Bolt::Util.windows_path(destination)
+              ]
+            else
+              command = ['mv', tmpfile, destination]
+            end
+            _, stderr, exitcode = conn.execute(*command, {})
+
             if exitcode != 0
               message = "Could not move temporary file '#{tmpfile}' to #{destination}: #{stderr}"
               raise Bolt::Node::FileError.new(message, 'MV_ERROR')
@@ -73,7 +82,12 @@ module Bolt
           command = "#{target.options['shell-command']} \" #{command}\""
         end
         with_connection(target) do |conn|
-          stdout, stderr, exitcode = conn.execute(*Shellwords.split(command), options)
+          # Use the correct Shellwords splitter based on platform
+          if windows_container?(conn)
+            stdout, stderr, exitcode = conn.execute(*Bolt::Util::Windows::Shellwords.split(command), options)
+          else
+            stdout, stderr, exitcode = conn.execute(*Shellwords.split(command), options)
+          end
           Bolt::Result.for_command(target, stdout, stderr, exitcode, 'command', command)
         end
       end
@@ -85,7 +99,9 @@ module Bolt
         with_connection(target) do |conn|
           conn.with_remote_tempdir do |dir|
             remote_path = conn.write_remote_executable(dir, script)
-            stdout, stderr, exitcode = conn.execute(remote_path, *arguments, {})
+            execute_options = {}
+            execute_options[:interpreter] = select_interpreter(remote_path, target.options['interpreters'])
+            stdout, stderr, exitcode = conn.execute(remote_path, *arguments, execute_options)
             Bolt::Result.for_command(target, stdout, stderr, exitcode, 'script', script)
           end
         end
@@ -107,8 +123,8 @@ module Bolt
             if extra_files.empty?
               task_dir = dir
             else
-              # TODO: optimize upload of directories
-              arguments['_installdir'] = dir
+              # TODO: Optimize upload of directories as it tends to double up in the list
+              arguments['_installdir'] = windows_container?(conn) ? Bolt::Util.windows_path(dir) : dir
               task_dir = File.join(dir, task.tasks_dir)
               conn.mkdirs([task_dir] + extra_files.map { |file| File.join(dir, File.dirname(file['name'])) })
               extra_files.each do |file|
@@ -136,6 +152,15 @@ module Bolt
         with_connection(target) { true }
       rescue Bolt::Node::ConnectError
         false
+      end
+
+      private
+
+      # Returns whether the current connection is against a Windows container
+      # @param conn [Bolt::Transport::Docker::Connection] The connection object
+      # @return [Boolean] Whether the connection is a Windows container
+      def windows_container?(conn)
+        conn.respond_to?(:windows_container?) && conn.windows_container?
       end
     end
   end

--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -248,6 +248,13 @@ module Bolt
         !!File::ALT_SEPARATOR
       end
 
+      # Returns the Windows equivalent of the ruby path
+      def windows_path(path)
+        # Note we can not use the usual helpers (e.g. expand_path) as they depend on the local OS to help.
+        # So we need to construct the path ourselves
+        path.tr('/', '\\')
+      end
+
       # Accept hash and return hash with top level keys of type "String" converted to symbols.
       def symbolize_top_level_keys(hsh)
         hsh.each_with_object({}) { |(k, v), h| k.is_a?(String) ? h[k.to_sym] = v : h[k] = v }

--- a/lib/bolt/util/windows/shellwords.rb
+++ b/lib/bolt/util/windows/shellwords.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# Based on the Shellwords Windows fork by Lars Kanis - Licensed under MIT
+# https://github.com/larskanis/shellwords/blob/master/lib/shellwords/msvcrt.rb
+
+module Bolt
+  module Util
+    module Windows
+      module Shellwords
+        # Splits a string into an array of tokens in the same way the Microsoft
+        # C-runtime does.
+        #
+        #   argv = Shellwords.split('here are "two words"')
+        #   argv #=> ["here", "are", "two words"]
+        def self.split(line)
+          words = []
+          field = +''
+          field = +field
+          line.scan(/\G\s*(?>((?:[^\s\\\"]|\\+[^\s\\\"]|(?:\\\\)*\\")+)|((?:\\\\)*)"((?:[^\\\"]|\\+[^\\\"]|(?:\\\\)*\\")*)("|(?:\\\\)*)"|(\\+)(?:\s|\z)|(\S))(\s|\z)?/m) do |word, bsbq, dq, bsaq, trbs, garbage, sep| # rubocop:disable Metrics/LineLength
+            raise ArgumentError, "Unmatched double quote: #{line}" if garbage
+            bsbq, bsaq = [bsbq, bsaq].map { |a| a.to_s.gsub("\\\\", "\\") }
+            field << bsbq
+            field << (word || dq || '').gsub(/((?:\\\\)*)\\"/) { "\\" * (Regexp.last_match(1).length / 2) + '"' }
+            field << bsaq
+            field << trbs if trbs
+            if sep || trbs
+              words << field
+              field = +''
+            end
+          end
+          words
+        end
+
+        # Escapes a string so that it can be safely used in a Windows
+        # command line for most C applications.
+        # +str+ can be a non-string object that responds to +to_s+.
+        #
+        # Note that a resulted string should be used unquoted and is not
+        # intended for use in double quotes nor in single quotes.
+        #
+        #   argv = Shellwords.escape("It's better to give than to receive")
+        #   argv #=> "\"It's better to give than to receive\""
+        #
+        # Returns an empty quoted String if +str+ has a length of zero.
+        def self.escape(str)
+          str = str.to_s
+
+          # An empty argument will be skipped, so return empty quotes.
+          return '""' if str.empty?
+
+          str = str.dup
+
+          str.gsub!(/((?:\\)*)"/) { "\\" * (Regexp.last_match(1).length * 2) + "\\\"" }
+          if str =~ /\s/
+            str.gsub!(/(\\+)\z/) { "\\" * (Regexp.last_match(1).length * 2) }
+            str = "\"#{str}\""
+          end
+
+          str
+        end
+
+        def self.join(array)
+          array.map { |arg| escape(arg) }.join(' ')
+        end
+      end
+    end
+  end
+end

--- a/scripts/windows_containers.ps1
+++ b/scripts/windows_containers.ps1
@@ -1,0 +1,26 @@
+$InformationPreference = 'Continue'
+$ErrorActionPreference = 'Stop'
+
+$ReleaseID = (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion").ReleaseId
+if ($ReleaseID -eq "1607") {
+  # Default cached images on GitHub Actions Windows 2016 workers
+  # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/software-installed-on-github-hosted-runners#docker-images
+  $ENV:WINDOWS_TAG = "ltsc2016"
+} else {
+  # Default cached images on GitHub Actions Windows 2019 workers
+  # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/software-installed-on-github-hosted-runners#docker-images-1
+  $ENV:WINDOWS_TAG = "ltsc2019"
+}
+Write-Output "Will use windows image tag $($ENV:WINDOWS_TAG)"
+
+# Remove the current NAT network and pre-create the network for docker-compose
+Write-Output "Removing current NAT network..."
+Remove-NetNat -Confirm:$false
+
+# Create the new network
+Write-Output "Creating spec_default docker network..."
+& cmd /c --% docker network create spec_default --driver nat 2>&1
+
+# Create the needed containers for testing
+Write-Output "Creating windows container/s..."
+& cmd /c --% docker-compose --file spec/docker-compose-windows.yml --verbose --no-ansi up --detach --build 2>&1

--- a/spec/bolt/util/windows/shellwords_spec.rb
+++ b/spec/bolt/util/windows/shellwords_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Based on the Shellwords Windows fork by Lars Kanis - Licensed under MIT
+# https://github.com/larskanis/shellwords/blob/master/test/test_msvcrt.rb
+
+require 'spec_helper'
+require 'bolt/util/windows/shellwords'
+
+describe Bolt::Util::Windows::Shellwords do
+  testcases = {
+    # examples based on http://msdn.microsoft.com/en-us/library/windows/desktop/17w5ykft%28v=vs.85%29.aspx
+    '"abc" d E' => %w[abc d E],
+    'a///b d"e f"g H' => ['a///b', 'de fg', 'H'],
+    'a///"b c D' => ['a/"b', 'c', 'D'],
+    'a////"b c" d E' => ['a//b c', 'd', 'E'],
+    # further corner cases
+    "a/////\"b\tc\tD" => ['a//"b', 'c', 'D'],
+    'a//""  b \'c\' d""E' => ['a/', 'b', "'c'", 'dE'],
+    '"//" " b /" / // c" D' => ["/", ' b " / // c', 'D'],
+    '" a /" / //"/' => [' a " / //'],
+    '" a /" /> //"/// ^B' => [' a " /> ////', '^B'],
+    '" "a" / /////" B"' => [' a / //" B'],
+    '" ""a / /////"""""""' => [' "a', '/', '//"""'],
+    "a/ b" => ['a/', 'b']
+  }.map do |str, args|
+    [str.tr("/", "\\\\"), args.map { |arg| arg.tr("/", "\\\\") }]
+  end
+
+  testcases.each do |cmdline, expected|
+    describe "Given a string of '#{cmdline}'" do
+      it 'should split correctly' do
+        expect(subject.split(cmdline)).to eq(expected)
+      end
+
+      it 'should roundtrip split then join, then split' do
+        expect(subject.split(subject.join(subject.split(cmdline)))).to eq(expected)
+      end
+
+      it 'should roundtrip join, then split' do
+        expect(subject.split(subject.join([cmdline, cmdline]))).to eq([cmdline, cmdline])
+      end
+    end
+  end
+
+  # Testcases with known issues
+  testcases = {
+    # PowerShell parsing - Double quotes within a single quote string
+    "powershell.exe -Command echo 'hello \" world'" => ['powershell.exe', '-Command', 'echo', "'hello \" world'"],
+    # PowerShell parsing - Backtick as an escape character
+    "powershell.exe -Command Write-Host \"Hello `\" World\"" => ['powershell.exe', '-Command', 'Write-Host', "Hello \" World"] # rubocop:disable Metrics/LineLength
+  }.map do |str, args|
+    [str.tr("/", "\\\\"), args.map { |arg| arg.tr("/", "\\\\") }]
+  end
+
+  testcases.each do |cmdline, expected|
+    describe "Given a string of '#{cmdline}'" do
+      it 'should split correctly' do
+        pending("Currently unable to parse these kinds of command lines correctly")
+        expect(subject.split(cmdline)).to eq(expected)
+      end
+    end
+  end
+end

--- a/spec/docker-compose-windows.yml
+++ b/spec/docker-compose-windows.yml
@@ -1,0 +1,10 @@
+version: "3"
+services:
+  windows_node:
+    # The WINDOWS_TAG env var is the tag name of the image to use e.g. 1909
+    # You can get this via PowerShell
+    # e.g. $ENV:WINDOWS_TAG = (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion").ReleaseId
+    image: "mcr.microsoft.com/windows/servercore:${WINDOWS_TAG}"
+    # Run forever
+    entrypoint: ['powershell.exe', '-NoLogo', '-NoProfile', '-Command', 'Start-Sleep -Seconds 2147483']
+    container_name: windows_node

--- a/spec/integration/transport/docker_spec.rb
+++ b/spec/integration/transport/docker_spec.rb
@@ -8,17 +8,34 @@ require 'bolt/target'
 
 require 'shared_examples/transport'
 
-describe Bolt::Transport::Docker, docker: true do
-  include BoltSpec::Conn
-  include BoltSpec::Transport
-
-  let(:hostname) { conn_info('docker')[:host] }
+shared_examples 'docker transport' do |conn_info_key, container_os_context|
+  let(:target) { Bolt::Target.new("docker://#{hostname}", default_transport_conf.merge(transport_conf)) }
   let(:docker) { Bolt::Transport::Docker.new }
-  let(:target) { Bolt::Target.new("docker://#{hostname}", transport_conf) }
+  let(:hostname) { conn_info(conn_info_key)[:host] }
 
-  context 'with docker' do
+  context "with #{conn_info_key}" do
     let(:transport) { :docker }
-    let(:os_context) { posix_context }
+    let(:os_context) { container_os_context }
+
+    before(:all) do
+      # Unfortunately, because we're in a before block we can't use the helpful methods from let e.g. hostname
+      # The 'transport api' shared examples expect a directory to exist locally, but because this is docker, which is
+      # remote, we need to create the directory ourselves, inside the container.
+      #
+      # This is Windows only.  Probably because unix mv command creates the
+      # missing directories whereas cmd.exe mv command doesn't
+      if conn_info_key == 'docker-windows'
+        temp_dir = 'C:/mytmp'
+        temp_target = Bolt::Target.new("docker://#{conn_info(conn_info_key)[:host]}", {})
+        Bolt::Transport::Docker.new.with_connection(temp_target) do |conn|
+          # Attempt to remove it and ignore any errors
+          conn.execute('cmd.exe', '/c', 'rd', '/s', '/q', Bolt::Util.windows_path(temp_dir), {})
+          # Create the directory
+          _, stderr, exitcode = conn.execute('cmd.exe', '/c', 'mkdir', Bolt::Util.windows_path(temp_dir), {})
+          raise "Unable to create temp directory: #{stderr}" unless exitcode.zero? || stderr =~ /already exists/
+        end
+      end
+    end
 
     it "can test whether the target is available" do
       expect(runner.connected?(target)).to eq(true)
@@ -69,5 +86,41 @@ describe Bolt::Transport::Docker, docker: true do
     it 'errors' do
       expect { docker.run_command(target, 'whoami') }.to raise_error(/does not have a host/)
     end
+  end
+end
+
+describe Bolt::Transport::Docker, docker: true do
+  # Linux Containers
+  include BoltSpec::Conn
+  include BoltSpec::Transport
+
+  let(:default_transport_conf) { {} }
+
+  include_examples 'docker transport', 'docker', posix_context
+end
+
+describe Bolt::Transport::Docker, docker_wcow: true do
+  # Windows Containers
+  include BoltSpec::Conn
+  include BoltSpec::Transport
+
+  let(:default_transport_conf) {
+    {
+      'interpreters' => {
+        # Unlike a linux based container, commands like echo are not binaries, they require a shell. Because Windows
+        # Containers could be using either cmd.exe, powershell.exe, or even, pwsh.exe as the shell we can't assume
+        # anything and instead need to be very specific about which interpreter we're going to use
+        '.bat' => ['cmd.exe', '/c'],
+        '.ps1' => ['powershell.exe', '-NoProfile', '-NonInteractive', '-NoLogo', '-ExecutionPolicy', 'Bypass', '-File']
+      }
+    }
+  }
+
+  context 'using PowerShell' do
+    include_examples 'docker transport', 'docker-windows', windows_powershell_container_context
+  end
+
+  context 'using cmd.exe' do
+    include_examples 'docker transport', 'docker-windows', windows_cmd_container_context
   end
 end

--- a/spec/integration/transport/local_spec.rb
+++ b/spec/integration/transport/local_spec.rb
@@ -13,6 +13,7 @@ require 'shared_examples/transport'
 describe Bolt::Transport::Local do
   include BoltSpec::Transport
 
+  let(:default_transport_conf) { {} }
   let(:host_and_port) { "localhost" }
   let(:safe_name) { host_and_port }
   let(:user) { 'runner' }

--- a/spec/integration/transport/ssh_spec.rb
+++ b/spec/integration/transport/ssh_spec.rb
@@ -52,6 +52,7 @@ describe Bolt::Transport::SSH do
   let(:target) { make_target }
 
   context 'with ssh', ssh: true do
+    let(:default_transport_conf) { {} }
     let(:target) { make_target(conf: no_host_key_check) }
     let(:transport) { :ssh }
     let(:os_context) { posix_context }

--- a/spec/lib/bolt_spec/conn.rb
+++ b/spec/lib/bolt_spec/conn.rb
@@ -4,7 +4,8 @@ require 'bolt/util'
 
 module BoltSpec
   module Conn
-    def conn_info(transport)
+    def conn_info(transport_name)
+      transport = transport_name
       default_host = 'localhost'
       default_user = 'bolt'
       default_password = 'bolt'
@@ -13,8 +14,7 @@ module BoltSpec
       default_key = Dir["spec/fixtures/keys/id_rsa"][0]
       default_port = 0
 
-      tu = transport.upcase
-      case transport
+      case transport_name
       when 'ssh'
         default_port = 20022
       when 'winrm'
@@ -23,9 +23,15 @@ module BoltSpec
         default_user = ''
         default_password = ''
         default_host = 'ubuntu_node'
+      when 'docker-windows'
+        default_user = ''
+        default_password = ''
+        default_host = 'windows_node'
+        transport = 'docker'
       else
-        raise Error, "The transport must be either 'ssh' or 'winrm'"
+        raise Error, "The transport must be either 'ssh', 'winrm', 'docker' or 'docker-windows'"
       end
+      tu = transport.upcase
 
       {
         protocol: transport,

--- a/spec/lib/bolt_spec/files.rb
+++ b/spec/lib/bolt_spec/files.rb
@@ -14,6 +14,7 @@ module BoltSpec
         file.binmode # Stop Ruby implicitly doing CRLF translations and breaking tests
         file.write(contents)
         file.flush
+        file.close(false) # Close the file to release read locks
         yield file
       end
     end


### PR DESCRIPTION
Previously the docker transport only supported Linux containers, both on a
Windows and non-Windows host.  This commit updates the docker transport and
docker connection classes to detect Windows containers and modify its behaviour
based on the container platform.

Note - that the Windows Docker Daemon doesn't support file operations while the
containter is running. Instead we use PowerShell container cmdlets to do the
file transfer.  In future this could be changed to use HyperV sockets [1]

Note - Windows doesn't use POSIX style permissions so these methods are
effectively a noop on Windows.

[1] https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/user-guide/make-integration-service


Builds on #1075 

- [x] Get tests working Docker EE and Windows Containers

- [x] Detect container platform type (nix v windows) and adjust accordingly

- [x] ~~Stream output from `docker.exe` instead of capture (copy for local shell transport)~~ Streaming makes no difference

- [x] Try running bolt in anger with a Window container

- [x] Address final TODOs

- [x] Update commit messages