### PR TITLE
(GH-1174) Expand file paths for orchestrator client config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
   When using the winrm transport do not try to read the cacert file when not using ssl. This avoids confusing errors when the cacert is not readable but ssl is not being used.
 
+* **Some configuration options would not support file path expansion** ([#1174](https://github.com/puppetlabs/bolt/issues/1174))
+
+  The `token-file` and `cacert` file paths for the `pcp` transport now support file expansion. Similarly the `cacert` for the `winrm` transport has been updated to support file expansion.
+
 ## 1.30.1
 
 #### Bug fixes

--- a/lib/bolt/transport/orch/connection.rb
+++ b/lib/bolt/transport/orch/connection.rb
@@ -24,8 +24,10 @@ module Bolt
             acc[k] = opts[k] if opts.include?(k)
           end
           client_opts['User-Agent'] = "Bolt/#{VERSION}"
+          %w[token-file cacert].each do |f|
+            client_opts[f] = File.expand_path(client_opts[f]) if client_opts[f]
+          end
           logger.debug("Creating orchestrator client for #{client_opts}")
-
           @client = OrchestratorClient.new(client_opts, true)
           @plan_job = start_plan(plan_context)
           logger.debug("Started plan #{@plan_job}")

--- a/spec/bolt/transport/orch_spec.rb
+++ b/spec/bolt/transport/orch_spec.rb
@@ -58,6 +58,22 @@ describe Bolt::Transport::Orch, orchestrator: true do
         expect(c.instance_variable_get(:@client).config.config["User-Agent"]).to eq("Bolt/#{Bolt::VERSION}")
       end
     end
+
+    it "bolt expands file paths for cacert and token-file" do
+      config = {
+        'service-url' => 'https://foo.bar:8143',
+        'cacert' => '~/foo/bar',
+        'token-file' => '~/bar/foo'
+      }
+      expected = {
+        "service-url" => "https://foo.bar:8143",
+        "token-file" => "#{Dir.home}/bar/foo",
+        "cacert" => "#{Dir.home}/foo/bar",
+        "User-Agent" => "Bolt/#{Bolt::VERSION}"
+      }
+      expect(OrchestratorClient).to receive(:new).with(expected, true)
+      Bolt::Transport::Orch::Connection.new(config, nil, orch.logger)
+    end
   end
 
   describe :build_request do


### PR DESCRIPTION
Previously when the `token-file` or `cacert` file paths were used to construct a new orchestrator client instance, the paths were not expanded. Other paths in bolt expand and there are examples in the wild where paths need to be expanded (for example `token-file: ~/.puppetlabs/token`). This commit updates the orch transport to expand file paths before creeting an Orchestrator client object.