### PR TITLE
(GH-1358) Track YAML plugin usage

### DIFF
--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -131,7 +131,8 @@ module Bolt
       plugins
     end
 
-    BUILTIN_PLUGINS = %w[task terraform pkcs7 prompt vault aws_inventory puppetdb azure_inventory].freeze
+    BUILTIN_PLUGINS = %w[task terraform pkcs7 prompt vault aws_inventory
+                         puppetdb azure_inventory yaml].freeze
 
     attr_reader :pal, :plugin_context
 


### PR DESCRIPTION
We forgot to iniclude yaml in the BUNDLED_CONTENT list for bundled plugins. This commit adds it.