### PR TITLE
(BOLT-1315) Collect analytics about Boltdir usage

### DIFF
--- a/lib/bolt/analytics.rb
+++ b/lib/bolt/analytics.rb
@@ -21,7 +21,8 @@ module Bolt
       statement_count: :cd6,
       resource_mean: :cd7,
       plan_steps: :cd8,
-      return_type: :cd9
+      return_type: :cd9,
+      boltdir_type: :cd11
     }.freeze
 
     def self.build_client

--- a/lib/bolt/boltdir.rb
+++ b/lib/bolt/boltdir.rb
@@ -6,10 +6,10 @@ module Bolt
   class Boltdir
     BOLTDIR_NAME = 'Boltdir'
 
-    attr_reader :path, :config_file, :inventory_file, :modulepath, :hiera_config, :puppetfile, :rerunfile
+    attr_reader :path, :config_file, :inventory_file, :modulepath, :hiera_config, :puppetfile, :rerunfile, :type
 
     def self.default_boltdir
-      Boltdir.new(File.join('~', '.puppetlabs', 'bolt'))
+      Boltdir.new(File.join('~', '.puppetlabs', 'bolt'), 'user')
     end
 
     # Search recursively up the directory hierarchy for the Boltdir. Look for a
@@ -19,9 +19,9 @@ module Bolt
     def self.find_boltdir(dir)
       dir = Pathname.new(dir)
       if (dir + BOLTDIR_NAME).directory?
-        new(dir + BOLTDIR_NAME)
+        new(dir + BOLTDIR_NAME, 'embedded')
       elsif (dir + 'bolt.yaml').file?
-        new(dir)
+        new(dir, 'local')
       elsif dir.root?
         default_boltdir
       else
@@ -29,7 +29,7 @@ module Bolt
       end
     end
 
-    def initialize(path)
+    def initialize(path, type = 'option')
       @path = Pathname.new(path).expand_path
       @config_file = @path + 'bolt.yaml'
       @inventory_file = @path + 'inventory.yaml'
@@ -37,6 +37,7 @@ module Bolt
       @hiera_config = @path + 'hiera.yaml'
       @puppetfile = @path + 'Puppetfile'
       @rerunfile = @path + '.rerun.json'
+      @type = type
     end
 
     def to_s

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -282,9 +282,9 @@ module Bolt
       if options.key?(:targets)
         screen_view_fields.merge!(target_nodes: options[:targets].count,
                                   inventory_nodes: inventory.node_names.count,
-                                  inventory_groups: inventory.group_names.count)
+                                  inventory_groups: inventory.group_names.count,
+                                  boltdir_type: config.boltdir.type)
       end
-
       @analytics.screen_view(screen, screen_view_fields)
 
       if options[:action] == 'show'

--- a/spec/bolt/boltdir_spec.rb
+++ b/spec/bolt/boltdir_spec.rb
@@ -78,6 +78,25 @@ describe Bolt::Boltdir do
       end
     end
 
+    describe 'when setting a type' do
+      it 'sets type to embedded when a Boltdir is used' do
+        pwd = boltdir_path.parent
+        expect(Bolt::Boltdir.find_boltdir(pwd).type).to eq('embedded')
+      end
+
+      it 'sets type to local when a bolt.yaml is used' do
+        pwd = @tmpdir
+        FileUtils.touch(pwd + 'bolt.yaml')
+
+        expect(Bolt::Boltdir.find_boltdir(pwd).type).to eq('local')
+      end
+
+      it 'sets type to user when the default is used' do
+        pwd = @tmpdir
+        expect(Bolt::Boltdir.find_boltdir(pwd).type).to eq('user')
+      end
+    end
+
     it 'returns the default when no Boltdir is found' do
       pwd = @tmpdir
       expect(Bolt::Boltdir.find_boltdir(pwd)).to eq(Bolt::Boltdir.default_boltdir)


### PR DESCRIPTION
Adds a custom dimension to the screen view for Boltdir usage. When the Boltdir is set up, it will log its type as either Boltdir, bolt.yaml, the default directory, missing default directory, or a Boltdir specified as a command line option.