### PR TITLE
(Docs) Remove duplicate entry in ditamap

### DIFF
--- a/documentation/bolt.ditamap
+++ b/documentation/bolt.ditamap
@@ -17,7 +17,6 @@
         <topicref href="inspecting_tasks_and_plans.md" format="markdown"/>
         <topicref href="bolt_running_tasks.md" format="markdown"/>
         <topicref href="bolt_running_plans.md" format="markdown"/>
-        <topicref href="bolt_running_tasks.md" format="markdown"/>
         <topicref href="bolt_installing_modules.md" format="markdown"/>
         <topicref href="directory_structure.md" format="markdown"/>
         <topicref href="writing_tasks.md" format="markdown"/>


### PR DESCRIPTION
I'm assuming this file is used in building https://puppet.com/docs/bolt/latest/writing_tasks_and_plans.html where `Running tasks` currently appears twice under the `Tasks and plans` menu.