### PR TITLE
(GH-1379) Show all aliases for a target in inventory show --detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* **`bolt inventory show -- detail` now displays all target aliases** ([#1379](https://github.com/puppetlabs/bolt/issues/1379))
+* **`bolt inventory show --detail` now displays all target aliases** ([#1379](https://github.com/puppetlabs/bolt/issues/1379))
 
   Bolt now displays aliases from all groups, where a target is a member, in the output for `bolt inventory show --detail`. Previously, only the rightmost alias appeared in the output.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Bolt Next
+
+### Bug fixes
+
+* **`bolt inventory show -- detail` now displays all target aliases** ([#1379](https://github.com/puppetlabs/bolt/issues/1379))
+
+  Bolt now displays aliases from all groups, where a target is a member, in the output for `bolt inventory show --detail`. Previously, only the rightmost alias appeared in the output.
+
 ## Bolt 1.38.0
 
 ### New features
@@ -38,7 +46,6 @@
 * **Results from `file::exists` and `file::readable` errored** ([#1415](https://github.com/puppetlabs/bolt/pull/1415))
 
   The `file::exists` and `file::readable` functions no longer error when the file path is specified relative to a module and the file doesn't exist.
-
 
 ## Bolt 1.37.0
 

--- a/lib/bolt/inventory/group2.rb
+++ b/lib/bolt/inventory/group2.rb
@@ -153,6 +153,10 @@ module Bolt
         end
       end
 
+      def clear_alia(target_name)
+        @aliases.reject! { |_alias, name| name == target_name }
+      end
+
       def data_merge(data1, data2)
         if data2.nil? || data1.nil?
           return data2 || data1
@@ -162,7 +166,8 @@ module Bolt
           'config' => Bolt::Util.deep_merge(data1['config'], data2['config']),
           'name' => data1['name'] || data2['name'],
           'uri' => data1['uri'] || data2['uri'],
-          'alias' => data1['alias'] || data2['alias'],
+          # Collect all aliases across all groups for each target uri
+          'alias' => [*data1['alias'], *data2['alias']],
           # Shallow merge instead of deep merge so that vars with a hash value
           # are assigned a new hash, rather than merging the existing value
           # with the value meant to replace it

--- a/lib/bolt/inventory/inventory2.rb
+++ b/lib/bolt/inventory/inventory2.rb
@@ -173,10 +173,12 @@ module Bolt
         existing_target = @targets.key?(new_target.name)
         @targets[new_target.name] = new_target
 
-        unless existing_target
+        if existing_target
+          clear_alia_from_group(@groups, new_target.name)
+        else
           add_to_group([new_target], 'all')
         end
-        # Insert target alias into groups that contain the target
+
         if (aliases = new_target.target_alias)
           aliases = [aliases] if aliases.is_a?(String)
           unless aliases.is_a?(Array)
@@ -184,18 +186,18 @@ module Bolt
             raise ValidationError.new(msg, @name)
           end
 
-          insert_alias_into_group(@groups, new_target.name, aliases)
+          @groups.insert_alia(new_target.name, aliases)
         end
 
         new_target
       end
 
-      def insert_alias_into_group(group, target_name, aliases)
+      def clear_alia_from_group(group, target_name)
         if group.all_target_names.include?(target_name)
-          group.insert_alia(target_name, aliases)
+          group.clear_alia(target_name)
         end
         group.groups.each do |grp|
-          insert_alias_into_group(grp, target_name, aliases)
+          clear_alia_from_group(grp, target_name)
         end
       end
 

--- a/spec/bolt/inventory/group2_spec.rb
+++ b/spec/bolt/inventory/group2_spec.rb
@@ -490,6 +490,21 @@ describe Bolt::Inventory::Group2 do
       it { expect(group.target_aliases).to eq('alias1' => 'target1', 'alias2' => 'target1', 'alias3' => 'target2') }
     end
 
+    context 'multiple aliases in multiple groups' do
+      let(:data) do
+        {
+          'name' => 'root',
+          'groups' => [
+            { 'name' => 'group1', 'targets' => [{ 'name' => 'target', 'alias' => 'alias1' }] },
+            { 'name' => 'group2', 'targets' => [{ 'name' => 'target', 'alias' => 'alias2' }] }
+          ]
+        }
+      end
+
+      it { expect(group.target_aliases).to eq('alias1' => 'target', 'alias2' => 'target') }
+      it { expect(group.target_collect('target')['alias']).to eq(%w[alias2 alias1]) }
+    end
+
     context 'redundant targets' do
       let(:data) do
         {

--- a/spec/bolt/inventory/inventory2_spec.rb
+++ b/spec/bolt/inventory/inventory2_spec.rb
@@ -1273,11 +1273,20 @@ describe Bolt::Inventory::Inventory2 do
   context 'when using inventory show' do
     let(:data) {
       { 'version' => 2,
-        'targets' => [{
-          'uri' => 'foo',
-          'alias' => %w[bar baz],
-          'config' => { 'ssh' => { 'disconnect-timeout' => 100 } },
-          'facts' => { 'foo' => 'bar' }
+        'groups' => [{
+          'name' => 'group1',
+          'targets' => [{
+            'uri' => 'foo',
+            'alias' => %w[bar]
+          }]
+        }, {
+          'name' => 'group2',
+          'targets' => [{
+            'uri' => 'foo',
+            'alias' => %w[baz],
+            'config' => { 'ssh' => { 'disconnect-timeout' => 100 } },
+            'facts' => { 'foo' => 'bar' }
+          }]
         }] }
     }
 
@@ -1286,7 +1295,7 @@ describe Bolt::Inventory::Inventory2 do
     let(:expected_data) {
       { 'name' => 'foo',
         'uri' => 'foo',
-        'alias' => %w[bar baz],
+        'alias' => %w[baz bar],
         'config' => {
           'transport' => 'ssh',
           'ssh' => {

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -751,11 +751,20 @@ describe Bolt::Inventory do
 
   context 'when using inventory show' do
     let(:data) {
-      { 'nodes' => [{
-        'name' => 'foo',
-        'alias' => %w[bar baz],
-        'config' => { 'ssh' => { 'disconnect-timeout' => 100 } },
-        'facts' => { 'foo' => 'bar' }
+      { 'groups' => [{
+        'name' => 'group1',
+        'nodes' => [{
+          'name' => 'foo',
+          'alias' => %w[bar]
+        }]
+      }, {
+        'name' => 'group2',
+        'nodes' => [{
+          'name' => 'foo',
+          'alias' => %w[baz],
+          'config' => { 'ssh' => { 'disconnect-timeout' => 100 } },
+          'facts' => { 'foo' => 'bar' }
+        }]
       }] }
     }
 


### PR DESCRIPTION
This commit fixes a bug where `inventory show --detail` only showed the
rightmost alias for a target. Now, all aliases for a given target will
be displayed in the output.