### PR TITLE
(GH-1375) Add deprecation warning for `--nodes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
   The `--password` and `--sudo-password` options now require a password as an argument. Previously, if the password was omitted the user would be prompted to enter one. To continue to be prompted for a password, use the `prompt` plugin.
 
+* **Favor `--targets` over `--nodes`** ([#1375](https://github.com/puppetlabs/bolt/issues/1375))
+
+  The `--nodes` command line option has been deprecated in favor of `--targets`. When using `--nodes`, a deprecation warning will be displayed.
+
 ### New features
 
 * **`prompt` messages print to `stderr`** ([#1269](https://github.com/puppetlabs/bolt/issues/1269))

--- a/acceptance/lib/acceptance/bolt_command_helper.rb
+++ b/acceptance/lib/acceptance/bolt_command_helper.rb
@@ -6,7 +6,7 @@ module Acceptance
     # @param [Beaker::Host] host the host to execute the command on
     # @param [String] command the command to execute on the bolt SUT
     # @param [Hash] flags the command flags to append to the command
-    # @option flags [String] '--nodes' the nodes to run on
+    # @option flags [String] '--targets' the nodes to run on
     # @option flags [String] '--user' the user to run the command as
     # @option flags [String] '--password' the password for the user
     # @option flags [nil] '--no-host-key-check' specify nil to use

--- a/acceptance/tests/bolt_apply.rb
+++ b/acceptance/tests/bolt_apply.rb
@@ -39,7 +39,7 @@ test_name "bolt apply should apply manifest block on remote hosts via ssh and wi
   end
 
   step "execute `bolt apply -e <code>` with json output" do
-    bolt_command = "bolt apply -e \"notify { 'hello world': }\" --nodes #{targets.join(',')}"
+    bolt_command = "bolt apply -e \"notify { 'hello world': }\" --targets #{targets.join(',')}"
     flags = {
       '--format' => 'json'
     }
@@ -50,7 +50,7 @@ test_name "bolt apply should apply manifest block on remote hosts via ssh and wi
 
   step "execute `bolt apply -e <code>` with json output against localhost" do
     # TODO: Execute with '--run-as local_user' when BOLT-1283 is fixed
-    bolt_command = "bolt apply -e \"notify { 'hello world': }\" --nodes localhost"
+    bolt_command = "bolt apply -e \"notify { 'hello world': }\" --targets localhost"
     flags = {
       '--format' => 'json'
     }
@@ -65,7 +65,7 @@ test_name "bolt apply should apply manifest block on remote hosts via ssh and wi
     notify { "hello world": }
     MANIFEST
 
-    bolt_command = "bolt apply '#{dir}/test.pp' --nodes #{targets.join(',')}"
+    bolt_command = "bolt apply '#{dir}/test.pp' --targets #{targets.join(',')}"
     flags = {
       '--format' => 'json'
     }

--- a/acceptance/tests/command_local.rb
+++ b/acceptance/tests/command_local.rb
@@ -11,7 +11,7 @@ test_name "bolt command run should execute command on localhost via local transp
   step "execute `bolt command run` via local transport" do
     command = 'echo """hello from $(hostname)"""'
     bolt_command = "bolt command run '#{command}'"
-    flags = { '--nodes' => 'localhost' }
+    flags = { '--targets' => 'localhost' }
 
     result = bolt_command_on(bolt, bolt_command, flags)
 
@@ -23,7 +23,7 @@ test_name "bolt command run should execute command on localhost via local transp
   step "execute `bolt command run` via local transport using run-as" do
     command = 'whoami'
     bolt_command = "bolt command run '#{command}'"
-    flags = { '--nodes' => 'localhost', '--run-as' => "'#{local_user}'" }
+    flags = { '--targets' => 'localhost', '--run-as' => "'#{local_user}'" }
 
     result = bolt_command_on(bolt, bolt_command, flags)
 

--- a/acceptance/tests/command_ssh.rb
+++ b/acceptance/tests/command_ssh.rb
@@ -12,7 +12,7 @@ test_name "C100546: \
   step "execute `bolt command run` via SSH" do
     command = 'echo """hello from $(hostname)"""'
     bolt_command = "bolt command run '#{command}'"
-    flags = { '--nodes' => 'ssh_nodes' }
+    flags = { '--targets' => 'ssh_nodes' }
 
     result = bolt_command_on(bolt, bolt_command, flags)
 

--- a/acceptance/tests/command_winrm.rb
+++ b/acceptance/tests/command_winrm.rb
@@ -12,7 +12,7 @@ test_name "C100547: \
   step "execute `bolt command run` via WinRM" do
     command = '[System.Net.Dns]::GetHostByName(($env:computerName))'
     bolt_command = "bolt command run '#{command}'"
-    flags = { '--nodes' => 'winrm_nodes' }
+    flags = { '--targets' => 'winrm_nodes' }
 
     result = bolt_command_on(bolt, bolt_command, flags)
 

--- a/acceptance/tests/cross_platform_task.rb
+++ b/acceptance/tests/cross_platform_task.rb
@@ -43,7 +43,7 @@ test_name "cross-platform tasks run on multiple kinds of nodes" do
   step "execute `bolt task run` via both SSH and WinRM" do
     bolt_command = "bolt task run test::hostname"
     flags = {
-      '--nodes' => 'all',
+      '--targets' => 'all',
       '--modulepath' => "#{dir}/modules"
     }
 

--- a/acceptance/tests/file_local.rb
+++ b/acceptance/tests/file_local.rb
@@ -19,7 +19,7 @@ test_name "Bolt file upload should copy local file to remote hosts via ssh" do
   step "execute `bolt file upload` via local transport" do
     source = dest = 'local_file.txt'
     bolt_command = "bolt file upload #{dir}/#{source} /tmp/#{dest}"
-    flags = { '--nodes' => 'localhost' }
+    flags = { '--targets' => 'localhost' }
     result = bolt_command_on(bolt, bolt_command, flags)
 
     message = "Unexpected output from the command:\n#{result.cmd}"
@@ -42,7 +42,7 @@ test_name "Bolt file upload should copy local file to remote hosts via ssh" do
     # previous test has root-owned copy, local user cannot overwrite it
     on(bolt, "rm -f /tmp/#{dest}")
     bolt_command = "bolt file upload #{local_user_homedir}/#{source} /tmp/#{dest}"
-    flags = { '--nodes' => 'localhost', '--run-as' => "'#{local_user}'" }
+    flags = { '--targets' => 'localhost', '--run-as' => "'#{local_user}'" }
     result = bolt_command_on(bolt, bolt_command, flags)
 
     message = "Unexpected output from the command:\n#{result.cmd}"

--- a/acceptance/tests/file_ssh.rb
+++ b/acceptance/tests/file_ssh.rb
@@ -20,7 +20,7 @@ test_name "C1005xx: \
   step "execute `bolt file upload` via SSH" do
     source = dest = 'C1005xx_file.txt'
     bolt_command = "bolt file upload #{dir}/#{source} /tmp/#{dest}"
-    flags = { '--nodes' => 'ssh_nodes' }
+    flags = { '--targets' => 'ssh_nodes' }
     result = bolt_command_on(bolt, bolt_command, flags)
 
     message = "Unexpected output from the command:\n#{result.cmd}"

--- a/acceptance/tests/file_winrm.rb
+++ b/acceptance/tests/file_winrm.rb
@@ -28,7 +28,7 @@ test_name "C1005xx: \
     source = dest = 'C1005xx_file.txt'
     bolt_command = "bolt file upload '#{dir}/#{source}' '#{testdir}/#{dest}'"
 
-    flags = { '--nodes' => 'winrm_nodes' }
+    flags = { '--targets' => 'winrm_nodes' }
 
     result = bolt_command_on(bolt, bolt_command, flags)
     message = "Unexpected output from the command:\n#{result.cmd}"

--- a/acceptance/tests/script_local.rb
+++ b/acceptance/tests/script_local.rb
@@ -17,7 +17,7 @@ test_name "bolt script run should execute script on localhost via local transpor
 
     step "execute powershell script via local transport without loading powershell profile" do
       bolt_command = "bolt script run #{script}"
-      flags = { '--nodes' => 'localhost' }
+      flags = { '--targets' => 'localhost' }
 
       inspect_profile_tracker = "\"if (Test-Path -Path #{profile_tracker.inspect}) " \
                                 "{ Get-Content -Path #{profile_tracker.inspect} }\""
@@ -40,7 +40,7 @@ test_name "bolt script run should execute script on localhost via local transpor
     step "execute `bolt script run` on localhost" do
       bolt_command = "bolt script run #{script} hello"
 
-      flags = { '--nodes' => 'localhost' }
+      flags = { '--targets' => 'localhost' }
 
       result = bolt_command_on(bolt, bolt_command, flags)
       message = "Unexpected output from the command:\n#{result.cmd}"
@@ -55,7 +55,7 @@ test_name "bolt script run should execute script on localhost via local transpor
 
       bolt_command = "bolt script run #{local_owned_script} hello"
 
-      flags = { '--nodes' => 'localhost', '--run-as' => "'#{local_user}'" }
+      flags = { '--targets' => 'localhost', '--run-as' => "'#{local_user}'" }
 
       result = bolt_command_on(bolt, bolt_command, flags)
       message = "Unexpected output from the command:\n#{result.cmd}"

--- a/acceptance/tests/script_ssh.rb
+++ b/acceptance/tests/script_ssh.rb
@@ -21,7 +21,7 @@ test_name "C100548: \
   step "execute `bolt script run` via SSH" do
     bolt_command = "bolt script run #{script} hello"
 
-    flags = { '--nodes' => 'ssh_nodes' }
+    flags = { '--targets' => 'ssh_nodes' }
 
     result = bolt_command_on(bolt, bolt_command, flags)
     ssh_nodes.each do |node|

--- a/acceptance/tests/script_winrm.rb
+++ b/acceptance/tests/script_winrm.rb
@@ -19,7 +19,7 @@ test_name "C100549: \
 
   step "execute `bolt script run` via WinRM" do
     bolt_command = "bolt script run #{script} hello"
-    flags = { '--nodes' => 'winrm_nodes' }
+    flags = { '--targets' => 'winrm_nodes' }
 
     result = bolt_command_on(bolt, bolt_command, flags)
     winrm_nodes.each do |node|

--- a/acceptance/tests/task_local.rb
+++ b/acceptance/tests/task_local.rb
@@ -19,7 +19,7 @@ test_name "bolt task run should execute tasks on localhost via local transport" 
       bolt_command = "bolt task run test::test_profile"
 
       flags = {
-        '--nodes' => 'localhost',
+        '--targets' => 'localhost',
         '--modulepath' => "#{dir}/modules"
       }
 
@@ -43,7 +43,7 @@ test_name "bolt task run should execute tasks on localhost via local transport" 
     step "execute `bolt task run` on localhost via local transport" do
       bolt_command = "bolt task run test::whoami_nix greetings=hello"
       flags = {
-        '--nodes' => 'localhost',
+        '--targets' => 'localhost',
         '--modulepath' => "#{dir}/modules"
       }
 
@@ -59,7 +59,7 @@ test_name "bolt task run should execute tasks on localhost via local transport" 
 
       bolt_command = "bolt task run test::whoami_nix greetings=hello"
       flags = {
-        '--nodes' => 'localhost',
+        '--targets' => 'localhost',
         '--modulepath' => "#{local_user_homedir}/modules",
         '--run-as' => "'#{local_user}'"
       }

--- a/acceptance/tests/task_ssh.rb
+++ b/acceptance/tests/task_ssh.rb
@@ -21,7 +21,7 @@ test_name "C100550: \
   step "execute `bolt task run` via SSH" do
     bolt_command = "bolt task run test::hostname_nix"
     flags = {
-      '--nodes' => 'ssh_nodes',
+      '--targets' => 'ssh_nodes',
       '--modulepath' => "#{dir}/modules"
     }
 

--- a/acceptance/tests/task_winrm.rb
+++ b/acceptance/tests/task_winrm.rb
@@ -22,7 +22,7 @@ test_name "C100551: \
     bolt_command = "bolt task run test::hostname_win"
 
     flags = {
-      '--nodes' => 'winrm_nodes',
+      '--targets' => 'winrm_nodes',
       '--modulepath' => "#{dir}/modules"
     }
 

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -344,7 +344,8 @@ module Bolt
       @options = options
 
       define('-n', '--nodes NODES',
-             'Alias for --targets') do |nodes|
+             'Alias for --targets',
+             'Deprecated in favor of --targets') do |nodes|
         @options [:nodes] ||= []
         @options[:nodes] << get_arg_input(nodes)
       end

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -147,6 +147,12 @@ module Bolt
         options[:verbose] = options[:subcommand] != 'plan'
       end
 
+      # TODO: Remove deprecation warning
+      if options[:nodes]
+        @logger.warn("Deprecation Warning: The --nodes command line option has been " \
+                     "deprecated in favor of --targets.")
+      end
+
       warn_inventory_overrides_cli(options)
       options
     rescue Bolt::Error => e

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -219,7 +219,7 @@ module Bolt
         # Building lots of strings...
         pretty_params = +""
         task_info = +""
-        usage = +"bolt task run --nodes <node-name> #{task['name']}"
+        usage = +"bolt task run --targets <node-name> #{task['name']}"
 
         task['metadata']['parameters']&.each do |k, v|
           pretty_params << "- #{k}: #{v['type'] || 'Any'}\n"

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -114,7 +114,7 @@ c1   d
 cinnamon_roll - A delicious sweet bun
 
 USAGE:
-bolt task run --nodes <node-name> cinnamon_roll icing=<value>
+bolt task run --targets <node-name> cinnamon_roll icing=<value>
 
 PARAMETERS:
 - icing: Cream cheese
@@ -152,7 +152,7 @@ MODULE:
 sticky_bun - A delicious sweet bun with nuts
 
 USAGE:
-bolt task run --nodes <node-name> sticky_bun glaze=<value> pecans=<value>
+bolt task run --targets <node-name> sticky_bun glaze=<value> pecans=<value>
 
 PARAMETERS:
 - glaze: Sticky
@@ -178,7 +178,7 @@ MODULE:
 monkey_bread
 
 USAGE:
-bolt task run --nodes <node-name> monkey_bread
+bolt task run --targets <node-name> monkey_bread
 
 MODULE:
 built-in module

--- a/spec/bolt/rerun_spec.rb
+++ b/spec/bolt/rerun_spec.rb
@@ -133,7 +133,7 @@ describe 'rerun' do
       allow(executor).to receive(:run_command)
         .with(targets, 'whoami', kind_of(Hash))
         .and_return(result_set)
-      run_cli(['command', 'run', 'whoami', '--nodes', target_spec.join(',')])
+      run_cli(['command', 'run', 'whoami', '--targets', target_spec.join(',')])
 
       expect(read_rerun).to eq(failure_array)
     end
@@ -142,7 +142,7 @@ describe 'rerun' do
       allow(executor).to receive(:run_command)
         .with(targets, 'whoami', kind_of(Hash))
         .and_return(result_set)
-      run_cli(['command', 'run', 'whoami', '--no-tty', '--no-save-rerun', '--nodes', target_spec.join(',')])
+      run_cli(['command', 'run', 'whoami', '--no-tty', '--no-save-rerun', '--targets', target_spec.join(',')])
 
       expect(read_rerun).to eq(['original result'])
     end
@@ -153,7 +153,7 @@ describe 'rerun' do
       allow(executor).to receive(:run_command)
         .with(targets, 'whoami', kind_of(Hash))
         .and_return(result_set)
-      run_cli(['command', 'run', 'whoami', '--nodes', target_spec.join(',')])
+      run_cli(['command', 'run', 'whoami', '--targets', target_spec.join(',')])
 
       expect(read_rerun).to eq(['original result'])
     end
@@ -185,7 +185,7 @@ describe 'rerun' do
       allow(pal).to receive(:in_plan_compiler)
       allow(pal).to receive(:with_bolt_executor)
         .and_return(Bolt::ResultSet.new([Bolt::ApplyResult.new(targets[0], error: { 'kind' => 'oops' })]))
-      run_cli(['apply', '--nodes', 'node1', '-e', 'include foo'])
+      run_cli(['apply', '--targets', 'node1', '-e', 'include foo'])
       expect(read_rerun).to eq([{ "status" => "failure", "target" => "node1" }])
     end
 
@@ -193,7 +193,7 @@ describe 'rerun' do
       allow(pal).to receive(:in_plan_compiler)
       allow(pal).to receive(:with_bolt_executor)
         .and_return(Bolt::ResultSet.new([Bolt::ApplyResult.new(targets[0], report: {})]))
-      run_cli(['apply', '--nodes', 'node1', '-e', 'include foo'])
+      run_cli(['apply', '--targets', 'node1', '-e', 'include foo'])
       expect(read_rerun).to eq([{ "status" => "success", "target" => "node1" }])
     end
   end

--- a/spec/fixtures/linuxdev/bolt-kerberos-test.sh
+++ b/spec/fixtures/linuxdev/bolt-kerberos-test.sh
@@ -15,8 +15,8 @@ Basic auth bolt:${BOLT_PASSWORD}
 
 EOF
 
-bundle exec bolt command run "whoami" --nodes winrm://omiserver.bolt.test:5985 --user bolt --password $BOLT_PASSWORD --no-ssl
-bundle exec bolt command run "whoami" --nodes winrm://omiserver.bolt.test:5986 --user bolt --password $BOLT_PASSWORD --no-ssl-verify
+bundle exec bolt command run "whoami" --targets winrm://omiserver.bolt.test:5985 --user bolt --password $BOLT_PASSWORD --no-ssl
+bundle exec bolt command run "whoami" --targets winrm://omiserver.bolt.test:5986 --user bolt --password $BOLT_PASSWORD --no-ssl-verify
 
 cat << EOF
 
@@ -61,7 +61,7 @@ Failed on omiserver.bolt.test:
 
 EOF
 
-bundle exec bolt command run "whoami" --nodes winrm://omiserver.bolt.test:5985 --no-ssl --debug --verbose --connect-timeout 9999
+bundle exec bolt command run "whoami" --targets winrm://omiserver.bolt.test:5985 --no-ssl --debug --verbose --connect-timeout 9999
 
 cat << EOF
 
@@ -82,4 +82,4 @@ Failed on omiserver.bolt.test:
 
 EOF
 
-bundle exec bolt command run "whoami" --nodes winrm://omiserver.bolt.test:5986 --no-ssl-verify --debug --verbose --connect-timeout 9999
+bundle exec bolt command run "whoami" --targets winrm://omiserver.bolt.test:5986 --no-ssl-verify --debug --verbose --connect-timeout 9999

--- a/spec/integration/analytics_spec.rb
+++ b/spec/integration/analytics_spec.rb
@@ -28,7 +28,7 @@ describe Bolt::Analytics do
     [
       '--configfile', fixture_path('configs', 'empty.yml'),
       '--modulepath', modulepath,
-      '--nodes', target,
+      '--targets', target,
       '--password', password,
       '--no-host-key-check',
       '--no-ssl',

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -15,7 +15,7 @@ describe "passes parsed AST to the apply_catalog task" do
   include BoltSpec::PuppetDB
 
   let(:modulepath) { File.join(__dir__, '../fixtures/apply') }
-  let(:config_flags) { %W[--format json --nodes #{uri} --password #{password} --modulepath #{modulepath}] + tflags }
+  let(:config_flags) { %W[--format json --targets #{uri} --password #{password} --modulepath #{modulepath}] + tflags }
 
   before(:each) do
     allow(Bolt::ApplyResult).to receive(:from_task_result) { |r| r }

--- a/spec/integration/apply_error_spec.rb
+++ b/spec/integration/apply_error_spec.rb
@@ -10,7 +10,7 @@ describe "errors gracefully attempting to apply a manifest block" do
   include BoltSpec::Integration
 
   let(:modulepath) { File.join(__dir__, '../fixtures/apply') }
-  let(:config_flags) { %W[--format json --nodes #{uri} --password #{password} --modulepath #{modulepath}] + tflags }
+  let(:config_flags) { %W[--format json --targets #{uri} --password #{password} --modulepath #{modulepath}] + tflags }
 
   describe 'over ssh', ssh: true do
     let(:uri) { conn_uri('ssh') }

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -16,7 +16,7 @@ describe "apply" do
 
   let(:modulepath) { File.join(__dir__, '../fixtures/apply') }
   let(:hiera_config) { File.join(__dir__, '../fixtures/configs/empty.yml') }
-  let(:config_flags) { %W[--format json --nodes #{uri} --password #{password} --modulepath #{modulepath}] + tflags }
+  let(:config_flags) { %W[--format json --targets #{uri} --password #{password} --modulepath #{modulepath}] + tflags }
 
   describe 'over ssh', ssh: true do
     let(:uri) { conn_uri('ssh') }
@@ -154,7 +154,7 @@ describe "apply" do
 
       it 'runs a ruby task' do
         with_tempfile_containing('inventory', YAML.dump(agent_version_inventory), '.yaml') do |inv|
-          results = run_cli_json(%W[task run basic::ruby_task --nodes agent_targets
+          results = run_cli_json(%W[task run basic::ruby_task --targets agent_targets
                                     --modulepath #{modulepath} --inventoryfile #{inv.path}])
           results['items'].each do |result|
             expect(result['status']).to eq('success')
@@ -165,7 +165,7 @@ describe "apply" do
 
       it 'runs an apply plan' do
         with_tempfile_containing('inventory', YAML.dump(agent_version_inventory), '.yaml') do |inv|
-          results = run_cli_json(%W[plan run basic::notify --nodes agent_targets
+          results = run_cli_json(%W[plan run basic::notify --targets agent_targets
                                     --modulepath #{modulepath} --inventoryfile #{inv.path}])
           results.each do |result|
             expect(result['status']).to eq('success')
@@ -188,7 +188,7 @@ describe "apply" do
 
       it 'gets resources' do
         with_tempfile_containing('inventory', YAML.dump(agent_version_inventory), '.yaml') do |inv|
-          results = run_cli_json(%W[plan run basic::resources --nodes agent_targets
+          results = run_cli_json(%W[plan run basic::resources --targets agent_targets
                                     --modulepath #{modulepath} --inventoryfile #{inv.path}])
           results.each do |result|
             expect(result['status']).to eq('success')
@@ -423,7 +423,7 @@ describe "apply" do
 
       it 'runs a ruby task' do
         with_tempfile_containing('bolt', YAML.dump(config), '.yaml') do |conf|
-          results = run_cli_json(%W[task run basic::ruby_task --nodes #{uri}
+          results = run_cli_json(%W[task run basic::ruby_task --targets #{uri}
                                     --configfile #{conf.path}])
           results['items'].each do |result|
             expect(result).to include('status' => 'success')
@@ -434,7 +434,7 @@ describe "apply" do
 
       it 'runs an apply plan' do
         with_tempfile_containing('bolt', YAML.dump(config), '.yaml') do |conf|
-          results = run_cli_json(%W[plan run basic::notify --nodes #{uri}
+          results = run_cli_json(%W[plan run basic::notify --targets #{uri}
                                     --configfile #{conf.path}])
           results.each do |result|
             expect(result).to include('status' => 'success')
@@ -469,7 +469,7 @@ describe "apply" do
 
       it 'runs a ruby task' do
         with_tempfile_containing('bolt', YAML.dump(config), '.yaml') do |conf|
-          results = run_cli_json(%W[task run basic::ruby_task --nodes #{uri}
+          results = run_cli_json(%W[task run basic::ruby_task --targets #{uri}
                                     --configfile #{conf.path}])
           results['items'].each do |result|
             expect(result).to include('status' => 'success')
@@ -480,7 +480,7 @@ describe "apply" do
 
       it 'runs an apply plan' do
         with_tempfile_containing('bolt', YAML.dump(config), '.yaml') do |conf|
-          results = run_cli_json(%W[plan run basic::notify --nodes #{uri}
+          results = run_cli_json(%W[plan run basic::notify --targets #{uri}
                                     --configfile #{conf.path}])
           results.each do |result|
             expect(result).to include('status' => 'success')

--- a/spec/integration/catch_errors_spec.rb
+++ b/spec/integration/catch_errors_spec.rb
@@ -23,7 +23,7 @@ describe "catch_errors", ssh: true do
     ['--format', 'json',
      '--configfile', fixture_path('configs', 'empty.yml'),
      '--modulepath', modulepath,
-     '--nodes', target] + transport_flags
+     '--targets', target] + transport_flags
   }
   let(:plan) { "catch_errors" }
 

--- a/spec/integration/device_spec.rb
+++ b/spec/integration/device_spec.rb
@@ -15,7 +15,7 @@ describe "devices" do
   include BoltSpec::Run
 
   let(:modulepath) { File.join(__dir__, '../fixtures/apply') }
-  let(:config_flags) { %W[--format json --nodes #{uri} --password #{password} --modulepath #{modulepath}] + tflags }
+  let(:config_flags) { %W[--format json --targets #{uri} --password #{password} --modulepath #{modulepath}] + tflags }
 
   describe 'over ssh', ssh: true do
     let(:uri) { conn_uri('ssh') }
@@ -69,7 +69,7 @@ describe "devices" do
 
       it 'runs a plan that collects facts' do
         with_tempfile_containing('inventory', YAML.dump(device_inventory), '.yaml') do |inv|
-          results = run_cli_json(%W[plan run device_test::facts --nodes device_targets
+          results = run_cli_json(%W[plan run device_test::facts --targets device_targets
                                     --modulepath #{modulepath} --inventoryfile #{inv.path}])
           expect(results).not_to include("kind")
           name, facts = results.first
@@ -83,7 +83,7 @@ describe "devices" do
       it 'runs a plan that applies resources' do
         with_tempfile_containing('inventory', YAML.dump(device_inventory), '.yaml') do |inv|
           results = run_cli_json(%W[plan run device_test::set_a_val
-                                    --nodes device_targets
+                                    --targets device_targets
                                     --modulepath #{modulepath} --inventoryfile #{inv.path}])
           expect(results).not_to include("kind")
 
@@ -94,7 +94,7 @@ describe "devices" do
           expect(content).to eq({ key1: "val1" }.to_json)
 
           resources = run_cli_json(%W[plan run device_test::resources
-                                      --nodes device_targets
+                                      --targets device_targets
                                       --modulepath #{modulepath} --inventoryfile #{inv.path}])
           expect(resources[0]['result']['resources'][0]).to eq("key1" =>
                                                                { "content" => "val1",

--- a/spec/integration/docker_spec.rb
+++ b/spec/integration/docker_spec.rb
@@ -20,7 +20,7 @@ describe "when running over the docker transport", docker: true do
 
   context 'when using CLI options' do
     let(:config_flags) {
-      %W[--nodes #{uri} --no-host-key-check --format json --modulepath #{modulepath}]
+      %W[--targets #{uri} --no-host-key-check --format json --modulepath #{modulepath}]
     }
 
     it 'runs multiple commands' do
@@ -54,8 +54,8 @@ describe "when running over the docker transport", docker: true do
         } }
     end
 
-    let(:config_flags) { %W[--nodes #{uri}] }
-    let(:single_target_conf) { %W[--nodes #{conn_uri('docker')}] }
+    let(:config_flags) { %W[--targets #{uri}] }
+    let(:single_target_conf) { %W[--targets #{conn_uri('docker')}] }
     let(:interpreter_task) { 'sample::interpreter' }
     let(:interpreter_ext) do
       { 'interpreters' => {

--- a/spec/integration/inventory2_spec.rb
+++ b/spec/integration/inventory2_spec.rb
@@ -72,7 +72,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
      '--password', conn[:password]]
   }
 
-  let(:run_command) { ['command', 'run', shell_cmd, '--nodes', target] + config_flags }
+  let(:run_command) { ['command', 'run', shell_cmd, '--targets', target] + config_flags }
 
   let(:run_plan) { ['plan', 'run', 'inventory', "command=#{shell_cmd}", "host=#{target}"] + config_flags }
 
@@ -117,7 +117,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
   context 'when running a plan' do
     let(:run_plan) { ['plan', 'run', 'inventory::get_host'] + config_flags }
     it 'can access the host' do
-      r = run_cli_json(run_plan + ['--nodes', 'hostless'])
+      r = run_cli_json(run_plan + ['--targets', 'hostless'])
       expect(r).to eq('result' => nil)
     end
   end
@@ -295,7 +295,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
     end
 
     it 'computes facts and vars based on group hierarchy' do
-      plan = ['plan', 'run', 'add_group::inventory2', '--nodes', 'add_me'] + config_flags
+      plan = ['plan', 'run', 'add_group::inventory2', '--targets', 'add_me'] + config_flags
       expected_hash_pre = { 'top_level' => 'keep',
                             'preserve_hierarchy' => 'keep',
                             'parent' => 'keep',
@@ -318,14 +318,14 @@ describe 'running with an inventory file', reset_puppet_settings: true do
     end
 
     it 'errors when trying to add to non-existent group' do
-      plan = ['plan', 'run', 'add_group::x_fail_non_existent_group', '--nodes', 'add_me'] + config_flags
+      plan = ['plan', 'run', 'add_group::x_fail_non_existent_group', '--targets', 'add_me'] + config_flags
       result = run_cli_json(plan)
       expect(result['kind']).to eq('bolt.inventory/validation-error')
       expect(result['msg']).to match(/Group does_not_exist does not exist in inventory/)
     end
 
     it 'errors when trying to add new target with name that conflicts with group name' do
-      plan = ['plan', 'run', 'add_group::x_fail_group_name_exists', '--nodes', 'add_me'] + config_flags
+      plan = ['plan', 'run', 'add_group::x_fail_group_name_exists', '--targets', 'add_me'] + config_flags
       result = run_cli_json(plan)
       expect(result['kind']).to eq('bolt.inventory/validation-error')
       expect(result['msg']).to match(/Group foo conflicts with target of the same name for group/)
@@ -362,7 +362,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
     end
 
     it 'passes the correct host to the task' do
-      task = ['task', 'run', 'remote', '--nodes', 'remote_target'] + config_flags
+      task = ['task', 'run', 'remote', '--targets', 'remote_target'] + config_flags
 
       result = run_one_node(task)
       expect(result['_target']).to include('host' => 'not.the.name')
@@ -440,7 +440,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
 
         it 'uses tmpdir' do
           with_tempfile_containing('script', 'echo "`dirname $0`"', '.sh') do |f|
-            run_script = ['script', 'run', f.path, '--nodes', target] + config_flags
+            run_script = ['script', 'run', f.path, '--targets', target] + config_flags
             expect(run_one_node(run_script)['stdout'].strip).to match(/#{Regexp.escape(tmpdir)}/)
           end
         end
@@ -467,7 +467,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
 
         it 'uses tmpdir' do
           with_tempfile_containing('script', 'echo "`dirname $0`"', '.sh') do |f|
-            run_script = ['script', 'run', f.path, '--nodes', target] + config_flags
+            run_script = ['script', 'run', f.path, '--targets', target] + config_flags
             expect(run_one_node(run_script)['stdout'].strip).to match(/#{Regexp.escape(tmpdir)}/)
           end
         end
@@ -655,7 +655,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
 
       expect(STDOUT).to receive(:print).with("password please:").once
 
-      result = run_one_node(['command', 'run', shell_cmd, '--nodes', 'target-1'] + config_flags)
+      result = run_one_node(['command', 'run', shell_cmd, '--targets', 'target-1'] + config_flags)
       expect(result).to include('stdout' => "bolt\n")
     end
   end

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -50,11 +50,11 @@ describe 'running with an inventory file', reset_puppet_settings: true do
      '--password', conn[:password]]
   }
 
-  let(:run_command) { ['command', 'run', shell_cmd, '--nodes', target] + config_flags }
+  let(:run_command) { ['command', 'run', shell_cmd, '--targets', target] + config_flags }
 
   let(:run_plan) { ['plan', 'run', 'inventory', "command=#{shell_cmd}", "host=#{target}"] + config_flags }
 
-  let(:show_inventory) { ['inventory', 'show', '--nodes', target] + config_flags }
+  let(:show_inventory) { ['inventory', 'show', '--targets', target] + config_flags }
   let(:show_group) { %w[group show] + config_flags }
 
   around(:each) do |example|
@@ -235,7 +235,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
     end
 
     it 'computes facts and vars based on group hierarchy' do
-      plan = ['plan', 'run', 'add_group', '--nodes', 'add_me'] + config_flags
+      plan = ['plan', 'run', 'add_group', '--targets', 'add_me'] + config_flags
       expected_hash_pre = { 'top_level' => 'keep',
                             'preserve_hierarchy' => 'keep',
                             'parent' => 'keep',
@@ -256,14 +256,14 @@ describe 'running with an inventory file', reset_puppet_settings: true do
     end
 
     it 'errors when trying to add to non-existent group' do
-      plan = ['plan', 'run', 'add_group::x_fail_non_existent_group', '--nodes', 'add_me'] + config_flags
+      plan = ['plan', 'run', 'add_group::x_fail_non_existent_group', '--targets', 'add_me'] + config_flags
       result = run_cli_json(plan)
       expect(result['kind']).to eq('bolt.inventory/validation-error')
       expect(result['msg']).to match(/Group does_not_exist does not exist in inventory/)
     end
 
     it 'errors when trying to add new target with name that conflicts with group name' do
-      plan = ['plan', 'run', 'add_group::x_fail_group_name_exists', '--nodes', 'add_me'] + config_flags
+      plan = ['plan', 'run', 'add_group::x_fail_group_name_exists', '--targets', 'add_me'] + config_flags
       result = run_cli_json(plan)
       expect(result['kind']).to eq('bolt.inventory/validation-error')
       expect(result['msg']).to match(/Group foo conflicts with node of the same name for group/)
@@ -354,7 +354,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
 
         it 'uses tmpdir' do
           with_tempfile_containing('script', 'echo "`dirname $0`"', '.sh') do |f|
-            run_script = ['script', 'run', f.path, '--nodes', target] + config_flags
+            run_script = ['script', 'run', f.path, '--targets', target] + config_flags
             expect(run_one_node(run_script)['stdout'].strip).to match(/#{Regexp.escape(tmpdir)}/)
           end
         end
@@ -380,7 +380,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
 
         it 'uses tmpdir' do
           with_tempfile_containing('script', 'echo "`dirname $0`"', '.sh') do |f|
-            run_script = ['script', 'run', f.path, '--nodes', target] + config_flags
+            run_script = ['script', 'run', f.path, '--targets', target] + config_flags
             expect(run_one_node(run_script)['stdout'].strip).to match(/#{Regexp.escape(tmpdir)}/)
           end
         end

--- a/spec/integration/local_spec.rb
+++ b/spec/integration/local_spec.rb
@@ -20,16 +20,16 @@ describe "when running over the local transport" do
   context 'when using CLI options' do
     let(:echo) { "echo hi" }
     let(:config_flags) {
-      %W[--nodes localhost --format json --modulepath #{modulepath}]
+      %W[--targets localhost --format json --modulepath #{modulepath}]
     }
 
     it 'runs multiple commands' do
-      result = run_nodes(%W[command run #{echo} --nodes #{uri} --format json])
+      result = run_nodes(%W[command run #{echo} --targets #{uri} --format json])
       expect(result.map { |r| r['stdout'].strip }).to eq(%w[hi hi])
     end
 
     it 'reports errors when command fails' do
-      result = run_failed_nodes(%W[command run boop --nodes #{uri} --format json])
+      result = run_failed_nodes(%W[command run boop --targets #{uri} --format json])
       expect(result[0]['_error']).to be
     end
 
@@ -42,12 +42,12 @@ describe "when running over the local transport" do
 
   context 'when using CLI options on POSIX OS', bash: true do
     let(:config_flags) {
-      %W[--nodes #{uri} --format json --modulepath #{modulepath}]
+      %W[--targets #{uri} --format json --modulepath #{modulepath}]
     }
 
     it 'runs script with parameter', :reset_puppet_settings do
       with_tempfile_containing('script', "#!/usr/bin/env bash \n echo $1", '.sh') do |script|
-        results = run_cli_json(%W[script run #{script.path} param --nodes localhost])
+        results = run_cli_json(%W[script run #{script.path} param --targets localhost])
         results['items'].each do |result|
           expect(result['status']).to eq('success')
           expect(result['result']).to eq("stdout" => "param\n", "stderr" => "", "exit_code" => 0)
@@ -88,7 +88,7 @@ describe "when running over the local transport" do
 
   context 'runs as an escalated user', sudo: true do
     let(:config_flags) {
-      %W[--nodes #{uri} --format json --modulepath #{modulepath}] +
+      %W[--targets #{uri} --format json --modulepath #{modulepath}] +
         %W[--run-as #{sudo_user} --sudo-password #{sudo_password}]
     }
 
@@ -110,7 +110,7 @@ describe "when running over the local transport" do
 
   context 'when using CLI options on Windows OS', windows: true do
     let(:config_flags) {
-      %W[--nodes localhost --format json --modulepath #{modulepath}]
+      %W[--targets localhost --format json --modulepath #{modulepath}]
     }
 
     it 'runs powershell script with parameter', :reset_puppet_settings do

--- a/spec/integration/logging_spec.rb
+++ b/spec/integration/logging_spec.rb
@@ -21,7 +21,7 @@ describe "when logging executor activity", ssh: true do
   let(:lines) { @log_output.readlines }
 
   let(:config_flags) {
-    %W[--nodes #{uri} --no-host-key-check --format json --modulepath #{modulepath} --password #{password}]
+    %W[--targets #{uri} --no-host-key-check --format json --modulepath #{modulepath} --password #{password}]
   }
 
   before :each do

--- a/spec/integration/parsing_spec.rb
+++ b/spec/integration/parsing_spec.rb
@@ -20,7 +20,7 @@ describe "CLI parses input" do
   it 'parses plan parameters' do
     params = ['string=foo',
               'string_bool="true"',
-              '--nodes', 'foo', '--nodes', 'bar',
+              '--targets', 'foo', '--targets', 'bar',
               'array=[1, 2, 3]',
               'hash={"this": "that"}']
     result = run_cli_json(%w[plan run parsing] + params + config_flags)
@@ -50,7 +50,7 @@ describe "CLI parses input" do
   it 'fails with invalid plan params' do
     params = ['string=foo',
               'string_bool="true"',
-              '--nodes', 'foo', '--nodes', 'bar',
+              '--targets', 'foo', '--targets', 'bar',
               'array=13',
               'hash={"this": "that"}']
     result = run_cli_json(%w[plan run parsing] + params + config_flags, rescue_exec: true)
@@ -60,7 +60,7 @@ describe "CLI parses input" do
   it 'parses plan parameters' do
     params = ['string=false',
               'string_bool=true',
-              '--nodes', 'foo,bar',
+              '--targets', 'foo,bar',
               'array=[13]',
               'hash={"this": "that"}']
     result = run_cli_json(%w[plan run parsing] + params + config_flags, rescue_exec: true)
@@ -78,7 +78,7 @@ describe "CLI parses input" do
       'string_bool="true"',
       'array=[1, 2, 3]'
     ]
-    result = run_one_node(['task', 'run', 'parsing', '--nodes', target] + params + config_flags)
+    result = run_one_node(['task', 'run', 'parsing', '--targets', target] + params + config_flags)
     expect(result).to eq("string_bool" => "true",
                          "array" => [1, 2, 3],
                          "_task" => "parsing")
@@ -90,13 +90,13 @@ describe "CLI parses input" do
       'array="123"',
       '_task="parsing"'
     ]
-    result = run_cli_json(['task', 'run', 'parsing', '--nodes', target] + params + config_flags, rescue_exec: true)
+    result = run_cli_json(['task', 'run', 'parsing', '--targets', target] + params + config_flags, rescue_exec: true)
     expect(result['_error']['msg']).to eq("Task parsing:\n parameter 'array' expects an Array value, got String")
   end
 
   it 'parses script parameters without munging task parameters', ssh: true do
     params = ['dont=split']
-    result = run_one_node(['script', 'run', script_path, '--nodes', target] + params + config_flags)
+    result = run_one_node(['script', 'run', script_path, '--targets', target] + params + config_flags)
     expect(result['stdout']).to match(/dont=split/)
   end
 end

--- a/spec/integration/plan_spec.rb
+++ b/spec/integration/plan_spec.rb
@@ -30,7 +30,7 @@ describe "When a plan succeeds" do
   end
 
   it 'prints a placeholder if no result is returned', ssh: true do
-    result = run_cli(['plan', 'run', 'sample::single_task', '--nodes', target] + config_flags,
+    result = run_cli(['plan', 'run', 'sample::single_task', '--targets', target] + config_flags,
                      outputter: Bolt::Outputter::JSON)
     json = JSON.parse(result)[0]
     expect(json['node']).to eq(target.to_s)
@@ -38,7 +38,7 @@ describe "When a plan succeeds" do
   end
 
   it 'prints a placeholder if no result is returned', ssh: true do
-    result = run_cli(['plan', 'run', 'sample::single_task', '--nodes', target] + config_flags,
+    result = run_cli(['plan', 'run', 'sample::single_task', '--targets', target] + config_flags,
                      outputter: Bolt::Outputter::Human)
     expect(result).to match(/got passed the message: hi there/)
     expect(result).to match(/Successful on 1 node:/)
@@ -46,7 +46,7 @@ describe "When a plan succeeds" do
   end
 
   it 'runs a yaml plan', ssh: true do
-    result = run_cli(['plan', 'run', 'sample::yaml', '--nodes', target] + config_flags)
+    result = run_cli(['plan', 'run', 'sample::yaml', '--targets', target] + config_flags)
     expect(JSON.parse(result)).to eq('stdout' => "hello world\n", 'stderr' => '', 'exit_code' => 0)
   end
 
@@ -64,7 +64,7 @@ describe "When a plan succeeds" do
     it 'runs registers types defined in $Boltdir/.resource_types', ssh: true do
       # generate types based and save in boltdir (based on value of --configfile)
       run_cli(%w[puppetfile generate-types] + config_flags)
-      result = run_cli(['plan', 'run', 'resource_types', '--nodes', target] + config_flags)
+      result = run_cli(['plan', 'run', 'resource_types', '--targets', target] + config_flags)
       expect(JSON.parse(result)).to eq('built-in' => 'success', 'core' => 'success', 'custom' => 'success')
     end
   end

--- a/spec/integration/plugin/task_spec.rb
+++ b/spec/integration/plugin/task_spec.rb
@@ -221,7 +221,7 @@ describe 'using the task plugin' do
     context 'with a failing task' do
       it 'fails cleanly' do
         result = run_cli_json(['plan', 'run',
-                               'test_plan', '--nodes', 'agentless', '--boltdir', boltdir],
+                               'test_plan', '--targets', 'agentless', '--boltdir', boltdir],
                               rescue_exec: true)
 
         expect(result).to include('kind' => "bolt/run-failure")
@@ -237,7 +237,7 @@ describe 'using the task plugin' do
 
       it 'fails cleanly' do
         result = run_cli_json(['plan', 'run',
-                               'test_plan', '--nodes', 'agentless', '--boltdir', boltdir],
+                               'test_plan', '--targets', 'agentless', '--boltdir', boltdir],
                               rescue_exec: true)
 
         expect(result).to include('kind' => "bolt/run-failure")
@@ -253,7 +253,7 @@ describe 'using the task plugin' do
 
       it 'fails cleanly' do
         result = run_cli_json(['plan', 'run',
-                               'test_plan', '--nodes', 'agentless', '--boltdir', boltdir],
+                               'test_plan', '--targets', 'agentless', '--boltdir', boltdir],
                               rescue_exec: true)
 
         expect(result).to include('kind' => "bolt/run-failure")

--- a/spec/integration/shareable_task_spec.rb
+++ b/spec/integration/shareable_task_spec.rb
@@ -8,7 +8,7 @@ describe "Shareable tasks with files", bash: true do
   include BoltSpec::Integration
 
   let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
-  let(:config_flags) { %W[--format json --nodes localhost --modulepath #{modulepath}] }
+  let(:config_flags) { %W[--format json --targets localhost --modulepath #{modulepath}] }
 
   it 'runs a task with multiple files' do
     result = run_cli_json(%w[task run shareable] + config_flags)

--- a/spec/integration/ssh_spec.rb
+++ b/spec/integration/ssh_spec.rb
@@ -21,7 +21,7 @@ describe "when runnning over the ssh transport", ssh: true do
 
   context 'when using CLI options' do
     let(:config_flags) {
-      %W[--nodes #{uri} --no-host-key-check --format json --modulepath #{modulepath} --password #{password}]
+      %W[--targets #{uri} --no-host-key-check --format json --modulepath #{modulepath} --password #{password}]
     }
 
     it 'runs a command' do
@@ -93,8 +93,8 @@ describe "when runnning over the ssh transport", ssh: true do
     end
 
     let(:uri) { (1..2).map { |i| "#{conn_uri('ssh')}?id=#{i}" }.join(',') }
-    let(:config_flags) { %W[--nodes #{uri}] }
-    let(:single_target_conf) { %W[--nodes #{conn_uri('ssh')}] }
+    let(:config_flags) { %W[--targets #{uri}] }
+    let(:single_target_conf) { %W[--targets #{conn_uri('ssh')}] }
     let(:interpreter_task) { 'sample::interpreter' }
     let(:interpreter_ext) do
       { 'interpreters' => {

--- a/spec/integration/task_param.rb
+++ b/spec/integration/task_param.rb
@@ -9,7 +9,7 @@ describe "Passes the _task metaparameter" do
   include BoltSpec::Conn
 
   let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
-  let(:config_flags) { %W[--format json --nodes #{target} --modulepath #{modulepath}] }
+  let(:config_flags) { %W[--format json --targets #{target} --modulepath #{modulepath}] }
 
   describe 'over ssh', ssh: true do
     let(:target) { conn_uri('ssh', include_password: true) }

--- a/spec/integration/winrm_spec.rb
+++ b/spec/integration/winrm_spec.rb
@@ -17,7 +17,7 @@ describe "when runnning over the winrm transport", winrm: true do
 
   context 'when using CLI options' do
     let(:config_flags) {
-      %W[--nodes #{uri} --no-ssl --no-ssl-verify --format json --modulepath #{modulepath}
+      %W[--targets #{uri} --no-ssl --no-ssl-verify --format json --modulepath #{modulepath}
          --password #{password}]
     }
 
@@ -99,8 +99,8 @@ describe "when runnning over the winrm transport", winrm: true do
       }
     }
     let(:uri) { (1..2).map { |i| "#{conn_uri('winrm')}?id=#{i}" }.join(',') }
-    let(:config_flags) { %W[--nodes #{uri}] }
-    let(:single_target_conf) { %W[--nodes #{conn_uri('winrm')}] }
+    let(:config_flags) { %W[--targets #{uri}] }
+    let(:single_target_conf) { %W[--targets #{conn_uri('winrm')}] }
     let(:interpreter_task) { 'sample::bolt_ruby' }
     let(:interpreter_ext) do
       { 'interpreters' => {


### PR DESCRIPTION
This adds a deprecation warning for `--nodes` to let users know the CLI
option has been deprecated in favor of `--targets`.

Closes https://github.com/puppetlabs/bolt/issues/1375