### PR TITLE
(GH-1243) Log/output safe name for plan steps

### DIFF
--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -135,7 +135,7 @@ module Bolt
         target_str = if targets.length > 5
                        "#{targets.count} targets"
                      else
-                       targets.map(&:uri).join(', ')
+                       targets.map(&:safe_name).join(', ')
                      end
         @stream.puts(colorize(:green, "Starting: #{description} on #{target_str}"))
       end

--- a/lib/bolt/outputter/logger.rb
+++ b/lib/bolt/outputter/logger.rb
@@ -27,7 +27,7 @@ module Bolt
         target_str = if targets.length > 5
                        "#{targets.count} targets"
                      else
-                       targets.map(&:uri).join(', ')
+                       targets.map(&:safe_name).join(', ')
                      end
         @logger.info("Starting: #{description} on #{target_str}")
       end


### PR DESCRIPTION
Logging and outputting target references in plan steps was missed in initial GH-1243 PR. This commit updates the human outputter and logger to use safe_name instead of URI when logging/outputting plan_step events.