### PR TITLE
(maint) Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,28 @@
+---
+name: Bug Report
+about: Create a report to help us improve.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the Bug**
+A clear and concise description of what the bug is.
+
+**Expected Behavior**
+A clear and concise description of what you expected to happen.
+
+**Steps to Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Environment**
+ - Version [e.g. 1.27.0]
+ - Platform [e.g. Ubuntu 18.04]
+
+**Additional Context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,22 +7,22 @@ assignees: ''
 
 ---
 
-**Describe the Bug**
+## Describe the Bug
 A clear and concise description of what the bug is.
 
-**Expected Behavior**
+## Expected Behavior
 A clear and concise description of what you expected to happen.
 
-**Steps to Reproduce**
+## Steps to Reproduce
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Environment**
+## Environment
  - Version [e.g. 1.27.0]
  - Platform [e.g. Ubuntu 18.04]
 
-**Additional Context**
+## Additional Context
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request
+about: Suggest a new feature.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Use Case**
+A clear and concise description of what the problem you're trying to solve is. Ex. I'm always frustrated when [...]
+
+**Describe the Solution You Would Like**
+A clear and concise description of what you want to happen.
+
+**Describe Alternatives You've Considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional Context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -7,14 +7,14 @@ assignees: ''
 
 ---
 
-**Use Case**
+## Use Case
 A clear and concise description of what the problem you're trying to solve is. Ex. I'm always frustrated when [...]
 
-**Describe the Solution You Would Like**
+## Describe the Solution You Would Like
 A clear and concise description of what you want to happen.
 
-**Describe Alternatives You've Considered**
+## Describe Alternatives You've Considered
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional Context**
+## Additional Context
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -1,0 +1,17 @@
+---
+name: Improvement
+about: Suggest an improvement to an existing feature.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the Improvement You Would Like**
+A clear and concise description of what you want to happen.
+
+**Describe What Currently Happens**
+A clear and concise description of what currently happens.
+
+**Additional Context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -7,11 +7,11 @@ assignees: ''
 
 ---
 
-**Describe the Improvement You Would Like**
+## Describe the Improvement You Would Like
 A clear and concise description of what you want to happen.
 
-**Describe What Currently Happens**
+## Describe What Currently Happens
 A clear and concise description of what currently happens.
 
-**Additional Context**
+## Additional Context
 Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This adds issue templates for Bug Reports, Feature Requests, and Improvements. With the move from Jira to Github Projects, issue templates should help standardize the format for new issues and encourage users to provide enough information to address the issue.