### PR TITLE
(maint) Add eql? method for Target2

### DIFF
--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -147,6 +147,11 @@ module Bolt
       Addressable::URI.unencode_component(component)
     end
     private :unencode
+
+    def eql?(other)
+      self.class.equal?(other.class) && @name == other.name
+    end
+    alias == eql?
   end
 
   class Target

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -252,13 +252,10 @@ module Bolt
     # should we just compare names? is there something else that is meaninful?
     def eql?(other)
       if self.class.equal?(other.class)
-        if @uri
-          return @uri == other.uri
-        else
-          @name = other.name
-        end
+        @uri ? @uri == other.uri : @name == other.name
+      else
+        false
       end
-      false
     end
     alias == eql?
 

--- a/spec/bolt/target_spec.rb
+++ b/spec/bolt/target_spec.rb
@@ -378,5 +378,12 @@ describe Bolt::Target2 do
       target = inventory.get_target('ssh://[::1]:22')
       expect(target.feature_set).to be_a(Set)
     end
+
+    it 'can compare targets' do
+      target = inventory.get_target('target')
+      other = inventory.get_target('other')
+      expect(target.eql?(target)).to eq(true)
+      expect(target.eql?(other)).to eq(false)
+    end
   end
 end

--- a/spec/bolt/target_spec.rb
+++ b/spec/bolt/target_spec.rb
@@ -52,6 +52,18 @@ describe Bolt::Target do
                        /Invalid port number/)
     end
 
+    it 'can compare targets' do
+      target = Bolt::Target.new('target')
+      other = Bolt::Target.new('other')
+      target_same_name_foo = Bolt::Target.new(nil, 'name' => 'target')
+      target_same_name_bar = Bolt::Target.new(nil, 'name' => 'target')
+      other_name = Bolt::Target.new(nil, 'name' => 'other')
+      expect(target.eql?(target)).to eq(true)
+      expect(target.eql?(other)).to eq(false)
+      expect(target_same_name_bar.eql?(target_same_name_foo)).to eq(true)
+      expect(target_same_name_foo.eql?(other_name)).to eq(false)
+    end
+
     it "accepts escaped special characters in password" do
       table = {
         "\n" => '%0A',


### PR DESCRIPTION
This commit adds the eql? method for the Target2 object. Given Target2 objects are singletons, we only need to compare the target name as an indication of equality.