### PR TITLE
(maint) Unpin ffi due to updating to macos 10.14 bolt controller

### DIFF
--- a/acceptance/setup/common/pre-suite/010_install_ruby.rb
+++ b/acceptance/setup/common/pre-suite/010_install_ruby.rb
@@ -46,9 +46,6 @@ PS
       install_package(bolt, 'rubygem-io-console')
       result = on(bolt, 'ruby --version')
     when /osx/
-      # ruby dev tools should be already installed
-      # Pin ffi to 1.9.25 to avoid incompatability with 1.11.1
-      on(bolt, 'gem install ffi --no-document -v 1.9.25')
       result = on(bolt, 'ruby --version')
     else
       fail_test("#{bolt['platform']} not currently a supported bolt controller")


### PR DESCRIPTION
Update component pipeline to use 10.14 instead of 10.13 due to issues with installing ffi with native ruby.