### PR TITLE
(GH-1427) Use environment variable for puppetdb config path in Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Bolt Next
+
+### Bug fixes
+
+* **Default PuppetDB config lookup used hardcoded path in Windows** ([#1427](https://github.com/puppetlabs/bolt/pull/1427))
+
+  Bolt will now lookup the default PuppetDB config at `%COMMON_APPDATA%\PuppetLabs\client-tools\puppetdb.conf` instead of the hardcoded path `C:\ProgramData\PuppetLabs\client-tools\puppetdb.conf`.
+
 ## Bolt 1.41.0
 
 ### New features

--- a/documentation/bolt_connect_puppetdb.md
+++ b/documentation/bolt_connect_puppetdb.md
@@ -57,7 +57,7 @@ puppetdb:
   key: /etc/puppetlabs/puppet/ssl/private_keys/my-host.example.com.pem
 ```
 
-If PE is installed and PuppetDB is not defined in a config file, Bolt uses the PuppetDB config defined in either: `$HOME/.puppetlabs/client-tools/puppetdb.conf`or `/etc/puppetlabs/client-tools/puppetdb.conf` (Windows: `C:\ProgramData\PuppetLabs\client-tools\puppetdb.conf`).
+If PE is installed and PuppetDB is not defined in a config file, Bolt uses the PuppetDB config defined in either: `$HOME/.puppetlabs/client-tools/puppetdb.conf`or `/etc/puppetlabs/client-tools/puppetdb.conf` (Windows: `%CSIDL_COMMON_APPDATA%\PuppetLabs\client-tools\puppetdb.conf`).
 
 **Important:** Bolt does not merge config files into a conf.d format the way that pe-client-tools does.
 

--- a/lib/bolt/puppetdb/config.rb
+++ b/lib/bolt/puppetdb/config.rb
@@ -9,19 +9,22 @@ module Bolt
       if !ENV['HOME'].nil?
         DEFAULT_TOKEN = File.expand_path('~/.puppetlabs/token')
         DEFAULT_CONFIG = { user: File.expand_path('~/.puppetlabs/client-tools/puppetdb.conf'),
-                           global: '/etc/puppetlabs/client-tools/puppetdb.conf',
-                           win_global: 'C:/ProgramData/PuppetLabs/client-tools/puppetdb.conf' }.freeze
+                           global: '/etc/puppetlabs/client-tools/puppetdb.conf' }.freeze
       else
         DEFAULT_TOKEN = Bolt::Util.windows? ? 'nul' : '/dev/null'
         DEFAULT_CONFIG = { user: '/etc/puppetlabs/puppet/puppetdb.conf',
-                           global: '/etc/puppetlabs/puppet/puppetdb.conf',
-                           win_global: 'C:/ProgramData/PuppetLabs/client-tools/puppetdb.conf' }.freeze
+                           global: '/etc/puppetlabs/puppet/puppetdb.conf' }.freeze
 
+      end
+
+      def self.default_windows_config
+        require 'win32/dir'
+        File.expand_path(File.join(Dir::COMMON_APPDATA, 'PuppetLabs/client-tools/puppetdb.conf'))
       end
 
       def self.load_config(filename, options, boltdir_path = nil)
         config = {}
-        global_path = Bolt::Util.windows? ? DEFAULT_CONFIG[:win_global] : DEFAULT_CONFIG[:global]
+        global_path = Bolt::Util.windows? ? default_windows_config : DEFAULT_CONFIG[:global]
         if filename
           if File.exist?(filename)
             config = JSON.parse(File.read(filename))

--- a/spec/bolt/puppetdb/config_spec.rb
+++ b/spec/bolt/puppetdb/config_spec.rb
@@ -194,10 +194,10 @@ describe Bolt::PuppetDB::Config do
       Bolt::PuppetDB::Config.load_config(nil, {})
     end
 
-    it "on windows OS loads from default location when filename is nil" do
+    it "on windows OS loads from default location when filename is nil", :winrm do
       allow(Bolt::Util).to receive(:windows?).and_return(true)
       expect(File).to receive(:exist?).with(Bolt::PuppetDB::Config::DEFAULT_CONFIG[:user])
-      expect(File).to receive(:exist?).with(Bolt::PuppetDB::Config::DEFAULT_CONFIG[:win_global])
+      expect(File).to receive(:exist?).with(Bolt::PuppetDB::Config.default_windows_config)
       Bolt::PuppetDB::Config.load_config(nil, {})
     end
 


### PR DESCRIPTION
This updates how Bolt locates the puppetdb config file on Windows.
Previously, the path was hardcoded as `C:\ProgramData\`, which could
cause issues if the user redirected the folder or had a different system
drive. Bolt will now use the `win32-dir` constant
`Dir::COMMON_APPDATA` to get the known folder.

Fixes #1427 