### PR TITLE
(maint) Plugin lookup error message looks for wrong key

### DIFF
--- a/lib/bolt/inventory/group2.rb
+++ b/lib/bolt/inventory/group2.rb
@@ -201,7 +201,7 @@ module Bolt
 
       def lookup_targets(lookup)
         unless (plugin = @plugins.by_name(lookup['_plugin']))
-          raise ValidationError.new("Target lookup specifies an unknown plugin: '#{lookup['plugin']}'", @name)
+          raise ValidationError.new("Target lookup specifies an unknown plugin: \"#{lookup['_plugin']}\"", @name)
         end
         unless plugin.hooks.include?('inventory_targets')
           raise ValidationError.new("#{plugin.name} does not support inventory_targets.", @name)

--- a/spec/bolt/inventory/group2_spec.rb
+++ b/spec/bolt/inventory/group2_spec.rb
@@ -1026,10 +1026,18 @@ describe Bolt::Inventory::Group2 do
           .to raise_error(/Cannot set target "uri" with plugin/)
       end
 
-      it 'fails if an unknown plugin is requested' do
-        data['config'] = { 'ssh' => { 'password' => { '_plugin' => 'unknown' } } }
-        expect { Bolt::Inventory::Group2.new(data, plugins) }
-          .to raise_error(/unknown plugin: "unknown"/)
+      context 'fails if an unknown plugin is requested' do
+        it 'for config only plugin' do
+          data['config'] = { 'ssh' => { 'password' => { '_plugin' => 'unknown' } } }
+          expect { Bolt::Inventory::Group2.new(data, plugins) }
+            .to raise_error(/unknown plugin: "unknown"/)
+        end
+
+        it 'for target plugin' do
+          data['targets'] = [{ '_plugin' => 'unknown' }]
+          expect { Bolt::Inventory::Group2.new(data, plugins) }
+            .to raise_error(/unknown plugin: "unknown"/)
+        end
       end
 
       it 'fails with an unsupported targets plugin' do


### PR DESCRIPTION
When the `inventory_targets` plugin hook doesn't find the specified
plugin, it used the wrong key in the error message to find the name.