### PR TITLE
(GH-1207) Run task function should respect _noop option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 
   Previously when parsing `yaml` config files a generic error message was surfaced with no information about where in the file the problem occurred. Now an error message that contains the path to the file as well as the line and column in the file where the error originated from.
 
+* **Run task function should respect _noop option** ([#1311](https://github.com/puppetlabs/bolt/pull/1311))
+
+  Previously when calling the `run_task` function from a plan with the `_noop` metaparameter, `_noop` would not be passed to the task. Now the parameter is correctly passed to the task.
+
 ## 1.33.0
 
 ### Bug fixes

--- a/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
@@ -12,7 +12,7 @@ Puppet::Functions.create_function(:run_task) do
   # Run a task.
   # @param task_name The task to run.
   # @param targets A pattern identifying zero or more targets. See {get_targets} for accepted patterns.
-  # @param args Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.
+  # @param args Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as', '_noop'.
   # @return A list of results, one entry per target.
   # @example Run a task as root
   #   run_task('facts', $targets, '_run_as' => 'root')
@@ -27,7 +27,7 @@ Puppet::Functions.create_function(:run_task) do
   # @param task_name The task to run.
   # @param targets A pattern identifying zero or more targets. See {get_targets} for accepted patterns.
   # @param description A description to be output when calling this function.
-  # @param args Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.
+  # @param args Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as', '_noop'.
   # @return A list of results, one entry per target.
   # @example Run a task
   #   run_task('facts', $targets, 'Gather OS facts')
@@ -108,7 +108,9 @@ Puppet::Functions.create_function(:run_task) do
       end
     end
 
-    if executor.noop
+    # executor.noop is set when run task is called from the CLI
+    # options[:noop] is set when it's called from a plan
+    if executor.noop || options[:noop]
       if task.supports_noop
         params['_noop'] = true
       else

--- a/documentation/plan_functions.md
+++ b/documentation/plan_functions.md
@@ -636,7 +636,7 @@ run_task(String[1] $task_name, Boltlib::TargetSpec $targets, Optional[Hash[Strin
 
 * **task_name** `String[1]` The task to run.
 * **targets** `Boltlib::TargetSpec` A pattern identifying zero or more targets. See [`get_targets`](#get_targets) for accepted patterns.
-* **args** `Optional[Hash[String[1], Any]]` Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.
+* **args** `Optional[Hash[String[1], Any]]` Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as', '_noop'.
 
 **Example:** Run a task as root
 ```
@@ -654,7 +654,7 @@ run_task(String[1] $task_name, Boltlib::TargetSpec $targets, Optional[String] $d
 * **task_name** `String[1]` The task to run.
 * **targets** `Boltlib::TargetSpec` A pattern identifying zero or more targets. See [`get_targets`](#get_targets) for accepted patterns.
 * **description** `Optional[String]` A description to be output when calling this function.
-* **args** `Optional[Hash[String[1], Any]]` Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.
+* **args** `Optional[Hash[String[1], Any]]` Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as', '_noop'.
 
 **Example:** Run a task
 ```

--- a/documentation/writing_tasks.md
+++ b/documentation/writing_tasks.md
@@ -739,7 +739,7 @@ Tasks support no-operation functionality, also known as no-op mode. This functio
 
 No-op support allows a user to pass the `--noop` flag with a command to test whether the task will succeed on all targets before making changes.
 
-To support no-op, your task must include code that looks for the `_noop` metaparameter. No-op is supported only in Puppet Enterprise.
+To support no-op, your task must include code that looks for the `_noop` metaparameter.
 
 If the user passes the `--noop` flag with their command, this parameter is set to `true`, and your task must not make changes. You must also set `supports_noop` to `true` in your task metadata or the task runner will refuse to run the task in noop mode.
 

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -424,9 +424,8 @@ module Bolt
         plan_arguments['nodes'] = nodes.join(',')
       end
 
-      params = options[:noop] ? plan_arguments.merge('_noop' => true) : plan_arguments
       plan_context = { plan_name: plan_name,
-                       params: params }
+                       params: plan_arguments }
       plan_context[:description] = options[:description] if options[:description]
 
       executor = Bolt::Executor.new(config.concurrency, analytics, options[:noop])

--- a/spec/fixtures/modules/sample/plans/noop.pp
+++ b/spec/fixtures/modules/sample/plans/noop.pp
@@ -1,0 +1,5 @@
+plan sample::noop (
+  TargetSpec $nodes
+) {
+  return run_task('sample::noop', $nodes, message => 'This works', _noop => true)
+}

--- a/spec/integration/ssh_spec.rb
+++ b/spec/integration/ssh_spec.rb
@@ -63,6 +63,11 @@ describe "when runnning over the ssh transport", ssh: true do
       expect(result['_output'].strip).to eq("somemessage with noop true")
     end
 
+    it 'passes noop to a plan that runs a task with noop', :reset_puppet_settings do
+      result = run_cli_json(%w[plan run sample::noop] + config_flags)[0]['result']
+      expect(result['_output'].strip).to eq("This works with noop true")
+    end
+
     it 'does not pass noop to a task by default', :reset_puppet_settings do
       result = run_one_node(%w[task run sample::noop message=somemessage] + config_flags)
       expect(result['_output'].strip).to eq("somemessage with noop")


### PR DESCRIPTION
When running a task from a plan, the `run_task` function should respect
the `_noop` option. Now when the `run_task` function is called either
with an executor in noop mode or with the `_noop` option it will run in
noop.

Closes #1207