### PR TITLE
(maint) Run rubocop before tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ before_script:
 - sudo sh -c "echo 'Defaults authenticate' >> /etc/sudoers"
 - sudo sh -c "echo 'travis  ALL=(ALL) PASSWD:ALL' >> /etc/sudoers"
 script:
+- bundle exec rubocop || travis_terminate 1
 - bundle exec rake travisci
-- bundle exec rubocop
 - |
   status=0
   for i in 'boltlib' 'ctrl' 'file' 'out' 'system'; do


### PR DESCRIPTION
This commit updates the build script for Travis to run rubocop before
any tests. This is helpful to catch any failures caused by rubocop early
on before running tests, which can take a significant amount of time.