### PR TITLE
(GH-1377) Add project migrate command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 * **Add `--password-prompt` and `--sudo-password-prompt` CLI flags** ([#1269](https://github.com/puppetlabs/bolt/issues/1269))
   Two new flags have been added to support the case where the user would like to set a `password` or `sudo-password` from a prompt without using a plugin. Deprecations messages have been added when a value is not supplied for `--password` or `--sudo-password`.
+  
+* **Subcommand `project migrate` new to the CLI** ([#1377](https://github.com/puppetlabs/bolt/issues/1377))
+
+  The CLI now provides the subcommand `project migrate` which migrates Bolt projects to the latest version. When migrating a project, the [inventory file](https://puppet.com/docs/bolt/latest/inventory_file.html) will be changed from `v1` to `v2`. Changes are made in place and will not preserve comments or formatting.
 
 ## Bolt 1.37.0
 

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -54,6 +54,9 @@ module Bolt
         when 'init'
           { flags: OPTIONS[:global],
             banner: PROJECT_INIT_HELP }
+        when 'migrate'
+          { flags: OPTIONS[:global] + %w[inventoryfile boltdir configfile],
+            banner: PROJECT_MIGRATE_HELP }
         else
           { flags: OPTIONS[:global],
             banner: PROJECT_HELP }
@@ -131,6 +134,7 @@ module Bolt
         bolt inventory show              Show the list of targets an action would run on
         bolt group show                  Show the list of groups in the inventory
         bolt project init                Create a new Bolt project
+        bolt project migrate             Migrate a Bolt project to the latest version
 
       Run `bolt <subcommand> --help` to view specific examples.
 
@@ -325,6 +329,7 @@ module Bolt
 
       Available actions are:
         init                     Create a new Bolt project
+        migrate                  Migrate a Bolt project to the latest version
 
       Available options are:
     PROJECT_HELP
@@ -337,6 +342,16 @@ module Bolt
 
       Available options are:
     PROJECT_INIT_HELP
+
+    PROJECT_MIGRATE_HELP = <<~PROJECT_MIGRATE_HELP
+      Usage: bolt project migrate
+
+      Migrate a Bolt project to the latest version.
+      Loads a Bolt project's inventory file and migrates it to the latest version. The
+      inventory file is modified in place and will not preserve comments or formatting.
+
+      Available options are:
+    PROJECT_MIGRATE_HELP
 
     attr_reader :warnings
     def initialize(options)


### PR DESCRIPTION
This adds support for a `project migrate` command that migrates a Bolt
project to the newest version. Specifically, the inventory file for the
project will be migrated from an earlier version (`v1`) to the latest
version (`v2`). Changes to the inventory file are made in place and
comments/formatting are not preserved during migration.

Closes #1377 