### PR TITLE
(maint) Copy, don't modify, `features` for localhost_defaults

### DIFF
--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -212,7 +212,7 @@ module Bolt
       }
       data = Bolt::Util.deep_merge(defaults, data)
       # If features is an empty array deep_merge won't add the puppet-agent
-      data['features'] << 'puppet-agent' if data['features'].empty?
+      data['features'] += ['puppet-agent'] if data['features'].empty?
       data
     end
 


### PR DESCRIPTION
Previously, we used the concat operator `<<` to insert the
'puppet-agent' feature into the localhost features set. In some cases,
the features set could be a plain reference to group data from the
inventory, so modifying it in place could cause that modification to be
visible to any other target in the same group. We now use the `+=`
operator which will first make a copy of the original set, ensuring we
don't affect unintended targets with the change.