### PR TITLE
(GH-1173) Allow task parameters to have a "default"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Bolt Next
 
+### New features
+
+* **Task metadata can now specify parameter defaults** ([#1394](https://github.com/puppetlabs/bolt/pull/1394))
+
+  Parameter defaults can be set in the task metadata file and will be used if no value is supplied for the parameter.
+
 ### Bug fixes
 
 * **`bolt inventory show --detail` now displays all target aliases** ([#1379](https://github.com/puppetlabs/bolt/issues/1379))

--- a/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
@@ -80,11 +80,14 @@ Puppet::Functions.create_function(:run_task) do
         raise Bolt::Error.unknown_task(task_name)
       end
 
+      task = Bolt::Task.new(task_signature.task_hash)
+
+      # Set the default value for any params that have one and were not provided
+      params = task.parameter_defaults.merge(params)
+
       task_signature.runnable_with?(params) do |mismatch_message|
         raise with_stack(:TYPE_MISMATCH, mismatch_message)
       end || (raise with_stack(:TYPE_MISMATCH, 'Task parameters do not match'))
-
-      task = Bolt::Task.new(task_signature.task_hash)
     end
 
     unless Puppet::Pops::Types::TypeFactory.data.instance?(params)

--- a/bolt-modules/boltlib/spec/fixtures/modules/test/tasks/params.json
+++ b/bolt-modules/boltlib/spec/fixtures/modules/test/tasks/params.json
@@ -25,6 +25,16 @@
     "optional_hash": {
       "description": "Optional hash parameter",
       "type": "Optional[Hash]"
+    },
+    "default_string": {
+      "description": "String parameter with default",
+      "type": "String",
+      "default": "hello"
+    },
+    "optional_default_string": {
+      "description": "Optional String parameter with default",
+      "type": "Optional[String]",
+      "default": "goodbye"
     }
   }
 }

--- a/bolt-modules/boltlib/spec/functions/run_task_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_spec.rb
@@ -96,6 +96,39 @@ describe 'run_task' do
       is_expected.to run.with_params('test::yes', hostname).and_return(result_set)
     end
 
+    it 'uses the default if a parameter is not specified' do
+      executable = File.join(tasks_root, 'params.sh')
+      args = {
+        'mandatory_string' => 'str',
+        'mandatory_integer' => 10,
+        'mandatory_boolean' => true
+      }
+
+      expected_args = args.merge('default_string' => 'hello', 'optional_default_string' => 'goodbye')
+      executor.expects(:run_task).with([target], mock_task(executable, 'stdin'), expected_args, {})
+              .returns(result_set)
+      inventory.expects(:get_targets).with(hostname).returns([target])
+
+      is_expected.to run.with_params('Test::Params', hostname, args)
+    end
+
+    it 'does not use the default if a parameter is specified' do
+      executable = File.join(tasks_root, 'params.sh')
+      args = {
+        'mandatory_string' => 'str',
+        'mandatory_integer' => 10,
+        'mandatory_boolean' => true,
+        'default_string' => 'something',
+        'optional_default_string' => 'something else'
+      }
+
+      executor.expects(:run_task).with([target], mock_task(executable, 'stdin'), args, {})
+              .returns(result_set)
+      inventory.expects(:get_targets).with(hostname).returns([target])
+
+      is_expected.to run.with_params('Test::Params', hostname, args)
+    end
+
     it 'when called with no destinations - does not invoke bolt' do
       executor.expects(:run_task).never
       inventory.expects(:get_targets).with([]).returns([])

--- a/documentation/writing_tasks.md
+++ b/documentation/writing_tasks.md
@@ -889,6 +889,29 @@ To define a parameter as sensitive within the JSON metadata, add the `"sensitive
 }
 ```
 
+#### Set default values
+
+You can set a default value for a parameter which will be used if the parameter isn't specified. The default value must be valid according to the parameter's `type`.
+
+Note that not every version of Bolt supports parameter defaults, so you should either make the parameter required or explicitly check for its presence in the task implementation.
+
+```json
+{
+  "description": "This task has a parameter with a default value",
+  "input_method": "stdin",
+  "parameters": {
+    "platform" : {
+      "description": "Which operating system to provision",
+      "type": "String[1]"
+    },
+    "count": {
+      "description": "How many instances to provision",
+      "type": "Integer",
+      "default": 1
+    }
+  }
+```
+
 ### Task metadata reference
 
 The following table shows task metadata keys, values, and default values.

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -223,6 +223,7 @@ module Bolt
 
         task['metadata']['parameters']&.each do |k, v|
           pretty_params << "- #{k}: #{v['type'] || 'Any'}\n"
+          pretty_params << "    Default: #{v['default'].inspect}\n" if v.key?('default')
           pretty_params << "    #{v['description']}\n" if v['description']
           usage << if v['type'].is_a?(Puppet::Pops::Types::POptionalType)
                      " [#{k}=<value>]"

--- a/lib/bolt/task.rb
+++ b/lib/bolt/task.rb
@@ -42,6 +42,12 @@ module Bolt
       metadata['parameters']
     end
 
+    def parameter_defaults
+      (parameters || {}).each_with_object({}) do |(name, param_spec), defaults|
+        defaults[name] = param_spec['default'] if param_spec.key?('default')
+      end
+    end
+
     def supports_noop
       metadata['supports_noop']
     end


### PR DESCRIPTION
This adds a new "default" field to the parameter specification in task
metadata. If a parameter is not specified and has a default value defined, the
default value will be used in its place. The default will be validated against
the parameter type specification and rejected if invalid.

Fixes #1173.