### PR TITLE
Always return boolean from file predicate functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,15 @@
 
   The CLI now provides the subcommand `project migrate` which migrates Bolt projects to the latest version. When migrating a project, the [inventory file](https://puppet.com/docs/bolt/latest/inventory_file.html) will be changed from `v1` to `v2`. Changes are made in place and will not preserve comments or formatting.
 
-## Bug fixed
+## Bug fixes
 
 * **Support unset environment variables with system::env** ([#1414](https://github.com/puppetlabs/bolt/issues/1414))
 
   The `system::env` function will no longer error when the environment variable is unset.
+
+* **Always return boolean results from file::exists and file::readable** ([#1415](https://github.com/puppetlabs/bolt/pull/1415))
+
+  The `file::exists` and `file::readable` functions will no longer error when the file path is specified relative to a module and the file doesn't exist.
 
 
 ## Bolt 1.37.0

--- a/bolt-modules/file/lib/puppet/functions/file/exists.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/exists.rb
@@ -16,6 +16,6 @@ Puppet::Functions.create_function(:'file::exists', Puppet::Functions::InternalFu
   def exists(scope, filename)
     Puppet.lookup(:bolt_executor) {}&.report_function_call(self.class.name)
     found = Puppet::Parser::Files.find_file(filename, scope.compiler.environment)
-    found && Puppet::FileSystem.exist?(found)
+    found ? Puppet::FileSystem.exist?(found) : false
   end
 end

--- a/bolt-modules/file/lib/puppet/functions/file/readable.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/readable.rb
@@ -16,6 +16,6 @@ Puppet::Functions.create_function(:'file::readable', Puppet::Functions::Internal
   def readable(scope, filename)
     Puppet.lookup(:bolt_executor) {}&.report_function_call(self.class.name)
     found = Puppet::Parser::Files.find_file(filename, scope.compiler.environment)
-    found && File.readable?(found)
+    found ? File.readable?(found) : false
   end
 end


### PR DESCRIPTION
Previously, file::exists and file::readable could return nil in the case
where the file path was specified relative to a module and didn't exist.
That would cause the function (and in turn the plan) to fail with an
invalid return type.

We now ensure these functions always return a boolean.