### PR TITLE
(maint) Pin winrm-fs in OSX component acceptance tests

### DIFF
--- a/acceptance/setup/common/pre-suite/010_install_ruby.rb
+++ b/acceptance/setup/common/pre-suite/010_install_ruby.rb
@@ -46,6 +46,8 @@ PS
       install_package(bolt, 'rubygem-io-console')
       result = on(bolt, 'ruby --version')
     when /osx/
+      # System ruby for osx is 2.3. winrm-fs and its dependencies require > 2.3.
+      on(bolt, 'gem install winrm-fs -v 1.3.3 --no-rdoc --no-ri')
       result = on(bolt, 'ruby --version')
     else
       fail_test("#{bolt['platform']} not currently a supported bolt controller")


### PR DESCRIPTION
The winrm-fs gem effectively dropped support for ruby 2.3 which is the system ruby version we use in the osx bolt controller for component acceptance tests. This commit pre-installs the last ruby 2.3 compatible version of the winrm-fs gem on osx.