### PR TITLE
Add "developer updates" blog section to website

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -17,3 +17,8 @@ defaults:
       type: examples
     values:
       layout: example
+  - scope:
+      type: posts
+    values:
+      layout: post
+      permalink: /:categories/:year-:month-:day-:title

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -56,6 +56,14 @@
             </ul>
           </li>
           <li>
+            <span class="nav-header">Bolt Developer Updates</span>
+            <ul>
+              {% for post in site.posts limit: 3 %}
+                <li><a href="{{ post.url | remove: "/index.html" | relative_url }}">{{ post.title }}</a><br><small>{{ post.date | date: "%m-%d-%y" }}</small></li>
+              {% endfor %}
+            </ul>
+          </li>
+          <li>
             <span class="nav-header">External Resources</span>
             <ul>
               <li><a href="https://puppet.com/docs/bolt/latest/bolt.html">Bolt Docs</a></li>

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -1,0 +1,16 @@
+---
+layout: default
+---
+
+{{ content }}
+
+{% if page.next.url %}
+<div>
+Next post: <a href="{{ page.next.url | remove: "/index.html" | relative_url }}">{{ page.next.date | date_to_string: "ordinal", "US" }} - {{ page.next.title }}</a>
+</div>
+{% endif %}
+{% if page.previous.url %}
+<div>
+Previous post: <a href="{{ page.previous.url | remove: "/index.html" | relative_url }}">{{ page.previous.date | date_to_string: "ordinal", "US" }} - {{ page.previous.title }}</a>
+</div>
+{% endif %}

--- a/docs/_posts/2019-08-07-vault-target-api-apply-prep.md
+++ b/docs/_posts/2019-08-07-vault-target-api-apply-prep.md
@@ -1,0 +1,38 @@
+---
+title: Vault, the Target API, and apply_prep
+---
+
+Welcome to the *first ever* Bolt developer update! This is a new experiment we're trying to communicate more directly about what we're actively working on and what we're thinking about in the near term.
+
+This week, we released Bolt 1.28.0. The feature I want to highlight is the new Vault plugin. This plugin allows you to query inventory information (such as passwords) from [HashiCorp Vault](https://www.vaultproject.io/).
+
+As an example, this inventory snippet retrieves a private key from Vault and uses it to connect to `host.example.com`.
+
+```yaml
+targets:
+  - host.example.com
+config:
+  ssh:
+    user: root
+    private-key:
+      key-data:
+        _plugin: vault
+        server_url: http://127.0.0.1:8200
+        auth:
+          method: userpass
+          user: bolt
+          pass: bolt
+        path: secrets/bolt
+        field: private-key
+        version: 2
+```
+
+Try out the plugin and let us know what you think.
+
+## Up next
+
+Coming down the pipe, Alex posted [a specification](https://github.com/puppetlabs/bolt/issues/1125) for some refinements to the Target/inventory API. Our aim with that is to standardize the operations you can use within a plan to dynamically create, modify, and regroup targets.
+
+We've also started discussing extensions to the `apply_prep()` function to make it possible to use custom agent install methods and alternate fact sources. Please check out the [current state of that proposal](https://github.com/puppetlabs/bolt/issues/1123) and give feedback.
+
+Speaking of feedback, please reach out in `#bolt` on Slack or by email to let us know what you think of this newsletter format.


### PR DESCRIPTION
This finally uses the official built-in "posts" capability of Jekyll to
provide a "developer updates" blog, for posts related to what's going on in
Bolt. These posts are written as markdown files, linked from the sidebar,
and each one has a link to the next and previous post chronologically.