### PR TITLE
(GH-1350) Configure plugins using other plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,17 @@
   Bolt now accepts the `_run_as` metaparameter for puppet_library hooks. `_run_as` specifies which user the library install task will be executed as.
 
 * **Added `--password-prompt` and `--sudo-password-prompt` to CLI flags** ([#1269](https://github.com/puppetlabs/bolt/issues/1269))
+
   Two new flags have been added to support users who would like to set a `password` or `sudo-password` from a prompt without using a plugin. A deprecation message will appear when a value is not supplied for `--password` or `--sudo-password`.
 
 * **Subcommand `project migrate` new to the CLI** ([#1377](https://github.com/puppetlabs/bolt/issues/1377))
 
   The CLI now provides the subcommand `project migrate` which migrates Bolt projects to the latest version. When migrating a project the [inventory file](https://puppet.com/docs/bolt/latest/inventory_file.html) will be changed from `v1` to `v2`. Changes are made in place and will not preserve comments or formatting.
+
+* **Plugin support in `bolt.yml`** ([#1381](https://github.com/puppetlabs/bolt/pull/1381))
+
+  Plugin configuration can now be set by looking up data from other plugins. For example, the password for one plugin can be queried from another plugin.
+
 
 ## Bug fixes
 

--- a/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
@@ -14,7 +14,7 @@ describe 'apply_prep' do
   include PuppetlabsSpec::Fixtures
   let(:applicator) { mock('Bolt::Applicator') }
   let(:executor) { Bolt::Executor.new(1, Bolt::Analytics::NoopClient.new) }
-  let(:plugins) { Bolt::Plugin.new(nil, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(Bolt::Config.default, nil, nil, Bolt::Analytics::NoopClient.new) }
   let(:plugin_result) { {} }
   let(:task_hook) { proc { |_opts, target, _fun| proc { Bolt::Result.new(target, value: plugin_result) } } }
   let(:inventory) { Bolt::Inventory.create_version({}, nil, plugins) }
@@ -171,7 +171,7 @@ describe 'apply_prep' do
 
       let(:config) { Bolt::Config.new(Bolt::Boltdir.new('.'), {}) }
       let(:pal) { nil }
-      let(:plugins) { Bolt::Plugin.new(config, pal, Bolt::Analytics::NoopClient.new) }
+      let(:plugins) { Bolt::Plugin.setup(config, pal, nil, Bolt::Analytics::NoopClient.new) }
       let(:inventory) { Bolt::Inventory.create_version(data, config, plugins) }
       let(:target) { inventory.get_target(hostname) }
       let(:targets) { inventory.get_targets(hostname) }

--- a/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
@@ -116,7 +116,7 @@ describe 'run_plan' do
   context 'with inventory v2' do
     let(:config) { Bolt::Config.new(Bolt::Boltdir.new('.'), {}) }
     let(:pal) { nil }
-    let(:plugins) { Bolt::Plugin.new(config, pal, Bolt::Analytics::NoopClient.new) }
+    let(:plugins) { Bolt::Plugin.setup(config, pal, nil, Bolt::Analytics::NoopClient.new) }
     let(:inventory) { Bolt::Inventory.create_version({ 'version' => 2 }, config, plugins) }
 
     it 'parameters with type TargetSpec are added to inventory' do

--- a/documentation/bolt_configuration_options.md
+++ b/documentation/bolt_configuration_options.md
@@ -244,3 +244,14 @@ plugin_hooks:
       master: 'puppet.example.com'
       cacert_content: <CERT>
 ```
+
+You can also configure `plugin_hooks` using `_plugin` references:
+
+```yaml
+plugin_hooks:
+  puppet_library:
+    plugin: puppet_agent
+    version:
+      _plugin: prompt
+      message: "Which version of Puppet do you want to install?"
+```

--- a/documentation/using_plugins.md
+++ b/documentation/using_plugins.md
@@ -94,6 +94,26 @@ plugins:
     private-key: ~/bolt_private_key.pem
 ```
 
+Plugin configuration can be derived from other plugins using `_plugin` references. For example, you can encrypt the credentials used to configure the `vault` plugin.
+
+```
+plugins:
+  vault:
+    auth:
+      token:
+        _plugin: pkcs7
+        encrypted_value: |
+              ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEw
+              DQYJKoZIhvcNAQEBBQAEggEARQNZqnN8ByTelBjokvkgOemMxyjmblWga8g6
+              y0nYfmA5Hdqj1nC/wIJTZafbmfzCEtUQZ+Hf70YPV04OYy7PU1WtYp0u/B0t
+              YCX7GgWHoXUSrEV+YtGyIpoa/pStvzzP12CBIaXwGh62TP6ZSbRnr/q/pnfk
+              mOx6HghUoNXfKBLW+sq8KgyNN1DJDTl0KubHVLnJvTc1jjHX7YK+qxV4eb3B
+              yklwuaDziPd+pipQOcUfjMnVW45THRUzE06iI8Q+DqVGA7/RsTEdG0HGtj5h
+              P7i5wLUdZ2AhYBkP1sacW7yiUjqwPjwMwx0T/xn/DqVW02QOjFgqsaSwi1CD
+              MOA3pDBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBC87Iy6lvqGicslM6si
+              994ogCDRAeJgS/0HTaFdhjdxC8CmMCADl7qVgxKDf1ztpXznyg==]
+```
+
 ## Bundled plugins
 
 Bolt ships with a few plugins out of the box: task, puppetdb, terraform, azure_inventory, aws ec2, prompt, pkcs7, and vault.

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -526,6 +526,7 @@ module Bolt
     end
 
     def apply_manifest(code, targets, filename = nil, noop = false)
+      Puppet[:tasks] = false
       ast = pal.parse_manifest(code, filename)
 
       executor = Bolt::Executor.new(config.concurrency, analytics, noop)

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -71,7 +71,7 @@ module Bolt
       @save_rerun = true
       @puppetfile_config = {}
       @plugins = {}
-      @plugin_hooks = { 'puppet_library' => { 'plugin' => 'puppet_agent', 'stop_service' => true } }
+      @plugin_hooks = {}
 
       # add an entry for the default console logger
       @log = { 'console' => {} }
@@ -167,7 +167,7 @@ module Bolt
       @save_rerun = data['save-rerun'] if data.key?('save-rerun')
 
       @plugins = data['plugins'] if data.key?('plugins')
-      @plugin_hooks.merge!(data['plugin_hooks']) if data.key?('plugin_hooks')
+      @plugin_hooks = data['plugin_hooks'] if data.key?('plugin_hooks')
 
       %w[concurrency format puppetdb color].each do |key|
         send("#{key}=", data[key]) if data.key?(key)

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -234,7 +234,7 @@ module Bolt
       set_facts(target.name, data['facts']) unless @target_facts[target.name]
       data['features']&.each { |feature| set_feature(target, feature) } unless @target_features[target.name]
       unless @target_plugin_hooks[target.name]
-        set_plugin_hooks(target.name, (@plugins&.default_plugin_hooks || {}).merge(data['plugin_hooks'] || {}))
+        set_plugin_hooks(target.name, (@plugins&.plugin_hooks || {}).merge(data['plugin_hooks'] || {}))
       end
 
       # Use Config object to ensure config section is treated consistently with config file

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -234,7 +234,7 @@ module Bolt
       set_facts(target.name, data['facts']) unless @target_facts[target.name]
       data['features']&.each { |feature| set_feature(target, feature) } unless @target_features[target.name]
       unless @target_plugin_hooks[target.name]
-        set_plugin_hooks(target.name, @config.plugin_hooks.merge(data['plugin_hooks'] || {}))
+        set_plugin_hooks(target.name, (@plugins&.default_plugin_hooks || {}).merge(data['plugin_hooks'] || {}))
       end
 
       # Use Config object to ensure config section is treated consistently with config file

--- a/lib/bolt/inventory/target.rb
+++ b/lib/bolt/inventory/target.rb
@@ -78,7 +78,7 @@ module Bolt
       def plugin_hooks
         # Merge plugin_hooks from the config file with any defined by the group
         # or assigned dynamically to the target
-        @inventory.plugins.default_plugin_hooks.merge(group_cache['plugin_hooks']).merge(@plugin_hooks)
+        @inventory.plugins.plugin_hooks.merge(group_cache['plugin_hooks']).merge(@plugin_hooks)
       end
 
       def set_config(key_or_key_path, value)

--- a/lib/bolt/inventory/target.rb
+++ b/lib/bolt/inventory/target.rb
@@ -78,7 +78,7 @@ module Bolt
       def plugin_hooks
         # Merge plugin_hooks from the config file with any defined by the group
         # or assigned dynamically to the target
-        @inventory.config.plugin_hooks.merge(group_cache['plugin_hooks']).merge(@plugin_hooks)
+        @inventory.plugins.default_plugin_hooks.merge(group_cache['plugin_hooks']).merge(@plugin_hooks)
       end
 
       def set_config(key_or_key_path, value)

--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -137,16 +137,17 @@ module Bolt
         plugins.by_name(plugin)
       end
 
-      plugins.default_plugin_hooks = plugins.resolve_references(config.plugin_hooks)
+      plugins.plugin_hooks.merge!(plugins.resolve_references(config.plugin_hooks))
 
       plugins
     end
 
     RUBY_PLUGINS = %w[install_agent task pkcs7 prompt].freeze
     BUILTIN_PLUGINS = %w[task terraform pkcs7 prompt vault aws_inventory puppetdb azure_inventory].freeze
+    DEFAULT_PLUGIN_HOOKS = { 'puppet_library' => { 'plugin' => 'puppet_agent', 'stop_service' => true } }.freeze
 
     attr_reader :pal, :plugin_context
-    attr_accessor :default_plugin_hooks
+    attr_accessor :plugin_hooks
 
     private_class_method :new
 
@@ -159,7 +160,7 @@ module Bolt
       @unknown = Set.new
       @resolution_stack = []
       @unresolved_plugin_configs = config.plugins.dup
-      @default_plugin_hooks = {}
+      @plugin_hooks = DEFAULT_PLUGIN_HOOKS.dup
     end
 
     def modules

--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -177,12 +177,6 @@ module Bolt
       add_plugin(plugin)
     end
 
-    def add_from_config
-      @config.plugins.keys.each do |plugin_name|
-        by_name(plugin_name)
-      end
-    end
-
     def config_for_plugin(plugin_name)
       @config.plugins[plugin_name] || {}
     end

--- a/lib/bolt/plugin/prompt.rb
+++ b/lib/bolt/plugin/prompt.rb
@@ -20,7 +20,7 @@ module Bolt
 
       def resolve_reference(opts)
         # rubocop:disable Style/GlobalVars
-        $future ? STDERR.print("#{opts['message']}:") : STDOUT.print("#{opts['message']}:")
+        $future ? STDERR.print("#{opts['message']}: ") : STDOUT.print("#{opts['message']}: ")
         value = STDIN.noecho(&:gets).chomp
         $future ? STDERR.puts : STDOUT.puts
         # rubocop:enable Style/GlobalVars

--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -204,6 +204,10 @@ module Bolt
         File.stat(File.expand_path(path))
       end
 
+      def snake_name_to_class_name(snake_name)
+        snake_name.split('_').map(&:capitalize).join
+      end
+
       def class_name_to_file_name(cls_name)
         # Note this turns Bolt::CLI -> 'bolt/cli' not 'bolt/c_l_i'
         # this won't handle Bolt::Inventory2Foo

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1818,7 +1818,7 @@ describe "Bolt::CLI" do
                                                      anything,
                                                      true).and_return(executor)
 
-        plugins = Bolt::Plugin.new(nil, nil, nil)
+        plugins = Bolt::Plugin.setup(Bolt::Config.default, nil, nil, nil)
         allow(cli).to receive(:plugins).and_return(plugins)
 
         outputter = Bolt::Outputter::JSON.new(false, false, false, output)

--- a/spec/bolt/inventory/group2_spec.rb
+++ b/spec/bolt/inventory/group2_spec.rb
@@ -13,7 +13,7 @@ describe Bolt::Inventory::Group2 do
 
   let(:data) { { 'name' => 'all' } }
   let(:pal) { nil } # Not used
-  let(:plugins) { Bolt::Plugin.new(config, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config, nil, nil, Bolt::Analytics::NoopClient.new) }
   let(:group) {
     # Inventory always resolves unknown labels to names or aliases from the top-down when constructed,
     # passing the collection of all aliases in it. Do that manually here to ensure plain target strings
@@ -764,7 +764,7 @@ describe Bolt::Inventory::Group2 do
     let(:pal) { Bolt::PAL.new(modulepath, nil, nil) }
 
     let(:plugins) do
-      plugins = Bolt::Plugin.new(config, pal, Bolt::Analytics::NoopClient.new)
+      plugins = Bolt::Plugin.setup(config, pal, nil, Bolt::Analytics::NoopClient.new)
       plugins.add_plugin(BoltSpec::Plugins::Constant.new)
       plugins.add_plugin(BoltSpec::Plugins::Error.new)
       plugins.add_plugin(BoltSpec::Plugins::TestLookup.new(lookup_data))

--- a/spec/bolt/inventory/inventory2_spec.rb
+++ b/spec/bolt/inventory/inventory2_spec.rb
@@ -16,7 +16,7 @@ describe Bolt::Inventory::Inventory2 do
   end
 
   let(:pal) { nil } # Not used
-  let(:plugins) { Bolt::Plugin.new(config, pal, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config, pal, nil, Bolt::Analytics::NoopClient.new) }
   let(:target_name) { "example.com" }
   let(:target_entry) { target_name }
   let(:targets) { [target_entry] }
@@ -1250,7 +1250,7 @@ describe Bolt::Inventory::Inventory2 do
     }
 
     let(:plugins) do
-      plugins = Bolt::Plugin.new(nil, pal, Bolt::Analytics::NoopClient.new)
+      plugins = Bolt::Plugin.setup(config, pal, nil, Bolt::Analytics::NoopClient.new)
       plugin = double('plugin')
       allow(plugin).to receive(:name).and_return('test_plugin')
       allow(plugin).to receive(:hooks).and_return([:resolve_reference])

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -21,7 +21,7 @@ describe Bolt::Inventory do
   end
 
   let(:pal) { nil } # Not used
-  let(:plugins) { Bolt::Plugin.new(config, pal, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config, pal, nil, Bolt::Analytics::NoopClient.new) }
 
   let(:data) {
     {

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -759,7 +759,7 @@ describe Bolt::Inventory do
       }] }
     }
 
-    let(:inventory) { Bolt::Inventory.new(data) }
+    let(:inventory) { Bolt::Inventory.new(data, plugins: plugins) }
     let(:target) { get_target(inventory, 'foo') }
     let(:expected_data) {
       { 'name' => 'foo',

--- a/spec/bolt/plugin/module_spec.rb
+++ b/spec/bolt/plugin/module_spec.rb
@@ -15,7 +15,7 @@ describe Bolt::Plugin::Module do
   let(:config_data) { { 'modulepath' => modulepath, 'plugins' => plugin_config } }
 
   let(:pal) { Bolt::PAL.new(modulepath, {}, nil) }
-  let(:plugins) { Bolt::Plugin.new(config(config_data), pal, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config(config_data), pal, nil, Bolt::Analytics::NoopClient.new) }
 
   let(:module_name) { 'empty_plug' }
   let(:mod) { Bolt::Module.new(module_name, fixtures_path('plugin_modules', module_name)) }

--- a/spec/bolt/plugin/prompt_spec.rb
+++ b/spec/bolt/plugin/prompt_spec.rb
@@ -21,7 +21,7 @@ describe Bolt::Plugin::Prompt do
   it 'concurrent delay prompts for data on STDOUT when executed' do
     allow(STDIN).to receive(:noecho).and_return(password)
     allow(STDOUT).to receive(:puts)
-    expect(STDOUT).to receive(:print).with("#{prompt_data['message']}:")
+    expect(STDOUT).to receive(:print).with("#{prompt_data['message']}: ")
 
     val = subject.resolve_reference(prompt_data)
     expect(val).to eq(password)
@@ -34,7 +34,7 @@ describe Bolt::Plugin::Prompt do
 
     allow(STDIN).to receive(:noecho).and_return(password)
     allow(STDERR).to receive(:puts)
-    expect(STDERR).to receive(:print).with("#{prompt_data['message']}:")
+    expect(STDERR).to receive(:print).with("#{prompt_data['message']}: ")
 
     val = subject.resolve_reference(prompt_data)
     expect(val).to eq(password)

--- a/spec/bolt/plugin_spec.rb
+++ b/spec/bolt/plugin_spec.rb
@@ -76,7 +76,29 @@ describe Bolt::Plugin do
           'param' => identity('foobar')
         }
       }
-      expect(plugins.default_plugin_hooks['puppet_library']).to eq('plugin' => 'my_hook', 'param' => 'foobar')
+      expect(plugins.plugin_hooks['puppet_library']).to eq('plugin' => 'my_hook', 'param' => 'foobar')
+    end
+
+    it 'allows the whole plugin_hooks value to be set with a reference' do
+      hooks = {
+        'another_hook' => {
+          'plugin' => 'my_hook',
+          'param' => identity('foobar')
+        }
+      }
+
+      config_data['plugin_hooks'] = identity(hooks)
+
+      expect(plugins.plugin_hooks).to eq(
+        'another_hook' => {
+          'plugin' => 'my_hook',
+          'param' => 'foobar'
+        },
+        'puppet_library' => {
+          'plugin' => 'puppet_agent',
+          'stop_service' => true
+        }
+      )
     end
   end
 end

--- a/spec/bolt/plugin_spec.rb
+++ b/spec/bolt/plugin_spec.rb
@@ -7,8 +7,7 @@ require 'bolt/pal'
 require 'bolt/plugin'
 require 'bolt/analytics'
 
-# TODO: This is probably just for Bolt::Plugin::Module
-describe Bolt::Plugin::Module do
+describe Bolt::Plugin do
   include BoltSpec::Files
   include BoltSpec::Config
 
@@ -16,8 +15,16 @@ describe Bolt::Plugin::Module do
   let(:plugin_config) { {} }
   let(:config_data) { { 'modulepath' => modulepath, 'plugins' => plugin_config } }
   let(:pal) { Bolt::PAL.new(modulepath, nil, nil) }
+  let(:pdb_client) { double('pdb_client') }
 
-  let(:plugins) { Bolt::Plugin.new(config(config_data), pal, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config(config_data), pal, pdb_client, Bolt::Analytics::NoopClient.new) }
+
+  def identity(value)
+    {
+      '_plugin' => 'identity',
+      'value' => value
+    }
+  end
 
   it 'loads an empty plugin module' do
     expect(plugins.by_name('empty_plug').hooks).to eq([:validate_resolve_reference])
@@ -35,5 +42,29 @@ describe Bolt::Plugin::Module do
     expect(hooks).to include(:resolve_reference)
     expect(hooks).to include(:createkeys)
     expect(hooks).not_to include(:decrypt)
+  end
+
+  context 'evaluating plugin config' do
+    it 'lets a plugin depend on another plugin' do
+      plugin_config.replace('pkcs7' => { 'keysize' => identity(1024) })
+      expect(plugins.by_name('pkcs7').keysize).to eq(1024)
+    end
+
+    it 'fails if a plugin depends on itself' do
+      plugin_config.replace('identity' => { 'foo' => identity('bar') })
+      expect { plugins }.to raise_error(/Configuration for plugin 'identity' depends on the plugin itself/)
+    end
+
+    it 'fails if an indirect plugin dependency cycle is found' do
+      plugin_config.replace('pkcs7' => { 'keysize' => identity(1024) },
+                            'identity' => { 'foo' => { '_plugin' => 'pkcs7' } })
+      expect { plugins }.to raise_error(/Configuration for plugin 'pkcs7' depends on the plugin itself/)
+    end
+
+    it 'fails if the entire plugins key is set with a reference' do
+      plugin_config.replace(identity('pkcs7' => { 'keysize' => 1024 }))
+
+      expect { plugins }.to raise_error(/The 'plugins' setting cannot be set by a plugin reference/)
+    end
   end
 end

--- a/spec/bolt/plugin_spec.rb
+++ b/spec/bolt/plugin_spec.rb
@@ -67,4 +67,16 @@ describe Bolt::Plugin do
       expect { plugins }.to raise_error(/The 'plugins' setting cannot be set by a plugin reference/)
     end
   end
+
+  context 'loading plugin_hooks' do
+    it 'evaluates plugin references in the plugin_hooks configuration' do
+      config_data['plugin_hooks'] = {
+        'puppet_library' => {
+          'plugin' => 'my_hook',
+          'param' => identity('foobar')
+        }
+      }
+      expect(plugins.default_plugin_hooks['puppet_library']).to eq('plugin' => 'my_hook', 'param' => 'foobar')
+    end
+  end
 end

--- a/spec/bolt/target_spec.rb
+++ b/spec/bolt/target_spec.rb
@@ -216,7 +216,7 @@ describe Bolt::Target2 do
   describe "when parsing userinfo" do
     let(:config) { Bolt::Config.new(Bolt::Boltdir.new('.'), {}) }
     let(:pal) { nil }
-    let(:plugins) { Bolt::Plugin.new(config, pal, Bolt::Analytics::NoopClient.new) }
+    let(:plugins) { Bolt::Plugin.setup(config, pal, nil, Bolt::Analytics::NoopClient.new) }
     let(:inventory) { Bolt::Inventory.create_version({ 'version' => 2 }, config, plugins) }
     let(:user)     { 'gunther' }
     let(:password) { 'foobar' }

--- a/spec/integration/inventory2_spec.rb
+++ b/spec/integration/inventory2_spec.rb
@@ -653,7 +653,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
       allow(STDIN).to receive(:noecho).and_return('bolt').once
       allow(STDOUT).to receive(:puts)
 
-      expect(STDOUT).to receive(:print).with("password please:").once
+      expect(STDOUT).to receive(:print).with("password please: ").once
 
       result = run_one_node(['command', 'run', shell_cmd, '--targets', 'target-1'] + config_flags)
       expect(result).to include('stdout' => "bolt\n")


### PR DESCRIPTION
Previously, the `plugins` section of `bolt.yaml` was required to be 
 completely static. Now, plugin can use the same `_plugin` hashes as in
 `inventory.yaml` to define their configuration. For example, this allows 
 secrets for plugins to be encrypted or read from vault.

 We now instantiate (and thus validate) all plugins that are configured in
 `bolt.yaml` at the time the plugin system is initialized.

 We also now support `_plugin` lookups under the `plugin_hooks` key for
 similar reasons.
Closes GH-1350