### PR TITLE
(GH-1131) Add remote state support for Terraform plugin

### DIFF
--- a/lib/bolt/plugin/terraform.rb
+++ b/lib/bolt/plugin/terraform.rb
@@ -5,6 +5,10 @@ require 'json'
 module Bolt
   class Plugin
     class Terraform
+      KNOWN_KEYS = Set['_plugin', 'dir', 'resource_type', 'uri', 'name', 'statefile',
+                       'config', 'backend']
+      REQ_KEYS = Set['dir', 'resource_type']
+
       def initialize
         @logger = Logging.logger[self]
       end
@@ -21,7 +25,25 @@ module Bolt
         @logger.warn("Could not find property #{property} of terraform resource #{name}")
       end
 
+      # Make sure no unexpected keys are in the inventory config and
+      # that required keys are present
+      def validate_options(opts)
+        opt_keys = opts.keys.to_set
+
+        unless KNOWN_KEYS.superset?(opt_keys)
+          keys = opt_keys - KNOWN_KEYS
+          raise Bolt::ValidationError, "Unexpected key(s) in inventory config: #{keys.to_a.inspect}"
+        end
+
+        unless opt_keys.superset?(REQ_KEYS)
+          keys = REQ_KEYS - opt_keys
+          raise Bolt::ValidationError, "Expected key(s) in inventory config: #{keys.to_a.inspect}"
+        end
+      end
+
       def inventory_targets(opts)
+        validate_options(opts)
+
         state = load_statefile(opts)
 
         resources = extract_resources(state)
@@ -49,11 +71,32 @@ module Bolt
       end
 
       def load_statefile(opts)
+        statefile = if opts['backend'] == 'remote'
+                      load_remote_statefile(opts)
+                    else
+                      load_local_statefile(opts)
+                    end
+
+        JSON.parse(statefile)
+      end
+
+      # Uses the Terraform CLI to pull remote state files
+      def load_remote_statefile(opts)
+        stdout_str, stderr_str, = Open3.capture3('terraform state pull', chdir: opts['dir'])
+
+        unless stderr_str.empty?
+          err = stdout_str.split("\n").first
+          msg = "Could not pull Terraform remote state file for #{opts['dir']}: #{err}"
+          raise Bolt::Error.new(msg, 'bolt/terraform-state-error')
+        end
+
+        stdout_str
+      end
+
+      def load_local_statefile(opts)
         dir = opts['dir']
         filename = opts.fetch('statefile', 'terraform.tfstate')
-        statefile = File.expand_path(File.join(dir, filename))
-
-        JSON.parse(File.read(statefile))
+        File.read(File.expand_path(File.join(dir, filename)))
       rescue StandardError => e
         raise Bolt::FileError.new("Could not load Terraform state file #{filename}: #{e}", filename)
       end

--- a/lib/bolt/plugin/terraform.rb
+++ b/lib/bolt/plugin/terraform.rb
@@ -111,8 +111,10 @@ module Bolt
             resource_set['instances'].map do |resource|
               instance_name = prefix
               instance_name += ".#{resource['index_key']}" if resource['index_key']
-
-              [instance_name, resource['attributes']]
+              # When using `terraform state pull` with terraform >= 0.12 version 3 statefiles
+              # Will be converted to version 4. When converted attributes is converted to attributes_flat
+              attributes = resource['attributes'] || resource['attributes_flat']
+              [instance_name, attributes]
             end
           end
         else

--- a/pre-docs/inventory_version2.md
+++ b/pre-docs/inventory_version2.md
@@ -312,12 +312,13 @@ groups:
 The Terraform plugin supports looking up target object from a Terraform state
 file. It accepts several fields:
 
-`dir`: The directory from which to load Terraform state
+`dir`: The directory containing either a local Terraform state file or Terraform configuration to read remote state from
 `resource_type`: The Terraform resources to match, as a regular expression
 `uri`: The property of the Terraform resource to use as the target URI (optional)
-`statefile`: The name of the Terraform state file to load within `dir` (optional, defaults to `terraform.tfstate`)
+`statefile`: The name of the local Terraform state file to load, relative to `dir` (optional, defaults to `terraform.tfstate`)
 `name`: The property of the Terraform resource to use as the target name (optional)
 `config`: A Bolt config map where each value is the Terraform property to use for that config setting
+`backend`: The type of backend to load the state from, either `remote` or `local` (optional, defaults to `local`)
 
 One of `uri` or `name` is required. If only `uri` is set, then the value of `uri` will be used as the `name`.
 

--- a/spec/bolt/plugin/terraform_spec.rb
+++ b/spec/bolt/plugin/terraform_spec.rb
@@ -27,6 +27,11 @@ describe Bolt::Plugin::Terraform do
     expect(state).to eq(JSON.parse(File.read(statefile)))
   end
 
+  it 'fails when config is missing a required key' do
+    opts = {}
+    expect { subject.validate_options(opts) }.to raise_error(/Expected key/)
+  end
+
   shared_examples('loading terraform targets') do
     let(:opts) do
       { 'dir' => terraform_dir,


### PR DESCRIPTION
This adds support for loading a remote Terraform state file using the
Terraform CLI. Previously, state could only be read from local
state files.

Additionally, inventory cofig options are validated to ensure only known
keys are used and that all required keys are present.