### PR TITLE
(GH-1147) Allow resolve_reference plugins everywhere in inventory

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   TargetRubyVersion: 2.3
   Exclude:
+    - 'Boltdir/**/*'
     - 'vendor/**/*'
     - 'vendored/**/*'
     - 'acceptance/vendor/**/*'

--- a/documentation/using_plugins.md
+++ b/documentation/using_plugins.md
@@ -12,7 +12,7 @@ Reference plugins fetch data from an external source and store it in a static da
 
 To use a reference, add an object with a `_plugin` key where you want to use the resolved value. The `_plugin` value must be the name of the plugin to use, and the object must contain any required plugin-specific options.
 
-Bolt currently supports references in the `inventory.yaml` file, at the top level of the `targets` array, and in any location in a `config` object. It resolves references only as needed, which means that `targets` references are resolved when the inventory is loaded, while `config` references are resolved when a target that uses that config is loaded in a plan.
+Bolt currently supports references in the `inventory.yaml` file to define targets, groups, and any data like facts or config. It resolves references only as needed, which means that `targets` and `groups` references are resolved when the inventory is loaded, while data (`vars`, `facts`, `features`, `config`) references are resolved when a target that uses that data is loaded in a plan.
 
 For example, the following `inventory.yaml` will prompt a user for a password the first time the `example.com` target is used.
 
@@ -41,6 +41,8 @@ groups:
         resource_type: google_compute_instance.web
         uri: network_interface.0.access_config.0.nat_ip
 ```
+
+This reference will be resolved as soon as Bolt runs.
 
 ## Secret plugins
 

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -269,7 +269,7 @@ module Bolt
     private :resolve_name
 
     def create_target(data)
-      Target.new(data)
+      Bolt::Target.new(data)
     end
     private :create_target
 

--- a/lib/bolt/inventory/group.rb
+++ b/lib/bolt/inventory/group.rb
@@ -153,7 +153,7 @@ module Bolt
         @nodes.each_key do |n|
           # Require nodes to be parseable as a Target.
           begin
-            Target.new(n)
+            Bolt::Target.new(n)
           rescue Bolt::ParseError => e
             @logger.debug(e)
             raise ValidationError.new("Invalid node name #{n}", @name)

--- a/lib/bolt/inventory/inventory2.rb
+++ b/lib/bolt/inventory/inventory2.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bolt/inventory/group2'
+require 'bolt/inventory/target'
 
 module Bolt
   class Inventory
@@ -23,7 +24,7 @@ module Bolt
         @group_lookup = {}
         # The targets hash is the canonical source for all targets in inventory
         @targets = {}
-        @groups.resolve_aliases(@groups.target_aliases, @groups.target_names)
+        @groups.resolve_string_targets(@groups.target_aliases, @groups.all_targets)
         collect_groups
       end
 
@@ -49,34 +50,26 @@ module Bolt
       end
 
       def target_names
-        @groups.target_names
+        @groups.all_targets
       end
       # alias for analytics
       alias node_names target_names
 
       def get_targets(targets)
-        flat_target_list(targets).map { |t| update_target(t) }
+        target_array = expand_targets(targets)
+        if target_array.is_a? Array
+          target_array.flatten.uniq(&:name)
+        else
+          [target_array]
+        end
       end
 
       def get_target(target)
-        target_array = flat_target_list(target)
+        target_array = get_targets(target)
         if target_array.count > 1
           raise ValidationError.new("'#{target}' refers to #{target_array.count} targets", nil)
         end
-        get_targets(target_array.first).first
-      end
-
-      def add_to_group(targets, desired_group)
-        if group_names.include?(desired_group)
-          targets.each do |target|
-            if group_names.include?(target.name)
-              raise ValidationError.new("Group #{target.name} conflicts with target of the same name", target.name)
-            end
-            add_target(@groups, target, desired_group)
-          end
-        else
-          raise ValidationError.new("Group #{desired_group} does not exist in inventory", nil)
-        end
+        target_array.first
       end
 
       def data_hash
@@ -92,79 +85,9 @@ module Bolt
       end
 
       #### PRIVATE ####
-      #
-      # For debugging only now
-      def groups_in(target_name)
-        @groups.data_for(target_name)['groups'] || {}
+      def group_data_for(target_name)
+        @groups.group_collect(target_name)
       end
-      private :groups_in
-
-      # Look for _plugins
-      def config_plugin(data)
-        Bolt::Util.walk_vals(data) do |val|
-          if val.is_a?(Concurrent::Delay)
-            # We should raise any error from the delay now
-            val.value!
-          else
-            val
-          end
-        end
-      end
-      private :config_plugin
-
-      # Pass a target to get_targets for a public version of this
-      def update_target(target)
-        # Ensure all targets in inventory are included in the all group.
-        unless @groups.target_names.include?(target.name)
-          add_to_group([target], 'all')
-        end
-
-        # Get merged data between targets and groups
-        data = @groups.data_for(target.name)
-        data ||= {}
-
-        unless data['config']
-          @logger.debug("Did not find config for #{target.name} in inventory")
-          data['config'] = {}
-        end
-
-        # Add defaults for special 'localhost' target (currently just config and features)
-        if target.name == 'localhost'
-          data = Bolt::Inventory.localhost_defaults(data)
-        end
-
-        # Data from inventory
-        data['config'] = config_plugin(data['config'])
-        # Data from set_config (make sure to resolve plugins)
-        resolved_target_config = config_plugin(@targets[target.name]['config'] || {})
-        data['config'] = Bolt::Util.deep_merge(data['config'], resolved_target_config)
-
-        # Use Config object to ensure config section is treated consistently with config file
-        conf = @config.deep_clone
-        conf.update_from_inventory(data['config'])
-        conf.validate
-
-        # Recompute the target cached state with the merged data
-        update_target_state(target, conf, data)
-
-        unless target.transport.nil? || Bolt::TRANSPORTS.include?(target.transport.to_sym)
-          raise Bolt::UnknownTransportError.new(target.transport, target.uri)
-        end
-
-        target
-      end
-      private :update_target
-
-      # This algorithm for getting a flat list of targets is used several times.
-      def flat_target_list(targets)
-        target_array = expand_targets(targets)
-        if target_array.is_a? Array
-          target_array.flatten.uniq(&:name)
-        else
-          [target_array]
-        end
-      end
-      private :flat_target_list
 
       # If target is a group name, expand it to the members of that group.
       # Else match against targets in inventory by name or alias.
@@ -172,13 +95,13 @@ module Bolt
       # Else fall back to [target] if no matches are found.
       def resolve_name(target)
         if (group = @group_lookup[target])
-          group.target_names
+          group.all_targets
         else
           # Try to wildcard match targets in inventory
           # Ignore case because hostnames are generally case-insensitive
           regexp = Regexp.new("^#{Regexp.escape(target).gsub('\*', '.*?')}$", Regexp::IGNORECASE)
 
-          targets = @groups.target_names.select { |targ| targ =~ regexp }
+          targets = @groups.all_targets.select { |targ| targ =~ regexp }
           targets += @groups.target_aliases.select { |target_alias, _target| target_alias =~ regexp }.values
 
           if targets.empty?
@@ -201,8 +124,12 @@ module Bolt
           targets.split(/[[:space:],]+/).reject(&:empty?).map do |name|
             ts = resolve_name(name)
             ts.map do |t|
-              # If the target exists, return it, otherwise create one
-              @targets[t] ? @targets[t]['self'] : create_target(t)
+              # If the target doesn't exist, evaluate it from the inventory.
+              # Then return a Bolt::Target2.
+              unless @targets.key?(t)
+                @targets[t] = create_target_from_inventory(t)
+              end
+              Bolt::Target2.new(t, self)
             end
           end
         end
@@ -211,9 +138,9 @@ module Bolt
 
       def add_target(current_group, target, desired_group)
         if current_group.name == desired_group
-          current_group.add_target(target.target_data_hash)
+          current_group.add_target(target)
           @groups.validate
-          update_target(target)
+          target.invalidate_caches!
           return true
         end
         # Recurse on children Groups if not desired_group
@@ -223,170 +150,88 @@ module Bolt
       end
       private :add_target
 
-      # This is effectively the init method for Target2
-      def create_target(target_name, target_hash = nil)
-        # Prefer target hash, then data from inventoryfile, allow for uri only with empty hash
-        data = target_hash || @groups.target_collect(target_name) || {}
-        data = { 'uri' => target_name } if data['uri'].nil? && data['name'].nil?
-        data['uri_obj'] = Bolt::Inventory::Inventory2.parse_uri(data['uri'])
+      # Pull in a target definition from the inventory file and evaluate any
+      # associated references. This is used when a target is resolved by
+      # get_targets.
+      def create_target_from_inventory(target_name)
+        target_data = @groups.target_collect(target_name) || { 'uri' => target_name }
 
-        if data['uri'] && data['name'].nil?
-          data['name'] = data['uri']
-          data['safe_name'] = data['uri_obj'].omit(:password).to_str.sub(%r{^//}, '')
-        elsif data['name']
-          data['safe_name'] = data['name']
-        else
-          data['name'] = target_name
-          data['safe_name'] = if data['uri_obj']
-                                data['uri_obj'].omit(:password).to_str.sub(%r{^//}, '')
-                              else
-                                target_name
-                              end
-        end
-        unless data['name'].ascii_only?
-          raise ValidationError.new("Target name must be ASCII characters: #{data['name']}", nil)
-        end
-        # Data set on target itself (either in inventory, target.new or with set_config)
-        data['config'] ||= {}
-        data['vars'] ||= {}
-        data['facts'] ||= {}
-        data['features'] = data['features'] ? Set.new(data['features']) : Set.new
-        data['groups'] ||= []
-        data['options'] ||= {}
-        data['plugin_hooks'] ||= {}
-        data['target_alias'] ||= []
+        target = Bolt::Inventory::Target.new(target_data, self)
+        @targets[target.name] = target
 
-        # Every call to update_target will rebuild this state based on merging together target, group, and config data
-        data['cached_state'] = {}
+        add_to_group([target], 'all')
 
-        target = Target2.new(nil, data['name'])
-        target.inventory = self
-        data['self'] = target
-        @targets[data['name']] = data
         target
       end
-      private :create_target
 
+      # Add a brand new target, overriding any existing target with the same
+      # name. This method does not honor target config from the inventory. This
+      # is used when Target.new is called from a plan.
       def create_target_from_plan(data)
-        t_name = data['name'] || data['uri']
-
         # If target already exists, delete old and replace with new, otherwise add to new to all group
-        if @targets[t_name]
-          @targets.delete(t_name)
-          t = create_target(t_name, data)
-          update_target(t)
-        else
-          t = create_target(t_name, data)
-          update_target(t)
-          add_to_group([t], 'all')
+        new_target = Bolt::Inventory::Target.new(data, self)
+        existing_target = @targets.key?(new_target.name)
+        @targets[new_target.name] = new_target
+
+        unless existing_target
+          add_to_group([new_target], 'all')
         end
-        t
+
+        new_target
       end
 
-      def self.parse_uri(string)
-        require 'addressable/uri'
-        if string.nil?
-          nil
-        # Forbid empty uri
-        elsif string.empty?
-          raise Bolt::ParseError, "Could not parse target URI: URI is empty string"
-        elsif string =~ %r{^[^:]+://}
-          Addressable::URI.parse(string)
+      def add_to_group(targets, desired_group)
+        if group_names.include?(desired_group)
+          targets.each do |target|
+            if group_names.include?(target.name)
+              raise ValidationError.new("Group #{target.name} conflicts with target of the same name", target.name)
+            end
+            # Add the inventory copy of the target
+            add_target(@groups, @targets[target.name], desired_group)
+          end
         else
-          # Initialize with an empty scheme to ensure we parse the hostname correctly
-          Addressable::URI.parse("//#{string}")
+          raise ValidationError.new("Group #{desired_group} does not exist in inventory", nil)
         end
-      rescue Addressable::URI::InvalidURIError => e
-        raise Bolt::ParseError, "Could not parse target URI: #{e.message}"
       end
 
       def set_var(target, var_hash)
-        @targets[target.name]['vars'] = @targets[target.name]['vars'].merge(var_hash)
-        update_target(target)
+        @targets[target.name].set_var(var_hash)
       end
 
       def vars(target)
-        @targets[target.name]['cached_state']['vars'] || {}
+        @targets[target.name].vars
       end
 
       def add_facts(target, new_facts = {})
-        @targets[target.name]['facts'] = Bolt::Util.deep_merge(@targets[target.name]['facts'], new_facts)
-        update_target(target)
+        @targets[target.name].add_facts(new_facts)
         # rubocop:disable Style/GlobalVars
         $future ? target : facts(target)
         # rubocop:enable Style/GlobalVars
       end
 
       def facts(target)
-        @targets[target.name]['cached_state']['facts'] || {}
+        @targets[target.name].facts
       end
 
       def set_feature(target, feature, value = true)
-        if value
-          @targets[target.name]['features'] << feature
-        else
-          @targets[target.name]['features'].delete(feature)
-        end
-        update_target(target)
+        @targets[target.name].set_feature(feature, value)
       end
 
       def features(target)
-        if @targets[target.name]['cached_state']['features']
-          Set.new(@targets[target.name]['cached_state']['features'])
-        else
-          Set.new
-        end
+        @targets[target.name].features
       end
 
       def plugin_hooks(target)
-        @targets[target.name]['cached_state']['plugin_hooks'] || {}
+        @targets[target.name].plugin_hooks
       end
 
       def set_config(target, key_or_key_path, value)
-        config = key_or_key_path.empty? ? value : build_config_hash([key_or_key_path].flatten, value)
-        @targets[target.name]['config'] = @targets[target.name]['config'].merge(config)
-        update_target(target)
+        @targets[target.name].set_config(key_or_key_path, value)
       end
 
       def target_config(target)
-        @targets[target.name]['cached_state']['config'] || {}
+        @targets[target.name].config
       end
-
-      def build_config_hash(key_or_key_path, value)
-        # https://stackoverflow.com/questions/5095077/ruby-convert-array-to-nested-hash
-        key_or_key_path.reverse.inject(value) { |acc, key| { key => acc } }
-      end
-      private :build_config_hash
-
-      def update_target_state(target, conf, merged_data)
-        @targets[target.name]['protocol'] = conf.transport_conf[:transport]
-        t_conf = conf.transport_conf[:transports][target.transport.to_sym] || {}
-        @targets[target.name]['user'] = t_conf['user']
-        @targets[target.name]['password'] = t_conf['password']
-        @targets[target.name]['port'] = t_conf['port']
-        @targets[target.name]['host'] = t_conf['host']
-        @targets[target.name]['options'] = t_conf
-
-        @targets[target.name]['cached_state'] = merged_data
-
-        target_facts = @targets[target.name]['facts'] || {}
-        new_facts = merged_data['facts'] || {}
-        @targets[target.name]['cached_state']['facts'] = Bolt::Util.deep_merge(new_facts, target_facts)
-
-        target_vars = @targets[target.name]['vars'] || {}
-        new_vars = merged_data['vars'] || {}
-        @targets[target.name]['cached_state']['vars'] = new_vars.merge(target_vars)
-
-        target_features = Set.new(@targets[target.name]['features'])
-        new_features = Set.new(merged_data['features'])
-        @targets[target.name]['cached_state']['features'] = new_features.merge(target_features)
-
-        target_plugin_hooks = @targets[target.name]['plugin_hooks'] || {}
-        new_plugin_hooks = merged_data['plugin_hooks'] || {}
-        plugin_hooks_from_inv = new_plugin_hooks.merge(target_plugin_hooks)
-        @targets[target.name]['cached_state']['plugin_hooks'] = conf.plugin_hooks.merge(plugin_hooks_from_inv)
-      end
-      private :update_target_state
     end
   end
 end

--- a/lib/bolt/inventory/inventory2.rb
+++ b/lib/bolt/inventory/inventory2.rb
@@ -140,7 +140,7 @@ module Bolt
         if current_group.name == desired_group
           current_group.add_target(target)
           @groups.validate
-          target.invalidate_caches!
+          target.invalidate_group_cache!
           return true
         end
         # Recurse on children Groups if not desired_group

--- a/lib/bolt/inventory/target.rb
+++ b/lib/bolt/inventory/target.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+module Bolt
+  class Inventory
+    # This class represents the active state of a target within the inventory.
+    class Target
+      attr_reader :name, :uri, :safe_name
+
+      def initialize(target_data, inventory)
+        unless target_data['name'] || target_data['uri']
+          raise Bolt::Inventory::ValidationError.new("Target must have either a name or uri", nil)
+        end
+
+        @logger = Logging.logger[inventory]
+
+        # If the target isn't mentioned by any groups, it won't have a uri or
+        # name and we will use the target_name as both
+        @uri = target_data['uri']
+        @uri_obj = self.class.parse_uri(@uri)
+
+        # If the target has a name, use that as the safe name. Otherwise, turn
+        # the uri into a safe name by omitting the password.
+        if target_data['name']
+          @name = target_data['name']
+          @safe_name = target_data['name']
+        else
+          @name = @uri
+          @safe_name = @uri_obj.omit(:password).to_str.sub(%r{^//}, '')
+        end
+
+        @config = target_data['config'] || {}
+        @vars = target_data['vars'] || {}
+        @facts = target_data['facts'] || {}
+        @features = target_data['features'] || Set.new
+        @options = target_data['options'] || {}
+        @plugin_hooks = target_data['plugin_hooks'] || {}
+        @target_alias = target_data['target_alias'] || []
+
+        @inventory = inventory
+
+        validate
+      end
+
+      def vars
+        # XXX Return vars from the cache
+        group_cache['vars'].merge(@vars)
+      end
+
+      # This method isn't actually an accessor and we want the name to
+      # correspond to the Puppet function
+      # rubocop:disable Naming/AccessorMethodName
+      def set_var(var_hash)
+        @vars.merge!(var_hash)
+      end
+      # rubocop:enable Naming/AccessorMethodName
+
+      def facts
+        # XXX Return facts from the cache
+        Bolt::Util.deep_merge(group_cache['facts'], @facts)
+      end
+
+      def add_facts(new_facts = {})
+        @facts = Bolt::Util.deep_merge(@facts, new_facts)
+      end
+
+      def features
+        group_cache['features'] + @features
+      end
+
+      def set_feature(feature, value = true)
+        if value
+          @features << feature
+        else
+          @features.delete(feature)
+        end
+      end
+
+      def plugin_hooks
+        # Merge plugin_hooks from the config file with any defined by the group
+        # or assigned dynamically to the target
+        @inventory.config.plugin_hooks.merge(group_cache['plugin_hooks']).merge(@plugin_hooks)
+      end
+
+      def set_config(key_or_key_path, value)
+        if key_or_key_path.empty?
+          @config = value
+        else
+          *path, key = Array(key_or_key_path)
+          location = path.inject(@config) do |working_object, p|
+            working_object[p] ||= {}
+          end
+          location[key] = value
+        end
+        invalidate_caches!
+      end
+
+      def invalidate_caches!
+        @group_cache = nil
+        @transport_config_cache = nil
+        nil
+      end
+
+      # Computing the transport config is expensive as it requires cloning the
+      # base config, so we cache the effective config
+      def transport_config_cache
+        if @transport_config_cache.nil?
+          merged_config = Bolt::Util.deep_merge(group_cache['config'], @config)
+          # Use the base config to ensure we handle the config validation and
+          # munging correctly
+          config = @inventory.config.deep_clone
+          config.update_from_inventory(merged_config)
+          config.validate
+          @transport_config_cache = {
+            'transport' => config.transport_conf[:transport],
+            'transports' => config.transport_conf[:transports]
+          }
+        end
+
+        @transport_config_cache
+      end
+
+      # Validate the target. This implicitly also primes the group and config
+      # caches and resolves any config references in the target's groups.
+      def validate
+        unless name.ascii_only?
+          raise Bolt::Inventory::ValidationError.new("Target name must be ASCII characters: #{@name}", nil)
+        end
+
+        unless transport.nil? || Bolt::TRANSPORTS.include?(transport.to_sym)
+          raise Bolt::UnknownTransportError.new(transport, uri)
+        end
+      end
+
+      def host
+        @uri_obj.hostname || transport_config['host']
+      end
+
+      def port
+        @uri_obj.port || transport_config['port']
+      end
+
+      def protocol
+        transport
+      end
+
+      def transport
+        @uri_obj.scheme || transport_config_cache['transport']
+      end
+
+      def user
+        Addressable::URI.unencode_component(@uri_obj.user) || transport_config['user']
+      end
+
+      def password
+        Addressable::URI.unencode_component(@uri_obj.password) || transport_config['password']
+      end
+
+      def options
+        transport_config.dup
+      end
+
+      # We only want to look up transport config keys for the configured
+      # transport
+      def transport_config
+        transport_config_cache['transports'][transport.to_sym]
+      end
+
+      def config
+        Bolt::Util.deep_merge(group_cache['config'], @config)
+      end
+
+      def group_cache
+        if @group_cache.nil?
+          group_data = @inventory.group_data_for(@name)
+
+          unless group_data && group_data['config']
+            @logger.debug("Did not find config for #{self} in inventory")
+          end
+
+          group_data ||= {
+            'config' => {},
+            'vars' => {},
+            'facts' => {},
+            'features' => Set.new,
+            'options' => {},
+            'plugin_hooks' => {},
+            'target_alias' => []
+          }
+
+          # This should be handled by `get_targets`
+          if @name == 'localhost'
+            group_data = Bolt::Inventory.localhost_defaults(group_data)
+          end
+
+          @group_cache = group_data
+        end
+
+        @group_cache
+      end
+
+      def to_s
+        @safe_name
+      end
+
+      def self.parse_uri(string)
+        require 'addressable/uri'
+        if string.nil?
+          Addressable::URI.new
+        # Forbid empty uri
+        elsif string.empty?
+          raise Bolt::ParseError, "Could not parse target URI: URI is empty string"
+        elsif string =~ %r{^[^:]+://}
+          Addressable::URI.parse(string)
+        else
+          # Initialize with an empty scheme to ensure we parse the hostname correctly
+          Addressable::URI.parse("//#{string}")
+        end
+      rescue Addressable::URI::InvalidURIError => e
+        raise Bolt::ParseError, "Could not parse target URI: #{e.message}"
+      end
+    end
+  end
+end

--- a/lib/bolt/inventory/target.rb
+++ b/lib/bolt/inventory/target.rb
@@ -91,13 +91,17 @@ module Bolt
           end
           location[key] = value
         end
-        invalidate_caches!
+        invalidate_config_cache!
       end
 
-      def invalidate_caches!
+      def invalidate_group_cache!
         @group_cache = nil
+        # The config cache depends on the group cache, so invalidate it as well
+        invalidate_config_cache!
+      end
+
+      def invalidate_config_cache!
         @transport_config_cache = nil
-        nil
       end
 
       # Computing the transport config is expensive as it requires cloning the

--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -147,6 +147,24 @@ module Bolt
         end
       end
 
+      # Accepts a Data object and returns a copy with all hash and array values
+      # modified by the given block. Descendants are modified before their
+      # parents.
+      def postwalk_vals(data, skip_top = false, &block)
+        new_data = if data.is_a? Hash
+                     map_vals(data) { |v| postwalk_vals(v, &block) }
+                   elsif data.is_a? Array
+                     data.map { |v| postwalk_vals(v, &block) }
+                   else
+                     data
+                   end
+        if skip_top
+          new_data
+        else
+          yield(new_data)
+        end
+      end
+
       # Performs a deep_clone, using an identical copy if the cloned structure contains multiple
       # references to the same object and prevents endless recursion.
       # Credit to Jan Molic via https://github.com/rubyworks/facets/blob/master/LICENSE.txt

--- a/spec/bolt/inventory/group2_spec.rb
+++ b/spec/bolt/inventory/group2_spec.rb
@@ -5,6 +5,7 @@ require 'bolt/inventory'
 require 'bolt/inventory/group'
 require 'bolt/plugin'
 require 'bolt_spec/config'
+require 'bolt_spec/plugins'
 
 # This is largely internal and probably shouldn't be tested
 describe Bolt::Inventory::Group2 do
@@ -18,13 +19,13 @@ describe Bolt::Inventory::Group2 do
     # passing the collection of all aliases in it. Do that manually here to ensure plain target strings
     # are included as targets.
     g = Bolt::Inventory::Group2.new(data, plugins)
-    g.resolve_aliases(g.target_aliases, g.target_names)
+    g.resolve_string_targets(g.target_aliases, g.all_targets)
     g
   }
-  let(:target1_ssh) { group.data_for('target1')['config']['ssh']['user'] }
 
   it 'returns nil' do
-    expect(group.data_for('target1')).to be_nil
+    expect(group.target_collect('target1')).to be_nil
+    expect(group.group_collect('target1')).to be_nil
   end
 
   context 'with targets at the top level' do
@@ -46,23 +47,19 @@ describe Bolt::Inventory::Group2 do
       expect(group).to be
     end
 
-    it 'should have three targets' do
-      expect(group.targets.length).to eq(3)
-    end
-
     it 'should return empty data' do
-      expect(group.target_data('target1')).to eq('config' => {},
-                                                 'vars' => {},
-                                                 'name' => nil,
-                                                 'plugin_hooks' => {},
-                                                 'uri' => 'target1',
-                                                 'facts' => {},
-                                                 'features' => [],
-                                                 'groups' => [])
+      expect(group.target_collect('target1')).to eq('config' => {},
+                                                    'vars' => {},
+                                                    'name' => nil,
+                                                    'plugin_hooks' => {},
+                                                    'uri' => 'target1',
+                                                    'facts' => {},
+                                                    'features' => Set.new,
+                                                    'groups' => [])
     end
 
     it 'should find three targets' do
-      expect(group.target_names.to_a.sort).to eq(%w[target1 target2 target3])
+      expect(group.all_targets.to_a.sort).to eq(%w[target1 target2 target3])
     end
 
     it 'should collect one group' do
@@ -72,15 +69,15 @@ describe Bolt::Inventory::Group2 do
     end
 
     it 'should return a hash for a string target' do
-      expect(group.data_for('target1')).to be
+      expect(group.target_collect('target1')).to be
     end
 
     it 'should return a hash for hash defined targets' do
-      expect(group.data_for('target2')).to be
+      expect(group.target_collect('target2')).to be
     end
 
     it 'should return nil for an unknown target' do
-      expect(group.data_for('target5')).to be_nil
+      expect(group.target_collect('target5')).to be_nil
     end
   end
 
@@ -104,12 +101,8 @@ describe Bolt::Inventory::Group2 do
       }
     end
 
-    it 'uses the childs target definition' do
-      expect(group.data_for('target1')['config']['ssh']['user']).to eq('child_target')
-    end
-
     it 'should find one target' do
-      expect(group.target_names.to_a).to eq(%w[target1])
+      expect(group.all_targets.to_a).to eq(%w[target1])
     end
 
     it 'should collect 2 groups' do
@@ -121,198 +114,7 @@ describe Bolt::Inventory::Group2 do
 
     it 'should find one target in the subgroup' do
       groups = group.collect_groups
-      expect(groups['group1'].target_names.to_a).to eq(%w[target1])
-    end
-  end
-
-  context 'with target data in parent and group in the child' do
-    let(:data) do
-      {
-        'name' => 'all',
-        'targets' => [{
-          'name' => 'target1',
-          'config' => { 'ssh' => { 'user' => 'parent_target' } }
-        }],
-        'config' => { 'ssh' => { 'user' => 'parent_group' } },
-        'groups' => [{
-          'name' => 'group1',
-          'targets' => [{
-            'name' => 'target1'
-          }],
-          'config' => { 'ssh' => { 'user' => 'child_group' } }
-        }]
-      }
-    end
-
-    it 'uses the parents target definition' do
-      expect(group.data_for('target1')['config']['ssh']['user']).to eq('parent_target')
-    end
-  end
-
-  context 'with group data at all levels' do
-    let(:data) do
-      {
-        'name' => 'all',
-        'targets' => [{
-          'name' => 'target1'
-        }],
-        'config' => { 'ssh' => { 'user' => 'parent_group' } },
-        'groups' => [{
-          'name' => 'group1',
-          'targets' => [{
-            'name' => 'target1'
-          }],
-          'config' => { 'ssh' => { 'user' => 'child_group' } }
-        }]
-      }
-    end
-
-    it 'uses the childs group definition' do
-      expect(group.data_for('target1')['config']['ssh']['user']).to eq('child_group')
-    end
-  end
-
-  context 'with two children which both set target' do
-    let(:data) do
-      {
-        'name' => 'all',
-        'targets' => [{
-          'name' => 'target1',
-          'config' => { 'ssh' => { 'user' => 'parent_target' } }
-        }],
-        'config' => { 'ssh' => { 'user' => 'parent_group' } },
-        'groups' => [
-          {
-            'name' => 'group1',
-            'targets' => [{
-              'name' => 'target1',
-              'config' => { 'ssh' => { 'user' => 'child1_target' } }
-            }],
-            'config' => { 'ssh' => { 'user' => 'child1_group' } }
-          },
-          {
-            'name' => 'group2',
-            'targets' => [{
-              'name' => 'target1',
-              'config' => { 'ssh' => { 'user' => 'child2_target' } }
-            }],
-            'config' => { 'ssh' => { 'user' => 'child2_group' } }
-          }
-
-        ]
-      }
-    end
-
-    it 'uses the first childs target definition' do
-      expect(target1_ssh).to eq('child1_target')
-    end
-  end
-
-  context 'with two children where the second sets target' do
-    let(:data) do
-      {
-        'name' => 'all',
-        'targets' => [{
-          'name' => 'target1',
-          'config' => { 'ssh' => { 'user' => 'parent_target' } }
-        }],
-        'config' => { 'ssh' => { 'user' => 'parent_group' } },
-        'groups' => [
-          {
-            'name' => 'group1',
-            'targets' => [{
-              'name' => 'target1',
-              'config' => { 'ssh' => {} }
-            }],
-            'config' => { 'ssh' => { 'user' => 'child1_group' } }
-          },
-          {
-            'name' => 'group2',
-            'targets' => [{
-              'name' => 'target1',
-              'config' => { 'ssh' => { 'user' => 'child2_target' } }
-            }],
-            'config' => { 'ssh' => { 'user' => 'child2_group' } }
-          }
-
-        ]
-      }
-    end
-
-    it 'uses the first childs target definition' do
-      expect(target1_ssh).to eq('child2_target')
-    end
-  end
-
-  context 'with two children where both set group' do
-    let(:data) do
-      {
-        'name' => 'all',
-        'targets' => [{
-          'name' => 'target1',
-          'config' => { 'ssh' => {} }
-        }],
-        'config' => { 'ssh' => { 'user' => 'parent_group' } },
-        'groups' => [
-          {
-            'name' => 'group1',
-            'targets' => [{
-              'name' => 'target1',
-              'config' => { 'ssh' => {} }
-            }],
-            'config' => { 'ssh' => { 'user' => 'child1_group' } }
-          },
-          {
-            'name' => 'group2',
-            'targets' => [{
-              'name' => 'target1',
-              'config' => { 'ssh' => {} }
-            }],
-            'config' => { 'ssh' => { 'user' => 'child2_group' } }
-          }
-
-        ]
-      }
-    end
-
-    it 'uses the first childs group definition' do
-      expect(target1_ssh).to eq('child1_group')
-    end
-  end
-
-  context 'with two children where the second sets group' do
-    let(:data) do
-      {
-        'name' => 'all',
-        'targets' => [{
-          'name' => 'target1',
-          'config' => { 'ssh' => {} }
-        }],
-        'config' => { 'ssh' => { 'user' => 'parent_group' } },
-        'groups' => [
-          {
-            'name' => 'group1',
-            'targets' => [{
-              'name' => 'target1',
-              'config' => { 'ssh' => {} }
-            }],
-            'config' => { 'ssh' => {} }
-          },
-          {
-            'name' => 'group2',
-            'targets' => [{
-              'name' => 'target1',
-              'config' => { 'ssh' => {} }
-            }],
-            'config' => { 'ssh' => { 'user' => 'child2_group' } }
-          }
-
-        ]
-      }
-    end
-
-    it 'uses the second childs group definition' do
-      expect(target1_ssh).to eq('child2_group')
+      expect(groups['group1'].all_targets.to_a).to eq(%w[target1])
     end
   end
 
@@ -331,7 +133,7 @@ describe Bolt::Inventory::Group2 do
     end
 
     it 'should find two targets' do
-      expect(group.target_names.to_a).to eq(%w[127.0.0.1 2001:db8:0:1:8080])
+      expect(group.all_targets.to_a).to eq(%w[127.0.0.1 2001:db8:0:1:8080])
     end
 
     it 'should collect 2 groups' do
@@ -343,7 +145,7 @@ describe Bolt::Inventory::Group2 do
 
     it 'should find one target in the subgroup' do
       groups = group.collect_groups
-      expect(groups['group1'].target_names.to_a).to eq(%w[2001:db8:0:1:8080])
+      expect(groups['group1'].all_targets.to_a).to eq(%w[2001:db8:0:1:8080])
     end
   end
 
@@ -359,7 +161,7 @@ describe Bolt::Inventory::Group2 do
     end
 
     it 'should find two distinct targets' do
-      expect(group.target_names.to_a).to eq(%w[ssh://127.0.0.1:22 127.0.0.1])
+      expect(group.all_targets.to_a).to eq(%w[ssh://127.0.0.1:22 127.0.0.1])
     end
   end
 
@@ -369,15 +171,15 @@ describe Bolt::Inventory::Group2 do
         'name' => 'group1',
         'targets' => [
           { 'name' => 'target1',
-            'val' => 'a' },
+            'vars' => { 'val' => 'a' } },
           { 'name' => 'target1',
-            'val' => 'b' }
+            'vars' => { 'val' => 'b' } }
         ]
       }
     end
 
     it 'uses the first value' do
-      expect(group.targets['target1']['val']).to eq('a')
+      expect(group.target_collect('target1').dig('vars', 'val')).to eq('a')
     end
   end
 
@@ -465,14 +267,17 @@ describe Bolt::Inventory::Group2 do
         'groups' => [
           {
             'name' => 'foo1',
-            'targets' => [{ 'name' => 'foo1', 'config' => 'foo' }]
+            'targets' => [{ 'name' => 'footarget', 'config' => 'foo' }]
           }
         ]
       }
     end
 
     it 'raises an error' do
-      expect { group.validate }.to raise_error(Bolt::Inventory::ValidationError, /Invalid configuration for target/)
+      expect { group.validate }.to raise_error(
+        Bolt::Inventory::ValidationError,
+        /Expected config to be of type Hash.*for target footarget/
+      )
     end
   end
 
@@ -500,19 +305,19 @@ describe Bolt::Inventory::Group2 do
       end
 
       it 'returns the target as a member of the parent group' do
-        expect(group.target_names).to include('target1')
+        expect(group.all_targets).to include('target1')
       end
 
       it 'overrides parent group data with child group data' do
-        expect(group.data_for('target1')['vars']).to eq('foo' => 'bar', 'a' => 'b')
+        expect(group.group_collect('target1')['vars']).to eq('foo' => 'bar', 'a' => 'b')
       end
 
       it 'combines parent group features with child group features' do
-        expect(group.data_for('target1')['features']).to match_array(%w[a b])
+        expect(group.group_collect('target1')['features']).to match_array(%w[a b])
       end
 
       it 'returns the whole ancestry as the list of groups for the target' do
-        expect(group.data_for('target1')['groups']).to eq(%w[child parent root])
+        expect(group.group_collect('target1')['groups']).to eq(%w[child parent root])
       end
     end
 
@@ -541,17 +346,17 @@ describe Bolt::Inventory::Group2 do
       end
 
       it 'returns all child targets as members of the parent group' do
-        expect(group.target_names.to_a.sort).to eq(%w[target1 target2])
+        expect(group.all_targets.to_a.sort).to eq(%w[target1 target2])
       end
 
       it 'overrides parent group data with child group data' do
-        expect(group.data_for('target1')['vars']).to eq('foo' => 'bar', 'a' => 'b')
-        expect(group.data_for('target2')['vars']).to eq('foo' => 'baz', 'a' => 'b')
+        expect(group.group_collect('target1')['vars']).to eq('foo' => 'bar', 'a' => 'b')
+        expect(group.group_collect('target2')['vars']).to eq('foo' => 'baz', 'a' => 'b')
       end
 
       it 'returns the whole ancestry as the list of groups for the target' do
-        expect(group.data_for('target1')['groups']).to eq(%w[child1 parent root])
-        expect(group.data_for('target2')['groups']).to eq(%w[child2 parent root])
+        expect(group.group_collect('target1')['groups']).to eq(%w[child1 parent root])
+        expect(group.group_collect('target2')['groups']).to eq(%w[child2 parent root])
       end
     end
   end
@@ -607,9 +412,9 @@ describe Bolt::Inventory::Group2 do
     end
 
     it 'uses values from the first branch encountered, picking the most specific subgroup' do
-      expect(group.data_for('target1')['groups']).to eq(%w[parent1 child1 parent2 root])
-      expect(group.data_for('target1')['vars']).to eq('foo' => 'bar', 'a' => 'b')
-      expect(group.data_for('target1')['features']).to match_array(%w[a b])
+      expect(group.group_collect('target1')['groups']).to eq(%w[parent1 child1 parent2 root])
+      expect(group.group_collect('target1')['vars']).to eq('foo' => 'bar', 'a' => 'b')
+      expect(group.group_collect('target1')['features']).to match_array(%w[a b])
     end
   end
 
@@ -628,37 +433,37 @@ describe Bolt::Inventory::Group2 do
 
     it 'fails if the targets list is not an array' do
       data['targets'] = 'foo.example.com,bar.example.com'
-      expect { Bolt::Inventory::Group2.new(data, plugins) }.to raise_error(/Expected targets to be of type Array/)
-    end
-
-    it 'fails if a target in the list is not a string or hash' do
-      data['targets'] = [['foo.example.com']]
-      expect { Bolt::Inventory::Group2.new(data, plugins) }.to raise_error(/Node entry must be a String or Hash/)
+      expect { group }.to raise_error(/Targets list must be an Array/)
     end
 
     it 'fails if the groups list is not an array' do
       data['groups'] = { 'name' => 'foo_group' }
-      expect { Bolt::Inventory::Group2.new(data, plugins) }.to raise_error(/Expected groups to be of type Array/)
+      expect { group }.to raise_error(/Expected groups list to be an Array/)
     end
 
     it 'fails if vars is not a hash' do
       data['vars'] = ['foo=bar']
-      expect { Bolt::Inventory::Group2.new(data, plugins) }.to raise_error(/Expected vars to be of type Hash/)
+      expect { group }.to raise_error(/Expected vars to be of type Hash/)
     end
 
     it 'fails if facts is not a hash' do
       data['facts'] = ['foo=bar']
-      expect { Bolt::Inventory::Group2.new(data, plugins) }.to raise_error(/Expected facts to be of type Hash/)
+      expect { group }.to raise_error(/Expected facts to be of type Hash/)
     end
 
     it 'fails if features is not an array' do
       data['features'] = 'shell'
-      expect { Bolt::Inventory::Group2.new(data, plugins) }.to raise_error(/Expected features to be of type Array/)
+      expect { group }.to raise_error(/Expected features to be of type Array/)
     end
 
     it 'fails if config is not a hash' do
       data['config'] = 'transport=ssh'
-      expect { Bolt::Inventory::Group2.new(data, plugins) }.to raise_error(/Expected config to be of type Hash/)
+      expect { group }.to raise_error(/Expected config to be of type Hash/)
+    end
+
+    it 'fails if plugin_hooks is not a hash' do
+      data['plugin_hooks'] = 'puppet_library'
+      expect { group }.to raise_error(/Expected plugin_hooks to be of type Hash/)
     end
   end
 
@@ -673,7 +478,7 @@ describe Bolt::Inventory::Group2 do
         }
       end
 
-      it { expect(group.target_names.to_a).to eq(%w[target1]) }
+      it { expect(group.all_targets.to_a).to eq(%w[target1]) }
       it { expect(group.target_aliases).to eq('alias1' => 'target1') }
     end
 
@@ -690,7 +495,7 @@ describe Bolt::Inventory::Group2 do
         }
       end
 
-      it { expect(group.target_names.to_a).to eq(%w[target1 target2]) }
+      it { expect(group.all_targets.to_a).to eq(%w[target1 target2]) }
       it { expect(group.target_aliases).to eq('alias1' => 'target1', 'alias2' => 'target1', 'alias3' => 'target2') }
     end
 
@@ -705,7 +510,7 @@ describe Bolt::Inventory::Group2 do
         }
       end
 
-      it { expect(group.target_names.to_a).to eq(%w[target1]) }
+      it { expect(group.all_targets.to_a).to eq(%w[target1]) }
       it { expect(group.target_aliases).to eq('alias1' => 'target1') }
     end
 
@@ -722,7 +527,7 @@ describe Bolt::Inventory::Group2 do
         }
       end
 
-      it { expect(group.target_names.to_a).to eq(%w[target1]) }
+      it { expect(group.all_targets.to_a).to eq(%w[target1]) }
       it { expect(group.target_aliases).to eq('alias1' => 'target1') }
     end
 
@@ -737,7 +542,7 @@ describe Bolt::Inventory::Group2 do
         }
       end
 
-      it { expect(group.target_names.to_a).to eq(%w[target1]) }
+      it { expect(group.all_targets.to_a).to eq(%w[target1]) }
       it { expect(group.target_aliases).to eq('alias1' => 'target1') }
     end
 
@@ -948,129 +753,275 @@ describe Bolt::Inventory::Group2 do
     end
   end
 
-  describe "with config plugins" do
-    context "when parsing/evaluating config _plugin" do
-      let(:data) do
-        {
-          'name' => 'root',
-          'targets' => ['foo.example.com', 'bar.example.com'],
-          'groups' => [{ 'name' => 'foo_group' }],
-          'vars' => { 'key' => 'value' },
-          'facts' => { 'osfamily' => 'windows' },
-          'features' => ['shell'],
-          'config' => { 'transport' => 'ssh' }
-        }
+  describe "defining a group with plugins" do
+    let(:data) do
+      {
+        'name' => 'root',
+        'targets' => ['foo.example.com', 'bar.example.com'],
+        'groups' => [{ 'name' => 'foo_group' }],
+        'vars' => { 'key' => 'value' },
+        'facts' => { 'osfamily' => 'windows' },
+        'features' => ['shell'],
+        'config' => { 'transport' => 'ssh' },
+        'plugin_hooks' => { 'puppet_library' => { 'plugin' => 'install_puppet' } }
+      }
+    end
+
+    let(:lookup_data) { {} }
+
+    let(:modulepath) { [''] }
+    let(:pal) { Bolt::PAL.new(modulepath, nil, nil) }
+
+    let(:plugins) do
+      plugins = Bolt::Plugin.new(config, pal, Bolt::Analytics::NoopClient.new)
+      plugins.add_plugin(BoltSpec::Plugins::Constant.new)
+      plugins.add_plugin(BoltSpec::Plugins::Error.new)
+      plugins.add_plugin(BoltSpec::Plugins::TestLookup.new(lookup_data))
+      plugins
+    end
+
+    # Returns a reference to the 'constant' plugin with the specified value
+    def constant(value)
+      { '_plugin' => 'constant', 'value' => value }
+    end
+
+    it "fails if any keys are specified as plugins" do
+      data.replace('name' => 'testgroup', constant('groups') => [])
+      expect { group }.to raise_error(Bolt::Inventory::ValidationError, /keys cannot be specified as _plugin/)
+    end
+
+    context "defining the entire group with a plugin" do
+      it 'evaluates a single plugin' do
+        data.replace(constant('name' => 'testgroup', 'config' => { 'transport' => 'ssh' }))
+        expect(group.name).to eq('testgroup')
+        expect(group.group_data['config']).to eq('transport' => 'ssh')
       end
 
-      let(:fake_plugin) { { '_plugin' => 'fake' } }
-
-      let(:target) do
-        {
-          'name' => 'foo',
-          'alias' => 'bar',
-          'uri' => 'baz',
-          'vars' => { 'key' => 'value' },
-          'facts' => { 'osfamily' => 'windows' },
-          'features' => ['shell'],
-          'config' => { 'transport' => 'ssh' }
-        }
+      it 'evaluates a plugin that returns a plugin' do
+        lookup_data['groupdata'] = constant('name' => 'testgroup', 'config' => { 'transport' => 'ssh' })
+        data.replace('_plugin' => 'test_lookup', 'key' => 'groupdata')
+        expect(group.name).to eq('testgroup')
+        expect(group.group_data['config']).to eq('transport' => 'ssh')
       end
 
-      let(:hooks) { [] }
-
-      let(:modulepath) { [''] }
-      let(:pal) { Bolt::PAL.new(modulepath, nil, nil) }
-
-      let(:plugins) do
-        plugins = Bolt::Plugin.new(config, pal, Bolt::Analytics::NoopClient.new)
-        plugin = double('plugin')
-        allow(plugin).to receive(:name).and_return('fake')
-        allow(plugin).to receive(:hooks).and_return(hooks)
-        plugins.add_plugin(plugin)
-        plugins
+      it 'evaluates a plugin with nested plugins' do
+        data.replace(constant('name' => 'testgroup', 'config' => { 'ssh' => { 'port' => constant(3456) } }))
+        expect(group.name).to eq('testgroup')
+        expect(group.group_data['config']).to eq('ssh' => { 'port' => 3456 })
       end
 
-      it 'fails if group name is a config plugin' do
-        data['name'] = fake_plugin
-        expect { Bolt::Inventory::Group2.new(data, plugins) }
-          .to raise_error(/Cannot set group "name" with plugin/)
+      it 'does lazily evaluates plugins in the config section' do
+        lookup_data['groupdata'] = { 'name' => 'testgroup', 'config' => { '_plugin' => 'error' } }
+        data.replace('_plugin' => 'test_lookup', 'key' => 'groupdata')
+        expect { group }.not_to raise_error
+        expect(group.name).to eq('testgroup')
+        expect { group.group_data }.to raise_error(/The Error plugin was called/)
+      end
+    end
+
+    context "defining the targets list with a plugin" do
+      it 'evaluates a single plugin' do
+        data['targets'] = constant([{ 'name' => 'foo' }, { 'name' => 'bar' }])
+        expect(group.local_targets).to eq(Set.new(%w[foo bar]))
       end
 
-      it 'fails if target-lookups is present' do
-        data['target-lookups'] = [fake_plugin]
-        expect { Bolt::Inventory::Group2.new(data, plugins) }
-          .to raise_error(/'target-lookups' are no longer/)
+      it 'evaluates multiple plugins and concatenates the target lists' do
+        data['targets'] = [
+          constant([{ 'name' => 'foo' }, { 'name' => 'bar' }]),
+          constant([{ 'name' => 'baz' }, { 'name' => 'quux' }])
+        ]
+        expect(group.local_targets).to eq(Set.new(%w[foo bar baz quux]))
       end
 
-      it 'fails if group groups is a config plugin' do
-        data['groups'] = [fake_plugin]
-        expect { Bolt::Inventory::Group2.new(data, plugins) }
-          .to raise_error(/Cannot set group with plugin/)
+      it 'lazily evaluates plugins in the config section of a target' do
+        data['targets'] = [
+          { 'name' => 'foo', 'config' => { 'transport' => { '_plugin' => 'error' } } }
+        ]
+        expect { group }.not_to raise_error
+        expect { group.group_data }.not_to raise_error
+        expect { group.target_collect('foo') }.to raise_error(/The Error plugin was called/)
       end
 
-      it 'fails if group vars is a config plugin' do
-        data['vars']['key'] = fake_plugin
-        expect { Bolt::Inventory::Group2.new(data, plugins) }
-          .to raise_error(/Cannot set group "vars" with plugin/)
+      it 'evaluates a plugin that returns a list of strings' do
+        data['targets'] = constant(%w[foo bar])
+        expect(group.local_targets).to eq(Set.new(%w[foo bar]))
       end
 
-      it 'fails if group facts is a config plugin' do
-        data['facts'] = fake_plugin
-        expect { Bolt::Inventory::Group2.new(data, plugins) }
-          .to raise_error(/Cannot set group "facts" with plugin/)
+      it 'allows mixing plugins and literal targets' do
+        data['targets'] = [
+          constant([{ 'name' => 'foo' }]),
+          { 'name' => 'bar' }
+        ]
+        expect(group.local_targets).to eq(Set.new(%w[foo bar]))
+      end
+    end
+
+    context "defining the group data with plugins" do
+      it 'lazily evaluates plugins in the config section' do
+        data['config'] = { '_plugin' => 'error' }
+        expect { group }.not_to raise_error
+        expect { group.group_data }.to raise_error(/The Error plugin was called/)
       end
 
-      it 'fails if group features is a config plugin' do
-        data['features'] = fake_plugin
-        expect { Bolt::Inventory::Group2.new(data, plugins) }
-          .to raise_error(/Cannot set group "features" with plugin/)
+      it 'evaluates a plugin to set name' do
+        data['name'] = constant('testgroup')
+        expect(group.name).to eq('testgroup')
       end
 
-      it 'fails if target name is config plugin' do
-        target['uri'] = fake_plugin
-        data['targets'] = [target]
-        expect { Bolt::Inventory::Group2.new(data, plugins) }
-          .to raise_error(/Cannot set target "uri" with plugin/)
+      it 'evaluates a plugin with a nested plugin to set name' do
+        data['name'] = constant(constant('testgroup'))
+        expect(group.name).to eq('testgroup')
       end
 
-      it 'fails if target alias is config plugin' do
-        target['alias'] = fake_plugin
-        data['targets'] = [target]
-        expect { Bolt::Inventory::Group2.new(data, plugins) }
-          .to raise_error(/Cannot set target "alias" with plugin/)
+      it 'evaluates a plugin that returns a plugin to set name' do
+        lookup_data['group_name'] = constant('testgroup')
+        data['name'] = { '_plugin' => 'test_lookup', 'key' => 'group_name' }
+        expect(group.name).to eq('testgroup')
       end
 
-      it 'fails if target uri is config plugin' do
-        target['uri'] = fake_plugin
-        data['targets'] = [target]
-        expect { Bolt::Inventory::Group2.new(data, plugins) }
-          .to raise_error(/Cannot set target "uri" with plugin/)
-      end
-
-      context 'fails if an unknown plugin is requested' do
-        it 'for config only plugin' do
-          data['config'] = { 'ssh' => { 'password' => { '_plugin' => 'unknown' } } }
-          expect { Bolt::Inventory::Group2.new(data, plugins) }
-            .to raise_error(/Unknown plugin: 'unknown'/)
+      context "setting config" do
+        it 'sets the value of a top-level setting' do
+          data['config']['transport'] = constant('winrm')
+          expect(group.group_data['config']['transport']).to eq('winrm')
         end
 
-        it 'for target plugin' do
-          data['targets'] = [{ '_plugin' => 'unknown' }]
-          expect { Bolt::Inventory::Group2.new(data, plugins) }
-            .to raise_error(/Unknown plugin: 'unknown'/)
+        it 'sets the value of a transport-specific setting' do
+          data['config']['ssh'] = { 'port' => constant(9876) }
+          expect(group.group_data.dig('config', 'ssh', 'port')).to eq(9876)
+        end
+
+        it 'sets the value of the entire "config" hash' do
+          data['config'] = constant('transport' => 'winrm',
+                                    'winrm' => { 'port' => 9876 })
+          expect(group.group_data['config']).to eq('transport' => 'winrm', 'winrm' => { 'port' => 9876 })
+        end
+
+        it 'fails if the value of "config" is not a hash' do
+          data['config'] = constant('ssh')
+          expect { group.group_data['config'] }.to raise_error(/Expected config to be of type Hash/)
         end
       end
 
-      it 'fails with an unsupported targets plugin' do
-        data['targets'] = [fake_plugin]
-        expect { Bolt::Inventory::Group2.new(data, plugins) }
-          .to raise_error(/fake does not support resolve_reference/)
+      context "setting vars" do
+        it 'sets the value of a single var' do
+          data['vars']['key2'] = constant('value2')
+          expect(group.group_data['vars']).to eq('key' => 'value', 'key2' => 'value2')
+        end
+
+        it 'sets the value of a nested var' do
+          data['vars']['key2'] = { 'foo' => constant('bar') }
+          expect(group.group_data['vars']).to eq('key' => 'value', 'key2' => { 'foo' => 'bar' })
+        end
+
+        it 'sets the value of the entire "vars" hash' do
+          data['vars'] = constant('foo' => 'bar', 'baz' => 'quux')
+          expect(group.group_data['vars']).to eq('foo' => 'bar', 'baz' => 'quux')
+        end
+
+        it 'fails if the value of "vars" is not a hash' do
+          data['vars'] = constant('foo=bar')
+          expect { group.group_data['vars'] }.to raise_error(/Expected vars to be of type Hash/)
+        end
       end
 
-      it 'fails with an unsupported config plugin' do
-        data['config'] = fake_plugin
-        expect { Bolt::Inventory::Group2.new(data, plugins) }
-          .to raise_error(/fake does not support resolve_reference/)
+      context "setting facts" do
+        it 'sets the value of a single fact' do
+          data['facts']['ipaddress'] = constant('10.0.1.0')
+          expect(group.group_data['facts']).to eq('osfamily' => 'windows', 'ipaddress' => '10.0.1.0')
+        end
+
+        it 'sets the value of a nested fact' do
+          data['facts']['os'] = { 'name' => constant('windows') }
+          expect(group.group_data['facts']).to eq('osfamily' => 'windows', 'os' => { 'name' => 'windows' })
+        end
+
+        it 'sets value of the entire "facts" hash' do
+          data['facts'] = constant('osfamily' => 'Ubuntu', 'os' => { 'name' => 'Ubuntu' })
+          expect(group.group_data['facts']).to eq('osfamily' => 'Ubuntu', 'os' => { 'name' => 'Ubuntu' })
+        end
+
+        it 'fails if the value of "facts" is not a hash' do
+          data['facts'] = constant(%w[foo bar])
+          expect { group.group_data['facts'] }.to raise_error(/Expected facts to be of type Hash/)
+        end
+      end
+
+      context "setting features" do
+        it 'adds a single feature' do
+          data['features'] << constant('puppet-agent')
+          expect(group.group_data['features']).to eq(Set['shell', 'puppet-agent'])
+        end
+
+        it 'adds a nested array of features' do
+          data['features'] << constant(%w[puppet-agent python])
+          expect(group.group_data['features']).to eq(Set['shell', 'puppet-agent', 'python'])
+        end
+
+        it 'sets the value of the entire "features" array' do
+          data['features'] = constant(%w[puppet-agent shell python])
+          expect(group.group_data['features']).to eq(Set['puppet-agent', 'shell', 'python'])
+        end
+
+        it 'fails if the value of "features" is not an array' do
+          data['features'] = constant('puppet-agent')
+          expect { group.group_data['features'] }.to raise_error(/Expected features to be of type Array/)
+        end
+      end
+
+      context "setting plugin_hooks" do
+        it 'sets the value of a single plugin_hook' do
+          data['plugin_hooks']['another_hook'] = constant('plugin' => 'task', 'task' => 'do_a_thing')
+          expect(group.group_data['plugin_hooks']).to eq(
+            'puppet_library' => { 'plugin' => 'install_puppet' },
+            'another_hook' => { 'plugin' => 'task', 'task' => 'do_a_thing' }
+          )
+        end
+
+        it 'sets the value of one setting of a plugin_hook' do
+          data['plugin_hooks']['puppet_library']['plugin'] = constant('alternate_install')
+          expect(group.group_data['plugin_hooks']).to eq('puppet_library' => { 'plugin' => 'alternate_install' })
+        end
+
+        it 'sets the value of the entire "plugin_hooks" hash' do
+          plugin_hooks = {
+            'puppet_library' => { 'plugin' => 'something' },
+            'another_hook' => { 'plugin' => 'something_else' }
+          }
+          data['plugin_hooks'] = constant(plugin_hooks)
+          expect(group.group_data['plugin_hooks']).to eq(plugin_hooks)
+        end
+
+        it 'fails of the value of "plugin_hooks" is not a hash' do
+          data['plugin_hooks'] = constant('puppet_library')
+          expect { group.group_data['plugin_hooks'] }.to raise_error(/Expected plugin_hooks to be of type Hash/)
+        end
+      end
+
+      it 'allows the value of a plugin to be passed as an argument to another plugin' do
+        # This should evaluate the constant plugin and return foo, then pass
+        # that to the lookup plugin which will find the value bar. If it
+        # evaluates in the wrong order, it will try to lookup with the plugin
+        # invocation as the key and return nil
+        lookup_data['foo'] = 'winrm'
+        data['config']['transport'] = { '_plugin' => 'test_lookup', 'key' => constant('foo') }
+        expect(group.group_data['config']['transport']).to eq('winrm')
+      end
+
+      it 'allows a plugin to return a reference to another plugin' do
+        # The lookup plugin will return a reference to the constant plugin, which will then return 3456
+        lookup_data['foo'] = constant(3456)
+        data['config']['ssh'] = { 'port' => { '_plugin' => 'test_lookup', 'key' => 'foo' } }
+        expect(group.group_data.dig('config', 'ssh', 'port')).to eq(3456)
+      end
+
+      it 'allows a plugin to return a nested plugin reference' do
+        lookup_data['ssh_config'] = {
+          'port' => 3456,
+          'password' => { '_plugin' => 'test_lookup', 'key' => 'ssh_password' }
+        }
+        lookup_data['ssh_password'] = constant('secret_password')
+        data['config']['ssh'] = { '_plugin' => 'test_lookup', 'key' => 'ssh_config' }
+        expect(group.group_data['config']['ssh']).to eq('port' => 3456, 'password' => 'secret_password')
       end
     end
   end

--- a/spec/bolt/inventory/inventory2_spec.rb
+++ b/spec/bolt/inventory/inventory2_spec.rb
@@ -293,7 +293,7 @@ describe Bolt::Inventory::Inventory2 do
           ts = ['ssh://a', 'winrm://b:5000', 'u:p@c']
           names = 'ssh://a, winrm://b:5000, u:p@c'
           inventory.get_targets(names)
-          targets = inventory.get_targets(names).map(&:uri)
+          targets = inventory.get_targets('all').map(&:uri)
           expect(targets).to eq(ts)
         end
 
@@ -1161,7 +1161,7 @@ describe Bolt::Inventory::Inventory2 do
   end
 
   describe 'add_facts' do
-    context 'whith and without $future flag' do
+    context 'with and without $future flag' do
       let(:target) { inventory.get_target('foo') }
       let(:facts) { { 'foo' => 'bar' } }
       after(:each) do

--- a/spec/integration/plugin/task_spec.rb
+++ b/spec/integration/plugin/task_spec.rb
@@ -169,19 +169,6 @@ describe 'using the task plugin' do
         end
       end
 
-      it 'errors when targets are strings' do
-        inventory['targets'][0]['parameters']['value'] = %w[foo bar]
-        with_boltdir(inventory: inventory, config: config) do |boltdir|
-          plan_dir = File.join(boltdir, 'modules', 'passw', 'plans')
-          FileUtils.mkdir_p(plan_dir)
-          File.write(File.join(plan_dir, 'init.pp'), plan)
-          result = run_cli_json(['plan', 'run', 'passw', '--boltdir', boltdir], rescue_exec: true)
-
-          expect(result).to include('kind' => "bolt.inventory/validation-error")
-          expect(result['msg']).to match(/Node entry must be a Hash, not String/)
-        end
-      end
-
       it 'errors when execution fails' do
         inventory['targets'][0]['parameters']['bad-key'] = 10
         with_boltdir(inventory: inventory, config: config) do |boltdir|
@@ -190,7 +177,7 @@ describe 'using the task plugin' do
           File.write(File.join(plan_dir, 'init.pp'), plan)
           result = run_cli_json(['plan', 'run', 'passw', '--boltdir', boltdir], rescue_exec: true)
 
-          expect(result).to include('kind' => "bolt/plugin-error")
+          expect(result).to include('kind' => "bolt/validation-error")
           expect(result['msg']).to match(/bad-key/)
         end
       end

--- a/spec/lib/bolt_spec/plugins.rb
+++ b/spec/lib/bolt_spec/plugins.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module BoltSpec
+  module Plugins
+    # Implements a resolve_reference plugin that returns the given "value"
+    class Constant
+      def name
+        'constant'
+      end
+
+      def hooks
+        [:resolve_reference]
+      end
+
+      def resolve_reference(opts)
+        opts['value']
+      end
+    end
+
+    # Implements a resolve_reference plugin that raises an error when called
+    class Error
+      def name
+        'error'
+      end
+
+      def hooks
+        [:resolve_reference]
+      end
+
+      def resolve_reference(_opts)
+        raise "The Error plugin was called"
+      end
+    end
+
+    class TestLookup
+      def initialize(data)
+        @data = data
+      end
+
+      def name
+        'test_lookup'
+      end
+
+      def hooks
+        [:resolve_reference]
+      end
+
+      def resolve_reference(opts)
+        key = opts['key']
+        if @data.key?(key)
+          @data[key]
+        else
+          raise "No lookup value set for key '#{key}'"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously, resolve_reference plugins could only be used in the
inventory in select ways. Namely, they could only be used to lookup
targets or to set config on a group or target. They couldn't be used to
set any other attributes of a group (vars, facts, etc) or to set the
arguments to another plugin.

We now allow every value in the inventory to be specified using a plugin
reference, including the inventory itself. Keys are never allowed to be
plugin references.

Some references will be resolved as soon as the inventory is loaded.
For a group, these are `name`, `targets`, `groups`. For each target, we
will immediately resolve its `name`, uri`, and `alias`.

The other fields (`vars`, `facts`, `features`, `config`, `plugin_hooks`)
are termed "group/target data" and are resolved only when looking up a
target with that data.

We no longer use `Concurrent::Delay` objects to defer plugin evaluation.
Instead, the group tracks whether its data has been resolved and will do
it on demand if necessary. Similarly, the group tracks which of its
targets have been resolved and will resolve them as needed.

References are now allowed to return data containing more references,
which will be recursively re-evaluated until all the references are
gone. The exceptions to this rule are the `targets` and `groups` keys,
which will only be re-evaluated until the top-level object is no longer
a reference. This allows them to return references for their "data"
which will still be lazily resolved.

We now use an internal `Bolt::Inventory::Target` object to track the
current state of a target in the inventory and reconcile it with the
data set by its groups and config. Previously, this was a combination of
a hash on the inventory as well as the `Bolt::Target2` class. The
`Bolt::Inventory::Target` is now the canonical representation of the
current state of a target, tracking both the data set on that target
individually as well as querying the data from its group.

Instead of computing and caching the "final" merged data for the target,
we now only store the target-specific data and the cached group data
separately and compute results when needed. This allows us to invalidate
the group cache less frequently, as it now needs only be done when the
target is added to a new group and not whenever any value is set on the
target.

The `Bolt::Target2` class is now a thin, stateless wrapper around the
inventory and defers to the internal `Bolt::Inventory::Target` object
for all of its logic. This decouples the way we expose targets to plans
from the way that we store their state internally.

This update to the way we store target data simplifies the evaluation
patterns for the references in a group. Specifically, we query the
target-level data in each group exactly once, when we initially reify
the target (add it to the inventory via `get_targets`). After that, the
data is no longer needed as it is stored in its own space on the target.
We query the group-level data only when the target is first reified or
when its list of groups changes.