### PR TITLE
(maint) Fix verbose logging and catch_errors

### DIFF
--- a/docs/_lab/10-deploying-an-application/index.md
+++ b/docs/_lab/10-deploying-an-application/index.md
@@ -316,7 +316,7 @@ Bolt logs every action on each node which results in 5 messages for each node.
 By default these messages are logged at the `notice` level and can make it hard
 to see the more useful `notice` messages that the plan logs directly. To make the
 automatic messages log at `info` instead so they won't appear on the terminal
-with the `--verbose` flag the plan wraps the loop in a
+without the `--verbose` flag the plan wraps the loop in a
 `without_default_logging` block. All code executed inside a
 `without_default_logging` block including in functions or subplans will log
 actions at `info` instead of `notice`.
@@ -344,6 +344,7 @@ run_task('my_app::lb', $lb_server,
   action => 'drain',
   backend => $instance,
   server => $server.name,
+  _catch_errors => $force
 )
 ```
 

--- a/docs/_lab/10-deploying-an-application/index.md
+++ b/docs/_lab/10-deploying-an-application/index.md
@@ -312,14 +312,14 @@ notice about which server is going to be deployed to next.
 
 ### Suppress default log messages
 
-Bolt logs every action on each node which results in 5 messages for each node.
+Bolt logs every action on each node, which results in 5 messages for each node.
 By default these messages are logged at the `notice` level and can make it hard
-to see the more useful `notice` messages that the plan logs directly. To make the
-automatic messages log at `info` instead so they won't appear on the terminal
-without the `--verbose` flag the plan wraps the loop in a
-`without_default_logging` block. All code executed inside a
-`without_default_logging` block including in functions or subplans will log
-actions at `info` instead of `notice`.
+to see the more useful `notice` messages that the plan logs directly. You can
+wrap code in a `without_default_logging` block to make the automatic messages
+log at `info` instead so they only appear on the terminal with the `--verbose`
+flag. All code executed inside a `without_default_logging` block including in
+functions or subplans will log actions at `info` instead of
+`notice`.
 
 ```
 without_default_logging() || {


### PR DESCRIPTION
Fixes 'no info with --verbose' to 'no info without --verbose'
Adds missing '_catch_errors' line
