### PR TITLE
(GH-1060) Port over unused docker-api option tty, remove unused option wait

### DIFF
--- a/lib/bolt/transport/docker.rb
+++ b/lib/bolt/transport/docker.rb
@@ -51,10 +51,8 @@ module Bolt
       end
 
       def run_command(target, command, options = {})
-        if target.options['tty']
-          options[:Tty] = true
-        end
-        options[:wait] = 24 * 60 * 60 # Choose 24 hour as timeout. But needs to be big
+        options[:tty] = target.options['tty']
+
         if target.options['shell-command'] && !target.options['shell-command'].empty?
           # escape any double quotes in command
           command = command.gsub('"', '\"')

--- a/lib/bolt/transport/docker/connection.rb
+++ b/lib/bolt/transport/docker/connection.rb
@@ -51,6 +51,7 @@ module Bolt
           command_options = []
           # Need to be interactive if redirecting STDIN
           command_options << '--interactive' unless options[:stdin].nil?
+          command_options << '--tty' if options[:tty]
           command_options.concat(envs) unless envs.empty?
           command_options << container_id
           command_options.concat(command)


### PR DESCRIPTION
When moving to the docker cli instead of the gem the tty option was not ported over, this commit adds the -tty flag when a the tty transport option is requested. The wait option was added as a workaround which was specific to the docker-api gem and was added after the original PR was raised, this commit removes it as it does not appear to be an issue with the CLI.