### PR TITLE
(GH-1241) Handle unexpect results from the apply task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## BOLT NEXT
+
+#### Bug fixes
+
+* A plan apply() incorrectly returns successful if the report is unparseable([#1241](https://github.com/puppetlabs/bolt/issues/1241))
+
 ## 1.31.1
 
 #### Bug fixes

--- a/spec/fixtures/apply/apply_catalog.sh
+++ b/spec/fixtures/apply/apply_catalog.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
+echo '{"metrics": {}, "resource_statuses": {}, "status": "unchanged", "catalog":'
 printenv PT_catalog
+echo '}'

--- a/spec/fixtures/apply/basic/plans/init.pp
+++ b/spec/fixtures/apply/basic/plans/init.pp
@@ -12,6 +12,6 @@ plan basic(TargetSpec $nodes) {
       content => "hi there I'm ${$facts['os']['family']}\n",
     }
   }.map |$r| {
-    $r.report['resources']
+    $r.report['catalog']['resources']
   }
 }

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -18,6 +18,7 @@ describe "passes parsed AST to the apply_catalog task" do
   let(:config_flags) { %W[--format json --nodes #{uri} --password #{password} --modulepath #{modulepath}] + tflags }
 
   before(:each) do
+    allow(Bolt::ApplyResult).to receive(:from_task_result) { |r| r }
     allow_any_instance_of(Bolt::Applicator).to receive(:catalog_apply_task) {
       path = File.join(__dir__, "../fixtures/apply/#{apply_task}")
       impl = { 'name' => apply_task, 'path' => path }
@@ -29,7 +30,7 @@ describe "passes parsed AST to the apply_catalog task" do
   def get_notifies(result)
     expect(result).not_to include('kind')
     expect(result[0]).to include('status' => 'success')
-    result[0]['result']['report']['resources'].select { |r| r['type'] == 'Notify' }
+    result[0]['result']['report']['catalog']['resources'].select { |r| r['type'] == 'Notify' }
   end
 
   # SSH only required to simplify capturing stdin passed to the task. WinRM omitted as slower and unnecessary.
@@ -99,7 +100,7 @@ describe "passes parsed AST to the apply_catalog task" do
     it 'applies a complex type from the modulepath' do
       result = run_cli_json(%w[plan run basic::type] + config_flags)
       report = result[0]['result']['report']
-      warn = report['resources'].select { |r| r['type'] == 'Warn' }
+      warn = report['catalog']['resources'].select { |r| r['type'] == 'Warn' }
       expect(warn.count).to eq(1)
     end
 


### PR DESCRIPTION
Previously ApplyResult would create difficult to use objects when it got
unexpected reports back from the apply task. It will now treat those
results as errors. This may result in an apply erroring when a
misbehaved provider prints to stdout even when the application otherwise
appears successful.

@jpartlow do you want to test this with your use case.