### PR TITLE
Fix bug in pkcs7 plugin resolving home directories

### DIFF
--- a/lib/bolt/plugin/pkcs7.rb
+++ b/lib/bolt/plugin/pkcs7.rb
@@ -39,7 +39,7 @@ module Bolt
 
       def private_key_path
         path = @options['private-key'] || 'keys/private_key.pkcs7.pem'
-        path = File.absolute_path(path, boltdir)
+        path = File.expand_path(path, boltdir)
         @logger.debug("Using private-key: #{path}")
         path
       end
@@ -50,7 +50,7 @@ module Bolt
 
       def public_key_path
         path = @options['public-key'] || 'keys/public_key.pkcs7.pem'
-        path = File.absolute_path(path, boltdir)
+        path = File.expand_path(path, boltdir)
         @logger.debug("Using public-key: #{path}")
         path
       end

--- a/spec/bolt/plugin/pkcs7_spec.rb
+++ b/spec/bolt/plugin/pkcs7_spec.rb
@@ -38,13 +38,12 @@ describe Bolt::Plugin::Pkcs7 do
     expect(pkcs7.secret_decrypt('encrypted_value' => enc)).to eq(value)
   end
 
-  context 'using home directory in for key paths'do
-    
+  context 'using home directory in for key paths' do
     let(:pkcs7) do
       Bolt::Plugin::Pkcs7.new(context: context,
                               config: {
                                 'private-key' => '~/.keys/private_key.pkcs7.pem',
-                                'public-key' => '~/.keys/public_key.pkcs7.pem',
+                                'public-key' => '~/.keys/public_key.pkcs7.pem'
                               })
     end
 

--- a/spec/bolt/plugin/pkcs7_spec.rb
+++ b/spec/bolt/plugin/pkcs7_spec.rb
@@ -37,4 +37,21 @@ describe Bolt::Plugin::Pkcs7 do
     expect(enc).to start_with('ENC[PKCS7,')
     expect(pkcs7.secret_decrypt('encrypted_value' => enc)).to eq(value)
   end
+
+  context 'using home directory in for key paths'do
+    
+    let(:pkcs7) do
+      Bolt::Plugin::Pkcs7.new(context: context,
+                              config: {
+                                'private-key' => '~/.keys/private_key.pkcs7.pem',
+                                'public-key' => '~/.keys/public_key.pkcs7.pem',
+                              })
+    end
+
+    it 'resolves file paths' do
+      home_dir = File.expand_path('~')
+      expect(pkcs7.private_key_path).to eq("#{home_dir}/.keys/private_key.pkcs7.pem")
+      expect(pkcs7.public_key_path).to eq("#{home_dir}/.keys/public_key.pkcs7.pem")
+    end
+  end
 end


### PR DESCRIPTION
Previously the `pkcs7` plugin was not able to resolve a path like so:
```yaml
plugins:
  pkcs7:
    public-key: ~/.puppetlabs/bolt/keys/public_key.pkcs7.pem
    private-key: ~/.puppetlabs/bolt/keys/private_key.pkcs7.pem
```

When running it would produce an error:

```
Error executing plugin pkcs7 from resolve_reference in dev: No such file or directory @ rb_sysopen - /home/nmaludy/src/puppet-xxx/~/.puppetlabs/bolt/keys/private_key.pkcs7.pem
```

That's definitely not what we want.

Looking at the way we resolve paths in `config.rb` shows that we were using `File.expand_path()` where in `pkcs7.rb` we were using `File.absolute_path()`.

The fix was to simply make it `File.expand_path()` lookups and everything seems happy.

**NEED HELP  HERE**
On the testing side... i'm not sure how to create a spec test that can utilize a home directory to store these temporary keys for testing?

Any other thoughts here on the best way to test this?
