### PR TITLE
 (BOLT-1492) Note behavior change for get_targets 

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/get_targets.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/get_targets.rb
@@ -3,6 +3,10 @@
 require 'bolt/error'
 
 # Parses common ways of referring to targets and returns an array of Targets.
+#
+# **NOTE:** Calling `get_targets` inside an `apply` block with a
+# version 2 inventory creates a new Target object.
+# `get_targets('all')` returns an empty array.
 Puppet::Functions.create_function(:get_targets) do
   # @param names A pattern or array of patterns identifying a set of targets.
   # @return A list of unique Targets resolved from any target URIs and groups.

--- a/pre-docs/plan_functions.md
+++ b/pre-docs/plan_functions.md
@@ -345,6 +345,10 @@ get_resources('target1,target2', [Package, File[/etc/puppetlabs]])
 
 Parses common ways of referring to targets and returns an array of Targets.
 
+**NOTE:** Calling `get_targets` inside an `apply` block with a
+version 2 inventory creates a new Target object.
+`get_targets('all')` returns an empty array.
+
 
 ```
 get_targets(Boltlib::TargetSpec $names)


### PR DESCRIPTION
Add note that `get_targets` behaves different within apply blocks when
used with version 2 inventory as opposed to version 1. Include docs on
how to convert a plan using the version 2 inventory to version 1
inventory behavior.