### PR TITLE
(GH-1205) Allow powershell task parameters with `type` in the name

### DIFF
--- a/lib/bolt/transport/powershell.rb
+++ b/lib/bolt/transport/powershell.rb
@@ -193,7 +193,7 @@ PROCESS{
     return $xml.Objects | ConvertFrom-Xml
   }
   $propbag = @{}
-  foreach ($name in Get-Member -InputObject $xml -MemberType Properties | Where-Object{$_.Name -notmatch "^__|type"} | Select-Object -ExpandProperty name) {
+  foreach ($name in Get-Member -InputObject $xml -MemberType Properties | Where-Object{$_.Name -notmatch "^(__.*|type)$"} | Select-Object -ExpandProperty name) {
     Write-Debug "$Name Type: $($xml.$Name.type)" -Debug:$false
     $propbag."$Name" = Convert-Properties $xml."$name"
   }

--- a/spec/fixtures/complex_params/input.json
+++ b/spec/fixtures/complex_params/input.json
@@ -23,5 +23,6 @@
   "argtimespan": "12:34:56",
   "argguid": "74be6039-e777-45fe-aa56-3d356443e096",
   "argregex": "^http:\\/\\/",
-  "argswitch": true
+  "argswitch": true,
+  "types": "foo"
 }

--- a/spec/fixtures/complex_params/output
+++ b/spec/fixtures/complex_params/output
@@ -45,3 +45,5 @@ hello all
 True
 * ArgTimeSpan (timespan):
 12:34:56
+* types (string):
+foo

--- a/spec/fixtures/modules/sample/tasks/complex_params.ps1
+++ b/spec/fixtures/modules/sample/tasks/complex_params.ps1
@@ -46,7 +46,12 @@ param(
 
   [Parameter(Mandatory = $False)]
   [Switch]
-  $ArgSwitch
+  $ArgSwitch,
+
+  # Parameters may have the string `type` in them, but not have the name `type`
+  [Parameter(Mandatory = $False)]
+  [String]
+  $types
 )
 
 function ConvertTo-String


### PR DESCRIPTION
closes https://github.com/puppetlabs/bolt/issues/1205
Previously, when parsing xml in the `Get-ContentAsJson` implementation a regex used to filter out xml elements with whos `MemberType` `Properties` had a name that was preceeded with `__` or contained the string `type`. Filtering on the string `type` caused task parameters that contain that string to be ignored, preventing users from being able to effectively pass powershell task paramters with the `type` in the name. Unfortunately, with the current implementation powershell parameters with the name `type` will be clobbered by a `Property` called type. However this commit updates the regex to *only* filter out the property that exactly matches `type`. Note that this work allows powershell task parameters with `type` in the name, but not the name `type` and only affects powershell < 2.