### PR TITLE
(BOLT-1328) Add AWS EC2 target-lookup plugin

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = "~> 2.3"
 
   spec.add_dependency "addressable", '~> 2.5'
+  spec.add_dependency "aws-sdk-ec2", '~> 1'
   spec.add_dependency "CFPropertyList", "~> 2.2"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "docker-api", "~> 1.34"

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -31,7 +31,7 @@ module Bolt
   end
 
   class Config
-    attr_accessor :concurrency, :format, :trace, :log, :puppetdb, :color, :save_rerun,
+    attr_accessor :aws, :concurrency, :format, :trace, :log, :puppetdb, :color, :save_rerun,
                   :transport, :transports, :inventoryfile, :compile_concurrency, :boltdir,
                   :puppetfile_config, :plugins
     attr_writer :modulepath
@@ -162,7 +162,7 @@ module Bolt
       # Plugins are only settable from config not inventory so we can overwrite
       @plugins = data['plugins'] if data.key?('plugins')
 
-      %w[concurrency format puppetdb color transport].each do |key|
+      %w[aws concurrency format puppetdb color transport].each do |key|
         send("#{key}=", data[key]) if data.key?(key)
       end
 

--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -5,6 +5,7 @@ require 'bolt/plugin/terraform'
 require 'bolt/plugin/pkcs7'
 require 'bolt/plugin/prompt'
 require 'bolt/plugin/task'
+require 'bolt/plugin/aws'
 
 module Bolt
   class Plugin
@@ -22,6 +23,7 @@ module Bolt
       plugins.add_plugin(Bolt::Plugin::Prompt.new)
       plugins.add_plugin(Bolt::Plugin::Pkcs7.new(config.boltdir.path, config.plugins['pkcs7'] || {}))
       plugins.add_plugin(Bolt::Plugin::Task.new(config))
+      plugins.add_plugin(Bolt::Plugin::Aws::EC2.new(config))
       plugins
     end
 

--- a/lib/bolt/plugin/aws.rb
+++ b/lib/bolt/plugin/aws.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Bolt
+  class Plugin
+    class Aws
+      class EC2
+        attr_accessor :client
+        attr_reader :config
+
+        def initialize(config)
+          require 'aws-sdk-ec2'
+          @config = config
+          @logger = Logging.logger[self]
+        end
+
+        def name
+          'aws::ec2'
+        end
+
+        def hooks
+          %w[inventory_targets]
+        end
+
+        def config_client(opts)
+          return client if client
+
+          options = {}
+
+          if opts.key?('region')
+            options[:region] = opts['region']
+          end
+          if opts.key?('profile')
+            options[:profile] = opts['profile']
+          end
+          if config.aws&.key?('credentials')
+            creds = File.expand_path(config.aws['credentials'])
+            if File.exist?(creds)
+              options[:credentials] = ::Aws::SharedCredentials.new(path: creds)
+            else
+              raise Bolt::ValidationError, "Cannot load credentials file #{config.aws['credentials']}"
+            end
+          end
+
+          ::Aws::EC2::Client.new(options)
+        end
+
+        def inventory_targets(opts)
+          client = config_client(opts)
+          resource = ::Aws::EC2::Resource.new(client: client)
+
+          # Retrieve a list of EC2 instances and create a list of targets
+          # Note: It doesn't seem possible to filter stubbed responses...
+          resource.instances(filters: opts['filters']).map do |instance|
+            next unless instance.state.name == 'running'
+            target = {}
+
+            if opts.key?('uri')
+              uri = lookup(instance, opts['uri'])
+              target['uri'] = uri if uri
+            end
+            if opts.key?('name')
+              real_name = lookup(instance, opts['name'])
+              target['name'] = real_name if real_name
+            end
+            if opts.key?('config')
+              target['config'] = resolve_config(instance, opts['config'])
+            end
+
+            target if target['uri'] || target['name']
+          end.compact
+        end
+
+        # Look for an instance attribute specified in the inventory file
+        def lookup(instance, attribute)
+          value = instance.data.respond_to?(attribute) ? instance.data[attribute] : nil
+          unless value
+            warn_missing_attribute(instance, attribute)
+          end
+          value
+        end
+
+        def warn_missing_attribute(instance, attribute)
+          @logger.warn("Could not find attribute #{attribute} of instance #{instance.instance_id}")
+        end
+
+        # Walk the "template" config mapping provided in the plugin config and
+        # replace all values with the corresponding value from the resource
+        # parameters.
+        def resolve_config(name, config_template)
+          Bolt::Util.walk_vals(config_template) do |value|
+            if value.is_a?(String)
+              lookup(name, value)
+            else
+              value
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/pre-docs/inventory_version2.md
+++ b/pre-docs/inventory_version2.md
@@ -83,6 +83,7 @@ The following plugins can be used for targets
 
 * `puppetdb` - Query PuppetDB to populate the targets.
 * `terraform` - Load a Terraform state file to populate the targets.
+* `aws::ec2` - Load running AWS EC2 instances to populate the targets.
 
 #### Config plugins
 
@@ -350,6 +351,77 @@ google_compute_instance.app.1:
   project = cloud-app1
   self_link = https://www.googleapis.com/compute/v1/projects/cloud-app1/zones/us-west1-a/instances/app-1
   zone = us-west1-a
+```
+
+#### AWS EC2
+
+The AWS EC2 plugin supports looking up running AWS EC2 instances. It supports several fields:
+
+- `profile`: The [named profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) to use when loading from AWS `config` and `credentials` files. (optional, defaults to `default`)
+- `region`: The region to look up EC2 instances from.
+- `name`: The [EC2 instance attribute](https://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Instance.html) to use as the target name. (optional)
+- `uri`: The [EC2 instance attribute](https://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Instance.html) to use as the target URI. (optional)
+- `filters`: The [filter request parameters](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html) used to filter the EC2 instances by. Filters are name-values pairs, where the name is a request parameter and the values are an array of values to filter by. (optional)
+- `config`: A Bolt config map where the value for each config setting is an EC2 instance attribute.
+
+One of `uri` or `name` is required. If only `uri` is set, then the value of `uri` will be used as the `name`.
+
+```
+groups:
+  - name: aws
+    targets:
+      - _plugin: aws::ec2
+        profile: user1
+        region: us-west-1
+        name: public_dns_name
+        uri: public_ip_address
+        filters:
+          - name: tag:Owner
+            values: [Devs]
+          - name: instance-type
+            values: [t2.micro, c5.large]
+        config:
+          ssh:
+            host: public_dns_name
+    config:
+      ssh:
+        user: ec2-user
+        private-key: ~/.aws/private-key.pem
+        host-key-check: false
+```
+
+Accessing EC2 instances requires a region and valid credentials to be specified. The following locations are searched in order until a value is found:
+
+**Region**
+- `region: <region>` in the inventory file
+- `ENV['AWS_REGION']`
+- `credentials: <filepath>` in the config file
+- `~/.aws/credentials`
+
+**Credentials**
+- `ENV['AWS_ACCESS_KEY_ID']` and `ENV['AWS_SECRET_ACCESS_KEY']`
+- `credentials: <filepath>` in the config file
+- `~/.aws/credentials`
+
+If the region or credentials are located in a shared credentials file, a `profile` can be specified in the inventory file to choose which set of credentials to use. For example, if the inventory file were set to `profile: user1`, the second set of credentials would be used:
+
+```
+[default]
+aws_access_key_id=...
+aws_secret_access_key=...
+region=...
+
+[user1]
+aws_access_key_id=...
+aws_secret_access_key=...
+region=...
+```
+
+AWS credential files stored in a non-standard location (`~/.aws/credentials`) can be specified in the Bolt config file:
+
+```
+aws:
+  credentials: ~/alternate_path/credentials
 ```
 
 #### Prompt plugin

--- a/spec/bolt/plugin/aws_spec.rb
+++ b/spec/bolt/plugin/aws_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/plugin/aws'
+
+describe Bolt::Plugin::Aws::EC2 do
+  let(:ip1) { '255.255.255.255' }
+  let(:ip2) { '127.0.0.1' }
+  let(:name1) { 'test-instance-1' }
+  let(:name2) { 'test-instance-2' }
+  let(:test_instances) {
+    [
+      { instance_id: name1,
+        public_ip_address: ip1,
+        public_dns_name: name1,
+        state: { name: 'running' } },
+      { instance_id: name2,
+        public_ip_address: ip2,
+        public_dns_name: name2,
+        state: { name: 'running' } }
+    ]
+  }
+
+  let(:test_client) {
+    ::Aws::EC2::Client.new(
+      stub_responses: { describe_instances: { reservations: [{ instances: test_instances }] } }
+    )
+  }
+
+  let(:aws_dir) { File.expand_path(File.join(__dir__, '../../fixtures/configs')) }
+  let(:plugin) { Bolt::Plugin::Aws::EC2.new(File.join(aws_dir, 'empty.yaml')) }
+
+  let(:opts) do
+    {
+      'name' => 'public_dns_name',
+      'uri' => 'public_ip_address',
+      'filters' => [{ name: 'tag:Owner', values: ['foo'] }]
+    }
+  end
+
+  before(:each) do
+    plugin.client = test_client
+  end
+
+  it 'has a hook for inventory_targets' do
+    expect(plugin.hooks).to eq(['inventory_targets'])
+  end
+
+  it 'matches all running instances' do
+    targets = plugin.inventory_targets(opts)
+    expect(targets).to contain_exactly({ 'name' => name1, 'uri' => ip1 },
+                                       'name' => name2, 'uri' => ip2)
+  end
+
+  it 'sets only name if uri is not specified' do
+    opts.delete('uri')
+    targets = plugin.inventory_targets(opts)
+    expect(targets).to contain_exactly({ 'name' => name1 },
+                                       'name' => name2)
+  end
+
+  it 'returns nothing if neither name nor uri are specified' do
+    targets = plugin.inventory_targets({})
+    expect(targets).to be_empty
+  end
+
+  it 'builds a config map from the inventory' do
+    config_template = { 'ssh' => { 'host' => 'public_ip_address' } }
+    targets = plugin.inventory_targets(opts.merge('config' => config_template))
+
+    config1 = { 'ssh' => { 'host' => ip1 } }
+    config2 = { 'ssh' => { 'host' => ip2 } }
+    expect(targets).to contain_exactly({ 'name' => name1, 'uri' => ip1, 'config' => config1 },
+                                       'name' => name2, 'uri' => ip2, 'config' => config2)
+  end
+
+  it 'warns on missing instance properties' do
+    opts['name'] = 'foo'
+    expect(plugin).to receive(:warn_missing_attribute).twice.with(::Aws::EC2::Instance, /foo/)
+    plugin.inventory_targets(opts)
+  end
+
+  it 'raises a validation error when credentials file path does not exist' do
+    config_data = { 'aws' => { 'credentials' => '~/foo/credentials' } }
+    boltdir = Bolt::Boltdir.new(File.join(Dir.tmpdir, rand(1000).to_s))
+    config = Bolt::Config.new(boltdir, config_data)
+    plugin = Bolt::Plugin::Aws::EC2.new(config)
+    expect { plugin.config_client(opts) }.to raise_error(Bolt::ValidationError, %r{foo/credentials})
+  end
+end


### PR DESCRIPTION
This adds a plugin that can lookup AWS EC2 instances in a specified region, allowing Bolt to dynamically determine the targets to use when running a command. Instances can also be filtered by tags and other instance properties.