### PR TITLE
(maint) Fixes from puppet-strings 2.3.0 release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ gem "puma", '>= 3.12.0'
 gem "rack", '>= 2.0.5'
 gem "rails-auth", '>= 2.1.4'
 gem "sinatra", '>= 2.0.4'
-gem "yard", "0.9.19"
 
 group(:test) do
   gem "beaker-hostgenerator"

--- a/Rakefile
+++ b/Rakefile
@@ -68,6 +68,7 @@ task :docs do
                                      'bolt-modules/system'])
   json = JSON.parse(File.read(tmpfile))
   funcs = json.delete('puppet_functions')
+  json.delete('data_types')
   json.each { |k, v| raise "Expected #{k} to be empty, found #{v}" unless v.empty? }
 
   # @functions will be a list of function descriptions, structured as


### PR DESCRIPTION
- Unpin yard gem from 0.9.19
Previously, yard was pinned due to changes in how dynamic symbols are handled by yard 0.9.20, causing formatting issues for plan functions such as out::message. The puppet-strings gem was updated to fix this formatting issue.

- Delete data_types field from generated docs
As of puppet-strings 2.3.0, an additional field is generated for the docs, causing the docs rake task to fail. This commit deletes the data_types field.