### PR TITLE
(GH-1269) Warn when --{sudo}-password is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Bolt 1.36.1
+
+## Bug fixes
+
+* **Allow optional `--password` and `--sudo-password` parameters** ([#1269](https://github.com/puppetlabs/bolt/issues/1269))
+
+  Optional parameters for `--password` and `--sudo-password` were prematurely removed. The previous behavior of prompting for a password when an argument is not specified for `--password` or `--sudo-password` has been added back. Arguments will be required in a future version.
+
 ## Bolt 1.36.0
 
 ### Deprecation
@@ -29,10 +37,6 @@
 * **Bolt issues a warning when inventory overrides a CLI option** ([#1341](https://github.com/puppetlabs/bolt/issues/1341))
 
   Bolt issues a warning when an option is set both on the CLI and in the inventory, whether the inventory loads from a file or from the `bolt_inventory` environment variable.
-
-* **New `resolve_references` plan function** ([#1365](https://github.com/puppetlabs/bolt/issues/1365))
-
-  The new plan function, `resolve_references`, accepts a hash of structured data and returns a hash of structured data with all plugin references resolved.
   
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## Bolt 1.36.1
+## Bolt 1.37.0
+
+## New features
+
+* **New `resolve_references` plan function** ([#1365](https://github.com/puppetlabs/bolt/issues/1365))
+
+  The new plan function, `resolve_references`, accepts a hash of structured data and returns a hash of structured data with all plugin references resolved.
 
 ## Bug fixes
 

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -396,13 +396,13 @@ module Bolt
       end
       define('-p', '--password [PASSWORD]',
              'Password to authenticate with') do |password|
-        # TODO: Remove deprecation message
-        unless password
-          msg = "Optional parameter for --password is deprecated and no longer prompts for password. " \
-                "Use the prompt plugin instead to prompt for passwords."
-          raise Bolt::CLIError, msg
+        if password.nil?
+          STDOUT.print "Please enter your password: "
+          @options[:password] = STDIN.noecho(&:gets).chomp
+          STDOUT.puts
+        else
+          @options[:password] = password
         end
-        @options[:password] = password
       end
       define('--private-key KEY', 'Private ssh key to authenticate with') do |key|
         @options[:'private-key'] = key
@@ -423,13 +423,13 @@ module Bolt
       end
       define('--sudo-password [PASSWORD]',
              'Password for privilege escalation') do |password|
-        # TODO: Remove deprecation message
-        unless password
-          msg = "Optional parameter for --sudo-password is deprecated and no longer prompts for password. " \
-                "Use the prompt plugin instead to prompt for passwords."
-          raise Bolt::CLIError, msg
+        if password.nil?
+          STDOUT.print "Please enter your privilege escalation password: "
+          @options[:'sudo-password'] = STDIN.noecho(&:gets).chomp
+          STDOUT.puts
+        else
+          @options[:'sudo-password'] = password
         end
-        @options[:'sudo-password'] = password
       end
 
       separator "\nRun context:"

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -380,6 +380,14 @@ describe "Bolt::CLI" do
         cli = Bolt::CLI.new(%w[command run uptime --password opensesame --targets foo])
         expect(cli.parse).to include(password: 'opensesame')
       end
+
+      it "prompts the user for password if not specified" do
+        allow(STDIN).to receive(:noecho).and_return('opensesame')
+        allow(STDOUT).to receive(:print).with('Please enter your password: ')
+        allow(STDOUT).to receive(:puts)
+        cli = Bolt::CLI.new(%w[command run uptime --nodes foo --password])
+        expect(cli.parse).to include(password: 'opensesame')
+      end
     end
 
     describe "key" do
@@ -521,6 +529,15 @@ describe "Bolt::CLI" do
     describe "sudo-password" do
       it "accepts a password" do
         cli = Bolt::CLI.new(%w[command run uptime --sudo-password opensez --run-as alibaba --targets foo])
+        expect(cli.parse).to include('sudo-password': 'opensez')
+      end
+
+      it "prompts the user for sudo-password if not specified" do
+        allow(STDIN).to receive(:noecho).and_return('opensez')
+        pw_prompt = 'Please enter your privilege escalation password: '
+        allow(STDOUT).to receive(:print).with(pw_prompt)
+        allow(STDOUT).to receive(:puts)
+        cli = Bolt::CLI.new(%w[command run uptime --nodes foo --run-as alibaba --sudo-password])
         expect(cli.parse).to include('sudo-password': 'opensez')
       end
     end


### PR DESCRIPTION
The initial implementation of GH-1269 prematurely forbit optional parameters for cli opts that could expect a prompt. This PR re-allows them and issues a warning when there is no value provided for `--password` or `--sudo-password`. This is accompished by adding a new instance variable to `BoltOptionParser` that is available with an attr reader to collect a hash of warnings when parsing options and surface them once the logger is configured.