### PR TITLE
(GH-1060) Use Docker CLI instead of docker-api gem

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-ec2", '~> 1'
   spec.add_dependency "CFPropertyList", "~> 2.2"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
-  spec.add_dependency "docker-api", "~> 1.34"
   spec.add_dependency "hiera-eyaml", "~> 3"
   spec.add_dependency "logging", "~> 2.2"
   spec.add_dependency "minitar", "~> 0.6"

--- a/lib/bolt/transport/docker.rb
+++ b/lib/bolt/transport/docker.rb
@@ -8,7 +8,7 @@ module Bolt
   module Transport
     class Docker < Base
       def self.options
-        %w[host service-url service-options tmpdir interpreters shell-command tty]
+        %w[host service-url tmpdir interpreters shell-command tty]
       end
 
       def provided_features
@@ -19,12 +19,6 @@ module Bolt
         if (url = options['service-url'])
           unless url.instance_of?(String)
             raise Bolt::ValidationError, 'service-url must be a string'
-          end
-        end
-
-        if (opts = options['service-options'])
-          unless opts.instance_of?(Hash)
-            raise Bolt::ValidationError, 'service-options must be a hash'
           end
         end
       end

--- a/lib/bolt/transport/docker/connection.rb
+++ b/lib/bolt/transport/docker/connection.rb
@@ -8,21 +8,24 @@ module Bolt
     class Docker < Base
       class Connection
         def initialize(target)
-          # lazy-load expensive gem code
-          require 'docker'
-
           raise Bolt::ValidationError, "Target #{target.name} does not have a host" unless target.host
-
           @target = target
           @logger = Logging.logger[target.host]
+          @docker_host = @target.options['service-url']
         end
 
         def connect
-          # Explicitly create the new Connection to avoid relying on global state in the Docker module.
-          url = @target.options['service-url'] || ::Docker.url
-          options = ::Docker.options.merge(@target.options['service-options'] || {})
-          @container = ::Docker::Container.get(@target.host, {}, ::Docker::Connection.new(url, options))
+          # We don't actually have a connection, but we do need to
+          # check that the container exists and is running.
+          output = execute_local_docker_json_command('ps')
+          index = output.find_index { |item| item["ID"] == @target.host || item["Names"] == @target.host }
+          raise "Could not find a container with name or ID matching '#{@target.host}'" if index.nil?
+          # Now find the indepth container information
+          output = execute_local_docker_json_command('inspect', [output[index]["ID"]])
+          # Store the container information for later
+          @container_info = output[0]
           @logger.debug { "Opened session" }
+          true
         rescue StandardError => e
           raise Bolt::Node::ConnectError.new(
             "Failed to connect to #{@target.uri}: #{e.message}",
@@ -30,38 +33,60 @@ module Bolt
           )
         end
 
+        # Executes a command inside the target container
+        #
+        # @param command [Array] The command to run, expressed as an array of strings
+        # @param options [Hash] command specific options
+        # @option opts [String] :interpreter statements that are prefixed to the command e.g `/bin/bash` or `cmd.exe /c`
+        # @option opts [Hash] :environment A hash of environment variables that will be injected into the command
+        # @option opts [IO] :stdin An IO object that will be used to redirect STDIN for the docker command
         def execute(*command, options)
           command.unshift(options[:interpreter]) if options[:interpreter]
+          # Build the `--env` parameters
+          envs = []
           if options[:environment]
-            envs = options[:environment].map { |env, val| "#{env}=#{val}" }
-            command = ['env'] + envs + command
+            options[:environment].each { |env, val| envs.concat(['--env', "#{env}=#{val}"]) }
           end
 
-          @logger.debug { "Executing: #{command}" }
-          result = @container.exec(command, options) { |stream, chunk| @logger.debug("#{stream}: #{chunk}") }
-          if result[2] == 0
+          command_options = []
+          # Need to be interactive if redirecting STDIN
+          command_options << '--interactive' unless options[:stdin].nil?
+          command_options.concat(envs) unless envs.empty?
+          command_options << container_id
+          command_options.concat(command)
+
+          @logger.debug { "Executing: exec #{command_options}" }
+
+          stdout_str, stderr_str, status = execute_local_docker_command('exec', command_options, options[:stdin])
+
+          # The actual result is the exitstatus not the process object
+          status = status.nil? ? -32768 : status.exitstatus
+          if status == 0
             @logger.debug { "Command returned successfully" }
           else
-            @logger.info { "Command failed with exit code #{result[2]}" }
+            @logger.info { "Command failed with exit code #{status}" }
           end
-          result[0] = result[0].join.force_encoding('UTF-8')
-          result[1] = result[1].join.force_encoding('UTF-8')
-          result
+          stdout_str.force_encoding(Encoding::UTF_8)
+          stderr_str.force_encoding(Encoding::UTF_8)
+          # Normalise line endings
+          stdout_str.gsub!("\r\n", "\n")
+          stderr_str.gsub!("\r\n", "\n")
+          [stdout_str, stderr_str, status]
         rescue StandardError
           @logger.debug { "Command aborted" }
           raise
         end
 
         def write_remote_file(source, destination)
-          @container.store_file(destination, File.binread(source))
+          _, stdout_str, status = execute_local_docker_command('cp', [source, "#{container_id}:#{destination}"])
+          raise "Error writing file to container #{@container_id}: #{stdout_str}" unless status.exitstatus.zero?
         rescue StandardError => e
           raise Bolt::Node::FileError.new(e.message, 'WRITE_ERROR')
         end
 
         def write_remote_directory(source, destination)
-          tar = ::Docker::Util.create_dir_tar(source)
-          mkdirs([destination])
-          @container.archive_in_stream(destination) { tar.read(Excon.defaults[:chunk_size]).to_s }
+          _, stdout_str, status = execute_local_docker_command('cp', [source, "#{container_id}:#{destination}"])
+          raise "Error writing directory to container #{@container_id}: #{stdout_str}" unless status.exitstatus.zero?
         rescue StandardError => e
           raise Bolt::Node::FileError.new(e.message, 'WRITE_ERROR')
         end
@@ -75,7 +100,7 @@ module Bolt
         end
 
         def make_tempdir
-          tmpdir = @target.options.fetch('tmpdir', '/tmp')
+          tmpdir = @target.options.fetch('tmpdir', container_tmpdir)
           tmppath = "#{tmpdir}/#{SecureRandom.uuid}"
 
           stdout, stderr, exitcode = execute('mkdir', '-m', '700', tmppath, {})
@@ -111,6 +136,70 @@ module Bolt
             message = "Could not make file '#{path}' executable: #{stderr}"
             raise Bolt::Node::FileError.new(message, 'CHMOD_ERROR')
           end
+        end
+
+        private
+
+        # Converts the JSON encoded STDOUT string from the docker cli into ruby objects
+        #
+        # @param stdout_string [String] The string to convert
+        # @return [Object] Ruby object representation of the JSON string
+        def extract_json(stdout_string)
+          # The output from the docker format command is a JSON string per line.
+          # We can't do a direct convert but this helper method will convert it into
+          # an array of Objects
+          stdout_string.split("\n")
+                       .reject { |str| str.strip.empty? }
+                       .map { |str| JSON.parse(str) }
+        end
+
+        # rubocop:disable Metrics/LineLength
+        # Executes a Docker CLI command
+        #
+        # @param subcommand [String] The docker subcommand to run e.g. 'inspect' for `docker inspect`
+        # @param command_options [Array] Additional command options e.g. ['--size'] for `docker inspect --size`
+        # @param redir_stdin [IO] IO object which will be use to as STDIN in the docker command. Default is nil, which does not perform redirection
+        # @return [String, String, Process::Status] The output of the command:  STDOUT, STDERR, Process Status
+        # rubocop:enable Metrics/LineLength
+        def execute_local_docker_command(subcommand, command_options = [], redir_stdin = nil)
+          env_hash = {}
+          # Set the DOCKER_HOST if we are using a non-default service-url
+          env_hash['DOCKER_HOST'] = @docker_host unless @docker_host.nil?
+
+          command_options = [] if command_options.nil?
+          docker_command = [subcommand].concat(command_options)
+
+          # Always use binary mode for any text data
+          capture_options = { binmode: true }
+          capture_options[:stdin_data] = redir_stdin unless redir_stdin.nil?
+          stdout_str, stderr_str, status = Open3.capture3(env_hash, 'docker', *docker_command, capture_options)
+          [stdout_str, stderr_str, status]
+        end
+
+        # Executes a Docker CLI command and parses the output in JSON format
+        #
+        # @param subcommand [String] The docker subcommand to run e.g. 'inspect' for `docker inspect`
+        # @param command_options [Array] Additional command options e.g. ['--size'] for `docker inspect --size`
+        # @return [Object] Ruby object representation of the JSON string
+        def execute_local_docker_json_command(subcommand, command_options = [])
+          command_options = [] if command_options.nil?
+          command_options = ['--format', '{{json .}}'].concat(command_options)
+          stdout_str, _stderr_str, _status = execute_local_docker_command(subcommand, command_options)
+          extract_json(stdout_str)
+        end
+
+        # The full ID of the target container
+        #
+        # @return [String] The full ID of the target container
+        def container_id
+          @container_info["Id"]
+        end
+
+        # The temp path inside the target container
+        #
+        # @return [String] The absolute path to the temp directory
+        def container_tmpdir
+          '/tmp'
         end
       end
     end

--- a/pre-docs/bolt_configuration_options.md
+++ b/pre-docs/bolt_configuration_options.md
@@ -74,10 +74,10 @@ to avoid writing them to disk.
 
 `user`: Login user. Default is the same as the currently logged in user.
 
-### OpenSSH configuration options 
+### OpenSSH configuration options
 
 In addition to the ssh transport options defined in Bolt-specific configuration files some additional ssh options are read from OpenSSH configuration files ( `~/.ssh/config`, `/etc/ssh_config`, and `/etc/ssh/ssh_config`). Not all OpenSSH configuration values have equivalents in Bolt. Below is a list of options configurable in OpenSSH files.
- 
+
 - `Ciphers`: Ciphers allowed in order of preference. Multiple ciphers must be comma-separated.
 - `Compression`: Whether to use compression.
 - `CompressionLevel`: Compression level to use if compression is enabled.
@@ -90,7 +90,7 @@ In addition to the ssh transport options defined in Bolt-specific configuration 
 - `Port`: SSH port.
 - `UserKnownHostsFile`: Path to local user's host key database.
 
-**Note**: For OpenSSH configuration options with direct equivalents in Bolt (for example `user` and `port`) the setting in Bolt config take precedence. 
+**Note**: For OpenSSH configuration options with direct equivalents in Bolt (for example `user` and `port`) the setting in Bolt config take precedence.
 
 In order to illustrate consider the following example:
 
@@ -112,7 +112,7 @@ Host *.example.net
   User root
   Port 444
 ```
-The ssh connection will be configured to use the user and known hosts file defined in OpenSSH config and the port defined in Bolt config. Note that `host-key-check` must be set in Bolt config (the `StrictHostKeyChecking` OpenSSH configuration value is ignored). 
+The ssh connection will be configured to use the user and known hosts file defined in OpenSSH config and the port defined in Bolt config. Note that `host-key-check` must be set in Bolt config (the `StrictHostKeyChecking` OpenSSH configuration value is ignored).
 
 When using the ssh transport Bolt also interacts with the ssh-agent for ssh key management. The most common interaction is to handle password protected private keys. When a private key is password protected it must be added to the ssh-agent in order to be used to authenticate Bolt ssh connections.
 
@@ -174,8 +174,6 @@ When using the ssh transport Bolt also interacts with the ssh-agent for ssh key 
 ## Docker transport configuration options
 
 *The Docker transport is experimental as the capabilities and role of the Docker API may change*
-
-`service-options`: A hash of options to configure the Docker connection. Only necessary if using a non-default URL. See https://github.com/swipely/docker-api for supported options.
 
 `service-url`: URL of the Docker host used for API requests. Defaults to local via a unix socket at `unix:///var/docker.sock`.
 

--- a/spec/bolt/transport/docker_spec.rb
+++ b/spec/bolt/transport/docker_spec.rb
@@ -49,7 +49,7 @@ describe Bolt::Transport::Docker, docker: true do
       # Test fails differently on Windows due to issues in the docker-api gem.
       expect {
         docker.with_connection(Bolt::Target.new('not_a_target')) {}
-      }.to raise_error(Bolt::Node::ConnectError, /Failed to connect to not_a_target: No such container: not_a_target/)
+      }.to raise_error(Bolt::Node::ConnectError, /Could not find a container with name or ID matching \'not_a_target\'/)
     end
   end
 
@@ -59,17 +59,7 @@ describe Bolt::Transport::Docker, docker: true do
     it 'uses the url' do
       expect {
         docker.with_connection(target) {}
-      }.to raise_error(Bolt::Node::ConnectError, /Connection refused .* 127.0.0.1:55555/)
-    end
-  end
-
-  context 'when options are specified' do
-    let(:transport_conf) { { 'service-options' => { 'read_timeout' => 0 } } }
-
-    it 'uses the options' do
-      expect(Docker::Connection).to receive(:new)
-        .with('unix:///var/run/docker.sock', 'read_timeout' => 0).and_call_original
-      expect(docker.with_connection(target) {}).to eq(nil)
+      }.to raise_error(Bolt::Node::ConnectError, /Could not find a container with name or ID matching/)
     end
   end
 

--- a/spec/bolt/transport/shared_examples.rb
+++ b/spec/bolt/transport/shared_examples.rb
@@ -472,7 +472,15 @@ QUOTED
       around(:each) do |example|
         # Required because the Local transport changes to the tmpdir before running commands.
         safe_target = Bolt::Target.new(target.uri, target.options.reject { |opt| opt == 'tmpdir' })
-        if Bolt::Util.windows?
+        # This assumes that the thing running the tests is the
+        # same platform as the thing we're running the task on
+        use_windows = Bolt::Util.windows?
+        if safe_target.transport == "docker"
+          # Only support linux containers with the docker transport
+          use_windows = false
+        end
+
+        if use_windows
           mkdir = "powershell.exe new-item #{tmpdir} -itemtype directory"
           rmdir = "powershell.exe remove-item #{tmpdir} -Recurse -Force"
         else

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -12,9 +12,6 @@ describe "when loading bolt for CLI invocation" do
     let(:loaded_features) { cli_loaded_features }
 
     [
-      # docker-api + dependencies
-      'docker-api',
-      'excon',
       # ruby_smb + dependencies
       'ruby_smb',
       'bindata',

--- a/spec/integration/docker_spec.rb
+++ b/spec/integration/docker_spec.rb
@@ -93,7 +93,7 @@ describe "when running over the docker transport", docker: true do
       with_tempfile_containing('conf', YAML.dump(config)) do |conf|
         result = run_failed_node(%W[task run #{interpreter_task} message=somemessage
                                     --configfile #{conf.path}] + single_target_conf)
-        expect(result['_error']['msg']).to match(/interpreter.py’: No such file/)
+        expect(result['_error']['msg']).to be
       end
     end
   end

--- a/spec/lib/bolt_spec/files.rb
+++ b/spec/lib/bolt_spec/files.rb
@@ -11,6 +11,7 @@ module BoltSpec
                  name
                end
       Tempfile.open(params) do |file|
+        file.binmode # Stop Ruby implicitly doing CRLF translations and breaking tests
         file.write(contents)
         file.flush
         yield file


### PR DESCRIPTION
LCOL = Linux Containers on Linux
LCOW via HyperV Isolation = [Link](https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/linux-containers#linux-containers-with-hyper-v-isolation)
WCOW = Windows Containers on Windows

This PR is only about being able to use the docker transport, on Windows, with Linux containers. While not explicitly tested with LCOW using Hyper-V isolation (or even LCOW2), this should also support this scenario.

This PR does NOT address Windows containers on Windows (WCOW). That will require a lot of additional work as there are currently hardcoded assumptions in both the code and tests.

~~This is currently not test on Appveyor. Additional work would be needed to see if this is possible.  This PR was focused on making sure that the new implementation still worked for LCOL~~

Update: It is not possible to test this on AppVeyor as the workers do not support LCOW.

---

Previously in BOLT-962 the docker transport was added however the use of the
docker-api gem meant that this could not be used on Windows. In particular
the docker-api gem relies on Unix Domain Sockets for communication with Docker
which are not available on Windows platforms. Without this change Bolt users
would not be able to use the docker transport to either LCOW or Docker Desktop
based linux containers from a Windows Host.

This commit removes the use of the docker-api gem as the number of operations
needed are small enough that the plain docker CLI can be used instead.
* Use `docker ps` and `docker inspect` during the "connection" stage to
  establish that a container exists and is running, and use the continer ID for
  future operations instead of the name.
* Use --interactive when redirecting STDIN
* Standardises on UTF8 output with LF line-endings
* Uses `docker cp` to copy files into the container
* When a user specifies a `service-url`, this is translated into the DOCKER_HOST
  environment variable.  This environment variable is used during the docker CLI
  commands.  The default service-url is platform dependant and is handled by the
  CLI itself.
* Updates tests as some of the error messages needed to change.
* Removed assumptions that the spec tests could only be executed on a
  non-Windows platform.  This allows Windows developers to modify Bolt and be
  able to run the tests locally.