### PR TITLE
(maint) Install linux-headers for alpine to support nio4r gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM alpine:3.8 as build
 
 RUN \
-apk --no-cache add build-base ruby-dev ruby-bundler ruby-json ruby-bigdecimal git openssl-dev && \
+apk --no-cache add build-base ruby-dev ruby-bundler ruby-json ruby-bigdecimal git openssl-dev linux-headers && \
 echo 'gem: --no-document' > /etc/gemrc && \
 bundle config --global silence_root_warning 1
 

--- a/scripts/server_client.rb
+++ b/scripts/server_client.rb
@@ -42,7 +42,7 @@ class Client
 
   def run_task(task_name, target_name, params, base_uri: 'https://localhost:62658')
     target = target(target_name)
-    body = build_request(task_name, target, params)
+    body = build_task_request(task_name, target, params)
 
     uri = URI("#{base_uri}/#{target.protocol}/run_task")
     req = Net::HTTP::Post.new(uri)


### PR DESCRIPTION
The bolt-server container needs a new package installed with apk so that native extensions can be built for the nio4r gem that is required by puma. Also, the server_client script needs an update to for the BoltSpec::BoltServer module.