### PR TITLE
(docs) Fix puppet_library plugin hook reference

### DIFF
--- a/pre-docs/bolt_configuration_options.md
+++ b/pre-docs/bolt_configuration_options.md
@@ -243,7 +243,7 @@ plugin_hooks:
   puppet_library:
     plugin: task
     task: 'bootstrap'
-    params:
+    parameters:
       master: 'puppet.example.com'
       cacert_content: <cert>
 ```

--- a/pre-docs/inventory_version2.md
+++ b/pre-docs/inventory_version2.md
@@ -244,7 +244,7 @@ plugin_hooks:
   puppet_library:
     plugin: task
     task: puppet_agent::install
-    params:
+    parameters:
       version: 6.2.0
       yum_source: yum.customurl.net
 ```
@@ -255,7 +255,7 @@ plugin_hooks:
   puppet_library:
     plugin: task
     task: bootstrap::linux
-    params:
+    parameters:
       master: mymaster.fqdn
       environment: dev
 ```
@@ -269,14 +269,14 @@ sets some config and starts the agent service.
 version: 2
 groups:
   - name: custom_nodes
-    nodes:
+    targets:
       - foo
       - bar
     plugin_hooks:
       puppet_library:
         plugin: task
         task: custom_agent::install
-        params:
+        parameters:
           version: 6.2.0
 ```
 


### PR DESCRIPTION
Previously the documentation suggests specifying parameters with `params`, this commit updates it to use the correct `parameters` as well as fixing a reference to `nodes` in an inventory 2 file.