### PR TITLE
(GH-1125) Catch puppet errors in apply prep with puppet_library hook

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
@@ -104,7 +104,7 @@ Puppet::Functions.create_function(:apply_prep) do
                 hook = inventory.plugins.get_hook(opts['plugin'], :puppet_library)
                 { 'target' => t,
                   'hook_proc' => hook.call(opts, t, self) }
-              rescue Bolt::Error => e
+              rescue StandardError => e
                 Bolt::Result.from_exception(t, e)
               end
             end


### PR DESCRIPTION
Previously only `Bolt::Error`s were caught when executing a `puppet_library` task. Other errors (from example parsing metadata files) were surfaced. This commit rescues `StandardError` when executing the `puppet_library` hook so that the error can be turned in to a bolt result.