### PR TITLE
Check that names of targets returned from plugins are strings

### DIFF
--- a/lib/bolt/inventory/group2.rb
+++ b/lib/bolt/inventory/group2.rb
@@ -108,6 +108,10 @@ module Bolt
           raise ValidationError.new("No name or uri for target: #{target}", @name)
         end
 
+        unless t_name.is_a? String
+          raise ValidationError.new("Target name must be a String, not #{t_name.class}", @name)
+        end
+
         unless t_name.ascii_only?
           raise ValidationError.new("Target name must be ASCII characters: #{target}", @name)
         end

--- a/spec/bolt/inventory/group2_spec.rb
+++ b/spec/bolt/inventory/group2_spec.rb
@@ -210,6 +210,19 @@ describe Bolt::Inventory::Group2 do
     end
   end
 
+  context 'where a target name is not a string' do
+    let(:data) do
+      {
+        'name' => 'group1',
+        'targets' => [{ 'name' => ['foo'] }]
+      }
+    end
+
+    it 'raises an error' do
+      expect { group.validate }.to raise_error(Bolt::Inventory::ValidationError, /Target name must be a String/)
+    end
+  end
+
   context 'where a group name conflicts with a prior target name' do
     let(:data) do
       {


### PR DESCRIPTION
This adds a check to ensure that the name of a target returned from a
plugin is a String before adding it to a group. Since plugins using the new
ruby plugin helper can populate target data with any type of data, setting 
the `name` or `uri` of a target as anything other than a String would raise 
an obscure error.