### PR TITLE
(GH-1408) Update puppetdb plugin to use target_mapping field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
   `bolt plan show` now uses Puppet Strings to parse plan documentation to show plan and parameter descriptions and parameter defaults.
 
+* **Added `target_mapping` field in `puppetdb` inventory plugin** ([#1408](https://github.com/puppetlabs/bolt/pull/1408))
+
+  The `puppetdb` inventory plugin has a new `target_mapping` field that accepts a hash of target configuration options and the facts to populate them with.
+
 ## Bolt 1.39.0
 
 ### New features

--- a/documentation/using_plugins.md
+++ b/documentation/using_plugins.md
@@ -180,14 +180,13 @@ json.dump({'value': secret}, sys.stdout)
 
 ## PuppetDB
 
-The PuppetDB plugin supports looking up targets from PuppetDB. It takes a `query` field, which is
-either a string containing a [PQL](https://puppet.com/docs/puppetdb/latest/api/query/v4/pql.html)
-query or an array containing a [PuppetDB
-AST](https://puppet.com/docs/puppetdb/latest/api/query/v4/ast.html) format query. The query
-determines which targets should be included in the group. If `name` or `uri` is not specified with
-a [fact lookup](#fact-lookup) then the `[certname]` for each target in the query result will be used as the `uri`
-for the new target. Read the [Migrating to Version 2](inventory_file_v2.md#migrating-to-version-2)
-section for more details on `uri` and `name` keys.
+The PuppetDB plugin supports looking up targets from PuppetDB. It accepts the following fields:
+
+- `_plugin`: The value of `_plugin` must be `puppetdb`.
+- `query`: A string containing a [PQL](https://puppet.com/docs/puppetdb/latest/api/query/v4/pql.html) query or an array containing a [PuppetDB AST](https://puppet.com/docs/puppetdb/latest/api/query/v4/ast.html) format query.
+- `target_mapping`: A hash of target attributes (`name`, `uri`, `config`) to populate with fact lookup values. 
+
+The query determines which targets should be included in the group. If `name` or `uri` is not specified under `target_mapping` with a [fact lookup](#fact-lookup) then the `[certname]` for each target in the query result will be used as the `uri` for the new target. Read the [Migrating to Version 2](inventory_file_v2.md#migrating-to-version-2) section for more details on `uri` and `name` keys.
 
 ```
 groups:
@@ -209,7 +208,7 @@ Make sure you have [configured PuppetDB](bolt_connect_puppetdb.md)
 
 ### Fact Lookup
 
-If target-specific configuration is required the PuppetDB plugin can be used to lookup configuration values for the `name`, `uri`, and `config` inventory options for each target. The fact lookup values can be either `certname` to reference the `[certname]` of the target or a [PQL dot notation](https://puppet.com/docs/puppetdb/latest/api/query/v4/ast.html#dot-notation) facts string such as `facts.os.family` to reference fact value. Dot notation is required for both structured and unstructured facts.
+If target-specific configuration is required the PuppetDB plugin can be used to lookup configuration values for the `name`, `uri`, and `config` inventory options for each target. These values can be set in the `target_mapping` field. The fact lookup values can be either `certname` to reference the `[certname]` of the target or a [PQL dot notation](https://puppet.com/docs/puppetdb/latest/api/query/v4/ast.html#dot-notation) facts string such as `facts.os.family` to reference fact value. Dot notation is required for both structured and unstructured facts.
 
 **Note:** If the `name` or `uri` values are set to a lookup the PuppetDB plugin will **not** set the `uri` to the certname of the target.
 
@@ -222,10 +221,11 @@ groups:
     targets:
       - _plugin: puppetdb
         query: "inventory[certname] { facts.osfamily = 'RedHat' }"
-        config:
-          ssh:
-            # Lookup config from PuppetDB facts
-            user: facts.identity.user
+        target_mapping:
+          config:
+            ssh:
+              # Lookup config from PuppetDB facts
+              user: facts.identity.user
     # And include static config
     config:
       ssh:
@@ -241,11 +241,12 @@ groups:
     targets:
       - _plugin: puppetdb
         query: "inventory[certname] { facts.osfamily = 'RedHat' }"
-        name: certname
-        config:
-          ssh:
-            # Lookup config from PuppetDB facts
-            hostname: facts.networking.interfaces.en0.ipaddress
+        target_mapping:
+          name: certname
+          config:
+            ssh:
+              # Lookup config from PuppetDB facts
+              hostname: facts.networking.interfaces.en0.ipaddress
 ```
 ## YAML
 

--- a/spec/bolt/plugin/puppetdb_spec.rb
+++ b/spec/bolt/plugin/puppetdb_spec.rb
@@ -52,12 +52,37 @@ describe Bolt::Plugin::Puppetdb do
     context "with a name configured" do
       let(:opts) do
         { "query" => '',
-          "name" => 'facts.name_fact' }
+          "target_mapping" => { "name" => 'facts.name_fact' } }
       end
 
       it "sets the uri to the specified name" do
         expect(plugin.resolve_reference(opts))
           .to eq([{ "name" => "thefakeslimcertname" }])
+      end
+    end
+
+    context "with misplaced config keys" do
+      let(:opts) do
+        { "query" => '',
+          "name" => 'facts.name_fact' }
+      end
+
+      it "raises a validation error" do
+        expect { plugin.resolve_reference(opts) }
+          .to raise_error(/PuppetDB plugin expects keys \["name"\]/)
+      end
+    end
+
+    context "with unknown keys" do
+      let(:opts) do
+        { "query" => '',
+          "target_mapping" => {},
+          "bad_key" => '' }
+      end
+
+      it "raises a validation error" do
+        expect { plugin.resolve_reference(opts) }
+          .to raise_error(/Unknown keys in PuppetDB plugin: \["bad_key"\]/)
       end
     end
   end

--- a/spec/integration/inventory2_spec.rb
+++ b/spec/integration/inventory2_spec.rb
@@ -479,7 +479,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
   context 'with pdb lookups', ssh: true, puppetdb: true do
     let(:shell_cmd) { 'whoami' }
     let(:ssh_config) { {} }
-    let(:addtl_inv) { {} }
+    let(:addtl_mapping) { {} }
     let(:facts) { {} }
 
     before(:each) do
@@ -499,10 +499,12 @@ describe 'running with an inventory file', reset_puppet_settings: true do
           {
             _plugin: 'puppetdb',
             query: 'inventory { facts.fact1 = true }',
-            config: {
-              ssh: ssh_config
-            }
-          }.merge(addtl_inv)
+            target_mapping: {
+              config: {
+                ssh: ssh_config
+              }
+            }.merge(addtl_mapping)
+          }
         ],
         config: {
           transport: conn[:protocol],
@@ -535,7 +537,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
           } }
         end
 
-        let(:addtl_inv) do
+        let(:addtl_mapping) do
           { name: 'facts.name_fact',
             uri: 'facts.uri_fact' }
         end
@@ -569,7 +571,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
           } }
         end
 
-        let(:addtl_inv) do
+        let(:addtl_mapping) do
           { name: 'facts.name_fact',
             uri: 'facts.uri_fact' }
         end


### PR DESCRIPTION
This updates the `puppetdb` inventory plugin to accept a
`target_mapping` field that is used to populate target configuration
values with facts loaded from PuppetDB. This is to match the behavior of
other inventory plugins that use the Ruby plugin helper.

> **Do not merge** until other inventory plugins have been updated to use the Ruby plugin helper