### PR TITLE
(GH-1200) Add --detail option to show resolved inventory information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### New Features
 
+* **Add `--detail` option for `inventory show` command** ([#1200](https://github.com/puppetlabs/bolt/issues/1200))
+
+  The `inventory show` command now supports a `--detail` option to show resolved configuration for specified targets.
+
 * **Support `limit` option for `do_until` function** ([#1270](https://github.com/puppetlabs/bolt/issues/1270))
 
   The `do_until` function now supports a limit option that prevents it from iterating infinitely.

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -29,7 +29,7 @@ module Bolt
         { flags: ACTION_OPTS + %w[tmpdir],
           banner: FILE_HELP }
       when 'inventory'
-        { flags: OPTIONS[:inventory] + OPTIONS[:global] + %w[format inventoryfile boltdir configfile],
+        { flags: OPTIONS[:inventory] + OPTIONS[:global] + %w[format inventoryfile boltdir configfile detail],
           banner: INVENTORY_HELP }
       when 'group'
         { flags: OPTIONS[:global] + %w[format inventoryfile boltdir configfile],
@@ -356,6 +356,9 @@ module Bolt
       define('-e', '--execute CODE',
              "Puppet manifest code to apply to the targets") do |code|
         @options[:code] = code
+      end
+      define('--detail', 'Show resolved configuration for the targets') do |detail|
+        @options[:detail] = detail
       end
 
       separator "\nAuthentication:"

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -307,7 +307,11 @@ module Bolt
             list_plans
           end
         elsif options[:subcommand] == 'inventory'
-          list_targets
+          if options[:detail]
+            show_targets
+          else
+            list_targets
+          end
         elsif options[:subcommand] == 'group'
           list_groups
         end
@@ -413,7 +417,12 @@ module Bolt
 
     def list_targets
       update_targets(options)
-      outputter.print_targets(options)
+      outputter.print_targets(options[:targets])
+    end
+
+    def show_targets
+      update_targets(options)
+      outputter.print_target_info(options[:targets])
     end
 
     def list_groups

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -311,11 +311,20 @@ module Bolt
         end
       end
 
-      def print_targets(options)
-        targets = options[:targets].map(&:name)
+      def print_targets(targets)
         count = "#{targets.count} target#{'s' unless targets.count == 1}"
-        @stream.puts targets.join("\n")
+        @stream.puts targets.map(&:name).join("\n")
         @stream.puts colorize(:green, count)
+      end
+
+      def print_target_info(targets)
+        data = targets.map(&:detail).map do |target|
+          target.transform_values do |value|
+            value.nil? ? "nil" : value
+          end
+        end
+
+        @stream.puts data.to_yaml
       end
 
       def print_groups(groups)

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -89,11 +89,18 @@ module Bolt
                        "moduledir": moduledir }.to_json)
       end
 
-      def print_targets(options)
-        targets = options[:targets].map(&:name)
-        count = targets.count
-        @stream.puts({ "targets": targets,
-                       "count": count }.to_json)
+      def print_targets(targets)
+        @stream.puts ::JSON.pretty_generate(
+          "targets": targets.map(&:name),
+          "count": targets.count
+        )
+      end
+
+      def print_target_info(targets)
+        @stream.puts ::JSON.pretty_generate(
+          "targets": targets.map(&:detail),
+          "count": targets.count
+        )
       end
 
       def print_groups(groups)

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -80,6 +80,22 @@ module Bolt
       )
     end
 
+    def detail
+      {
+        'name' => name,
+        'uri' => uri,
+        'alias' => @target_alias,
+        'config' => config.merge(
+          'transport' => transport,
+          transport => options
+        ),
+        'vars' => vars,
+        'features' => features,
+        'facts' => facts,
+        'plugin_hooks' => Bolt::Util.deep_clone(plugin_hooks)
+      }
+    end
+
     def inventory_target
       @inventory.targets[@name]
     end
@@ -226,6 +242,14 @@ module Bolt
       end
     end
 
+    def vars
+      @inventory.vars(self)
+    end
+
+    def facts
+      @inventory.facts(self)
+    end
+
     # TODO: WHAT does equality mean here?
     # should we just compare names? is there something else that is meaninful?
     def eql?(other)
@@ -256,6 +280,22 @@ module Bolt
         'host' => host,
         'port' => port
       )
+    end
+
+    def detail
+      {
+        'name' => name,
+        'uri' => uri,
+        'alias' => @target_alias,
+        'config' => {
+          'transport' => transport,
+          transport => options
+        },
+        'vars' => vars,
+        'facts' => facts,
+        'features' => features.to_a,
+        'plugin_hooks' => Bolt::Util.deep_clone(plugin_hooks)
+      }
     end
 
     def host

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -2100,6 +2100,12 @@ describe "Bolt::CLI" do
       cli.execute(cli.parse)
     end
 
+    it 'lists targets with resolved configuration' do
+      cli = Bolt::CLI.new(%w[inventory show -t localhost --detail])
+      expect_any_instance_of(Bolt::Outputter::Human).to receive(:print_target_info)
+      cli.execute(cli.parse)
+    end
+
     it 'lists groups in the inventory file' do
       cli = Bolt::CLI.new(%w[group show])
       expect_any_instance_of(Bolt::Outputter::Human).to receive(:print_groups)


### PR DESCRIPTION
This commit adds support for a `--detail` flag that shows resolved
inventory information when using the `inventory show` subcommand.

Closes #1200 