### PR TITLE
(GH-1285) Add project init command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
   The prompt plugin now prints messages to `stderr` instead of `stdout`.
 
+* **New `project init` subcommand** ([#1285](https://github.com/puppetlabs/bolt/issues/1285))
+
+  The CLI now provides a subcommand `bolt project init` that will create a new file `bolt.yaml` in the current working directory, making the directory a [Bolt project directory](https://puppet.com/docs/bolt/latest/bolt_project_directories.html#local-project-directory)
+
 ## 1.35.0
 
 ### Deprecation

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -49,6 +49,15 @@ module Bolt
           { flags: ACTION_OPTS + %w[params compile-concurrency tmpdir],
             banner: PLAN_HELP }
         end
+      when 'project'
+        case action
+        when 'init'
+          { flags: OPTIONS[:global],
+            banner: PROJECT_INIT_HELP }
+        else
+          { flags: OPTIONS[:global],
+            banner: PROJECT_HELP }
+        end
       when 'puppetfile'
         case action
         when 'install'
@@ -121,6 +130,7 @@ module Bolt
         bolt secret decrypt <encrypted>  Decrypt a value
         bolt inventory show              Show the list of targets an action would run on
         bolt group show                  Show the list of groups in the inventory
+        bolt project init                Create a new Bolt project
 
       Run `bolt <subcommand> --help` to view specific examples.
 
@@ -309,6 +319,24 @@ module Bolt
 
       Available options are:
     GROUP_HELP
+
+    PROJECT_HELP = <<~PROJECT_HELP
+      Usage: bolt project <action>
+
+      Available actions are:
+        init                     Create a new Bolt project
+
+      Available options are:
+    PROJECT_HELP
+
+    PROJECT_INIT_HELP = <<~PROJECT_INIT_HELP
+      Usage: bolt project init [directory]
+
+      Create a new Bolt project.
+      Specify a directory to create the Bolt project in. Defaults to the current working directory.
+
+      Available options are:
+    PROJECT_INIT_HELP
 
     def initialize(options)
       super()

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -37,6 +37,7 @@ module Bolt
                  'secret' => %w[encrypt decrypt createkeys],
                  'inventory' => %w[show],
                  'group' => %w[show],
+                 'project' => %w[init],
                  'apply' => %w[] }.freeze
 
     attr_reader :config, :options
@@ -134,6 +135,7 @@ module Bolt
       # options[:targets] will contain a resolved set of Target objects
       unless options[:subcommand] == 'puppetfile' ||
              options[:subcommand] == 'secret' ||
+             options[:subcommand] == 'project' ||
              options[:action] == 'show' ||
              options[:action] == 'convert'
 
@@ -328,6 +330,8 @@ module Bolt
       end
 
       case options[:subcommand]
+      when 'project'
+        code = initialize_project
       when 'plan'
         code = run_plan(options[:object], options[:task_options], options[:target_args], options)
       when 'puppetfile'
@@ -502,6 +506,21 @@ module Bolt
       # generate_types will surface a nice error with helpful message if it fails
       pal.generate_types
       0
+    end
+
+    def initialize_project
+      path = File.expand_path(options[:object] || Dir.pwd)
+      FileUtils.mkdir_p(path)
+      ok = FileUtils.touch(File.join(path, 'bolt.yaml'))
+
+      result = if ok
+                 "Successfully created Bolt project directory at #{path}"
+               else
+                 "Could not create Bolt project directory at #{path}"
+               end
+      outputter.print_message result
+
+      ok ? 0 : 1
     end
 
     def install_puppetfile(config, puppetfile, modulepath)

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -2107,4 +2107,24 @@ describe "Bolt::CLI" do
       end
     end
   end
+
+  describe 'project' do
+    it 'init creates a new project at the specified path' do
+      Dir.mktmpdir do |dir|
+        file = File.join(dir, 'bolt.yaml')
+        cli = Bolt::CLI.new(%W[project init #{dir}])
+        cli.execute(cli.parse)
+        expect(File.file?(file)).to be
+      end
+    end
+
+    it 'init creates a new project in the current working directory' do
+      Dir.mktmpdir do |dir|
+        file = File.join(dir, 'bolt.yaml')
+        cli = Bolt::CLI.new(%w[project init])
+        Dir.chdir(dir) { cli.execute(cli.parse) }
+        expect(File.file?(file)).to be
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds a `project init` subcommand that creates a new Bolt project. When
specifying a filepath using `bolt project init [filepath]`, the project
directory will be created at the filepath. Otherwise, the project
directory is created in the current working directory.