### PR TITLE
(GH-1327) Reword add_facts return documentation

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/add_facts.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/add_facts.rb
@@ -8,7 +8,7 @@ require 'bolt/error'
 Puppet::Functions.create_function(:add_facts) do
   # @param target A target.
   # @param facts A hash of fact names to values that may include structured facts.
-  # @return The target's new facts or a `Target` object if you are using the `future` flag
+  # @return The target's new facts or a `Target` object if the `future` flag is set to true
   # @example Adding facts to a target
   #   add_facts($target, { 'os' => { 'family' => 'windows', 'name' => 'windows' } })
   dispatch :add_facts do

--- a/documentation/plan_functions.md
+++ b/documentation/plan_functions.md
@@ -12,7 +12,7 @@ Deep merges a hash of facts with the existing facts on a target.
 add_facts(Target $target, Hash $facts)
 ```
 
-*Returns:* `Variant[Target, Hash[String, Data]]` The target's new facts or a `Target` object if you are using the `future` flag
+*Returns:* `Variant[Target, Hash[String, Data]]` The target's new facts or a `Target` object if the `future` flag is set to true
 
 * **target** `Target` A target.
 * **facts** `Hash` A hash of fact names to values that may include structured facts.


### PR DESCRIPTION
This rewords the `add_facts` documentation for better readability

Closes #1327