### PR TITLE
(maint) Update orch spec for orchestrator_client 0.4.3

### DIFF
--- a/spec/bolt/transport/orch_spec.rb
+++ b/spec/bolt/transport/orch_spec.rb
@@ -50,7 +50,7 @@ describe Bolt::Transport::Orch, orchestrator: true do
       with_tempfile_containing('token', 'faketoken') do |conf|
         config = {
           'service-url' => 'https://foo.bar:8143',
-          'cacert' => 'bar',
+          'cacert' => conf.path,
           'token-file' => conf.path
         }
         allow(OrchestratorClient).to receive(:new).and_call_original


### PR DESCRIPTION
The newest version of the orchestrator_client gem does file path validation for cacert. Pass an existing file in test setup.