### PR TITLE
(maint) Include hours and minutes in duration display

### DIFF
--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -161,7 +161,7 @@ module Bolt
         @plan_depth -= 1
         plan = event[:plan]
         duration = event[:duration]
-        @stream.puts(colorize(:green, "Finished: plan #{plan} in #{duration.round(2)} sec"))
+        @stream.puts(colorize(:green, "Finished: plan #{plan} in #{duration_to_string(duration)}"))
       end
 
       def print_summary(results, elapsed_time = nil)
@@ -185,7 +185,7 @@ module Bolt
         total_msg = format('Ran on %<size>d node%<plural>s',
                            size: results.size,
                            plural: results.size == 1 ? '' : 's')
-        total_msg += format(' in %<elapsed>.2f seconds', elapsed: elapsed_time) unless elapsed_time.nil?
+        total_msg << " in #{duration_to_string(elapsed_time)}" unless elapsed_time.nil?
         @stream.puts total_msg
       end
 
@@ -365,6 +365,20 @@ module Bolt
 
       def print_message(message)
         @stream.puts(message)
+      end
+
+      def duration_to_string(duration)
+        hrs = (duration / 3600).floor
+        mins = ((duration % 3600) / 60).floor
+        secs = (duration % 60)
+        if hrs > 0
+          "#{hrs} hr, #{mins} min, #{secs.round} sec"
+        elsif mins > 0
+          "#{mins} min, #{secs.round} sec"
+        else
+          # Include 2 decimal places if the duration is under a minute
+          "#{secs.round(2)} sec"
+        end
       end
     end
   end

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -27,7 +27,7 @@ describe "Bolt::Outputter::Human" do
   it "allows empty items" do
     outputter.print_head
     outputter.print_summary(Bolt::ResultSet.new([]), 2.0)
-    expect(output.string).to eq("Ran on 0 nodes in 2.00 seconds\n")
+    expect(output.string).to eq("Ran on 0 nodes in 2.0 sec\n")
   end
 
   it "prints status" do
@@ -44,7 +44,7 @@ describe "Bolt::Outputter::Human" do
     summary = lines.split("\n")[-3..-1]
     expect(summary[0]).to eq('Successful on 1 node: node1')
     expect(summary[1]).to eq('Failed on 1 node: node2')
-    expect(summary[2]).to eq('Ran on 2 nodes in 10.00 seconds')
+    expect(summary[2]).to eq('Ran on 2 nodes in 10.0 sec')
   end
 
   context 'with multiple successes' do
@@ -61,7 +61,7 @@ describe "Bolt::Outputter::Human" do
       outputter.print_summary(results, 0.0)
       summary = output.string.split("\n")
       expect(summary[0]).to eq('Successful on 2 nodes: node1,node2')
-      expect(summary[1]).to eq('Ran on 2 nodes in 0.00 seconds')
+      expect(summary[1]).to eq('Ran on 2 nodes in 0.0 sec')
     end
   end
 
@@ -79,7 +79,7 @@ describe "Bolt::Outputter::Human" do
       outputter.print_summary(results, 0.0)
       summary = output.string.split("\n")
       expect(summary[0]).to eq('Failed on 2 nodes: node1,node2')
-      expect(summary[1]).to eq('Ran on 2 nodes in 0.00 seconds')
+      expect(summary[1]).to eq('Ran on 2 nodes in 0.0 sec')
     end
   end
 
@@ -316,5 +316,32 @@ plans/plans/plans/plans
     outputter.handle_event(type: :disable_default_output)
     outputter.handle_event(type: :message, message: "hello!")
     expect(output.string).to eq("hello!\n")
+  end
+
+  context '#duration_to_string' do
+    it 'includes only seconds when the duration is less than a minute' do
+      str = outputter.duration_to_string(34)
+      expect(str).to eq("34 sec")
+    end
+
+    it 'includes up to two decimal places if the duration is less than a minute' do
+      str = outputter.duration_to_string(34.5678)
+      expect(str).to eq("34.57 sec")
+    end
+
+    it 'includes minutes when the duration is more than a minute' do
+      str = outputter.duration_to_string(99)
+      expect(str).to eq("1 min, 39 sec")
+    end
+
+    it 'rounds to the nearest whole second if the duration is more than a minute' do
+      str = outputter.duration_to_string(99.99)
+      expect(str).to eq("1 min, 40 sec")
+    end
+
+    it 'includes hours when the duration is more than an hour' do
+      str = outputter.duration_to_string(3750)
+      expect(str).to eq("1 hr, 2 min, 30 sec")
+    end
   end
 end


### PR DESCRIPTION
Previously, we displayed durations as only seconds. That meant that
lengthy operations would be reported as, for instance, 123 seconds. We
now break these times down into hours and minutes where applicable,
written as:

1 hr, 2 min, 3 sec
2 min, 3 sec
3.76 sec

When the duration is under a minute, we include two decimal places for
the seconds display. Otherwise, we strip the sub-second duration and
round to the nearest second.