### PR TITLE
(GH-1382) Ignore settings for localhost target when running plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
   Bolt now displays aliases from all groups, where a target is a member, in the output for `bolt inventory show --detail`. Previously, only the rightmost alias appeared in the output.
 
+* **Plugins now ignore command-line flags** ([#1382](https://github.com/puppetlabs/bolt/issues/1382))
+
+  When running plugins locally to populate config or inventory information, command-line flags such as `--run-as` will no longer be applied to the local transport.
+
 ## Bolt 1.38.0
 
 ### New features

--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -51,7 +51,7 @@ module Bolt
       private :serial_executor
 
       def empty_inventory
-        @empty_inventory ||= Bolt::Inventory::Inventory2.new({}, @config, plugins: @plugins)
+        @empty_inventory ||= Bolt::Inventory::Inventory2.new({}, plugins: @plugins)
       end
       private :empty_inventory
 


### PR DESCRIPTION
Previously, we passed the Bolt config through to the "empty" inventory
used by plugins. That meant that any bolt.yaml configuration for the
`local` transport and any CLI flags were used when running plugins.
For example, running bolt with `--run-as` would cause plugins to run as
the `run-as` user, which is clearly not intended.

We now bypass the standard Bolt config and just use the defaults,
which means that plugins will always run against a standard unconfigured
localhost transport.