### PR TITLE
(GH-1145) Remove sudo-password with no run-as warning

### DIFF
--- a/lib/bolt/transport/local.rb
+++ b/lib/bolt/transport/local.rb
@@ -12,8 +12,7 @@ module Bolt
       end
 
       def self.validate(options)
-        logger = Logging.logger[self]
-        validate_sudo_options(options, logger)
+        validate_sudo_options(options)
       end
 
       def with_connection(target, *_args)

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -28,8 +28,7 @@ module Bolt
       end
 
       def self.validate(options)
-        logger = Logging.logger[self]
-        validate_sudo_options(options, logger)
+        validate_sudo_options(options)
 
         host_key = options['host-key-check']
         unless !!host_key == host_key

--- a/lib/bolt/transport/sudoable.rb
+++ b/lib/bolt/transport/sudoable.rb
@@ -6,12 +6,7 @@ require 'bolt/transport/base'
 module Bolt
   module Transport
     class Sudoable < Base
-      def self.validate_sudo_options(options, logger)
-        if options['sudo-password'] && options['run-as'].nil?
-          logger.warn("--sudo-password will not be used without specifying a " \
-                      "user to escalate to with --run-as")
-        end
-
+      def self.validate_sudo_options(options)
         run_as_cmd = options['run-as-command']
         if run_as_cmd && (!run_as_cmd.is_a?(Array) || run_as_cmd.any? { |n| !n.is_a?(String) })
           raise Bolt::ValidationError, "run-as-command must be an Array of Strings, received #{run_as_cmd}"


### PR DESCRIPTION
Closes #1145 

This removes a warning that's raised when `--sudo-password` is specified
on the command line when `--run-as` is not specified on the command
line. The warning was often raised for valid use cases where
`--sudo-password` was specified and `--run-as` was not, and predicting
whether the warning was needed is more difficult than the warning is
worth.