### PR TITLE
Loosening of minitar dependency

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "hiera-eyaml", "~> 3"
   spec.add_dependency "logging", "~> 2.2"
-  spec.add_dependency "minitar", "~> 0.6"
+  spec.add_dependency "minitar", ">= 0.6", "< 1.0"
   spec.add_dependency "net-scp", "~> 1.2"
   spec.add_dependency "net-ssh", ">= 4.0"
   spec.add_dependency "orchestrator_client", "~> 0.4"


### PR DESCRIPTION
Puppet has moved to using minitar `~> 0.9`, but pdk and bolt still have minitar as `~> 0.6`. That's a problem as users can't use them all in module testing.

Loosening constraint to accept any version before 1.0