### PR TITLE
(maint) Ensure that rspec unit tag does not rely on ssh/winrm targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,11 @@ Some tests require a Windows VM or Linux containers. For Linux tests (recommende
 
 Additional tests may run in a local environment and require certain shell capabilities. For example tests that require a Bash-like environment are tagged with `:bash` in rspec.
 
+Some tests will also require that the [bundled modules](#contributing-to-bundled-modules) described above are installed. Ensure the modules are installed for testing with the following command:
+```
+bundle exec r10k puppetfile install .
+```
+
 To run all tests, run:
 
     $ bundle exec rake test

--- a/spec/integration/catch_errors_spec.rb
+++ b/spec/integration/catch_errors_spec.rb
@@ -7,7 +7,7 @@ require 'bolt_spec/files'
 require 'bolt_spec/integration'
 require 'bolt/util'
 
-describe "catch_errors" do
+describe "catch_errors", ssh: true do
   include BoltSpec::Integration
   include BoltSpec::Config
   include BoltSpec::Conn
@@ -15,22 +15,9 @@ describe "catch_errors" do
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
   let(:modulepath) { [fixture_path('modules'), fixture_path('apply')].join(File::PATH_SEPARATOR) }
-  let(:target) do
-    if Bolt::Util.windows?
-      conn_uri('winrm')
-    else
-      conn_uri('ssh', include_password: true)
-    end
-  end
-  let(:transport_flags) do
-    if Bolt::Util.windows?
-      ['--password', conn_info('winrm')[:password],
-       '--no-ssl',
-       '--no-ssl-verify']
-    else
-      ['--no-host-key-check']
-    end
-  end
+  let(:target) { conn_uri('ssh', include_password: true) }
+
+  let(:transport_flags) { ['--no-host-key-check'] }
 
   let(:config_flags) {
     ['--format', 'json',


### PR DESCRIPTION
Limit the catch_errors integration tests to ssh targets. Also note in the CONTRIBUTING.md that bundled modules are required for some tests. 