### PR TITLE
(maint) Remove installation instruction for deprecated platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## 1.30.1
 
+#### Deprecations and removals
+
+* **WARNING**: Starting with this release the puppetlabs apt repo for trusty (Ubuntu 1404) no longer contains new puppet-bolt packages.
+
 #### Bug fixes
 
 * **`apply()` blocks would ignore the `_run_as` argument passed to

--- a/pre-docs/bolt_installing.md
+++ b/pre-docs/bolt_installing.md
@@ -145,14 +145,6 @@ The Puppet Tools repository for the APT package management system is [https://ap
         sudo apt-get install puppet-bolt
         ```
 
-    -    Ubuntu 14.04
-
-        ```
-        wget https://apt.puppet.com/puppet-tools-release-trusty.deb
-        sudo dpkg -i puppet-tools-release-trusty.deb
-        sudo apt-get update
-        sudo apt-get install puppet-bolt
-        ```
 
     -    Ubuntu 16.04
 


### PR DESCRIPTION
As of 1.30.1 bolt is no-longer built and shipped for ubuntu 1404. Remove platform from install page.