### PR TITLE
(ORCH-2339) Add `run_script` endpoint to bolt server

### DIFF
--- a/developer-docs/bolt-api-servers.md
+++ b/developer-docs/bolt-api-servers.md
@@ -248,6 +248,70 @@ For example, the following uploads file 'abc' on windows_target.net:
 }
 ```
 
+### POST /ssh/run_script
+- `target`: [SSH Target Object](#ssh-target-object), *required* - Target information to run script on.
+- `script`: Object, *required* - The script being executed.
+    - `filename`: String, *required* - The destination for the script on the target.
+    - `uri`: Object, *required* - The location of where to find the script.
+        - `path`: String, *required* - The endpoint to retrieve the script.
+        - `params`: Object, *required* - The parameters to supply the endpoint.
+    - `sha256`: String, *required* - The SHA256 value for the script.
+- `arguments`: String, *optional* - Which arguments to pass to the script.
+
+For example, the following runs script 'file.sh' on linux_target.net:
+```
+{
+  "target": {
+    "hostname": "linux_target.net",
+    "user": "marauder",
+    "password": "I solemnly swear that I am up to no good",
+    "host-key-check": false,
+    "run-as": "george_weasley"
+  },
+  "script" : {
+    "filename": "file.sh",
+    "uri": {
+      "path": "/puppet/v3/file_content/modules/some_module/file.sh",
+      "params": {}
+    },
+    "sha256": "SHA256VALUE"
+  },
+  "arguments": "--test",
+}
+```
+
+### POST /winrm/run_script
+- `target`: [WinRM Target Object](#winrm-target-object), *required* - Target information to run script on.
+- `script`: Object, *required* - The script being executed.
+    - `filename`: String, *required* - The destination for the script on the target.
+    - `uri`: Object, *required* - The location of where to find the script.
+        - `path`: String, *required* - The endpoint to retrieve the script.
+        - `params`: Object, *required* - The parameters to supply the endpoint.
+    - `sha256`: String, *required* - The SHA256 value for the script.
+- `arguments`: String, *optional* - Which arguments to pass to the script.
+
+For example, the following runs script 'file.sh' on windows_target.net:
+```
+{
+  "target": {
+    "hostname": "windows_target.net",
+    "user": "Administrator",
+    "password": "Secret",
+    "ssl": false,
+    "ssl-verify": false
+  },
+  "script" : {
+    "filename": "file.ps1",
+    "uri": {
+      "path": "/puppet/v3/file_content/modules/some_module/file.ps1",
+      "params": {}
+    },
+    "sha256": "SHA256VALUE"
+  },
+  "arguments": "-Test",
+}
+```
+
 ### POST /ssh/check_node_connections
 - `targets`: An array of [SSH Target Objects](#ssh-target-object), *required* - A set of targets to check once for connectivity over SSH.
 

--- a/lib/bolt_server/schemas/action-run_script.json
+++ b/lib/bolt_server/schemas/action-run_script.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "run_script request",
+  "description": "POST <transport>/run_script request schema",
+  "type": "object",
+  "properties": {
+    "script": {
+      "type": "object",
+      "properties": {
+        "filename": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "params": {
+              "type": "object"
+            }
+          },
+          "required": [
+            "path",
+            "params"
+          ]
+        },
+        "sha256": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "filename",
+        "uri",
+        "sha256"
+      ]
+    },
+    "arguments": {
+      "type": "string"
+    },
+    "target": { "$ref": "partial:target-any" }
+  },
+  "required": ["script", "target"]
+}

--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -23,6 +23,7 @@ module BoltServer
       action-check_node_connections
       action-run_command
       action-run_task
+      action-run_script
       action-upload_file
       transport-ssh
       transport-winrm
@@ -162,6 +163,16 @@ module BoltServer
       [@executor.upload_file(target, upload_source, destination), nil]
     end
 
+    def run_script(target, body)
+      error = validate_schema(@schemas["action-run_script"], body)
+      return [], error unless error.nil?
+
+      # Download the file onto the machine.
+      file_location = @file_cache.update_file(body['script'])
+
+      [@executor.run_script(target, file_location, body['arguments'])]
+    end
+
     get '/' do
       200
     end
@@ -185,6 +196,7 @@ module BoltServer
       check_node_connections
       run_command
       run_task
+      run_script
       upload_file
     ].freeze
 

--- a/spec/bolt_server/app_integration_spec.rb
+++ b/spec/bolt_server/app_integration_spec.rb
@@ -167,6 +167,38 @@ describe "BoltServer::TransportApp", puppetserver: true do
       end
     end
 
+    describe "run_script" do
+      let(:path) { '/ssh/run_script' }
+
+      it 'copies and runs script' do
+        body = build_script_request(conn_target('ssh', include_password: true))
+        post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
+        expect(last_response).to be_ok
+        expect(last_response.status).to eq(200)
+        result = JSON.parse(last_response.body)
+        expect(result).to include('status' => 'success')
+        expect(result).to include('action' => 'script')
+        expect(result['result']['stdout'])
+          .to match(/hi!/)
+          .and match(/test-file\.sh/)
+          .and match(/--arg/)
+      end
+
+      it 'works without arguments' do
+        body = build_script_request(conn_target('ssh', include_password: true))
+        body.delete('arguments')
+        post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
+        expect(last_response).to be_ok
+        expect(last_response.status).to eq(200)
+        result = JSON.parse(last_response.body)
+        expect(result).to include('status' => 'success')
+        expect(result).to include('action' => 'script')
+        expect(result['result']['stdout'])
+          .to match(/hi!/)
+          .and match(/test-file\.sh/)
+      end
+    end
+
     describe "check_node_connections" do
       let(:path) { '/ssh/check_node_connections' }
 

--- a/spec/fixtures/modules/upload_file/files/test-file.sh
+++ b/spec/fixtures/modules/upload_file/files/test-file.sh
@@ -1,1 +1,5 @@
-Content!
+#!/bin/bash
+
+echo 'hi!'
+echo $0
+echo $@

--- a/spec/lib/bolt_spec/bolt_server.rb
+++ b/spec/lib/bolt_spec/bolt_server.rb
@@ -127,6 +127,27 @@ module BoltSpec
       }
     end
 
+    def build_script_request(target)
+      sha = lambda do |path|
+        Digest::SHA256.file(
+          File.join(File.dirname(__FILE__),
+                    '..', '..', 'fixtures', 'modules', 'upload_file', 'files', path)
+        )
+      end
+
+      {
+        'script' =>
+            {
+              "filename" => 'test-file.sh',
+              "uri" => { "path" => "/puppet/v3/file_content/modules/upload_file/test-file.sh",
+                         "params" => { "environment" => "production" } },
+              "sha256" => sha['test-file.sh']
+            },
+        'arguments' => '--arg',
+        'target' => target2request(target)
+      }
+    end
+
     def build_check_node_connections_request(targets)
       {
         'targets' => targets.map { |target| target2request(target) }


### PR DESCRIPTION
In cases where PXP Agent is not installed on a target node and thus
cannot run a script, SSH or WinRM should be used. This commit adds the
`POST /run_script` endpoint which will delegate either to SSH or to
WinRM accordingly.