### PR TITLE
(GH-1158) Quote paths for interpreter and task when using winrm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 #### Bug fixes
 
-* A plan apply() incorrectly returns successful if the report is unparseable([#1241](https://github.com/puppetlabs/bolt/issues/1241))
+* **A plan apply() incorrectly returns successful if the report is unparseable** ([#1241](https://github.com/puppetlabs/bolt/issues/1241))
+
+  Unexpect results for the result of an `apply` are now treated as errors.
+
+* **`interpreters` with spaces fail with the winrm transport** ([#1158](https://github.com/puppetlabs/bolt/issues/1158))
+
+  When using the interpreters setting on the WinRM transport, a task would fail to execute if the path to the specified interpreter contains a space. Interpreter paths with spaces in the name are now supported.
+
 
 ## 1.31.1
 

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -163,8 +163,7 @@ module Bolt
               if Powershell.powershell_file?(remote_task_path) && stdin.nil?
                 conn.execute(Powershell.run_ps_task(arguments, remote_task_path, input_method))
               else
-                interpreter = select_interpreter(remote_task_path, target.options['interpreters'])
-                if interpreter
+                if (interpreter = select_interpreter(remote_task_path, target.options['interpreters']))
                   path = interpreter
                   args = [remote_task_path]
                 else

--- a/spec/lib/bolt_spec/integration.rb
+++ b/spec/lib/bolt_spec/integration.rb
@@ -24,10 +24,10 @@ module BoltSpec
         begin
           opts = cli.parse
           cli.execute(opts)
-        # rubocop:disable HandleExceptions
+        # rubocop:disable Lint/HandleExceptions
         rescue Bolt::Error
         end
-        # rubocop:enable HandleExceptions
+        # rubocop:enable Lint/HandleExceptions
       else
         opts = cli.parse
         cli.execute(opts)


### PR DESCRIPTION
Previously when running a task over winrm where a space was contained in a user defined `interpreter` path or the path to the temporary task executable the task could fail due to not quoting the paths to handle the spaces. This commit updates the winrm transport to quote both paths when `interpreters` is configured. Note that for the `interpreter` path, if the user has specified a quoted path, no additional quoting will be added.

closes https://github.com/puppetlabs/bolt/issues/1158