### PR TITLE
(GH-1418) Add remove_from_group plan function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 
   Parameter defaults can be set in the task metadata file and will be used if no value is supplied for the parameter.
 
+* **New `remove_from_group` plan function** ([#1418](https://github.com/puppetlabs/bolt/issues/1418))
+
+  The new plan function, `remove_from_group`, allows you to remove a target from an inventory group during plan execution.
+
 ### Bug fixes
 
 * **`bolt inventory show --detail` did not display all target aliases** ([#1379](https://github.com/puppetlabs/bolt/issues/1379))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
   `bolt plan show` now uses Puppet Strings to parse plan documentation to show plan and parameter descriptions and parameter defaults.
 
+* **New `remove_from_group` plan function** ([#1418](https://github.com/puppetlabs/bolt/issues/1418))
+
+  The new plan function, `remove_from_group`, allows you to remove a target from an inventory group during plan execution.
+
 * **Added `target_mapping` field in `puppetdb` inventory plugin** ([#1408](https://github.com/puppetlabs/bolt/pull/1408))
 
   The `puppetdb` inventory plugin has a new `target_mapping` field that accepts a hash of target configuration options and the facts to populate them with.
@@ -19,10 +23,6 @@
 * **Task metadata can now specify parameter defaults** ([#1394](https://github.com/puppetlabs/bolt/pull/1394))
 
   Parameter defaults can be set in the task metadata file and will be used if no value is supplied for the parameter.
-
-* **New `remove_from_group` plan function** ([#1418](https://github.com/puppetlabs/bolt/issues/1418))
-
-  The new plan function, `remove_from_group`, allows you to remove a target from an inventory group during plan execution.
 
 ### Bug fixes
 

--- a/bolt-modules/boltlib/lib/puppet/functions/remove_from_group.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/remove_from_group.rb
@@ -14,7 +14,7 @@ Puppet::Functions.create_function(:remove_from_group) do
   # @example Remove Target from group.
   #   remove_from_group('foo@example.com', 'group1')
   # @example Remove failing Targets from the rest of a plan
-  #   $result = run_command(uptime, my_group)
+  #   $result = run_command(uptime, my_group, '_catch_errors' => true)
   #   $result.error_set.targets.each |$t| { remove_from_group($t, my_group) }
   #   run_command(next_command, my_group) # does not target the failing nodes.
   dispatch :remove_from_group do

--- a/bolt-modules/boltlib/lib/puppet/functions/remove_from_group.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/remove_from_group.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'bolt/error'
+
+# Removes a target from the specified inventory group.
+#
+# The target is removed from all child groups and all parent groups where the target has
+# not been explicitly defined. A target cannot be removed from the 'all' group.
+#
+# **NOTE:** Not available in apply block
+Puppet::Functions.create_function(:remove_from_group) do
+  # @param target A pattern identifying a single target.
+  # @param group The name of the group to remove the target from.
+  # @example Remove Target from group.
+  #   remove_from_group('foo@example.com', 'group1')
+  # @example Remove failing Targets from the rest of a plan
+  #   $result = run_command(uptime, my_group)
+  #   $result.error_set.targets.each |$t| { remove_from_group($t, my_group) }
+  #   run_command(next_command, my_group) # does not target the failing nodes.
+  dispatch :remove_from_group do
+    param 'Boltlib::TargetSpec', :target
+    param 'String[1]', :group
+  end
+
+  def remove_from_group(target, group)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING,
+                              action: 'remove_from_group')
+    end
+
+    inventory = Puppet.lookup(:bolt_inventory)
+    executor = Puppet.lookup(:bolt_executor)
+    executor.report_function_call(self.class.name)
+
+    inventory.remove_from_group(inventory.get_targets(target), group)
+  end
+end

--- a/bolt-modules/boltlib/spec/functions/remove_from_group_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/remove_from_group_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+describe 'remove_from_group' do
+  include PuppetlabsSpec::Fixtures
+  let(:executor) { Bolt::Executor.new }
+  let(:config) { Bolt::Config.new(Bolt::Boltdir.new('.'), {}) }
+  let(:pal) { nil }
+  let(:plugins) { Bolt::Plugin.setup(config, pal, nil, Bolt::Analytics::NoopClient.new) }
+  let(:inventory) { Bolt::Inventory.create_version(data, config, plugins) }
+  let(:tasks_enabled) { true }
+  let(:target1) { 'target1' }
+  let(:target2) { 'target2' }
+  let(:parent) { 'group1' }
+  let(:child) { 'group2' }
+
+  let(:data) do
+    { 'groups' => [
+      { 'name' => parent,
+        'nodes' => [target1],
+        'groups' => [
+          { 'name' => child,
+            'nodes' => [target1, target2] }
+        ] }
+    ] }
+  end
+
+  around(:each) do |example|
+    Puppet[:tasks] = tasks_enabled
+    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
+      example.run
+    end
+  end
+
+  it 'errors when passed invalid data types' do
+    is_expected.to run.with_params(target1, 1)
+                      .and_raise_error(ArgumentError,
+                                       "'remove_from_group' parameter 'group' expects a String value, got Integer")
+  end
+
+  it 'reports the call to analytics' do
+    executor.expects(:report_function_call).with('remove_from_group')
+    is_expected.to run.with_params(target1, parent)
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+    it 'fails and reports that remove_from_group is not available' do
+      is_expected.to run.with_params(target1, parent)
+                        .and_raise_error(/Plan language function 'remove_from_group' cannot be used/)
+    end
+  end
+
+  shared_examples('removing target from a group') do
+    it 'errors when removing multiple targets' do
+      is_expected.to run.with_params(%w[foo bar], 'group1')
+                        .and_raise_error(Bolt::Inventory::ValidationError,
+                                         "'remove_from_group' expects a single Target, got 2")
+    end
+
+    it "errors when removing targets from 'all' group" do
+      is_expected.to run.with_params(target1, 'all')
+                        .and_raise_error(Bolt::Inventory::ValidationError,
+                                         "Cannot remove Target from Group 'all'")
+    end
+
+    it 'removes target from the specified group' do
+      is_expected.to run.with_params(target1, child)
+      targets = inventory.get_targets(child).map(&:name)
+      expect(targets).not_to include(target1)
+    end
+
+    it 'removes target from child groups' do
+      is_expected.to run.with_params(target1, parent)
+      targets = inventory.get_targets(child).map(&:name)
+      expect(targets).not_to include(target1)
+    end
+
+    it 'removes target from parent groups' do
+      is_expected.to run.with_params(target2, child)
+      targets = inventory.get_targets(parent).map(&:name)
+      expect(targets).not_to include(target2)
+    end
+
+    it 'does not remove targets from parent groups that also define the target' do
+      is_expected.to run.with_params(target1, child)
+      targets = inventory.get_targets(parent).map(&:name)
+      expect(targets).to include(target1)
+    end
+  end
+
+  describe 'using inventory version 2' do
+    let(:data) do
+      { 'version' => 2,
+        'groups' => [
+          { 'name' => parent,
+            'targets' => [target1],
+            'groups' => [
+              { 'name' => child,
+                'targets' => [target1, target2] }
+            ] }
+        ] }
+    end
+
+    include_examples 'removing target from a group'
+  end
+
+  describe 'using inventory version 1' do
+    include_examples 'removing target from a group'
+  end
+end

--- a/lib/bolt/inventory/group2.rb
+++ b/lib/bolt/inventory/group2.rb
@@ -142,6 +142,10 @@ module Bolt
         @unresolved_targets[t_name] = target
       end
 
+      def remove_target(target)
+        @resolved_targets.delete(target.name)
+      end
+
       def add_target(target)
         @resolved_targets[target.name] = { 'name' => target.name }
       end

--- a/lib/bolt/inventory/group2.rb
+++ b/lib/bolt/inventory/group2.rb
@@ -144,6 +144,7 @@ module Bolt
 
       def remove_target(target)
         @resolved_targets.delete(target.name)
+        @unresolved_targets.delete(target.name)
       end
 
       def add_target(target)

--- a/lib/bolt/inventory/inventory2.rb
+++ b/lib/bolt/inventory/inventory2.rb
@@ -136,6 +136,18 @@ module Bolt
       end
       private :expand_targets
 
+      def remove_target(current_group, target, desired_group)
+        if current_group.name == desired_group
+          current_group.remove_target(target)
+        end
+        current_group.groups.each do |child_group|
+          # If target was in current group, remove it from all child groups
+          desired_group = child_group.name if current_group.name == desired_group
+          remove_target(child_group, target, desired_group)
+        end
+      end
+      private :remove_target
+
       def add_target(current_group, target, desired_group)
         if current_group.name == desired_group
           current_group.add_target(target)
@@ -198,6 +210,22 @@ module Bolt
         end
         group.groups.each do |grp|
           clear_alia_from_group(grp, target_name)
+        end
+      end
+
+      def remove_from_group(target, desired_group)
+        unless target.length == 1
+          raise ValidationError.new("'remove_from_group' expects a single Target, got #{target.length}", nil)
+        end
+
+        if desired_group == 'all'
+          raise ValidationError.new("Cannot remove Target from Group 'all'", nil)
+        end
+
+        if group_names.include?(desired_group)
+          remove_target(@groups, @targets[target.first.name], desired_group)
+        else
+          raise ValidationError.new("Group #{desired_group} does not exist in inventory", nil)
         end
       end
 

--- a/lib/bolt/inventory/inventory2.rb
+++ b/lib/bolt/inventory/inventory2.rb
@@ -139,11 +139,15 @@ module Bolt
       def remove_target(current_group, target, desired_group)
         if current_group.name == desired_group
           current_group.remove_target(target)
+          target.invalidate_group_cache!
         end
         current_group.groups.each do |child_group|
           # If target was in current group, remove it from all child groups
-          desired_group = child_group.name if current_group.name == desired_group
-          remove_target(child_group, target, desired_group)
+          if current_group.name == desired_group
+            remove_target(child_group, target, child_group.name)
+          else
+            remove_target(child_group, target, desired_group)
+          end
         end
       end
       private :remove_target

--- a/spec/bolt/inventory/inventory2_spec.rb
+++ b/spec/bolt/inventory/inventory2_spec.rb
@@ -1217,6 +1217,28 @@ describe Bolt::Inventory::Inventory2 do
     end
   end
 
+  describe 'remove_from_group' do
+    let(:data) {
+      {
+        'groups' => [{
+          'name' => 'test',
+          'targets' => ['target'],
+          'features' => ['foo']
+        }],
+        'features' => ['bar']
+      }
+    }
+
+    let(:inventory) { Bolt::Inventory::Inventory2.new(data, plugins: plugins) }
+
+    it 'removes target from a group and disinherits config' do
+      target = get_target(inventory, 'target')
+      expect(target.features).to match_array(%w[foo bar])
+      inventory.remove_from_group([target], 'test')
+      expect(target.features).to match_array(%w[bar])
+    end
+  end
+
   context 'with lookup_targets plugins' do
     let(:data) {
       {

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -794,4 +794,29 @@ describe Bolt::Inventory do
       expect(target.detail).to eq(expected_data)
     end
   end
+
+  describe 'remove_from_group' do
+    let(:data) {
+      {
+        'groups' => [{
+          'name' => 'test',
+          'nodes' => ['target'],
+          'features' => ['foo']
+        }, {
+          'name' => 'other',
+          'features' => ['bak']
+        }],
+        'features' => ['bar']
+      }
+    }
+
+    let(:inventory) { Bolt::Inventory.new(data) }
+
+    it 'removes target from a group and disinherits config' do
+      target = get_target(inventory, 'target')
+      expect(target.features).to match_array(%w[foo bar])
+      inventory.remove_from_group([target], 'test')
+      expect(target.features).to match_array(%w[bar])
+    end
+  end
 end


### PR DESCRIPTION
This adds a new `remove_from_group` plan function that allows you to
remove a target from an inventory group during plan execution. The
removed target is removed from all child groups and all parent groups,
except when the parent group explicitly defines the target.

Closes #1418 