### PR TITLE
(GH-1365) Add resolve_references plan function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 * **Bolt issues a warning when inventory overrides a CLI option** ([#1341](https://github.com/puppetlabs/bolt/issues/1341))
 
   Bolt issues a warning when an option is set both on the CLI and in the inventory, whether the inventory loads from a file or from the `bolt_inventory` environment variable.
+
+* **New `resolve_references` plan function** ([#1365](https://github.com/puppetlabs/bolt/issues/1365))
+
+  The new plan function, `resolve_references`, accepts a hash of structured data and returns a hash of structured data with all plugin references resolved.
   
 ### Bug fixes
 

--- a/bolt-modules/boltlib/lib/puppet/functions/resolve_references.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/resolve_references.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'bolt/error'
+
+# Evaulates all _plugin references in a hash and returns the resolved reference data.
+Puppet::Functions.create_function(:resolve_references) do
+  # Resolve references.
+  # @param references A hash of reference data to resolve.
+  # @return A hash of resolved reference data.
+  # @example Resolve a hash of reference data
+  #   $references = {
+  #     "targets" => [
+  #       "_plugin" => "terraform",
+  #       "dir" => "path/to/terraform/project",
+  #       "resource_type" => "aws_instance.web",
+  #       "uri" => "public_ip"
+  #     ]
+  #   }
+  #
+  #   resolve_references($references)
+  dispatch :resolve_references do
+    param 'Data', :references
+    return_type 'Data'
+  end
+
+  def resolve_references(references)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(
+          Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING,
+          action: 'resolve_references'
+        )
+    end
+
+    plugins = Puppet.lookup(:bolt_inventory).plugins
+    plugins.resolve_references(references)
+  end
+end

--- a/bolt-modules/boltlib/spec/fixtures/modules/test/tasks/references.rb
+++ b/bolt-modules/boltlib/spec/fixtures/modules/test/tasks/references.rb
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+
+values = {
+  "value" => {
+    "name" => "127.0.0.1"
+  }
+}
+
+puts values.to_json


### PR DESCRIPTION
This adds support for a `resolve_references` plan function that accepts
a hash of target data, resolves all references in the hash, and returns
the resolved target data.

Closes #1365 