### PR TITLE
(maint) Update pdb container setup for new ssl setup

### DIFF
--- a/spec/Dockerfile.puppetdb
+++ b/spec/Dockerfile.puppetdb
@@ -1,13 +1,7 @@
 FROM puppet/puppetdb
 
-ARG hostname="bolt-puppetdb"
-
 # Use our own certs so this doesn't have to wait for puppetserver startup
-COPY fixtures/ssl/ca.pem /etc/puppetlabs/puppet/ssl/certs/ca.pem
-COPY fixtures/ssl/cert.pem /etc/puppetlabs/puppet/ssl/certs/pdb.pem
-COPY fixtures/ssl/key.pem /etc/puppetlabs/puppet/ssl/private_keys/pdb.pem
-COPY fixtures/ssl/crl.pem /etc/puppetlabs/puppet/ssl/ca/ca_crl.pem
-
-# Use our own entrypoint
-COPY fixtures/puppetdb/docker-entrypoint.sh /docker-entrypoint.sh
-RUN chmod +x /docker-entrypoint.sh
+COPY fixtures/ssl/ca.pem /opt/puppetlabs/server/data/puppetdb/certs/certs/ca.pem
+COPY fixtures/ssl/cert.pem /opt/puppetlabs/server/data/puppetdb/certs/certs/pdb.pem
+COPY fixtures/ssl/key.pem /opt/puppetlabs/server/data/puppetdb/certs/private_keys/pdb.pem
+COPY fixtures/ssl/crl.pem /opt/puppetlabs/server/data/puppetdb/certs/ca/ca_crl.pem

--- a/spec/docker-compose.yml
+++ b/spec/docker-compose.yml
@@ -31,8 +31,11 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.puppetdb
+      args:
+        hostname: bolt-puppetdb
     environment:
       - "USE_PUPPETSERVER=false"
+      - "CERTNAME=pdb"
     image: puppetdb
     ports:
       # 8081 is a common port

--- a/spec/fixtures/puppetdb/docker-entrypoint.sh
+++ b/spec/fixtures/puppetdb/docker-entrypoint.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-set -e
-
-CERTNAME=pdb /ssl-setup.sh
-
-exec java $PUPPETDB_JAVA_ARGS -cp /puppetdb.jar \
-    clojure.main -m puppetlabs.puppetdb.core "$@" \
--c /etc/puppetlabs/puppetdb/conf.d/


### PR DESCRIPTION
The ssl-setup.sh script is no longer used by the puppetdb container. This commit removes the curtom entrypoint for setting up docker-compose stack for testing to use the entrypoint defined by the base image. It also updates the destination for the ssl setup to the expected location.