### PR TITLE
(BOLT-1504) Update bundled modules to latest versions

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -7,7 +7,7 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '1.0.0'
 mod 'puppetlabs-facts', '0.5.1'
-mod 'puppetlabs-puppet_agent', '2.1.2'
+mod 'puppetlabs-puppet_agent', '2.2.0'
 
 # Core types and providers for Puppet 6
 mod 'puppetlabs-augeas_core', '1.0.4'
@@ -15,7 +15,7 @@ mod 'puppetlabs-host_core', '1.0.2'
 mod 'puppetlabs-scheduled_task', '1.0.1'
 mod 'puppetlabs-sshkeys_core', '1.0.2'
 mod 'puppetlabs-zfs_core', '1.0.2'
-mod 'puppetlabs-cron_core', '1.0.1'
+mod 'puppetlabs-cron_core', '1.0.2'
 mod 'puppetlabs-mount_core', '1.0.3'
 mod 'puppetlabs-selinux_core', '1.0.2'
 mod 'puppetlabs-yumrepo_core', '1.0.3'
@@ -25,7 +25,7 @@ mod 'puppetlabs-zone_core', '1.0.2'
 mod 'puppetlabs-package', '0.6.0'
 mod 'puppetlabs-puppet_conf', '0.3.1'
 mod 'puppetlabs-python_task_helper', '0.2.0'
-mod 'puppetlabs-reboot', '2.1.2'
+mod 'puppetlabs-reboot', '2.2.0'
 mod 'puppetlabs-ruby_task_helper', '0.3.0'
 
 # If we don't list these modules explicitly, r10k will purge them

--- a/acceptance/setup/common/pre-suite/071_install_modules.rb
+++ b/acceptance/setup/common/pre-suite/071_install_modules.rb
@@ -9,7 +9,7 @@ test_name "Install modules" do
   create_remote_file(bolt, "#{default_boltdir}/Puppetfile", <<-PUPPETFILE)
 mod 'puppetlabs-facts', '0.5.1'
 mod 'puppetlabs-service', '1.0.0'
-mod 'puppetlabs-puppet_agent', '2.1.2'
+mod 'puppetlabs-puppet_agent', '2.2.0'
 PUPPETFILE
 
   bolt_command_on(bolt, 'bolt puppetfile install')


### PR DESCRIPTION
This commit updates the puppet_agent, reboot, and cron_core modules to their latest releases to be shipped with bolt.