### PR TITLE
(maint) Update facts module to 0.6.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,7 +6,7 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '1.0.0'
-mod 'puppetlabs-facts', '0.5.1'
+mod 'puppetlabs-facts', '0.6.0'
 mod 'puppetlabs-puppet_agent', '2.2.0'
 
 # Core types and providers for Puppet 6

--- a/acceptance/setup/common/pre-suite/071_install_modules.rb
+++ b/acceptance/setup/common/pre-suite/071_install_modules.rb
@@ -7,7 +7,7 @@ test_name "Install modules" do
 
   on(bolt, "mkdir -p #{default_boltdir}")
   create_remote_file(bolt, "#{default_boltdir}/Puppetfile", <<-PUPPETFILE)
-mod 'puppetlabs-facts', '0.5.1'
+mod 'puppetlabs-facts', '0.6.0'
 mod 'puppetlabs-service', '1.0.0'
 mod 'puppetlabs-puppet_agent', '2.2.0'
 PUPPETFILE


### PR DESCRIPTION
The facts module now supports detecting os.distro.codename in the shell implementation.