### PR TITLE
(packaging) Ship Puppetfile with bolt gem

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -27,7 +27,8 @@ Gem::Specification.new do |spec|
                        Dir['modules/*/lib/**/*.rb'] +
                        Dir['modules/*/locales/**/*'] +
                        Dir['modules/*/plans/**/*.pp'] +
-                       Dir['modules/*/tasks/**/*']
+                       Dir['modules/*/tasks/**/*'] +
+                       Dir['Puppetfile']
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
With this commit the Puppetfile that defines module versions shipped with bolt system packages is included in the gem artifact. This enables consumers of the gem to be able to install the module versions shipped with the corresponding system package.