### PR TITLE
(maint) Eagerly evaluate OS in analytics client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.31.1
+
+#### Bug fixes
+
+* **Spurious plan failures and warnings on startup**
+
+  A race condition with the analytics client could cause Bolt operations to fail or extraneous warnings to be printed during startup.
+
 ## 1.31.0
 
 #### Deprecations and removals

--- a/lib/bolt/analytics.rb
+++ b/lib/bolt/analytics.rb
@@ -162,16 +162,14 @@ module Bolt
           # User locale
           ul: Locale.current.to_rfc,
           # Custom Dimension 1 (Operating System)
-          cd1: @os.value
+          cd1: @os
         }
       end
 
       def compute_os
-        Concurrent::Future.execute(executor: @executor) do
-          require 'facter'
-          os = Facter.value('os')
-          "#{os['name']} #{os.dig('release', 'major')}"
-        end
+        require 'facter'
+        os = Facter.value('os')
+        "#{os['name']} #{os.dig('release', 'major')}"
       end
 
       # If the user is running a very fast command, there may not be time for

--- a/spec/bolt/analytics_spec.rb
+++ b/spec/bolt/analytics_spec.rb
@@ -60,7 +60,7 @@ describe Bolt::Analytics::Client do
   end
 
   before :each do
-    allow_any_instance_of(described_class).to receive(:compute_os).and_return(double('os_future', value: 'CentOS 7'))
+    allow_any_instance_of(described_class).to receive(:compute_os).and_return('CentOS 7')
   end
 
   subject { described_class.new(uuid) }


### PR DESCRIPTION
Previously, we spun evaluation of the client OS into another thread to
avoid slowing down the main execution thread by needing to require
facter. This caused a race condition in facter between the thread
compting the OS and the main thread loading PAL which also needs to
evaluate some facts. As it turns out, by the time the analytics client
is instantiated we've already required facter anyway, so we don't have
to pay that cost. Evaluating the OS fact is negligible (~25ms), so we
now do it in the main thread to avoid the race condition.