### PR TITLE
(DO NOT MERGE) (GH-1325) Update modules to ship Ruby plugin helper

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -27,12 +27,13 @@ mod 'puppetlabs-puppet_conf', '0.4.0'
 mod 'puppetlabs-python_task_helper', '0.3.0'
 mod 'puppetlabs-reboot', '2.2.0'
 mod 'puppetlabs-ruby_task_helper', '0.4.0'
+mod 'puppetlabs-ruby_plugin_helper', '0.1.0'
 
 # Plugin modules
 mod 'puppetlabs-azure_inventory', '0.2.0'
 mod 'puppetlabs-terraform', '0.2.0'
 mod 'puppetlabs-vault', '0.2.2'
-mod 'puppetlabs-aws_inventory', '0.2.0'
+mod 'puppetlabs-aws_inventory', '0.3.0'
 
 # If we don't list these modules explicitly, r10k will purge them
 mod 'canary', local: true


### PR DESCRIPTION
This updates the Puppetfile to include the new ruby plugin helper, which
provides helper methods for writing Bolt plugins in ruby. It also
updates the AWS inventory plugin to the newer version, which uses the
plugin helper

Closes #1325