### PR TITLE
(GH-1409) Show plan info using puppet strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Bolt Next
+
+### New features
+
+* **`bolt plan show` shows plan and parameter descriptions** ([#1442](https://github.com/puppetlabs/bolt/pull/1442))
+
+  `bolt plan show` now uses Puppet Strings to parse plan documentation to show plan and parameter descriptions and parameter defaults.
+
 ## Bolt 1.39.0
 
 ### New features

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -257,15 +257,18 @@ module Bolt
         plan_info = +""
         usage = +"bolt plan run #{plan['name']}"
 
-        plan['parameters']&.each do |name, p|
+        plan['parameters'].each do |name, p|
           pretty_params << "- #{name}: #{p['type']}\n"
+          pretty_params << "    Default: #{p['default_value']}\n" unless p['default_value'].nil?
+          pretty_params << "    #{p['description']}\n" if p['description']
           usage << (p.include?('default_value') ? " [#{name}=<value>]" : " #{name}=<value>")
         end
 
         plan_info << "\n#{plan['name']}"
+        plan_info << " - #{plan['description']}" if plan['description']
         plan_info << "\n\n"
         plan_info << "USAGE:\n#{usage}\n\n"
-        plan_info << "PARAMETERS:\n#{pretty_params}\n" if plan['parameters']
+        plan_info << "PARAMETERS:\n#{pretty_params}\n" unless plan['parameters'].empty?
         plan_info << "MODULE:\n"
 
         path = plan['module']

--- a/lib/bolt/pal/yaml_plan.rb
+++ b/lib/bolt/pal/yaml_plan.rb
@@ -6,16 +6,17 @@ require 'bolt/pal/yaml_plan/step'
 module Bolt
   class PAL
     class YamlPlan
-      PLAN_KEYS = Set['parameters', 'steps', 'return', 'version']
+      PLAN_KEYS = Set['parameters', 'steps', 'return', 'version', 'description']
       VAR_NAME_PATTERN = /\A[a-z_][a-z0-9_]*\z/.freeze
 
-      attr_reader :name, :parameters, :steps, :return
+      attr_reader :name, :parameters, :steps, :return, :description
 
       def initialize(name, plan)
         # Top-level plan keys aren't allowed to be Puppet code, so force them
         # all to strings.
         plan = Bolt::Util.walk_keys(plan) { |key| stringify(key) }
         @name = name.freeze
+        @description = stringify(plan['description']) if plan['description']
 
         params_hash = stringify(plan.fetch('parameters', {}))
         # Ensure params is a hash

--- a/lib/bolt/pal/yaml_plan/loader.rb
+++ b/lib/bolt/pal/yaml_plan/loader.rb
@@ -53,7 +53,7 @@ module Bolt
           PuppetVisitor.create_visitor.accept(parse_tree)
         end
 
-        def self.create(loader, typed_name, source_ref, yaml_string)
+        def self.from_string(name, yaml_string, source_ref)
           result = parse_plan(yaml_string, source_ref)
           unless result.is_a?(Hash)
             type = result.class.name
@@ -61,11 +61,14 @@ module Bolt
           end
 
           begin
-            plan_definition = YamlPlan.new(typed_name, result).freeze
+            YamlPlan.new(name, result).freeze
           rescue Bolt::Error => e
             raise Puppet::ParseError.new(e.message, source_ref)
           end
+        end
 
+        def self.create(loader, typed_name, source_ref, yaml_string)
+          plan_definition = from_string(typed_name.name, yaml_string, source_ref)
           created = create_function_class(plan_definition)
           closure_scope = nil
 

--- a/lib/bolt/pal/yaml_plan/parameter.rb
+++ b/lib/bolt/pal/yaml_plan/parameter.rb
@@ -4,7 +4,7 @@ module Bolt
   class PAL
     class YamlPlan
       class Parameter
-        attr_reader :name, :value, :type_expr
+        attr_reader :name, :value, :type_expr, :description
 
         PARAMETER_KEYS = Set['type', 'default', 'description']
 
@@ -15,6 +15,7 @@ module Bolt
           @name = param
           @value = definition['default']
           @type_expr = Puppet::Pops::Types::TypeParser.singleton.parse(definition['type']) if definition['type']
+          @description = definition['description']
         end
 
         def validate_param(param, definition)

--- a/lib/bolt/pal/yaml_plan/transpiler.rb
+++ b/lib/bolt/pal/yaml_plan/transpiler.rb
@@ -48,7 +48,6 @@ module Bolt
           plan_string
         end
 
-        # Save me from all these rescue statements...
         def parse_plan
           begin
             file_contents = File.read(@plan_path)
@@ -57,18 +56,7 @@ module Bolt
             raise Bolt::FileError.new(msg, @plan_path)
           end
 
-          begin
-            result = Bolt::PAL::YamlPlan::Loader.parse_plan(file_contents, @plan_path)
-          rescue Error => e
-            raise ConvertError.new("Failed to convert yaml plan: #{e.message}", @plan_path)
-          end
-
-          unless result.is_a?(Hash)
-            type = result.class.name
-            raise ArgumentError, "The data loaded from #{source_ref} does not contain an object - its type is #{type}"
-          end
-
-          Bolt::PAL::YamlPlan.new(@modulename, result).freeze
+          Bolt::PAL::YamlPlan::Loader.from_string(@modulename, file_contents, @plan_path)
         end
 
         def validate_path

--- a/modules/canary/plans/init.pp
+++ b/modules/canary/plans/init.pp
@@ -24,7 +24,7 @@
 #
 # @example Run a command
 #   run_plan(canary, command => 'whoami', nodes => $mynodes)
-
+#
 plan canary(
   Optional[String[0]] $task = undef,
   Optional[String[0]] $command = undef,

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1165,17 +1165,21 @@ describe "Bolt::CLI" do
           json = JSON.parse(output.string)
           expect(json).to eq(
             "name" => "sample::optional_params_task",
+            "description" => "Demonstrates plans with optional parameters",
             "module_dir" => File.absolute_path(File.join(__dir__, "..", "fixtures", "modules", "sample")),
             "parameters" => {
               "param_mandatory" => {
-                "type" => "String"
+                "type" => "String",
+                "description" => "A mandatory parameter"
               },
               "param_optional" => {
-                "type" => "Optional[String]"
+                "type" => "Optional[String]",
+                "description" => "An optional parameter"
               },
               "param_with_default_value" => {
                 "type" => "String",
-                "default_value" => nil
+                "description" => "A parameter with a default value",
+                "default_value" => "'foo'"
               }
             }
           )
@@ -1192,18 +1196,20 @@ describe "Bolt::CLI" do
           json = JSON.parse(output.string)
           expect(json).to eq(
             "name" => "sample::yaml",
+            "description" => nil,
             "module_dir" => File.absolute_path(File.join(__dir__, "..", "fixtures", "modules", "sample")),
             "parameters" => {
               "nodes" => {
-                "type" => "TargetSpec"
+                "type" => "TargetSpec",
+                "default_value" => nil
               },
               "param_optional" => {
                 "type" => "Optional[String]",
-                "default_value" => nil
+                "default_value" => 'undef'
               },
               "param_with_default_value" => {
                 "type" => "String",
-                "default_value" => nil
+                "default_value" => 'hello'
               }
             }
           )

--- a/spec/bolt/pal/yaml_plan/transpiler_spec.rb
+++ b/spec/bolt/pal/yaml_plan/transpiler_spec.rb
@@ -50,7 +50,7 @@ describe Bolt::PAL::YamlPlan::Transpiler do
 
     it 'errors on duplicate step names' do
       expect { transpiler.transpile(plan_path) }
-        .to raise_error(Bolt::Error, /#{error}/)
+        .to raise_error(Puppet::ParseError, /#{error}/)
     end
   end
 

--- a/spec/fixtures/modules/sample/plans/optional_params_task.pp
+++ b/spec/fixtures/modules/sample/plans/optional_params_task.pp
@@ -1,3 +1,9 @@
+# @summary
+#   Demonstrates plans with optional parameters
+#
+# @param param_mandatory A mandatory parameter
+# @param param_optional An optional parameter
+# @param param_with_default_value A parameter with a default value
 plan sample::optional_params_task(
   String $param_mandatory,
   Optional[String] $param_optional,

--- a/spec/integration/parsing_spec.rb
+++ b/spec/integration/parsing_spec.rb
@@ -36,13 +36,14 @@ describe "CLI parses input" do
 
     expect(result).to eq(
       "name" => "parsing",
+      "description" => nil,
       "module_dir" => File.absolute_path(File.join(__dir__, '..', 'fixtures', 'modules', 'parsing')),
       "parameters" => {
         "string" => { "type" => "String" },
         "string_bool" => { "type" => "Variant[String, Boolean]" },
         "nodes" => { "type" => "TargetSpec" },
-        "array" => { "type" => "Optional[Array]", "default_value" => nil },
-        "hash" => { "type" => "Optional[Hash]", "default_value" => nil }
+        "array" => { "type" => "Optional[Array]", "default_value" => 'undef' },
+        "hash" => { "type" => "Optional[Hash]", "default_value" => 'undef' }
       }
     )
   end


### PR DESCRIPTION
Previously, the info we showed with `bolt plan show <plan>` was very basic
and only included some of the information that Puppet could load from the
plan object. We now use puppet strings to parse the docstrings for the plan
so we can show description for the plan and its parameters as well as
parameter defaults.

We also now show the same data for YAML plans, though not through Puppet 
strings.