### PR TITLE
(BOLT-1424) Add Vault plugin

### DIFF
--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -6,6 +6,7 @@ require 'bolt/plugin/pkcs7'
 require 'bolt/plugin/prompt'
 require 'bolt/plugin/task'
 require 'bolt/plugin/aws'
+require 'bolt/plugin/vault'
 
 module Bolt
   class Plugin
@@ -38,6 +39,7 @@ module Bolt
       plugins.add_plugin(Bolt::Plugin::Pkcs7.new(config.boltdir.path, config.plugins['pkcs7'] || {}))
       plugins.add_plugin(Bolt::Plugin::Task.new(config))
       plugins.add_plugin(Bolt::Plugin::Aws::EC2.new(config.plugins['aws'] || {}))
+      plugins.add_plugin(Bolt::Plugin::Vault.new(config.plugins['vault'] || {}))
       plugins
     end
 

--- a/lib/bolt/plugin/vault.rb
+++ b/lib/bolt/plugin/vault.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+module Bolt
+  class Plugin
+    class Vault
+      class VaultHTTPError < Bolt::Error
+        def initialize(response)
+          err = JSON.parse(response.body)['errors']
+          m = String.new("#{response.code} \"#{response.msg}\"")
+          m << ": #{err.join(';')}" unless err.nil?
+          super(m, 'bolt.plugin/vault-http-error')
+        end
+      end
+
+      attr_reader :config
+
+      # All requests for secrets must have a token in the request header
+      TOKEN_HEADER = "X-Vault-Token"
+
+      # Default header for all requests, including auth methods
+      DEFAULT_HEADER = {
+        "Content-Type" => "application/json",
+        "Accept" => "application/json"
+      }.freeze
+
+      # Make sure no unexpected keys are in the config
+      def validate_config(config)
+        known_keys = %w[server_url auth]
+
+        config.each do |key, _v|
+          next if known_keys.include?(key)
+          raise Bolt::ValidationError, "Unexpected key in Vault plugin config: #{key}"
+        end
+      end
+
+      # Make sure no unexpected keys are in the inventory config and
+      # that required keys are present
+      def validate_options(opts)
+        known_keys = %w[_plugin server_url auth path field version]
+        required_keys = %w[path]
+
+        opts.each do |key, _v|
+          next if known_keys.include?(key)
+          raise Bolt::ValidationError, "Unpexpected key in inventory config: #{key}"
+        end
+
+        required_keys.each do |key|
+          next if opts[key]
+          raise Bolt::ValidationError, "Expected key in inventory config: #{key}"
+        end
+      end
+
+      def name
+        'vault'
+      end
+
+      def hooks
+        ['inventory_config']
+      end
+
+      def initialize(config)
+        validate_config(config)
+        @config = config
+        @logger = Logging.logger[self]
+      end
+
+      def inventory_config(opts)
+        validate_options(opts)
+
+        header = {
+          TOKEN_HEADER => token(opts)
+        }
+
+        response = request(:Get, uri(opts), nil, header)
+
+        parse_response(response, opts)
+      end
+
+      # Request uri - built up from Vault server url and secrets path
+      def uri(opts, path = nil)
+        url = opts['server_url'] || config['server_url'] || ENV['VAULT_ADDR']
+
+        # Handle the different versions of the API
+        if opts['version'] == 2
+          opts['path'] = opts['path'].split('/').insert(1, 'data').join('/')
+        end
+
+        path ||= opts['path']
+
+        URI.parse(File.join(url, "v1", path))
+      end
+
+      # Auth token to vault server
+      def token(opts)
+        if (auth = opts['auth'] || config['auth'])
+          request_token(auth, opts)
+        else
+          ENV['VAULT_TOKEN']
+        end
+      end
+
+      def request(verb, uri, data, header = {})
+        # Add on any header options
+        header = DEFAULT_HEADER.merge(header)
+
+        # Create the HTTP request
+        http = Net::HTTP.new(uri.host, uri.port)
+        request = Net::HTTP.const_get(verb).new(uri.request_uri, header)
+
+        # Attach any data
+        request.body = data if data
+
+        # Send the request
+        begin
+          response = http.request(request)
+        rescue StandardError => e
+          raise Bolt::Error.new(
+            "Failed to connect to #{uri}: #{e.message}",
+            'CONNECT_ERROR'
+          )
+        end
+
+        case response
+        when Net::HTTPOK
+          JSON.parse(response.body)
+        else
+          raise VaultHTTPError, response
+        end
+      end
+
+      def parse_response(response, opts)
+        data = case opts['version']
+               when 2
+                 response['data']['data']
+               else
+                 response['data']
+               end
+
+        if opts['field']
+          unless data[opts['field']]
+            raise Bolt::ValidationError, "Unknown secrets field: #{opts['field']}"
+          end
+          data[opts['field']]
+        else
+          data
+        end
+      end
+
+      # Request a token from Vault using one of the auth methods
+      def request_token(auth, opts)
+        case auth['method']
+        when 'token'
+          auth_token(auth)
+        when 'userpass'
+          auth_userpass(auth, opts)
+        else
+          raise Bolt::ValidationError, "Unknown auth method: #{auth['method']}"
+        end
+      end
+
+      def validate_auth(auth, required_keys)
+        required_keys.each do |key|
+          next if auth[key]
+          raise Bolt::ValidationError, "Expected key in #{auth['method']} auth method: #{key}"
+        end
+      end
+
+      # Authenticate with Vault using the 'Token' auth method
+      def auth_token(auth)
+        validate_auth(auth, %w[token])
+        auth['token']
+      end
+
+      # Authenticate with Vault using the 'Userpass' auth method
+      def auth_userpass(auth, opts)
+        validate_auth(auth, %w[user pass])
+        path = "auth/userpass/login/#{auth['user']}"
+        uri = uri(opts, path)
+        data = { "password" => auth['pass'] }.to_json
+
+        request(:Post, uri, data)['auth']['client_token']
+      end
+    end
+  end
+end

--- a/pre-docs/inventory_version2.md
+++ b/pre-docs/inventory_version2.md
@@ -541,6 +541,82 @@ plugins:
 * `private-key`: The path to the private key file. default: `keys/private_key.pkcs7.pem`
 * `public-key`: The path to the public key file. default: `keys/public_key.pkcs7.pem`
 
+#### Vault plugin
+
+
+This plugin allows config values to be set by accessing secrets from a Key/Value engine on a Vault server. It supports several fields:
+
+- `_plugin`: The value of `_plugin` must be `vault`
+- `server_url`: The URL of the Vault server (optional, defaults to `ENV['VAULT_ADDR']`)
+- `auth`: The method for authorizing with the Vault server and any necessary parameters (optional, defaults to `ENV['VAULT_TOKEN']`)
+- `path`: The path to the secrets engine (required)
+- `field`: The specific secret being used (optional, defaults to a Ruby hash of all secrets at the `path`)
+- `version`: The version of the K/V engine (optional, defaults to 1)
+
+
+**Authentication Methods**
+
+Vault requires a token to assign an identity and set of policies to a user before accessing secrets. The Vault plugin offers 2 authentication methods:
+
+
+`token`
+
+Authenticate using a token. This method requires the following fields:
+
+- `method`: The value of `method` must be `token`
+- `token`: The token to authenticate with
+
+
+`userpass`
+
+Request a token by logging into the Vault server with a username and password. This method requires the following fields:
+
+- `method`: The value of `method` must be `userpass`
+- `user`: The username
+- `pass`: The password
+
+
+You can add any Vault plugin field to the inventory configuration. The following example shows how you would access the `private-key` secret on a KVv2 engine mounted at `secrets/bolt`:
+
+
+```
+---
+version: 2
+targets:
+  - ...
+config:
+  ssh:
+    user: root
+    private-key:
+      key-data:
+        _plugin: vault
+        server_url: http://127.0.0.1:8200
+        auth:
+          method: userpass
+          user: bolt
+          pass: bolt
+        path: secrets/bolt
+        field: private-key
+        version: 2
+```
+
+
+You can also set configuration in the config file (typically `bolt.yaml`) under the `plugins` field. If a field is set in both the inventory file and the config file, Bolt will use the value set in the inventory file. The available fields for the config file are:
+
+- `server_url`
+- `auth`
+
+
+```
+---
+plugins:
+  vault:
+    server_url: http://127.0.0.1:8200
+    auth:
+      method: token
+      token: xxxxx-xxxxx
+```
+
 ## Inventory config
 
 You can only set transport configuration in the inventory file. This means using a top level `transport` value to assign a transport to the target and all values in the section named for the transport (`ssh`, `winrm`, `remote`, etc.). You can set config on targets or groups in the inventory file. Bolt performs a depth first search of targets, followed by a search of groups, and uses the first value it finds. Nested hashes are merged.

--- a/pre-docs/inventory_version2.md
+++ b/pre-docs/inventory_version2.md
@@ -552,6 +552,7 @@ This plugin allows config values to be set by accessing secrets from a Key/Value
 - `path`: The path to the secrets engine (required)
 - `field`: The specific secret being used (optional, defaults to a Ruby hash of all secrets at the `path`)
 - `version`: The version of the K/V engine (optional, defaults to 1)
+- `cacert`: Path to the CA certificate (required when using `https`, defaults to `ENV['VAULT_CACERT']`)
 
 
 **Authentication Methods**
@@ -604,6 +605,7 @@ config:
 You can also set configuration in the config file (typically `bolt.yaml`) under the `plugins` field. If a field is set in both the inventory file and the config file, Bolt will use the value set in the inventory file. The available fields for the config file are:
 
 - `server_url`
+- `cacert`
 - `auth`
 
 
@@ -611,7 +613,8 @@ You can also set configuration in the config file (typically `bolt.yaml`) under 
 ---
 plugins:
   vault:
-    server_url: http://127.0.0.1:8200
+    server_url: https://127.0.0.1:8200
+    cacert: /path/to/cert
     auth:
       method: token
       token: xxxxx-xxxxx

--- a/spec/bolt/plugin/vault_spec.rb
+++ b/spec/bolt/plugin/vault_spec.rb
@@ -41,6 +41,12 @@ describe Bolt::Plugin::Vault do
     expect(plugin.hooks).to eq(['inventory_config'])
   end
 
+  it 'errors when missing cacert and using https' do
+    config['server_url'] = 'https://127.0.0.1:8200'
+    uri = plugin.uri(options)
+    expect { plugin.client(uri, options) }.to raise_error(Bolt::ValidationError, /https/)
+  end
+
   context 'when validating keys' do
     it 'errors with invalid config keys' do
       config['foo'] = 'bar'

--- a/spec/bolt/plugin/vault_spec.rb
+++ b/spec/bolt/plugin/vault_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/plugin/vault'
+
+describe Bolt::Plugin::Vault do
+  let(:server_url) { 'http://127.0.0.1:8200' }
+  let(:path) { 'foo/bar' }
+  let(:field) { 'foo' }
+  let(:secret) { 'bar' }
+
+  let(:config) do
+    {
+      'server_url' => server_url,
+      'auth' => {
+        'method' => 'token',
+        'token' => 'secret'
+      }
+    }
+  end
+
+  let(:options) do
+    {
+      '_plugin' => 'vault',
+      'path' => path,
+      'field' => field
+    }
+  end
+
+  let(:response) do
+    {
+      'data' => {
+        'foo' => secret
+      }
+    }
+  end
+
+  let(:plugin) { Bolt::Plugin::Vault.new(config) }
+
+  it 'has a hook for inventory_targets' do
+    expect(plugin.hooks).to eq(['inventory_config'])
+  end
+
+  context 'when validating keys' do
+    it 'errors with invalid config keys' do
+      config['foo'] = 'bar'
+      expect { plugin }.to raise_error(Bolt::ValidationError, /foo/)
+    end
+
+    it 'errors with invalid inventory config keys' do
+      options['foo'] = 'bar'
+      expect { plugin.validate_options(options) }.to raise_error(Bolt::ValidationError, /foo/)
+    end
+
+    it 'errors when missing required inventory config key' do
+      options.delete('path')
+      expect { plugin.validate_options(options) }.to raise_error(Bolt::ValidationError, /path/)
+    end
+
+    it 'errors when missing required auth method key' do
+      auth = config['auth'].delete('token')
+      keys = %w[token]
+      expect { plugin.validate_auth(auth, keys) }.to raise_error(Bolt::ValidationError, /token/)
+    end
+
+    it 'errors when using unknown auth method' do
+      auth = config['auth']
+      auth['method'] = 'foo'
+      expect { plugin.request_token(auth, options) }.to raise_error(
+        Bolt::ValidationError, /foo/
+      )
+    end
+  end
+
+  context 'when building the uri' do
+    it 'builds the correct v1 uri' do
+      expect(plugin.uri(options).to_s).to eq("#{server_url}/v1/#{path}")
+    end
+
+    it 'builds the correct v2 uri' do
+      path_v2 = path.split('/').insert(1, 'data').join('/')
+      options['version'] = 2
+      expect(plugin.uri(options).to_s).to eq("#{server_url}/v1/#{path_v2}")
+    end
+
+    it 'prefers keys from inventory config' do
+      server_url = 'http://127.0.0.1:9000'
+      options['server_url'] = server_url
+      expect(plugin.uri(options).to_s).to eq("#{server_url}/v1/#{path}")
+    end
+
+    it 'prefers a path from an auth method' do
+      path = 'cat/dog'
+      expect(plugin.uri(options, path).to_s).to eq("#{server_url}/v1/#{path}")
+    end
+  end
+
+  context 'when parsing the response' do
+    it 'errors when response is missing field from inventory config' do
+      options['field'] = 'baz'
+      expect { plugin.parse_response(response, options) }.to raise_error(
+        Bolt::ValidationError, /baz/
+      )
+    end
+
+    it 'accesses v2 data' do
+      response_v2 = { 'data' => response }
+      options['version'] = 2
+      expect(plugin.parse_response(response_v2, options)).to eq(secret)
+    end
+
+    it 'returns the value of a field from the inventory config' do
+      expect(plugin.parse_response(response, options)).to eq(secret)
+    end
+
+    it 'returns a hash of data when no field is given' do
+      options.delete('field')
+      expect(plugin.parse_response(response, options)).to eq(response['data'])
+    end
+  end
+end


### PR DESCRIPTION
This adds support for looking up secrets from a Vault server to populate
fields in the inventory config. Secrets can be looked up by specifying
the path of a KV engine and the address of the server, and authenticating
through a token or userpass.