### PR TITLE
(maint) Allow rubocop to be used on Windows

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -89,3 +89,7 @@ Metrics/PerceivedComplexity:
 Lint/HandleExceptions:
   Exclude:
     - lib/bolt/transport/local/shell.rb
+
+# Enforce LF line endings, even when on Windows
+Layout/EndOfLine:
+  EnforcedStyle: lf


### PR DESCRIPTION
Rubocop unfortunately expects all files on Windows to be CRLF however in most
cross platform projects, like Bolt, the line endings are LF.  This commit
updates Rubocop to expect LF line-endings instead.