### PR TITLE
python 2.4 json module does not work with this code, but the simplejson module does

### DIFF
--- a/docs/_includes/lesson1-10/Boltdir/site-modules/exercise9/tasks/yesorno.py
+++ b/docs/_includes/lesson1-10/Boltdir/site-modules/exercise9/tasks/yesorno.py
@@ -6,7 +6,11 @@ has a boolean value. It should flip between returning true and false
 at random
 """
 
-import json
+import sys
+if sys.version_info[0] == 2 and sys.version_info[1] < 5:
+  import simplejson as json
+else:
+  import json
 import random
 
 print(json.dumps({'answer': bool(random.getrandbits(1))}))


### PR DESCRIPTION
The example code does not work on RHEL5. The Python 2.4 json module does not work correctly, but the simplejson module does.

Later versions of python are okay.
