### PR TITLE
(GH-1183) Correct file path separator in task show modulepath

### DIFF
--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -209,7 +209,7 @@ module Bolt
 
       def print_tasks(tasks, modulepath)
         print_table(tasks)
-        print_message("\nMODULEPATH:\n#{modulepath.join(':')}\n"\
+        print_message("\nMODULEPATH:\n#{modulepath.join(File::PATH_SEPARATOR)}\n"\
                         "\nUse `bolt task show <task-name>` to view "\
                         "details and parameters for a specific task.")
       end
@@ -278,7 +278,7 @@ module Bolt
 
       def print_plans(plans, modulepath)
         print_table(plans)
-        print_message("\nMODULEPATH:\n#{modulepath.join(':')}\n"\
+        print_message("\nMODULEPATH:\n#{modulepath.join(File::PATH_SEPARATOR)}\n"\
                         "\nUse `bolt plan show <plan-name>` to view "\
                         "details and parameters for a specific plan.")
       end

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -185,6 +185,17 @@ built-in module
     TASK_OUTPUT
   end
 
+  it 'prints correct file separator for modulepath' do
+    task = {
+      'name' => 'monkey_bread',
+      'files' => [{ 'name' => 'monkey_bread.rb',
+                    'path' => "#{Bolt::PAL::MODULES_PATH}/monkey/bread" }],
+      'metadata' => {}
+    }
+    outputter.print_tasks([task], %w[path1 path2])
+    expect(output.string).to include("path1#{File::PATH_SEPARATOR}path2")
+  end
+
   it "formats a plan" do
     plan = {
       'name' => 'planity_plan',


### PR DESCRIPTION
Closes #1183

The modulepath listed in `bolt task show` and `bolt plan show` output used a hardcoded ':' as the file path separator, which is incorrect on Windows. It now uses ruby's `File::PATH_SEPARATOR` to display the correct path separator