### PR TITLE
(ORCH-2341) Fix aggregate results reporting in bolt_server

### DIFF
--- a/developer-docs/bolt-api-servers.md
+++ b/developer-docs/bolt-api-servers.md
@@ -248,6 +248,56 @@ For example, the following uploads file 'abc' on windows_target.net:
 }
 ```
 
+### POST /ssh/check_node_connections
+- `targets`: An array of [SSH Target Objects](#ssh-target-object), *required* - A set of targets to check once for connectivity over SSH.
+
+Example request for a single connectivity check on two nodes over SSH:
+```
+{
+  "targets": [
+      {
+        "hostname": "first.ssh_node.net",
+        "user": "marauder",
+        "password": "I solemnly swear that I am up to no good",
+        "host-key-check": false,
+        "run-as": "george_weasley"
+      }, {
+        "hostname": "second.ssh_node.net",
+        "user": "marauder",
+        "password": "I solemnly swear that I am up to no good",
+        "host-key-check": false,
+        "run-as": "fred_weasley"
+      }
+  ]
+}
+```
+
+This returns a JSON object of the shape:
+```
+{
+    "status": "success",
+    "result": [
+        {
+            "status": "success"
+            "target": "first.ssh_node.net"
+            ...
+        }, {
+            "status": "success"
+            "target": "second.ssh_node.net"
+            ...
+        }
+    ]
+}
+```
+
+- This endpoint returns 200 when the checks were successfully conducted, even if some or all of the individual checks failed.
+- If at least one check failed, the parent result `status` will be set to `failure`.
+
+### POST /winrm/check_node_connections
+- `targets`: An array of [WinRM Target Objects](#winrm-target-object), *required* - A set of targets to check once for connectivity over WinRM.
+
+This endpoint behaves identically to the /ssh/check_node_connections endpoint, but acts over WinRM instead.
+
 ### SSH Target Object
 The Target is a JSON object. See the [schema](../lib/bolt_server/schemas/partials/target-ssh.json)
 

--- a/spec/bolt_server/app_integration_spec.rb
+++ b/spec/bolt_server/app_integration_spec.rb
@@ -138,15 +138,20 @@ describe "BoltServer::TransportApp", puppetserver: true do
     describe "check_node_connections" do
       let(:path) { '/ssh/check_node_connections' }
 
-      it 'checks connections on multiple targets' do
-        body = build_check_node_connections_request(
-          [conn_target('ssh', include_password: true)]
-        )
+      it 'checks connections on multiple targets, returning aggregated results' do
+        targets = [
+          conn_target('ssh', include_password: true)
+        ]
+        body = build_check_node_connections_request(targets)
         post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
 
         response_body = JSON.parse(last_response.body)
         expect(response_body['status']).to eq('success')
         expect(last_response.status).to eq(200)
+
+        expect(response_body['result']).to be_a(Array)
+        expect(response_body['result'].length).to eq(targets.length)
+        expect(response_body['result'].all? { |r| r['status'] == 'success' })
       end
     end
   end


### PR DESCRIPTION
Fixes a bug I introduced yesterday in #1221:

Previously, the conversion to JSON of bolt_server responses that use
`targets` instead of `target` was broken - it did not correctly format
the results as a parsable array.

This change fixes that, and instead of returning just the result list,
aggregate endpoints now return their own status hash, with two entries:

- 'status': will be 'success' only if all targets succeeded. If at least
  one target failed, this will also be set to 'failure', even though the
  request itself was successful and returns 200.
- 'result': contains the array with individual status hashes for each target.