### PR TITLE
(maint) Update script path in hands-on-lab

### DIFF
--- a/docs/_lab/04-running-scripts/index.md
+++ b/docs/_lab/04-running-scripts/index.md
@@ -31,7 +31,7 @@ curl -O https://raw.githubusercontent.com/puppetlabs/bolt/master/docs/_includes/
 Run the script using the command `bolt script run <script-name>`. This uploads the script to the nodes you have specified, ensures it's executable, runs it, and returns output to the console.
 
 ```shell
-bolt script run src/bashcheck.sh --nodes node1
+bolt script run bashcheck.sh --nodes node1
 ```
 
 The result:


### PR DESCRIPTION
This commit updates the path to the `bashcheck.sh` script in the example for
`bolt script run`. If you use the `curl` command above to download the script,
it get downloaded as `bashcheck.sh` in the top level of your current working
directory, NOT nested under `src`.