### PR TITLE
(BOLT-1433) Load resource types for plan execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,15 @@
 
   When using the interpreters setting on the WinRM transport, a task would fail to execute if the path to the specified interpreter contains a space. Interpreter paths with spaces in the name are now supported.
 
+* **Resource Types were not registered while running plans** ([#1140](https://github.com/puppetlabs/bolt/issues/1140))
+
+  When referencing a resource type in a plan (for example `get_resources($nodes, Package)`) the plan would fail because the `Package` type is not found. Now all built in types and types on the modulepath can be generated with an invocation of `puppetfile generate-types` which will be registered for plan execution.
+  
 #### New features
 
 * **Azure inventory plugin** ([#1148](https://github.com/puppetlabs/bolt/issues/1148))
 
   A new [module based plugin](https://github.com/puppetlabs/puppetlabs-azure_inventory) allows generation of Bolt targets from Azure VMs.
-
 
 ## 1.31.1
 

--- a/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
@@ -8,12 +8,13 @@ describe 'run_plan' do
   include PuppetlabsSpec::Fixtures
   let(:executor) { Bolt::Executor.new }
   let(:tasks_enabled) { true }
+  let(:inventory) { Bolt::Inventory.new({}) }
 
   around(:each) do |example|
     Puppet[:tasks] = tasks_enabled
     executor.stubs(:noop).returns(false)
 
-    Puppet.override(bolt_executor: executor) do
+    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
       example.run
     end
   end

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -54,6 +54,9 @@ module Bolt
         when 'show-modules'
           { flags: OPTIONS[:global] + OPTIONS[:global_config_setters],
             banner: PUPPETFILE_SHOWMODULES_HELP }
+        when 'generate-types'
+          { flags: OPTIONS[:global] + OPTIONS[:global_config_setters],
+            banner: PUPPETFILE_GENERATETYPES_HELP }
         else
           { flags: OPTIONS[:global] + OPTIONS[:global_config_setters],
             banner: PUPPETFILE_HELP }
@@ -229,6 +232,7 @@ module Bolt
       Available actions are:
         install                          Install modules from a Puppetfile into a Boltdir
         show-modules                     List modules available to Bolt
+        generate-types                   Generate type references to register in Plans
 
       Install modules into the local Boltdir
         bolt puppetfile install
@@ -247,6 +251,18 @@ module Bolt
 
     PUPPETFILE_SHOWMODULES_HELP = <<~HELP
       Usage: bolt puppetfile show-modules
+
+      List modules available to Bolt
+        bolt puppetfile show-modules
+
+      Available options are:
+    HELP
+
+    PUPPETFILE_GENERATETYPES_HELP = <<~HELP
+      Usage: bolt puppetfile generate-types
+
+      Generate type references to register in Plans
+        bolt puppetfile generate-types
 
       Available options are:
     HELP

--- a/lib/bolt/boltdir.rb
+++ b/lib/bolt/boltdir.rb
@@ -6,7 +6,8 @@ module Bolt
   class Boltdir
     BOLTDIR_NAME = 'Boltdir'
 
-    attr_reader :path, :config_file, :inventory_file, :modulepath, :hiera_config, :puppetfile, :rerunfile, :type
+    attr_reader :path, :config_file, :inventory_file, :modulepath, :hiera_config,
+                :puppetfile, :rerunfile, :type, :resource_types
 
     def self.default_boltdir
       Boltdir.new(File.join('~', '.puppetlabs', 'bolt'), 'user')
@@ -37,6 +38,7 @@ module Bolt
       @hiera_config = @path + 'hiera.yaml'
       @puppetfile = @path + 'Puppetfile'
       @rerunfile = @path + '.rerun.json'
+      @resource_types = @path + '.resource_types'
       @type = type
     end
 

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -33,7 +33,7 @@ module Bolt
                  'task' => %w[show run],
                  'plan' => %w[show run convert],
                  'file' => %w[upload],
-                 'puppetfile' => %w[install show-modules],
+                 'puppetfile' => %w[install show-modules generate-types],
                  'secret' => %w[encrypt decrypt createkeys],
                  'inventory' => %w[show],
                  'apply' => %w[] }.freeze
@@ -76,7 +76,6 @@ module Bolt
 
     def parse
       parser = BoltOptionParser.new(options)
-
       # This part aims to handle both `bolt <mode> --help` and `bolt help <mode>`.
       remaining = handle_parser_errors { parser.permute(@argv) } unless @argv.empty?
       if @argv.empty? || help?(remaining)
@@ -320,7 +319,11 @@ module Bolt
       when 'plan'
         code = run_plan(options[:object], options[:task_options], options[:target_args], options)
       when 'puppetfile'
-        code = install_puppetfile(@config.puppetfile_config, @config.puppetfile, @config.modulepath)
+        if options[:action] == 'generate-types'
+          code = generate_types
+        elsif options[:action] == 'install'
+          code = install_puppetfile(@config.puppetfile_config, @config.puppetfile, @config.modulepath)
+        end
       when 'secret'
         code = Bolt::Secret.execute(plugins, outputter, options)
       when 'apply'
@@ -474,6 +477,12 @@ module Bolt
       outputter.print_module_list(pal.list_modules)
     end
 
+    def generate_types
+      # generate_types will surface a nice error with helpful message if it fails
+      pal.generate_types
+      0
+    end
+
     def install_puppetfile(config, puppetfile, modulepath)
       require 'r10k/cli'
       require 'bolt/r10k_log_proxy'
@@ -495,6 +504,8 @@ module Bolt
 
         ok = install_action.call
         outputter.print_puppetfile_result(ok, puppetfile, moduledir)
+        # Automatically generate types after installing modules
+        pal.generate_types
 
         ok ? 0 : 1
       else
@@ -505,7 +516,10 @@ module Bolt
     end
 
     def pal
-      @pal ||= Bolt::PAL.new(config.modulepath, config.hiera_config, config.compile_concurrency)
+      @pal ||= Bolt::PAL.new(config.modulepath,
+                             config.hiera_config,
+                             config.boltdir.resource_types,
+                             config.compile_concurrency)
     end
 
     def convert_plan(plan)
@@ -546,7 +560,7 @@ module Bolt
                   'Task' => [],
                   'Plugin' => Bolt::Plugin::BUILTIN_PLUGINS }
       if %w[plan task].include?(options[:subcommand]) && options[:action] == 'run'
-        default_content = Bolt::PAL.new([], nil)
+        default_content = Bolt::PAL.new([], nil, nil)
         content['Plan'] = default_content.list_plans.each_with_object([]) do |iter, col|
           col << iter&.first
         end

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -39,7 +39,7 @@ module Bolt
 
     attr_reader :modulepath
 
-    def initialize(modulepath, hiera_config, max_compiles = Etc.nprocessors)
+    def initialize(modulepath, hiera_config, resource_types, max_compiles = Etc.nprocessors)
       # Nothing works without initialized this global state. Reinitializing
       # is safe and in practice only happens in tests
       self.class.load_puppet
@@ -48,6 +48,7 @@ module Bolt
       @modulepath = [BOLTLIB_PATH, *modulepath, MODULES_PATH]
       @hiera_config = hiera_config
       @max_compiles = max_compiles
+      @resource_types = resource_types
 
       @logger = Logging.logger[self]
       if modulepath && !modulepath.empty?
@@ -110,6 +111,21 @@ module Bolt
       compiler.evaluate_string('type PlanResult = Boltlib::PlanResult')
     end
 
+    # Register all resource types defined in $Boltdir/.resource_types as well as
+    # the built in types registered with the runtime_3_init method.
+    def register_resource_types(loaders)
+      static_loader = loaders.static_loader
+      static_loader.runtime_3_init
+      if File.directory?(@resource_types)
+        Dir.children(@resource_types).each do |resource_pp|
+          type_name_from_file = File.basename(resource_pp, '.pp').capitalize
+          typed_name = Puppet::Pops::Loader::TypedName.new(:type, type_name_from_file)
+          resource_type = Puppet::Pops::Types::TypeFactory.resource(type_name_from_file)
+          loaders.static_loader.set_entry(typed_name, resource_type)
+        end
+      end
+    end
+
     # Runs a block in a PAL script compiler configured for Bolt.  Catches
     # exceptions thrown by the block and re-raises them ensuring they are
     # Bolt::Errors since the script compiler block will squash all exceptions.
@@ -119,6 +135,7 @@ module Bolt
       r = Puppet::Pal.in_tmp_environment('bolt', modulepath: @modulepath, facts: {}) do |pal|
         pal.with_script_compiler do |compiler|
           alias_types(compiler)
+          register_resource_types(Puppet.lookup(:loaders)) if @resource_types
           begin
             Puppet.override(yaml_plan_instantiator: Bolt::PAL::YamlPlan::Loader) do
               yield compiler
@@ -348,6 +365,16 @@ module Bolt
 
           [path, values]
         end.to_h
+      end
+    end
+
+    def generate_types
+      require 'puppet/face/generate'
+      in_bolt_compiler do
+        generator = Puppet::Generate::Type
+        inputs = generator.find_inputs(:pcore)
+        FileUtils.mkdir_p(@resource_types)
+        generator.generate(inputs, @resource_types, true)
       end
     end
 

--- a/lib/bolt_spec/plans.rb
+++ b/lib/bolt_spec/plans.rb
@@ -172,7 +172,7 @@ module BoltSpec
     end
 
     def run_plan(name, params)
-      pal = Bolt::PAL.new(config.modulepath, config.hiera_config)
+      pal = Bolt::PAL.new(config.modulepath, config.hiera_config, config.boltdir.resource_types)
       result = pal.run_plan(name, params, executor, inventory, puppetdb_client)
 
       if executor.error_message

--- a/lib/bolt_spec/run.rb
+++ b/lib/bolt_spec/run.rb
@@ -152,7 +152,10 @@ module BoltSpec
       end
 
       def pal
-        @pal ||= Bolt::PAL.new(config.modulepath, config.hiera_config, config.compile_concurrency)
+        @pal ||= Bolt::PAL.new(config.modulepath,
+                               config.hiera_config,
+                               config.boltdir.resource_types,
+                               config.compile_concurrency)
       end
 
       def resolve_targets(target_spec)

--- a/lib/plan_executor/app.rb
+++ b/lib/plan_executor/app.rb
@@ -39,7 +39,7 @@ module PlanExecutor
       # functional will be making changes to Puppet that remove the need for
       # global Puppet state.
       # https://github.com/puppetlabs/bolt/blob/master/lib/bolt/pal.rb#L166
-      @pal = Bolt::PAL.new(config['modulepath'], nil)
+      @pal = Bolt::PAL.new(config['modulepath'], nil, nil)
 
       @schema = JSON.parse(File.read(File.join(__dir__, 'schemas', 'run_plan.json')))
       @worker = Concurrent::SingleThreadExecutor.new

--- a/pre-docs/bolt_command_reference.md
+++ b/pre-docs/bolt_command_reference.md
@@ -328,6 +328,22 @@ List modules available to Bolt.
 | `--boltdir FILEPATH` | Specify what Boltdir to load config from. | Autodiscovered from current working directory. |
 | `--configfile FILEPATH` | Specify where to load config from. | `~/.puppetlabs/bolt/bolt.yaml` |
 
+## `puppetfile generate-types`
+
+Generate type references to register in Plans
+
+### Usage
+
+`bolt puppetfile generate-types`
+
+### Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| **Run Context** |
+| `-m`, `--modulepath FILEPATHS` | List of directories containing modules, separated by `:`. <br> Directories are case-sensitive. |
+| `--boltdir FILEPATH` | Specify what Boltdir to load config from. | Autodiscovered from current working directory. |
+| `--configfile FILEPATH` | Specify where to load config from. | `~/.puppetlabs/bolt/bolt.yaml` |
 
 ## `script run`
 

--- a/pre-docs/plan_functions.md
+++ b/pre-docs/plan_functions.md
@@ -324,19 +324,22 @@ Query the state of resources on a list of targets using resource definitions in 
 The results are returned as a list of hashes representing each resource.
 
 Requires the Puppet Agent be installed on the target, which can be accomplished with apply_prep
-or by directly running the puppet_agent::install task.
+or by directly running the puppet_agent::install task. In order to be able to reference types without
+string quoting (for example `get_resources($target, Package)` instead of `get_resources($target, 'Package')`)
+run the command `bolt puppetfile generate-types` to generate type references in `$Boldir/.resource_types`.
+
 
 **NOTE:** Not available in apply block
 
 
 ```
-get_resources(Boltlib::TargetSpec $targets, Variant[String, Resource, Array[Variant[String, Resource]]] $resources)
+get_resources(Boltlib::TargetSpec $targets, Variant[String, Type[Resource], Array[Variant[String, Type[Resource]]]] $resources)
 ```
 
 *Returns:* `Any` 
 
 * **targets** `Boltlib::TargetSpec` A pattern or array of patterns identifying a set of targets.
-* **resources** `Variant[String, Resource, Array[Variant[String, Resource]]]` A resource type or instance, or an array of such.
+* **resources** `Variant[String, Type[Resource], Array[Variant[String, Type[Resource]]]]` A resource type or instance, or an array of such.
 
 **Example:** Collect resource states for packages and a file
 ```

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -59,6 +59,7 @@ describe "Bolt::CLI" do
     let(:boltdir) { Bolt::Boltdir.new('.') }
     before(:each) do
       allow(Bolt::Boltdir).to receive(:find_boltdir).and_return(boltdir)
+      allow_any_instance_of(Bolt::Boltdir).to receive(:resource_types)
       allow(Bolt::Util).to receive(:read_config_file).and_return({})
     end
 
@@ -1911,13 +1912,13 @@ describe "Bolt::CLI" do
       let(:puppetfile) { Pathname.new('path/to/puppetfile') }
       let(:modulepath) { [Pathname.new('path/to/modules')] }
       let(:action_stub) { double('r10k_action_puppetfile_install') }
+
       let(:cli) { Bolt::CLI.new({}) }
 
       before :each do
         allow(cli).to receive(:outputter).and_return(Bolt::Outputter::JSON.new(false, false, false, output))
         allow(puppetfile).to receive(:exist?).and_return(true)
-
-        # Ensure we never actually install modules.
+        allow_any_instance_of(Bolt::PAL).to receive(:generate_types)
         allow(R10K::Action::Puppetfile::Install).to receive(:new).and_return(action_stub)
       end
 

--- a/spec/bolt/pal/yaml_plan/evaluator_spec.rb
+++ b/spec/bolt/pal/yaml_plan/evaluator_spec.rb
@@ -6,7 +6,7 @@ require 'bolt/pal/yaml_plan/evaluator'
 
 describe Bolt::PAL::YamlPlan::Evaluator do
   let(:plan_name) { Puppet::Pops::Loader::TypedName.new(:plan, 'test') }
-  let(:pal) { Bolt::PAL.new([], nil) }
+  let(:pal) { Bolt::PAL.new([], nil, nil) }
   # It doesn't really matter which loader or scope we use, but we need them, so take the
   # static loader and global scope
   let(:loader) { Puppet.lookup(:loaders).static_loader }

--- a/spec/bolt/pal/yaml_plan/loader_spec.rb
+++ b/spec/bolt/pal/yaml_plan/loader_spec.rb
@@ -6,7 +6,7 @@ require 'bolt/pal/yaml_plan/loader'
 
 describe Bolt::PAL::YamlPlan::Loader do
   let(:plan_name) { Puppet::Pops::Loader::TypedName.new(:plan, 'test') }
-  let(:pal) { Bolt::PAL.new([], nil) }
+  let(:pal) { Bolt::PAL.new([], nil, nil) }
   # It doesn't really matter which loader or scope we use, but we need them, so take the
   # static loader and global scope
   let(:loader) { Puppet.lookup(:loaders).static_loader }

--- a/spec/bolt/pal/yaml_plan_spec.rb
+++ b/spec/bolt/pal/yaml_plan_spec.rb
@@ -6,7 +6,7 @@ require 'bolt/pal/yaml_plan'
 
 describe Bolt::PAL::YamlPlan do
   let(:plan_name) { Puppet::Pops::Loader::TypedName.new(:plan, 'test') }
-  let(:pal) { Bolt::PAL.new([], nil) }
+  let(:pal) { Bolt::PAL.new([], nil, nil) }
   # It doesn't really matter which loader or scope we use, but we need them, so take the
   # static loader and global scope
   let(:loader) { Puppet.lookup(:loaders).static_loader }

--- a/spec/bolt/pal_spec.rb
+++ b/spec/bolt/pal_spec.rb
@@ -13,7 +13,7 @@ describe Bolt::PAL do
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
   describe :parse_manifest do
-    let(:pal) { Bolt::PAL.new(nil, nil) }
+    let(:pal) { Bolt::PAL.new(nil, nil, nil) }
 
     it "should parse a manifest string" do
       ast = pal.parse_manifest('notify { "hello world": }', 'test.pp')

--- a/spec/bolt/plugin/module_spec.rb
+++ b/spec/bolt/plugin/module_spec.rb
@@ -14,7 +14,7 @@ describe Bolt::Plugin::Module do
   let(:plugin_config) { {} }
   let(:config_data) { { 'modulepath' => modulepath, 'plugins' => plugin_config } }
 
-  let(:pal) { Bolt::PAL.new(modulepath, {}) }
+  let(:pal) { Bolt::PAL.new(modulepath, {}, nil) }
   let(:plugins) { Bolt::Plugin.new(config(config_data), pal, Bolt::Analytics::NoopClient.new) }
 
   let(:module_name) { 'empty_plug' }

--- a/spec/bolt/plugin_spec.rb
+++ b/spec/bolt/plugin_spec.rb
@@ -15,7 +15,7 @@ describe Bolt::Plugin::Module do
   let(:modulepath) { [fixtures_path('plugin_modules')] }
   let(:plugin_config) { {} }
   let(:config_data) { { 'modulepath' => modulepath, 'plugins' => plugin_config } }
-  let(:pal) { Bolt::PAL.new(modulepath, nil) }
+  let(:pal) { Bolt::PAL.new(modulepath, nil, nil) }
 
   let(:plugins) { Bolt::Plugin.new(config(config_data), pal, Bolt::Analytics::NoopClient.new) }
 

--- a/spec/fixtures/modules/resource_types/lib/puppet/provider/my_type/my_type.rb
+++ b/spec/fixtures/modules/resource_types/lib/puppet/provider/my_type/my_type.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Puppet::Type.type(:my_type).provide(:ruby) do
+  desc "Empty provider"
+
+  def self.instances
+    []
+  end
+end

--- a/spec/fixtures/modules/resource_types/lib/puppet/type/my_type.rb
+++ b/spec/fixtures/modules/resource_types/lib/puppet/type/my_type.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Puppet::Type.newtype(:my_type) do
+  @doc = "Empty type"
+end

--- a/spec/fixtures/modules/resource_types/plans/init.pp
+++ b/spec/fixtures/modules/resource_types/plans/init.pp
@@ -1,0 +1,12 @@
+plan resource_types(TargetSpec $nodes){
+  # Reference built-in type
+  $package = get_resources($nodes, User).to_data[0]['status']
+  # Reference core type 
+  $cron = get_resources($nodes, Cron).to_data[0]['status']
+  # Reference custom type
+  $mytype = get_resources($nodes, My_type).to_data[0]['status']
+
+  $result = { 'built-in' => $package, 'core' => $cron, 'custom' => $mytype }
+
+  return $result
+}

--- a/spec/integration/puppetfile_spec.rb
+++ b/spec/integration/puppetfile_spec.rb
@@ -54,6 +54,7 @@ describe "installing puppetfiles" do
     expect(result['success']).to eq(true)
     expect(result['puppetfile']).to eq(File.join(boltdir, 'Puppetfile'))
     expect(result['moduledir']).to eq(File.join(boltdir, 'modules'))
+    expect(Dir.exist?(File.join(boltdir, '.resource_types')))
 
     result = JSON.parse(run_cli(%W[task show --boltdir #{boltdir}]))
     installed_tasks = Set.new(result['tasks'].map(&:first))
@@ -61,7 +62,6 @@ describe "installing puppetfiles" do
 
     result = JSON.parse(run_cli(%W[plan show --boltdir #{boltdir}]))
     installed_plans = Set.new(result['plans'].map(&:first))
-
     expect(installed_plans).to be_superset(Set.new(%w[foo::c foo::d bar::g bar::h]))
   end
 end

--- a/spec/lib/bolt_spec/integration.rb
+++ b/spec/lib/bolt_spec/integration.rb
@@ -12,7 +12,6 @@ module BoltSpec
 
       # prevent tests from reading users config
       allow(Bolt::Boltdir).to receive(:find_boltdir).and_return(Bolt::Boltdir.new(Dir.mktmpdir))
-
       allow(cli).to receive(:puppetdb_client).and_return(pdb_client)
 
       output =  StringIO.new

--- a/spec/lib/bolt_spec/pal.rb
+++ b/spec/lib/bolt_spec/pal.rb
@@ -39,7 +39,7 @@ module BoltSpec
     def pal_with_module_content(mods)
       Dir.mktmpdir do |tmpdir|
         mk_files(tmpdir, mods)
-        pal = Bolt::PAL.new(tmpdir, nil)
+        pal = Bolt::PAL.new(tmpdir, nil, nil)
         yield pal
       end
     end

--- a/spec/pal/apply_result_spec.rb
+++ b/spec/pal/apply_result_spec.rb
@@ -13,7 +13,7 @@ describe 'ApplyResult DataType' do
   before(:all) { Bolt::PAL.load_puppet }
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
-  let(:pal) { Bolt::PAL.new(modulepath, nil) }
+  let(:pal) { Bolt::PAL.new(modulepath, nil, nil) }
   let(:result_code) do
     <<-PUPPET
 $result = results::make_apply_result('pcp://example.com', {'report' => {}})

--- a/spec/pal/facts_spec.rb
+++ b/spec/pal/facts_spec.rb
@@ -22,7 +22,7 @@ describe 'Facts functions' do
     }
   }
   let(:inv) { Bolt::Inventory.new(data) }
-  let(:pal) { Bolt::PAL.new(modulepath, nil) }
+  let(:pal) { Bolt::PAL.new(modulepath, nil, nil) }
 
   let(:analytics) { Bolt::Analytics::NoopClient.new }
   let(:executor) { Bolt::Executor.new(1, analytics) }

--- a/spec/pal/features_spec.rb
+++ b/spec/pal/features_spec.rb
@@ -23,7 +23,7 @@ describe 'set_features function' do
     }
   }
   let(:inventory) { Bolt::Inventory.new(data) }
-  let(:pal) { Bolt::PAL.new(modulepath, nil) }
+  let(:pal) { Bolt::PAL.new(modulepath, nil, nil) }
   let(:target) { inventory.get_targets('example')[0] }
 
   it 'adds the feature to the target' do

--- a/spec/pal/result_set_spec.rb
+++ b/spec/pal/result_set_spec.rb
@@ -13,7 +13,7 @@ describe 'ResultSet DataType' do
   before(:all) { Bolt::PAL.load_puppet }
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
-  let(:pal) { Bolt::PAL.new(modulepath, nil) }
+  let(:pal) { Bolt::PAL.new(modulepath, nil, nil) }
   let(:result_code) do
     <<-PUPPET
 $result_set = results::make_result_set( {

--- a/spec/pal/result_spec.rb
+++ b/spec/pal/result_spec.rb
@@ -13,7 +13,7 @@ describe 'Result DataType' do
   before(:all) { Bolt::PAL.load_puppet }
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
-  let(:pal) { Bolt::PAL.new(modulepath, nil) }
+  let(:pal) { Bolt::PAL.new(modulepath, nil, nil) }
   let(:result_code) do
     <<-PUPPET
 $result = results::make_result('pcp://example.com', {'key' => 'value'})

--- a/spec/pal/target_spec.rb
+++ b/spec/pal/target_spec.rb
@@ -13,7 +13,7 @@ describe 'Target DataType' do
   before(:all) { Bolt::PAL.load_puppet }
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
-  let(:pal) { Bolt::PAL.new(modulepath, nil) }
+  let(:pal) { Bolt::PAL.new(modulepath, nil, nil) }
 
   let(:target_code) { "$target = Target('pcp://user1:pass1@example.com:33')\n" }
 

--- a/spec/pal/vars_spec.rb
+++ b/spec/pal/vars_spec.rb
@@ -20,7 +20,7 @@ describe 'Vars function' do
     }
   }
   let(:inventory) { Bolt::Inventory.new(data) }
-  let(:pal) { Bolt::PAL.new(modulepath, nil) }
+  let(:pal) { Bolt::PAL.new(modulepath, nil, nil) }
 
   let(:analytics) { Bolt::Analytics::NoopClient.new }
   let(:executor) { Bolt::Executor.new(1, analytics) }


### PR DESCRIPTION
With this commit resource types are loaded when a plan is run. This allows resource types to be referenced without running in to `Evaluation Error: Resource type not found...` for use with plan functions such as `get_resources`.