### PR TITLE
(GH-1162) Expand configured paths relative to Boltdir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@
 
   When a CLI option that can be overridden in inventory is provided and inventory is loaded from a file or from the BOLT_INVENTORY environment variable an issue is warned about which options could be overridden.
 
+### Bug fixes
+
+* **Standardize configured paths to be relative to Boltdir** ([#1162](https://github.com/puppetlabs/bolt/issues/1162))
+
+  Previously we expanded some configured paths relative to the directory Bolt was run from, and other paths were expanded relative to the Boltdir. This standardizes all configured paths, including the modulepath, to be relative to the Boltdir. This only applies to file-based config, not command line flags, which are expanded relative to CWD. This fix is gated on the `future` config option, and will be available by default in Bolt 2.0
+
 ## 1.35.0
 
 ### Deprecation

--- a/Puppetfile
+++ b/Puppetfile
@@ -30,9 +30,9 @@ mod 'puppetlabs-ruby_task_helper', '0.4.0'
 
 # Plugin modules
 mod 'puppetlabs-azure_inventory', '0.2.0'
-mod 'puppetlabs-terraform', '0.1.0'
+mod 'puppetlabs-terraform', '0.2.0'
 mod 'puppetlabs-vault', '0.2.1'
-mod 'puppetlabs-aws_inventory', '0.1.0'
+mod 'puppetlabs-aws_inventory', '0.2.0'
 
 # If we don't list these modules explicitly, r10k will purge them
 mod 'canary', local: true

--- a/documentation/bolt_configuration_options.md
+++ b/documentation/bolt_configuration_options.md
@@ -45,7 +45,8 @@ ssh:
 -   `host-key-check`: Whether to perform host key validation when connecting over SSH. Default is `true`.
 -   `password`: Login password.
 -   `port`: Connection port. Default is `22`.
--   `private-key`: The path to the private key file to use for SSH authentication.
+-   `private-key`: Either the path to the private key file to use for SSH authentication, or a hash
+    with key `key-data` and the contents of the private key.
 -   `proxyjump`: A jump host to proxy SSH connections through, and an optional user to connect with, for example: jump.example.com or user1@jump.example.com.
 -   `run-as`: A different user to run commands as after login.
 -   `run-as-command`: The command to elevate permissions. Bolt appends the user and command strings to the configured run as a command before running it on the target. This command must not require an interactive password prompt, and the `sudo-password` option is ignored when `run-as-command` is specified. The run-as command must be specified as an array.
@@ -53,6 +54,22 @@ ssh:
 -   `tmpdir`: The directory to upload and execute temporary files on the target.
 -   `tty`: Request a pseudo tty for the SSH session. This option is generally only used in conjunction with the `run_as` option when the sudoers policy requires a `tty`. Default is `false`.
 -   `user`: Login user. Default is `root`.
+
+For example:
+
+```yaml
+targets:
+  - name: host1.example.net
+    config:
+      transport: ssh
+      ssh:
+        host-key-check: true
+        port: 22
+        run-as-command: ['sudo', '-k', '-n']
+        private-key:
+          key-data: |
+            MY PRIVATE KEY CONTENT
+```
 
 
 ## OpenSSH configuration options
@@ -83,14 +100,14 @@ To illustrate, consider this example:
 `inventory.yaml`
 
 ```yaml
-nodes:
+targets:
   - name: host1.example.net
     config:
       transport: ssh
       ssh:
         host-key-check: true
         port: 22
-        private-key: /.ssh/id_rsa-example
+        private-key: ~/.ssh/id_rsa-example
 ```
 
 `ssh.config`

--- a/documentation/configuring_bolt.md
+++ b/documentation/configuring_bolt.md
@@ -2,7 +2,14 @@
 
 Create a configuration file to store and automate the command-line flags you use every time you run Bolt.
 
-Configuration for Bolt is loaded from the [Bolt project directory](bolt_project_directories.md#). To set up a configuration file for Bolt to use outside of a project directory, create a `~/.puppetlabs/bolt/bolt.yaml` file with global options at the top level of the file. Configure transport-specific options for each transport. If a config option is set in the config file and passed with the corresponding command-line flag, the flag takes precedence.
+Configuration for Bolt is loaded from the [Bolt project directory](bolt_project_directories.md#). The default project directory is `~/.puppetlabs/bolt/`. Configure global options (i.e. the modulepath) at the top level of `<boltdir>/bolt.yaml`, and configure transport-specific options for each transport.
+
+Bolt config uses the following precedence, from highest precedence (cannot be overridden) to lowest:
+- Target URI (i.e. ssh://user:password@hostname:port)
+- [Inventory file](inventory_file.md) options
+- Command line flags
+- Config file options
+- SSH config file options (`~/.ssh/config`, if using SSH)
 
 -   **[Project directories](bolt_project_directories.md#)**  
  Bolt runs in the context of a project directory or a `Boltdir`. This directory contains all of the configuration, code, and data loaded by Bolt.

--- a/documentation/using_plugins.md
+++ b/documentation/using_plugins.md
@@ -271,8 +271,8 @@ plugins:
 ```
 
 -   `keysize`: They size of the key to generate with `bolt secret createkeys`: default: `2048`
--   `private-key`: The path to the private key file. default: `keys/private_key.pkcs7.pem`
--   `public-key`: The path to the public key file. default: `keys/public_key.pkcs7.pem`
+-   `private-key`: The path to the private key file. default: `<boltdir>/keys/private_key.pkcs7.pem`
+-   `public-key`: The path to the public key file. default: `<boltdir>/keys/public_key.pkcs7.pem`
 
 ## Vault plugin
 

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -247,7 +247,7 @@ module Bolt
 
     def puppetdb_client
       return @puppetdb_client if @puppetdb_client
-      puppetdb_config = Bolt::PuppetDB::Config.load_config(nil, config.puppetdb)
+      puppetdb_config = Bolt::PuppetDB::Config.load_config(nil, config.puppetdb, config.boltdir.path)
       @puppetdb_client = Bolt::PuppetDB::Client.new(puppetdb_config)
     end
 

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -701,7 +701,7 @@ describe Bolt::Inventory do
   end
 
   describe 'add_facts' do
-    context 'whith and without $future flag' do
+    context 'with and without $future flag' do
       let(:inventory) { Bolt::Inventory.new({}) }
       let(:target) { get_target(inventory, 'foo') }
       let(:facts) { { 'foo' => 'bar' } }

--- a/spec/bolt/puppetdb/config_spec.rb
+++ b/spec/bolt/puppetdb/config_spec.rb
@@ -5,6 +5,27 @@ require 'bolt/puppetdb/config'
 require 'bolt/util'
 
 describe Bolt::PuppetDB::Config do
+  context "with boltdir available" do
+    let(:cacert) { File.expand_path('relative/to/cacert') }
+    let(:token) { File.expand_path('relative/to/token') }
+    let(:boltdir) { '~/dirbolt' }
+    let(:options) do
+      {
+        'server_urls' => ['https://puppetdb:8081'],
+        'cacert' => cacert,
+        'token' => token
+      }
+    end
+
+    let(:config) { Bolt::PuppetDB::Config.new(options, boltdir) }
+
+    it 'expands the cacert relative to the boltdir if boltdir is available' do
+      allow(config).to receive(:validate_file_exists).with('cacert').and_return true
+
+      expect(config.cacert).to eq(File.expand_path(cacert, boltdir))
+    end
+  end
+
   context "when validating that options" do
     let(:cacert) { File.expand_path('/path/to/cacert') }
     let(:token) { File.expand_path('/path/to/token') }

--- a/spec/fixtures/configs/future.yml
+++ b/spec/fixtures/configs/future.yml
@@ -1,0 +1,1 @@
+future: true


### PR DESCRIPTION
There are a number of config options for Bolt that accept filepaths.
Previously we expanded the path relative to where Bolt was run in some
cases, and relative to the Boltdir in others. This standardizes all
configurable paths to be expanded relative to the Boltdir if they are
defined in a config file, and relative to the current working directory
if they are specified on the CLI. This change doesn't affect absolute
paths.  This provides consistent and predictable behavior for users. New
path expansions are gated on the `future` option being set to `true`.

Closes #1162 