### PR TITLE
(maint) Update inventoryfile in HOL to not use special localhost target

### DIFF
--- a/docs/_includes/lesson11/Boltdir/inventory.yaml
+++ b/docs/_includes/lesson11/Boltdir/inventory.yaml
@@ -9,9 +9,8 @@ groups:
         config:
           ssh:
             port: 20023
-      - name: "localhost"
+      - name: "ssh://localhost"
         config:
-          transport: ssh
           ssh:
             port: 20024
 config:


### PR DESCRIPTION
The inventoryfile for lesson 11 contains a target with the name `localhost` used to target a docker container with an exposed port on 20024. The special `localhost` target name inherits the localhost defaults (including the `puppet-agent' feature). This causes apply prep to fail when an agent is not installed on the target system. This commit updates the example so that the special "localhost" target name is not used so users do not run in to this problem.