### PR TITLE
(docs) Documents gotcha for enterprise win users with HOMEDRIVE set

### DIFF
--- a/pre-docs/bolt_installing_modules.md
+++ b/pre-docs/bolt_installing_modules.md
@@ -84,4 +84,4 @@ For more details about specifying modules in a Puppetfile, see the [Puppetfile d
      directory. To override this location, update the modulepath setting in the
      Bolt config file.
 
-
+NOTE: Bolt uses r10k to download modules, and caches them in `~/.r10k/cache` before unzipping them. If you're a Windows user in an enterprise environment, ensure `HOME` or `HOMEDRIVE + HOMEPATH` is set sensibly.


### PR DESCRIPTION
The command `bolt puppetfile install` fails in certain situations where the
cachedir is inaccessible; this change calls out the ENV variables responsible.

The $HOMEDRIVE is set in some Windows enterprise environments (for specifying DFS mounts), and the bolt docs currently do not call this out.