### PR TITLE
(maint) Fix badge for Travis build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bolt
 
-[![Travis Status](https://api.travis-ci.com/puppetlabs/bolt.svg?token=XsSSSxJhnBoKnL8JPVay&branch=master)](https://travis-ci.com/puppetlabs/bolt)
+[![Travis Status](https://travis-ci.org/puppetlabs/bolt.svg?branch=master)](https://travis-ci.org/puppetlabs/bolt)
 [![Appveyor Status](https://ci.appveyor.com/api/projects/status/m7dhiwxk455mkw2d/branch/master?svg=true)](https://ci.appveyor.com/project/puppetlabs/bolt/branch/master)
 [![Gem Version](https://badge.fury.io/rb/bolt.svg)](https://badge.fury.io/rb/bolt)
 


### PR DESCRIPTION
This commit updates the Travis CI badge on the README to be correct.