### PR TITLE
(maint) Allow empty hiera config, plus docs fixes

### DIFF
--- a/documentation/using_plugins.md
+++ b/documentation/using_plugins.md
@@ -198,14 +198,14 @@ groups:
 
 ## Terraform
 
-The `terraform` plugin is a module based plugin. For more information see https://github.com/puppetlabs/puppetlabs-terraform
+The `terraform` plugin is a module based plugin. For more information see [https://github.com/puppetlabs/puppetlabs-terraform](https://github.com/puppetlabs/puppetlabs-terraform)
 
 ## Azure inventory
 
-The `azure_inventory` plugin is a module based plugin. For more information see https://github.com/puppetlabs/puppetlabs-azure_inventory
+The `azure_inventory` plugin is a module based plugin. For more information see [https://github.com/puppetlabs/puppetlabs-azure_inventory](https://github.com/puppetlabs/puppetlabs-azure_inventory)
 
 ## AWS Inventory plugin
-The `aws_inventory` plugin is a module based plugin. For more information see https://github.com/puppetlabs/puppetlabs-aws_inventory
+The `aws_inventory` plugin is a module based plugin. For more information see [https://github.com/puppetlabs/puppetlabs-aws_inventory](https://github.com/puppetlabs/puppetlabs-aws_inventory)
 
 ## Prompt plugin
 

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -132,7 +132,9 @@ module Bolt
     def validate_hiera_config(hiera_config)
       if File.exist?(File.path(hiera_config))
         data = File.open(File.path(hiera_config), "r:UTF-8") { |f| YAML.safe_load(f.read, [Symbol]) }
-        unless data['version'] == 5
+        if data.nil?
+          return nil
+        elsif data['version'] != 5
           raise Bolt::ParseError, "Hiera v5 is required, found v#{data['version'] || 3} in #{hiera_config}"
         end
         hiera_config

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -422,7 +422,8 @@ module Bolt
         @options[:boltdir] = path
       end
       define('--configfile FILEPATH',
-             'Specify where to load config from (default: ~/.puppetlabs/bolt/bolt.yaml)') do |path|
+             'Specify where to load config from (default: ~/.puppetlabs/bolt/bolt.yaml). ' \
+             'Directory containing bolt.yaml will be used as the Boltdir.') do |path|
         @options[:configfile] = path
       end
       define('-i', '--inventoryfile FILEPATH',

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -15,6 +15,7 @@ describe "apply" do
   include BoltSpec::Run
 
   let(:modulepath) { File.join(__dir__, '../fixtures/apply') }
+  let(:hiera_config) { File.join(__dir__, '../fixtures/configs/empty.yml') }
   let(:config_flags) { %W[--format json --nodes #{uri} --password #{password} --modulepath #{modulepath}] + tflags }
 
   describe 'over ssh', ssh: true do
@@ -170,6 +171,17 @@ describe "apply" do
             expect(result['status']).to eq('success')
             report = result['result']['report']
             expect(report['resource_statuses']).to include("Notify[Apply: Hi!]")
+          end
+        end
+      end
+
+      it 'succeeds with an empty hiera config' do
+        with_tempfile_containing('bolt', YAML.dump("hiera-config" => hiera_config), '.yaml') do |conf|
+          results = run_cli_json(%W[plan run prep --configfile #{conf.path}] + config_flags)
+          results.each do |result|
+            expect(result['status']).to eq('success')
+            report = result['result']['report']
+            expect(report['resource_statuses']).to include("Notify[Hello #{uri}]")
           end
         end
       end


### PR DESCRIPTION
This includes a few small improvements:
1. When using the [Boltdir
repository](https://github.com/puppetlabs/Boltdir) we provide an empty
hiera config. If left in place Bolt will try to load this which results
in a traceback when we try to access data from the file. This PR adds a
check which will ignore the hiera config if there's no data in it.
2. When using `--configfile` as a command line argument the parent
directory of the specified file is used as the Boltdir to load other
Bolt config, such as the inventory. This PR adds documentation to the
flag letting users know we do this.
3. Lastly, we had some plain URLs in the `using_plugins.md` file, which
in github markdown will render as links but in Dita don't get rendered
as links. This makes them have explicit links syntax, so they render as
links on the website.