### PR TITLE
(BOLT-1400) Add `run_command` endpoint to bolt server

### DIFF
--- a/developer-docs/bolt-api-servers.md
+++ b/developer-docs/bolt-api-servers.md
@@ -140,6 +140,41 @@ For example, the following runs 'sample::complex_params' task on localhost:
   }
 }
 ```
+### POST /ssh/run_command
+- `target`: [SSH Target Object](#ssh-target-object), *required* - Target information to run task on.
+- `command`: String, *required* - Command to run on target.
+
+For example, the following runs "echo 'hi'" on linux_target.net:
+```
+{
+  "target": {
+    "hostname": "linux_target.net",
+    "user": "marauder",
+    "password": "I solemnly swear that I am up to no good",
+    "host-key-check": false,
+    "run-as": "george_weasley"
+  },
+  "command": "echo 'hi'"
+}
+```
+
+### POST /winrm/run_command
+- `target`: [WinRM Target Object](#winrm-target-object), *required* - Target information to run task on.
+- `command`: String, *required* - Command to run on target.
+
+For example, the following runs "echo 'hi'" on localhost:
+```
+{
+  "target": {
+    "hostname": "windows_target.net",
+    "user": "Administrator",
+    "password": "Secret",
+    "ssl": false,
+    "ssl-verify": false
+  },
+  "command": "echo 'hi'"
+}
+```
 
 ### SSH Target Object
 The Target is a JSON object. See the [schema](../lib/bolt_server/schemas/ssh-run_task.json)

--- a/lib/bolt_server/schemas/action-run_command.json
+++ b/lib/bolt_server/schemas/action-run_command.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "run_command request",
+  "description": "POST <transport>/run_command request schema",
+  "type": "object",
+  "properties": {
+    "command": { "type": "string" },
+    "target": { "$ref": "partial:target-any" }
+  },
+  "required": ["command", "target"],
+  "additionalProperties": false
+}

--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -19,7 +19,7 @@ module BoltServer
     PARTIAL_SCHEMAS = %w[target-any target-ssh target-winrm task].freeze
 
     # These schemas combine shared schemas to describe client requests
-    REQUEST_SCHEMAS = %w[action-run_task transport-ssh transport-winrm].freeze
+    REQUEST_SCHEMAS = %w[action-run_task action-run_command transport-ssh transport-winrm].freeze
 
     def initialize(config)
       @config = config
@@ -65,6 +65,14 @@ module BoltServer
       @executor.run_task(target, task, parameters)
     end
 
+    def run_command(target, body)
+      error = validate_schema(@schemas["action-run_command"], body)
+      return [400, error.to_json] unless error.nil?
+
+      command = body['command']
+      @executor.run_command(target, command)
+    end
+
     get '/' do
       200
     end
@@ -84,7 +92,7 @@ module BoltServer
       raise 'Unexpected error'
     end
 
-    ACTIONS = %w[run_task].freeze
+    ACTIONS = %w[run_task run_command].freeze
 
     post '/ssh/:action' do
       not_found unless ACTIONS.include?(params[:action])

--- a/spec/bolt_server/app_integration_spec.rb
+++ b/spec/bolt_server/app_integration_spec.rb
@@ -19,52 +19,85 @@ describe "BoltServer::TransportApp", puppetserver: true do
   end
 
   context 'with ssh target', ssh: true do
-    let(:path) { '/ssh/run_task' }
+    describe "run_task" do
+      let(:path) { '/ssh/run_task' }
 
-    it 'runs an echo task with a password' do
-      body = build_task_request('sample::echo',
-                                conn_target('ssh', include_password: true),
-                                "message": "Hello!")
+      it 'runs an echo task with a password' do
+        body = build_task_request('sample::echo',
+                                  conn_target('ssh', include_password: true),
+                                  "message": "Hello!")
 
-      post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
-      expect(last_response).to be_ok
-      expect(last_response.status).to eq(200)
-      result = JSON.parse(last_response.body)
-      expect(result).to include('status' => 'success')
-      expect(result['result']['_output'].chomp).to match(/\w+ got passed the message: Hello!/)
+        post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
+        expect(last_response).to be_ok
+        expect(last_response.status).to eq(200)
+        result = JSON.parse(last_response.body)
+        expect(result).to include('status' => 'success')
+        expect(result['result']['_output'].chomp).to match(/\w+ got passed the message: Hello!/)
+      end
+
+      it 'runs an echo task using a private key' do
+        private_key = ENV['BOLT_SSH_KEY'] || Dir["spec/fixtures/keys/id_rsa"][0]
+        private_key_content = File.read(private_key)
+        target = conn_target('ssh', options: { 'private-key-content' => private_key_content })
+        body = build_task_request('sample::echo',
+                                  target,
+                                  "message": "Hello!")
+
+        post path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json'
+        expect(last_response).to be_ok
+        expect(last_response.status).to eq(200)
+        result = JSON.parse(last_response.body)
+        expect(result).to include('status' => 'success')
+        expect(result['result']['_output'].chomp).to match(/\w+ got passed the message: Hello!/)
+      end
+
+      it 'runs a shareable task' do
+        body = build_task_request('shareable',
+                                  conn_target('ssh', include_password: true))
+
+        post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
+        expect(last_response).to be_ok
+        expect(last_response.status).to eq(200)
+        result = JSON.parse(last_response.body)
+        expect(result).to include('status' => 'success')
+        files = result['result']['_output'].split("\n").map(&:strip).sort
+        expect(files.count).to eq(4)
+        expect(files[0]).to match(%r{^174 .*/shareable/tasks/unknown_file.json$})
+        expect(files[1]).to match(%r{^236 .*/shareable/tasks/list.sh})
+        expect(files[2]).to match(%r{^310 .*/results/lib/puppet/functions/results/make_result.rb$})
+        expect(files[3]).to match(%r{^43 .*/error/tasks/fail.sh$})
+      end
     end
 
-    it 'runs an echo task using a private key' do
-      private_key = ENV['BOLT_SSH_KEY'] || Dir["spec/fixtures/keys/id_rsa"][0]
-      private_key_content = File.read(private_key)
-      target = conn_target('ssh', options: { 'private-key-content' => private_key_content })
-      body = build_task_request('sample::echo',
-                                target,
-                                "message": "Hello!")
+    describe "run_command" do
+      let(:path) { '/ssh/run_command' }
 
-      post path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json'
-      expect(last_response).to be_ok
-      expect(last_response.status).to eq(200)
-      result = JSON.parse(last_response.body)
-      expect(result).to include('status' => 'success')
-      expect(result['result']['_output'].chomp).to match(/\w+ got passed the message: Hello!/)
-    end
+      it 'runs an echo command' do
+        body = build_command_request('echo hi',
+                                     conn_target('ssh', include_password: true))
 
-    it 'runs a shareable task' do
-      body = build_task_request('shareable',
-                                conn_target('ssh', include_password: true))
+        post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
+        expect(last_response).to be_ok
+        expect(last_response.status).to eq(200)
+        result = JSON.parse(last_response.body)
+        expect(result).to include('status' => 'success')
+        expect(result['result']["exit_code"]).to eq(0)
+        expect(result['result']["stderr"]).to be_empty
+        expect(result['result']["stdout"]).to eq("hi\n")
+      end
 
-      post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
-      expect(last_response).to be_ok
-      expect(last_response.status).to eq(200)
-      result = JSON.parse(last_response.body)
-      expect(result).to include('status' => 'success')
-      files = result['result']['_output'].split("\n").map(&:strip).sort
-      expect(files.count).to eq(4)
-      expect(files[0]).to match(%r{^174 .*/shareable/tasks/unknown_file.json$})
-      expect(files[1]).to match(%r{^236 .*/shareable/tasks/list.sh})
-      expect(files[2]).to match(%r{^310 .*/results/lib/puppet/functions/results/make_result.rb$})
-      expect(files[3]).to match(%r{^43 .*/error/tasks/fail.sh$})
+      it 'fails reliably' do
+        body = build_command_request('not-a-command',
+                                     conn_target('ssh', include_password: true))
+
+        post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
+        expect(last_response).to be_ok
+        expect(last_response.status).to eq(200)
+        result = JSON.parse(last_response.body)
+        expect(result).to include('status' => 'failure')
+        expect(result['result']["exit_code"]).to eq(127)
+        expect(result['result']["stderr"]).to match(/not-a-command/)
+      end
     end
   end
 end

--- a/spec/lib/bolt_spec/bolt_server.rb
+++ b/spec/lib/bolt_spec/bolt_server.rb
@@ -87,5 +87,12 @@ module BoltSpec
         'parameters' => params
       }
     end
+
+    def build_command_request(command, target)
+      {
+        'command' => command,
+        'target' => target2request(target)
+      }
+    end
   end
 end


### PR DESCRIPTION
In cases where PXP Agent is not installed on a target node
and thus cannot run a command, SSH or WinRM should be used.
This commit adds the `POST /run_command` endpoint which will
delegate either to SSH or to WinRM accordingly.