### PR TITLE
(GH-1269) Add password-prompt CLI flags and deprecation warning for optional param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
   Bolt now accepts the `_run_as` metaparameter for puppet_library hooks. `_run_as` specifies which user the library install task will be executed as.
 
+* **Add `--password-prompt` and `--sudo-password-prompt` CLI flags** ([#1269](https://github.com/puppetlabs/bolt/issues/1269))
+  Two new flags have been added to support the case where the user would like to set a `password` or `sudo-password` from a prompt without using a plugin. Deprecations messages have been added when a value is not supplied for `--password` or `--sudo-password`.
+
 ## Bolt 1.37.0
 
 ## New features

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -129,6 +129,7 @@ module Bolt
       # Logger must be configured before checking path case, otherwise warnings will not display
       @config.check_path_case('modulepath', @config.modulepath)
 
+      parser.warnings.each { |warning| @logger.warn(warning[:msg]) }
       # After validation, initialize inventory and targets. Errors here are better to catch early.
       # After this step
       # options[:target_args] will contain a string/array version of the targetting options this is passed to plans

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -387,6 +387,17 @@ describe "Bolt::CLI" do
         allow(STDOUT).to receive(:puts)
         cli = Bolt::CLI.new(%w[command run uptime --nodes foo --password])
         expect(cli.parse).to include(password: 'opensesame')
+        expect(@log_output.readlines.join).to match(/Optional parameter for --password is deprecated/)
+      end
+    end
+
+    describe "password-prompt" do
+      it "prompts the user for password" do
+        allow(STDIN).to receive(:noecho).and_return('opensesame')
+        allow(STDERR).to receive(:print).with('Please enter your password: ')
+        allow(STDERR).to receive(:puts)
+        cli = Bolt::CLI.new(%w[command run uptime --nodes foo --password-prompt])
+        expect(cli.parse).to include(password: 'opensesame')
       end
     end
 
@@ -539,6 +550,17 @@ describe "Bolt::CLI" do
         allow(STDOUT).to receive(:puts)
         cli = Bolt::CLI.new(%w[command run uptime --nodes foo --run-as alibaba --sudo-password])
         expect(cli.parse).to include('sudo-password': 'opensez')
+        expect(@log_output.readlines.join).to match(/Optional parameter for --sudo-password is deprecated/)
+      end
+    end
+
+    describe "sudo password-prompt" do
+      it "prompts the user for escalation password" do
+        allow(STDIN).to receive(:noecho).and_return('opensesame')
+        allow(STDERR).to receive(:print).with('Please enter your privilege escalation password: ')
+        allow(STDERR).to receive(:puts)
+        cli = Bolt::CLI.new(%w[command run uptime --nodes foo --sudo-password-prompt])
+        expect(cli.parse).to include('sudo-password': 'opensesame')
       end
     end
 


### PR DESCRIPTION
This commit adds two new CLI flags: `password-prompt` and `sudo-password-prompt`. In order to make parsing commands simpler, moving forward all CLI options either expect a mandatory parameter or do not accept a parameter at all. The `password` and `sudo-password` options violate this by allowing users to optionally set the value on the CLI which, when no value is set a prompt is displayed and the user can enter a password. Currently we will only be warning when the user does not supply a value for `--password` or `--sudo-password`. In 2.0 supplying a value will cause an error.

Closes GH-1269