### PR TITLE
(maint) Load plugin modules from builtin modulepath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## BOLT NEXT
 
+### Bug fixes
+
+* **Load `azure_inventory` plugin from default modulepath** ([#1301](https://github.com/puppetlabs/bolt/pull/1301))
+
+  When the Azure inventory plugin was first shipped with Bolt version 1.32.0 it was not loaded from the default modulepath. The module plugin is now loaded and available.
+
 ### New features
 
 * **Only print `safe_name` when referencing `Target`s** ([#1271](https://github.com/puppetlabs/bolt/pull/1271))

--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -143,11 +143,12 @@ module Bolt
       @analytics = analytics
       @plugin_context = PluginContext.new(config, pal)
       @plugins = {}
+      @pal = pal
       @unknown = Set.new
     end
 
     def modules
-      @modules ||= Bolt::Module.discover(@config.modulepath)
+      @modules ||= Bolt::Module.discover(@pal.modulepath)
     end
 
     # Generally this is private. Puppetdb is special though

--- a/spec/bolt/inventory/group2_spec.rb
+++ b/spec/bolt/inventory/group2_spec.rb
@@ -978,6 +978,9 @@ describe Bolt::Inventory::Group2 do
 
       let(:hooks) { [] }
 
+      let(:modulepath) { [''] }
+      let(:pal) { Bolt::PAL.new(modulepath, nil, nil) }
+
       let(:plugins) do
         plugins = Bolt::Plugin.new(config, pal, Bolt::Analytics::NoopClient.new)
         plugin = double('plugin')


### PR DESCRIPTION
Now that we are shipping bundled module plugins we need to load them from the default modulepath.