### PR TITLE
(GH-1288) Use `include_undef` param with `to_hash` method for `Parame…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 
   When running plugins locally to populate config or inventory information, command-line flags such as `--run-as` will no longer be applied to the local transport.
 
+* **Optional plan parameters referenced in `apply` blocks issued warning** ([#1288](https://github.com/puppetlabs/bolt/issues/1288))
+
+    Previously plan parameters that were explicitly set to `undef` (optional parameters) that were referenced in an `apply` block resulted in a warning message when applying puppet code. The warning is no longer issued when optional parameters are referenced.
+
 ## Bolt 1.38.0
 
 ### New features

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-scp", "~> 1.2"
   spec.add_dependency "net-ssh", ">= 4.0"
   spec.add_dependency "orchestrator_client", "~> 0.4"
-  spec.add_dependency "puppet", [">= 6.4.0", "< 7"]
+  spec.add_dependency "puppet", [">= 6.11.0", "< 7"]
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "r10k", "~> 3.1"
   spec.add_dependency "ruby_smb", "~> 1.0"

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -156,7 +156,7 @@ module Bolt
       end
 
       # collect plan vars and merge them over target vars
-      plan_vars = scope.to_hash
+      plan_vars = scope.to_hash(true, true)
       %w[trusted server_facts facts].each { |k| plan_vars.delete(k) }
 
       targets = @inventory.get_targets(args[0])

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -111,6 +111,7 @@ describe Bolt::Applicator do
 
   context 'with Puppet mocked' do
     before(:each) do
+      allow(scope).to receive(:to_hash).and_return({})
       env = Puppet::Node::Environment.create(:testing, modulepath)
       allow(Puppet).to receive(:lookup).with(:pal_script_compiler).and_return(double(:script_compiler, type: nil))
       allow(Puppet).to receive(:lookup).with(:current_environment).and_return(env)
@@ -119,6 +120,8 @@ describe Bolt::Applicator do
       allow(applicator).to receive(:count_statements)
     end
 
+    let(:scope) { double('scope') }
+
     it 'replaces failures to find Puppet' do
       expect(applicator).to receive(:compile).and_return(ast)
       result = Bolt::Result.new(target, value: report)
@@ -126,13 +129,13 @@ describe Bolt::Applicator do
 
       expect(Bolt::ApplyResult).to receive(:puppet_missing_error).with(result).and_return(nil)
 
-      applicator.apply([target], :body, {})
+      applicator.apply([target], :body, scope)
     end
 
     it 'captures compile errors in a result set' do
       expect(applicator).to receive(:compile).and_raise('Something weird happened')
 
-      resultset = applicator.apply([uri, '_catch_errors' => true], :body, {})
+      resultset = applicator.apply([uri, '_catch_errors' => true], :body, scope)
       expect(resultset).to be_a(Bolt::ResultSet)
       expect(resultset).not_to be_ok
       expect(resultset.count).to eq(1)
@@ -146,7 +149,7 @@ describe Bolt::Applicator do
         Bolt::Result.new(target, value: report.merge('status' => 'failed'))
       )
 
-      resultset = applicator.apply([target, '_catch_errors' => true], :body, {})
+      resultset = applicator.apply([target, '_catch_errors' => true], :body, scope)
       expect(resultset).to be_a(Bolt::ResultSet)
       expect(resultset).not_to be_ok
       expect(resultset.count).to eq(1)
@@ -170,7 +173,7 @@ describe Bolt::Applicator do
       allow_any_instance_of(Bolt::Transport::SSH).to receive(:batch_task).and_return(*results)
 
       expect {
-        applicator.apply([targets], :body, {})
+        applicator.apply([targets], :body, scope)
       }.to raise_error(Bolt::ApplyFailure, <<-MSG.chomp)
 Resources failed to apply for node1
   File[/tmp/does/not/exist]: It failed.
@@ -200,7 +203,7 @@ MSG
       end
 
       t = Thread.new {
-        applicator.apply([targets], :body, {})
+        applicator.apply([targets], :body, scope)
       }
       sleep(0.2)
 

--- a/spec/fixtures/apply/basic/plans/plan_vars.pp
+++ b/spec/fixtures/apply/basic/plans/plan_vars.pp
@@ -1,9 +1,15 @@
-plan basic::plan_vars(TargetSpec $nodes) {
+plan basic::plan_vars(TargetSpec $nodes, Optional[String] $signature = undef) {
   $targets = get_targets($nodes)
   $targets.each |$t| { $t.set_var('foo', 'hello there') }
 
+  $plan_undef = undef
   $foo = 'hello world'
-  return apply($nodes) {
-    notify { $foo: }
+  # Make sure undef variables from parent scope are included. 
+  1.each |$iter| {
+    return apply($nodes) {
+      notify { $foo: }
+      notice("Plan vars set to undef: ${signature}${$plan_undef}")
+      notice($apply_undef)
+    }
   }
 }

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -69,11 +69,16 @@ describe "passes parsed AST to the apply_catalog task" do
       expect(notify[0]['title']).to eq('hello there')
     end
 
-    it 'plan vars override target vars' do
+    it 'plan vars override target vars and respects variables explicitly set to undef' do
       result = run_cli_json(%w[plan run basic::plan_vars] + config_flags)
       notify = get_notifies(result)
       expect(notify.count).to eq(1)
       expect(notify[0]['title']).to eq('hello world')
+      logs = @log_output.readlines
+      expect(logs).not_to include(/Unknown variable: 'signature'/)
+      expect(logs).not_to include(/Unknown variable: 'plan_undef'/)
+      expect(logs).to include(/Unknown variable: 'apply_undef'/)
+      expect(logs).to include(/Plan vars set to undef:/)
     end
 
     it 'applies a class from the modulepath' do


### PR DESCRIPTION
…terScope`

This commit pulls in a proposed change in the `Puppet::Parser::Scope::ParameterScope` class to allow gathering all explictly defined variables (including those declared `undef`).