### PR TITLE
(maint) Properly set the `wait` argument on PuppetDB commands

### DIFF
--- a/spec/lib/bolt_spec/puppetdb.rb
+++ b/spec/lib/bolt_spec/puppetdb.rb
@@ -20,9 +20,9 @@ module BoltSpec
     def make_command(command:, version:, payload:, wait: nil)
       client = pdb_client
       url = "#{client.uri}/pdb/cmd/v1"
+      url += "?secondsToWaitForCompletion=#{wait}" if wait
 
       body = { command: command, version: version, payload: payload }
-      body['secondsToWaitForCompletion' => wait] if wait
       body = JSON.generate(body)
 
       headers = { "Content-Type" => "application/json" }


### PR DESCRIPTION
Previously, this code was using an invalid hash lookup instead of a hash
assignment. However, it was also trying to set this parameter in the
POST body instead of the URL where it belongs. We now correctly set it
as a query param.