### PR TITLE
(BOLT-1501) Change AWS plugin config field

### DIFF
--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -31,7 +31,7 @@ module Bolt
   end
 
   class Config
-    attr_accessor :aws, :concurrency, :format, :trace, :log, :puppetdb, :color, :save_rerun,
+    attr_accessor :concurrency, :format, :trace, :log, :puppetdb, :color, :save_rerun,
                   :transport, :transports, :inventoryfile, :compile_concurrency, :boltdir,
                   :puppetfile_config, :plugins
     attr_writer :modulepath
@@ -162,7 +162,7 @@ module Bolt
       # Plugins are only settable from config not inventory so we can overwrite
       @plugins = data['plugins'] if data.key?('plugins')
 
-      %w[aws concurrency format puppetdb color transport].each do |key|
+      %w[concurrency format puppetdb color transport].each do |key|
         send("#{key}=", data[key]) if data.key?(key)
       end
 

--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -37,7 +37,7 @@ module Bolt
       plugins.add_plugin(Bolt::Plugin::Prompt.new)
       plugins.add_plugin(Bolt::Plugin::Pkcs7.new(config.boltdir.path, config.plugins['pkcs7'] || {}))
       plugins.add_plugin(Bolt::Plugin::Task.new(config))
-      plugins.add_plugin(Bolt::Plugin::Aws::EC2.new(config))
+      plugins.add_plugin(Bolt::Plugin::Aws::EC2.new(config.plugins['aws'] || {}))
       plugins
     end
 

--- a/lib/bolt/plugin/aws.rb
+++ b/lib/bolt/plugin/aws.rb
@@ -34,12 +34,12 @@ module Bolt
           if opts.key?('profile')
             options[:profile] = opts['profile']
           end
-          if config.aws&.key?('credentials')
-            creds = File.expand_path(config.aws['credentials'])
+          if config['credentials']
+            creds = File.expand_path(config['credentials'])
             if File.exist?(creds)
               options[:credentials] = ::Aws::SharedCredentials.new(path: creds)
             else
-              raise Bolt::ValidationError, "Cannot load credentials file #{config.aws['credentials']}"
+              raise Bolt::ValidationError, "Cannot load credentials file #{config['credentials']}"
             end
           end
 

--- a/pre-docs/inventory_version2.md
+++ b/pre-docs/inventory_version2.md
@@ -422,8 +422,9 @@ region=...
 AWS credential files stored in a non-standard location (`~/.aws/credentials`) can be specified in the Bolt config file:
 
 ```
-aws:
-  credentials: ~/alternate_path/credentials
+plugins:
+  aws:
+    credentials: ~/alternate_path/credentials
 ```
 
 #### Prompt plugin

--- a/spec/bolt/plugin/aws_spec.rb
+++ b/spec/bolt/plugin/aws_spec.rb
@@ -81,10 +81,10 @@ describe Bolt::Plugin::Aws::EC2 do
   end
 
   it 'raises a validation error when credentials file path does not exist' do
-    config_data = { 'aws' => { 'credentials' => '~/foo/credentials' } }
+    config_data = { 'plugins' => { 'aws' => { 'credentials' => '~/foo/credentials' } } }
     boltdir = Bolt::Boltdir.new(File.join(Dir.tmpdir, rand(1000).to_s))
     config = Bolt::Config.new(boltdir, config_data)
-    plugin = Bolt::Plugin::Aws::EC2.new(config)
+    plugin = Bolt::Plugin::Aws::EC2.new(config.plugins['aws'])
     expect { plugin.config_client(opts) }.to raise_error(Bolt::ValidationError, %r{foo/credentials})
   end
 end


### PR DESCRIPTION
This updates the location of AWS plugin configuration in the config
file. Previously, configuration settings were under the 'aws' field.
These settings should instead be under the 'plugins' field, similar to the
Prompt plugin.

**Current Config**
```
aws:
   credentials: /path/to/creds
```

**Updated Config**
```
plugins:
   aws:
      credentials: /path/to/creds
```