### PR TITLE
(maint) Update rubocop cop names

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,7 +38,7 @@ Style/StderrPuts:
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
 
 Layout/ClosingHeredocIndentation:
@@ -88,7 +88,7 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Enabled: false
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Exclude:
     - lib/bolt/transport/local/shell.rb
 

--- a/bolt-modules/boltlib/lib/puppet/functions/catch_errors.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/catch_errors.rb
@@ -44,9 +44,9 @@ Puppet::Functions.create_function(:catch_errors) do
     rescue Puppet::PreformattedError => e
       if e.cause.is_a?(Bolt::Error)
         if error_types.nil?
-          return e.cause.to_puppet_error
+          e.cause.to_puppet_error
         elsif error_types.include?(e.cause.to_h['kind'])
-          return e.cause.to_puppet_error
+          e.cause.to_puppet_error
         else
           raise e
         end

--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -63,7 +63,7 @@ module Bolt
         if defined?(Puppet)
           begin
             compiler = Puppet.lookup(:pal_compiler)
-          rescue Puppet::Context::UndefinedBindingError; end # rubocop:disable Lint/HandleExceptions
+          rescue Puppet::Context::UndefinedBindingError; end # rubocop:disable Lint/SuppressedException
         end
 
         if compiler

--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -176,7 +176,7 @@ module Bolt
         rescue TypeError
           # unclonable (TrueClass, Fixnum, ...)
           cloned[obj.object_id] = obj
-          return obj
+          obj
         else
           cloned[obj.object_id] = cl
           cloned[cl.object_id] = cl
@@ -195,7 +195,7 @@ module Bolt
             cl.instance_variable_set(var, v_cl)
           end
 
-          return cl
+          cl
         end
       end
 

--- a/spec/lib/bolt_spec/integration.rb
+++ b/spec/lib/bolt_spec/integration.rb
@@ -24,10 +24,10 @@ module BoltSpec
         begin
           opts = cli.parse
           cli.execute(opts)
-        # rubocop:disable Lint/HandleExceptions
+        # rubocop:disable Lint/SuppressedException
         rescue Bolt::Error
         end
-        # rubocop:enable Lint/HandleExceptions
+        # rubocop:enable Lint/SuppressedException
       else
         opts = cli.parse
         cli.execute(opts)


### PR DESCRIPTION
Rubocop updated some of the names of cops in its latest release. This
updates the rubocop config file to use the new names.

This also removes some redundant `return` statements that rubocop is now
picking up.