### PR TITLE
(GH-1140) Maintain ruby 2.3 compatibility by not using Dir.children

### DIFF
--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -117,7 +117,8 @@ module Bolt
       static_loader = loaders.static_loader
       static_loader.runtime_3_init
       if File.directory?(@resource_types)
-        Dir.children(@resource_types).each do |resource_pp|
+        # Ruby 2.3 does not support Dir.children
+        (Dir.entries(@resource_types) - %w[. ..]).each do |resource_pp|
           type_name_from_file = File.basename(resource_pp, '.pp').capitalize
           typed_name = Puppet::Pops::Loader::TypedName.new(:type, type_name_from_file)
           resource_type = Puppet::Pops::Types::TypeFactory.resource(type_name_from_file)


### PR DESCRIPTION
Ruby 2.3 does not support the `children` method for the `Dir` class. This commit updates the code to explicitly filter the `.` and `..` directories when loading resource types using the `Dir#entries` method.