### PR TITLE
(fix) Change read timeout on docker transport to large number

### DIFF
--- a/lib/bolt/transport/docker.rb
+++ b/lib/bolt/transport/docker.rb
@@ -60,6 +60,7 @@ module Bolt
         if target.options['tty']
           options[:Tty] = true
         end
+        options[:wait] = 24 * 60 * 60  # Choose 24 hour as timeout. But needs to be big
         if target.options['shell-command'] && !target.options['shell-command'].empty?
           # escape any double quotes in command
           command = command.gsub('"', '\"')


### PR DESCRIPTION
The default timeout of a command using a docker transport is 60 seconds. See this example:

```
$ bolt command run 'sleep 300' --targets a8ad33ff68069d48fdacc80172c8e4e79214f55523aaab143e1a7238e670a73a -i inventory.yaml
Started on a8ad33ff68069d48fdacc80172c8e4e79214f55523aaab143e1a7238e670a73a...
Failed on a8ad33ff68069d48fdacc80172c8e4e79214f55523aaab143e1a7238e670a73a:
  read timeout reached
Failed on 1 node: a8ad33ff68069d48fdacc80172c8e4e79214f55523aaab143e1a7238e670a73a
Ran on 1 node in 62.26 seconds
```

This is to short for some longer running commands (Like a puppet apply) The timeout seems ro be default value provided by the docker-api gem. You can override this value .

This PR allows uses a large number (24 hours) to override this default timeout.

With this change, the example looks like this:

```
 $ bolt command run 'sleep 300' --targets a8ad33ff68069d48fdacc80172c8e4e79214f55523aaab143e1a7238e670a73a -i inventory.yaml
Started on a8ad33ff68069d48fdacc80172c8e4e79214f55523aaab143e1a7238e670a73a...
Finished on a8ad33ff68069d48fdacc80172c8e4e79214f55523aaab143e1a7238e670a73a:
Successful on 1 node: a8ad33ff68069d48fdacc80172c8e4e79214f55523aaab143e1a7238e670a73a
Ran on 1 node in 299.95 seconds
```