### PR TITLE
(maint) Standardize params vs. options and use symbols

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
@@ -12,14 +12,14 @@ Puppet::Functions.create_function(:run_task) do
   # Run a task.
   # @param task_name The task to run.
   # @param targets A pattern identifying zero or more targets. See {get_targets} for accepted patterns.
-  # @param task_args Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.
+  # @param args Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.
   # @return A list of results, one entry per target.
   # @example Run a task as root
   #   run_task('facts', $targets, '_run_as' => 'root')
   dispatch :run_task do
     param 'String[1]', :task_name
     param 'Boltlib::TargetSpec', :targets
-    optional_param 'Hash[String[1], Any]', :task_args
+    optional_param 'Hash[String[1], Any]', :args
     return_type 'ResultSet'
   end
 
@@ -27,7 +27,7 @@ Puppet::Functions.create_function(:run_task) do
   # @param task_name The task to run.
   # @param targets A pattern identifying zero or more targets. See {get_targets} for accepted patterns.
   # @param description A description to be output when calling this function.
-  # @param task_args Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.
+  # @param args Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.
   # @return A list of results, one entry per target.
   # @example Run a task
   #   run_task('facts', $targets, 'Gather OS facts')
@@ -35,27 +35,29 @@ Puppet::Functions.create_function(:run_task) do
     param 'String[1]', :task_name
     param 'Boltlib::TargetSpec', :targets
     param 'Optional[String]', :description
-    optional_param 'Hash[String[1], Any]', :task_args
+    optional_param 'Hash[String[1], Any]', :args
     return_type 'ResultSet'
   end
 
-  def run_task(task_name, targets, task_args = nil)
-    run_task_with_description(task_name, targets, nil, task_args)
+  def run_task(task_name, targets, args = {})
+    run_task_with_description(task_name, targets, nil, args)
   end
 
-  def run_task_with_description(task_name, targets, description, task_args = nil)
+  def run_task_with_description(task_name, targets, description, args = {})
     unless Puppet[:tasks]
       raise Puppet::ParseErrorWithIssue
         .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'run_task')
     end
 
-    task_args ||= {}
+    options, params = args.partition { |k, _v| k.start_with?('_') }.map(&:to_h)
+    options = options.map { |k, v| [k.sub(/^_/, '').to_sym, v] }.to_h
+
     executor = Puppet.lookup(:bolt_executor)
     inventory = Puppet.lookup(:bolt_inventory)
 
     # Bolt calls this function internally to trigger tasks from the CLI. We
     # don't want to count those invocations.
-    unless task_args['_bolt_api_call']
+    unless options[:bolt_api_call]
       executor.report_function_call(self.class.name)
     end
 
@@ -65,9 +67,7 @@ Puppet::Functions.create_function(:run_task) do
     # Ensure that given targets are all Target instances
     targets = inventory.get_targets(targets)
 
-    options, use_args = task_args.partition { |k, _| k.start_with?('_') }.map(&:to_h)
-
-    options['_description'] = description if description
+    options[:description] = description if description
 
     # Don't bother loading the local task definition if all targets use the 'pcp' transport.
     if !targets.empty? && targets.all? { |t| t.transport == 'pcp' }
@@ -80,37 +80,37 @@ Puppet::Functions.create_function(:run_task) do
         raise Bolt::Error.unknown_task(task_name)
       end
 
-      task_signature.runnable_with?(use_args) do |mismatch_message|
+      task_signature.runnable_with?(params) do |mismatch_message|
         raise with_stack(:TYPE_MISMATCH, mismatch_message)
       end || (raise with_stack(:TYPE_MISMATCH, 'Task parameters do not match'))
 
       task = Bolt::Task.new(task_signature.task_hash)
     end
 
-    unless Puppet::Pops::Types::TypeFactory.data.instance?(use_args)
+    unless Puppet::Pops::Types::TypeFactory.data.instance?(params)
       # generate a helpful error message about the type-mismatch between the type Data
-      # and the actual type of use_args
-      use_args_t = Puppet::Pops::Types::TypeCalculator.infer_set(use_args)
+      # and the actual type of params
+      params_t = Puppet::Pops::Types::TypeCalculator.infer_set(params)
       desc = Puppet::Pops::Types::TypeMismatchDescriber.singleton.describe_mismatch(
         'Task parameters are not of type Data. run_task()',
-        Puppet::Pops::Types::TypeFactory.data, use_args_t
+        Puppet::Pops::Types::TypeFactory.data, params_t
       )
       raise with_stack(:TYPE_NOT_DATA, desc)
     end
 
     # Wrap parameters marked with '"sensitive": true' in the task metadata with a
     # Sensitive wrapper type. This way it's not shown in logs.
-    if (params = task.parameters)
-      use_args.each do |k, v|
-        if params[k] && params[k]['sensitive']
-          use_args[k] = Puppet::Pops::Types::PSensitiveType::Sensitive.new(v)
+    if (param_spec = task.parameters)
+      params.each do |k, v|
+        if param_spec[k] && param_spec[k]['sensitive']
+          params[k] = Puppet::Pops::Types::PSensitiveType::Sensitive.new(v)
         end
       end
     end
 
     if executor.noop
       if task.supports_noop
-        use_args['_noop'] = true
+        params['_noop'] = true
       else
         raise with_stack(:TASK_NO_NOOP, 'Task does not support noop')
       end
@@ -119,8 +119,8 @@ Puppet::Functions.create_function(:run_task) do
     if targets.empty?
       Bolt::ResultSet.new([])
     else
-      result = executor.run_task(targets, task, use_args, options)
-      if !result.ok && !task_args['_catch_errors']
+      result = executor.run_task(targets, task, params, options)
+      if !result.ok && !options[:catch_errors]
         raise Bolt::RunFailure.new(result, 'run_task', task_name)
       end
       result

--- a/bolt-modules/boltlib/spec/functions/run_command_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_command_spec.rb
@@ -44,7 +44,7 @@ describe 'run_command' do
     end
 
     it 'with _run_as' do
-      executor.expects(:run_command).with([target], command, '_run_as' => 'root').returns(result_set)
+      executor.expects(:run_command).with([target], command, run_as: 'root').returns(result_set)
       inventory.expects(:get_targets).with(target).returns([target])
 
       is_expected.to run.with_params(command, target, '_run_as' => 'root').and_return(result_set)
@@ -62,14 +62,14 @@ describe 'run_command' do
       let(:message) { 'test message' }
 
       it 'passes the description through if parameters are passed' do
-        executor.expects(:run_command).with([target], command, '_description' => message).returns(result_set)
+        executor.expects(:run_command).with([target], command, description: message).returns(result_set)
         inventory.expects(:get_targets).with(target).returns([target])
 
         is_expected.to run.with_params(command, target, message, {}).and_return(result_set)
       end
 
       it 'passes the description through if no parameters are passed' do
-        executor.expects(:run_command).with([target], command, '_description' => message).returns(result_set)
+        executor.expects(:run_command).with([target], command, description: message).returns(result_set)
         inventory.expects(:get_targets).with(target).returns([target])
 
         is_expected.to run.with_params(command, target, message).and_return(result_set)
@@ -125,7 +125,7 @@ describe 'run_command' do
         end
 
         it 'does not error with _catch_errors' do
-          executor.expects(:run_command).with([target, target2], command, '_catch_errors' => true)
+          executor.expects(:run_command).with([target, target2], command, catch_errors: true)
                   .returns(result_set)
           inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 

--- a/bolt-modules/boltlib/spec/functions/run_script_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_script_spec.rb
@@ -62,7 +62,7 @@ describe 'run_script' do
     end
 
     it 'with _run_as' do
-      executor.expects(:run_script).with([target], full_path, [], '_run_as' => 'root').returns(result_set)
+      executor.expects(:run_script).with([target], full_path, [], run_as: 'root').returns(result_set)
       inventory.expects(:get_targets).with(target).returns([target])
 
       is_expected.to run.with_params('test/uploads/hostname.sh', target, '_run_as' => 'root').and_return(result_set)
@@ -80,14 +80,14 @@ describe 'run_script' do
       let(:message) { 'test message' }
 
       it 'passes the description through if parameters are passed' do
-        executor.expects(:run_script).with([target], full_path, [], '_description' => message).returns(result_set)
+        executor.expects(:run_script).with([target], full_path, [], description: message).returns(result_set)
         inventory.expects(:get_targets).with(target).returns([target])
 
         is_expected.to run.with_params('test/uploads/hostname.sh', target, message, {})
       end
 
       it 'passes the description through if no parameters are passed' do
-        executor.expects(:run_script).with([target], full_path, [], '_description' => message).returns(result_set)
+        executor.expects(:run_script).with([target], full_path, [], description: message).returns(result_set)
         inventory.expects(:get_targets).with(target).returns([target])
 
         is_expected.to run.with_params('test/uploads/hostname.sh', target, message)
@@ -137,7 +137,7 @@ describe 'run_script' do
         end
 
         it 'does not error with _catch_errors' do
-          executor.expects(:run_script).with([target, target2], full_path, [], '_catch_errors' => true)
+          executor.expects(:run_script).with([target, target2], full_path, [], catch_errors: true)
                   .returns(result_set)
           inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 

--- a/bolt-modules/boltlib/spec/functions/run_task_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_spec.rb
@@ -79,7 +79,7 @@ describe 'run_task' do
       executable = File.join(tasks_root, 'meta.sh')
 
       executor.expects(:run_task)
-              .with([target], mock_task(executable, 'environment'), default_args, '_run_as' => 'root')
+              .with([target], mock_task(executable, 'environment'), default_args, run_as: 'root')
               .returns(result_set)
       inventory.expects(:get_targets).with(hostname).returns([target])
 
@@ -140,14 +140,14 @@ describe 'run_task' do
       let(:message) { 'test message' }
 
       it 'passes the description through if parameters are passed' do
-        executor.expects(:run_task).with([target], anything, {}, '_description' => message).returns(result_set)
+        executor.expects(:run_task).with([target], anything, {}, description: message).returns(result_set)
         inventory.expects(:get_targets).with(hostname).returns([target])
 
         is_expected.to run.with_params('test::yes', hostname, message, {})
       end
 
       it 'passes the description through if no parameters are passed' do
-        executor.expects(:run_task).with([target], anything, {}, '_description' => message).returns(result_set)
+        executor.expects(:run_task).with([target], anything, {}, description: message).returns(result_set)
         inventory.expects(:get_targets).with(hostname).returns([target])
 
         is_expected.to run.with_params('test::yes', hostname, message)
@@ -216,7 +216,7 @@ describe 'run_task' do
           executor.expects(:run_task).with([target, target2],
                                            mock_task(executable, 'environment'),
                                            default_args,
-                                           '_catch_errors' => true)
+                                           catch_errors: true)
                   .returns(result_set)
           inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 

--- a/bolt-modules/boltlib/spec/functions/upload_file_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/upload_file_spec.rb
@@ -58,7 +58,7 @@ describe 'upload_file' do
 
     it 'runs as another user' do
       executor.expects(:upload_file)
-              .with([target], full_dir_path, destination, '_run_as' => 'soandso')
+              .with([target], full_dir_path, destination, run_as: 'soandso')
               .returns(result_set)
       inventory.stubs(:get_targets).with(target).returns([target])
 
@@ -78,7 +78,7 @@ describe 'upload_file' do
 
       it 'passes the description through if parameters are passed' do
         executor.expects(:upload_file)
-                .with([target], full_dir_path, destination, '_description' => message)
+                .with([target], full_dir_path, destination, description: message)
                 .returns(result_set)
         inventory.stubs(:get_targets).with(target).returns([target])
 
@@ -87,7 +87,7 @@ describe 'upload_file' do
 
       it 'passes the description through if no parameters are passed' do
         executor.expects(:upload_file)
-                .with([target], full_dir_path, destination, '_description' => message)
+                .with([target], full_dir_path, destination, description: message)
                 .returns(result_set)
         inventory.stubs(:get_targets).with(target).returns([target])
 
@@ -141,7 +141,7 @@ describe 'upload_file' do
         end
 
         it 'does not error with _catch_errors' do
-          executor.expects(:upload_file).with([target, target2], full_path, destination, '_catch_errors' => true)
+          executor.expects(:upload_file).with([target, target2], full_path, destination, catch_errors: true)
                   .returns(result_set)
           inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 

--- a/documentation/plan_functions.md
+++ b/documentation/plan_functions.md
@@ -535,13 +535,13 @@ Runs the `plan` referenced by its name. A plan is autoloaded from `<moduleroot>/
 ### Run a plan
 
 ```
-run_plan(String $plan_name, Optional[Hash] $named_args)
+run_plan(String $plan_name, Optional[Hash] $args)
 ```
 
 *Returns:* `Boltlib::PlanResult` The result of running the plan. Undef if plan does not explicitly return results.
 
 * **plan_name** `String` The plan to run.
-* **named_args** `Optional[Hash]` Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.
+* **args** `Optional[Hash]` Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.
 
 **Example:** Run a plan
 ```
@@ -551,13 +551,13 @@ run_plan('canary', 'command' => 'false', 'nodes' => $targets, '_catch_errors' =>
 ### Run a plan, specifying $nodes as a positional argument.
 
 ```
-run_plan(String $plan_name, Boltlib::TargetSpec $targets, Optional[Hash] $named_args)
+run_plan(String $plan_name, Boltlib::TargetSpec $targets, Optional[Hash] $args)
 ```
 
 *Returns:* `Boltlib::PlanResult` The result of running the plan. Undef if plan does not explicitly return results.
 
 * **plan_name** `String` The plan to run.
-* **named_args** `Optional[Hash]` Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.
+* **args** `Optional[Hash]` Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.
 * **targets** `Boltlib::TargetSpec` A pattern identifying zero or more targets. See [`get_targets`](#get_targets) for accepted patterns.
 
 **Example:** Run a plan
@@ -629,14 +629,14 @@ This function does nothing if the list of targets is empty.
 ### Run a task.
 
 ```
-run_task(String[1] $task_name, Boltlib::TargetSpec $targets, Optional[Hash[String[1], Any]] $task_args)
+run_task(String[1] $task_name, Boltlib::TargetSpec $targets, Optional[Hash[String[1], Any]] $args)
 ```
 
 *Returns:* `ResultSet` A list of results, one entry per target.
 
 * **task_name** `String[1]` The task to run.
 * **targets** `Boltlib::TargetSpec` A pattern identifying zero or more targets. See [`get_targets`](#get_targets) for accepted patterns.
-* **task_args** `Optional[Hash[String[1], Any]]` Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.
+* **args** `Optional[Hash[String[1], Any]]` Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.
 
 **Example:** Run a task as root
 ```
@@ -646,7 +646,7 @@ run_task('facts', $targets, '_run_as' => 'root')
 ### Run a task, logging the provided description.
 
 ```
-run_task(String[1] $task_name, Boltlib::TargetSpec $targets, Optional[String] $description, Optional[Hash[String[1], Any]] $task_args)
+run_task(String[1] $task_name, Boltlib::TargetSpec $targets, Optional[String] $description, Optional[Hash[String[1], Any]] $args)
 ```
 
 *Returns:* `ResultSet` A list of results, one entry per target.
@@ -654,7 +654,7 @@ run_task(String[1] $task_name, Boltlib::TargetSpec $targets, Optional[String] $d
 * **task_name** `String[1]` The task to run.
 * **targets** `Boltlib::TargetSpec` A pattern identifying zero or more targets. See [`get_targets`](#get_targets) for accepted patterns.
 * **description** `Optional[String]` A description to be output when calling this function.
-* **task_args** `Optional[Hash[String[1], Any]]` Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.
+* **args** `Optional[Hash[String[1], Any]]` Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.
 
 **Example:** Run a task
 ```

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -341,7 +341,7 @@ module Bolt
 
         elapsed_time = Benchmark.realtime do
           executor_opts = {}
-          executor_opts['_description'] = options[:description] if options.key?(:description)
+          executor_opts[:description] = options[:description] if options.key?(:description)
           executor.subscribe(outputter)
           executor.subscribe(log_outputter)
           results =
@@ -462,7 +462,7 @@ module Bolt
         end
 
         results = pal.with_bolt_executor(executor, inventory, puppetdb_client) do
-          Puppet.lookup(:apply_executor).apply_ast(ast, targets, '_catch_errors' => true, '_noop' => noop)
+          Puppet.lookup(:apply_executor).apply_ast(ast, targets, catch_errors: true, noop: noop)
         end
       end
 

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -225,9 +225,9 @@ module Bolt
     end
 
     def run_command(targets, command, options = {})
-      description = options.fetch('_description', "command '#{command}'")
+      description = options.fetch(:description, "command '#{command}'")
       log_action(description, targets) do
-        options = { '_run_as' => run_as }.merge(options) if run_as
+        options[:run_as] = run_as if run_as && !options.key?(:run_as)
 
         batch_execute(targets) do |transport, batch|
           with_node_logging("Running command '#{command}'", batch) do
@@ -238,9 +238,9 @@ module Bolt
     end
 
     def run_script(targets, script, arguments, options = {})
-      description = options.fetch('_description', "script #{script}")
+      description = options.fetch(:description, "script #{script}")
       log_action(description, targets) do
-        options = { '_run_as' => run_as }.merge(options) if run_as
+        options[:run_as] = run_as if run_as && !options.key?(:run_as)
 
         batch_execute(targets) do |transport, batch|
           with_node_logging("Running script #{script} with '#{arguments.to_json}'", batch) do
@@ -251,9 +251,9 @@ module Bolt
     end
 
     def run_task(targets, task, arguments, options = {})
-      description = options.fetch('_description', "task #{task.name}")
+      description = options.fetch(:description, "task #{task.name}")
       log_action(description, targets) do
-        options = { '_run_as' => run_as }.merge(options) if run_as
+        options[:run_as] = run_as if run_as && !options.key?(:run_as)
         arguments['_task'] = task.name
 
         batch_execute(targets) do |transport, batch|
@@ -265,9 +265,9 @@ module Bolt
     end
 
     def upload_file(targets, source, destination, options = {})
-      description = options.fetch('_description', "file upload from #{source} to #{destination}")
+      description = options.fetch(:description, "file upload from #{source} to #{destination}")
       log_action(description, targets) do
-        options = { '_run_as' => run_as }.merge(options) if run_as
+        options[:run_as] = run_as if run_as && !options.key?(:run_as)
 
         batch_execute(targets) do |transport, batch|
           with_node_logging("Uploading file #{source} to #{destination}", batch) do

--- a/lib/bolt/plugin/module.rb
+++ b/lib/bolt/plugin/module.rb
@@ -164,7 +164,7 @@ module Bolt
         params = params.merge(metaparams)
 
         # There are no executor options to pass now.
-        options = { "_catch_errors" => true }
+        options = { catch_errors: true }
 
         result = @context.run_local_task(task,
                                          params,

--- a/lib/bolt/plugin/task.rb
+++ b/lib/bolt/plugin/task.rb
@@ -19,7 +19,7 @@ module Bolt
 
       def run_task(opts)
         params = opts['parameters'] || {}
-        options = { '_catch_errors' => true }
+        options = { catch_errors: true }
 
         raise Bolt::ValidationError, "Task plugin requires that the 'task' is specified" unless opts['task']
         task = @context.get_validated_task(opts['task'], params)

--- a/lib/bolt/task/run.rb
+++ b/lib/bolt/task/run.rb
@@ -44,7 +44,7 @@ module Bolt
         else
           result = executor.run_task(targets, task, params, options)
 
-          if !result.ok && !options['_catch_errors']
+          if !result.ok && !options[:catch_errors]
             raise Bolt::RunFailure.new(result, 'run_task', task.name)
           end
           result

--- a/lib/bolt/transport/local_windows.rb
+++ b/lib/bolt/transport/local_windows.rb
@@ -27,7 +27,7 @@ module Bolt
 
       def self.validate(options)
         logger = Logging.logger[self]
-        if options['sudo-password'] || options['run-as'] || options['run-as-command'] || options['_run_as']
+        if options['sudo-password'] || options['run-as'] || options['run-as-command'] || options[:run_as]
           logger.warn("run-as is not supported for Windows hosts using the local transport")
         end
       end

--- a/lib/bolt/transport/orch/connection.rb
+++ b/lib/bolt/transport/orch/connection.rb
@@ -78,7 +78,7 @@ module Bolt
         end
 
         def run_task(targets, task, arguments, options)
-          body = build_request(targets, task, arguments, options['_description'])
+          body = build_request(targets, task, arguments, options[:description])
           @client.run_task(body)
         end
 

--- a/lib/bolt/transport/sudoable.rb
+++ b/lib/bolt/transport/sudoable.rb
@@ -19,7 +19,7 @@ module Bolt
 
       def run_command(target, command, options = {})
         with_connection(target) do |conn|
-          conn.running_as(options['_run_as']) do
+          conn.running_as(options[:run_as]) do
             output = conn.execute(command, sudoable: true)
             Bolt::Result.for_command(target,
                                      output.stdout.string,
@@ -32,7 +32,7 @@ module Bolt
 
       def upload(target, source, destination, options = {})
         with_connection(target) do |conn|
-          conn.running_as(options['_run_as']) do
+          conn.running_as(options[:run_as]) do
             conn.with_tempdir do |dir|
               basename = File.basename(destination)
               tmpfile = File.join(dir.to_s, basename)
@@ -55,7 +55,7 @@ module Bolt
         arguments = unwrap_sensitive_args(arguments)
 
         with_connection(target) do |conn|
-          conn.running_as(options['_run_as']) do
+          conn.running_as(options[:run_as]) do
             conn.with_tempdir do |dir|
               path = conn.write_executable(dir.to_s, script)
               dir.chown(conn.run_as)
@@ -77,7 +77,7 @@ module Bolt
         extra_files = implementation['files']
 
         with_connection(target) do |conn|
-          conn.running_as(options['_run_as']) do
+          conn.running_as(options[:run_as]) do
             stdin, output = nil
             execute_options = {}
             execute_options[:interpreter] = select_interpreter(executable, target.options['interpreters'])

--- a/lib/bolt_spec/plans/action_stubs/command_stub.rb
+++ b/lib/bolt_spec/plans/action_stubs/command_stub.rb
@@ -35,7 +35,8 @@ module BoltSpec
       # Public methods
 
       def with_params(params)
-        @invocation[:options] = params
+        @invocation[:options] = params.select { |k, _v| k.start_with?('_') }
+                                      .map { |k, v| [k.sub(/^_/, '').to_sym, v] }.to_h
         self
       end
     end

--- a/lib/bolt_spec/plans/action_stubs/script_stub.rb
+++ b/lib/bolt_spec/plans/action_stubs/script_stub.rb
@@ -44,6 +44,7 @@ module BoltSpec
         @invocation[:params] = params
         @invocation[:arguments] = params['arguments']
         @invocation[:options] = params.select { |k, _v| k.start_with?('_') }
+                                      .map { |k, v| [k.sub(/^_/, '').to_sym, v] }.to_h
         self
       end
     end

--- a/lib/bolt_spec/plans/action_stubs/task_stub.rb
+++ b/lib/bolt_spec/plans/action_stubs/task_stub.rb
@@ -46,6 +46,7 @@ module BoltSpec
         @invocation[:params] = params
         @invocation[:arguments] = params.reject { |k, _v| k.start_with?('_') }
         @invocation[:options] = params.select { |k, _v| k.start_with?('_') }
+                                      .map { |k, v| [k.sub(/^_/, '').to_sym, v] }.to_h
         self
       end
     end

--- a/lib/bolt_spec/plans/action_stubs/upload_stub.rb
+++ b/lib/bolt_spec/plans/action_stubs/upload_stub.rb
@@ -56,7 +56,8 @@ module BoltSpec
       end
 
       def with_params(params)
-        @invocation[:options] = params
+        @invocation[:options] = params.select { |k, _v| k.start_with?('_') }
+                                      .map { |k, v| [k.sub(/^_/, '').to_sym, v] }.to_h
         self
       end
     end

--- a/lib/bolt_spec/run.rb
+++ b/lib/bolt_spec/run.rb
@@ -202,7 +202,7 @@ module BoltSpec
         end
 
         pal.with_bolt_executor(executor, inventory, puppetdb_client) do
-          Puppet.lookup(:apply_executor).apply_ast(ast, targets, '_catch_errors' => true, '_noop' => noop)
+          Puppet.lookup(:apply_executor).apply_ast(ast, targets, catch_errors: true, noop: noop)
         end
       end
     end

--- a/lib/plan_executor/executor.rb
+++ b/lib/plan_executor/executor.rb
@@ -79,7 +79,7 @@ module PlanExecutor
     end
 
     def run_command(targets, command, options = {})
-      description = options.fetch('_description', "command '#{command}'")
+      description = options.fetch(:description, "command '#{command}'")
       log_action(description, targets) do
         results = as_resultset(targets) do
           @orch_client.run_command(targets, command, options)
@@ -90,7 +90,7 @@ module PlanExecutor
     end
 
     def run_script(targets, script, arguments, options = {})
-      description = options.fetch('_description', "script #{script}")
+      description = options.fetch(:description, "script #{script}")
       log_action(description, targets) do
         results = as_resultset(targets) do
           @orch_client.run_script(targets, script, arguments, options)
@@ -101,7 +101,7 @@ module PlanExecutor
     end
 
     def run_task(targets, task, arguments, options = {})
-      description = options.fetch('_description', "task #{task.name}")
+      description = options.fetch(:description, "task #{task.name}")
       log_action(description, targets) do
         arguments['_task'] = task.name
 
@@ -114,7 +114,7 @@ module PlanExecutor
     end
 
     def upload_file(targets, source, destination, options = {})
-      description = options.fetch('_description', "file upload from #{source} to #{destination}")
+      description = options.fetch(:description, "file upload from #{source} to #{destination}")
       log_action(description, targets) do
         results = as_resultset(targets) do
           @orch_client.file_upload(targets, source, destination, options)

--- a/lib/plan_executor/orch_client.rb
+++ b/lib/plan_executor/orch_client.rb
@@ -61,7 +61,7 @@ module PlanExecutor
     end
 
     def send_request(targets, task, arguments, options = {})
-      description = options['_description']
+      description = options[:description]
       body = { task: task.name,
                environment: @environment,
                noop: arguments['_noop'],

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -28,7 +28,7 @@ describe "Bolt::Executor" do
     { type: :node_result, result: result }
   end
 
-  def mock_node_results(_run_as = nil)
+  def mock_node_results
     {
       targets[0] => Bolt::Result.new(targets[0]),
       targets[1] => Bolt::Result.new(targets[1])
@@ -48,10 +48,10 @@ describe "Bolt::Executor" do
       executor.run_command(targets, command, {})
     end
 
-    it 'passes _run_as' do
+    it 'passes run_as' do
       executor.run_as = 'foo'
       node_results.each do |target, result|
-        expect(ssh).to receive(:run_command).with(target, command, '_run_as' => 'foo').and_return(result)
+        expect(ssh).to receive(:run_command).with(target, command, run_as: 'foo').and_return(result)
       end
 
       executor.run_command(targets, command)
@@ -100,10 +100,10 @@ describe "Bolt::Executor" do
       end
     end
 
-    it 'passes _run_as' do
+    it 'passes run_as' do
       executor.run_as = 'foo'
       node_results.each do |target, result|
-        expect(ssh).to receive(:run_script).with(target, script, [], '_run_as' => 'foo').and_return(result)
+        expect(ssh).to receive(:run_script).with(target, script, [], run_as: 'foo').and_return(result)
       end
 
       results = executor.run_script(targets, script, [])
@@ -166,7 +166,7 @@ describe "Bolt::Executor" do
       node_results.each do |target, result|
         expect(ssh)
           .to receive(:run_task)
-          .with(target, task_type(task), task_arguments, { '_run_as' => 'foo' }.merge(task_options))
+          .with(target, task_type(task), task_arguments, { run_as: 'foo' }.merge(task_options))
           .and_return(result)
       end
 

--- a/spec/bolt/transport/local_spec.rb
+++ b/spec/bolt/transport/local_spec.rb
@@ -44,20 +44,20 @@ describe Bolt::Transport::Local do
       let(:target) { make_target }
 
       it "can override run_as for command via an option" do
-        expect(runner.run_command(target, 'whoami', '_run_as' => user)['stdout']).to eq("#{user}\n")
+        expect(runner.run_command(target, 'whoami', run_as: user)['stdout']).to eq("#{user}\n")
       end
 
       it "can override run_as for script via an option" do
         contents = "#!/bin/sh\nwhoami"
         with_tempfile_containing('script test', contents) do |file|
-          expect(runner.run_script(target, file.path, [], '_run_as' => user)['stdout']).to eq("#{user}\n")
+          expect(runner.run_script(target, file.path, [], run_as: user)['stdout']).to eq("#{user}\n")
         end
       end
 
       it "can override run_as for task via an option" do
         contents = "#!/bin/sh\nwhoami"
         with_task_containing('tasks_test', contents, 'environment') do |task|
-          expect(runner.run_task(target, task, {}, '_run_as' => user).message).to eq("#{user}\n")
+          expect(runner.run_task(target, task, {}, run_as: user).message).to eq("#{user}\n")
         end
       end
 
@@ -65,10 +65,10 @@ describe Bolt::Transport::Local do
         contents = "upload file test as root content"
         dest = '/tmp/root-file-upload-test'
         with_tempfile_containing('tasks test upload as root', contents) do |file|
-          expect(runner.upload(target, file.path, dest, '_run_as' => user).message).to match(/Uploaded/)
-          expect(runner.run_command(target, "cat #{dest}", '_run_as' => user)['stdout']).to eq(contents)
-          expect(runner.run_command(target, "stat -c %U #{dest}", '_run_as' => user)['stdout'].chomp).to eq(user)
-          expect(runner.run_command(target, "stat -c %G #{dest}", '_run_as' => user)['stdout'].chomp).to eq(user)
+          expect(runner.upload(target, file.path, dest, run_as: user).message).to match(/Uploaded/)
+          expect(runner.run_command(target, "cat #{dest}", run_as: user)['stdout']).to eq(contents)
+          expect(runner.run_command(target, "stat -c %U #{dest}", run_as:  user)['stdout'].chomp).to eq(user)
+          expect(runner.run_command(target, "stat -c %G #{dest}", run_as:  user)['stdout'].chomp).to eq(user)
         end
 
         runner.run_command(target, "rm #{dest}", sudoable: true, run_as: user)
@@ -131,7 +131,7 @@ describe Bolt::Transport::Local do
     end
 
     context 'with slow input' do
-      let(:file_size) { 100 }
+      let(:file_size) { 10 }
       let(:ruby_task) do
         <<~TASK
         #!/usr/bin/env ruby
@@ -176,7 +176,7 @@ describe Bolt::Transport::Local do
       let(:target) { make_target }
 
       it "warns when trying to use _run_as" do
-        runner.run_command(target, os_context[:stdout_command][0], '_run_as' => user)
+        runner.run_command(target, os_context[:stdout_command][0], run_as: user)
         logs = @log_output.readlines
         expect(logs).to include(/WARN  Bolt::Transport::LocalWindows : run-as is not supported/)
       end

--- a/spec/bolt/transport/orch_spec.rb
+++ b/spec/bolt/transport/orch_spec.rb
@@ -303,7 +303,7 @@ describe Bolt::Transport::Orch, orchestrator: true do
     it 'passes description through if supplied' do
       expect(mock_client).to receive(:run_task).with(include(description: 'test message')).and_return(results)
 
-      orch.batch_task(targets, mtask, params, '_description' => 'test message')
+      orch.batch_task(targets, mtask, params, description: 'test message')
     end
 
     it "unwraps Sensitive parameters" do
@@ -390,8 +390,8 @@ describe Bolt::Transport::Orch, orchestrator: true do
       end
     end
 
-    it 'ignores _run_as' do
-      results = orch.batch_command(targets, command, '_run_as' => 'root')
+    it 'ignores run_as' do
+      results = orch.batch_command(targets, command, run_as: 'root')
       expect(results[0]).to be_success
       expect(results[1]).to be_success
     end
@@ -556,8 +556,8 @@ describe Bolt::Transport::Orch, orchestrator: true do
         expect(results[1]['stderr']).to eq('there')
       end
 
-      it 'ignores _run_as' do
-        results = orch.batch_script(targets, script_path, args, '_run_as' => 'root')
+      it 'ignores run_as' do
+        results = orch.batch_script(targets, script_path, args, run_as: 'root')
         expect(results[0]).to be_success
         expect(results[1]).to be_success
       end

--- a/spec/bolt/transport/shared_examples.rb
+++ b/spec/bolt/transport/shared_examples.rb
@@ -115,7 +115,7 @@ shared_examples 'transport api' do
                 else
                   "exit 1"
                 end
-      result = runner.run_command(target, command, '_catch_errors' => true).value
+      result = runner.run_command(target, command, catch_errors: true).value
       expect(result['exit_code']).to eq(1)
     end
   end

--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -289,20 +289,20 @@ describe Bolt::Transport::SSH do
     end
 
     it "can override run_as for command via an option" do
-      expect(ssh.run_command(target, 'whoami', '_run_as' => 'root')['stdout']).to eq("root\n")
+      expect(ssh.run_command(target, 'whoami', run_as: 'root')['stdout']).to eq("root\n")
     end
 
     it "can override run_as for script via an option" do
       contents = "#!/bin/sh\nwhoami"
       with_tempfile_containing('script test', contents) do |file|
-        expect(ssh.run_script(target, file.path, [], '_run_as' => 'root')['stdout']).to eq("root\n")
+        expect(ssh.run_script(target, file.path, [], run_as: 'root')['stdout']).to eq("root\n")
       end
     end
 
     it "can override run_as for task via an option" do
       contents = "#!/bin/sh\nwhoami"
       with_task_containing('tasks_test', contents, 'environment') do |task|
-        expect(ssh.run_task(target, task, {}, '_run_as' => 'root').message).to eq("root\n")
+        expect(ssh.run_task(target, task, {}, run_as: 'root').message).to eq("root\n")
       end
     end
 
@@ -310,10 +310,10 @@ describe Bolt::Transport::SSH do
       contents = "upload file test as root content"
       dest = '/tmp/root-file-upload-test'
       with_tempfile_containing('tasks test upload as root', contents) do |file|
-        expect(ssh.upload(target, file.path, dest, '_run_as' => 'root').message).to match(/Uploaded/)
-        expect(ssh.run_command(target, "cat #{dest}", '_run_as' => 'root')['stdout']).to eq(contents)
-        expect(ssh.run_command(target, "stat -c %U #{dest}", '_run_as' => 'root')['stdout'].chomp).to eq('root')
-        expect(ssh.run_command(target, "stat -c %G #{dest}", '_run_as' => 'root')['stdout'].chomp).to eq('root')
+        expect(ssh.upload(target, file.path, dest, run_as:  'root').message).to match(/Uploaded/)
+        expect(ssh.run_command(target, "cat #{dest}", run_as: 'root')['stdout']).to eq(contents)
+        expect(ssh.run_command(target, "stat -c %U #{dest}", run_as:  'root')['stdout'].chomp).to eq('root')
+        expect(ssh.run_command(target, "stat -c %G #{dest}", run_as:  'root')['stdout'].chomp).to eq('root')
       end
 
       ssh.run_command(target, "rm #{dest}", sudoable: true, run_as: 'root')
@@ -322,7 +322,7 @@ describe Bolt::Transport::SSH do
     it "runs a task that expects big data on stdin" do
       with_task_containing('tasks_test', stdin_task, 'stdin') do |task|
         expect(ssh).not_to receive(:make_wrapper_stringio)
-        result = ssh.run_task(target, task, { 'data' => big_task_input }, '_run_as' => 'root')
+        result = ssh.run_task(target, task, { 'data' => big_task_input }, run_as: 'root')
         expect(result.value['data'].strip.size).to eq(task_input_size)
       end
     end
@@ -330,7 +330,7 @@ describe Bolt::Transport::SSH do
     it "runs a task that expects big data in environment variable" do
       expect(ssh).not_to receive(:make_wrapper_stringio)
       with_task_containing('tasks_test', env_task, 'environment') do |task|
-        result = ssh.run_task(target, task, { 'data' => big_task_input }, '_run_as' => 'root')
+        result = ssh.run_task(target, task, { 'data' => big_task_input }, run_as: 'root')
         expect(result.value['_output'].strip.size).to eq(task_input_size)
       end
     end
@@ -345,7 +345,7 @@ describe Bolt::Transport::SSH do
     it "runs a task that expects big data on stdin" do
       expect(ssh).not_to receive(:make_wrapper_stringio)
       with_task_containing('tasks_test', stdin_task, 'stdin', '.sh') do |task|
-        result = ssh.run_task(target, task, { 'data' => big_task_input }, '_run_as' => 'root')
+        result = ssh.run_task(target, task, { 'data' => big_task_input }, run_as: 'root')
         expect(result.value['data'].strip.size).to eq(task_input_size)
       end
     end
@@ -353,7 +353,7 @@ describe Bolt::Transport::SSH do
     it "runs a task that expects big data in environment variable" do
       expect(ssh).not_to receive(:make_wrapper_stringio)
       with_task_containing('tasks_test', env_task, 'environment', '.sh') do |task|
-        result = ssh.run_task(target, task, { 'data' => big_task_input }, '_run_as' => 'root')
+        result = ssh.run_task(target, task, { 'data' => big_task_input }, run_as: 'root')
         expect(result.value['_output'].strip.size).to eq(task_input_size)
       end
     end
@@ -404,7 +404,7 @@ describe Bolt::Transport::SSH do
     it "runs a task that expects big data on stdin" do
       expect(ssh).to receive(:make_wrapper_stringio).and_call_original
       with_task_containing('tasks_test', stdin_task, 'stdin') do |task|
-        result = ssh.run_task(target, task, { 'data' => big_task_input }, '_run_as' => 'root')
+        result = ssh.run_task(target, task, { 'data' => big_task_input }, run_as: 'root')
         expect(result.value['data'].strip.size).to eq(task_input_size)
       end
     end
@@ -412,7 +412,7 @@ describe Bolt::Transport::SSH do
     it "runs a task that expects big data in environment variable" do
       expect(ssh).not_to receive(:make_wrapper_stringio)
       with_task_containing('tasks_test', env_task, 'environment') do |task|
-        result = ssh.run_task(target, task, { 'data' => big_task_input }, '_run_as' => 'root')
+        result = ssh.run_task(target, task, { 'data' => big_task_input }, run_as: 'root')
         expect(result.value['_output'].strip.size).to eq(task_input_size)
       end
     end
@@ -427,7 +427,7 @@ describe Bolt::Transport::SSH do
     it "runs a task that expects big data on stdin" do
       expect(ssh).to receive(:make_wrapper_stringio).and_call_original
       with_task_containing('tasks_test', stdin_task, 'stdin', '.sh') do |task|
-        result = ssh.run_task(target, task, { 'data' => big_task_input }, '_run_as' => 'root')
+        result = ssh.run_task(target, task, { 'data' => big_task_input }, run_as: 'root')
         expect(result.value['data'].strip.size).to eq(task_input_size)
       end
     end
@@ -435,7 +435,7 @@ describe Bolt::Transport::SSH do
     it "runs a task that expects big data in environment variable" do
       expect(ssh).not_to receive(:make_wrapper_stringio)
       with_task_containing('tasks_test', env_task, 'environment', '.sh') do |task|
-        result = ssh.run_task(target, task, { 'data' => big_task_input }, '_run_as' => 'root')
+        result = ssh.run_task(target, task, { 'data' => big_task_input }, run_as: 'root')
         expect(result.value['_output'].strip.size).to eq(task_input_size)
       end
     end

--- a/spec/bolt/transport/winrm_spec.rb
+++ b/spec/bolt/transport/winrm_spec.rb
@@ -264,8 +264,8 @@ PS
       expect(winrm.run_command(target, command)['stdout']).to eq("#{user}\r\n")
     end
 
-    it "ignores _run_as", winrm: true do
-      expect(winrm.run_command(target, command, '_run_as' => 'root')['stdout']).to eq("#{user}\r\n")
+    it "ignores run_as", winrm: true do
+      expect(winrm.run_command(target, command, run_as: 'root')['stdout']).to eq("#{user}\r\n")
     end
 
     it "reuses a PowerShell host / runspace for multiple commands", winrm: true do
@@ -375,11 +375,11 @@ PS
       end
     end
 
-    it "ignores _run_as", winrm: true do
+    it "ignores run_as", winrm: true do
       contents = "Write-Output \"hellote\""
       with_tempfile_containing('script-test-winrm', contents, '.ps1') do |file|
         expect(
-          winrm.run_script(target, file.path, [], '_run_as' => 'root')['stdout']
+          winrm.run_script(target, file.path, [], run_as: 'root')['stdout']
         ).to eq("hellote\r\n")
       end
     end
@@ -564,12 +564,12 @@ SHELLWORDS
       end
     end
 
-    it "ignores _run_as", winrm: true do
+    it "ignores run_as", winrm: true do
       contents = 'Write-Host "$env:PT_message_one ${env:PT_message two}"'
       arguments = { message_one: 'task is running',
                     "message two": 'task has run' }
       with_task_containing('task-test-winrm', contents, 'environment', '.ps1') do |task|
-        expect(winrm.run_task(target, task, arguments, '_run_as' => 'root').message)
+        expect(winrm.run_task(target, task, arguments, run_as: 'root').message)
           .to eq("task is running task has run\r\n")
       end
     end

--- a/spec/bolt_spec/run_spec.rb
+++ b/spec/bolt_spec/run_spec.rb
@@ -42,7 +42,7 @@ describe "BoltSpec::Run", ssh: true do
     end
 
     it 'should accept _catch_errors' do
-      result = run_command('echo hello', 'non_existent_node', options: { '_catch_errors' => true })
+      result = run_command('echo hello', 'non_existent_node', options: { catch_errors: true })
 
       expect(result[0]['status']).to eq('failure')
       expect(result[0]['result']['_error']['kind']).to eq('puppetlabs.tasks/connect-error')
@@ -59,7 +59,7 @@ describe "BoltSpec::Run", ssh: true do
     end
 
     it 'should accept _catch_errors' do
-      result = run_script('missing.sh', 'non_existent_node', nil, options: { '_catch_errors' => true })
+      result = run_script('missing.sh', 'non_existent_node', nil, options: { catch_errors: true })
 
       expect(result[0]['status']).to eq('failure')
       expect(result[0]['result']['_error']['kind']).to eq('puppetlabs.tasks/connect-error')
@@ -76,7 +76,7 @@ describe "BoltSpec::Run", ssh: true do
     end
 
     it 'should accept _catch_errors' do
-      result = run_script('missing.sh', 'non_existent_node', nil, options: { '_catch_errors' => true })
+      result = run_script('missing.sh', 'non_existent_node', nil, options: { catch_errors: true })
 
       expect(result[0]['status']).to eq('failure')
       expect(result[0]['result']['_error']['kind']).to eq('puppetlabs.tasks/connect-error')


### PR DESCRIPTION
Previously, we split out params and options into separate hashes
based on whether the keys started with _, but then left the keys that
way. That meant that the internals of Bolt were littered with code that
included leading underscores and thus had some evidence of where those
options originated from. As the leading underscore is an implementation
detail of the Puppet functions, we now consistently strip them out when
exiting the Puppet language and standardize them to symbols.