### PR TITLE
Add required modules for installing puppet on lesson 11

### DIFF
--- a/docs/_includes/lesson11/Boltdir/Puppetfile
+++ b/docs/_includes/lesson11/Boltdir/Puppetfile
@@ -1,4 +1,32 @@
 forge 'http://forge.puppetlabs.com'
+
+moduledir File.join(File.dirname(__FILE__), 'modules')
+
+# modules used by my app
 mod 'puppetlabs-stdlib', '4.25.1'
 mod 'puppetlabs-concat', '4.2.1'
 mod 'puppetlabs-haproxy', '2.1.0'
+
+# Core modules used by 'apply'
+mod 'puppetlabs-service', '1.0.0'
+mod 'puppetlabs-facts', '0.6.0'
+mod 'puppetlabs-puppet_agent', '2.2.0'
+
+# Core types and providers for Puppet 6
+mod 'puppetlabs-augeas_core', '1.0.4'
+mod 'puppetlabs-host_core', '1.0.2'
+mod 'puppetlabs-scheduled_task', '1.0.1'
+mod 'puppetlabs-sshkeys_core', '1.0.2'
+mod 'puppetlabs-zfs_core', '1.0.2'
+mod 'puppetlabs-cron_core', '1.0.2'
+mod 'puppetlabs-mount_core', '1.0.3'
+mod 'puppetlabs-selinux_core', '1.0.2'
+mod 'puppetlabs-yumrepo_core', '1.0.3'
+mod 'puppetlabs-zone_core', '1.0.2'
+
+# Useful additional modules
+mod 'puppetlabs-package', '0.6.0'
+mod 'puppetlabs-puppet_conf', '0.3.1'
+mod 'puppetlabs-python_task_helper', '0.3.0'
+mod 'puppetlabs-reboot', '2.2.0'
+mod 'puppetlabs-ruby_task_helper', '0.4.0'


### PR DESCRIPTION
* If you don't include things like puppetlabs-puppet_agent, the
apply_prep will fail on new machines.

* I included all the other modules from the base bolt Puppetfile, but
they are probably not needed.