### PR TITLE
(GH-1125) Clear API for Target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
 
   A new [module based plugin](https://github.com/puppetlabs/puppetlabs-azure_inventory) allows generation of Bolt targets from Azure VMs.
 
+
+* **Clear API for `Target`** ([#1125](https://github.com/puppetlabs/bolt/issues/1125))
+
+  An updated `Target` API for creating and configuring bolt `Targets` during plan execution when using Inventory version 2 is now available.
+
 ## 1.31.1
 
 #### Bug fixes

--- a/bolt-modules/boltlib/lib/puppet/datatypes/target.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/target.rb
@@ -1,22 +1,55 @@
 # frozen_string_literal: true
 
 Puppet::DataTypes.create_type('Target') do
-  interface <<-PUPPET
-    attributes => {
-      uri => String[1],
-      options => { type => Hash[String[1], Data], value => {} }
-    },
-    functions => {
-      name => Callable[[], String[1]],
-      host => Callable[[], Optional[String]],
-      password => Callable[[], Optional[String[1]]],
-      port => Callable[[], Optional[Integer]],
-      protocol => Callable[[], Optional[String[1]]],
-      user => Callable[[], Optional[String[1]]],
-    }
-  PUPPET
-
+  begin
+    inventory = Puppet.lookup(:bolt_inventory)
+    inventory_version = inventory.version
+    if inventory_version != 1
+      target_implementation_class = inventory.target_implementation_class
+    end
+  rescue Puppet::Context::UndefinedBindingError
+    inventory_version = 1
+  end
   load_file('bolt/target')
 
-  implementation_class Bolt::Target
+  if inventory_version == 1
+    interface <<-PUPPET
+      attributes => {
+        uri => String[1],
+        options => { type => Hash[String[1], Data], value => {} }
+      },
+      functions => {
+        name => Callable[[], String[1]],
+        host => Callable[[], Optional[String]],
+        password => Callable[[], Optional[String[1]]],
+        port => Callable[[], Optional[Integer]],
+        protocol => Callable[[], Optional[String[1]]],
+        user => Callable[[], Optional[String[1]]],
+      }
+    PUPPET
+    implementation_class Bolt::Target
+  else
+    interface <<-PUPPET
+      attributes => {
+        uri => { type => Optional[String[1]], kind => given_or_derived },
+        name => { type => Optional[String[1]] , kind => given_or_derived },
+        target_alias => { type => Optional[Variant[String[1], Array[String[1]]]], kind => given_or_derived },
+        config => { type => Optional[Hash[String[1], Data]], kind => given_or_derived },
+        vars => { type => Optional[Hash[String[1], Data]], kind => given_or_derived  },
+        facts => { type => Optional[Hash[String[1], Data]], kind => given_or_derived  },
+        features => { type => Optional[Array[String[1]]], kind => given_or_derived },
+        plugin_hooks => { type => Optional[Hash[String[1], Data]], kind => given_or_derived  }
+      },
+      functions => {
+        safe_name => Callable[[], String[1]],
+        host => Callable[[], Optional[String]],
+        password => Callable[[], Optional[String[1]]],
+        port => Callable[[], Optional[Integer]],
+        protocol => Callable[[], Optional[String[1]]],
+        user => Callable[[], Optional[String[1]]],
+      }
+    PUPPET
+
+    implementation_class target_implementation_class
+  end
 end

--- a/bolt-modules/boltlib/lib/puppet/functions/get_target.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/get_target.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'bolt/error'
+
+# Get a single target from inventory if it exists, otherwise create a new Target.
+#
+# **NOTE:** Calling `get_target` inside an `apply` block with a
+# version 2 inventory creates a new Target object.
+# `get_target('all')` returns an empty array.
+# **NOTE:** Only compatible with inventory v2
+Puppet::Functions.create_function(:get_target) do
+  # @param name A Target name.
+  # @return A single target, either new or from inventory.
+  # @example Create a new Target from a URI
+  #   get_target('winrm://host2:54321')
+  # @example Get an existing Target from inventory
+  #   get_target('existing-target')
+  dispatch :get_target do
+    param 'Boltlib::TargetSpec', :name
+    return_type 'Target'
+  end
+
+  def get_target(name)
+    inventory = Puppet.lookup(:bolt_inventory)
+    # Bolt executor not expected when invoked from apply block
+    executor = Puppet.lookup(:bolt_executor) { nil }
+    executor&.report_function_call(self.class.name)
+
+    unless inventory.version > 1
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::UNSUPPORTED_INVENTORY_VERSION, action: 'get_target')
+    end
+
+    inventory.get_target(name)
+  end
+end

--- a/bolt-modules/boltlib/lib/puppet/functions/set_config.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_config.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'bolt/error'
+
+# Set configuration options on a target
+#
+# **NOTE:** Not available in apply block
+# **NOTE:** Only compatible with inventory v2
+Puppet::Functions.create_function(:set_config) do
+  # @param target The Target object to configure. See {get_targets}.
+  # @param key_or_key_path The configuration setting to update.
+  # @param value The configuration value
+  # @return The Target with the updated config
+  # @example Set the transport for a target
+  #   set_config($target, 'transport', 'ssh')
+  # @example Set the ssh password
+  #   set_config($target, ['ssh', 'password'], 'secret')
+  # @example Overwrite ssh config
+  #   set_config($target, 'ssh', { user => 'me', password => 'secret' })
+  dispatch :set_config do
+    param 'Target', :target
+    param 'Variant[String, Array[String]]', :key_or_key_path
+    param 'Any', :value
+    return_type 'Target'
+  end
+
+  def set_config(target, key_or_key_path, value = true)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'set_config')
+    end
+
+    inventory = Puppet.lookup(:bolt_inventory)
+    executor = Puppet.lookup(:bolt_executor)
+    executor.report_function_call(self.class.name)
+
+    unless inventory.version > 1
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::UNSUPPORTED_INVENTORY_VERSION, action: 'set_config')
+    end
+
+    inventory.set_config(target, key_or_key_path, value)
+
+    target
+  end
+end

--- a/bolt-modules/boltlib/lib/puppet/functions/set_feature.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_feature.rb
@@ -22,6 +22,7 @@ Puppet::Functions.create_function(:set_feature) do
     param 'Target', :target
     param 'String', :feature
     optional_param 'Boolean', :value
+    return_type 'Target'
   end
 
   def set_feature(target, feature, value = true)

--- a/bolt-modules/boltlib/lib/puppet/functions/set_var.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_var.rb
@@ -9,13 +9,14 @@ Puppet::Functions.create_function(:set_var) do
   # @param target The Target object to set the variable for. See {get_targets}.
   # @param key The key for the variable.
   # @param value The value of the variable.
-  # @return [Undef]
+  # @return The target with the updated feature
   # @example Set a variable on a target
   #   $target.set_var('ephemeral', true)
   dispatch :set_var do
     param 'Target', :target
     param 'String', :key
     param 'Data', :value
+    return_type 'Target'
   end
 
   def set_var(target, key, value)
@@ -28,6 +29,9 @@ Puppet::Functions.create_function(:set_var) do
     executor = Puppet.lookup(:bolt_executor)
     executor.report_function_call(self.class.name)
 
-    inventory.set_var(target, key, value)
+    var_hash = { key => value }
+    inventory.set_var(target, var_hash)
+
+    target
   end
 end

--- a/bolt-modules/boltlib/spec/fixtures/modules/test/plans/targetspec_params.pp
+++ b/bolt-modules/boltlib/spec/fixtures/modules/test/plans/targetspec_params.pp
@@ -1,0 +1,11 @@
+plan test::targetspec_params(
+  Boltlib::TargetSpec $ts,
+  Optional[Boltlib::TargetSpec] $optional_ts,
+  Variant[Boltlib::TargetSpec, String] $variant_ts,
+  Array[Boltlib::TargetSpec] $array_ts,
+  Variant[Array[Boltlib::TargetSpec], String] $nested_ts,
+  String $string,
+  $typeless,
+){
+  return get_targets('all').map |$n| { $n.safe_name }
+}

--- a/bolt-modules/boltlib/spec/functions/add_facts_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/add_facts_spec.rb
@@ -14,6 +14,7 @@ describe 'add_facts' do
   around(:each) do |example|
     Puppet[:tasks] = tasks_enabled
     Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
+      inventory.stubs(:version).returns(1)
       example.run
     end
   end

--- a/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
@@ -168,9 +168,8 @@ describe 'apply_prep' do
       let(:hostname) { 'agentless' }
       let(:data) {
         {
-          'version' => 2,
-          'targets' => [{
-            'uri' => hostname,
+          'nodes' => [{
+            'name' => hostname,
             'plugin_hooks' => {
               'puppet_library' => {
                 'plugin' => 'task',

--- a/bolt-modules/boltlib/spec/functions/facts_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/facts_spec.rb
@@ -15,6 +15,7 @@ describe 'facts' do
   around(:each) do |example|
     Puppet[:tasks] = true
     Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
+      inventory.stubs(:version).returns(1)
       example.run
     end
   end

--- a/bolt-modules/boltlib/spec/functions/get_target_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/get_target_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/executor'
+require 'bolt/target'
+
+describe 'get_target' do
+  include PuppetlabsSpec::Fixtures
+  let(:executor) { Bolt::Executor.new }
+  let(:inventory) { mock('inventory') }
+  let(:tasks_enabled) { true }
+
+  around(:each) do |example|
+    Puppet[:tasks] = tasks_enabled
+    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
+      inventory.stubs(:version).returns(2)
+      inventory.stubs(:target_implementation_class).returns(Bolt::Target2)
+      example.run
+    end
+  end
+
+  context 'with inventory v1' do
+    it 'fails and reports that set_config is not available with inventory v1' do
+      inventory.stubs(:version).returns(1)
+      is_expected.to run
+        .with_params('foo').and_raise_error(/Plan language function 'get_target' cannot be used/)
+    end
+  end
+
+  context 'with inventory v2' do
+    let(:hostname) { 'foo.example.com ' }
+    let(:target) { Bolt::Target2.new(nil, hostname) }
+    let(:groupname) { 'all' }
+
+    it 'with given uri' do
+      inventory.expects(:get_target).with(hostname).returns(target)
+
+      is_expected.to run.with_params(hostname).and_return(target)
+    end
+
+    it 'with given Target' do
+      inventory.expects(:get_target).with(target).returns(target)
+
+      is_expected.to run.with_params(target).and_return(target)
+    end
+
+    it 'with given Target in array' do
+      inventory.expects(:get_target).with([target]).returns(target)
+
+      is_expected.to run.with_params([target]).and_return(target)
+    end
+
+    it 'errors when multiple targets returned' do
+      inventory.expects(:get_target).with(groupname).returns([target, target])
+
+      is_expected.to run.with_params(groupname)
+                        .and_raise_error(Puppet::Pops::Types::TypeAssertionError)
+    end
+
+    it 'errors on unknown types' do
+      is_expected.to run.with_params(mock('anything')).and_raise_error(ArgumentError)
+    end
+
+    it 'reports the call to analytics' do
+      inventory.expects(:get_target).with(hostname).returns(target)
+      executor.expects(:report_function_call).with('get_target')
+
+      is_expected.to run.with_params(hostname).and_return(target)
+    end
+  end
+end

--- a/bolt-modules/boltlib/spec/functions/get_targets_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/get_targets_spec.rb
@@ -12,6 +12,7 @@ describe 'get_targets' do
   around(:each) do |example|
     Puppet[:tasks] = tasks_enabled
     Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
+      inventory.stubs(:version).returns(1)
       example.run
     end
   end
@@ -40,7 +41,6 @@ describe 'get_targets' do
 
     it 'with array of Targets' do
       inventory.expects(:get_targets).with([target]).returns([target])
-
       is_expected.to run.with_params([target]).and_return([target])
     end
 

--- a/bolt-modules/boltlib/spec/functions/run_command_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_command_spec.rb
@@ -14,6 +14,7 @@ describe 'run_command' do
   around(:each) do |example|
     Puppet[:tasks] = tasks_enabled
     Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
+      inventory.stubs(:version).returns(1)
       example.run
     end
   end

--- a/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 require 'puppet_pal'
 require 'bolt/executor'
+require 'bolt/plugin'
 
 describe 'run_plan' do
   include PuppetlabsSpec::Fixtures
@@ -109,6 +110,25 @@ describe 'run_plan' do
     it 'fails and reports that run_plan is not available' do
       is_expected.to run.with_params('test::run_me')
                         .and_raise_error(/Plan language function 'run_plan' cannot be used/)
+    end
+  end
+
+  context 'with inventory v2' do
+    let(:config) { Bolt::Config.new(Bolt::Boltdir.new('.'), {}) }
+    let(:pal) { nil }
+    let(:plugins) { Bolt::Plugin.new(config, pal, Bolt::Analytics::NoopClient.new) }
+    let(:inventory) { Bolt::Inventory.create_version({ 'version' => 2 }, config, plugins) }
+
+    it 'parameters with type TargetSpec are added to inventory' do
+      params = { 'ts' => 'ts',
+                 'optional_ts' => 'optional_ts',
+                 'variant_ts' => 'variant_ts',
+                 'array_ts' => ['array_ts'],
+                 'nested_ts' => 'nested_ts',
+                 'string' => 'string',
+                 'typeless' => 'typeless' }
+      expected_targets = %w[ts optional_ts variant_ts array_ts nested_ts]
+      is_expected.to run.with_params('test::targetspec_params', params).and_return(expected_targets)
     end
   end
 end

--- a/bolt-modules/boltlib/spec/functions/run_script_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_script_spec.rb
@@ -15,6 +15,7 @@ describe 'run_script' do
   around(:each) do |example|
     Puppet[:tasks] = tasks_enabled
     Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
+      inventory.stubs(:version).returns(1)
       example.run
     end
   end

--- a/bolt-modules/boltlib/spec/functions/run_task_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_spec.rb
@@ -35,6 +35,7 @@ describe 'run_task' do
     executor.stubs(:noop).returns(false)
 
     Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
+      inventory.stubs(:version).returns(1)
       example.run
     end
   end

--- a/bolt-modules/boltlib/spec/functions/set_config_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/set_config_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/executor'
+require 'bolt/target'
+
+describe 'set_config' do
+  include PuppetlabsSpec::Fixtures
+  let(:executor) { Bolt::Executor.new }
+  let(:inventory) { mock('inventory') }
+  let(:target) { Bolt::Target2.new(nil, 'example') }
+  let(:tasks_enabled) { true }
+
+  around(:each) do |example|
+    Puppet[:tasks] = tasks_enabled
+    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
+      inventory.stubs(:version).returns(2)
+      inventory.stubs(:target_implementation_class).returns(Bolt::Target2)
+      example.run
+    end
+  end
+
+  context 'with inventory v1' do
+    let(:target) { Bolt::Target.new('target1') }
+    it 'fails and reports that set_config is not available with inventoy v1' do
+      inventory.stubs(:version).returns(1)
+      is_expected.to run
+        .with_params(target, 'ssh', 'name' => 'foo')
+        .and_raise_error(/Plan language function 'set_config' cannot be used/)
+    end
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+
+    it 'fails and reports that set_config is not available' do
+      is_expected.to run
+        .with_params(target, 'a', 'b').and_raise_error(/Plan language function 'set_config' cannot be used/)
+    end
+  end
+
+  it 'should set a config on a target' do
+    inventory.expects(:set_config).with(target, 'a', 'b').returns(target)
+    is_expected.to run.with_params(target, 'a', 'b').and_return(target)
+  end
+
+  it 'should sets nested config on a target' do
+    inventory.expects(:set_config).with(target, %w[a b], 'c').returns(target)
+    is_expected.to run.with_params(target, %w[a b], 'c').and_return(target)
+  end
+
+  it 'errors when passed invalid data types' do
+    is_expected.to run.with_params(target, 1, 'one')
+                      .and_raise_error(ArgumentError,
+                                       /'set_config' parameter 'key_or_key_path' expects a value of type String/)
+  end
+
+  it 'reports the call to analytics' do
+    executor.expects(:report_function_call).with('set_config')
+    inventory.expects(:set_config).with(target, 'a', 'b').returns(target)
+
+    is_expected.to run.with_params(target, 'a', 'b').and_return(target)
+  end
+end

--- a/bolt-modules/boltlib/spec/functions/set_feature_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/set_feature_spec.rb
@@ -15,6 +15,7 @@ describe 'set_feature' do
   around(:each) do |example|
     Puppet[:tasks] = tasks_enabled
     Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
+      inventory.expects(:version).returns(1)
       example.run
     end
   end

--- a/bolt-modules/boltlib/spec/functions/set_var_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/set_var_spec.rb
@@ -14,13 +14,14 @@ describe 'set_var' do
   around(:each) do |example|
     Puppet[:tasks] = tasks_enabled
     Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
+      inventory.stubs(:version).returns(1)
       example.run
     end
   end
 
   it 'should set a variable on a target' do
-    inventory.expects(:set_var).with(target, 'a', 'b').returns(nil)
-    is_expected.to run.with_params(target, 'a', 'b').and_return(nil)
+    inventory.expects(:set_var).with(target, 'a' => 'b').returns(target)
+    is_expected.to run.with_params(target, 'a', 'b').and_return(target)
   end
 
   it 'errors when passed invalid data types' do
@@ -31,9 +32,9 @@ describe 'set_var' do
 
   it 'reports the call to analytics' do
     executor.expects(:report_function_call).with('set_var')
-    inventory.expects(:set_var).with(target, 'a', 'b').returns(nil)
+    inventory.expects(:set_var).with(target, 'a' => 'b').returns(target)
 
-    is_expected.to run.with_params(target, 'a', 'b').and_return(nil)
+    is_expected.to run.with_params(target, 'a', 'b').and_return(target)
   end
 
   context 'without tasks enabled' do

--- a/bolt-modules/boltlib/spec/functions/upload_file_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/upload_file_spec.rb
@@ -15,6 +15,7 @@ describe 'upload_file' do
   around(:each) do |example|
     Puppet[:tasks] = tasks_enabled
     Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
+      inventory.stubs(:version).returns(1)
       example.run
     end
   end

--- a/bolt-modules/boltlib/spec/functions/vars_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/vars_spec.rb
@@ -15,6 +15,7 @@ describe 'vars' do
   around(:each) do |example|
     Puppet[:tasks] = true
     Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
+      inventory.stubs(:version).returns(1)
       example.run
     end
   end

--- a/bolt-modules/boltlib/spec/functions/wait_until_available_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/wait_until_available_spec.rb
@@ -14,6 +14,7 @@ describe 'wait_until_available' do
   around(:each) do |example|
     Puppet[:tasks] = tasks_enabled
     Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
+      inventory.stubs(:version).returns(1)
       example.run
     end
   end

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -139,9 +139,8 @@ module Bolt
       end
     end
 
-    def set_var(target, key, value)
-      data = { key => value }
-      set_vars_from_hash(target.name, data)
+    def set_var(target, var_hash)
+      set_vars_from_hash(target.name, var_hash)
     end
 
     def vars(target)

--- a/lib/bolt/inventory/group2.rb
+++ b/lib/bolt/inventory/group2.rb
@@ -1,19 +1,20 @@
 # frozen_string_literal: true
 
 require 'bolt/inventory/group'
+require 'bolt/inventory/inventory2'
 
 module Bolt
   class Inventory
     class Group2
       attr_accessor :name, :targets, :aliases, :name_or_alias, :groups,
-                    :config, :rest, :facts, :vars, :features, :plugin_hooks
+                    :config, :facts, :vars, :features, :plugin_hooks
 
       # THESE are duplicates with the old groups for now.
       # Regex used to validate group names and target aliases.
       NAME_REGEX = /\A[a-z0-9_][a-z0-9_-]*\Z/.freeze
 
       DATA_KEYS = %w[name config facts vars features plugin_hooks].freeze
-      NODE_KEYS = DATA_KEYS + %w[alias uri]
+      TARGET_KEYS = DATA_KEYS + %w[alias uri]
       GROUP_KEYS = DATA_KEYS + %w[groups targets]
       CONFIG_KEYS = Bolt::TRANSPORTS.keys.map(&:to_s) + ['transport']
 
@@ -59,8 +60,10 @@ module Bolt
         groups = fetch_value(data, 'groups', Array)
 
         @targets = {}
+        # @target_objects = {}
         @aliases = {}
         @name_or_alias = []
+
         targets.each do |target|
           # If target is a string, it can refer to either a target name or
           # alias. Which can't be determined until all groups have been
@@ -152,6 +155,7 @@ module Bolt
         unless target.is_a?(Hash)
           raise ValidationError.new("Node entry must be a Hash, not #{target.class}", @name)
         end
+
         # This check prevents plugins from returning plugins
         raise ValidationError.new("Cannot set target with plugin", @name) if target.key?('_plugin')
         target.each do |k, v|
@@ -159,56 +163,57 @@ module Bolt
           validate_config_plugin(v, k, @name)
         end
 
-        target['name'] ||= target['uri']
+        t_name = target['name'] || target['uri']
 
-        if target['name'].nil? || target['name'].empty?
+        if t_name.nil? || t_name.empty?
           raise ValidationError.new("No name or uri for target: #{target}", @name)
         end
 
-        if @targets.include?(target['name'])
+        unless t_name.ascii_only?
+          raise ValidationError.new("Target name must be ASCII characters: #{target}", @name)
+        end
+
+        if @targets.include?(t_name)
           @logger.warn("Ignoring duplicate target in #{@name}: #{target}")
           return
         end
 
-        raise ValidationError.new("Node #{target} does not have a name", @name) unless target['name']
-        @targets[target['name']] = target
-
-        unless (unexpected_keys = target.keys - NODE_KEYS).empty?
-          msg = "Found unexpected key(s) #{unexpected_keys.join(', ')} in target #{target['name']}"
+        unless (unexpected_keys = target.keys - TARGET_KEYS).empty?
+          msg = "Found unexpected key(s) #{unexpected_keys.join(', ')} in target #{t_name}"
           @logger.warn(msg)
         end
 
         unless target['config'].nil? || target['config'].is_a?(Hash)
-          raise ValidationError.new("Invalid configuration for target: #{target['name']}", @name)
+          raise ValidationError.new("Invalid configuration for target: #{t_name}", @name)
         end
 
         config_keys = target['config']&.keys || []
         unless (unexpected_keys = config_keys - CONFIG_KEYS).empty?
-          msg = "Found unexpected key(s) #{unexpected_keys.join(', ')} in config for target #{target['name']}"
+          msg = "Found unexpected key(s) #{unexpected_keys.join(', ')} in config for target #{t_name}"
           @logger.warn(msg)
         end
 
         target['config'] = config_only_plugin(target['config'])
 
-        unless target.include?('alias')
-          return
-        end
-
-        aliases = target['alias']
-        aliases = [aliases] if aliases.is_a?(String)
-        unless aliases.is_a?(Array)
-          msg = "Alias entry on #{target['name']} must be a String or Array, not #{aliases.class}"
-          raise ValidationError.new(msg, @name)
-        end
-
-        aliases.each do |alia|
-          raise ValidationError.new("Invalid alias #{alia}", @name) unless alia =~ NAME_REGEX
-
-          if (found = @aliases[alia])
-            raise ValidationError.new(alias_conflict(alia, found, target['name']), @name)
+        if target.include?('alias')
+          aliases = target['alias']
+          aliases = [aliases] if aliases.is_a?(String)
+          unless aliases.is_a?(Array)
+            msg = "Alias entry on #{t_name} must be a String or Array, not #{aliases.class}"
+            raise ValidationError.new(msg, @name)
           end
-          @aliases[alia] = target['name']
+
+          aliases.each do |alia|
+            raise ValidationError.new("Invalid alias #{alia}", @name) unless alia =~ NAME_REGEX
+
+            if (found = @aliases[alia])
+              raise ValidationError.new(alias_conflict(alia, found, t_name), @name)
+            end
+            @aliases[alia] = t_name
+          end
         end
+
+        @targets[t_name] = target
       end
 
       def lookup_targets(lookup)
@@ -307,21 +312,22 @@ module Bolt
 
         # Collect target names and aliases into a list used to validate that subgroups don't conflict.
         # Used names validate that previously used group names don't conflict with new target names/aliases.
-        @targets.each_key do |n|
+        @targets.each do |t_name, t_data|
           # Require targets to be parseable as a Target.
           begin
-            Target.new(n)
+            # Catch malformed URI here
+            Bolt::Inventory::Inventory2.parse_uri(t_data['uri'])
           rescue Bolt::ParseError => e
             @logger.debug(e)
-            raise ValidationError.new("Invalid target name #{n}", @name)
+            raise ValidationError.new("Invalid target uri #{t_data['uri']}", @name)
           end
 
-          raise ValidationError.new(group_target_conflict(n), @name) if used_names.include?(n)
-          if aliased.include?(n)
-            raise ValidationError.new(alias_target_conflict(n), @name)
+          raise ValidationError.new(group_target_conflict(t_name), @name) if used_names.include?(t_name)
+          if aliased.include?(t_name)
+            raise ValidationError.new(alias_target_conflict(t_name), @name)
           end
 
-          target_names << n
+          target_names << t_name
         end
 
         @aliases.each do |n, target|

--- a/lib/bolt/pal/issues.rb
+++ b/lib/bolt/pal/issues.rb
@@ -8,6 +8,12 @@ module Bolt
         Puppet::Pops::Issues.issue :PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, :action do
           "Plan language function '#{action}' cannot be used from declarative manifest code or apply blocks"
         end
+
+      # Inventory version 2
+      UNSUPPORTED_INVENTORY_VERSION =
+        Puppet::Pops::Issues.issue :UNSUPPORTED_INVENTORY_VERSION, :action do
+          "Plan language function '#{action}' cannot be used with Inventory v1"
+        end
     end
   end
 end

--- a/lib/bolt/task.rb
+++ b/lib/bolt/task.rb
@@ -73,7 +73,7 @@ module Bolt
     # and any additional files (name and path)
     def select_implementation(target, provided_features = [])
       impl = if (impls = implementations)
-               available_features = target.features + provided_features
+               available_features = target.feature_set + provided_features
                impl = impls.find do |imp|
                  remote_impl = imp['remote']
                  remote_impl = metadata['remote'] if remote_impl.nil?

--- a/pre-docs/inventory_version2.md
+++ b/pre-docs/inventory_version2.md
@@ -76,6 +76,96 @@ plan setup_lb (
 }
 ```
 
+## Creating targets in plans
+
+When using inventory v2 a new and improved API for interacting with `Target`s in inventory is available. Two new plan functions have been added: `get_target` which allows retrieving a single `Target` from inventory and `set_config` which allows setting config on a specific `Target`. The updated API also provides a way to instantiate new `Target`s with data that more closely resembles how targets are declared in an inventory file.
+
+For example, consider the following `new_targets` plan:
+```
+plan new_targets(){
+  $new_target = get_target('ssh://user:secret@1.2.3.4:2222')
+  $new_target.set_config(['ssh', 'host-key-check'], false)
+}
+```
+In the `new_targets` plan the `get_target` function returns a `Target` identified with the name `ssh://user:secret@1.2.3.4:2222`. If a `Target` with that name does not exist in inventory a new `Target` is instantiated with the `uri` and `name` attributes set to `ssh://user:secret@1.2.3.4:2222` and is added to the `all` group in inventory (where it inherits and configuration for the `all` group). If the `Target` with that name does exist, then it is simply returned.
+
+The `set_config` method is used to set a transport specific setting specified by the array of keys to that setting that matches the keys in the structured hash found in an inventoryfile under the `config` key. This illustrates how a new `Target` can be created from a URI and configuration options that are not able to be set in URI parts can be modified.
+
+The `Target.new` method may also be used to instantiate a `Target`:
+```
+plan new_target_alternate(){
+  $config = { 'transport' => 'ssh',
+              'ssh' => {
+                'user' => 'user',
+                'password' => 'secret',
+                'host' => '1.2.3.4'
+                'port' => 2222,
+                'host-key-check' => false
+                }}
+  $new_target = Target.new('name' => 'new_target', 'config' => $config)
+  $another_new_target = target.new('name' => 'another_new_target', 'uri' => ssh://foo:bar@baz.com:123, 'facts' => { 'datacenter' => 'east' })
+}
+```
+In the `new_target_alternate` plan a new `Target` is created from a hash and added to the `all` group in inventory. **Note**: If a `Target` with name `new_target` had already existed in inventory, that `Target` would be destroyed and the new `Target` would take its place.
+
+## `TargetSpec` parameters in plans
+
+When a plan parameter has the type `TargetSpec`, Bolt will ensure that values for that parameter are included in inventory. 
+
+For example:
+```
+plan auto_add(TargetSpec $nodes) {
+  return get_targets('all')
+}
+```
+The `auto_add` plan returns all of the targets in the `all` group, if the value of `$nodes` resolves to a `String` that does not match a `Target` name, a group name, a `Target` alias or a target regex, a new `Target` is created and added to the `all` group. 
+
+## `Target` reference
+
+A target object can be instantiated with `Target.new` from a plan with either a `String` representing the `Target` `name` and `uri` or a hash with the following structure:
+
+- `uri`: `String`, Target URI (will be used as the `Target` name if a name is not specified)
+- `name`: `String`, The name of the target
+- `target_alias`: `Variant[String, Array[String]]`, The alias to refer to a target by
+- `config`: `Hash`, Configuration options for the Target
+- `facts`: `Hash`, Target facts 
+- `vars`: `Hash`, Target vars
+- `features`: `Array`, Target features
+
+For example:
+```
+plan target_example(){
+  # From URI
+  $target_1 = Target.new('docker:://root:root@localhost:20024')
+  # From hash
+  $target_2 = Target.new('name' = 'new-pcp', 'target_alias' = 'test', 'config' => {'transport' => 'pcp'}, 'features' => [puppet-agent])
+}
+```
+In the `target_example` plan `target_1` is created from a URI, `target_2` is created from a hash. 
+
+**Note:** In the case where a `Target` is instantiated with only a `String` `uri` value, consider using `get_target` which will create a target without having to use the `Target.new` syntax. 
+
+When a target is instantiated from a `uri` and no `name` is provided, the `name` is set to the `uri`. The `Target` also gets assigned a `safe_name` which is the `uri` with the password redacted. 
+
+For example:
+```
+plan safe_name(){
+  $safe = get_target('ssh://user:secret@1.2.3.4:2222')
+  out::message($safe.safe_name)
+}
+```
+In the `safe_name` plan a new target with `name` and `uri` is created and added to inventory. The plan will print `ssh://urser@1.2.3.4:2222` as the safe name. 
+
+It is important to note that the `safe_name` is only different from the `name` in the case where the `Target` is constructed from a URI and there is no `name` specified. When a `name` is supplied, the `safe_name` will always equal the `name`. 
+
+For example:
+```
+plan unsafe_name(){
+  $unsafe = Target.new('name' => 'ssh://user:secret@1.2.3.4:2222')
+  out::message($unsafe.safe_name)
+}
+```
+In the `unsafe_name` plan, a `Target` is instantiated with the `name` set to the full `uri` that contains the sensitive password and thus the `safe_name` contains the password. 
 
 ## Creating a node with a human readable name and ip address
 

--- a/pre-docs/plan_functions.md
+++ b/pre-docs/plan_functions.md
@@ -347,6 +347,34 @@ get_resources('target1,target2', [Package, File[/etc/puppetlabs]])
 ```
 
 
+## get_target
+
+Get a single target from inventory if it exists, otherwise create a new Target.
+
+**NOTE:** Calling `get_target` inside an `apply` block with a
+version 2 inventory creates a new Target object.
+`get_target('all')` returns an empty array.
+**NOTE:** Only compatible with inventory v2
+
+
+```
+get_target(Boltlib::TargetSpec $name)
+```
+
+*Returns:* `Target` A single target, either new or from inventory.
+
+* **name** `Boltlib::TargetSpec` A Target name.
+
+**Example:** Create a new Target from a URI
+```
+get_target('winrm://host2:54321')
+```
+**Example:** Get an existing Target from inventory
+```
+get_target('existing-target')
+```
+
+
 ## get_targets
 
 Parses common ways of referring to targets and returns an array of Targets.
@@ -634,6 +662,38 @@ run_task('facts', $targets, 'Gather OS facts')
 ```
 
 
+## set_config
+
+Set configuration options on a target
+
+**NOTE:** Not available in apply block
+**NOTE:** Only compatible with inventory v2
+
+
+```
+set_config(Target $target, Variant[String, Array[String]] $key_or_key_path, Any $value)
+```
+
+*Returns:* `Target` The Target with the updated config
+
+* **target** `Target` The Target object to configure. See [`get_targets`](#get_targets).
+* **key_or_key_path** `Variant[String, Array[String]]` The configuration setting to update.
+* **value** `Any` The configuration value
+
+**Example:** Set the transport for a target
+```
+set_config($target, 'transport', 'ssh')
+```
+**Example:** Set the ssh password
+```
+set_config($target, ['ssh', 'password'], 'secret')
+```
+**Example:** Overwrite ssh config
+```
+set_config($target, 'ssh', { user => 'me', password => 'secret' })
+```
+
+
 ## set_feature
 
 Sets a particular feature to present on a target.
@@ -651,7 +711,7 @@ Currently supported features are
 set_feature(Target $target, String $feature, Optional[Boolean] $value)
 ```
 
-*Returns:* `Any` The target with the updated feature
+*Returns:* `Target` The target with the updated feature
 
 * **target** `Target` The Target object to add features to. See [`get_targets`](#get_targets).
 * **feature** `String` The string identifying the feature.
@@ -674,7 +734,7 @@ Sets a variable { key => value } for a target.
 set_var(Target $target, String $key, Data $value)
 ```
 
-*Returns:* `Undef` 
+*Returns:* `Target` The target with the updated feature
 
 * **target** `Target` The Target object to set the variable for. See [`get_targets`](#get_targets).
 * **key** `String` The key for the variable.

--- a/spec/bolt/inventory/group2_spec.rb
+++ b/spec/bolt/inventory/group2_spec.rb
@@ -381,16 +381,29 @@ describe Bolt::Inventory::Group2 do
     end
   end
 
-  context 'where a target uses an invalid name' do
+  context 'where a target uses an invalid uri' do
     let(:data) do
       {
         'name' => 'group1',
-        'targets' => [{ 'name' => 'foo:a/b@neptune"' }]
+        'targets' => [{ 'uri' => 'foo:a/b@neptune"' }]
       }
     end
 
     it 'raises an error' do
-      expect { group.validate }.to raise_error(Bolt::Inventory::ValidationError, /Invalid target name/)
+      expect { group.validate }.to raise_error(Bolt::Inventory::ValidationError, /Invalid target uri/)
+    end
+  end
+
+  context 'where a target uses an invalid name' do
+    let(:data) do
+      {
+        'name' => 'group1',
+        'targets' => [{ 'name' => 'ฒณดตษ๚' }]
+      }
+    end
+
+    it 'raises an error' do
+      expect { group.validate }.to raise_error(Bolt::Inventory::ValidationError, /Target name must be ASCII/)
     end
   end
 

--- a/spec/bolt/target_spec.rb
+++ b/spec/bolt/target_spec.rb
@@ -2,6 +2,9 @@
 
 require 'spec_helper'
 require 'bolt/target'
+require 'bolt/inventory'
+require 'bolt/plugin'
+require 'bolt/config'
 
 describe Bolt::Target do
   describe "when parsing userinfo" do
@@ -189,5 +192,191 @@ describe Bolt::Target do
     expect(t1.user).to be(nil)
     expect(t1.protocol).to be(nil)
     expect(t1.port).to be(nil)
+  end
+
+  it 'returns set object with feature_set' do
+    t1 = Bolt::Target.new(nil, 'name' => 'name1')
+    expect(t1.feature_set).to be_a(Set)
+  end
+end
+
+describe Bolt::Target2 do
+  describe "when parsing userinfo" do
+    let(:config) { Bolt::Config.new(Bolt::Boltdir.new('.'), {}) }
+    let(:pal) { nil }
+    let(:plugins) { Bolt::Plugin.new(config, pal, Bolt::Analytics::NoopClient.new) }
+    let(:inventory) { Bolt::Inventory.create_version({ 'version' => 2 }, config, plugins) }
+    let(:user)     { 'gunther' }
+    let(:password) { 'foobar' }
+    let(:complex)  { '~%F3/-w@ho!#$%^* ' }
+    let(:test_name) { 'foo' }
+
+    it "accepts userinfo when a port is specified" do
+      target = inventory.get_target("ssh://#{user}:#{password}@neptune:2222")
+      expect(target.user).to eq(user)
+      expect(target.password).to eq(password)
+    end
+
+    it "accepts userinfo without a port" do
+      target = inventory.get_target("ssh://#{user}:#{password}@neptune")
+      expect(target.user).to eq(user)
+      expect(target.password).to eq(password)
+    end
+
+    it "accepts userinfo when using the default protocol" do
+      target = inventory.get_target("#{user}:#{password}@neptune")
+      expect(target.user).to eq(user)
+      expect(target.password).to eq(password)
+    end
+
+    it "defaults user from options" do
+      target_hash = { 'name' => 'neptune', 'config' => { 'ssh' => { 'user' => complex } } }
+      target = inventory.create_target_from_plan(target_hash)
+      expect(target.user).to eq(complex)
+    end
+
+    it "defaults password from options" do
+      target_hash = { 'name' => 'neptune', 'config' => { 'ssh' => { 'password' => complex } } }
+      target = inventory.create_target_from_plan(target_hash)
+      expect(target.password).to eq(complex)
+    end
+
+    it "defaults port from options" do
+      target_hash = { 'name' => 'neptune', 'config' => { 'ssh' => { 'port' => 1234 } } }
+      target = inventory.create_target_from_plan(target_hash)
+      expect(target.port).to eq(1234)
+    end
+
+    it "rejects unescaped special characters" do
+      expect {
+        inventory.get_target("#{user}:a/b@neptune")
+      }.to raise_error(Bolt::ParseError,
+                       /Invalid port number/)
+    end
+
+    it "accepts escaped special characters in password" do
+      table = {
+        "\n" => '%0A',
+        ' ' => '%20',
+        '!' => '!',
+        '"' => '%22',
+        '#' => '%23',
+        '$' => '$',
+        '%' => '%25',
+        '&' => '&',
+        '\'' => '\'',
+        '(' => '(',
+        ')' => ')',
+        '*' => '*',
+        '+' => '+',
+        '-' => '-',
+        '.' => '.',
+        '/' => '%2F',
+        '0' => '0',
+        ':' => '%3A',
+        ';' => ';',
+        '<' => '%3C',
+        '=' => '=',
+        '>' => '%3E',
+        '?' => '%3F',
+        '@' => '@',
+        'A' => 'A',
+        '[' => '%5B',
+        '\\' => '%5C',
+        ']' => '%5D',
+        '^' => '%5E',
+        '_' => '%5F',
+        '`' => '%60'
+      }
+      unencoded = +''
+      encoded = +''
+      table.each_pair do |k, v|
+        unencoded.concat(k)
+        encoded.concat(v)
+      end
+
+      target = inventory.create_target_from_plan('name' => 'foo', 'uri' => "#{encoded}:#{encoded}@neptune")
+      expect(target.user).to eq(unencoded)
+      expect(target.password).to eq(unencoded)
+    end
+
+    it "does not default the port without a protocol" do
+      target = inventory.get_target('pluto')
+      expect(target.host).to eq('pluto')
+      expect(target.port).to be_nil
+    end
+
+    it "does not print password when converted to string" do
+      target = inventory.get_target("ssh://#{user}:#{password}@neptune:2222")
+      expect(target.to_s).to eq("ssh://#{user}@neptune:2222")
+    end
+
+    describe "with winrm" do
+      it "accepts 'winrm://host:port'" do
+        target = inventory.get_target('winrm://neptune:55985')
+        expect(target.protocol).to eq('winrm')
+        expect(target.host).to eq('neptune')
+        expect(target.port).to eq(55985)
+      end
+    end
+
+    describe "with ssh" do
+      it "accepts 'ssh://host:port'" do
+        target = inventory.get_target('ssh://pluto:2224')
+        expect(target.protocol).to eq('ssh')
+        expect(target.host).to eq('pluto')
+        expect(target.port).to eq(2224)
+      end
+
+      it "does not default the ssh port" do
+        target = inventory.get_target('ssh://pluto')
+        expect(target.protocol).to eq('ssh')
+        expect(target.host).to eq('pluto')
+        expect(target.port).to be_nil
+      end
+
+      it "accepts 'host:port' without a protocol" do
+        target = inventory.get_target('pluto:2224')
+        expect(target.protocol).to eq('ssh')
+        expect(target.host).to eq('pluto')
+        expect(target.port).to eq(2224)
+      end
+    end
+
+    describe "with pcp" do
+      it "accepts 'pcp://pluto:666'" do
+        target = inventory.get_target('pcp://pluto:666')
+        expect(target.protocol).to eq('pcp')
+        expect(target.host).to eq('pluto')
+        expect(target.port).to eq(666)
+      end
+
+      it "accepts 'pcp://pluto' without a port" do
+        target = inventory.get_target('pcp://pluto')
+        expect(target.protocol).to eq('pcp')
+        expect(target.host).to eq('pluto')
+        expect(target.port).to be_nil
+      end
+    end
+
+    it "strips brackets from ipv6 addresses in a uri" do
+      target = inventory.get_target('ssh://[::1]:22')
+      expect(target.host).to eq('::1')
+    end
+
+    it 'can have an empty uri' do
+      t1 = inventory.create_target_from_plan('name' => 'name1')
+      expect(t1.host).to be(nil)
+      expect(t1.name).to be('name1')
+      expect(t1.uri).to be(nil)
+      expect(t1.password).to be(nil)
+      expect(t1.user).to be(nil)
+      expect(t1.port).to be(nil)
+    end
+
+    it 'returns set object with feature_set' do
+      target = inventory.get_target('ssh://[::1]:22')
+      expect(target.feature_set).to be_a(Set)
+    end
   end
 end

--- a/spec/bolt/task_spec.rb
+++ b/spec/bolt/task_spec.rb
@@ -19,7 +19,7 @@ describe Bolt::Task do
     let(:task) { Bolt::Task.new(name: 'foo', files: files, metadata: metadata) }
 
     before :each do
-      allow(target).to receive(:features).and_return(Set.new(['powershell']))
+      allow(target).to receive(:feature_set).and_return(Set.new(['powershell']))
     end
 
     context 'with input_method in metadata' do

--- a/spec/fixtures/modules/add_group/plans/inventory2.pp
+++ b/spec/fixtures/modules/add_group/plans/inventory2.pp
@@ -1,0 +1,36 @@
+plan add_group::inventory2 (TargetSpec $nodes) {
+  $new_target_config = { 
+    'ssh' => {
+      "host-key-check" => false,
+      "user" => 'bolt',
+      'password' => 'bolt' }}
+  $new_target = Target.new(
+    uri => "0.0.0.0:20024",
+    config => $new_target_config
+  )
+
+  # Add new facts/var, specifically one that is novel, the other that should override existing.
+  $new_target.add_facts({'plan_context' => 'keep', 'override_parent' => 'keep'})
+  $new_target.set_var('plan_context','keep')
+  $new_target.set_var('override_parent', 'keep')
+  # Add from Target object
+  $new_target.add_to_group('add_me')
+  # When a Target already exists in a group, do nothing (bar_1 defined in bar)
+  add_to_group('bar_1', 'bar')
+  # Add to default "all" group
+  add_to_group('add_to_all', 'all')
+  $add_me_targets = get_targets('add_me')
+
+  $result = { 
+    'addme_group' => $add_me_targets,
+    'existing_facts' => $add_me_targets[0].facts,
+    'existing_vars' => $add_me_targets[0].vars,
+    'added_facts' => $add_me_targets[1].facts,
+    'added_vars' => $add_me_targets[1].vars,
+    'target_not_overwritten' => get_targets('bar')[0].vars['bar_1_var'],
+    'target_not_duplicated' => get_targets('bar'),
+    'target_to_all_group' => get_targets('all')
+  }
+
+  return $result
+}

--- a/spec/fixtures/modules/inventory/plans/new_target.pp
+++ b/spec/fixtures/modules/inventory/plans/new_target.pp
@@ -1,0 +1,18 @@
+plan inventory::new_target(Hash $new_target_hash) {
+  # Start with empty all group and add a new target using get_target
+  $transport = $new_target_hash['transport']
+  $user = $new_target_hash[$transport]['user']
+  $password = $new_target_hash[$transport]['password']
+  $host = $new_target_hash[$transport]['host']
+  $port = $new_target_hash[$transport]['port']
+  $uri = "${transport}://${user}:${password}@${host}:${port}"
+  $new_target_from_uri = get_target($uri)
+  $expected_host_key_fail = run_command('whoami', get_targets('all'), '_catch_errors' => true)
+  # Add a new target using Target.new 
+  $new_target_from_target_new = Target.new({ 'name' => 'new_target', 'config' => $new_target_hash })
+  # Update config for target created from uri with get_target
+  $new_target_from_uri.set_config(['ssh', 'host-key-check'], false)
+  $expected_success = run_command('whoami', get_targets('all'))
+  $result = { 'expected_host_key_fail' => $expected_host_key_fail, 'expected_success' => $expected_success }
+  return $result
+}

--- a/spec/integration/plugin/module_spec.rb
+++ b/spec/integration/plugin/module_spec.rb
@@ -31,7 +31,7 @@ describe 'using module based plugins' do
   let(:plan) do
     <<~PLAN
       plan test_plan() {
-        return(get_targets('node1')[0].password)
+        return(get_target('node1').password)
       }
     PLAN
   end
@@ -147,13 +147,13 @@ describe 'using module based plugins' do
     let(:plan) do
       <<~PLAN
         plan test_plan() {
-          return(get_targets('node1')[0].options['data'])
+          return(get_target('node1').config)
         }
       PLAN
     end
 
     it 'fails when configuration is incorrect' do
-      result = run_cli_json(['plan', 'run', 'test_plan', '--boltdir', @boltdir], rescue_exec: true)
+      result = run_cli_json(['plan', 'run', 'test_plan', '--boltdir', boltdir], rescue_exec: true)
 
       expect(result).to include('kind' => "bolt/validation-error")
       expect(result['msg']).to match(/conf_plug plugin expects a String for key required_key/)
@@ -165,9 +165,9 @@ describe 'using module based plugins' do
       it 'passes _config to the task' do
         result = run_cli_json(['plan', 'run', 'test_plan', '--boltdir', boltdir])
 
-        expect(result).to include('_config' => plugin_config['conf_plug'])
-        expect(result).to include('_boltdir' => boltdir)
-        expect(result).to include('value' => 'ssshhh')
+        expect(result['remote']['data']).to include('_config' => plugin_config['conf_plug'])
+        expect(result['remote']['data']).to include('_boltdir' => boltdir)
+        expect(result['remote']['data']).to include('value' => 'ssshhh')
       end
     end
   end

--- a/spec/pal/apply_result_spec.rb
+++ b/spec/pal/apply_result_spec.rb
@@ -5,6 +5,7 @@ require 'bolt_spec/files'
 require 'bolt_spec/pal'
 
 require 'bolt/pal'
+require 'bolt/inventory'
 
 describe 'ApplyResult DataType' do
   include BoltSpec::Files
@@ -22,7 +23,7 @@ PUPPET
 
   def result_attr(attr)
     code = result_code + attr
-    peval(code, pal)
+    peval(code, pal, nil, Bolt::Inventory.new({}))
   end
 
   it 'should expose target' do

--- a/spec/pal/result_set_spec.rb
+++ b/spec/pal/result_set_spec.rb
@@ -5,6 +5,7 @@ require 'bolt_spec/files'
 require 'bolt_spec/pal'
 
 require 'bolt/pal'
+require 'bolt/inventory'
 
 describe 'ResultSet DataType' do
   include BoltSpec::Files
@@ -24,7 +25,7 @@ PUPPET
 
   def result_set(attr)
     code = result_code + attr
-    peval(code, pal)
+    peval(code, pal, nil, Bolt::Inventory.new({}))
   end
 
   it 'should be ok' do

--- a/spec/pal/result_spec.rb
+++ b/spec/pal/result_spec.rb
@@ -5,6 +5,7 @@ require 'bolt_spec/files'
 require 'bolt_spec/pal'
 
 require 'bolt/pal'
+require 'bolt/inventory'
 
 describe 'Result DataType' do
   include BoltSpec::Files
@@ -22,7 +23,7 @@ PUPPET
 
   def result_attr(attr)
     code = result_code + attr
-    peval(code, pal)
+    peval(code, pal, nil, Bolt::Inventory.new({}))
   end
 
   it 'should expose target' do

--- a/spec/pal/target_spec.rb
+++ b/spec/pal/target_spec.rb
@@ -5,6 +5,7 @@ require 'bolt_spec/files'
 require 'bolt_spec/pal'
 
 require 'bolt/pal'
+require 'bolt/inventory'
 
 describe 'Target DataType' do
   include BoltSpec::Files
@@ -19,7 +20,7 @@ describe 'Target DataType' do
 
   def target(attr)
     code = target_code + attr
-    peval(code, pal)
+    peval(code, pal, nil, Bolt::Inventory.new({}))
   end
 
   it 'should expose uri' do


### PR DESCRIPTION
With this commit the API for interacting with `Target` objects in the Plan language is updated to more closely match the way targets are defined in inventory V2. The previous API was focused more on reading data and setting a limited set of `Target` attributes.

This work enables new `Target` objects to be defined in a plan and for the configuration of `Targets` to easily be modified. The fundamental idea for this implementation is that a target is a single unique entity which tracks the connection information and other data associated with a `Target`.

 In order for `Target` data to predictably be resolved it will be kept separate from `Group` and `config` data. Data set directly on the `Target` will be given the highest priority. `Target` level data can be assigned in an inventory file, when using `Target.new` in a plan or with the various `set_*` plan functions. `Target` data is computed by merging `Target` data with `Group` and `config` data each time a target is modified (for example with a `set_*` method or when it is added to a group).

An important new plan function `set_config` has been added to enable setting a particular config value on a `Target`. Similarly a `get_target` method has been introduced to return a single `Target` to unambiguously set `Target` data. In addition to the updated interface this work introduces a pattern whereby targets created during a plan are automatically added to the inventory (in the `all` group). Similarly when a plan parameters has the type `TargetSpec` the parameter’s `Target` values will be added to inventory automatically if not already defined in an inventoryfile.

closes #1125