### PR TITLE
(maint) Pin puppet-strings to ~> 2.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group(:test) do
 end
 
 group(:development) do
-  gem "puppet-strings", "~> 2.0"
+  gem "puppet-strings", "~> 2.2.0"
 end
 
 group(:packaging) do


### PR DESCRIPTION
 - The release of puppet-strings 2.3.0 has broken `rake docs` because
   of data_types.

   Pinning to 2.2.0 will temporarily resolve this issue

```
 rake aborted!
Expected data_types to be empty, found [{"name"=>"ApplyResult", "file"=>"bolt-modules/boltlib/lib/puppet/datatypes/applyresult.rb", "line"=>3, "docstring"=>{"text"=>"", "tags"=>[{"tag_name"=>"param", "text"=>"", "types"=>["Hash[String[1], Data]"], "name"=>"report"}, {"tag_name"=>"param", "text"=>"", "types"=>["Target"], "name"=>"target"}]}, "source"=>nil}, {"name"=>"Result", "file"=>"bolt-modules/boltlib/lib/puppet/datatypes/result.rb", "line"=>3, "docstring"=>{"text"=>"", "tags"=>[{"tag_name"=>"param", "text"=>"", "types"=>["Hash[String[1], Data]"], "name"=>"value"}, {"tag_name"=>"param", "text"=>"", "types"=>["Target"], "name"=>"target"}]}, "source"=>nil}, {"name"=>"ResultSet", "file"=>"bolt-modules/boltlib/lib/puppet/datatypes/resultset.rb", "line"=>3, "docstring"=>{"text"=>"", "tags"=>[{"tag_name"=>"param", "text"=>"", "types"=>["Array[Variant[Result, ApplyResult]]"], "name"=>"results"}]}, "source"=>nil}, {"name"=>"Target", "file"=>"bolt-modules/boltlib/lib/puppet/datatypes/target.rb", "line"=>3, "docstring"=>{"text"=>"", "tags"=>[{"tag_name"=>"param", "text"=>"", "types"=>["String[1]"], "name"=>"uri"}, {"tag_name"=>"param", "text"=>"", "types"=>["Hash[String[1], Data]"], "name"=>"options"}]}, "defaults"=>{"options"=>{}}, "source"=>nil}]
/home/travis/build/puppetlabs/bolt/Rakefile:71:in `block (2 levels) in <top (required)>'
/home/travis/build/puppetlabs/bolt/Rakefile:71:in `each'
/home/travis/build/puppetlabs/bolt/Rakefile:71:in `block in <top (required)>'
/home/travis/build/puppetlabs/bolt/vendor/bundle/ruby/2.5.0/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'
/home/travis/.rvm/gems/ruby-2.5.5@global/gems/bundler-2.0.1/exe/bundle:30:in `block in <top (required)>'
/home/travis/.rvm/gems/ruby-2.5.5@global/gems/bundler-2.0.1/exe/bundle:22:in `<top (required)>'
/home/travis/.rvm/gems/ruby-2.5.5@global/bin/bundle:23:in `load'
/home/travis/.rvm/gems/ruby-2.5.5@global/bin/bundle:23:in `<main>'
/home/travis/.rvm/gems/ruby-2.5.5@global/bin/ruby_executable_hooks:24:in `eval'
/home/travis/.rvm/gems/ruby-2.5.5@global/bin/ruby_executable_hooks:24:in `<main>'
Tasks: TOP => docs
```