### PR TITLE
(maint) Stub publish_event in mock-executor

### DIFF
--- a/lib/bolt_spec/plans.rb
+++ b/lib/bolt_spec/plans.rb
@@ -63,6 +63,8 @@ require 'bolt/pal'
 # - allow_upload(file), expect_upload(file): expect the identified source file
 # - allow_apply_prep: allows `apply_prep` to be invoked in the plan but does not allow modifiers
 # - allow_apply: allows `apply` to be invoked in the plan but does not allow modifiers
+# - allow_out_message, expect_out_message: expect a message to be passed to out::message (only modifiers are
+#   be_called_times(n), with_params(params), and not_be_called)
 #
 # Stub modifiers:
 # - be_called_times(n): if allowed, fail if the action is called more than 'n' times
@@ -127,6 +129,12 @@ require 'bolt/pal'
 #         Bolt::ResultSet.new(targets.map { |targ| Bolt::Result.new(targ, {'result_key' => 10'})})
 #       end
 #       expect(run_plan('my_plan', { 'param1' => 10 })).to eq(10)
+#     end
+
+#     it 'expects multiple messages to out::message' do
+#       expect_out_message.be_called_times(2).with_params(message)
+#       result = run_plan(plan_name, 'messages' => [message, message])
+#       expect(result).to be_ok
 #     end
 #   end
 #
@@ -219,6 +227,15 @@ module BoltSpec
     def allow_get_resources
       allow_task('apply_helpers::query_resources')
       nil
+    end
+
+    def allow_out_message
+      executor.stub_out_message.add_stub
+    end
+    alias allow_any_out_message allow_out_message
+
+    def expect_out_message
+      allow_out_message.expect_call
     end
 
     # Example helpers to mock other run functions

--- a/lib/bolt_spec/plans/publish_stub.rb
+++ b/lib/bolt_spec/plans/publish_stub.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'bolt/result'
+require 'bolt/util'
+
+module BoltSpec
+  module Plans
+    class PublishStub < ActionStub
+      def return
+        raise "return is not implemented for out_message"
+      end
+
+      def return_for_targets(_data)
+        raise "return_for_targets is not implemented for out_message"
+      end
+
+      def always_return(_data)
+        raise "always_return is not implemented for out_message"
+      end
+
+      def error_with(_data)
+        raise "error_with is not implemented for out_message"
+      end
+
+      def matches(message)
+        if @invocation[:options] && message != @invocation[:options]
+          return false
+        end
+
+        true
+      end
+
+      def call(_event)
+        @calls += 1
+      end
+
+      def parameters
+        @invocation[:options]
+      end
+
+      # Public methods
+
+      def with_params(params)
+        @invocation[:options] = params
+        self
+      end
+    end
+  end
+end

--- a/spec/bolt_spec/plan_spec.rb
+++ b/spec/bolt_spec/plan_spec.rb
@@ -221,4 +221,57 @@ describe "BoltSpec::Plans" do
       expect { run_plan(plan_name, 'nodes' => targets) }.to raise_error(RuntimeError, /Unexpected call to/)
     end
   end
+
+  context 'with out::message' do
+    let(:plan_name) { 'plans::out_message' }
+    let(:message) { 'foo' }
+    let(:other_message) { 'bar' }
+
+    it 'allows with params' do
+      allow_out_message.with_params(message)
+      result = run_plan(plan_name, 'messages' => [message])
+      expect(result).to be_ok
+    end
+
+    it 'allows any out message' do
+      allow_any_out_message
+      result = run_plan(plan_name, 'messages' => [message])
+      expect(result).to be_ok
+    end
+
+    it 'errors when not allowed' do
+      expect { run_plan(plan_name, 'messages' => [message]) }.to raise_error(RuntimeError, /Unexpected call to/)
+    end
+
+    it 'expects with params' do
+      expect_out_message.with_params(message)
+      result = run_plan(plan_name, 'messages' => [message])
+      expect(result).to be_ok
+    end
+
+    it 'expects multiple times with params' do
+      expect_out_message.be_called_times(2).with_params(message)
+      result = run_plan(plan_name, 'messages' => [message, message])
+      expect(result).to be_ok
+    end
+
+    it 'expects with different params' do
+      expect_out_message.with_params(message)
+      expect_out_message.with_params(other_message)
+      result = run_plan(plan_name, 'messages' => [message, other_message])
+      expect(result).to be_ok
+    end
+
+    it 'errors when not expected' do
+      expect_out_message.not_be_called
+      expect { run_plan(plan_name, 'messages' => [message]) }
+        .to raise_error(RuntimeError, /Expected out::message to be called 0 times/)
+    end
+
+    it 'errors with wrong params' do
+      expect_out_message.with_params(other_message)
+      expect { run_plan(plan_name, 'messages' => [message]) }
+        .to raise_error(RuntimeError, /Expected out::message to be called 1 times with parameters #{other_message}/)
+    end
+  end
 end

--- a/spec/fixtures/bolt_spec/plans/plans/out_message.pp
+++ b/spec/fixtures/bolt_spec/plans/plans/out_message.pp
@@ -1,0 +1,5 @@
+plan plans::out_message(Array[String] $messages) {
+  $messages.each |$message| {
+    out::message($message)
+  }
+}


### PR DESCRIPTION
This commit updates the mock executor to allow users to mock out an event collector for capturing messages from `out::message` when stubbing out plans with BoltSpec::Plans.