### PR TITLE
Add homepage for developer blog on website

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -52,11 +52,12 @@
           <li>
             <span class="nav-header">Tips &amp; Tricks</span>
             <ul>
-              <li><a href="{{ '/debugging.html' | relative_url }}">Debugging common Bolt errors</a></li>
+              <li><a href="{{ '/debugging' | relative_url }}">Debugging common Bolt errors</a></li>
             </ul>
           </li>
           <li>
-            <span class="nav-header">Bolt Developer Updates</span>
+            <span class="nav-header">
+              <a href="{{ '/blog' | relative_url }}" class="center-vertical">Bolt Developer Updates</a></span>
             <ul>
               {% for post in site.posts limit: 3 %}
                 <li><a href="{{ post.url | remove: "/index.html" | relative_url }}">{{ post.title }}</a><br><small>{{ post.date | date: "%m-%d-%y" }}</small></li>

--- a/docs/_sass/modified-cayman.scss
+++ b/docs/_sass/modified-cayman.scss
@@ -213,6 +213,16 @@ a {
     color: $section-headings-color;
   }
 
+  article {
+    border-top: solid 1px $hr-border-color;
+    margin-top: 2rem;
+    padding-top: 2rem;
+  }
+
+  article h3 {
+    margin-bottom: 0;
+  }
+
   p {
     margin-bottom: 1em;
   }
@@ -342,7 +352,7 @@ a {
   }
 
   hr {
-    height: 2px;
+    height: 1px;
     padding: 0;
     margin: 1rem 0;
     background-color: $hr-border-color;

--- a/docs/blog.html
+++ b/docs/blog.html
@@ -1,0 +1,20 @@
+---
+layout: default
+title: Bolt Developer Updates
+---
+
+<p>
+  Keep up to date with Bolt, what we’re actively working on, and what we’re thinking about in the near term.
+</p>
+
+{% if site.posts %}
+  {% for post in site.posts %}
+  <article>
+    <h3><a href="{{ post.url | remove: "/index.html" | relative_url }}">{{ post.title }}</a></h3>
+    <small>Posted {{ post.date | date: "%m-%d-%y" }}</small>
+    <p>
+      {{ post.excerpt }}
+    </p>
+  </article>
+  {% endfor %}
+{% endif %}


### PR DESCRIPTION
This adds a homepage that lists all developer blog posts in a single
location with short excerpts. It also lists posts in reverse
chronological order in the sidebar so new posts will be visible.