### PR TITLE
(GH-1245) Standardize JSON and Puppet Result objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## BOLT NEXT
 
+### New features
+
+* **Harmonize JSON and Puppet language Result Objects** ([#1245](https://github.com/puppetlabs/bolt/issues/1245))
+
+  Previously the JSON representation of a Result object showed different keys than were available for working with the object in a plan. With this feature the expected keys have been harmonized between the JSON representation and the Puppet object. Note this feature is only available with a new `future` flag in the [bolt configuration file](https://puppet.com/docs/bolt/latest/bolt_configuration_options.html#global-configuration-options).
+
 ### Bug fixes
 
 * **`apply_prep` error when using Inventory Version 2** ([#1303](https://github.com/puppetlabs/bolt/pull/1303))

--- a/bolt-modules/boltlib/lib/puppet/datatypes/result.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/result.rb
@@ -10,6 +10,7 @@ Puppet::DataTypes.create_type('Result') do
       error => Callable[[], Optional[Error]],
       message => Callable[[], Optional[String]],
       action => Callable[[], String],
+      status => Callable[[], String],
       to_data => Callable[[], Hash],
       ok => Callable[[], Boolean],
       '[]' => Callable[[String[1]], Data]

--- a/documentation/bolt_configuration_options.md
+++ b/documentation/bolt_configuration_options.md
@@ -35,6 +35,7 @@ ssh:
 -   `puppetfile`: A map containing options for the `bolt puppetfile install` command.
 -   `save-rerun`: Specify whether to update `.rerun.json` in the [Bolt project directory](bolt_project_directories.md#). If your target names include passwords, set this value to false to avoid writing passwords to disk.
 -   `transport`: Specify the default transport to use when the transport for a target is not specified in the URL or inventory. The valid options for transport are `docker`, `local`, `pcp`, `ssh`, and `winrm`.
+-   `future`: Whether to use new, breaking changes. This allows testing if Bolt content is compatible with expected future behaviour. 
 
 
 ## SSH transport configuration options

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -117,6 +117,11 @@ module Bolt
                   Bolt::Config.from_boltdir(boltdir, options)
                 end
 
+      # Set $future global if configured
+      # rubocop:disable Style/GlobalVars
+      $future = @config.future
+      # rubocop:enable Style/GlobalVars
+
       Bolt::Logger.configure(config.log, config.color)
 
       # Logger must be configured before checking path case, otherwise warnings will not display

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -33,7 +33,7 @@ module Bolt
   class Config
     attr_accessor :concurrency, :format, :trace, :log, :puppetdb, :color, :save_rerun,
                   :transport, :transports, :inventoryfile, :compile_concurrency, :boltdir,
-                  :puppetfile_config, :plugins, :plugin_hooks
+                  :puppetfile_config, :plugins, :plugin_hooks, :future
     attr_writer :modulepath
 
     TRANSPORT_OPTIONS = %i[password run-as sudo-password extensions
@@ -163,6 +163,8 @@ module Bolt
       # Plugins are only settable from config not inventory so we can overwrite
       @plugins = data['plugins'] if data.key?('plugins')
       @plugin_hooks.merge!(data['plugin_hooks']) if data.key?('plugin_hooks')
+
+      @future = data['future'] == true
 
       %w[concurrency format puppetdb color transport].each do |key|
         send("#{key}=", data[key]) if data.key?(key)

--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -92,12 +92,15 @@ module Bolt
 
     def status_hash
       # DEPRECATION: node in status hashes is deprecated and should be removed in 2.0
-      { node: @target.name,
+      base = {
         target: @target.name,
         action: action,
         object: object,
-        status: ok? ? 'success' : 'failure',
-        result: @value }
+        status: status
+      }
+      # rubocop:disable Style/GlobalVars
+      $future ? base.merge(value: @value) : base.merge(result: @value, node: @target.name)
+      # rubocop:enable Style/GlobalVars
     end
 
     def generic_value
@@ -130,6 +133,10 @@ module Bolt
 
     def to_data
       Bolt::Util.walk_keys(status_hash, &:to_s)
+    end
+
+    def status
+      ok? ? 'success' : 'failure'
     end
 
     def ok?

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -14,7 +14,7 @@ module Bolt
     end
 
     # Target.new from a plan with just a uri
-    # rubocop:disable UnusedMethodArgument
+    # rubocop:disable Lint/UnusedMethodArgument
     def self.from_asserted_args(uri = nil,
                                 name = nil,
                                 target_alias = nil,
@@ -38,7 +38,7 @@ module Bolt
                    plugin_hooks = nil)
       @name = name
     end
-    # rubocop:enable UnusedMethodArgument
+    # rubocop:enable Lint/UnusedMethodArgument
 
     # Used for munging target + group data
     def target_data_hash

--- a/spec/fixtures/modules/results/plans/test_result.pp
+++ b/spec/fixtures/modules/results/plans/test_result.pp
@@ -1,0 +1,5 @@
+plan results::test_result(TargetSpec $nodes){
+  $result_set = run_command('echo hi', $nodes)
+  notice("Result status: ${$result_set.first.status}")
+  return $result_set
+}

--- a/spec/integration/result_set_spec.rb
+++ b/spec/integration/result_set_spec.rb
@@ -64,6 +64,19 @@ describe "when running a plan that manipulates an execution result", ssh: true d
       end
     end
 
+    context 'with $future flag' do
+      it 'exposes `status` method for result and renames `result` to `value`' do
+        with_tempfile_containing('conf', { future: true }.to_json) do |conf|
+          params = { nodes: uri }.to_json
+          additional_flags = config_flags + ['--configfile', conf.path.to_s]
+          result = run_cli(['plan', 'run', 'results::test_result', "--params", params] + additional_flags)
+          expect(@log_output.readlines)
+            .to include("NOTICE  Puppet : Result status: success\n")
+          expect(JSON.parse(result).first).to include('value')
+        end
+      end
+    end
+
     it 'exposes errrors for results' do
       params = { target: uri }.to_json
       output = run_cli(['plan', 'run', 'results::test_error', "--params", params] + config_flags)

--- a/spec/lib/bolt_spec/integration.rb
+++ b/spec/lib/bolt_spec/integration.rb
@@ -32,6 +32,11 @@ module BoltSpec
         cli.execute(opts)
       end
       output.string
+    ensure
+      # Ensure that $future global is unset
+      # rubocop:disable Style/GlobalVars
+      $future = nil
+      # rubocop:enable Style/GlobalVars
     end
 
     def run_cli_json(arguments, **opts)


### PR DESCRIPTION
This commit standardizes the Result object interface in plans with the JSON representation. This involved exposing a new `status` method on the Puppet Type, removing the `node` key from the status hash (in favor of `target`), and renaming `result` to `value`. This change is able to be toggled on and off with the newly introduced `$future` global variable.