### PR TITLE
(maint) Install modules from bolt's Puppetfile for acceptance tests

### DIFF
--- a/acceptance/setup/common/pre-suite/071_install_modules.rb
+++ b/acceptance/setup/common/pre-suite/071_install_modules.rb
@@ -6,11 +6,6 @@ test_name "Install modules" do
   extend Acceptance::BoltCommandHelper
 
   on(bolt, "mkdir -p #{default_boltdir}")
-  create_remote_file(bolt, "#{default_boltdir}/Puppetfile", <<-PUPPETFILE)
-mod 'puppetlabs-facts', '0.6.0'
-mod 'puppetlabs-service', '1.1.0'
-mod 'puppetlabs-puppet_agent', '2.2.0'
-PUPPETFILE
-
-  bolt_command_on(bolt, 'bolt puppetfile install')
+  bolt_command_on(bolt, "cp bolt/Puppetfile #{default_boltdir}")
+  bolt_command_on(bolt, "cd #{default_boltdir} && r10k puppetfile install Puppetfile")
 end


### PR DESCRIPTION
Previously for component acceptance tests once bolt is cloned from git and a gem is built, a puppetfile was created in the default moduledir containing a reference to module versions independed from the modules shipped with bolt. We had to remember to manually update both the bolt Puppetfile as well as the acceptance test setup script when updating module references. With this commit, we use the Puppetfile from the bolt repo as the sole source of modules to be used in component acceptance tests.