### PR TITLE
(GH-1211) Return Target object with plan function `add_facts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
   Previously the JSON representation of a Result object showed different keys than were available for working with the object in a plan. With this feature the expected keys have been harmonized between the JSON representation and the Puppet object. Note this feature is only available with a new `future` flag in the [bolt configuration file](https://puppet.com/docs/bolt/latest/bolt_configuration_options.html#global-configuration-options).
 
+* **The `add_facts` plan function returns a `Target` object** ([#1211](https://github.com/puppetlabs/bolt/issues/1211))
+
+  The `add_facts` function has been updated to return a `Target` object to match the `set_*` plan functions for consistency and to allow chaining. Note this feature is only available with a new `future` flag in the [bolt configuration file](https://puppet.com/docs/bolt/latest/bolt_configuration_options.html#global-configuration-options).
+
 ### Bug fixes
 
 * **`apply_prep` error when using Inventory Version 2** ([#1303](https://github.com/puppetlabs/bolt/pull/1303))

--- a/bolt-modules/boltlib/lib/puppet/functions/add_facts.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/add_facts.rb
@@ -8,13 +8,13 @@ require 'bolt/error'
 Puppet::Functions.create_function(:add_facts) do
   # @param target A target.
   # @param facts A hash of fact names to values that may include structured facts.
-  # @return The target's new facts.
+  # @return The target's new facts or a `Target` object if you are using the `future` flag
   # @example Adding facts to a target
   #   add_facts($target, { 'os' => { 'family' => 'windows', 'name' => 'windows' } })
   dispatch :add_facts do
     param 'Target', :target
     param 'Hash', :facts
-    return_type 'Hash[String, Data]'
+    return_type 'Variant[Target, Hash[String, Data]]'
   end
 
   def add_facts(target, facts)

--- a/documentation/plan_functions.md
+++ b/documentation/plan_functions.md
@@ -12,7 +12,7 @@ Deep merges a hash of facts with the existing facts on a target.
 add_facts(Target $target, Hash $facts)
 ```
 
-*Returns:* `Hash[String, Data]` The target's new facts.
+*Returns:* `Variant[Target, Hash[String, Data]]` The target's new facts or a `Target` object if you are using the `future` flag
 
 * **target** `Target` A target.
 * **facts** `Hash` A hash of fact names to values that may include structured facts.

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -149,7 +149,10 @@ module Bolt
 
     def add_facts(target, new_facts = {})
       @logger.warn("No facts to add") if new_facts.empty?
-      set_facts(target.name, new_facts)
+      facts = set_facts(target.name, new_facts)
+      # rubocop:disable Style/GlobalVars
+      $future ? target : facts
+      # rubocop:enable Style/GlobalVars
     end
 
     def facts(target)

--- a/lib/bolt/inventory/inventory2.rb
+++ b/lib/bolt/inventory/inventory2.rb
@@ -312,7 +312,9 @@ module Bolt
       def add_facts(target, new_facts = {})
         @targets[target.name]['facts'] = Bolt::Util.deep_merge(@targets[target.name]['facts'], new_facts)
         update_target(target)
-        facts(target)
+        # rubocop:disable Style/GlobalVars
+        $future ? target : facts(target)
+        # rubocop:enable Style/GlobalVars
       end
 
       def facts(target)

--- a/spec/bolt/inventory/inventory2_spec.rb
+++ b/spec/bolt/inventory/inventory2_spec.rb
@@ -1160,6 +1160,32 @@ describe Bolt::Inventory::Inventory2 do
     end
   end
 
+  describe 'add_facts' do
+    context 'whith and without $future flag' do
+      let(:target) { inventory.get_target('foo') }
+      let(:facts) { { 'foo' => 'bar' } }
+      after(:each) do
+        # rubocop:disable Style/GlobalVars
+        $future = nil
+        # rubocop:enable Style/GlobalVars
+      end
+
+      it 'returns facts hash when $future flag is not set' do
+        result = inventory.add_facts(target, facts)
+        expect(result).to eq(facts)
+      end
+
+      it 'returns Target object when $future flag is set' do
+        # rubocop:disable Style/GlobalVars
+        $future = true
+        # rubocop:enable Style/GlobalVars
+        result = inventory.add_facts(target, facts)
+        expect(target).to eq(result)
+        expect(result.facts).to eq(facts)
+      end
+    end
+  end
+
   describe 'add_to_group' do
     context 'when updating existing values' do
       let(:data) {

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -686,6 +686,33 @@ describe Bolt::Inventory do
     end
   end
 
+  describe 'add_facts' do
+    context 'whith and without $future flag' do
+      let(:inventory) { Bolt::Inventory.new({}) }
+      let(:target) { get_target(inventory, 'foo') }
+      let(:facts) { { 'foo' => 'bar' } }
+      after(:each) do
+        # rubocop:disable Style/GlobalVars
+        $future = nil
+        # rubocop:enable Style/GlobalVars
+      end
+
+      it 'returns facts hash when $future flag is not set' do
+        result = inventory.add_facts(target, facts)
+        expect(result).to eq(facts)
+      end
+
+      it 'returns Target object when $future flag is set' do
+        # rubocop:disable Style/GlobalVars
+        $future = true
+        # rubocop:enable Style/GlobalVars
+        result = inventory.add_facts(target, facts)
+        expect(target).to eq(result)
+        expect(inventory.facts(result)).to eq(facts)
+      end
+    end
+  end
+
   describe :create_version do
     it 'creates a version1 inventory by default' do
       inv = Bolt::Inventory.create_version({}, config, plugins)


### PR DESCRIPTION
In order to be more consistent with the other `set_*` plan methods for setting target data, this commit updates the `add_facts` function to return a `Target` where previously a `Hash` of the updated facts was returned. Given this is a breaking change it is gated with the `future` flag.

Closes https://github.com/puppetlabs/bolt/issues/1211