### PR TITLE
(maint) Cache the puppet lookup for bolt_{inventory,executor}

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
@@ -28,7 +28,7 @@ Puppet::Functions.create_function(:apply_prep) do
   end
 
   def inventory
-    Puppet.lookup(:bolt_inventory)
+    @inventory ||= Puppet.lookup(:bolt_inventory)
   end
 
   def get_task(name, params = {})
@@ -61,7 +61,7 @@ Puppet::Functions.create_function(:apply_prep) do
   end
 
   def executor
-    Puppet.lookup(:bolt_executor)
+    @executor ||= Puppet.lookup(:bolt_executor)
   end
 
   def apply_prep(target_spec)


### PR DESCRIPTION
The test setup for the apply_prep spec relies on setting global context that is no-longer available to be set with override. This commit updates the apply_prep method to only look up the overridden values once.