### PR TITLE
(maint) Fix apply prep for inventory v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## BOLT NEXT
+
+### Bug fixes
+
+* **`apply_prep` error when using Inventory Version 2** ([#1303](https://github.com/puppetlabs/bolt/pull/1303))
+
+  When the `plugin_hooks` key was not set for a target/group in Inventory v2 the `apply_prep` function would not work. Bolt now uses the default `plugin_hooks` and honors the `plugin_hooks` from bolt config when using Inventory v2. 
+
 ## 1.33.0
 
 ### Bug fixes

--- a/lib/bolt/inventory/inventory2.rb
+++ b/lib/bolt/inventory/inventory2.rb
@@ -145,7 +145,7 @@ module Bolt
         conf.validate
 
         # Recompute the target cached state with the merged data
-        update_target_state(target, conf.transport_conf, data)
+        update_target_state(target, conf, data)
 
         unless target.transport.nil? || Bolt::TRANSPORTS.include?(target.transport.to_sym)
           raise Bolt::UnknownTransportError.new(target.transport, target.uri)
@@ -357,8 +357,8 @@ module Bolt
       private :build_config_hash
 
       def update_target_state(target, conf, merged_data)
-        @targets[target.name]['protocol'] = conf[:transport]
-        t_conf = conf[:transports][target.transport.to_sym] || {}
+        @targets[target.name]['protocol'] = conf.transport_conf[:transport]
+        t_conf = conf.transport_conf[:transports][target.transport.to_sym] || {}
         @targets[target.name]['user'] = t_conf['user']
         @targets[target.name]['password'] = t_conf['password']
         @targets[target.name]['port'] = t_conf['port']
@@ -381,7 +381,8 @@ module Bolt
 
         target_plugin_hooks = @targets[target.name]['plugin_hooks'] || {}
         new_plugin_hooks = merged_data['plugin_hooks'] || {}
-        @targets[target.name]['cached_state']['plugin_hooks'] = new_plugin_hooks.merge(target_plugin_hooks)
+        plugin_hooks_from_inv = new_plugin_hooks.merge(target_plugin_hooks)
+        @targets[target.name]['cached_state']['plugin_hooks'] = conf.plugin_hooks.merge(plugin_hooks_from_inv)
       end
       private :update_target_state
     end


### PR DESCRIPTION
Previously the default plugin_hooks from config were not being set on a Target2 object. This was causing failures in apply prep https://github.com/puppetlabs/bolt/blob/345131e31c02a3047c1607ce3b6df0a484976542/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb#L103 which assumes that `plugin_hooks` will have a value. This commit updates the inventory 2 update_target_state to consider the `plugin_hooks` set in config. The merge order in order of precedence is target level in inventory, group level in inventory, specified in bolt.yaml, default.