### PR TITLE
Toggle target count in inventory show with verbose logging

### DIFF
--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -315,7 +315,7 @@ module Bolt
         targets = options[:targets].map(&:name)
         count = "#{targets.count} target#{'s' unless targets.count == 1}"
         @stream.puts targets.join("\n")
-        @stream.puts colorize(:green, count)
+        @stream.puts colorize(:green, count) if @verbose
       end
 
       # @param [Bolt::ResultSet] apply_result A ResultSet object representing the result of a `bolt apply`


### PR DESCRIPTION
This allows users to toggle the target count when using the `inventory
show` command and printing in human format. Previously, the target count
would always display, making it more challenging to use the command's
output in scripts. The target count will only display when verbose
logging is set.