### PR TITLE
(maint) Maintain ruby 2.3 compatibility by not using Dir.children

### DIFF
--- a/lib/bolt/module.rb
+++ b/lib/bolt/module.rb
@@ -8,10 +8,10 @@ module Bolt
     def self.discover(modulepath)
       modulepath.each_with_object({}) do |path, mods|
         next unless File.exist?(path) && File.directory?(path)
-        Dir.children(path)
-           .map { |dir| File.join(path, dir) }
-           .select { |dir| File.directory?(dir) }
-           .each do |dir|
+        (Dir.entries(path) - %w[. ..])
+          .map { |dir| File.join(path, dir) }
+          .select { |dir| File.directory?(dir) }
+          .each do |dir|
           module_name = File.basename(dir)
           if module_name =~ MODULE_NAME_REGEX
             # Puppet will load some objects from shadowed modules but this won't


### PR DESCRIPTION
Ruby 2.3 does not support the `Dir#children` method. This commit updates
the `Bolt::Module` class to use `Dir#entries` and filter the `.` and
`..` directories instead.