### PR TITLE
(GH-1341) Warn when CLI inventory options may be overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 
   The CLI now provides a subcommand `bolt project init` that will create a new file `bolt.yaml` in the current working directory, making the directory a [Bolt project directory](https://puppet.com/docs/bolt/latest/bolt_project_directories.html#local-project-directory)
 
+* **Issue warning when cli options may be overridden by inventory** ([#1341](https://github.com/puppetlabs/bolt/issues/1341))
+
+  When a CLI option that can be overridden in inventory is provided and inventory is loaded from a file or from the BOLT_INVENTORY environment variable an issue is warned about which options could be overridden.
+
 ## 1.35.0
 
 ### Deprecation

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -47,6 +47,7 @@ module Bolt
       if ENV.include?(ENVIRONMENT_VAR)
         begin
           data = YAML.safe_load(ENV[ENVIRONMENT_VAR])
+          raise Bolt::ParseError, "Could not parse inventory from $#{ENVIRONMENT_VAR}" unless data.is_a?(Hash)
         rescue Psych::Exception
           raise Bolt::ParseError, "Could not parse inventory from $#{ENVIRONMENT_VAR}"
         end
@@ -67,7 +68,7 @@ module Bolt
       when 2
         Bolt::Inventory::Inventory2.new(data, config, plugins: plugins)
       else
-        raise ValidationError, "Unsupported version #{version} specified in inventory"
+        raise ValidationError.new("Unsupported version #{version} specified in inventory", nil)
       end
     end
 


### PR DESCRIPTION
With this commit a warning is logged when an inventory data source (environment, or inventoryfile) exists and the user has specified options that are configurable from the inventoryfile on the CLI.

Closes https://github.com/puppetlabs/bolt/issues/1341