### PR TITLE
(maint) Fix rubocop 

### DIFF
--- a/lib/bolt/transport/docker.rb
+++ b/lib/bolt/transport/docker.rb
@@ -60,7 +60,7 @@ module Bolt
         if target.options['tty']
           options[:Tty] = true
         end
-        options[:wait] = 24 * 60 * 60  # Choose 24 hour as timeout. But needs to be big
+        options[:wait] = 24 * 60 * 60 # Choose 24 hour as timeout. But needs to be big
         if target.options['shell-command'] && !target.options['shell-command'].empty?
           # escape any double quotes in command
           command = command.gsub('"', '\"')


### PR DESCRIPTION
An extra space before a comment somehow slipped through. Trivial to fix. 