### PR TITLE
(BOLT-1451) Implicitly call apply_prep for yaml resources step

### DIFF
--- a/lib/bolt/pal/yaml_plan/evaluator.rb
+++ b/lib/bolt/pal/yaml_plan/evaluator.rb
@@ -88,6 +88,8 @@ module Bolt
         end
 
         def resources_step(scope, step)
+          # TODO: Only call apply_prep when needed
+          scope.call_function('apply_prep', step['target'])
           manifest = generate_manifest(step['resources'])
 
           apply_manifest(scope, step['target'], manifest)

--- a/lib/bolt/pal/yaml_plan/step/resources.rb
+++ b/lib/bolt/pal/yaml_plan/step/resources.rb
@@ -65,6 +65,13 @@ module Bolt
 
           def transpile
             code = StringIO.new
+
+            code.print "  "
+            fn = 'apply_prep'
+            args = [@target]
+            code << function_call(fn, args)
+            code.print "\n"
+
             code.print "  "
             code.print "$#{@name} = " if @name
 

--- a/pre-docs/writing_yaml_plans.md
+++ b/pre-docs/writing_yaml_plans.md
@@ -175,7 +175,7 @@ steps:
 
 #### Resources step
 
-Use a `resources` step to apply a list of Puppet resources. A resource defines the _desired state_ for part of a target. Bolt will ensure each resource is in its desired state.
+Use a `resources` step to apply a list of Puppet resources. A resource defines the _desired state_ for part of a target. Bolt will ensure each resource is in its desired state. For each `resources` step, Bolt executes the `apply_prep` plan function against the targets specified with the `targets` field. For more information about `apply_prep` see the [How manifest blocks are applied](./applying_manifest_blocks.md#how-manifest-blocks-are-applied) reference.
 
 Like the steps in a plan, if any resource in the list fails, the rest will be skipped.
 
@@ -515,9 +515,6 @@ If the author were writing the code as a Puppet plan, they would likely not use 
 When applying Puppet resources in a resource step, variable interpolation behaves differently in YAML plans and Puppet plans. In order to illustrate an important distinction consider the following yaml plan:
 ```
 steps:
-  - description: apply prep
-    eval: >
-      apply_prep('localhost')
   - target: localhost
     description: Apply a file resource
     resources:
@@ -537,7 +534,6 @@ This plan performs `apply_prep` on a localhost target. Then it uses a Puppet `fi
 ```
 plan yaml_plans::interpolation_pp() {
   apply_prep('localhost')
-
   $interpolation = apply('localhost') {
     file { '/tmp/foo':
       content => $facts['os']['family'],
@@ -561,8 +557,6 @@ parameters:
   nodes:
     type: TargetSpec
 steps:
-  - eval: |
-      apply_prep($nodes)
   - name: pkg
     target: $nodes
     resources:
@@ -585,8 +579,6 @@ parameters:
   nodes:
     type: TargetSpec
 steps:
-  - eval: |
-      apply_prep($nodes)
   - name: pkg
     target: $nodes
     resources:

--- a/spec/bolt/pal/yaml_plan/step_spec.rb
+++ b/spec/bolt/pal/yaml_plan/step_spec.rb
@@ -182,6 +182,7 @@ OUT
       context "transpiling" do
         it "generates an apply() block" do
           output = <<-OUT
+  apply_prep($bread)
   apply($bread) {
     package { 'nginx': }
     ->
@@ -196,6 +197,7 @@ OUT
           resources.replace([])
 
           output = <<-OUT
+  apply_prep($bread)
   apply($bread) {
 
   }
@@ -208,6 +210,7 @@ OUT
           step_body['name'] = 'test_apply'
 
           output = <<-OUT
+  apply_prep($bread)
   $test_apply = apply($bread) {
     package { 'nginx': }
     ->
@@ -223,6 +226,7 @@ OUT
                              { 'service' => 'nginx', 'parameters' => { 'ensure' => 'running', 'enable' => true } }])
 
           output = <<-OUT
+  apply_prep($bread)
   apply($bread) {
     package { 'nginx':
       ensure => 'latest',

--- a/spec/fixtures/modules/yaml/plans/conversion.yaml
+++ b/spec/fixtures/modules/yaml/plans/conversion.yaml
@@ -11,7 +11,6 @@ steps:
     target: $nodes
     parameters:
       message: $message
-  - eval: $nodes.apply_prep
   - resources:
     - package: nginx
     - file: /etc/nginx/html/index.html

--- a/spec/fixtures/modules/yaml/plans/resource_failure.yaml
+++ b/spec/fixtures/modules/yaml/plans/resource_failure.yaml
@@ -3,7 +3,6 @@ parameters:
     type: TargetSpec
 
 steps:
-  - eval: $nodes.apply_prep
   - name: apply_resources
     target: $nodes
     resources:

--- a/spec/fixtures/modules/yaml/plans/resources.yaml
+++ b/spec/fixtures/modules/yaml/plans/resources.yaml
@@ -3,7 +3,6 @@ parameters:
     type: TargetSpec
 
 steps:
-  - eval: $nodes.apply_prep
   - name: apply_resources
     target: $nodes
     resources:

--- a/spec/integration/transpiler_spec.rb
+++ b/spec/integration/transpiler_spec.rb
@@ -20,7 +20,7 @@ describe "transpiling YAML plans" do
     String $message = 'hello world'
   ) {
     $sample = run_task('sample', $nodes, {'message' => $message})
-    $nodes.apply_prep
+    apply_prep($nodes)
     apply($nodes) {
       package { 'nginx': }
       ->


### PR DESCRIPTION
This commit implements calling apply_prep on the targets defined in a resources step of a yaml plan. Currently apply prep is implicitly called on all the targets listed in the step for each resources step. The transpiler has also been updated to reflect the change.