### PR TITLE
(maint) Remove bolt-inventory-pdb documentation

### DIFF
--- a/documentation/bolt.ditamap
+++ b/documentation/bolt.ditamap
@@ -34,7 +34,6 @@
     <topicref href="bolt_connect_puppetdb.md" format="markdown"/>
     <topicref href="inventory_file.md" format="markdown"/>
     <topicref href="inventory_file_v2.md" format="markdown">
-        <topicref href="inventory_file_generating.md" format="markdown"/>
         <topicref href="using_plugins.md" format="markdown"/>
         <topicref href="writing_plugins.md" format="markdown"/>
         <topicref href="bolt_examples.md" format="markdown"/>

--- a/documentation/inventory_file_generating.md
+++ b/documentation/inventory_file_generating.md
@@ -1,5 +1,7 @@
 # Generating inventory files
 
+**DEPRECATED** This command has been deprecated in favor of the [puppetdb inventory plugin](https://puppet.com/docs/bolt/latest/using_plugins.html#puppetdb)
+
 Use the `bolt-inventory-pdb` script to generate inventory files based on PuppetDB queries.
 
 ## Usage


### PR DESCRIPTION
This removes documentation for the outdate `bolt-inventory-pdb` command