### PR TITLE
Added detailed example of puppetdb_query() usage

### DIFF
--- a/documentation/bolt_connect_puppetdb.md
+++ b/documentation/bolt_connect_puppetdb.md
@@ -76,6 +76,20 @@ You can test your configuration with the following plan, which returns a list of
 
 ```
 plan pdb_test {
-  return(puppetdb_query("nodes[certname] {}"))
+  # query PuppetDB for a list of node certnames
+  # this returns an array of objects, each object containing a "certname" parameter:
+  # [ {"certname": "node1"}, {"certname": "node2"} ]
+  $query_results = puppetdb_query("nodes[certname] {}")
+  
+  # since puppetdb_query() returns the JSON results from the API call, we need to transform this
+  # data into Targets to use it in one of the run_*() functions.
+  # extract the "certname" values, so now we have an array of hostnames
+  $certnames = $query_results.map |$r| { $r['certname'] }
+  
+  # transform the arary of certnames into an array of Targets
+  $targets = get_targets($certnames)
+  
+  # gather facts about all of the nodes
+  run_task('facts', $targets)
 }
 ```

--- a/documentation/bolt_connect_puppetdb.md
+++ b/documentation/bolt_connect_puppetdb.md
@@ -82,9 +82,9 @@ plan pdb_test {
 
 ## Practical Usage
 
-In practice it is common to extract inventory from PuppetDB dynamically and use them
-in a plan. The following is an example of doing that using the `puppetdb_query()` function
-directly. This method works, but requires data munging to be effective.
+In practice, it is common to extract inventory from PuppetDB dynamically to use
+in a plan. The following is an example using the `puppetdb_query()` function
+directly. This method works but requires data munging to be effective.
 
 ```
 plan puppetdb_query_targets {

--- a/documentation/bolt_connect_puppetdb.md
+++ b/documentation/bolt_connect_puppetdb.md
@@ -76,7 +76,7 @@ You can test your configuration with the following plan, which returns a list of
 
 ```
 plan pdb_test {
-  returns(puppetdb_query("nodes[certname] {}"))
+  return(puppetdb_query("nodes[certname] {}"))
 }
 ```
 


### PR DESCRIPTION
Based on a conversation in Slack, i've added a more detailed example of how to use `puppetdb_query()` so new users understand that the plan function just returns the raw query results and needs to transform them into Targets to use them in `run_*()` functions.