### PR TITLE
(maint) Use squiggly heredoc in help text banner

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -83,181 +83,181 @@ module Bolt
     end
 
     def self.examples(cmd, desc)
-      <<-EXAMP
-#{desc} a Windows host via WinRM, providing for the password
-  bolt #{cmd} -n winrm://winhost -u Administrator -p
-#{desc} the local machine, a Linux host via SSH, and hosts from a group specified in an inventory file
-  bolt #{cmd} -n localhost,nixhost,node_group
-#{desc} Windows hosts queried from PuppetDB via WinRM as a domain user, prompting for the password
-  bolt #{cmd} -q 'inventory[certname] { facts.os.family = "windows" }' --transport winrm -u 'domain\\Administrator' -p
-EXAMP
+      <<~EXAMP
+      #{desc} a Windows host via WinRM, providing for the password
+        bolt #{cmd} -n winrm://winhost -u Administrator -p
+      #{desc} the local machine, a Linux host via SSH, and hosts from a group specified in an inventory file
+        bolt #{cmd} -n localhost,nixhost,node_group
+      #{desc} Windows hosts queried from PuppetDB via WinRM as a domain user, prompting for the password
+        bolt #{cmd} -q 'inventory[certname] { facts.os.family = "windows" }' --transport winrm -u 'domain\\Administrator' -p
+      EXAMP
     end
 
-    BANNER = <<-HELP
-Usage: bolt <subcommand> <action>
+    BANNER = <<~HELP
+      Usage: bolt <subcommand> <action>
 
-Available subcommands:
-  bolt command run <command>       Run a command remotely
-  bolt file upload <src> <dest>    Upload a local file or directory
-  bolt script run <script>         Upload a local script and run it remotely
-  bolt task show                   Show list of available tasks
-  bolt task show <task>            Show documentation for task
-  bolt task run <task> [params]    Run a Puppet task
-  bolt plan convert <plan_path>    Convert a YAML plan to a Puppet plan
-  bolt plan show                   Show list of available plans
-  bolt plan show <plan>            Show details for plan
-  bolt plan run <plan> [params]    Run a Puppet task plan
-  bolt apply <manifest>            Apply Puppet manifest code
-  bolt puppetfile install          Install modules from a Puppetfile into a Boltdir
-  bolt puppetfile show-modules     List modules available to Bolt
-  bolt secret createkeys           Create new encryption keys
-  bolt secret encrypt <plaintext>  Encrypt a value
-  bolt secret decrypt <encrypted>  Decrypt a value
-  bolt inventory show              Show the list of targets an action would run on
+      Available subcommands:
+        bolt command run <command>       Run a command remotely
+        bolt file upload <src> <dest>    Upload a local file or directory
+        bolt script run <script>         Upload a local script and run it remotely
+        bolt task show                   Show list of available tasks
+        bolt task show <task>            Show documentation for task
+        bolt task run <task> [params]    Run a Puppet task
+        bolt plan convert <plan_path>    Convert a YAML plan to a Puppet plan
+        bolt plan show                   Show list of available plans
+        bolt plan show <plan>            Show details for plan
+        bolt plan run <plan> [params]    Run a Puppet task plan
+        bolt apply <manifest>            Apply Puppet manifest code
+        bolt puppetfile install          Install modules from a Puppetfile into a Boltdir
+        bolt puppetfile show-modules     List modules available to Bolt
+        bolt secret createkeys           Create new encryption keys
+        bolt secret encrypt <plaintext>  Encrypt a value
+        bolt secret decrypt <encrypted>  Decrypt a value
+        bolt inventory show              Show the list of targets an action would run on
 
-Run `bolt <subcommand> --help` to view specific examples.
+      Run `bolt <subcommand> --help` to view specific examples.
 
-Available options are:
+      Available options are:
     HELP
 
-    TASK_HELP = <<-HELP
-Usage: bolt task <action> <task> [parameters]
+    TASK_HELP = <<~HELP
+      Usage: bolt task <action> <task> [parameters]
 
-Available actions are:
-  show                             Show list of available tasks
-  show <task>                      Show documentation for task
-  run <task>                       Run a Puppet task
+      Available actions are:
+        show                             Show list of available tasks
+        show <task>                      Show documentation for task
+        run <task>                       Run a Puppet task
 
-Parameters are of the form <parameter>=<value>.
+      Parameters are of the form <parameter>=<value>.
 
-#{examples('task run facts', 'run facter on')}
-Available options are:
+      #{examples('task run facts', 'run facter on')}
+      Available options are:
     HELP
 
-    TASK_SHOW_HELP = <<-HELP
-Usage: bolt task show <task>
+    TASK_SHOW_HELP = <<~HELP
+      Usage: bolt task show <task>
 
-Available actions are:
-  show                             Show list of available tasks
-  show <task>                      Show documentation for task
+      Available actions are:
+        show                             Show list of available tasks
+        show <task>                      Show documentation for task
 
-Available options are:
+      Available options are:
     HELP
 
-    TASK_RUN_HELP = <<-HELP
-Usage: bolt task run <task> [parameters]
+    TASK_RUN_HELP = <<~HELP
+      Usage: bolt task run <task> [parameters]
 
-Parameters are of the form <parameter>=<value>.
+      Parameters are of the form <parameter>=<value>.
 
-#{examples('task run facts', 'run facter on')}
-Available options are:
+      #{examples('task run facts', 'run facter on')}
+      Available options are:
     HELP
 
-    COMMAND_HELP = <<-HELP
-Usage: bolt command <action> <command>
+    COMMAND_HELP = <<~HELP
+      Usage: bolt command <action> <command>
 
-Available actions are:
-  run                              Run a command remotely
+      Available actions are:
+        run                              Run a command remotely
 
-#{examples('command run hostname', 'run hostname on')}
-Available options are:
+      #{examples('command run hostname', 'run hostname on')}
+      Available options are:
     HELP
 
-    SCRIPT_HELP = <<-HELP
-Usage: bolt script <action> <script> [[arg1] ... [argN]]
+    SCRIPT_HELP = <<~HELP
+      Usage: bolt script <action> <script> [[arg1] ... [argN]]
 
-Available actions are:
-  run                              Upload a local script and run it remotely
+      Available actions are:
+        run                              Upload a local script and run it remotely
 
-#{examples('script run my_script.ps1 some args', 'run a script on')}
-Available options are:
+      #{examples('script run my_script.ps1 some args', 'run a script on')}
+      Available options are:
     HELP
 
-    PLAN_HELP = <<-HELP
-Usage: bolt plan <action> <plan> [parameters]
+    PLAN_HELP = <<~HELP
+      Usage: bolt plan <action> <plan> [parameters]
 
-Available actions are:
-  convert <plan_path>              Convert a YAML plan to a Puppet plan
-  show                             Show list of available plans
-  show <plan>                      Show details for plan
-  run                              Run a Puppet task plan
+      Available actions are:
+        convert <plan_path>              Convert a YAML plan to a Puppet plan
+        show                             Show list of available plans
+        show <plan>                      Show details for plan
+        run                              Run a Puppet task plan
 
-Parameters are of the form <parameter>=<value>.
+      Parameters are of the form <parameter>=<value>.
 
-#{examples('plan run canary command=hostname', 'run the canary plan on')}
-Available options are:
+      #{examples('plan run canary command=hostname', 'run the canary plan on')}
+      Available options are:
     HELP
 
-    PLAN_CONVERT_HELP = <<-HELP
-Usage: bolt plan convert <plan_path>
+    PLAN_CONVERT_HELP = <<~HELP
+      Usage: bolt plan convert <plan_path>
 
-Available options are:
+      Available options are:
     HELP
 
-    PLAN_SHOW_HELP = <<-HELP
-Usage: bolt plan show <plan>
+    PLAN_SHOW_HELP = <<~HELP
+      Usage: bolt plan show <plan>
 
-Available actions are:
-  show                             Show list of available plans
-  show <plan>                      Show details for plan
+      Available actions are:
+        show                             Show list of available plans
+        show <plan>                      Show details for plan
 
-Available options are:
+      Available options are:
     HELP
 
-    PLAN_RUN_HELP = <<-HELP
-Usage: bolt plan run <plan> [parameters]
+    PLAN_RUN_HELP = <<~HELP
+      Usage: bolt plan run <plan> [parameters]
 
-Parameters are of the form <parameter>=<value>.
+      Parameters are of the form <parameter>=<value>.
 
-#{examples('plan run canary command=hostname', 'run the canary plan on')}
-Available options are:
+      #{examples('plan run canary command=hostname', 'run the canary plan on')}
+      Available options are:
     HELP
 
-    FILE_HELP = <<-HELP
-Usage: bolt file <action>
+    FILE_HELP = <<~HELP
+      Usage: bolt file <action>
 
-Available actions are:
-  upload <src> <dest>              Upload local file or directory <src> to <dest> on each node
+      Available actions are:
+        upload <src> <dest>              Upload local file or directory <src> to <dest> on each node
 
-#{examples('file upload /tmp/source /etc/profile.d/login.sh', 'upload a file to')}
-Available options are:
+      #{examples('file upload /tmp/source /etc/profile.d/login.sh', 'upload a file to')}
+      Available options are:
     HELP
 
-    PUPPETFILE_HELP = <<-HELP
-Usage: bolt puppetfile <action>
+    PUPPETFILE_HELP = <<~HELP
+      Usage: bolt puppetfile <action>
 
-Available actions are:
-  install                          Install modules from a Puppetfile into a Boltdir
-  show-modules                     List modules available to Bolt
+      Available actions are:
+        install                          Install modules from a Puppetfile into a Boltdir
+        show-modules                     List modules available to Bolt
 
-Install modules into the local Boltdir
-  bolt puppetfile install
+      Install modules into the local Boltdir
+        bolt puppetfile install
 
-Available options are:
+      Available options are:
     HELP
 
-    PUPPETFILE_INSTALL_HELP = <<-HELP
-Usage: bolt puppetfile install
+    PUPPETFILE_INSTALL_HELP = <<~HELP
+      Usage: bolt puppetfile install
 
-Install modules into the local Boltdir
-  bolt puppetfile install
+      Install modules into the local Boltdir
+        bolt puppetfile install
 
-Available options are:
+      Available options are:
     HELP
 
-    PUPPETFILE_SHOWMODULES_HELP = <<-HELP
-Usage: bolt puppetfile show-modules
+    PUPPETFILE_SHOWMODULES_HELP = <<~HELP
+      Usage: bolt puppetfile show-modules
 
-Available options are:
+      Available options are:
     HELP
 
-    APPLY_HELP = <<-HELP
-Usage: bolt apply <manifest.pp>
+    APPLY_HELP = <<~HELP
+      Usage: bolt apply <manifest.pp>
 
-#{examples('apply site.pp', 'apply a manifest on')}
-  bolt apply site.pp --nodes foo.example.com,bar.example.com
+      #{examples('apply site.pp', 'apply a manifest on')}
+        bolt apply site.pp --nodes foo.example.com,bar.example.com
 
-Available options are:
+      Available options are:
     HELP
 
     SECRET_HELP = <<~SECRET_HELP


### PR DESCRIPTION
This changes regular heredocs to squiggly heredocs in the option parser
help text banners. The only improves the readability of the file itself.