### PR TITLE
(GH-1148) Add Azure inventory plugin

### DIFF
--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -7,6 +7,7 @@ require 'bolt/plugin/prompt'
 require 'bolt/plugin/task'
 require 'bolt/plugin/aws'
 require 'bolt/plugin/vault'
+require 'bolt/plugin/azure'
 
 module Bolt
   class Plugin
@@ -40,6 +41,7 @@ module Bolt
       plugins.add_plugin(Bolt::Plugin::Task.new(config))
       plugins.add_plugin(Bolt::Plugin::Aws::EC2.new(config.plugins['aws'] || {}))
       plugins.add_plugin(Bolt::Plugin::Vault.new(config.plugins['vault'] || {}))
+      plugins.add_plugin(Bolt::Plugin::Azure.new(config.plugins['azure'] || {}))
       plugins
     end
 

--- a/lib/bolt/plugin/azure.rb
+++ b/lib/bolt/plugin/azure.rb
@@ -1,0 +1,199 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Bolt
+  class Plugin
+    class Azure
+      class AzureHTTPError < Bolt::Error
+        def initialize(response)
+          err = JSON.parse(response.body).dig('error', 'message')
+          m = String.new("#{response.code} \"#{response.msg}\"")
+          m += ": #{err}" if err
+          super(m, 'bolt.plugin/azure-http-error')
+        end
+      end
+
+      attr_reader :config
+
+      CONFIG_KEYS = Set['tenant_id', 'client_id', 'client_secret', 'subscription_id', 'profile']
+      OPTS_KEYS = Set['_plugin', 'location', 'tags', 'resource_group', 'scale_set'] + CONFIG_KEYS
+
+      def initialize(config)
+        validate_config(config)
+        @config = config
+        @logger = Logging.logger[self]
+      end
+
+      def name
+        'azure'
+      end
+
+      def hooks
+        %w[inventory_targets]
+      end
+
+      def validate_config(config)
+        keys = config.keys.to_set
+
+        unless CONFIG_KEYS.superset?(keys)
+          keys -= CONFIG_KEYS
+          raise Bolt::ValidationError, "Unexpected key(s) in plugin config: #{keys.to_a.inspect}"
+        end
+      end
+
+      def validate_options(opts)
+        keys = opts.keys.to_set
+
+        unless OPTS_KEYS.superset?(keys)
+          keys -= OPTS_KEYS
+          raise Bolt::ValidationError, "Unexpected key(s) in inventory config: #{keys.to_a.inspect}"
+        end
+      end
+
+      def inventory_targets(opts)
+        validate_options(opts)
+        creds = credentials(opts)
+        token = token(creds)
+        instances = instances(token, creds, opts)
+
+        # Filter by location
+        if opts['location']
+          instances.select! do |instance|
+            instance['location'] == opts['location']
+          end
+        end
+
+        # Filter by tags - tags are ANDed
+        if opts['tags']
+          instances.select! do |instance|
+            instance['tags'] && opts['tags'] <= instance['tags']
+          end
+        end
+
+        # Map the VMs to a list of targets
+        # name is set to the FQDN while uri is set to the public ip address
+        # Any VMs that have neither of these set are dropped
+        instances.map do |instance|
+          target = {
+            'name' => instance.dig('properties', 'dnsSettings', 'fqdn'),
+            'uri' => instance.dig('properties', 'ipAddress')
+          }.compact
+
+          target unless target.empty?
+        end.compact
+      end
+
+      # Hash of required credentials for authorizing with the Azure REST API
+      # These values can be set in 3 locations - inventory config, Bolt config, environment variables
+      # TODO: Add support for reading credentials from .ini file?
+      def credentials(opts)
+        creds = {
+          'tenant_id' => (opts['tenant_id'] || config['tenant_id'] || ENV['AZURE_TENANT_ID']),
+          'client_id' => (opts['client_id'] || config['client_id'] || ENV['AZURE_CLIENT_ID']),
+          'client_secret' => (opts['client_secret'] || config['client_secret'] || ENV['AZURE_CLIENT_SECRET']),
+          'subscription_id' => (opts['subscription_id'] || config['subscription_id'] || ENV['AZURE_SUBSCRIPTION_ID'])
+        }
+
+        # All credentials must be set, otherwise there's no point continuing
+        if creds.values.include? nil
+          keys = creds.select { |_, v| v.nil? }.keys
+          raise Bolt::ValidationError, "Missing required credentials: #{keys}"
+        end
+
+        creds
+      end
+
+      # Requests for VMs and scale sets are on a per-subscription basis
+      # You can also request VMs by a specific resource group
+      # Scale sets are always requested by resource group and scale set name
+      #
+      # Since each request only returns up to 1,000 results, requests will continue to be
+      # sent until there is no longer a nextLink token in the result set
+      def instances(token, creds, opts)
+        url = if opts['resource_group']
+                if opts['scale_set']
+                  "https://management.azure.com/subscriptions/#{creds['subscription_id']}/" \
+                  "resourceGroups/#{opts['resource_group']}/providers/Microsoft.Compute/" \
+                  "virtualMachineScaleSets/#{opts['scale_set']}/" \
+                  "publicipaddresses?api-version=2017-03-30"
+                else
+                  "https://management.azure.com/subscriptions/#{creds['subscription_id']}/" \
+                  "resourceGroups/#{opts['resource_group']}/providers/Microsoft.Network/" \
+                  "publicIPAddresses?api-version=2019-06-01"
+                end
+              else
+                "https://management.azure.com/subscriptions/#{creds['subscription_id']}/" \
+                "providers/Microsoft.Network/publicIPAddresses?api-version=2019-06-01"
+              end
+
+        header = {
+          'Authorization' => "#{token['token_type']} #{token['access_token']}"
+        }
+
+        instances = []
+
+        while url do
+          # Update the URI and make the next request
+          uri = URI.parse(url)
+          result = request(:Get, uri, nil, header)
+
+          # Add the VMs to the list of instances
+          instances << result['value']
+
+          # Continue making requests until there is no longer a nextLink
+          url = result['nextLink']
+        end
+
+        instances.flatten
+      end
+
+      # Uses the client credentials grant flow
+      # https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-oauth2-client-creds-grant-flow
+      def token(creds)
+        data = {
+          grant_type: 'client_credentials',
+          client_id: creds['client_id'],
+          client_secret: creds['client_secret'],
+          resource: 'https://management.azure.com'
+        }
+
+        uri = URI.parse("https://login.microsoftonline.com/#{creds['tenant_id']}/oauth2/token")
+
+        request(:Post, uri, data)
+      end
+
+      def request(verb, uri, data, header = {})
+        # Create the client
+        client = Net::HTTP.new(uri.host, uri.port)
+
+        # Azure REST API always uses SSL
+        client.use_ssl = true
+        client.verify_mode = OpenSSL::SSL::VERIFY_PEER
+
+        # Build the request
+        request = Net::HTTP.const_get(verb).new(uri.request_uri, header)
+
+        # Build the query if there's data to send
+        query = URI.encode_www_form(data) if data
+
+        # Send the request
+        begin
+          response = client.request(request, query)
+        rescue StandardError => e
+          raise Bolt::Error.new(
+            "Failed to connect to #{uri}: #{e.message}",
+            'CONNECT_ERROR'
+          )
+        end
+
+        case response
+        when Net::HTTPOK
+          JSON.parse(response.body)
+        else
+          raise AzureHTTPError, response
+        end
+      end
+    end
+  end
+end

--- a/pre-docs/inventory_version2.md
+++ b/pre-docs/inventory_version2.md
@@ -464,6 +464,67 @@ plugins:
     credentials: ~/alternate_path/credentials
 ```
 
+#### Azure
+
+The Azure plugin supports looking up virtual machines and virtual machine scale sets. It supports several fields:
+
+- `_plugin`: The value of `_plugin` must be `azure`
+- `resource_group`: The resource group to filter by (optional)
+- `scale_set`: The scale set to filter by (optional, requires that `resource_group` also be set)
+- `location`: The location to filter by (optional)
+- `tags`: A list of one or more tags to filter by (optional, tags are `name: value` pairs and instances must match all listed tags)
+
+Accessing Azure resources requires credentials for signing all API requests. Each credential can be set in the inventory config, Bolt config, or as an environment variable, and are searched in this order until a value is found.
+
+- `tenant_id`: The Azure AD tenant ID (defaults to `ENV['AZURE_TENANT_ID']`)
+- `client_id`: The Azure client application ID (defaults to `ENV['AZURE_CLIENT_ID']`)
+- `client_secret`: The Azure client application secret (defaults to `ENV['AZURE_CLIENT_SECRET']`)
+- `subscription_id`: The Azure subscription ID (defaults to `ENV['AZURE_SUBSCRIPTION_ID']`)
+
+You can consult the following documentation to obtain credentials:
+
+**Tenant ID:** https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-create-new-tenant
+
+**Client ID and secret:** https://docs.microsoft.com/en-us/rest/api/azure/#register-your-client-application-with-azure-ad
+
+**Subscription ID:** https://blogs.msdn.microsoft.com/mschray/2016/03/18/getting-your-azure-subscription-guid-new-portal/
+
+Bolt will only target virtual machines and virtual machine scale sets that have either a public IP address or fully qualified domain name set. By default, the `uri` of the target will be set to the public IP address and the `name` will be set to the fully qualified domain name.
+
+```yaml
+# inventory.yaml
+
+groups:
+  - name: azure-vms
+    targets:
+      - _plugin: azure
+        location: eastus
+        resource_group: bolt
+        tags:
+          foo: bar
+          baz: bak
+  - name: azure-scale-sets
+    targets:
+      - _plugin: azure
+        location: eastus2
+        resource_group: puppet
+        scale_set: bolt
+        tags:
+          foo: bar
+```
+
+```yaml
+# bolt.yaml
+
+plugins:
+  azure:
+    tenant_id: xxxx-xxx-xxxx
+    client_id: xxxx-xxx-xxxx
+    client_secret: xxxx-xxx-xxxx
+    subscription_id: xxxx-xxx-xxxx
+```
+
+
 #### Prompt plugin
 
 The 'prompt' plugin can be used to allow users to interactively enter sensitive configuration information on the CLI instead of storing that data in the inventoryfile. Data will only be looked up when the value is needed for the target and once the value has been stored it will be re-used for the rest of the Bolt run. The `prompt` plugin may only be used when nested under `config`. The prompt plugin can be used by replacing the config value with a hash that has the following keys:

--- a/spec/bolt/plugin/azure_spec.rb
+++ b/spec/bolt/plugin/azure_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/plugin/azure'
+
+describe Bolt::Plugin::Azure do
+  let(:config) do
+    {
+      'tenant_id' => 'HrGSPVAbDeRBIiGlDNVQkw3FMds10GlU',
+      'client_id' => 'HrGSPVAbDeRBIiGlDNVQkw3FMds10GlU',
+      'client_secret' => 'HrGSPVAbDeRBIiGlDNVQkw3FMds10GlU',
+      'subscription_id' => 'HrGSPVAbDeRBIiGlDNVQkw3FMds10GlU'
+    }
+  end
+
+  let(:options) do
+    {
+      '_plugin' => 'azure',
+      'resource_group' => 'puppet',
+      'scale_set' => 'bolt',
+      'location' => 'eastus',
+      'tags' => {
+        'foo' => 'bar',
+        'baz' => 'bak'
+      }
+    }
+  end
+
+  let(:plugin) { Bolt::Plugin::Azure.new(config) }
+
+  it 'has a hook for inventory_targets' do
+    expect(plugin.hooks).to eq(['inventory_targets'])
+  end
+
+  context 'when validating keys' do
+    it 'errors with unexpected config keys' do
+      config['foo'] = 'bar'
+      expect { plugin }.to raise_error(Bolt::ValidationError, /foo/)
+    end
+
+    it 'errors with unexpected inventory config keys' do
+      options['foo'] = 'bar'
+      expect { plugin.validate_options(options) }.to raise_error(Bolt::ValidationError, /foo/)
+    end
+  end
+
+  context 'when validating credentials' do
+    it 'errors when a credential is missing' do
+      config.delete('tenant_id')
+      expect { plugin.credentials(options) }.to raise_error(Bolt::ValidationError, /tenant_id/)
+    end
+
+    it 'prefers credentials set in the inventory' do
+      options['tenant_id'] = 'foo'
+      expect(plugin.credentials(options)).to include('tenant_id' => 'foo')
+    end
+  end
+end


### PR DESCRIPTION
This adds support for looking up virtual machines and virtual machine
scale sets on Azure. VMs can be filtered by location, resource group,
and tags.