### PR TITLE
(docs) Link to issue # not PR # for GH-1164

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Bug fixes
 
-* **Only read path to `cacert` for `winrm` transport when using `ssl`** ([#1232](https://github.com/puppetlabs/bolt/pull/1232))
+* **Only read path to `cacert` for `winrm` transport when using `ssl`** ([#1164](https://github.com/puppetlabs/bolt/issues/1164))
 
   When using the winrm transport do not try to read the cacert file when not using ssl. This avoids confusing errors when the cacert is not readable but ssl is not being used.
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,3 +3,4 @@
 
 /pre-docs @cwcowellshah @puppetlabs/bolt
 /lib/bolt_server @puppetlabs/skeletor
+CHANGELOG.md @cwcowellshah @puppetlabs/bolt


### PR DESCRIPTION
Accidentally linked to a PR instead of the issue. This commit updates the CHANGELOG with the correct link.