### PR TITLE
(GH-1322) Validate plugin config against task metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
   The `do_until` function now supports a limit option that prevents it from iterating infinitely.
 
+* **Improve parameter passing for module plugins** ([#1322](https://github.com/puppetlabs/bolt/issues/1322))
+
+  When there is no `config` section in `bolt_plugin.json` configuration options in `bolt.yaml` are validated against the intersection of the parameters schema specified for each task implementation of the plugin's hooks and the values are passed to the task at run time merged with options set in `inventory.yaml`.
+
 ## 1.34.0
 
 ### New features

--- a/spec/fixtures/plugin_modules/task_conf_plug/bolt_plugin.json
+++ b/spec/fixtures/plugin_modules/task_conf_plug/bolt_plugin.json
@@ -1,0 +1,8 @@
+{
+  "hooks": {
+    "resolve_reference": {
+      "task": "task_conf_plug"
+    },
+    "secret_decrypt": { "task": "task_conf_plug::value" }
+  }
+}

--- a/spec/fixtures/plugin_modules/task_conf_plug/tasks/init.json
+++ b/spec/fixtures/plugin_modules/task_conf_plug/tasks/init.json
@@ -1,0 +1,18 @@
+{
+  "input_method": "stdin",
+  "implementations": [
+    {"name": "win.ps1", "requirements": ["powershell"]},
+    {"name": "linux.sh", "requirements": ["shell"]}
+  ],
+  "parameters": {
+    "optional_key": {
+      "type": "Optional[String]"
+    },
+      "required_key": {
+        "type": "String"
+    },
+    "intersection_key": {
+      "type": "Optional[Integer]"
+    }
+  }
+}

--- a/spec/fixtures/plugin_modules/task_conf_plug/tasks/linux.sh
+++ b/spec/fixtures/plugin_modules/task_conf_plug/tasks/linux.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+echo '{"value":'
+cat
+echo '}'

--- a/spec/fixtures/plugin_modules/task_conf_plug/tasks/value.json
+++ b/spec/fixtures/plugin_modules/task_conf_plug/tasks/value.json
@@ -1,0 +1,7 @@
+{
+  "parameters": {
+    "intersection_key": {
+      "type": "String"
+    }
+  }
+}

--- a/spec/fixtures/plugin_modules/task_conf_plug/tasks/value.sh
+++ b/spec/fixtures/plugin_modules/task_conf_plug/tasks/value.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/spec/fixtures/plugin_modules/task_conf_plug/tasks/win.ps1
+++ b/spec/fixtures/plugin_modules/task_conf_plug/tasks/win.ps1
@@ -1,0 +1,4 @@
+$line = [Console]::In.ReadLine()
+Write-Output '{"value": '
+Write-Output "$line"
+Write-Output '}'


### PR DESCRIPTION
Previously when a config section existed in a `bolt_plugin.json` specification any config that was set in `bolt.yaml` would be passed to the task as under the key `_config`. Tasks that expect values to be set in either `bolt.yaml` or `inventory.yaml` would have to handle munging the values gathered from either file. This commit begins to phase out the config section in `bolt_plugin.json`. If there is not a config section in that file config values are validated against the intersection of the parameter metadata for the tasks that implement each hook. Values set in `bolt.yaml` are merged with those in inventory.yaml and passed as parameters. No `_config` is passed along.

Closes https://github.com/puppetlabs/bolt/issues/1322