### PR TITLE
(maint) Updates to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # Default to Bolt team
 * @puppetlabs/bolt
 
-/pre-docs @cwcowellshah @puppetlabs/bolt
+/documentation @cwcowellshah @K8med @puppetlabs/bolt
 /lib/bolt_server @puppetlabs/skeletor
-CHANGELOG.md @cwcowellshah @puppetlabs/bolt
+CHANGELOG.md @cwcowellshah @K8med @puppetlabs/bolt


### PR DESCRIPTION
Update `pre-docs` to `documentation` to reflect changes to docs build process. Add Kate Medred as codeowner for docs review.