### PR TITLE
(GH-1358) Add yaml plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### New features
 
+* **Addition of a YAML plugin** ([#1358](https://github.com/puppetlabs/bolt/issues/1358))
+
+  Bolt now includes a plugin to look up data from a YAML file.
+
 * **Support `_run_as` parameter for puppet_library hook** ([#1191](https://github.com/puppetlabs/bolt/issues/1191))
 
   Bolt now accepts the `_run_as` metaparameter for puppet_library hooks. `_run_as` specifies which user the library install task will be executed as.

--- a/Puppetfile
+++ b/Puppetfile
@@ -33,6 +33,7 @@ mod 'puppetlabs-azure_inventory', '0.2.0'
 mod 'puppetlabs-terraform', '0.2.0'
 mod 'puppetlabs-vault', '0.2.2'
 mod 'puppetlabs-aws_inventory', '0.2.0'
+mod 'puppetlabs-yaml', '0.1.0'
 
 # If we don't list these modules explicitly, r10k will purge them
 mod 'canary', local: true

--- a/documentation/using_plugins.md
+++ b/documentation/using_plugins.md
@@ -44,6 +44,38 @@ groups:
 
 This reference will be resolved as soon as Bolt runs.
 
+It is important to understand that plugins are used to reference data. The simplest example of this concept is the [YAML](#yaml) plugin. With the YAML plugin, you can effectively "insert" YAML from one file into another. This allows you to organize an inventory into multiple files.
+
+
+```yaml
+---
+# inventory.yaml
+version: 2
+groups:
+  - _plugin: yaml
+    filepath: inventory.d/first_group.yaml
+  - _plugin: yaml
+    filepath: invenotry.d/second_group.yaml
+```
+
+```yaml
+---
+# inventory.d/first_group.yaml
+name: first_group
+targets:
+  - one.example.com
+  - two.example.com
+```
+
+```yaml
+---
+# inventory.d/second_group.yaml
+name: second_group
+targets:
+  - three.example.com
+  - four.example.com
+```
+
 ## Secret plugins
 
 Secret plugins encrypt and decrypt sensitive values in data. The `bolt secret encrypt` and `bolt secret decrypt` commands encrypt or decrypt data that can be used as a reference in data files.
@@ -195,6 +227,9 @@ groups:
             # Lookup config from PuppetDB facts
             hostname: facts.networking.interfaces.en0.ipaddress
 ```
+## YAML
+
+The `yaml` plugin is a module based plugin. For more information see [https://github.com/puppetlabs/puppetlabs-yaml](https://github.com/puppetlabs/puppetlabs-yaml)
 
 ## Terraform
 


### PR DESCRIPTION
Ship a yaml plugin that reads yaml data from a specified file path and returns the contents. Enhance documentation with examples from this very simple concept.

Closes https://github.com/puppetlabs/bolt/issues/1358