### PR TITLE
(ORCH-2340) Add `upload_file` endpoint to bolt-server

### DIFF
--- a/developer-docs/bolt-api-servers.md
+++ b/developer-docs/bolt-api-servers.md
@@ -176,6 +176,78 @@ For example, the following runs "echo 'hi'" on localhost:
 }
 ```
 
+### POST /ssh/upload_file
+- `target`: [SSH Target Object](#ssh-target-object), *required* - Target information to run task on.
+- `files`: Object, *required* - Which file(s) to upload, and where.
+    - `relative_path`: String, *required* - The destination for the file.
+    - `uri`: Object, *required* - The location of where to find the file.
+        - `path`: String, *required* - The endpoint to retrieve the file.
+        - `params`: Object, *required* - The parameters to supply the endpoint.
+    - `sha256`: String, *required* - The SHA256 value for the file.
+    - `kind`: String, *required* - Whether the file is a `file` or `directory`.
+- `job_id`: Integer, *required* - An identifier for the job. If this matches an existing ID, cached files may be returned.
+- `destination`: String, *required* - Where to put the files on the target machine.
+
+For example, the following uploads file 'abc' on linux_target.net:
+```
+{
+  "target": {
+    "hostname": "linux_target.net",
+    "user": "marauder",
+    "password": "I solemnly swear that I am up to no good",
+    "host-key-check": false,
+    "run-as": "george_weasley"
+  },
+  "destination": "/home/bolt/root",
+  "job_id": 1,
+  "files" : [{
+    "relative_path": "file.sh"
+    "uri": {
+      "path": "/puppet/v3/file_content/modules/some_module/file.sh",
+      "params": {}
+    },
+    "sha256": "SHA256VALUE",
+    "kind": "file"
+  }]
+}
+```
+
+### POST /winrm/upload_file
+- `target`: [WinRM Target Object](#winrm-target-object), *required* - Target information to run task on.
+- `files`: Object, *required* - Which file(s) to upload, and where.
+    - `relative_path`: String, *required* - The destination for the file.
+    - `uri`: Object, *required* - The location of where to find the file.
+        - `path`: String, *required* - The endpoint to retrieve the file.
+        - `params`: Object, *required* - The parameters to supply the endpoint.
+    - `sha256`: String, *required* - The SHA256 value for the file.
+    - `kind`: String, *required* - Whether the file is a `file` or `directory`.
+- `job_id`: Integer, *required* - An identifier for the job. If this matches an existing ID, cached files may be returned.
+- `destination`: String, *required* - Where to put the files on the target machine.
+
+For example, the following uploads file 'abc' on windows_target.net:
+```
+{
+  "target": {
+    "hostname": "windows_target.net",
+    "user": "Administrator",
+    "password": "Secret",
+    "ssl": false,
+    "ssl-verify": false
+  },
+  "destination": "C:\\Users\\bolt\\root",
+  "job_id": 1,
+  "files" : [{
+    "relative_path": "file.exe"
+    "uri": {
+      "path": "/puppet/v3/file_content/modules/some_module/file.exe",
+      "params": {}
+    },
+    "sha256": "SHA256VALUE",
+    "kind": "file"
+  }]
+}
+```
+
 ### SSH Target Object
 The Target is a JSON object. See the [schema](../lib/bolt_server/schemas/partials/target-ssh.json)
 

--- a/lib/bolt_server/file_cache.rb
+++ b/lib/bolt_server/file_cache.rb
@@ -83,7 +83,7 @@ module BoltServer
       begin
         client.request(req) do |resp|
           if resp.code != "200"
-            msg = "Failed to download task: #{resp.body}"
+            msg = "Failed to download file: #{resp.body}"
             @logger.warn resp.body
             raise Error, msg
           end
@@ -96,7 +96,7 @@ module BoltServer
           raise e
         else
           @logger.warn e
-          raise Error, "Failed to download task: #{e.message}"
+          raise Error, "Failed to download file: #{e.message}"
         end
       end
     ensure
@@ -157,7 +157,7 @@ module BoltServer
       file_dir = create_cache_dir(file_data['sha256'])
       file_path = File.join(file_dir, File.basename(file_data['filename']))
       if check_file(file_path, sha)
-        @logger.debug("Using prexisting task file: #{file_path}")
+        @logger.debug("Using prexisting file: #{file_path}")
         return file_path
       end
 

--- a/lib/bolt_server/schemas/action-upload_file.json
+++ b/lib/bolt_server/schemas/action-upload_file.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "upload_file request",
+  "description": "POST <transport>/upload_file request schema",
+  "type": "object",
+  "properties": {
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "relative_path": {
+            "type": "string"
+          },
+          "uri": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string"
+              },
+              "params": {
+                "type": "object"
+              }
+            },
+            "required": ["path", "params"]
+          },
+          "sha256": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          }
+        },
+        "required": ["relative_path", "uri", "sha256", "kind"]
+      }
+    },
+    "job_id": {
+      "type": "integer"
+    },
+    "destination": {
+      "type": "string"
+    },
+    "target": { "$ref": "partial:target-any" }
+  },
+  "required": ["files", "job_id", "destination", "target"],
+  "additionalProperties": false
+}

--- a/spec/fixtures/modules/upload_file/files/subdir/sub-file.sh
+++ b/spec/fixtures/modules/upload_file/files/subdir/sub-file.sh
@@ -1,0 +1,1 @@
+Sub-content!

--- a/spec/fixtures/modules/upload_file/files/test-file.sh
+++ b/spec/fixtures/modules/upload_file/files/test-file.sh
@@ -1,0 +1,1 @@
+Content!

--- a/spec/lib/bolt_spec/bolt_server.rb
+++ b/spec/lib/bolt_spec/bolt_server.rb
@@ -94,5 +94,37 @@ module BoltSpec
         'target' => target2request(target)
       }
     end
+
+    def build_upload_request(job_id, target)
+      sha = lambda do |path|
+        Digest::SHA256.file(
+          File.join(File.dirname(__FILE__),
+                    '..', '..', 'fixtures', 'modules', 'upload_file', 'files', path)
+        )
+      end
+
+      {
+        'files' => [
+          { "uri" => { "path" => "/puppet/v3/file_content/modules/upload_file/test-file.sh",
+                       "params" => { "environment" => "production" } },
+            "relative_path" => "test-file.sh",
+            "sha256" => sha['test-file.sh'],
+            "kind" => "file" },
+          { "uri" => { "path" => "/puppet/v3/file_content/modules/upload_file/subdir",
+                       "params" => { "environment" => "production" } },
+            "relative_path" => "subdir",
+            "sha256" => "",
+            "kind" => "directory" },
+          { "uri" => { "path" => "/puppet/v3/file_content/modules/upload_file/subdir/sub-file.sh",
+                       "params" => { "environment" => "production" } },
+            "relative_path" => "subdir/sub-file.sh",
+            "sha256" => sha['subdir/sub-file.sh'],
+            "kind" => "file" }
+        ],
+        'job_id' => job_id,
+        'destination' => '/home/bolt/result-path',
+        'target' => target2request(target)
+      }
+    end
   end
 end


### PR DESCRIPTION
In cases where PXP Agent is not installed on a target node
and thus cannot upload a file, SSH or WinRM should be used.
This commit adds the `POST /upload_file` endpoint which will
delegate either to SSH or to WinRM accordingly.