### PR TITLE
(BOLT-1412) Only process task_options for tasks/plans

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -88,19 +88,21 @@ module Bolt
 
       options[:object] = remaining.shift
 
-      task_options, remaining = remaining.partition { |s| s =~ /.+=/ }
-      if options[:task_options]
-        unless task_options.empty?
-          raise Bolt::CLIError,
-                "Parameters must be specified through either the --params " \
-                "option or param=value pairs, not both"
+      # Only parse task_options for task or plan
+      if %w[task plan].include?(options[:subcommand])
+        task_options, remaining = remaining.partition { |s| s =~ /.+=/ }
+        if options[:task_options]
+          unless task_options.empty?
+            raise Bolt::CLIError,
+                  "Parameters must be specified through either the --params " \
+                  "option or param=value pairs, not both"
+          end
+          options[:params_parsed] = true
+        else
+          options[:params_parsed] = false
+          options[:task_options] = Hash[task_options.map { |a| a.split('=', 2) }]
         end
-        options[:params_parsed] = true
-      else
-        options[:params_parsed] = false
-        options[:task_options] = Hash[task_options.map { |a| a.split('=', 2) }]
       end
-
       options[:leftovers] = remaining
 
       validate(options)

--- a/spec/integration/parsing_spec.rb
+++ b/spec/integration/parsing_spec.rb
@@ -9,6 +9,7 @@ describe "CLI parses input" do
   include BoltSpec::Conn
 
   let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
+  let(:script_path) { File.join(__dir__, '../fixtures/scripts/success.sh') }
   let(:config_flags) {
     %W[--format json
        --modulepath #{modulepath}
@@ -91,5 +92,11 @@ describe "CLI parses input" do
     ]
     result = run_cli_json(['task', 'run', 'parsing', '--nodes', target] + params + config_flags, rescue_exec: true)
     expect(result['_error']['msg']).to eq("Task parsing:\n parameter 'array' expects an Array value, got String")
+  end
+
+  it 'parses script parameters without munging task parameters', ssh: true do
+    params = ['dont=split']
+    result = run_one_node(['script', 'run', script_path, '--nodes', target] + params + config_flags)
+    expect(result['stdout']).to match(/dont=split/)
   end
 end


### PR DESCRIPTION
When running a script there could be positional script arguments that contain `=` characters. Previously, regardless of the subcommand the cli parser would try to extract task_options by splitting arguments on the `=` character. This commit updates the parser to only attepmt to built a task_options hash if a task or plan is being run.