### PR TITLE
Feature: LXD transport

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,14 +19,14 @@ RSpec::Core::RakeTask.new(:spec)
 
 desc "Run RSpec tests that don't require VM fixtures or a particular shell"
 RSpec::Core::RakeTask.new(:unit) do |t|
-  t.rspec_opts = '--tag ~ssh --tag ~docker --tag ~bash --tag ~winrm ' \
+  t.rspec_opts = '--tag ~ssh --tag ~docker --tag ~lxd --tag ~bash --tag ~winrm ' \
                  '--tag ~appveyor_agents --tag ~puppetserver --tag ~puppetdb ' \
                  '--tag ~omi --tag ~kerberos'
 end
 
 desc "Run RSpec tests for AppVeyor that don't require SSH, Bash, Appveyor Puppet Agents, or orchestrator"
 RSpec::Core::RakeTask.new(:appveyor) do |t|
-  t.rspec_opts = '--tag ~ssh --tag ~docker --tag ~bash --tag ~appveyor_agents ' \
+  t.rspec_opts = '--tag ~ssh --tag ~docker --tag ~lxd --tag ~bash --tag ~appveyor_agents ' \
          '--tag ~orchestrator --tag ~puppetserver --tag ~puppetdb --tag ~omi ' \
          '--tag ~kerberos'
 end
@@ -180,6 +180,11 @@ namespace :integration do
   desc 'Run tests that require a host System Under Test configured with Docker'
   RSpec::Core::RakeTask.new(:docker) do |t|
     t.rspec_opts = '--tag docker'
+  end
+
+  desc 'Run tests that require a host System Under Test configured with LXD'
+  RSpec::Core::RakeTask.new(:lxd) do |t|
+    t.rspec_opts = '--tag lxd'
   end
 
   desc 'Run tests that require Bash on the local host'

--- a/Rakefile
+++ b/Rakefile
@@ -19,14 +19,14 @@ RSpec::Core::RakeTask.new(:spec)
 
 desc "Run RSpec tests that don't require VM fixtures or a particular shell"
 RSpec::Core::RakeTask.new(:unit) do |t|
-  t.rspec_opts = '--tag ~ssh --tag ~docker --tag ~lxd --tag ~bash --tag ~winrm ' \
+  t.rspec_opts = '--tag ~ssh --tag ~docker --tag ~bash --tag ~winrm ' \
                  '--tag ~appveyor_agents --tag ~puppetserver --tag ~puppetdb ' \
                  '--tag ~omi --tag ~kerberos'
 end
 
 desc "Run RSpec tests for AppVeyor that don't require SSH, Bash, Appveyor Puppet Agents, or orchestrator"
 RSpec::Core::RakeTask.new(:appveyor) do |t|
-  t.rspec_opts = '--tag ~ssh --tag ~docker --tag ~lxd --tag ~bash --tag ~appveyor_agents ' \
+  t.rspec_opts = '--tag ~ssh --tag ~docker --tag ~bash --tag ~appveyor_agents ' \
          '--tag ~orchestrator --tag ~puppetserver --tag ~puppetdb --tag ~omi ' \
          '--tag ~kerberos'
 end

--- a/documentation/bolt_configuration_options.md
+++ b/documentation/bolt_configuration_options.md
@@ -177,7 +177,7 @@ When using the SSH transport, Bolt also interacts with the ssh-agent for SSH key
 -   `service-url`: Remote name of the LXD host used for API requests. Defaults to `local`.
 -   `shell-command`: A shell command to wrap any lxc exec commands in, such as `bash -lc`.
 -   `tmpdir`: The directory to upload and execute temporary files on the target.
--   TODO `tty`: When `true`, enable tty on lxc exec commands. Default is `false`.
+-   `tty`: When `true`, enable tty on lxc exec commands. Default is `false`.
 
 
 ## Remote transport configuration options

--- a/documentation/bolt_configuration_options.md
+++ b/documentation/bolt_configuration_options.md
@@ -171,6 +171,15 @@ When using the SSH transport, Bolt also interacts with the ssh-agent for SSH key
 -   `tty`: When `true`, enable tty on Docker exec commands. Default is `false`.
 
 
+## LXD transport configuration options
+
+**Note:** The LXD transport is experimental because the capabilities and role of the LXD API might change.
+-   `service-url`: Remote name of the LXD host used for API requests. Defaults to `local`.
+-   `shell-command`: A shell command to wrap any lxc exec commands in, such as `bash -lc`.
+-   `tmpdir`: The directory to upload and execute temporary files on the target.
+-   TODO `tty`: When `true`, enable tty on lxc exec commands. Default is `false`.
+
+
 ## Remote transport configuration options
 
 **Note:** The remote transport is experimental. Its configuration options and behavior might change between Y releases.

--- a/documentation/bolt_configuration_options.md
+++ b/documentation/bolt_configuration_options.md
@@ -25,7 +25,7 @@ ssh:
 -   `concurrency`: The number of threads to use when executing on remote nodes. Default is `100`.
 -   `format`: The format to use when printing results. Options are `human` and `json`. Default is `human`.
 -   `hiera-config`: Specify the path to your Hiera config. The default path is `hiera.yaml` inside the [Bolt project directory](bolt_project_directories.md#).
--   `interpreters`: A map of an extension name to the absolute path of an executable, enabling you to override the shebang defined in a task executable. The extension can optionally be specified with the `.` character (`.py` and `py` both map to a task executable `task.py`) and the extension is case sensitive. The transports that support interpreter configuration are `docker`, `local`, `ssh`, and `winrm`. When a node's name is `localhost`, Ruby tasks run with the Bolt Ruby interpreter by default. This example demonstrates configuring Python tasks to run with a `python3` interpreter:
+-   `interpreters`: A map of an extension name to the absolute path of an executable, enabling you to override the shebang defined in a task executable. The extension can optionally be specified with the `.` character (`.py` and `py` both map to a task executable `task.py`) and the extension is case sensitive. The transports that support interpreter configuration are `docker`, `local`, `lxd`, `ssh`, and `winrm`. When a node's name is `localhost`, Ruby tasks run with the Bolt Ruby interpreter by default. This example demonstrates configuring Python tasks to run with a `python3` interpreter:
     ```yaml
     interpreters:
       py: /usr/bin/python3
@@ -34,7 +34,7 @@ ssh:
 -   `modulepath`: The module path for loading tasks and plan code. This is either an array of directories or a string containing a list of directories separated by the OS-specific `PATH` separator. The default path for modules is `modules:site-modules:site` inside the [Bolt project directory](bolt_project_directories.md#).
 -   `puppetfile`: A map containing options for the `bolt puppetfile install` command.
 -   `save-rerun`: Specify whether to update `.rerun.json` in the [Bolt project directory](bolt_project_directories.md#). If your target names include passwords, set this value to false to avoid writing passwords to disk.
--   `transport`: Specify the default transport to use when the transport for a target is not specified in the URL or inventory. Options are `docker`, `local`, `pcp`, `ssh`, and `winrm`.
+-   `transport`: Specify the default transport to use when the transport for a target is not specified in the URL or inventory. Options are `docker`, `local`, `lxd`, `pcp`, `ssh`, and `winrm`.
 -   `future`: Whether to use new, breaking changes. This allows testing if Bolt content is compatible with expected future behavior. Options are `true` and `false`. Default is `false`.
 
 

--- a/documentation/bolt_configuration_options.md
+++ b/documentation/bolt_configuration_options.md
@@ -177,7 +177,6 @@ When using the SSH transport, Bolt also interacts with the ssh-agent for SSH key
 -   `service-url`: Remote name of the LXD host used for API requests. Defaults to `local`.
 -   `shell-command`: A shell command to wrap any lxc exec commands in, such as `bash -lc`.
 -   `tmpdir`: The directory to upload and execute temporary files on the target.
--   `tty`: When `true`, enable tty on lxc exec commands. Default is `false`.
 
 
 ## Remote transport configuration options

--- a/documentation/bolt_options.md
+++ b/documentation/bolt_options.md
@@ -96,6 +96,7 @@ Available transports are:
 -   `winrm`
 -   `local`
 -   `docker`
+-   `lxd`
 -   `pcp`
 
 Pass the `--transport` option after the nodes list:

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -10,6 +10,7 @@ require 'bolt/transport/orch'
 require 'bolt/transport/local'
 require 'bolt/transport/local_windows'
 require 'bolt/transport/docker'
+require 'bolt/transport/lxd'
 require 'bolt/transport/remote'
 require 'bolt/util'
 
@@ -20,6 +21,7 @@ module Bolt
     pcp: Bolt::Transport::Orch,
     local: Bolt::Util.windows? ? Bolt::Transport::LocalWindows : Bolt::Transport::Local,
     docker: Bolt::Transport::Docker,
+    lxd: Bolt::Transport::LXD,
     remote: Bolt::Transport::Remote
   }.freeze
 

--- a/lib/bolt/transport/lxd.rb
+++ b/lib/bolt/transport/lxd.rb
@@ -8,7 +8,7 @@ module Bolt
   module Transport
     class LXD < Base
       def self.options
-        %w[host service-url tmpdir interpreters shell-command tty]
+        %w[host service-url tmpdir interpreters shell-command]
       end
 
       def provided_features
@@ -52,8 +52,6 @@ module Bolt
       end
 
       def run_command(target, command, options = {})
-        options[:tty] = target.options['tty']
-
         if target.options['shell-command'] && !target.options['shell-command'].empty?
           # escape any double quotes in command
           command = command.gsub('"', '\"')

--- a/lib/bolt/transport/lxd.rb
+++ b/lib/bolt/transport/lxd.rb
@@ -32,10 +32,11 @@ module Bolt
       def upload(target, source, destination, _options = {})
         with_connection(target) do |conn|
           conn.with_remote_tempdir do |dir|
-            basename = File.basename(destination)
+            # lxd can't upload dirs into another dirname, so tmpfile is basename of source for both dir and file
+            basename = File.basename(source)
             tmpfile = "#{dir}/#{basename}"
             if File.directory?(source)
-              conn.write_remote_directory(source, tmpfile)
+              conn.write_remote_directory(source, dir)
             else
               conn.write_remote_file(source, tmpfile)
             end

--- a/lib/bolt/transport/lxd.rb
+++ b/lib/bolt/transport/lxd.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'shellwords'
+require 'bolt/transport/base'
+
+module Bolt
+  module Transport
+    class LXD < Base
+      def self.options
+        %w[host service-url tmpdir interpreters shell-command tty]
+      end
+
+      def provided_features
+        ['shell']
+      end
+
+      def self.validate(options)
+        if (url = options['service-url'])
+          unless url.instance_of?(String)
+            raise Bolt::ValidationError, 'service-url must be a string'
+          end
+        end
+      end
+
+      def with_connection(target)
+        conn = Connection.new(target)
+        conn.connect
+        yield conn
+      end
+
+      def upload(target, source, destination, _options = {})
+        with_connection(target) do |conn|
+          conn.with_remote_tempdir do |dir|
+            basename = File.basename(destination)
+            tmpfile = "#{dir}/#{basename}"
+            if File.directory?(source)
+              conn.write_remote_directory(source, tmpfile)
+            else
+              conn.write_remote_file(source, tmpfile)
+            end
+
+            _, stderr, exitcode = conn.execute('mv', tmpfile, destination, {})
+            if exitcode != 0
+              message = "Could not move temporary file '#{tmpfile}' to #{destination}: #{stderr}"
+              raise Bolt::Node::FileError.new(message, 'MV_ERROR')
+            end
+          end
+          Bolt::Result.for_upload(target, source, destination)
+        end
+      end
+
+      def run_command(target, command, options = {})
+        options[:tty] = target.options['tty']
+
+        if target.options['shell-command'] && !target.options['shell-command'].empty?
+          # escape any double quotes in command
+          command = command.gsub('"', '\"')
+          command = "#{target.options['shell-command']} \" #{command}\""
+        end
+        with_connection(target) do |conn|
+          stdout, stderr, exitcode = conn.execute(*Shellwords.split(command), options)
+          Bolt::Result.for_command(target, stdout, stderr, exitcode, 'command', command)
+        end
+      end
+
+      def run_script(target, script, arguments, _options = {})
+        # unpack any Sensitive data
+        arguments = unwrap_sensitive_args(arguments)
+
+        with_connection(target) do |conn|
+          conn.with_remote_tempdir do |dir|
+            remote_path = conn.write_remote_executable(dir, script)
+            stdout, stderr, exitcode = conn.execute(remote_path, *arguments, {})
+            Bolt::Result.for_command(target, stdout, stderr, exitcode, 'script', script)
+          end
+        end
+      end
+
+      def run_task(target, task, arguments, _options = {})
+        implementation = task.select_implementation(target, provided_features)
+        executable = implementation['path']
+        input_method = implementation['input_method']
+        extra_files = implementation['files']
+        input_method ||= 'both'
+
+        # unpack any Sensitive data
+        arguments = unwrap_sensitive_args(arguments)
+        with_connection(target) do |conn|
+          execute_options = {}
+          execute_options[:interpreter] = select_interpreter(executable, target.options['interpreters'])
+          conn.with_remote_tempdir do |dir|
+            if extra_files.empty?
+              task_dir = dir
+            else
+              # TODO: optimize upload of directories
+              arguments['_installdir'] = dir
+              task_dir = File.join(dir, task.tasks_dir)
+              conn.mkdirs([task_dir] + extra_files.map { |file| File.join(dir, File.dirname(file['name'])) })
+              extra_files.each do |file|
+                conn.write_remote_file(file['path'], File.join(dir, file['name']))
+              end
+            end
+
+            remote_task_path = conn.write_remote_executable(task_dir, executable)
+
+            if STDIN_METHODS.include?(input_method)
+              execute_options[:stdin] = StringIO.new(JSON.dump(arguments))
+            end
+
+            if ENVIRONMENT_METHODS.include?(input_method)
+              execute_options[:environment] = envify_params(arguments)
+            end
+
+            stdout, stderr, exitcode = conn.execute(remote_task_path, execute_options)
+            Bolt::Result.for_task(target, stdout, stderr, exitcode, task.name)
+          end
+        end
+      end
+
+      def connected?(target)
+        with_connection(target) { true }
+      rescue Bolt::Node::ConnectError
+        false
+      end
+    end
+  end
+end
+
+require 'bolt/transport/lxd/connection'

--- a/lib/bolt/transport/lxd/connection.rb
+++ b/lib/bolt/transport/lxd/connection.rb
@@ -154,7 +154,7 @@ module Bolt
           env_hash['LXD_HOST'] = @lxd_host unless @lxd_host.nil?
 
           command_options = [] if command_options.nil?
-          lxc_command = [].concat(subcommand).concat(command_options)
+          lxc_command = ['--force-local'].concat(subcommand).concat(command_options)
 
           # Always use binary mode for any text data
           capture_options = { binmode: true }

--- a/lib/bolt/transport/lxd/connection.rb
+++ b/lib/bolt/transport/lxd/connection.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+require 'logging'
+require 'bolt/node/errors'
+
+module Bolt
+  module Transport
+    class LXD < Base
+      class Connection
+        def initialize(target)
+          raise Bolt::ValidationError, "Target #{target.safe_name} does not have a host" unless target.host
+          @target = target
+          @logger = Logging.logger[target.safe_name]
+          @lxd_host = @target.options['service-url']
+          @logger.debug("Initializing lxd connection to #{@target.safe_name}")
+        end
+
+        def connect
+          # We don't actually have a connection, but we do need to
+          # check that the container exists and is running.
+          output = execute_local_lxc_json_command(['list'])
+          index = output.find_index { |item| item["name"] == @target.host }
+          raise "Could not find a container with name matching '#{@target.host}'" if index.nil?
+          # Store the container information for later
+          @container_info = output[index]
+          @logger.debug { "Opened session" }
+          true
+        rescue StandardError => e
+          raise Bolt::Node::ConnectError.new(
+            "Failed to connect to #{@target.safe_name}: #{e.message}",
+            'CONNECT_ERROR'
+          )
+        end
+
+        # Executes a command inside the target container
+        #
+        # @param command [Array] The command to run, expressed as an array of strings
+        # @param options [Hash] command specific options
+        # @option opts [String] :interpreter statements that are prefixed to the command e.g `/bin/bash` or `cmd.exe /c`
+        # @option opts [Hash] :environment A hash of environment variables that will be injected into the command
+        # @option opts [IO] :stdin TODO, currently unset (lxc default is --mode=auto)
+        def execute(*command, options)
+          command.unshift(options[:interpreter]) if options[:interpreter]
+          # Build the `--env` parameters
+          envs = []
+          if options[:environment]
+            options[:environment].each { |env, val| envs.concat(['--env', "#{env}=#{val}"]) }
+          end
+
+          command_options = []
+          # :stdin TODO, currently unset (lxc default is --mode=auto)
+          command_options.concat(envs) unless envs.empty?
+          command_options << container_id
+          command_options.concat(command)
+
+          @logger.debug { "Executing: exec #{command_options}" }
+
+          stdout_str, stderr_str, status = execute_local_lxc_command(['exec'], command_options, options[:stdin])
+
+          # The actual result is the exitstatus not the process object
+          status = status.nil? ? -32768 : status.exitstatus
+          if status == 0
+            @logger.debug { "Command returned successfully" }
+          else
+            @logger.info { "Command failed with exit code #{status}" }
+          end
+          stdout_str.force_encoding(Encoding::UTF_8)
+          stderr_str.force_encoding(Encoding::UTF_8)
+          # Normalise line endings
+          stdout_str.gsub!("\r\n", "\n")
+          stderr_str.gsub!("\r\n", "\n")
+          [stdout_str, stderr_str, status]
+        rescue StandardError
+          @logger.debug { "Command aborted" }
+          raise
+        end
+
+        def write_remote_file(source, destination)
+          @logger.debug { "Uploading #{source}, to #{destination}" }
+          _, stdout_str, status = execute_local_lxc_command(['file', 'push'], [source, "#{container_id}/#{destination}"])
+          raise "Error writing file to container #{@container_id}: #{stdout_str}" unless status.exitstatus.zero?
+        rescue StandardError => e
+          raise Bolt::Node::FileError.new(e.message, 'WRITE_ERROR')
+        end
+
+        def write_remote_directory(source, destination)
+          @logger.debug { "Uploading #{source}, to #{destination}" }
+          _, stdout_str, status = execute_local_lxc_command(['file', 'push'], [source, "#{container_id}/#{destination}"])
+          raise "Error writing directory to container #{@container_id}: #{stdout_str}" unless status.exitstatus.zero?
+        rescue StandardError => e
+          raise Bolt::Node::FileError.new(e.message, 'WRITE_ERROR')
+        end
+
+        def mkdirs(dirs)
+          _, stderr, exitcode = execute('mkdir', '-p', *dirs, {})
+          if exitcode != 0
+            message = "Could not create directories: #{stderr}"
+            raise Bolt::Node::FileError.new(message, 'MKDIR_ERROR')
+          end
+        end
+
+        def make_tempdir
+          tmpdir = @target.options.fetch('tmpdir', container_tmpdir)
+          tmppath = "#{tmpdir}/#{SecureRandom.uuid}"
+
+          stdout, stderr, exitcode = execute('mkdir', '-m', '700', tmppath, {})
+          if exitcode != 0
+            raise Bolt::Node::FileError.new("Could not make tempdir: #{stderr}", 'TEMPDIR_ERROR')
+          end
+          tmppath || stdout.first
+        end
+
+        def with_remote_tempdir
+          dir = make_tempdir
+          yield dir
+        ensure
+          if dir
+            _, stderr, exitcode = execute('rm', '-rf', dir, {})
+            if exitcode != 0
+              @logger.warn("Failed to clean up tempdir '#{dir}': #{stderr}")
+            end
+          end
+        end
+
+        def write_remote_executable(dir, file, filename = nil)
+          filename ||= File.basename(file)
+          remote_path = File.join(dir.to_s, filename)
+          write_remote_file(file, remote_path)
+          make_executable(remote_path)
+          remote_path
+        end
+
+        def make_executable(path)
+          _, stderr, exitcode = execute('chmod', 'u+x', path, {})
+          if exitcode != 0
+            message = "Could not make file '#{path}' executable: #{stderr}"
+            raise Bolt::Node::FileError.new(message, 'CHMOD_ERROR')
+          end
+        end
+
+        private
+
+        # rubocop:disable Metrics/LineLength
+        # Executes a LXC CLI command
+        #
+        # @param subcommand [String] The lxc subcommands to run e.g. ['config', 'show'] for `lxc config show`
+        # @param command_options [Array] Additional command options e.g. ['--expanded'] for `lxc config show --expanded`
+        # @param redir_stdin [IO] TODO, currently unset (lxc default is --mode=auto)
+        # @return [String, String, Process::Status] The output of the command:  STDOUT, STDERR, Process Status
+        # rubocop:enable Metrics/LineLength
+        def execute_local_lxc_command(subcommand = [], command_options = [], redir_stdin = nil)
+          env_hash = {}
+          # Set the LXD_HOST if we are using a non-default service-url
+          env_hash['LXD_HOST'] = @lxd_host unless @lxd_host.nil?
+
+          command_options = [] if command_options.nil?
+          lxc_command = [].concat(subcommand).concat(command_options)
+
+          # Always use binary mode for any text data
+          capture_options = { binmode: true }
+          capture_options[:stdin_data] = redir_stdin unless redir_stdin.nil?
+          stdout_str, stderr_str, status = Open3.capture3(env_hash, 'lxc', *lxc_command, capture_options)
+          [stdout_str, stderr_str, status]
+        end
+
+        # Executes a LXC CLI command and parses the output in JSON format
+        #
+        # @param subcommand [String] The lxc subcommands to run e.g. ['config', 'show'] for `lxc config show`
+        # @param command_options [Array] Additional command options e.g. ['--expanded'] for `lxc config show --expanded`
+        # @return [Object] Ruby object representation of the JSON string
+        def execute_local_lxc_json_command(subcommand = [], command_options = [])
+          command_options = [] if command_options.nil?
+          command_options = ['--format', 'json'].concat(command_options)
+          stdout_str, _stderr_str, _status = execute_local_lxc_command(subcommand, command_options)
+          JSON.parse(stdout_str)
+        end
+
+        # The full ID of the target container
+        #
+        # @return [String] The full ID of the target container
+        def container_id
+          @container_info["name"]
+        end
+
+        # The temp path inside the target container
+        #
+        # @return [String] The absolute path to the temp directory
+        def container_tmpdir
+          '/tmp'
+        end
+      end
+    end
+  end
+end

--- a/lib/bolt/transport/lxd/connection.rb
+++ b/lib/bolt/transport/lxd/connection.rb
@@ -81,7 +81,8 @@ module Bolt
 
         def write_remote_file(source, destination)
           @logger.debug { "Uploading #{source}, to #{destination}" }
-          _, stdout_str, status = execute_local_lxc_command(%w[file push], [source, "#{container_id}/#{destination}"])
+          path = "#{container_id}/#{destination}"
+          _, stdout_str, status = execute_local_lxc_command(%w[file push], [source, path])
           raise "Error writing file to container #{@container_id}: #{stdout_str}" unless status.exitstatus.zero?
         rescue StandardError => e
           raise Bolt::Node::FileError.new(e.message, 'WRITE_ERROR')
@@ -89,7 +90,8 @@ module Bolt
 
         def write_remote_directory(source, destination)
           @logger.debug { "Uploading #{source}, to #{destination}" }
-          _, stdout_str, status = execute_local_lxc_command(%w[file push], [source, "#{container_id}/#{destination}", '-r'])
+          path = "#{container_id}/#{destination}"
+          _, stdout_str, status = execute_local_lxc_command(%w[file push], [source, path, '-r'])
           raise "Error writing directory to container #{@container_id}: #{stdout_str}" unless status.exitstatus.zero?
         rescue StandardError => e
           raise Bolt::Node::FileError.new(e.message, 'WRITE_ERROR')
@@ -153,7 +155,6 @@ module Bolt
         # @return [String, String, Process::Status] The output of the command:  STDOUT, STDERR, Process Status
         # rubocop:enable Metrics/LineLength
         def execute_local_lxc_command(subcommands = [], command_options = [], redir_stdin = nil)
-
           env_hash = {}
 
           command_options = [] if command_options.nil?

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -71,6 +71,7 @@ describe Bolt::Applicator do
             },
             local: {},
             docker: {},
+            lxd: {},
             remote: { 'run-on': 'localhost' }
           }
         }

--- a/spec/bolt/transport/lxd_spec.rb
+++ b/spec/bolt/transport/lxd_spec.rb
@@ -46,20 +46,19 @@ describe Bolt::Transport::LXD, lxd: true do
 
   context 'with_connection' do
     it "fails with an unknown host" do
-      # Test fails differently on Windows due to issues in the lxd-api gem.
       expect {
         lxd.with_connection(Bolt::Target.new('not_a_target')) {}
-      }.to raise_error(Bolt::Node::ConnectError, /Could not find a container with name or ID matching \'not_a_target\'/)
+      }.to raise_error(Bolt::Node::ConnectError, /Could not find a container with name matching \'not_a_target\'/)
     end
   end
 
   context 'when url is specified' do
-    let(:transport_conf) { { 'service-url' => 'tcp://localhost:55555' } }
+    let(:transport_conf) { { 'service-url' => 'anotherremote' } }
 
     it 'uses the url' do
       expect {
         lxd.with_connection(target) {}
-      }.to raise_error(Bolt::Node::ConnectError, /Could not find a container with name or ID matching/)
+      }.to raise_error(Bolt::Node::ConnectError, /Could not find remote/)
     end
   end
 

--- a/spec/bolt/transport/lxd_spec.rb
+++ b/spec/bolt/transport/lxd_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/conn'
+require 'bolt_spec/transport'
+require 'bolt/transport/lxd'
+require 'bolt/target'
+
+require_relative 'shared_examples'
+
+describe Bolt::Transport::LXD, lxd: true do
+  include BoltSpec::Conn
+  include BoltSpec::Transport
+
+  let(:hostname) { conn_info('lxd')[:host] }
+  let(:lxd) { Bolt::Transport::LXD.new }
+  let(:target) { Bolt::Target.new("lxd://#{hostname}", transport_conf) }
+
+  context 'with lxd' do
+    let(:transport) { :lxd }
+    let(:os_context) { posix_context }
+
+    it "can test whether the target is available" do
+      expect(runner.connected?(target)).to eq(true)
+    end
+
+    it "returns false if the target is not available" do
+      expect(runner.connected?(Bolt::Target.new('unknownfoo'))).to eq(false)
+    end
+
+    include_examples 'transport api'
+
+    context 'file errors' do
+      before(:each) do
+        allow_any_instance_of(Bolt::Transport::LXD::Connection).to receive(:write_remote_file).and_raise(
+          Bolt::Node::FileError.new("no write", "WRITE_ERROR")
+        )
+        allow_any_instance_of(Bolt::Transport::LXD::Connection).to receive(:make_tempdir).and_raise(
+          Bolt::Node::FileError.new("no tmpdir", "TEMDIR_ERROR")
+        )
+      end
+
+      include_examples 'transport failures'
+    end
+  end
+
+  context 'with_connection' do
+    it "fails with an unknown host" do
+      # Test fails differently on Windows due to issues in the lxd-api gem.
+      expect {
+        lxd.with_connection(Bolt::Target.new('not_a_target')) {}
+      }.to raise_error(Bolt::Node::ConnectError, /Could not find a container with name or ID matching \'not_a_target\'/)
+    end
+  end
+
+  context 'when url is specified' do
+    let(:transport_conf) { { 'service-url' => 'tcp://localhost:55555' } }
+
+    it 'uses the url' do
+      expect {
+        lxd.with_connection(target) {}
+      }.to raise_error(Bolt::Node::ConnectError, /Could not find a container with name or ID matching/)
+    end
+  end
+
+  context 'when there is no host in the target' do
+    let(:target) { Bolt::Target.new(nil, "name" => "hostless") }
+
+    it 'errors' do
+      expect { lxd.run_command(target, 'whoami') }.to raise_error(/does not have a host/)
+    end
+  end
+end

--- a/spec/bolt/transport/shared_examples.rb
+++ b/spec/bolt/transport/shared_examples.rb
@@ -108,9 +108,9 @@ shared_examples 'transport api' do
     end
 
     it "can return a non-zero exit status" do
-      command = if target.protocol == 'docker'
-                  # explicitly launch bash for Docker transport because Docker doesn't have
-                  # a default shell when you perform: docker exec
+      command = if target.protocol == 'docker' || target.protocol == 'lxd'
+                  # explicitly launch bash for Docker and LXD transport because they don't have
+                  # a default shell when you perform `exec`
                   "/bin/bash -c 'exit 1'"
                 else
                   "exit 1"

--- a/spec/bolt/transport/shared_examples.rb
+++ b/spec/bolt/transport/shared_examples.rb
@@ -475,8 +475,8 @@ QUOTED
         # This assumes that the thing running the tests is the
         # same platform as the thing we're running the task on
         use_windows = Bolt::Util.windows?
-        if safe_target.transport == "docker"
-          # Only support linux containers with the docker transport
+        if safe_target.transport == "docker" || safe_target.transport == "lxd"
+          # Only support linux containers with the docker and lxd transport
           use_windows = false
         end
 

--- a/spec/integration/inventory2_spec.rb
+++ b/spec/integration/inventory2_spec.rb
@@ -346,6 +346,13 @@ describe 'running with an inventory file', reset_puppet_settings: true do
     include_examples 'basic inventory'
   end
 
+  context 'when running over lxd', lxd: true do
+    let(:conn) { conn_info('lxd') }
+    let(:shell_cmd) { "whoami" }
+
+    include_examples 'basic inventory'
+  end
+
   context 'when running over remote with bash shell', bash: true do
     let(:inventory) do
       { version: 2,

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -285,6 +285,13 @@ describe 'running with an inventory file', reset_puppet_settings: true do
     include_examples 'basic inventory'
   end
 
+  context 'when running over lxd', lxd: true do
+    let(:conn) { conn_info('lxd') }
+    let(:shell_cmd) { "whoami" }
+
+    include_examples 'basic inventory'
+  end
+
   context 'when running over local with bash shell', bash: true do
     let(:shell_cmd) { "whoami" }
 

--- a/spec/integration/lxd_spec.rb
+++ b/spec/integration/lxd_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/conn'
+require 'bolt_spec/files'
+require 'bolt_spec/integration'
+
+describe "when running over the lxd transport", lxd: true do
+  include BoltSpec::Conn
+  include BoltSpec::Files
+  include BoltSpec::Integration
+
+  let(:whoami) { "whoami" }
+  let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
+  let(:stdin_task) { "sample::stdin" }
+  let(:uri) { (1..2).map { |i| "#{conn_uri('lxd')}?id=#{i}" }.join(',') }
+  let(:user) { 'root' }
+
+  after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
+
+  context 'when using CLI options' do
+    let(:config_flags) {
+      %W[--nodes #{uri} --no-host-key-check --format json --modulepath #{modulepath}]
+    }
+
+    it 'runs multiple commands' do
+      result = run_nodes(%W[command run #{whoami}] + config_flags)
+      expect(result.map { |r| r['stdout'].strip }).to eq([user, user])
+    end
+
+    it 'reports errors when command fails' do
+      result = run_failed_nodes(%w[command run boop] + config_flags)
+      expect(result[0]['_error']).to be
+    end
+
+    it 'runs multiple tasks', :reset_puppet_settings do
+      result = run_nodes(%W[task run #{stdin_task} message=somemessage] + config_flags)
+      expect(result.map { |r| r['message'].strip }).to eq(%w[somemessage somemessage])
+    end
+
+    it 'reports errors when task fails', :reset_puppet_settings do
+      result = run_failed_nodes(%w[task run results fail=true] + config_flags)
+      expect(result[0]['_error']).to be
+    end
+  end
+
+  context 'when using a configfile' do
+    let(:config) do
+      { 'format' => 'json',
+        'modulepath' => modulepath,
+        'transport' => 'lxd',
+        'lxd' => {
+          'user' => user
+        } }
+    end
+
+    let(:config_flags) { %W[--nodes #{uri}] }
+    let(:single_target_conf) { %W[--nodes #{conn_uri('lxd')}] }
+    let(:interpreter_task) { 'sample::interpreter' }
+    let(:interpreter_ext) do
+      { 'interpreters' => {
+        '.py' => '/usr/bin/python3'
+      } }
+    end
+    let(:interpreter_no_ext) do
+      { 'interpreters' => {
+        'py' => '/usr/bin/python3'
+      } }
+    end
+
+    it 'runs task with specified interpreter key py', :reset_puppet_settings do
+      lxd_conf = { 'lxd' => config['lxd'].merge(interpreter_no_ext) }
+      with_tempfile_containing('conf', YAML.dump(config.merge(lxd_conf))) do |conf|
+        result =
+          run_nodes(%W[task run #{interpreter_task} message=somemessage
+                       --configfile #{conf.path}] + config_flags)
+        expect(result.map { |r| r['env'].strip }).to eq(%w[somemessage somemessage])
+        expect(result.map { |r| r['stdin'].strip }).to eq(%w[somemessage somemessage])
+      end
+    end
+
+    it 'runs task with interpreter key .py', :reset_puppet_settings do
+      lxd_conf = { 'lxd' => config['lxd'].merge(interpreter_ext) }
+      with_tempfile_containing('conf', YAML.dump(config.merge(lxd_conf))) do |conf|
+        result = run_nodes(%W[task run #{interpreter_task} message=somemessage
+                              --configfile #{conf.path}] + config_flags)
+        expect(result.map { |r| r['env'].strip }).to eq(%w[somemessage somemessage])
+        expect(result.map { |r| r['stdin'].strip }).to eq(%w[somemessage somemessage])
+      end
+    end
+
+    it 'task fails when bad shebang is not overriden', :reset_puppet_settings do
+      with_tempfile_containing('conf', YAML.dump(config)) do |conf|
+        result = run_failed_node(%W[task run #{interpreter_task} message=somemessage
+                                    --configfile #{conf.path}] + single_target_conf)
+        expect(result['_error']['msg']).to be
+      end
+    end
+  end
+end

--- a/spec/lib/bolt_spec/conn.rb
+++ b/spec/lib/bolt_spec/conn.rb
@@ -23,6 +23,11 @@ module BoltSpec
         default_user = ''
         default_password = ''
         default_host = 'ubuntu_node'
+      when 'lxd'
+        default_user = ''
+        default_password = ''
+        # lxd container names are hostnames and thus underscores are not allowed
+        default_host = 'ubuntunode'
       else
         raise Error, "The transport must be either 'ssh' or 'winrm'"
       end

--- a/spec/lib/bolt_spec/conn.rb
+++ b/spec/lib/bolt_spec/conn.rb
@@ -100,7 +100,7 @@ module BoltSpec
             'targets' => [
               { 'name' => 'ubuntunode',
                 'alias' => 'agentless',
-                'config' => { 'ssh' => { 'port' => '20022' } } }
+                'config' => { 'ssh' => { 'port' => '20032' } } }
             ],
             'config' => {
               'ssh' => {

--- a/spec/lib/bolt_spec/conn.rb
+++ b/spec/lib/bolt_spec/conn.rb
@@ -92,6 +92,27 @@ module BoltSpec
         ] }
     end
 
+    def lxd_inventory(root: false)
+      usernamepassword = root ? 'root' : 'bolt'
+      { 'version' => 2,
+        'groups' => [
+          { 'name' => 'ssh',
+            'targets' => [
+              { 'name' => 'ubuntunode',
+                'alias' => 'agentless',
+                'config' => { 'ssh' => { 'port' => '20022' } } },
+            ],
+            'config' => {
+              'ssh' => {
+                'host' => 'localhost',
+                'host-key-check' => false,
+                'user' => usernamepassword,
+                'password' => usernamepassword
+              }
+            } }
+        ] }
+    end
+
     def root_password
       'root'
     end

--- a/spec/lib/bolt_spec/conn.rb
+++ b/spec/lib/bolt_spec/conn.rb
@@ -100,7 +100,7 @@ module BoltSpec
             'targets' => [
               { 'name' => 'ubuntunode',
                 'alias' => 'agentless',
-                'config' => { 'ssh' => { 'port' => '20022' } } },
+                'config' => { 'ssh' => { 'port' => '20022' } } }
             ],
             'config' => {
               'ssh' => {

--- a/spec/lxd-compose.sh
+++ b/spec/lxd-compose.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -o history -o histexpand -o nounset -e
+
+# remove container if existing
+lxc delete ubuntunode --force || true
+
+# create and start ubuntu container
+lxc launch ubuntu:bionic ubuntunode
+
+# configure and start ssh so we can ssh into it with user root and password root
+lxc exec ubuntunode -- ssh-keygen -A
+lxc exec ubuntunode -- sed -i -e 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+lxc exec ubuntunode -- sed -i -e 's/PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
+lxc exec ubuntunode -- bash -c 'echo -e "root\nroot" | passwd root'
+lxc exec ubuntunode -- service ssh start
+
+# add port forwarding for localhost only
+lxc config device add ubuntunode ext-ssh proxy listen=tcp:127.0.0.1:20032 connect=tcp:127.0.0.1:22


### PR DESCRIPTION
I've written a transport package for lxd very similiar to docker in source code and test code. Motivation is a potential transport package for kubernetes (using kubelet) but first learning the transport library with a known environment. I have almost no experience with ruby and just a little with bolt so reviewing it might be advised.

The lxd transport works the same way as docker: The node uri is the name of the container. Keep in mind that lxd container names are hostnames and thus the naming of the containers are a bit less flexible. But that's nothing this transport module cares, just a note ahead when playing around with it.

~~The only thing needed to run the tests is a linux with lxd installed and `lxc launch ubuntu:bionic ubuntunode`~~ I've added `spec/lxd-compose.sh` since I obviously can't add this container to docker-compose. I don't know how you want to add this step into the [testing requirements](https://github.com/puppetlabs/bolt/blob/master/CONTRIBUTING.md#testing)

To run the tests: `bundle exec rake integration:lxd`

On my machine the same tests fail for [docker](https://gist.github.com/dionysius/f9fec249454d6a44349dc3fc2954126b) and [lxd](https://gist.github.com/dionysius/6a2629d2e5702be7865043d3fa507ea0), assuming these are edge cases.

I also don't know which transport option I should use to define the lxd remote. There are no service-uri's in LXD. Each remote is configured in a file and per user, respectively using `lxc remote ...` and thus all remotes have just a name specified locally. I didn't want to introduce a new param so I reused it, but feel free to decide how you want it.