### PR TITLE
Fixing rubocop styling in the task helper docs

### DIFF
--- a/documentation/writing_tasks.md
+++ b/documentation/writing_tasks.md
@@ -423,12 +423,12 @@ Create task and metadata in a new module at `~/.puppetlabs/bolt/site-modules/mym
 #!/usr/bin/env ruby
 require_relative '../../ruby_task_helper/files/task_helper.rb'
 
-class MyTask < TaskHelper 
+# Example task that is based on the ruby_task_helper
+class MyTask < TaskHelper
   def task(name: nil, **kwargs)
     { greeting: "Hi, my name is #{name}" }
   end
 end
-
 
 MyTask.run if $PROGRAM_NAME == __FILE__
 ```

--- a/documentation/writing_tasks.md
+++ b/documentation/writing_tasks.md
@@ -430,7 +430,7 @@ class MyTask < TaskHelper
 end
 
 
-MyTask.run if __FILE__ == $0
+MyTask.run if $PROGRAM_NAME == __FILE__
 ```
 
 **Output**


### PR DESCRIPTION
Working on a ruby task based on the `ruby_task_helper` in the Bolt docs and i found that if i copy/pasted the code i got the following rubocop errors:

```
convention: rubocop: tasks/mytask.rb:4:1: Style/Documentation: Missing top-level class documentation comment.
convention: rubocop: tasks/mytask.rb:4:26: Layout/TrailingWhitespace: Trailing whitespace detected.
warning: rubocop: tasks/mytask.rb:5:25: Lint/UnusedMethodArgument: Unused method argument - `kwargs`. If it's necessary, use `_` or `_kwargs` as an argument name to indicate that it won't be used.
convention: rubocop: tasks/mytask.rb:10:1: Layout/EmptyLines: Extra blank line detected.
convention: rubocop: tasks/mytask.rb:11:15: Style/YodaCondition: Reverse the order of the operands `__FILE__ == $0`.
convention: rubocop: tasks/mytask.rb:11:27: Style/SpecialGlobalVars: Prefer `$PROGRAM_NAME` over `$0`.
```

This PR addresses many of those so that others can avoid fighting rubocop.

