### PR TITLE
(BOLT-1425) Expose orchestrator-client_ruby settings in bolt conf

### DIFF
--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -22,7 +22,7 @@ module Bolt
       attr_writer :plan_context
 
       def self.options
-        %w[host service-url cacert token-file task-environment]
+        %w[host service-url cacert token-file task-environment job-poll-interval job-poll-timeout]
       end
 
       def self.default_options

--- a/lib/bolt/transport/orch/connection.rb
+++ b/lib/bolt/transport/orch/connection.rb
@@ -19,7 +19,7 @@ module Bolt
         def initialize(opts, plan_context, logger)
           @logger = logger
           @key = self.class.get_key(opts)
-          client_keys = %w[service-url token-file cacert]
+          client_keys = %w[service-url token-file cacert job-poll-interval job-poll-timeout]
           client_opts = client_keys.each_with_object({}) do |k, acc|
             acc[k] = opts[k] if opts.include?(k)
           end

--- a/pre-docs/bolt_configuration_options.md
+++ b/pre-docs/bolt_configuration_options.md
@@ -153,6 +153,10 @@ When using the ssh transport Bolt also interacts with the ssh-agent for ssh key 
 
 `token-file`: The path to the token file.
 
+`job-poll-interval`: Set interval to poll orchestrator for job status.
+
+`job-poll-timeout`: Set time to wait for orchestrator job status.
+
 
 ## Local transport configuration options
 


### PR DESCRIPTION
Previously the `job-poll-{interval,timeout}` settings for the ruby orchestrator client were only configurable in `orchestrator.conf`. This commit exposes these settings in bolt configuration. If these are set in bolt config, they will override the settings in orchestrator.conf which is the desired behaviour because *only* the ruby implementation of the orchestrator client should use these settings.