### PR TITLE
(GH-1361) Add Singular version of TargetSpec

### DIFF
--- a/bolt-modules/boltlib/types/singletargetspec.pp
+++ b/bolt-modules/boltlib/types/singletargetspec.pp
@@ -1,0 +1,8 @@
+# A SingleTargetSpec represents any String, Target or single-element array of
+# one or the other that can be passed to get_targets() to return an
+# Array[Target, 1, 1]. This is a constrained type variant of
+# Boltlib::TargetSpec for use when a _single_ target is valid, but multiple
+# targets are not.
+type Boltlib::SingleTargetSpec = Variant[Pattern[/\A[^[:space:],]+\z/],
+                                         Target,
+                                         Array[Boltlib::SingleTargetSpec, 1, 1]]

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -102,12 +102,13 @@ module Bolt
       end
     end
 
-    # Create a top-level alias for TargetSpec and PlanResult so that users don't have to
-    # namespace it with Boltlib, which is just an implementation detail. This
-    # allows them to feel like a built-in type in bolt, rather than
-    # something has been, no pun intended, "bolted on".
+    # Create a top-level alias for TargetSpec, SingleTargetSpec, and PlanResult
+    # so that users don't have to namespace it with Boltlib, which is just an
+    # implementation detail. This allows them to feel like a built-in type in
+    # bolt, rather than something has been, no pun intended, "bolted on".
     def alias_types(compiler)
       compiler.evaluate_string('type TargetSpec = Boltlib::TargetSpec')
+      compiler.evaluate_string('type SingleTargetSpec = Boltlib::SingleTargetSpec')
       compiler.evaluate_string('type PlanResult = Boltlib::PlanResult')
     end
 


### PR DESCRIPTION
TargetSpec accepts a Variant[String, Target] OR an Array of the same, and is understood to best be treated as if it could refer to multiple endpoints.

Sometimes a plan (or task) parameter should accept a single target only. At present, there is no built-in data type to support that.

This commit creates and provides a data type defining a single Target(Spec): `Boltlib::SingleTargetSpec`.

It is aliased to `SingleTargetSpec` to let users avoid typing "Boltlib", just like the others.

Fixes #1361