### PR TITLE
(maint) Add powershell support to inventory tests

### DIFF
--- a/spec/fixtures/modules/remote/tasks/init.json
+++ b/spec/fixtures/modules/remote/tasks/init.json
@@ -1,3 +1,7 @@
 {
-  "remote": true
+  "remote": true,
+  "implementations": [
+    {"name": "init.sh", "requirements": ["shell"]},
+    {"name": "init.ps1", "requirements": ["powershell"]}
+  ]
 }

--- a/spec/fixtures/modules/remote/tasks/init.ps1
+++ b/spec/fixtures/modules/remote/tasks/init.ps1
@@ -1,0 +1,2 @@
+$line = [Console]::In.ReadLine()
+Write-Output $line

--- a/spec/integration/inventory2_spec.rb
+++ b/spec/integration/inventory2_spec.rb
@@ -14,7 +14,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
   include BoltSpec::Integration
   include BoltSpec::PuppetDB
 
-  let(:conn) { conn_info('ssh') }
+  let(:conn) { conn_info('winrm') }
   let(:inventory) do
     { version: 2,
       targets: [
@@ -324,7 +324,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
     include_examples 'basic inventory'
   end
 
-  context 'when running over remote', bash: true do
+  context 'when running over remote' do
     let(:inventory) do
       { version: 2,
         targets: [
@@ -346,7 +346,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
   end
 
   context 'when running over local', bash: true do
-    let(:shell_cmd) { "whoami" }
+    let(:shell_cmd) { Bolt::Util.windows? ? "$env:UserName" : "whoami" }
 
     let(:inventory) do
       { version: 2 }


### PR DESCRIPTION
We unnecessarily limited remote target and localhost testing to hosts
with bash. This adds support for those tests on systems with powershell
as well.