### PR TITLE
(BOLT-126) Add WinRM Kerberos support from Linux

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,24 +20,25 @@ desc "Run RSpec tests that don't require VM fixtures or a particular shell"
 RSpec::Core::RakeTask.new(:unit) do |t|
   t.rspec_opts = '--tag ~ssh --tag ~docker --tag ~bash --tag ~winrm ' \
                  '--tag ~appveyor_agents --tag ~puppetserver --tag ~puppetdb ' \
-                 '--tag ~omi'
+                 '--tag ~omi --tag ~kerberos'
 end
 
 desc "Run RSpec tests for AppVeyor that don't require SSH, Bash, Appveyor Puppet Agents, or orchestrator"
 RSpec::Core::RakeTask.new(:appveyor) do |t|
   t.rspec_opts = '--tag ~ssh --tag ~docker --tag ~bash --tag ~appveyor_agents ' \
-         '--tag ~orchestrator --tag ~puppetserver --tag ~puppetdb --tag ~omi'
+         '--tag ~orchestrator --tag ~puppetserver --tag ~puppetdb --tag ~omi ' \
+         '--tag ~kerberos'
 end
 
 desc "Run RSpec tests for TravisCI that don't require WinRM"
 RSpec::Core::RakeTask.new(:travisci) do |t|
   t.rspec_opts = '--tag ~winrm --tag ~appveyor_agents --tag ~puppetserver --tag ~puppetdb ' \
-  '--tag ~omi --tag ~windows'
+  '--tag ~omi --tag ~windows --tag ~kerberos'
 end
 
 desc "Run RSpec tests that require slow to start puppet containers"
 RSpec::Core::RakeTask.new(:puppetserver) do |t|
-  t.rspec_opts = '--tag puppetserver --tag puppetdb --tag omi'
+  t.rspec_opts = '--tag puppetserver --tag puppetdb --tag omi --tag kerberos'
 end
 
 RuboCop::RakeTask.new(:rubocop) do |t|

--- a/developer-docs/kerberos.md
+++ b/developer-docs/kerberos.md
@@ -1,0 +1,80 @@
+# Bolt + Kerberos
+
+### Overview
+
+Bolt supports using Kerberos as an authentication mechanism, in lieu of a username / password. An excellent background on key Kerberos concepts is available in [Designing an Authentication System: a Dialogue in Four Scenes](https://web.mit.edu/kerberos/www/dialogue.html).
+
+While Linux **does** support a standalone Kerberos KDC (Key Distribution Center), the [`winrm`](https://github.com/WinRb/WinRM) gem that provides connectivity support from Bolt has only been written for and tested against Active Directory.
+
+In the future, it's possible other transports like SSH may be able to authenticate and authorize with just a KDC, but for now, the primary use case for Kerberos is in conjunction with WinRM.
+
+### Kerberos Implementations
+
+There are three primary implementations of the Kerberos protocol widely available:
+
+* [Heimdal](#heimdal)
+* [MIT Kerberos](#mit-kerberos)
+* [Microsoft Kerberos](#microsoft-kerberos)
+
+#### Heimdal
+
+[Heimdal](https://www.h5l.org/) is an open source implementation that is shipped on Mac OSX and is the default library used for the Samba server packages on Linux.
+
+Even though Heimdal provided interoperability with [Microsoft DCE/RPC](https://en.wikipedia.org/wiki/DCE/RPC) first with the addition of [IOV message wrapping extension functions](https://web.mit.edu/kerberos/krb5-latest/doc/appdev/gssapi.html#iov-message-wrapping), these APIs are not exported in the OSX libraries that ship with the operating system.
+
+The [gssapi](https://github.com/zenchild/gssapi) gem that Bolt relies on for [Generic Security Services](https://en.wikipedia.org/wiki/Generic_Security_Services_Application_Program_Interface) defaults to MIT Kerberos, but also supports Heimdal via a programmatic opt-in by adding `require 'gssapi/heimdal'` prior to `require 'gssapi'` (for instance, to the code in `winrm/connection.rb`). Unfortunately the support for Heimdal is not well tested, the paths to the Heimdal libraries are currently hard-coded, and the library doesn't account for semantic differences in the Heimdal and MIT implementations of Kerberos APIs, which can cause segfaults.
+
+Samba also has optional experimental support for compiling against MIT Kerberos instead of the default Heimdal.
+
+#### MIT Kerberos
+
+[MIT Kerberos](https://web.mit.edu/kerberos/) is the default implementation used in Linux, and there is some general information on the [client installation instructions page](https://web.mit.edu/Kerberos/www/krb5-latest/doc/admin/install_clients.html).
+
+##### RHEL
+
+RHEL typically installs with the following packages
+
+> yum install krb5-workstation krb5-libs krb5-auth-dialog
+
+RedHat maintains docs about [Configuring a Kerberos 5 client](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/managing_smart_cards/configuring_a_kerberos_5_client)
+
+##### Ubuntu
+
+Ubuntu typically installs with the following packages
+
+> apt-get install krb5-user libpam-krb5 libpam-ccreds auth-client-config
+
+Canonical maintains docs about running a [Kerberos Linux Client](https://help.ubuntu.com/lts/serverguide/kerberos.html#kerberos-linux-client)
+
+#### Microsoft Kerberos
+
+Microsoft Kerberos is built-in to Windows and most easily consumed transparently by domain joining computers to Active Directory.
+
+Microsoft provides some guidance around [SSPI/Kerberos Interopability with GSSAPI](https://docs.microsoft.com/en-us/windows/win32/secauthn/sspi-kerberos-interoperability-with-gssapi) that covers how to map gssapi calls to their equivalent Windows APIs.
+
+### Kerberos Tooling
+
+On Linux and OSX, regardless of the package in use, client configuration is typically stored in `/etc/krb5.conf` (overridable with the `KRB5_CONFIG` environment variable). Windows Active Directory does not use such a config file.
+
+Important client tools include:
+
+* `kinit` for acquiring tickets (not used on Windows)
+* `klist` for listing tickets
+* `kdestroy` for destroying tickets (not used on Windows)
+
+### Usage
+
+Manual verification of Bolt can be performed from a Linux node that is domain joined to Active Directory using the following steps:
+
+- Set the default winrm authentication to specify the domain in `~/puppetlabs/bolt/bolt.yaml` like:
+
+```yaml
+winrm:
+  realm: DOMAIN.COM
+```
+
+- `kinit -C Administrator@domain.com` to acquire a TGT (ticket granting ticket)
+- `bolt command run 'whoami' --targets winrm://dc.domain.com` to connect over HTTPS (`--no-ssl-verify` may be required if the target uses a self-signed certificate)
+- `bolt command run 'whoami' --targets winrm://dc.domain.com --no-ssl` to connect over HTTP
+
+In the future, this testing will be automated.

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -38,7 +38,7 @@ module Bolt
 
     TRANSPORT_OPTIONS = %i[password run-as sudo-password extensions
                            private-key tty tmpdir user connect-timeout
-                           cacert token-file service-url interpreters file-protocol smb-port].freeze
+                           cacert token-file service-url interpreters file-protocol smb-port realm].freeze
 
     PUPPETFILE_OPTIONS = %w[proxy forge].freeze
 

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -10,7 +10,7 @@ module Bolt
       def self.options
         %w[
           host port user password connect-timeout ssl ssl-verify tmpdir
-          cacert extensions interpreters file-protocol smb-port
+          cacert extensions interpreters file-protocol smb-port realm
         ]
       end
 

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -38,13 +38,17 @@ module Bolt
             scheme = 'http'
             transport = :negotiate
           end
+
+          transport = :kerberos if target.options['realm']
           endpoint = "#{scheme}://#{target.host}:#{@port}/wsman"
           options = { endpoint: endpoint,
-                      user: @user,
-                      password: target.password,
+                      # https://github.com/WinRb/WinRM/issues/270
+                      user: target.options['realm'] ? 'dummy' : @user,
+                      password: target.options['realm'] ? 'dummy' : target.password,
                       retry_limit: 1,
                       transport: transport,
                       ca_trust_path: target.options['cacert'],
+                      realm: target.options['realm'],
                       no_ssl_peer_verification: !target.options['ssl-verify'] }
 
           Timeout.timeout(target.options['connect-timeout']) do

--- a/pre-docs/bolt_configuration_options.md
+++ b/pre-docs/bolt_configuration_options.md
@@ -128,7 +128,7 @@ When using the ssh transport Bolt also interacts with the ssh-agent for ssh key 
 
 **Note**: The SMB file protocol is experimental and is currently unsupported in conjunction with SSL given that only SMB2 is currently implemented.
 
-`password`: Login password. Required.
+`password`: Login password. Required unless using Kerberos.
 
 `port`: Connection port. Default is `5986`, or `5985` if `ssl: false`.
 
@@ -140,7 +140,11 @@ When using the ssh transport Bolt also interacts with the ssh-agent for ssh key 
 
 `tmpdir`: The directory to upload and execute temporary files on the target.
 
-`user`: Login user. Required.
+`user`: Login user. Required unless using Kerberos.
+
+`realm`: Kerberos realm (Active Directory domain) to authenticate against.
+
+**Note**: Kerberos client support is experimental and is only supported when Bolt is run on a Linux node. OSX and Windows support will be implemented in the future.
 
 
 ## PCP transport configuration options

--- a/pre-docs/bolt_known_issues.md
+++ b/pre-docs/bolt_known_issues.md
@@ -27,8 +27,8 @@ Workaround: Generate new keys with the ssh-keygen flag `-m PEM`. For existing ke
 
 When passing complex arguments to tasks with `--params`, Bolt may require a JSON string (typically created with the `ConvertTo-Json` cmdlet) to have additional escaping. In some cases, the PowerShell stop parsing symbol `--%` may be used as a workaround, until Bolt provides better PowerShell support [\(BOLT-1130\)](https://tickets.puppet.com/browse/BOLT-1130)
 
-## No Kerberos support
+## Limited Kerberos support
 
 While we would like to support Kerberos over SSH for authentication, a license incompatibility with other components we are distributing means that we cannot recommend using the net-ssh-krb gem for this functionality. [\(BOLT-980\)](https://tickets.puppet.com/browse/BOLT-980)
 
-Note that support for Kerberos over WinRM, both from Windows and non-Windows hosts, is also unimplemented. [\(BOLT-126\)](https://tickets.puppet.com/browse/BOLT-126)
+Support for Kerberos over WinRM from a Linux host is currently experimental and requires the [MIT kerberos library be installed](https://web.mit.edu/Kerberos/www/krb5-latest/doc/admin/install_clients.html). Support from Windows [\(BOLT-1323\)](https://tickets.puppet.com/browse/BOLT-1323) and OSX [\(BOLT-1471\)](https://tickets.puppet.com/browse/BOLT-1471) will be implemented in the future.

--- a/pre-docs/bolt_options.md
+++ b/pre-docs/bolt_options.md
@@ -138,7 +138,7 @@ If `localhost` is passed to `--nodes` when invoking Bolt the `local` trans
 
 ## Specify connection credentials
 
-To run Bolt on target nodes that require a username and password, pass credentials as options on the command line.
+To run Bolt on target nodes that require a username and password, pass credentials as options on the command line. For target nodes that use Kerberos authentication, pass a realm instead.
 
 Bolt connects to remote nodes with either SSH or WinRM.
 

--- a/pre-docs/inventory_file.md
+++ b/pre-docs/inventory_file.md
@@ -52,8 +52,7 @@ groups:
           - 172.16.219.30
         config:
           winrm:
-            user: vagrant
-            password: vagrant
+            realm: MYDOMAIN
             ssl: false
     config:
       transport: winrm

--- a/pre-docs/inventory_version2.md
+++ b/pre-docs/inventory_version2.md
@@ -542,8 +542,7 @@ groups:
           - 172.16.219.30
         config:
           winrm:
-            user: vagrant
-            password: vagrant
+            realm: MYDOMAIN
             ssl: false
     config:
       transport: winrm

--- a/spec/bolt/transport/winrm_spec.rb
+++ b/spec/bolt/transport/winrm_spec.rb
@@ -204,6 +204,36 @@ PS
     end
   end
 
+  context "authenticating with Kerberos", kerberos: true do
+    before(:all) do
+      # disable all tests on Windows for now
+      skip('Windows Active Directory tickets are different') if Bolt::Util.windows?
+
+      @kerb_user = 'Administrator'
+      @kerb_realm = 'BOLT.TEST'
+    end
+
+    let(:omi_http_kerb_target) do
+      conf = mk_config(ssl: false, realm: @kerb_realm)
+      make_target(host_: 'omiserver.bolt.test', port_: 45985, conf: conf)
+    end
+
+    let(:omi_https_kerb_target) do
+      conf = mk_config(ssl: true, realm: @kerb_realm, 'ssl-verify': false)
+      make_target(host_: 'omiserver.bolt.test', port_: 45986, conf: conf)
+    end
+
+    it "executes a command on a host over HTTP" do
+      pending("Not yet implemented")
+      expect(winrm.run_command(omi_http_kerb_target, command)['stdout']).to eq("#{@kerb_user}\r\n")
+    end
+
+    it "executes a command on a host over HTTPS" do
+      pending("Not yet implemented")
+      expect(winrm.run_command(omi_https_kerb_target, command)['stdout']).to eq("#{@kerb_user}\r\n")
+    end
+  end
+
   context "with an open connection" do
     it "can test whether the target is available", winrm: true do
       expect(winrm.connected?(target)).to eq(true)


### PR DESCRIPTION
* #999, except without the not-quite-working-yet Docker container setup!
* supersedes #950 

 - This PR is considered experimental due to a number of current
   limitations:

   * Works only with MIT Kerberos from a Linux node
   * Does not work with Heimdal on OSX
     - gssapi gem support for Heimdal is not well vetted
     - OSX doesn't export Kerberos IOV functions needed for MS DCE RPC
   * Does not work from a Windows node as winrm / gssapi gems only
     support MIT Kerberos, and Windows has its own APIs
   * Has been manually tested in a simple AD environment that has a
     CentOS host domain joined to Windows Active Directory

   Note that Kerberos is an authentication method, not a transport, so
   can be used with or without SSL just like other authentication.

 - Automated tests have been scaffolded, to be completed in a future PR
   that enables a Kerberos authentication test setup through Docker

- Manual verification includes the following steps:

   * Acquire ticket from KDC (in this case Active Directory)

```
[centos@bolt-dev-centos7 bolt]$ echo '*****!' | kinit -C Administrator@bolt.puppet
Password for Administrator@bolt.puppet:

[centos@bolt-dev-centos7 bolt]$ klist
Ticket cache: KEYRING:persistent:1000:1000
Default principal: Administrator@BOLT.PUPPET

Valid starting       Expires              Service principal
07/12/2019 18:18:04  07/13/2019 04:18:04  krbtgt/BOLT.PUPPET@BOLT.PUPPET
	renew until 07/19/2019 18:18:04
```

   * Show that bolt.yaml contains the default winrm realm configuration

```
[centos@bolt-dev-centos7 bolt]$ cat ~/.puppetlabs/bolt/bolt.yaml
---
winrm:
  realm: BOLT.PUPPET
```

   * Ask Bolt to run a command over WinRM over HTTPS using the AD domain as realm

```
[centos@bolt-dev-centos7 bolt]$ bundle exec bolt command run 'whoami' --targets winrm://bolt-dc.bolt.puppet --no-ssl-verify
Started on bolt-dc.bolt.puppet...
Finished on bolt-dc.bolt.puppet:
  STDOUT:
    bolt\administrator
Successful on 1 node: winrm://bolt-dc.bolt.puppet
Ran on 1 node in 0.82 seconds
```

   * Verify Kerberos tickets (note the new `HTTP` service ticket)

```
[centos@bolt-dev-centos7 bolt]$ klist
Ticket cache: KEYRING:persistent:1000:1000
Default principal: Administrator@BOLT.PUPPET

Valid starting       Expires              Service principal
07/12/2019 18:18:20  07/13/2019 04:18:04  HTTP/bolt-dc.bolt.puppet@BOLT.PUPPET
	renew until 07/19/2019 18:18:04
07/12/2019 18:18:04  07/13/2019 04:18:04  krbtgt/BOLT.PUPPET@BOLT.PUPPET
	renew until 07/19/2019 18:18:04
```

   * Ask Bolt to run a command over WinRM over HTTP using the AD domain as realm

```
[centos@bolt-dev-centos7 bolt]$ bundle exec bolt command run 'whoami' --targets winrm://bolt-dc.bolt.puppet --no-ssl
Started on bolt-dc.bolt.puppet...
Finished on bolt-dc.bolt.puppet:
  STDOUT:
    bolt\administrator
Successful on 1 node: winrm://bolt-dc.bolt.puppet
Ran on 1 node in 0.74 seconds
```

   * Show that bolt.yaml contains an invalid realm

```
[centos@bolt-dev-centos7 bolt]$ cat ~/.puppetlabs/bolt/bolt.yaml
---
winrm:
  realm: foo
```

   * Verify an incorrectly specified realm fails to connnect over HTTP

```
[centos@bolt-dev-centos7 bolt]$ bundle exec bolt command run 'whoami' --targets winrm://bolt-dc.bolt.puppet --no-ssl
Started on bolt-dc.bolt.puppet...
Failed on bolt-dc.bolt.puppet:
  Failed to connect to http://bolt-dc.bolt.puppet:5985/wsman: gss_init_sec_context did not return GSS_S_COMPLETE: Unspecified GSS failure.  Minor code may provide more information
  Server not found in Kerberos database
Failed on 1 node: winrm://bolt-dc.bolt.puppet
Ran on 1 node in 0.22 seconds
```

   * Verify an incorrectly specified realm fails to connnect over HTTPS

```
[centos@bolt-dev-centos7 bolt]$ bundle exec bolt command run 'whoami' --targets winrm://bolt-dc.bolt.puppet --no-ssl-verify
Started on bolt-dc.bolt.puppet...
Failed on bolt-dc.bolt.puppet:
  Failed to connect to bolt-dc.bolt.puppet:5986/wsman: gss_init_sec_context did not return GSS_S_COMPLETE: Unspecified GSS failure.  Minor code may provide more information
  Server not found in Kerberos database
Failed on 1 node: winrm://bolt-dc.bolt.puppet
Ran on 1 node in 0.16 seconds
```

 - This PR also relies on version 2.3.2 of the winrm gem which includes
   a critical Kerberos encryption bug that was fixed in
   WinRb/WinRM#302

 - There is a separate PR which will add a Docker container setup to
   verify Kerberos in an automated fashion against TravisCI using
   Samba and OMI server. At present, there is a problem properly
   establishing a connection between the WinRM gem and OMI server, which
   appears to be a bug in the WinRM gem protocol handling.

 - Windows support is https://tickets.puppet.com/browse/BOLT-1323

 - OSX support is https://tickets.puppet.com/browse/BOLT-1471

 - Includes basic experimental docs