### PR TITLE
(packaging) Update {python,ruby}_task_helper modules

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -24,9 +24,9 @@ mod 'puppetlabs-zone_core', '1.0.2'
 # Useful additional modules
 mod 'puppetlabs-package', '0.6.0'
 mod 'puppetlabs-puppet_conf', '0.3.1'
-mod 'puppetlabs-python_task_helper', '0.2.0'
+mod 'puppetlabs-python_task_helper', '0.3.0'
 mod 'puppetlabs-reboot', '2.2.0'
-mod 'puppetlabs-ruby_task_helper', '0.3.0'
+mod 'puppetlabs-ruby_task_helper', '0.4.0'
 
 # If we don't list these modules explicitly, r10k will purge them
 mod 'canary', local: true


### PR DESCRIPTION
The task helpers were not wrapping errors in an `_error` key. That bug has been fixed in both, this commit pulls in the bugfix releases for those modules.