### PR TITLE
Add Atom feed to website

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: Bolt Hands-on Lab
+title: Bolt
 google_analytics: UA-120367942-3
 exclude: [vendor, Boltdir, acceptance, modules, .git, Gemfile, Gemfile.lock]
 
@@ -22,3 +22,6 @@ defaults:
     values:
       layout: post
       permalink: /:categories/:year-:month-:day-:title
+
+plugins:
+  - jekyll-feed

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -19,6 +19,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
     <link rel="icon" href="{{ '/favicon.ico' | relative_url }}" type="image/x-icon" />
+    {% feed_meta %}
   </head>
   <body>
     <div class="container">


### PR DESCRIPTION
This adds support for an Atom feed for the Bolt Developer Updates blog  using the
jekyll-feed plugin.