### PR TITLE
(ORCH-2317) Update upload_file in bolt-server to work with single files

### DIFF
--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -148,7 +148,18 @@ module BoltServer
                                        'boltserver/schema-error').to_json]
         end
       end
-      [@executor.upload_file(target, cache_dir, destination), nil]
+      # We need to special case the scenario where only one file was
+      # included in the request to download. Otherwise, the call to upload_file
+      # will attempt to upload with a directory as a source and potentially a
+      # filename as a destination on the host. In that case the end result will
+      # be the file downloaded to a directory with the same name as the source
+      # filename, rather than directly to the filename set in the destination.
+      upload_source = if files.size == 1 && files[0]['kind'] == 'file'
+                        File.join(cache_dir, files[0]['relative_path'])
+                      else
+                        cache_dir
+                      end
+      [@executor.upload_file(target, upload_source, destination), nil]
     end
 
     get '/' do


### PR DESCRIPTION
Prior to this commit, the bolt-server implementation of upload_file would
always attempt to download with a source location of cache_dir/job_id (i.e. a
top-level directory). This breaks downloads for single files, since a single
file download request could have a destination with a fully qualified
filename, in which case the download would make the destination filename in to
a directory and download the single file in to that directory.

This commit updates upload_file in transport_app.rb to special case the single
file scenario, so that the upload source is `cache_dir/job_id/relative_path`
(i.e. a fully qualified path to the single file).