### PR TITLE
(GH-1288) Pass parameter references explicitly set to undef to apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
   When there is no `config` section in `bolt_plugin.json` configuration options in `bolt.yaml` are validated against the intersection of the parameters schema specified for each task implementation of the plugin's hooks and the values are passed to the task at run time merged with options set in `inventory.yaml`.
 
+### Bug fixes
+
+* **Optional plan parameters referenced in `apply` blocks issued warning** ([#1288](https://github.com/puppetlabs/bolt/issues/1288))
+
+    Previously plan parameters that were explicitly set to `undef` (optional parameters) that were referenced in an `apply` block resulted in a warning message when applying puppet code. The warning is no longer issued when optional parameters are referenced.
+
 ## 1.34.0
 
 ### New features

--- a/spec/fixtures/apply/basic/plans/plan_vars.pp
+++ b/spec/fixtures/apply/basic/plans/plan_vars.pp
@@ -1,9 +1,15 @@
-plan basic::plan_vars(TargetSpec $nodes) {
+plan basic::plan_vars(TargetSpec $nodes, Optional[String] $signature = undef) {
   $targets = get_targets($nodes)
   $targets.each |$t| { $t.set_var('foo', 'hello there') }
 
+  $plan_undef = undef
   $foo = 'hello world'
-  return apply($nodes) {
-    notify { $foo: }
+  # Make sure undef variables from parent scope are included. 
+  1.each |$iter| {
+    return apply($nodes) {
+      notify { $foo: }
+      notice("Plan vars set to undef: ${signature}${$plan_undef}")
+      notice($apply_undef)
+    }
   }
 }

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -68,11 +68,16 @@ describe "passes parsed AST to the apply_catalog task" do
       expect(notify[0]['title']).to eq('hello there')
     end
 
-    it 'plan vars override target vars' do
+    it 'plan vars override target vars and respects variables explicitly set to undef' do
       result = run_cli_json(%w[plan run basic::plan_vars] + config_flags)
       notify = get_notifies(result)
       expect(notify.count).to eq(1)
       expect(notify[0]['title']).to eq('hello world')
+      logs = @log_output.readlines
+      expect(logs).not_to include(/Unknown variable: 'signature'/)
+      expect(logs).not_to include(/Unknown variable: 'plan_undef'/)
+      expect(logs).to include(/Unknown variable: 'apply_undef'/)
+      expect(logs).to include(/Plan vars set to undef:/)
     end
 
     it 'applies a class from the modulepath' do


### PR DESCRIPTION
Previously plan parameters that were explicitly set to `undef` were not passed to apply scope which resulted in warnings about undefined variable references. This commit passes variables explicitly set to `undef` to apply to avoid the errors.

Closes https://github.com/puppetlabs/bolt/issues/1288