### PR TITLE
(maint) Set host-key-check to false for bolt-server

### DIFF
--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -103,7 +103,8 @@ module BoltServer
       error = validate_schema(@schemas["transport-ssh"], body)
       return [400, error.to_json] unless error.nil?
 
-      opts = body['target'].clone
+      defaults = { 'host-key-check' => false }
+      opts = defaults.merge(body['target'])
       if opts['private-key-content']
         opts['private-key'] = { 'key-data' => opts['private-key-content'] }
         opts.delete('private-key-content')


### PR DESCRIPTION
We recently modified the behavior of Bolt's SSH transport when
`host-key-check` is nil. Previously it would not check the host key but
now it tries to add the host key to known_hosts. Since Bolt defaulted to
`host-key-check: true` this didn't change Bolt's behavior, but did
affect `bolt-server` which bypasses the config defaults that Bolt has.
`bolt-server` now defaults to `host-key-check: false` over the SSH
transport.