### PR TITLE
Add a newline to the site_content on lesson 11

### DIFF
--- a/docs/_includes/lesson11/Boltdir/site/profiles/plans/nginx_install.pp
+++ b/docs/_includes/lesson11/Boltdir/site/profiles/plans/nginx_install.pp
@@ -11,7 +11,7 @@ plan profiles::nginx_install(
 
   apply($servers) {
     class { 'profiles::server':
-      site_content => "${site_content} from ${$trusted['certname']}",
+      site_content => "${site_content} from ${$trusted['certname']}\n",
     }
   }
 


### PR DESCRIPTION
When `curl`ing from the command line, it is easy to have your output
swallowed up by a fancy prompt.  It's probably cleaner anyhow.