### PR TITLE
(BOLT-1492) Fix error in get_targets with inventory v2 in apply

### DIFF
--- a/lib/bolt/inventory/inventory2.rb
+++ b/lib/bolt/inventory/inventory2.rb
@@ -111,7 +111,7 @@ module Bolt
             target_facts: {},
             target_features: {}
           },
-          config: { transports: {} }
+          config: @config.transport_data_get
         }
       end
 

--- a/spec/fixtures/apply/basic/plans/inventory_2_lookup.pp
+++ b/spec/fixtures/apply/basic/plans/inventory_2_lookup.pp
@@ -1,0 +1,11 @@
+plan basic::inventory_2_lookup(TargetSpec $nodes) {
+  # TODO: Provide inventory data to bolt_catalog to support get_targets in apply
+  return apply($nodes) {
+    # get_targets should return empty list for 'all'
+    $t_all = get_targets('all')
+    notify { "Num Targets: ${$t_all.length}": }
+    # get_targets should return a new target object for any other value
+    $t_foo = get_targets('foo')
+    notify { "Target Name: ${$t_foo[0].name}": }
+  }
+}

--- a/spec/fixtures/apply/inventory_2.yaml
+++ b/spec/fixtures/apply/inventory_2.yaml
@@ -1,0 +1,3 @@
+version: 2
+targets:
+  - uri: foo@example.com

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -280,5 +280,22 @@ describe "passes parsed AST to the apply_catalog task" do
         end
       end
     end
+
+    context 'with version 2 inventoryfile stubbed' do
+      let(:inventory) {
+        {
+          'inventoryfile' => File.join(__dir__, '../fixtures/apply/inventory_2.yaml').to_s
+        }
+      }
+
+      it 'targets in inventory can be queried' do
+        with_tempfile_containing('conf', YAML.dump(inventory)) do |conf|
+          result = run_cli_json(%W[plan run basic::inventory_2_lookup --configfile #{conf.path}] + config_flags)
+          notify = get_notifies(result)
+          expect(notify[0]['title']).to eq("Num Targets: 0")
+          expect(notify[1]['title']).to eq("Target Name: foo")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Until get_targets is supported for inventory v2 in apply blocks empty data should be passed to bolt_catalog. There is still the expectation that config data (namely transport information) is passed along in order for a net new target to be returned when get_targets is used within an apply block with inventory v2. This commit sends along the expected serialized config data while still excluding any existing target information in the inventory.