### PR TITLE
(GH-1345) Install bundled modules on gem path in acceptance test

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -22,7 +22,7 @@ mod 'puppetlabs-yumrepo_core', '1.0.3'
 mod 'puppetlabs-zone_core', '1.0.2'
 
 # Useful additional modules
-mod 'puppetlabs-package', '0.6.0'
+mod 'puppetlabs-package', '0.7.0'
 mod 'puppetlabs-puppet_conf', '0.4.0'
 mod 'puppetlabs-python_task_helper', '0.3.0'
 mod 'puppetlabs-reboot', '2.2.0'

--- a/acceptance/setup/common/pre-suite/071_install_modules.rb
+++ b/acceptance/setup/common/pre-suite/071_install_modules.rb
@@ -5,12 +5,12 @@ require 'bolt_command_helper'
 test_name "Install modules" do
   extend Acceptance::BoltCommandHelper
 
-  on(bolt, "mkdir -p #{default_boltdir}")
-  create_remote_file(bolt, "#{default_boltdir}/Puppetfile", <<-PUPPETFILE)
-mod 'puppetlabs-facts', '0.6.0'
-mod 'puppetlabs-service', '1.1.0'
-mod 'puppetlabs-puppet_agent', '2.2.1'
-PUPPETFILE
-
-  bolt_command_on(bolt, 'bolt puppetfile install')
+  # Install modules to the `modules` dir in bolt gem path to replicate
+  # where modules will be with system packages.
+  find_bolt_gem = bolt_command_on(bolt, "gem which bolt")
+  bolt_gem_path = find_bolt_gem.stdout.strip.sub(%r{/lib/bolt.rb}, "")
+  command = "cd #{bolt_gem_path}; r10k puppetfile install"
+  # For osx, ensure command uses bash instead of sh
+  command = "bash -c '#{command}'" if bolt.platform =~ /osx/
+  bolt_command_on(bolt, command)
 end


### PR DESCRIPTION
Previously we maintained a subset of modules needed for acceptance tests by statically defining module versions in acceptance test setup. This is prone to error because when modules are updated in the Puppetfile, there is a risk the acceptance test will not be updated. Also, the statically defined modules were installed into the default boltdir modulepath, not the modules dir in the gem path. Now that we ship the Puppetfile with the bolt gem, we can use it to simply install the modules in the expected bolt gem path with r10k to mirror modules shipped in system packages.