### PR TITLE
(GH-1167) Honor run_plan(..., _run_as => ...) from apply()

### DIFF
--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -195,6 +195,7 @@ module Bolt
               arguments = {
                 'catalog' => Puppet::Pops::Types::PSensitiveType::Sensitive.new(catalog),
                 'plugins' => Puppet::Pops::Types::PSensitiveType::Sensitive.new(plugins),
+                '_task' => catalog_apply_task.name,
                 '_noop' => options['_noop']
               }
 
@@ -204,6 +205,8 @@ module Bolt
                 end
                 @executor.publish_event(event)
               end
+              # Respect the run_as default set on the executor
+              options = { '_run_as' => @executor.run_as }.merge(options) if @executor.run_as
               results = transport.batch_task(batch, catalog_apply_task, arguments, options, &callback)
               Array(results).map { |result| ApplyResult.from_task_result(result) }
             end

--- a/spec/fixtures/apply/basic/plans/run_as_apply.pp
+++ b/spec/fixtures/apply/basic/plans/run_as_apply.pp
@@ -1,0 +1,6 @@
+plan basic::run_as_apply(
+  TargetSpec $nodes,
+  String $user
+) {
+  return run_plan(basic::whoami, $nodes, _run_as => $user)
+}

--- a/spec/fixtures/apply/basic/plans/whoami.pp
+++ b/spec/fixtures/apply/basic/plans/whoami.pp
@@ -1,0 +1,8 @@
+plan basic::whoami(TargetSpec $nodes) {
+  $result = apply($nodes) {
+    exec { "/usr/bin/whoami":
+      logoutput => true,
+    }
+  }
+  return $result.first.report['logs']
+}

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -201,6 +201,12 @@ describe "apply" do
           raise 'remote pid was not found' if remote_pid.nil?
           expect(local_pid).not_to eq(remote_pid)
         end
+
+        it 'respects _run_as on a plan invocation' do
+          user = conn_info('ssh')[:user]
+          logs = run_cli_json(%W[plan run basic::run_as_apply user=#{user}] + config_flags)
+          expect(logs.first['message']).to eq(conn_info('ssh')[:user])
+        end
       end
 
       context "bolt apply command" do


### PR DESCRIPTION
Previously, apply() blocks would ignore the `_run_as` argument passed to
their containing plan.

    plan a() {
      run_plan(b, _run_as => 'someone')
    }
    plan b() {
      apply(...) { }
    }

In this case, the catalog compiled for the `apply()` block in plan b
would be executed as whatever user bolt connected to the user as instead
of the "someone" user specified via `_run_as`. This happened because the
Applicator class failed to replicate the full executor behavior of
running a task.

The Applicator now honors `run_as` if it's set on the executor, passing
it through to the transport's `batch_task` method.

This already worked fine for `run_as` set on a Target in the inventory
or for the `--run-as` flag.