### PR TITLE
(maint) Remove redundant test cases

### DIFF
--- a/spec/bolt/transport/shared_examples.rb
+++ b/spec/bolt/transport/shared_examples.rb
@@ -180,23 +180,15 @@ shared_examples 'transport api' do
                              'with spaces',
                              "\"double double\"",
                              "'double single'",
-                             '\'single single\'',
-                             '"single double"',
                              "double \"double\" double",
-                             "double 'single' double",
-                             'single "double" single',
-                             'single \'single\' single'])['stdout']
+                             "double 'single' double"])['stdout']
         ).to eq(<<QUOTED)
 nospaces
 with spaces
 "double double"
 'double single'
-'single single'
-"single double"
 double "double" double
 double 'single' double
-single "double" single
-single 'single' single
 QUOTED
       end
     end


### PR DESCRIPTION
Previously the transport shared examples attempted to test various scenarios
however the ruby strings used contain duplicates:

'\'single single\'' is just the same as "'double single'" from a ruby point of
view except the first word has changed.  The same goes for single double,
single "double" single and single \'single\' single.

This commit removes the redundant tests and their expectations.