### PR TITLE
(GH-1269) Require argument for --password and --sudo-password options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Bolt NEXT
+
+### Deprecation
+
+* **Replace optional arguments for `--password` and `--sudo-password` options with required arguments** ([#1269](https://github.com/puppetlabs/bolt/issues/1269))
+
+  The `--password` and `--sudo-password` options now require a password as an argument. Previously, if the password was omitted the user would be prompted to enter one. If you wish to be prompted for a password, use the `prompt` plugin.
+
+### New features
+
+* **`prompt` messages print to `stderr`** ([#1269](https://github.com/puppetlabs/bolt/issues/1269))
+
+  The prompt plugin now prints messages to `stderr` instead of `stdout`.
+
 ## 1.35.0
 
 ### Deprecation

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -363,14 +363,14 @@ module Bolt
         @options[:user] = user
       end
       define('-p', '--password [PASSWORD]',
-             'Password to authenticate with. Omit the value to prompt for the password.') do |password|
-        if password.nil?
-          STDOUT.print "Please enter your password: "
-          @options[:password] = STDIN.noecho(&:gets).chomp
-          STDOUT.puts
-        else
-          @options[:password] = password
+             'Password to authenticate with') do |password|
+        # TODO: Remove deprecation message
+        unless password
+          msg = "Optional parameter for --password is deprecated and no longer prompts for password. " \
+                "Use the prompt plugin instead to prompt for passwords."
+          raise Bolt::CLIError, msg
         end
+        @options[:password] = password
       end
       define('--private-key KEY', 'Private ssh key to authenticate with') do |key|
         @options[:'private-key'] = key
@@ -390,14 +390,14 @@ module Bolt
         @options[:'run-as'] = user
       end
       define('--sudo-password [PASSWORD]',
-             'Password for privilege escalation. Omit the value to prompt for the password.') do |password|
-        if password.nil?
-          STDOUT.print "Please enter your privilege escalation password: "
-          @options[:'sudo-password'] = STDIN.noecho(&:gets).chomp
-          STDOUT.puts
-        else
-          @options[:'sudo-password'] = password
+             'Password for privilege escalation') do |password|
+        # TODO: Remove deprecation message
+        unless password
+          msg = "Optional parameter for --sudo-password is deprecated and no longer prompts for password. " \
+                "Use the prompt plugin instead to prompt for passwords."
+          raise Bolt::CLIError, msg
         end
+        @options[:'sudo-password'] = password
       end
 
       separator "\nRun context:"

--- a/lib/bolt/plugin/prompt.rb
+++ b/lib/bolt/plugin/prompt.rb
@@ -19,9 +19,12 @@ module Bolt
       end
 
       def resolve_reference(opts)
-        STDOUT.print "#{opts['message']}:"
+        # rubocop:disable Style/GlobalVars
+        $future ? STDERR.print("#{opts['message']}:") : STDOUT.print("#{opts['message']}:")
         value = STDIN.noecho(&:gets).chomp
-        STDOUT.puts
+        $future ? STDERR.puts : STDOUT.puts
+        # rubocop:enable Style/GlobalVars
+
         value
       end
     end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -380,14 +380,6 @@ describe "Bolt::CLI" do
         cli = Bolt::CLI.new(%w[command run uptime --password opensesame --nodes foo])
         expect(cli.parse).to include(password: 'opensesame')
       end
-
-      it "prompts the user for password if not specified" do
-        allow(STDIN).to receive(:noecho).and_return('opensesame')
-        allow(STDOUT).to receive(:print).with('Please enter your password: ')
-        allow(STDOUT).to receive(:puts)
-        cli = Bolt::CLI.new(%w[command run uptime --nodes foo --password])
-        expect(cli.parse).to include(password: 'opensesame')
-      end
     end
 
     describe "key" do
@@ -529,15 +521,6 @@ describe "Bolt::CLI" do
     describe "sudo-password" do
       it "accepts a password" do
         cli = Bolt::CLI.new(%w[command run uptime --sudo-password opensez --run-as alibaba --nodes foo])
-        expect(cli.parse).to include('sudo-password': 'opensez')
-      end
-
-      it "prompts the user for sudo-password if not specified" do
-        allow(STDIN).to receive(:noecho).and_return('opensez')
-        pw_prompt = 'Please enter your privilege escalation password: '
-        allow(STDOUT).to receive(:print).with(pw_prompt)
-        allow(STDOUT).to receive(:puts)
-        cli = Bolt::CLI.new(%w[command run uptime --nodes foo --run-as alibaba --sudo-password])
         expect(cli.parse).to include('sudo-password': 'opensez')
       end
     end

--- a/spec/bolt/plugin/prompt_spec.rb
+++ b/spec/bolt/plugin/prompt_spec.rb
@@ -8,15 +8,33 @@ describe Bolt::Plugin::Prompt do
   let(:prompt_data) { { '_plugin' => 'prompt', 'message' => 'Password Please' } }
   let(:invalid_prompt_data) { { '_plugin' => 'prompt' } }
   let(:password) { 'opensesame' }
+  after(:each) do
+    # rubocop:disable Style/GlobalVars
+    $future = nil
+    # rubocop:enable Style/GlobalVars
+  end
 
   it 'raises a validation error when no prompt message is provided' do
     expect { subject.validate_resolve_reference(invalid_prompt_data) }.to raise_error(Bolt::ValidationError)
   end
 
-  it 'concurrent delay prompts for data when executed' do
+  it 'concurrent delay prompts for data on STDOUT when executed' do
     allow(STDIN).to receive(:noecho).and_return(password)
     allow(STDOUT).to receive(:puts)
     expect(STDOUT).to receive(:print).with("#{prompt_data['message']}:")
+
+    val = subject.resolve_reference(prompt_data)
+    expect(val).to eq(password)
+  end
+
+  it 'concurrent delay prompts for data on STDERR when executed with $future flag set' do
+    # rubocop:disable Style/GlobalVars
+    $future = true
+    # rubocop:enable Style/GlobalVars
+
+    allow(STDIN).to receive(:noecho).and_return(password)
+    allow(STDERR).to receive(:puts)
+    expect(STDERR).to receive(:print).with("#{prompt_data['message']}:")
 
     val = subject.resolve_reference(prompt_data)
     expect(val).to eq(password)


### PR DESCRIPTION
This commit removes the optional argument for the `--password` and
`--sudo-password` options and replaces it with a required option.
Previously, if a password was omitted as an argument, the user would be
prompted to enter one.

This also updates the `prompt` plugin to print to `stderr` instead of
`stdout`.