### PR TITLE
(BOLT-1475) Kerberos Development Container

### DIFF
--- a/developer-docs/kerberos.md
+++ b/developer-docs/kerberos.md
@@ -245,3 +245,21 @@ In some cases, OMI server source has to be modified to increase log output, in a
 # define ENABLE_TRACING 1
 # define TRACING_LEVEL 4
 ```
+
+#### Bolt Development Environment
+
+In addition to building OMI from source, it can be useful to run the Bolt source from a Linux agent to iterate on Bolt itself. To really vet Kerberos, this should be performed on a separate container image from the Samba Active Directory controller or the OMI server. This new dev container is defined in `spec/docker-compose-dev.yml` and can be built in addition to the other relevant containers by running `docker-compose`:
+
+> docker-compose -f spec/docker-compose.yml -f spec/docker-compose-dev.yml build --build-arg BUILD_OMI=true samba-ad omiserver linuxdev
+> docker-compose -f spec/docker-compose.yml -f spec/docker-compose-dev.yml up samba-ad omiserver linuxdev
+
+This will:
+
+* Provision Ubuntu 18.04
+* Join the Samba domain just like OMI server
+* Verify pwsh can use all authentication mechanisms against OMI
+* Expose port 422 on the Docker host for SSH access
+* Install vim, git, rbenv / ruby 2.55 / bundler
+* Clone the Bolt source to ~/bolt
+* Install all gems with bundler including pry-byebug and pry-stackexplorer
+* Provide a test script `/bolt-kerberos-test.sh` that can be used for simple test reproductions using Kerberos, noting that some failures that result are currently expected given incompatibilities between winrm gem and OMI server

--- a/spec/Dockerfile.linuxdev
+++ b/spec/Dockerfile.linuxdev
@@ -1,0 +1,86 @@
+FROM ubuntu:18.04
+
+ARG BOLT_PASSWORD=bolt
+ARG RUBY_VERSION=2.5.5
+# NOTE: Only designed to be set at build time, not at run time!
+ENV BOLT_PASSWORD=${BOLT_PASSWORD}
+ENV KRB5_REALM=
+ENV KRB5_KDC=
+ENV KRB5_ADMINSERVER=
+ENV SMB_ADMIN=Administrator
+ENV SMB_ADMIN_PASSWORD=
+
+# rbenv expects bash
+SHELL ["/bin/bash", "-c"]
+RUN useradd bolt \
+ && echo "bolt:${BOLT_PASSWORD}" | chpasswd
+
+# install Microsoft package repo for access to omi and powershell packages
+# gss-ntlmssp is for OMI server NTLM + Kerb support
+# ntp, realmd, sssd, samba-*, adcli are for working with Active Directory
+# krb5-config, krb5-user are Kerberos libraries
+# remaining packages are for .NET Core / PowerShell
+RUN export DEBIAN_FRONTEND=noninteractive \
+ && apt-get update -y \
+ && apt-get install -y wget \
+ && wget http://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb \
+ && dpkg -i packages-microsoft-prod.deb \
+ && apt-get update -y \
+ && apt-get install -y \
+    vim \
+    git \
+    ssh \
+    dnsutils \
+    gettext-base \
+    gss-ntlmssp \
+    libgssapi-krb5-2 \
+    ntp \
+    krb5-config \
+    krb5-user \
+    realmd \
+    sssd \
+    sssd-tools \
+    samba-common \
+    samba-dsdb-modules \
+    samba-common-bin \
+    samba-libs \
+    adcli \
+    powershell \
+    # rbenv dependencies
+    autoconf \
+    bison \
+    build-essential \
+    libssl-dev \
+    libyaml-dev \
+    libreadline6-dev \
+    zlib1g-dev \
+    libncurses5-dev \
+    libffi-dev \
+    libgdbm5 \
+    libgdbm-dev
+
+# ruby-build standalone
+RUN git clone https://github.com/rbenv/ruby-build.git \
+ && PREFIX=/usr/local ./ruby-build/install.sh \
+ && CONFIGURE_OPTS="--disable-install-doc" ruby-build ${RUBY_VERSION} /usr/local \
+ # gem / bundler setup
+ && echo "gem: --no-document" > ~/.gemrc \
+ && gem update --system \
+ # bolt source
+ && git clone https://github.com/puppetlabs/bolt ~/bolt \
+ && cd ~/bolt \
+ && printf 'gem "pry-byebug"\ngem "pry-stack_explorer"\n' >> ./Gemfile.local \
+ && bundle install --path .bundle/gems
+
+EXPOSE 22
+
+ADD fixtures/linuxdev/docker-entrypoint.sh /
+ADD fixtures/linuxdev/bolt-kerberos-test.sh /
+ADD fixtures/samba-ad/kerberos-client-config.sh /
+ADD fixtures/samba-ad/krb5.conf.tmpl /
+ADD fixtures/omiserver/domain-join.sh /
+ADD fixtures/omiserver/realmd.conf.tmpl /
+ADD fixtures/omiserver/smb.conf.tmpl /
+ADD fixtures/omiserver/sssd.conf.tmpl /
+ADD fixtures/omiserver/verify-pwsh-authentication.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/spec/Dockerfile.omiserver
+++ b/spec/Dockerfile.omiserver
@@ -3,8 +3,12 @@
 FROM ubuntu:18.04
 
 ARG BOLT_PASSWORD=bolt
+# Use this argument to build from OMI sources rather than use packages
+ARG BUILD_OMI=
+
 # NOTE: Only designed to be set at build time, not at run time!
 ENV BOLT_PASSWORD=${BOLT_PASSWORD}
+ENV OMI_EXTRA_LOGS=${BUILD_OMI:-false}
 ENV KRB5_REALM=
 ENV KRB5_KDC=
 ENV KRB5_ADMINSERVER=
@@ -45,6 +49,29 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     powershell \
  && wget https://github.com/PowerShell/psl-omi-provider/releases/download/v1.4.2-2/psrp-1.4.2-2.universal.x64.deb \
  && dpkg -i psrp-1.4.2-2.universal.x64.deb
+
+ADD fixtures/omiserver/build-omi.sh /
+RUN if [ "$BUILD_OMI" = "true" ]; \
+ then \
+   DEBIAN_FRONTEND=noninteractive \
+     apt-get install -y \
+     vim \
+     lsb \
+     equivs \
+     git \
+     pkg-config \
+     make \
+     g++ \
+     rpm \
+     librpm-dev \
+     libpam0g-dev \
+     libssl-dev \
+     libkrb5-dev \
+     libgssapi-krb5-2 \
+     gawk \
+   && git clone https://github.com/Microsoft/omi /tmp/omi \
+   && /build-omi.sh; \
+ fi
 
 # Configure ports 5985 and 5986 with OMI
 # and enable the NTLM auth file

--- a/spec/docker-compose-dev.yml
+++ b/spec/docker-compose-dev.yml
@@ -1,0 +1,26 @@
+version: "3"
+services:
+  linuxdev:
+    hostname: linuxdev
+    domainname: bolt.test
+    # must use Samba AD for DNS
+    dns:
+      - 172.22.0.100
+      - 8.8.8.8
+    build:
+      context: .
+      dockerfile: Dockerfile.linuxdev
+      args:
+        BOLT_PASSWORD: bolt
+    ports:
+      - "422:22"
+    environment:
+      KRB5_REALM: ${KRB5_REALM:-BOLT.TEST}
+      KRB5_KDC: ${KRB5_KDC:-samba-ad.bolt.test}
+      SMB_DOMAIN: ${SMB_DOMAIN:-BOLT}
+      SMB_ADMIN: Administrator
+      SMB_ADMIN_PASSWORD: ${SMB_ADMIN_PASSWORD:-B0ltrules!}
+    depends_on:
+      - samba-ad
+    networks:
+      BOLT.TEST:

--- a/spec/fixtures/linuxdev/bolt-kerberos-test.sh
+++ b/spec/fixtures/linuxdev/bolt-kerberos-test.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+mkdir -p ~/.puppetlabs/bolt
+rm -f ~/.puppetlabs/bolt/bolt.yaml
+
+cd ~/bolt
+
+cat << EOF
+
+************************************************************
+Using Bolt to retrieve username using:
+
+Basic auth bolt:${BOLT_PASSWORD}
+************************************************************
+
+EOF
+
+bundle exec bolt command run "whoami" --nodes winrm://omiserver.bolt.test:5985 --user bolt --password $BOLT_PASSWORD --no-ssl
+bundle exec bolt command run "whoami" --nodes winrm://omiserver.bolt.test:5986 --user bolt --password $BOLT_PASSWORD --no-ssl-verify
+
+cat << EOF
+
+************************************************************
+Using PowerShell to retrieve username using:
+
+HTTP Kerberos auth ${SMB_ADMIN}@${KRB5_REALM} ${SMB_ADMIN_PASSWORD}
+
+NOTE: Expected error will result when closing connection
+
+[omiserver] Closing the remote server shell instance failed with the following error message : ERROR_INTERNAL_ERROR
+************************************************************
+
+EOF
+
+/usr/bin/pwsh -Command 'Invoke-Command -ComputerName omiserver -Command { whoami } -Authentication Kerberos -Credential (New-Object System.Management.Automation.PSCredential("${ENV:SMB_ADMIN}@${ENV:KRB5_REALM}", (ConvertTo-SecureString $ENV:SMB_ADMIN_PASSWORD -AsPlainText -Force)))'
+# set default kerb realm for testing this way
+
+
+cat << EOF>~/.puppetlabs/bolt/bolt.yaml
+---
+winrm:
+  realm: BOLT.TEST
+EOF
+
+cat << EOF
+
+************************************************************
+Using Bolt to retrieve username using:
+
+HTTP Kerberos auth ${SMB_ADMIN}@${KRB5_REALM} ${SMB_ADMIN_PASSWORD}
+
+NOTE: Expected error will result when transferring data due to a Kerberos
+negotiation bug between winrm gem and omi server:
+
+Failed on omiserver.bolt.test:
+  Failed to connect to http://omiserver.bolt.test:5985/wsman:
+  Unable to parse WinRM response: #<ArgumentError: invalid byte sequence in UTF-8>
+
+<Encoding::UndefinedConversionError> "\xXX" from ASCII-8BIT to UTF-8
+************************************************************
+
+EOF
+
+bundle exec bolt command run "whoami" --nodes winrm://omiserver.bolt.test:5985 --no-ssl --debug --verbose --connect-timeout 9999
+
+cat << EOF
+
+************************************************************
+Using Bolt to retrieve username using:
+
+HTTPS Kerberos auth ${SMB_ADMIN}@${KRB5_REALM} ${SMB_ADMIN_PASSWORD}
+
+NOTE: Expected error will result when transferring data due to a Kerberos
+negotiation bug between winrm gem and omi server:
+
+Failed on omiserver.bolt.test:
+  Failed to connect to https://omiserver.bolt.test:5986/wsman:
+  Bad HTTP response returned from server. Body(if present)
+
+<Encoding::UndefinedConversionError> "\xXX" from ASCII-8BIT to UTF-8
+************************************************************
+
+EOF
+
+bundle exec bolt command run "whoami" --nodes winrm://omiserver.bolt.test:5986 --no-ssl-verify --debug --verbose --connect-timeout 9999

--- a/spec/fixtures/linuxdev/docker-entrypoint.sh
+++ b/spec/fixtures/linuxdev/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+pwsh --version
+
+./kerberos-client-config.sh
+./domain-join.sh
+
+sync
+
+./verify-pwsh-authentication.sh
+
+cat << EOF
+
+************************************************************
+Tailing SSH logs
+************************************************************
+
+EOF
+
+touch /var/log/ssh.log
+tail -f /var/log/ssh.log

--- a/spec/fixtures/omiserver/build-omi.sh
+++ b/spec/fixtures/omiserver/build-omi.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+# inspired by https://github.com/microsoft/omi/blob/master/docker/nightly/ubuntu16.04/Dockerfile
+set -e
+
+ORIGINAL_PATH=`pwd`
+
+cat << EOF
+
+************************************************************
+Building OMI server from source...
+************************************************************
+
+EOF
+
+export OMI_VERSION=$(git -C /tmp/omi describe --tags | cut -d - -f 1 | sed 's/^v//')
+
+cat << EOF
+
+************************************************************
+Detected OMI candidate version from git tag: ${OMI_VERSION}
+************************************************************
+
+EOF
+
+export OMI_BUILDVERSION_MAJOR=$(echo $OMI_VERSION | cut -d . -f 1)
+export OMI_BUILDVERSION_MINOR=$(echo $OMI_VERSION | cut -d . -f 2)
+export OMI_BUILDVERSION_PATCH=$(echo $OMI_VERSION | cut -d . -f 3)
+export OMI_BUILDVERSION_BUILDNR=0
+
+cd /tmp/omi/Unix
+# this config switch installs to /opt/omi instead of /opt/omi-version
+# and makes sure config is loaded from /etc/opt/omi, just like packages
+./configure --enable-microsoft --enable-debug
+make -j
+
+cat << EOF
+
+************************************************************
+Overwrite existing /opt/omi with newly built binaries
+************************************************************
+
+EOF
+
+make install
+cd $ORIGINAL_PATH
+
+cat << EOF
+
+************************************************************
+Enabling VERBOSE logging and restarting omi service
+************************************************************
+
+EOF
+
+cat /etc/opt/omi/conf/omiserver.conf \
+ | /opt/omi/bin/omiconfigeditor loglevel --set 'VERBOSE' \
+ | /opt/omi/bin/omiconfigeditor loglevel --uncomment \
+ >/tmp/tmp.conf \
+ && mv -f /tmp/tmp.conf /etc/opt/omi/conf/omiserver.conf
+
+service omid restart

--- a/spec/fixtures/omiserver/docker-entrypoint.sh
+++ b/spec/fixtures/omiserver/docker-entrypoint.sh
@@ -26,9 +26,17 @@ sync
 cat << EOF
 
 ************************************************************
-Tailing OMI Server Logs
+Tailing OMI Server Logs - Extra Logs: ${OMI_EXTRA_LOGS}
 ************************************************************
 
 EOF
 
-tail -f /var/opt/omi/log/omiserver.log
+if [ "$OMI_EXTRA_LOGS" = "true" ]
+then
+  tail -f /var/opt/omi/log/omiserver.log \
+    /var/log/sssd/sssd.log \
+    /var/opt/omi/log/omiserver-recv.trc \
+    /var/opt/omi/log/omiserver-send.trc
+else
+  tail -f /var/opt/omi/log/omiserver.log
+fi

--- a/spec/fixtures/omiserver/sssd.conf.tmpl
+++ b/spec/fixtures/omiserver/sssd.conf.tmpl
@@ -5,10 +5,10 @@ config_file_version = 2
 domains = ${KRB5_REALM}
 
 [nss]
-debug_level = 3
+debug_level = 6
 
 [domain/${KRB5_REALM}]
 id_provider = ad
 access_provider = ad
 fallback_homedir = /home/%u@%d
-debug_level = 3
+debug_level = 6


### PR DESCRIPTION
Builds on top of #999
Blocks #1101 

This adds a development environment useful for testing / debugging *any* problem between the winrm / gssapi gem and OMI server. 

Note that the final commit currently clones source from https://github.com/Iristyle/omi/tree/debugging-winrm-gem-kerberos which has extra debug / trace statements.

There are at least 2 known problems for interop between the winrm gem and OMI server that this should help diagnosing:

* [BOLT-1476](https://tickets.puppetlabs.com/browse/BOLT-1476) Kerberos auth fails somewhere after OMI server authorizes the connection. Then the next payload OMI returns is encrypted, but cannot be decrypted by the winrm gem. It's unclear if the wrong cipher is being used or if there is another problem?

* There are problems running tasks + higher level Bolt constructs against OMI (basic commands generally work)

* OMI server, even against the PowerShell 6 client, seems to close connections unexpectedly

