### PR TITLE
(GH-1159) Do not use wrapper script for tasks that require data on stdin 

### DIFF
--- a/acceptance/tests/task_local.rb
+++ b/acceptance/tests/task_local.rb
@@ -38,9 +38,6 @@ test_name "bolt task run should execute tasks on localhost via local transport" 
       #!/bin/sh
       echo "$PT_greetings from $(whoami)"
       FILE
-      # TODO: Use input_method: both (default) once bug BOLT-1283 is fixed
-      conf = { 'input_method' => 'environment' }
-      create_remote_file(bolt, "#{dir}/modules/test/tasks/whoami_nix.json", conf.to_json)
     end
 
     step "execute `bolt task run` on localhost via local transport" do

--- a/lib/bolt/transport/local/shell.rb
+++ b/lib/bolt/transport/local/shell.rb
@@ -131,7 +131,7 @@ module Bolt
             else
               sudo_str = Shellwords.shelljoin(@target.options['run-as-command'] + [run_as])
             end
-            command_str = build_sudoable_command_str(command_str, sudo_str, @sudo_id, options[:stdin])
+            command_str = build_sudoable_command_str(command_str, sudo_str, @sudo_id, options)
           end
 
           command_arr = options[:environment].nil? ? [command_str] : [options[:environment], command_str]

--- a/lib/bolt/transport/local/shell.rb
+++ b/lib/bolt/transport/local/shell.rb
@@ -20,17 +20,18 @@ module Bolt
           @user = ENV['USER'] || Etc.getlogin
           @run_as = target.options['run-as']
           @logger = Logging.logger[self]
+          @sudo_id = SecureRandom.uuid
         end
 
         # If prompted for sudo password, send password to stdin and return an
         # empty string. Otherwise, check for sudo errors and raise Bolt error.
+        # If sudo_id is detected, that means the task needs to have stdin written.
         # If error is not sudo-related, return the stderr string to be added to
         # node output
-        def handle_sudo(stdin, err, pid)
+        def handle_sudo(stdin, err, pid, sudo_stdin)
           if err.include?(Sudoable.sudo_prompt)
             # A wild sudo prompt has appeared!
             if @target.options['sudo-password']
-              # Hopefully no one's sudo-password is > 64kb
               stdin.write("#{@target.options['sudo-password']}\n")
               ''
             else
@@ -39,6 +40,12 @@ module Bolt
                 'NO_PASSWORD'
               )
             end
+          elsif err =~ /^#{@sudo_id}/
+            if sudo_stdin
+              stdin.write("#{sudo_stdin}\n")
+              stdin.close
+            end
+            ''
           else
             handle_sudo_errors(err, pid)
           end
@@ -96,12 +103,12 @@ module Bolt
 
         # See if there's a sudo prompt in the output
         # If not, return the output
-        def check_sudo(out, inp, pid)
+        def check_sudo(out, inp, pid, stdin)
           buffer = out.readpartial(CHUNK_SIZE)
           # Split on newlines, including the newline
           lines = buffer.split(/(?<=[\n])/)
           # handle_sudo will return the line if it is not a sudo prompt or error
-          lines.map! { |line| handle_sudo(inp, line, pid) }
+          lines.map! { |line| handle_sudo(inp, line, pid, stdin) }
           lines.join("")
         # If stream has reached EOF, no password prompt is expected
         # return an empty string
@@ -114,33 +121,25 @@ module Bolt
           escalate = sudoable && run_as && @user != run_as
           use_sudo = escalate && @target.options['run-as-command'].nil?
 
-          if options[:interpreter]
-            if command.is_a?(Array)
-              command.unshift(options[:interpreter])
-            else
-              command = [options[:interpreter], command]
-            end
-          end
-
-          command_str = command.is_a?(String) ? command : Shellwords.shelljoin(command)
+          command_str = inject_interpreter(options[:interpreter], command)
 
           if escalate
             if use_sudo
               sudo_flags = ["sudo", "-k", "-S", "-u", run_as, "-p", Sudoable.sudo_prompt]
               sudo_flags += ["-E"] if options[:environment]
               sudo_str = Shellwords.shelljoin(sudo_flags)
-              command_str = "#{sudo_str} #{command_str}"
             else
-              run_as_str = Shellwords.shelljoin(@target.options['run-as-command'] + [run_as])
-              command_str = "#{run_as_str} #{command_str}"
+              sudo_str = Shellwords.shelljoin(@target.options['run-as-command'] + [run_as])
             end
+            command_str = build_sudoable_command_str(command_str, sudo_str, @sudo_id, options[:stdin])
           end
 
           command_arr = options[:environment].nil? ? [command_str] : [options[:environment], command_str]
 
           # Prepare the variables!
           result_output = Bolt::Node::Output.new
-          in_buffer = options[:stdin] || ''
+          # Sudo handler will pass stdin if needed.
+          in_buffer = !use_sudo && options[:stdin] ? options[:stdin] : ''
           # Chunks of this size will be read in one iteration
           index = 0
           timeout = 0.1
@@ -153,7 +152,7 @@ module Bolt
           # See if there's a sudo prompt
           if use_sudo
             ready_read = select([err], nil, nil, timeout * 5)
-            read_streams[err] << check_sudo(err, inp, t.pid) if ready_read
+            read_streams[err] << check_sudo(err, inp, t.pid, options[:stdin]) if ready_read
           end
 
           # True while the process is running or waiting for IO input
@@ -166,7 +165,7 @@ module Bolt
               begin
                 # Check for sudo prompt
                 read_streams[stream] << if use_sudo
-                                          check_sudo(stream, inp, t.pid)
+                                          check_sudo(stream, inp, t.pid, options[:stdin])
                                         else
                                           stream.readpartial(CHUNK_SIZE)
                                         end

--- a/lib/bolt/transport/local_windows.rb
+++ b/lib/bolt/transport/local_windows.rb
@@ -201,5 +201,3 @@ module Bolt
     end
   end
 end
-
-require 'bolt/transport/local/shell'

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -20,6 +20,7 @@ module Bolt
           require 'net/ssh/proxy/jump'
 
           raise Bolt::ValidationError, "Target #{target.name} does not have a host" unless target.host
+          @sudo_id = SecureRandom.uuid
 
           @target = target
           @load_config = target.options['load-config']
@@ -135,7 +136,7 @@ module Bolt
           end
         end
 
-        def handled_sudo(channel, data)
+        def handled_sudo(channel, data, stdin)
           if data.lines.include?(Sudoable.sudo_prompt)
             if target.options['sudo-password']
               channel.send_data "#{target.options['sudo-password']}\n"
@@ -149,6 +150,12 @@ module Bolt
                 'NO_PASSWORD'
               )
             end
+          elsif data =~ /^#{@sudo_id}/
+            if stdin
+              channel.send_data "#{stdin}\n"
+              channel.eof!
+            end
+            return true
           elsif data =~ /^#{@user} is not in the sudoers file\./
             @logger.debug { data }
             raise Bolt::Node::EscalateError.new(
@@ -171,21 +178,17 @@ module Bolt
           escalate = sudoable && run_as && @user != run_as
           use_sudo = escalate && @target.options['run-as-command'].nil?
 
-          if options[:interpreter]
-            command.is_a?(Array) ? command.unshift(options[:interpreter]) : [options[:interpreter], command]
-          end
+          command_str = inject_interpreter(options[:interpreter], command)
 
-          command_str = command.is_a?(String) ? command : Shellwords.shelljoin(command)
           if escalate
             if use_sudo
               sudo_flags = ["sudo", "-S", "-u", run_as, "-p", Sudoable.sudo_prompt]
               sudo_flags += ["-E"] if options[:environment]
               sudo_str = Shellwords.shelljoin(sudo_flags)
-              command_str = "#{sudo_str} #{command_str}"
             else
-              run_as_str = Shellwords.shelljoin(@target.options['run-as-command'] + [run_as])
-              command_str = "#{run_as_str} #{command_str}"
+              sudo_str = Shellwords.shelljoin(@target.options['run-as-command'] + [run_as])
             end
+            command_str = build_sudoable_command_str(command_str, sudo_str, @sudo_id, options[:stdin])
           end
 
           # Including the environment declarations in the shelljoin will escape
@@ -212,14 +215,14 @@ module Bolt
               end
 
               channel.on_data do |_, data|
-                unless use_sudo && handled_sudo(channel, data)
+                unless use_sudo && handled_sudo(channel, data, options[:stdin])
                   result_output.stdout << data
                 end
                 @logger.debug { "stdout: #{data.strip}" }
               end
 
               channel.on_extended_data do |_, _, data|
-                unless use_sudo && handled_sudo(channel, data)
+                unless use_sudo && handled_sudo(channel, data, options[:stdin])
                   result_output.stderr << data
                 end
                 @logger.debug { "stderr: #{data.strip}" }
@@ -228,8 +231,7 @@ module Bolt
               channel.on_request("exit-status") do |_, data|
                 result_output.exit_code = data.read_long
               end
-
-              if options[:stdin]
+              if options[:stdin] && !use_sudo
                 channel.send_data(options[:stdin])
                 channel.eof!
               end

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -139,7 +139,7 @@ module Bolt
         def handled_sudo(channel, data, stdin)
           if data.lines.include?(Sudoable.sudo_prompt)
             if target.options['sudo-password']
-              channel.send_data "#{target.options['sudo-password']}\n"
+              channel.send_data("#{target.options['sudo-password']}\n")
               channel.wait
               return true
             else
@@ -152,7 +152,7 @@ module Bolt
             end
           elsif data =~ /^#{@sudo_id}/
             if stdin
-              channel.send_data "#{stdin}\n"
+              channel.send_data(stdin)
               channel.eof!
             end
             return true
@@ -188,7 +188,7 @@ module Bolt
             else
               sudo_str = Shellwords.shelljoin(@target.options['run-as-command'] + [run_as])
             end
-            command_str = build_sudoable_command_str(command_str, sudo_str, @sudo_id, options[:stdin])
+            command_str = build_sudoable_command_str(command_str, sudo_str, @sudo_id, options)
           end
 
           # Including the environment declarations in the shelljoin will escape
@@ -231,7 +231,8 @@ module Bolt
               channel.on_request("exit-status") do |_, data|
                 result_output.exit_code = data.read_long
               end
-              if options[:stdin] && !use_sudo
+              # A wrapper is used to direct stdin when elevating privilage or using tty
+              if options[:stdin] && !use_sudo && !options[:wrapper]
                 channel.send_data(options[:stdin])
                 channel.eof!
               end

--- a/lib/bolt/transport/sudoable/connection.rb
+++ b/lib/bolt/transport/sudoable/connection.rb
@@ -70,6 +70,33 @@ module Bolt
           message = "#{self.class.name} must implement #{method} to execute commands"
           raise NotImplementedError, message
         end
+
+        def prepend_sudo_success(sudo_id, command_str)
+          "sh -c 'echo #{sudo_id} 1>&2; #{command_str}'"
+        end
+
+        # A helper to build up a single string that contains all of the options
+        # for privilage escalation.
+        def build_sudoable_command_str(command_str, sudo_str, sudo_id, stdin)
+          if stdin
+            "#{sudo_str} #{prepend_sudo_success(sudo_id, command_str)}"
+          else
+            "#{sudo_str} #{command_str}"
+          end
+        end
+
+        # Returns string with the interpreter conditionally prepended
+        def inject_interpreter(interpreter, command)
+          if interpreter
+            if command.is_a?(Array)
+              command.unshift(interpreter)
+            else
+              command = [interpreter, command]
+            end
+          end
+
+          command.is_a?(String) ? command : Shellwords.shelljoin(command)
+        end
       end
     end
   end

--- a/lib/bolt/transport/sudoable/connection.rb
+++ b/lib/bolt/transport/sudoable/connection.rb
@@ -71,14 +71,20 @@ module Bolt
           raise NotImplementedError, message
         end
 
+        # In the case where a task is run with elevated privilege and needs stdin
+        # a random string is echoed to stderr indicating that the stdin is available
+        # for task input data because the sudo password has already either been
+        # provided on stdin or was not needed.
         def prepend_sudo_success(sudo_id, command_str)
           "sh -c 'echo #{sudo_id} 1>&2; #{command_str}'"
         end
 
-        # A helper to build up a single string that contains all of the options
-        # for privilage escalation.
-        def build_sudoable_command_str(command_str, sudo_str, sudo_id, stdin)
-          if stdin
+        # A helper to build up a single string that contains all of the options for
+        # privilege escalation. A wrapper script is used to direct task input to stdin
+        # when a tty is allocated and thus we do not need to prepend_sudo_success when
+        # using the wrapper or when the task does not require stdin data.
+        def build_sudoable_command_str(command_str, sudo_str, sudo_id, options)
+          if options[:stdin] && !options[:wrapper]
             "#{sudo_str} #{prepend_sudo_success(sudo_id, command_str)}"
           else
             "#{sudo_str} #{command_str}"

--- a/pre-docs/bolt_configuration_options.md
+++ b/pre-docs/bolt_configuration_options.md
@@ -72,6 +72,8 @@ to avoid writing them to disk.
 
 `tmpdir`: The directory to upload and execute temporary files on the target.
 
+`tty`: Request a pseudo tty for the ssh session. This option is generally only used in conjunction with the `run_as` option when the sudoers policy requires a `tty`. Default is `false`.
+
 `user`: Login user. Default is the same as the currently logged in user.
 
 ### OpenSSH configuration options 

--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -245,15 +245,6 @@ describe Bolt::Transport::SSH do
     it "returns false if the target is not available", ssh: true do
       expect(ssh.connected?(Bolt::Target.new('unknownfoo'))).to eq(false)
     end
-
-    it "doesn't generate a task wrapper when not needed", ssh: true do
-      contents = "#!/bin/sh\necho -n ${PT_message_one} ${PT_message_two}"
-      arguments = { message_one: 'Hello from task', message_two: 'Goodbye' }
-      expect(ssh).not_to receive(:make_wrapper_stringio)
-      with_task_containing('tasks_test', contents, 'environment') do |task|
-        ssh.run_task(target, task, arguments)
-      end
-    end
   end
 
   # Local transport doesn't have concept of 'user'

--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -38,8 +38,12 @@ describe Bolt::Transport::SSH do
   let(:no_host_key_check) { mk_config('host-key-check' => false, user: user, password: password) }
   let(:no_user_config) { mk_config('host-key-check' => false, user: nil, password: password) }
   let(:ssh) { Bolt::Transport::SSH.new }
-
   let(:transport_conf) { {} }
+  let(:task_input_size) { 100000 }
+  let(:big_task_input) { "f" * task_input_size }
+  let(:stdin_task) { "#!/bin/sh\ngrep data" }
+  let(:env_task) { "#!/bin/sh\necho $PT_data" }
+
   def make_target(host_: hostname, port_: port, conf: config)
     Bolt::Target.new("#{host_}:#{port_}", transport_conf).update_conf(conf.transport_conf)
   end
@@ -290,6 +294,45 @@ describe Bolt::Transport::SSH do
 
       ssh.run_command(target, "rm #{dest}", sudoable: true, run_as: 'root')
     end
+
+    it "runs a task that expects big data on stdin" do
+      with_task_containing('tasks_test', stdin_task, 'stdin') do |task|
+        expect(ssh).not_to receive(:make_wrapper_stringio)
+        result = ssh.run_task(target, task, { 'data' => big_task_input }, '_run_as' => 'root')
+        expect(result.value['data'].strip.size).to eq(task_input_size)
+      end
+    end
+
+    it "runs a task that expects big data in environment variable" do
+      expect(ssh).not_to receive(:make_wrapper_stringio)
+      with_task_containing('tasks_test', env_task, 'environment') do |task|
+        result = ssh.run_task(target, task, { 'data' => big_task_input }, '_run_as' => 'root')
+        expect(result.value['_output'].strip.size).to eq(task_input_size)
+      end
+    end
+  end
+
+  context "with sudo with task interpreter set", sudo: true, ssh: true do
+    let(:config) {
+      mk_config('host-key-check' => false, 'sudo-password' => password, 'run-as' => 'root',
+                user: user, password: password, interpreters: { sh: '/bin/sh' })
+    }
+
+    it "runs a task that expects big data on stdin" do
+      expect(ssh).not_to receive(:make_wrapper_stringio)
+      with_task_containing('tasks_test', stdin_task, 'stdin', '.sh') do |task|
+        result = ssh.run_task(target, task, { 'data' => big_task_input }, '_run_as' => 'root')
+        expect(result.value['data'].strip.size).to eq(task_input_size)
+      end
+    end
+
+    it "runs a task that expects big data in environment variable" do
+      expect(ssh).not_to receive(:make_wrapper_stringio)
+      with_task_containing('tasks_test', env_task, 'environment', '.sh') do |task|
+        result = ssh.run_task(target, task, { 'data' => big_task_input }, '_run_as' => 'root')
+        expect(result.value['_output'].strip.size).to eq(task_input_size)
+      end
+    end
   end
 
   context "as bash user with no password", sudo: true do
@@ -324,14 +367,53 @@ describe Bolt::Transport::SSH do
     end
   end
 
-  context "requesting a pty", sudo: true do
+  context "requesting a pty", sudo: true, ssh: true do
     let(:config) {
       mk_config('host-key-check' => false, 'sudo-password' => password, 'run-as' => 'root',
                 tty: true, user: user, password: password)
     }
 
-    it "can execute a command when a tty is requested", ssh: true do
+    it "can execute a command when a tty is requested" do
       expect(ssh.run_command(target, 'whoami')['stdout'].strip).to eq('root')
+    end
+
+    it "runs a task that expects big data on stdin" do
+      expect(ssh).to receive(:make_wrapper_stringio).and_call_original
+      with_task_containing('tasks_test', stdin_task, 'stdin') do |task|
+        result = ssh.run_task(target, task, { 'data' => big_task_input }, '_run_as' => 'root')
+        expect(result.value['data'].strip.size).to eq(task_input_size)
+      end
+    end
+
+    it "runs a task that expects big data in environment variable" do
+      expect(ssh).not_to receive(:make_wrapper_stringio)
+      with_task_containing('tasks_test', env_task, 'environment') do |task|
+        result = ssh.run_task(target, task, { 'data' => big_task_input }, '_run_as' => 'root')
+        expect(result.value['_output'].strip.size).to eq(task_input_size)
+      end
+    end
+  end
+
+  context "when requesting a pty with task interpreter set", sudo: true, ssh: true do
+    let(:config) {
+      mk_config('host-key-check' => false, 'sudo-password' => password, 'run-as' => 'root',
+                tty: true, user: user, password: password, interpreters: { sh: '/bin/sh' })
+    }
+
+    it "runs a task that expects big data on stdin" do
+      expect(ssh).to receive(:make_wrapper_stringio).and_call_original
+      with_task_containing('tasks_test', stdin_task, 'stdin', '.sh') do |task|
+        result = ssh.run_task(target, task, { 'data' => big_task_input }, '_run_as' => 'root')
+        expect(result.value['data'].strip.size).to eq(task_input_size)
+      end
+    end
+
+    it "runs a task that expects big data in environment variable" do
+      expect(ssh).not_to receive(:make_wrapper_stringio)
+      with_task_containing('tasks_test', env_task, 'environment', '.sh') do |task|
+        result = ssh.run_task(target, task, { 'data' => big_task_input }, '_run_as' => 'root')
+        expect(result.value['_output'].strip.size).to eq(task_input_size)
+      end
     end
   end
 


### PR DESCRIPTION
Previously when running a task that required parameters to be passed on stdin using the run-as option for the ssh or local transport a wrapper script was used on the target. The data to be sent on stdin to the task executable was written to the wrapper script which was directed to stdin. This allowed reserving stdin to *only* pass the privilage escalation password. Writing input data to disk is undesirable given sensitive parameters could be written to disk as well as permissions issues on the wrapper when executing bolt as root with the run-as option set to a less privileged user for the local transport. This commit updates the local and ssh transports to not use a wrapper script. This is accomplished by generating a random string and echoing it before executing a task executable, when the string is detected that indicates the privilege escalation has succeeded and it is safe to pass task data on stdin.