### PR TITLE
(GH-1175) Populate $nodes and $targets with --targets and --nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
   Bolt now includes a plugin to look up data from a YAML file.
 
+* **Pass value of `--targets` or `--nodes` to `TargetSpec $target` plan parameter** ([#1175](https://github.com/puppetlabs/bolt/issues/1175))
+
+  Bolt now passes the value of `--targets` or `--nodes` to plans with a `TargetSpec $targets` parameter.
+
 * **Support `_run_as` parameter for puppet_library hook** ([#1191](https://github.com/puppetlabs/bolt/issues/1191))
 
   Bolt now accepts the `_run_as` metaparameter for puppet_library hooks. `_run_as` specifies which user the library install task will be executed as.

--- a/documentation/bolt_running_plans.md
+++ b/documentation/bolt_running_plans.md
@@ -16,6 +16,8 @@ bolt plan run mymodule::myplan load_balancer=lb.myorg.com
 
 Note that, like `--nodes`, you can pass a comma-separated list of node names, wildcard patterns, or group names to a plan parameter that is passed to a run function or that the plan resolves using `get_targets`.
 
+When a plan has the parameter `$nodes` and the plan is invoked with either the `--nodes` or `--targets` CLI arguments the argument value will be passed as a plan parameter (for example `nodes=[value]`). Similarly, when a plan accepts a `TargetSpec $targets` parameter the value of `--nodes` or `--targets` is passed as the `targets=[value]` parameter. When a plan contains both a `$nodes` parameter and a `TargetSpec $targets` parameter, the value of the `--nodes` or `--targets` arguments will not be passed.
+
 **Tip:** Bolt is packaged with a collection of modules that contain useful plans to support common workflows. For details, see [Packaged modules](packaged_modules.md).
 
 **Related information**  

--- a/spec/fixtures/modules/sample/plans/single_task_targets.pp
+++ b/spec/fixtures/modules/sample/plans/single_task_targets.pp
@@ -1,0 +1,11 @@
+# one line plan to show we can run a task by name
+plan sample::single_task_targets(
+  TargetSpec       $targets,
+  Optional[String] $description = undef,
+) {
+  return if $description {
+    run_task("sample::echo", $targets, $description, message => "hi there", _catch_errors => true)
+  } else {
+    run_task("sample::echo", $targets, message => "hi there", _catch_errors => true)
+  }
+}

--- a/spec/fixtures/modules/sample/plans/targets_nodes.pp
+++ b/spec/fixtures/modules/sample/plans/targets_nodes.pp
@@ -1,0 +1,7 @@
+# one line plan to show we can run a task by name
+plan sample::targets_nodes(
+  TargetSpec $targets,
+  TargetSpec $nodes
+) {
+  return 'done'
+}


### PR DESCRIPTION
When `--nodes` or `--targets` is provided on CLI, "magically" pass that arg to `$nodes` or `$targets` if there is a plan parameter with name `$targets` XOR `$nodes` of type `TargetSpec` AND there is not a plan argument specified on the CLI with name `nodes` or `targets`.