### PR TITLE
(ORCH-2317) Update transport_app upload_file to use thread safe download

### DIFF
--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -139,7 +139,7 @@ module BoltServer
           # but this is to be on the safe side.
           parent = File.dirname(path)
           FileUtils.mkdir_p(parent)
-          @file_cache.download_file(path, sha256, uri)
+          @file_cache.serial_execute { @file_cache.download_file(path, sha256, uri) }
         elsif kind == 'directory'
           # Create directory in cache so we can move files in.
           FileUtils.mkdir_p(path)


### PR DESCRIPTION
The upload_file api in transport_app.rb (for bolt-server) uses
`@file_cache.download_file` to download files to a cachedir before actually
uploading them to hosts.

This is broken when more than one thread is in use, because download_file
should be wrapped in `@file_cache.serial_execute` so downloads only happen one
at a time (the download function itself is not thread safe).

This commit updates upload_file to use `serial_execute`