### PR TITLE
(GH-1243) Refer to Targets by their safe name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## BOLT NEXT
+
+### Bug fixes
+
+
+### New features
+
+* **Only print `safe_name` when referencing `Target`s** ([#1271](https://github.com/puppetlabs/bolt/pull/1271))
+
+  When using Inventory v2 a Target's safe name is the `uri` minus the password component (unless the target `name` is explicitly defined in which case the `name` is used). For Inventory v1, the safe name is the `host`. 
+
+
 ## 1.32.0
 
 ### Bug fixes

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -81,7 +81,7 @@ module Bolt
     end
 
     def compile(target, ast, plan_vars)
-      trusted = Puppet::Context::TrustedInformation.new('local', target.host, {})
+      trusted = Puppet::Context::TrustedInformation.new('local', target.name, {})
       facts = @inventory.facts(target).merge('bolt' => true)
 
       catalog_input = {
@@ -90,7 +90,7 @@ module Bolt
         pdb_config: @pdb_client.config.to_hash,
         hiera_config: @hiera_config,
         target: {
-          name: target.host,
+          name: target.name,
           facts: facts,
           variables: @inventory.vars(target).merge(plan_vars),
           trusted: trusted.to_h

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -218,7 +218,7 @@ module Bolt
     end
 
     def with_node_logging(description, batch)
-      @logger.info("#{description} on #{batch.map(&:uri)}")
+      @logger.info("#{description} on #{batch.map(&:safe_name)}")
       result = yield
       @logger.info(result.to_json)
       result

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -73,14 +73,14 @@ module Bolt
       end
 
       def print_start(target)
-        @stream.puts(colorize(:green, "Started on #{target.host}..."))
+        @stream.puts(colorize(:green, "Started on #{target.safe_name}..."))
       end
 
       def print_result(result)
         if result.success?
-          @stream.puts(colorize(:green, "Finished on #{result.target.host}:"))
+          @stream.puts(colorize(:green, "Finished on #{result.target.safe_name}:"))
         else
-          @stream.puts(colorize(:red, "Failed on #{result.target.host}:"))
+          @stream.puts(colorize(:red, "Failed on #{result.target.safe_name}:"))
         end
 
         if result.error_hash
@@ -170,7 +170,7 @@ module Bolt
           @stream.puts format('Successful on %<size>d node%<plural>s: %<names>s',
                               size: ok_set.size,
                               plural: ok_set.size == 1 ? '' : 's',
-                              names: ok_set.names.join(','))
+                              names: ok_set.targets.map(&:safe_name).join(','))
         end
 
         error_set = results.error_set
@@ -179,7 +179,7 @@ module Bolt
                                 format('Failed on %<size>d node%<plural>s: %<names>s',
                                        size: error_set.size,
                                        plural: error_set.size == 1 ? '' : 's',
-                                       names: error_set.names.join(',')))
+                                       names: error_set.targets.map(&:safe_name).join(',')))
         end
 
         total_msg = format('Ran on %<size>d node%<plural>s',

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -281,6 +281,7 @@ module Bolt
     def host
       @uri_obj&.hostname || @host
     end
+    alias safe_name host
 
     def name
       @name || @uri

--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -125,7 +125,7 @@ module Bolt
         assert_batch_size_one("batch_task()", targets)
         target = targets.first
         with_events(target, callback) do
-          @logger.debug { "Running task run '#{task}' on #{target.uri}" }
+          @logger.debug { "Running task run '#{task}' on #{target.safe_name}" }
           run_task(target, task, arguments, options)
         end
       end
@@ -139,7 +139,7 @@ module Bolt
         assert_batch_size_one("batch_command()", targets)
         target = targets.first
         with_events(target, callback) do
-          @logger.debug("Running command '#{command}' on #{target.uri}")
+          @logger.debug("Running command '#{command}' on #{target.safe_name}")
           run_command(target, command, options)
         end
       end
@@ -153,7 +153,7 @@ module Bolt
         assert_batch_size_one("batch_script()", targets)
         target = targets.first
         with_events(target, callback) do
-          @logger.debug { "Running script '#{script}' on #{target.uri}" }
+          @logger.debug { "Running script '#{script}' on #{target.safe_name}" }
           run_script(target, script, arguments, options)
         end
       end
@@ -167,7 +167,7 @@ module Bolt
         assert_batch_size_one("batch_upload()", targets)
         target = targets.first
         with_events(target, callback) do
-          @logger.debug { "Uploading: '#{source}' to #{destination} on #{target.uri}" }
+          @logger.debug { "Uploading: '#{source}' to #{destination} on #{target.safe_name}" }
           upload(target, source, destination, options)
         end
       end

--- a/lib/bolt/transport/docker/connection.rb
+++ b/lib/bolt/transport/docker/connection.rb
@@ -8,9 +8,9 @@ module Bolt
     class Docker < Base
       class Connection
         def initialize(target)
-          raise Bolt::ValidationError, "Target #{target.name} does not have a host" unless target.host
+          raise Bolt::ValidationError, "Target #{target.safe_name} does not have a host" unless target.host
           @target = target
-          @logger = Logging.logger[target.host]
+          @logger = Logging.logger[target.safe_name]
           @docker_host = @target.options['service-url']
         end
 
@@ -28,7 +28,7 @@ module Bolt
           true
         rescue StandardError => e
           raise Bolt::Node::ConnectError.new(
-            "Failed to connect to #{@target.uri}: #{e.message}",
+            "Failed to connect to #{@target.safe_name}: #{e.message}",
             'CONNECT_ERROR'
           )
         end

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -81,7 +81,7 @@ module Bolt
               target,
               value: { '_error' => {
                 'kind' => 'puppetlabs.tasks/skipped-node',
-                'msg' => "Node #{target.host} was skipped",
+                'msg' => "Node #{target.safe_name} was skipped",
                 'details' => {}
               } },
               action: 'task', object: task_name

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -73,7 +73,7 @@ module Bolt
         begin
           conn&.disconnect
         rescue StandardError => e
-          logger.info("Failed to close connection to #{target.uri} : #{e.message}")
+          logger.info("Failed to close connection to #{target.safe_name} : #{e.message}")
         end
       end
 

--- a/lib/bolt/transport/sudoable/connection.rb
+++ b/lib/bolt/transport/sudoable/connection.rb
@@ -10,7 +10,7 @@ module Bolt
         def initialize(target)
           @target = target
           @run_as = nil
-          @logger = Logging.logger[@target.host]
+          @logger = Logging.logger[@target.safe_name]
         end
 
         # This method allows the @run_as variable to be used as a per-operation

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -75,7 +75,7 @@ module Bolt
         begin
           conn&.disconnect
         rescue StandardError => e
-          logger.info("Failed to close connection to #{target.uri} : #{e.message}")
+          logger.info("Failed to close connection to #{target.safe_name} : #{e.message}")
         end
       end
 

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -12,7 +12,7 @@ module Bolt
         DEFAULT_EXTENSIONS = ['.ps1', '.rb', '.pp'].freeze
 
         def initialize(target, transport_logger)
-          raise Bolt::ValidationError, "Target #{target.name} does not have a host" unless target.host
+          raise Bolt::ValidationError, "Target #{target.safe_name} does not have a host" unless target.host
           @target = target
 
           default_port = target.options['ssl'] ? HTTPS_PORT : HTTP_PORT
@@ -23,7 +23,7 @@ module Bolt
           extensions += target.options['interpreters'].keys if target.options['interpreters']
           @extensions = DEFAULT_EXTENSIONS.to_set.merge(extensions)
 
-          @logger = Logging.logger[@target.host]
+          @logger = Logging.logger[@target.safe_name]
           @transport_logger = transport_logger
         end
 
@@ -243,12 +243,12 @@ module Bolt
             @logger.debug { "Connected to #{@client.dns_host_name}" }
           when WindowsError::NTStatus::STATUS_LOGON_FAILURE
             raise Bolt::Node::ConnectError.new(
-              "SMB authentication failed for #{target.host}",
+              "SMB authentication failed for #{target.safe_name}",
               'AUTH_ERROR'
             )
           else
             raise Bolt::Node::ConnectError.new(
-              "Failed to connect to #{target.host} using SMB: #{status.description}",
+              "Failed to connect to #{target.safe_name} using SMB: #{status.description}",
               'CONNECT_ERROR'
             )
           end
@@ -267,12 +267,12 @@ module Bolt
         rescue Errno::ECONNREFUSED => e
           # handle this to prevent obscuring error message as SMB problem
           raise Bolt::Node::ConnectError.new(
-            "Failed to connect to #{target.host} using SMB: #{e.message}",
+            "Failed to connect to #{target.safe_name} using SMB: #{e.message}",
             'CONNECT_ERROR'
           )
         rescue Timeout::Error
           raise Bolt::Node::ConnectError.new(
-            "Timeout after #{target.options['connect-timeout']} seconds connecting to #{target.host}",
+            "Timeout after #{target.options['connect-timeout']} seconds connecting to #{target.safe_name}",
             'CONNECT_ERROR'
           )
         end

--- a/spec/bolt/transport/local_spec.rb
+++ b/spec/bolt/transport/local_spec.rb
@@ -14,6 +14,7 @@ describe Bolt::Transport::Local do
   include BoltSpec::Transport
 
   let(:host_and_port) { "localhost" }
+  let(:safe_name) { host_and_port }
   let(:user) { 'travis' }
   let(:password) { 'travis' }
   let(:transport) { :local }

--- a/spec/bolt/transport/shared_examples.rb
+++ b/spec/bolt/transport/shared_examples.rb
@@ -560,6 +560,7 @@ end
 # - host_and_port: host and port to connect to
 # - user: the default user
 # - password: the default user password
+# - safe_name: expected target safe_name
 shared_examples 'with sudo', sudo: true do
   context "with sudo" do
     let(:config) {
@@ -631,7 +632,7 @@ SHELL
         expect {
           runner.run_command(target, 'whoami')
         }.to raise_error(Bolt::Node::EscalateError,
-                         "Sudo password for user #{user} not recognized on #{host_and_port}")
+                         "Sudo password for user #{user} not recognized on #{safe_name}")
       end
     end
 
@@ -643,7 +644,7 @@ SHELL
         expect {
           runner.run_command(target, 'whoami')
         }.to raise_error(Bolt::Node::EscalateError,
-                         "Sudo password for user #{user} was not provided for #{host_and_port}")
+                         "Sudo password for user #{user} was not provided for #{safe_name}")
       end
     end
   end

--- a/spec/bolt/transport/ssh_spec.rb
+++ b/spec/bolt/transport/ssh_spec.rb
@@ -32,6 +32,7 @@ describe Bolt::Transport::SSH do
   let(:bash_password) { 'test' }
   let(:port) { conn_info('ssh')[:port] }
   let(:host_and_port) { "#{hostname}:#{port}" }
+  let(:safe_name) { hostname.to_s }
   let(:key) { conn_info('ssh')[:key] }
   let(:command) { "pwd" }
   let(:config) { mk_config(user: user, password: password) }
@@ -371,7 +372,7 @@ describe Bolt::Transport::SSH do
         expect {
           ssh.run_script(target, file.path, [])
         }.to raise_error(Bolt::Node::EscalateError,
-                         "Sudo password for user #{bash_user} was not provided for #{host_and_port}")
+                         "Sudo password for user #{bash_user} was not provided for #{safe_name}")
       end
     end
   end

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -57,7 +57,7 @@ describe "passes parsed AST to the apply_catalog task" do
       notify = get_notifies(result)
       expect(notify.count).to eq(1)
       expect(notify[0]['title']).to eq(
-        'trusted {authenticated => local, certname => localhost, extensions => {}, hostname => localhost, domain => }'
+        "trusted {authenticated => local, certname => #{uri}, extensions => {}, hostname => #{uri}, domain => }"
       )
     end
 

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -220,7 +220,7 @@ describe "apply" do
             expect(result.count).to eq(1)
             expect(result[0]['status']).to eq('success')
             report = result[0]['result']['report']
-            expect(report['resource_statuses']).to include("Notify[Hello #{conn_info('ssh')[:host]}]")
+            expect(report['resource_statuses']).to include("Notify[Hello #{conn_uri('ssh')}]")
           end
         end
 
@@ -252,8 +252,7 @@ describe "apply" do
             expect(result.count).to eq(1)
             expect(result[0]['status']).to eq('success')
             report = result[0]['result']['report']
-            expect(report['resource_statuses']).to include("Notify[Hello #{conn_info('ssh')[:host]}]")
-
+            expect(report['resource_statuses']).to include("Notify[Hello #{conn_uri('ssh')}]")
             result = run_cli_json(%W[task run puppet_agent::version -i #{inv.path}] + config_flags)['items']
             expect(result.count).to eq(1)
             expect(result[0]).to include('status' => 'success')
@@ -268,7 +267,7 @@ describe "apply" do
         expect(result.count).to eq(1)
         expect(result[0]['status']).to eq('success')
         report = result[0]['result']['report']
-        expect(report['resource_statuses']).to include("Notify[Hello #{conn_info('ssh')[:host]}]")
+        expect(report['resource_statuses']).to include("Notify[Hello #{conn_uri('ssh')}]")
 
         # Includes agent facts from apply_prep
         agent_facts = report['resource_statuses']['Notify[agent facts]']['events'][0]['desired_value'].split("\n")
@@ -282,7 +281,7 @@ describe "apply" do
         expect(result.count).to eq(1)
         expect(result[0]['status']).to eq('success')
         report = result[0]['result']['report']
-        expect(report['resource_statuses']).to include("Notify[Hello #{conn_info('ssh')[:host]}]")
+        expect(report['resource_statuses']).to include("Notify[Hello #{conn_uri('ssh')}]")
       end
     end
 

--- a/spec/integration/ssh_spec.rb
+++ b/spec/integration/ssh_spec.rb
@@ -42,7 +42,7 @@ describe "when runnning over the ssh transport", ssh: true do
         result = run_failed_node(%W[command run #{whoami}] + config_flags)
         expect(result['_error']['kind']).to eq('puppetlabs.tasks/connect-error')
         expect(result['_error']['msg']).to match(
-          %r{Failed to connect to ssh:\/\/bolt@localhost:62223: Connection refused}
+          /Failed to connect to localhost: Connection refused/
         )
       end
     end


### PR DESCRIPTION
This commit updates all logging and outputters to refer to targets by their `safe_name`. For an `Target2` object this is the uri minus the password. For a `Target` object it is the host.