### PR TITLE
(maint) Add _raw_source to upload-file/run_script

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
@@ -55,6 +55,7 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
 
     options ||= {}
     options = options.merge('_description' => description) if description
+    options = options.merge('_raw_source' => source)
     executor = Puppet.lookup(:bolt_executor)
     inventory = Puppet.lookup(:bolt_inventory)
 

--- a/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
@@ -59,6 +59,7 @@ Puppet::Functions.create_function(:upload_file, Puppet::Functions::InternalFunct
 
     options ||= {}
     options = options.merge('_description' => description) if description
+    options = options.merge('_raw_source' => source)
     executor = Puppet.lookup(:bolt_executor)
     inventory = Puppet.lookup(:bolt_inventory)
 


### PR DESCRIPTION
In PE, we will require the raw source parameter passed to both upload_file and
run_script. This commit adds _raw_source to the options hash provided to
executor.run_script and executor.upload_file in those respective functions.