### PR TITLE
(maint) Do not exclude bolt_plugin.json in gemspec

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
                        Dir['bolt-modules/*/lib/**/*.rb'] +
                        Dir['bolt-modules/*/types/**/*.pp'] +
                        Dir['modules/*/metadata.json'] +
+                       Dir['modules/*/bolt_plugin.json'] +
                        Dir['modules/*/files/**/*'] +
                        Dir['modules/*/lib/**/*.rb'] +
                        Dir['modules/*/locales/**/*'] +


### PR DESCRIPTION
Now that modules need to be shiped with a bolt_plugin.json, do not exclude that file when building bolt packages.