### PR TITLE
(maint) Do not automatically restart samba-ad container

### DIFF
--- a/spec/docker-compose.yml
+++ b/spec/docker-compose.yml
@@ -84,7 +84,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.samba-ad
-    restart: always
     # SYS_ADMIN necessary for samba-tool domain provision
     # otherwise set_nt_acl_no_snum: fset_nt_acl returned NT_STATUS_ACCESS_DENIED
     cap_add:


### PR DESCRIPTION
Setting the restart policy to `always` for the samba-ad container results in the container automatically starting when not explicitly stoped. Restarting the samba-ad container *without* the rest of the containers in the docker-compose stack can result in improper configuration. This commit removes the restart policy with the assumption that the docker-compose stack will always be initialized at once.