### PR TITLE
(GH-1164) Only try to read cacert for winrm when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## BOLT NEXT
+
+#### Bug fixes
+
+* **Only read path to `cacert` for `winrm` transport when using `ssl`** ([#1232](https://github.com/puppetlabs/bolt/pull/1232))
+
+  When using the winrm transport do not try to read the cacert file when not using ssl. This avoids confusing errors when the cacert is not readable but ssl is not being used.
+
 ## 1.30.1
 
 #### Bug fixes

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -42,6 +42,10 @@ module Bolt
           raise Bolt::ValidationError, 'SMB file transfers are not allowed with SSL enabled'
         end
 
+        if ssl_flag && (ca_path = options['cacert'])
+          Bolt::Util.validate_file('cacert', ca_path)
+        end
+
         ssl_verify_flag = options['ssl-verify']
         unless !!ssl_verify_flag == ssl_verify_flag
           raise Bolt::ValidationError, 'ssl-verify option must be a Boolean true or false'

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -41,7 +41,7 @@ module Bolt
 
           transport = :kerberos if target.options['realm']
           endpoint = "#{scheme}://#{target.host}:#{@port}/wsman"
-          cacert = target.options['cacert'] && target.options['ssl'] ? target.options['cacert'] : nil
+          cacert = target.options['cacert'] && target.options['ssl'] ? File.expand_path(target.options['cacert']) : nil
           options = { endpoint: endpoint,
                       # https://github.com/WinRb/WinRM/issues/270
                       user: target.options['realm'] ? 'dummy' : @user,

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -41,13 +41,14 @@ module Bolt
 
           transport = :kerberos if target.options['realm']
           endpoint = "#{scheme}://#{target.host}:#{@port}/wsman"
+          cacert = target.options['cacert'] && target.options['ssl'] ? target.options['cacert'] : nil
           options = { endpoint: endpoint,
                       # https://github.com/WinRb/WinRM/issues/270
                       user: target.options['realm'] ? 'dummy' : @user,
                       password: target.options['realm'] ? 'dummy' : target.password,
                       retry_limit: 1,
                       transport: transport,
-                      ca_trust_path: target.options['cacert'],
+                      ca_trust_path: cacert,
                       realm: target.options['realm'],
                       no_ssl_peer_verification: !target.options['ssl-verify'] }
 

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -217,5 +217,19 @@ describe Bolt::Config do
       }
       expect { Bolt::Config.new(boltdir, config) }.to raise_error(Bolt::ValidationError)
     end
+
+    it "validates cacert file exists when 'ssl' is true" do
+      config = {
+        'winrm' => { 'ssl' => true, 'cacert' => 'does not exist' }
+      }
+      expect { Bolt::Config.new(boltdir, config) }.to raise_error(Bolt::FileError, /'does not exist'/)
+    end
+
+    it "ignores invalid cacert file when 'ssl' is false" do
+      config = {
+        'winrm' => { 'ssl' => false, 'cacert' => 'does not exist' }
+      }
+      expect { Bolt::Config.new(boltdir, config) }.not_to raise_error
+    end
   end
 end

--- a/spec/bolt/transport/winrm_spec.rb
+++ b/spec/bolt/transport/winrm_spec.rb
@@ -182,6 +182,13 @@ PS
 
       expect(winrm.run_command(omi_target, command)['stdout']).to eq("#{user}\r\n")
     end
+
+    it "ignores invalid cacert when ssl: false" do
+      target.options['cacert'] = 'does not exist'
+      target.options['ssl'] = false
+
+      expect(winrm.run_command(omi_target, command)['stdout']).to eq("#{user}\r\n")
+    end
   end
 
   context "connecting over SSL to OMI container ", omi: true do


### PR DESCRIPTION
This commit adds logic to the winrm transport to not try to read the `cacert` file when not using `ssl`. This avoids confusing errors when the `cacert` is not readable but `ssl` is not being used.