### PR TITLE
(GH-1404) Update bundled plugins to use ruby_plugin_helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Bolt 1.41.0
+
+### New features
+
+* **Added `target_mapping` field in `terraform` and `aws_inventory` inventory plugins** ([#1404](https://github.com/puppetlabs/bolt/issues/1404))
+
+  The `terraform` and `aws_inventory` inventory plugins have a new `target_mapping` field which accepts a hash of target configuration options and the lookup values to populate them with.
+
+* **Ruby helper library for inventory plugins** ([#1404](https://github.com/puppetlabs/bolt/issues/1404))
+
+    A new library has been added to help write inventory plugins in Ruby:
+
+    * https://github.com/puppetlabs/puppetlabs-ruby_plugin_helper
+
+    Use this library to map lookup values to a target's configuration options in a `resolve_references` task.
+    
 ## Bolt 1.40.0
 
 ### New features

--- a/Puppetfile
+++ b/Puppetfile
@@ -27,12 +27,13 @@ mod 'puppetlabs-puppet_conf', '0.4.0'
 mod 'puppetlabs-python_task_helper', '0.3.0'
 mod 'puppetlabs-reboot', '2.2.0'
 mod 'puppetlabs-ruby_task_helper', '0.4.0'
+mod 'puppetlabs-ruby_plugin_helper', '0.1.0'
 
 # Plugin modules
 mod 'puppetlabs-azure_inventory', '0.2.0'
-mod 'puppetlabs-terraform', '0.2.0'
+mod 'puppetlabs-terraform', '0.3.0'
 mod 'puppetlabs-vault', '0.2.2'
-mod 'puppetlabs-aws_inventory', '0.2.0'
+mod 'puppetlabs-aws_inventory', '0.3.0'
 mod 'puppetlabs-yaml', '0.1.0'
 
 # If we don't list these modules explicitly, r10k will purge them


### PR DESCRIPTION
This updates Bolt's Puppetfile to include version 0.3.0 of both the
`terraform` and `aws_inventory` plugins, as well as the initial release
of the `ruby_plugin_helper`.

Closes #1404 