### PR TITLE
(maint) Fix formatting in docs dita file

### DIFF
--- a/documentation/bolt.ditamap
+++ b/documentation/bolt.ditamap
@@ -38,5 +38,4 @@
         <topicref href="writing_plugins.md" format="markdown"/>
     </topicref>
     <topicref href="bolt_examples.md" format="markdown"/>
-    </topicref>
 </map>


### PR DESCRIPTION
This fixes a formatting error in the docs dita file that prevents the
docs publishing pipeline from running successfully.