### PR TITLE
(GH-1152) Improve error messages when task metadata cannot be loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,16 @@
 
 * **`apply_prep` error when using Inventory Version 2** ([#1303](https://github.com/puppetlabs/bolt/pull/1303))
 
-  When the `plugin_hooks` key was not set for a target/group in Inventory v2 the `apply_prep` function would not work. Bolt now uses the default `plugin_hooks` and honors the `plugin_hooks` from bolt config when using Inventory v2. 
+  When the `plugin_hooks` key was not set for a target/group in Inventory v2 the `apply_prep` function would not work. Bolt now uses the default `plugin_hooks` and honors the `plugin_hooks` from bolt config when using Inventory v2.
 
 * **Better error output when parsing malformed `yaml` files** ([#1296](https://github.com/puppetlabs/bolt/issues/1296))
 
   Previously when parsing `yaml` config files a generic error message was surfaced with no information about where in the file the problem occurred. Now an error message that contains the path to the file as well as the line and column in the file where the error originated from.
 
+* **More detailed error message when task metadata has wrong form** ([#1152](https://github.com/puppetlabs/bolt/issues/1152))
+
+  Raise more informative error message to replace the cryptic message that was surfaced when `requirements` field in a task's `implementations` metadata was not an array.
+  
 ## 1.33.0
 
 ### Bug fixes

--- a/lib/bolt/task.rb
+++ b/lib/bolt/task.rb
@@ -77,6 +77,10 @@ module Bolt
                impl = impls.find do |imp|
                  remote_impl = imp['remote']
                  remote_impl = metadata['remote'] if remote_impl.nil?
+                 unless imp['requirements'].is_a?(Array) || imp['requirements'].nil?
+                   msg = "The task metadata 'requirements' key expects an Array, got #{imp['requirements'].class}"
+                   raise ValidationError, msg
+                 end
                  Set.new(imp['requirements']).subset?(available_features) && !!remote_impl == @remote
                end
                raise NoImplementationError.new(target, self) unless impl

--- a/spec/bolt/task_spec.rb
+++ b/spec/bolt/task_spec.rb
@@ -84,5 +84,16 @@ describe Bolt::Task do
         expect { task.select_implementation(target) }.to raise_error('No suitable implementation of foo for example')
       }
     end
+
+    context 'requirements is not an array' do
+      let(:implementations) {
+        [{ 'name' => 'foo.rb', 'requirements' => 'foo' }]
+      }
+
+      it {
+        expect { task.select_implementation(target) }
+          .to raise_error(Bolt::ValidationError, "The task metadata 'requirements' key expects an Array, got String")
+      }
+    end
   end
 end


### PR DESCRIPTION
Raise more informative error message to replace the cryptic message that was surfaced when `requirements` field in a task's `implementations` metadata was not an array.

Closes https://github.com/puppetlabs/bolt/issues/1152