### PR TITLE
(GH-1244) Serialize plan variables as pcore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### New features
 
+* **Plan language objects available inside apply blocks** ([#1244](https://github.com/puppetlabs/bolt/issues/1244))
+
+  Previously, plan language objects (Result, ApplyResult, ResultSet, and Target) were not available
+  inside apply blocks as objects, only as flat data. They're now accessible as read-only objects,
+  where functions that modify the object (such as `$target.set_var`) are not available but functions
+  that read data (such as `$target.vars`) can be used.
+
 * **`run_plan` plan function will specify a plan's `$targets` parameter using the second positional argument** ([#1446](https://github.com/puppetlabs/bolt/issues/1446))
 
   When running a plan with a `$targets` parameter with the `run_plan` plan function, the second positional argument can be used to specify the `$targets` parameter. If a plan has a `$nodes` parameter, the second positional argument will only specify the `$nodes` parameter.

--- a/bolt-modules/boltlib/lib/puppet/datatypes/target.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/target.rb
@@ -3,6 +3,7 @@
 Puppet::DataTypes.create_type('Target') do
   begin
     inventory = Puppet.lookup(:bolt_inventory)
+
     inventory_version = inventory.version
     if inventory_version != 1
       target_implementation_class = inventory.target_implementation_class
@@ -10,7 +11,7 @@ Puppet::DataTypes.create_type('Target') do
   rescue Puppet::Context::UndefinedBindingError
     inventory_version = 1
   end
-  load_file('bolt/target')
+  require 'bolt/target'
 
   if inventory_version == 1
     interface <<-PUPPET
@@ -33,15 +34,15 @@ Puppet::DataTypes.create_type('Target') do
       attributes => {
         uri => { type => Optional[String[1]], kind => given_or_derived },
         name => { type => Optional[String[1]] , kind => given_or_derived },
+        safe_name => { type =>  Optional[String[1]], kind => given_or_derived },
         target_alias => { type => Optional[Variant[String[1], Array[String[1]]]], kind => given_or_derived },
         config => { type => Optional[Hash[String[1], Data]], kind => given_or_derived },
-        vars => { type => Optional[Hash[String[1], Data]], kind => given_or_derived  },
-        facts => { type => Optional[Hash[String[1], Data]], kind => given_or_derived  },
+        vars => { type => Optional[Hash[String[1], Data]], kind => given_or_derived },
+        facts => { type => Optional[Hash[String[1], Data]], kind => given_or_derived },
         features => { type => Optional[Array[String[1]]], kind => given_or_derived },
-        plugin_hooks => { type => Optional[Hash[String[1], Data]], kind => given_or_derived  }
+        plugin_hooks => { type => Optional[Hash[String[1], Data]], kind => given_or_derived }
       },
       functions => {
-        safe_name => Callable[[], String[1]],
         host => Callable[[], Optional[String]],
         password => Callable[[], Optional[String[1]]],
         port => Callable[[], Optional[Integer]],

--- a/bolt-modules/boltlib/lib/puppet/functions/get_target.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/get_target.rb
@@ -4,10 +4,9 @@ require 'bolt/error'
 
 # Get a single target from inventory if it exists, otherwise create a new Target.
 #
-# **NOTE:** Calling `get_target` inside an `apply` block with a
-# version 2 inventory creates a new Target object.
-# `get_target('all')` returns an empty array.
+# **NOTE:** Calling `get_target('all')` returns an empty array.
 # **NOTE:** Only compatible with inventory v2
+# **NOTE:** Not available in apply block when `future` is true
 Puppet::Functions.create_function(:get_target) do
   # @param name A Target name.
   # @return A single target, either new or from inventory.

--- a/bolt-modules/boltlib/lib/puppet/functions/get_targets.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/get_targets.rb
@@ -3,10 +3,9 @@
 require 'bolt/error'
 
 # Parses common ways of referring to targets and returns an array of Targets.
-#
-# **NOTE:** Calling `get_targets` inside an `apply` block with a
-# version 2 inventory creates a new Target object.
 # `get_targets('all')` returns an empty array.
+#
+# **NOTE:** Not available in apply block when `future` is true
 Puppet::Functions.create_function(:get_targets) do
   # @param names A pattern or array of patterns identifying a set of targets.
   # @return A list of unique Targets resolved from any target URIs and groups.

--- a/documentation/applying_manifest_blocks.md
+++ b/documentation/applying_manifest_blocks.md
@@ -91,7 +91,6 @@ In addition to the standard Puppet functions available to a catalog, such as `lo
 
 -   [`puppetdb_query`](plan_functions.md#)
 -   [`puppetdb_facts`](plan_functions.md#)
--   [`get_targets`](plan_functions.md#)
 -   [`facts`](plan_functions.md#)
 -   [`vars`](plan_functions.md#)
 

--- a/lib/bolt/apply_inventory.rb
+++ b/lib/bolt/apply_inventory.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'bolt/boltdir'
+require 'bolt/config'
+require 'bolt/error'
+
+module Bolt
+  class ApplyInventory
+    class InvalidFunctionCall < Bolt::Error
+      def initialize(function)
+        super("The function '#{function}' is not callable within an apply block",
+              'bolt.inventory/invalid-function-call')
+      end
+    end
+
+    attr_reader :config_hash
+
+    def initialize(config_hash = {})
+      @config_hash = config_hash
+      @targets = {}
+    end
+
+    def create_apply_target(target)
+      @targets[target.name] = target
+    end
+
+    def validate
+      @groups.validate
+    end
+
+    def version
+      2
+    end
+
+    def target_implementation_class
+      Bolt::ApplyTarget
+    end
+
+    def get_targets(*_params)
+      raise InvalidFunctionCall, 'get_targets'
+    end
+
+    def get_target(*_params)
+      raise InvalidFunctionCall, 'get_target'
+    end
+
+    # rubocop:disable Naming/AccessorMethodName
+    def set_var(*_params)
+      raise InvalidFunctionCall, 'set_var'
+    end
+
+    def set_feature(*_params)
+      raise InvalidFunctionCall, 'set_feature'
+    end
+    # rubocop:enable Naming/AccessorMethodName
+
+    def vars(target)
+      @targets[target.name].vars
+    end
+
+    def add_facts(*_params)
+      raise InvalidFunctionCall, 'add_facts'
+    end
+
+    def facts(target)
+      @targets[target.name].facts
+    end
+
+    def features(target)
+      @targets[target.name].features
+    end
+
+    def add_to_group(*_params)
+      raise InvalidFunctionCall, 'add_to_group'
+    end
+
+    def plugin_hooks(target)
+      @targets[target.name].plugin_hooks
+    end
+
+    def set_config(_target, _key_or_key_path, _value)
+      raise InvalidFunctionCall, 'set_config'
+    end
+
+    def target_config(target)
+      @targets[target.name].config
+    end
+  end
+end

--- a/lib/bolt/apply_result.rb
+++ b/lib/bolt/apply_result.rb
@@ -85,6 +85,13 @@ module Bolt
       end
     end
 
+    # Other pcore methods are inherited from Result
+    def _pcore_init_hash
+      { 'target' => @target,
+        'error' => value['_error'],
+        'report' => value['report'] }
+    end
+
     def initialize(target, error: nil, report: nil)
       @target = target
       @value = {}

--- a/lib/bolt/apply_target.rb
+++ b/lib/bolt/apply_target.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Bolt
+  class ApplyTarget
+    ATTRIBUTES = %i[uri name target_alias config vars facts features
+                    plugin_hooks safe_name].freeze
+    COMPUTED = %i[host password port protocol user].freeze
+
+    attr_reader(*ATTRIBUTES)
+    attr_accessor(*COMPUTED)
+
+    # rubocop:disable Lint/UnusedMethodArgument
+    # Target.new from a plan initialized with a hash
+    def self.from_asserted_hash(hash)
+      raise Bolt::Error.new("Target objects cannot be instantiated inside apply blocks", 'bolt/apply-error')
+    end
+
+    # Target.new from a plan with just a uri.
+    def self.from_asserted_args(uri = nil,
+                                name = nil,
+                                safe_name = nil,
+                                target_alias = nil,
+                                config = nil,
+                                facts = nil,
+                                vars = nil,
+                                features = nil,
+                                plugin_hooks = nil)
+      raise Bolt::Error.new("Target objects cannot be instantiated inside apply blocks", 'bolt/apply-error')
+    end
+    # rubocop:enable Lint/UnusedMethodArgument
+
+    def self._pcore_init_from_hash
+      raise "ApplyTarget shouldn't be instantiated from a pcore_init class method. How did this get called?"
+    end
+
+    def _pcore_init_from_hash(init_hash)
+      inventory = Puppet.lookup(:bolt_inventory)
+      initialize(init_hash, inventory.config_hash)
+      inventory.create_apply_target(self)
+      self
+    end
+
+    def initialize(target_hash, config)
+      ATTRIBUTES.each do |attr|
+        instance_variable_set("@#{attr}", target_hash[attr.to_s])
+      end
+
+      # Merge the config hash with inventory config
+      config = Bolt::Util.deep_merge(config, @config)
+      transport = config['transport'] || 'ssh'
+      t_conf = config['transports'][transport] || {}
+      uri_obj = parse_uri(uri)
+      @host = uri_obj.hostname || t_conf['host']
+      @password = Addressable::URI.unencode_component(uri_obj.password) || t_conf['password']
+      @port = uri_obj.port || t_conf['port']
+      @protocol = uri_obj.scheme || transport
+      @user = Addressable::URI.unencode_component(uri_obj.user) || t_conf['user']
+    end
+
+    def parse_uri(string)
+      require 'addressable/uri'
+      if string.nil?
+        Addressable::URI.new
+        # Forbid empty uri
+      elsif string.empty?
+        raise Bolt::ParseError, "Could not parse target URI: URI is empty string"
+      elsif string =~ %r{^[^:]+://}
+        Addressable::URI.parse(string)
+      else
+        # Initialize with an empty scheme to ensure we parse the hostname correctly
+        Addressable::URI.parse("//#{string}")
+      end
+    rescue Addressable::URI::InvalidURIError => e
+      raise Bolt::ParseError, "Could not parse target URI: #{e.message}"
+    end
+  end
+end

--- a/lib/bolt/catalog.rb
+++ b/lib/bolt/catalog.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+require 'bolt/apply_target'
 require 'bolt/config'
+require 'bolt/error'
 require 'bolt/inventory'
+require 'bolt/apply_inventory'
 require 'bolt/pal'
 require 'bolt/puppetdb'
 require 'bolt/util'
@@ -65,17 +68,29 @@ module Bolt
       target = request['target']
       pdb_client = Bolt::PuppetDB::Client.new(Bolt::PuppetDB::Config.new(request['pdb_config']))
       options = request['puppet_config'] || {}
+
       with_puppet_settings(request['hiera_config']) do
         Puppet[:rich_data] = true
         Puppet[:node_name_value] = target['name']
-        Puppet::Pal.in_tmp_environment('bolt_catalog',
-                                       modulepath: request["modulepath"] || [],
-                                       facts: target["facts"] || {},
-                                       variables: target["variables"] || {}) do |pal|
+        env_conf = { modulepath: request['modulepath'] || [],
+                     facts: target['facts'] || {} }
+        env_conf[:variables] = request['future'] ? {} : target['variables']
+        Puppet::Pal.in_tmp_environment('bolt_catalog', env_conf) do |pal|
+          inv = if request['future']
+                  Bolt::ApplyInventory.new(request['config'])
+                else
+                  setup_inventory(request['inventory'])
+                end
           Puppet.override(bolt_pdb_client: pdb_client,
-                          bolt_inventory: setup_inventory(request['inventory'])) do
+                          bolt_inventory: inv) do
             Puppet.lookup(:pal_current_node).trusted_data = target['trusted']
             pal.with_catalog_compiler do |compiler|
+              if request['future']
+                # This needs to happen inside the catalog compiler so loaders are initialized for loading
+                vars = Puppet::Pops::Serialization::FromDataConverter.convert(request['plan_vars'])
+                pal.send(:add_variables, compiler.send(:topscope), vars.merge(target['variables']))
+              end
+
               # Configure language strictness in the CatalogCompiler. We want Bolt to be able
               # to compile most Puppet 4+ manifests, so we default to allowing deprecated functions.
               Puppet[:strict] = options['strict'] || :warning

--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -72,6 +72,24 @@ module Bolt
       new(target, value: value)
     end
 
+    def self._pcore_init_from_hash
+      raise "Result shouldn't be instantiated from a pcore_init class method. How did this get called?"
+    end
+
+    def _pcore_init_from_hash(init_hash)
+      opts = init_hash.reject { |k, _v| k == 'target' }
+      initialize(init_hash['target'], opts.map { |k, v| [k.to_sym, v] }.to_h)
+    end
+
+    def _pcore_init_hash
+      { 'target' => @target,
+        'error' => @value['_error'],
+        'message' => @value['_output'],
+        'value' => @value,
+        'action' => @action,
+        'object' => @object }
+    end
+
     def initialize(target, error: nil, message: nil, value: nil, action: nil, object: nil)
       @target = target
       @value = value || {}

--- a/lib/bolt/result_set.rb
+++ b/lib/bolt/result_set.rb
@@ -12,6 +12,18 @@ module Bolt
       include(Puppet::Pops::Types::IteratorProducer)
     end
 
+    def self._pcore_init_from_hash
+      raise "ResultSet shouldn't be instantiated from a pcore_init class method. How did this get called?"
+    end
+
+    def _pcore_init_from_hash(init_hash)
+      initialize(init_hash['results'])
+    end
+
+    def _pcore_init_hash
+      { 'results' => @results }
+    end
+
     def iterator
       if Object.const_defined?(:Puppet) && Puppet.const_defined?(:Pops) &&
          self.class.included_modules.include?(Puppet::Pops::Types::Iterable)

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -20,6 +20,7 @@ module Bolt
     # rubocop:disable Lint/UnusedMethodArgument
     def self.from_asserted_args(uri = nil,
                                 name = nil,
+                                safe_name = nil,
                                 target_alias = nil,
                                 config = nil,
                                 facts = nil,

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -174,12 +174,12 @@ describe Bolt::Applicator do
 
       expect {
         applicator.apply([targets], :body, scope)
-      }.to raise_error(Bolt::ApplyFailure, <<-MSG.chomp)
-Resources failed to apply for node1
-  File[/tmp/does/not/exist]: It failed.
-Resources failed to apply for node2
-  File[C:/does/not/exist]: It failed.
-MSG
+      }.to raise_error(Bolt::ApplyFailure, <<~MSG.chomp)
+        Resources failed to apply for node1
+          File[/tmp/does/not/exist]: It failed.
+        Resources failed to apply for node2
+          File[C:/does/not/exist]: It failed.
+      MSG
     end
 
     it "only creates 2 threads" do
@@ -213,6 +213,192 @@ MSG
       expect(promises.count).to eq(2)
       promises.each(&:execute)
       t.join
+    end
+  end
+
+  context "with future true" do
+    let(:input) {
+      {
+        code_ast: ast,
+        modulepath: modulepath,
+        pdb_config: config.to_hash,
+        hiera_config: nil,
+        future: true
+      }
+    }
+
+    let(:target_hash) {
+      {
+        target: {
+          name: uri,
+          facts: { 'bolt' => true },
+          variables: {},
+          trusted: {
+            authenticated: 'local',
+            certname: uri,
+            extensions: {},
+            hostname: uri,
+            domain: nil,
+            external: {}
+          }
+        }
+      }
+    }
+
+    before(:each) do
+      # rubocop:disable Style/GlobalVars
+      $future = true
+      # rubocop:enable Style/GlobalVars
+    end
+
+    after(:each) do
+      # rubocop:disable Style/GlobalVars
+      $future = nil
+      # rubocop:enable Style/GlobalVars
+    end
+
+    it 'instantiates' do
+      expect(applicator).to be
+    end
+
+    it 'passes catalog input' do
+      expect(Open3).to receive(:capture3)
+        .with('ruby', /bolt_catalog/, 'compile', stdin_data: input.merge(target_hash).to_json)
+        .and_return(['{}', '', double(:status, success?: true)])
+      expect(applicator.future_compile(target, input)).to eq({})
+    end
+
+    it 'logs messages returned on stderr' do
+      logs = [
+        { debug: 'A message' },
+        { notice: 'Stuff happened' }
+      ]
+
+      expect(Open3).to receive(:capture3)
+        .with('ruby', /bolt_catalog/, 'compile', stdin_data: input.merge(target_hash).to_json)
+        .and_return(['{}', logs.map(&:to_json).join("\n"), double(:status, success?: true)])
+      expect(applicator.future_compile(target, input)).to eq({})
+      expect(@log_output.readlines).to eq(
+        [
+          " DEBUG  Bolt::Executor : Started with 1 max thread(s)\n",
+          " DEBUG  Bolt::Applicator : #{target.uri}: A message\n",
+          "NOTICE  Bolt::Applicator : #{target.uri}: Stuff happened\n"
+        ]
+      )
+    end
+
+    context 'with Puppet mocked' do
+      let(:loaders) { double('loaders') }
+      let(:env_loader) { double('env_loader') }
+      before(:each) do
+        env = Puppet::Node::Environment.create(:testing, modulepath)
+        allow(Puppet).to receive(:lookup).with(:current_environment).and_return(env)
+        allow(scope).to receive(:to_hash).and_return({})
+        allow(Puppet).to receive(:lookup).with(:pal_script_compiler).and_return(double(:script_compiler, type: nil))
+        allow(Puppet).to receive(:lookup).with(:loaders).and_return(loaders)
+        allow(loaders).to receive(:private_environment_loader).and_return(env_loader)
+        allow(env_loader).to receive(:load).with(:type, 'result').and_return(double('result'))
+        allow(env_loader).to receive(:load).with(:type, 'resultset').and_return(double('resultset'))
+        allow(env_loader).to receive(:load).with(:type, 'applyresult').and_return(double('applyresult'))
+        allow(Puppet::Pal).to receive(:assert_type)
+        allow(Puppet::Pops::Serialization::ToDataConverter).to receive(:convert).and_return(ast)
+        allow(applicator).to receive(:count_statements)
+      end
+
+      let(:scope) { double('scope') }
+
+      it 'replaces failures to find Puppet' do
+        expect(applicator).to receive(:future_compile).and_return(ast)
+        result = Bolt::Result.new(target, value: report)
+        allow_any_instance_of(Bolt::Transport::SSH).to receive(:batch_task).and_return(result)
+
+        expect(Bolt::ApplyResult).to receive(:puppet_missing_error).with(result).and_return(nil)
+
+        applicator.apply([target], :body, scope)
+      end
+
+      it 'captures compile errors in a result set' do
+        expect(applicator).to receive(:future_compile).and_raise('Something weird happened')
+
+        resultset = applicator.apply([uri, '_catch_errors' => true], :body, scope)
+        expect(resultset).to be_a(Bolt::ResultSet)
+        expect(resultset).not_to be_ok
+        expect(resultset.count).to eq(1)
+        expect(resultset.first).not_to be_ok
+        expect(resultset.first.error_hash['msg']).to eq('Something weird happened')
+      end
+
+      it 'fails if the report signals failure' do
+        expect(applicator).to receive(:future_compile).and_return(ast)
+        allow_any_instance_of(Bolt::Transport::SSH).to receive(:batch_task).and_return(
+          Bolt::Result.new(target, value: report.merge('status' => 'failed'))
+        )
+
+        resultset = applicator.apply([target, '_catch_errors' => true], :body, scope)
+        expect(resultset).to be_a(Bolt::ResultSet)
+        expect(resultset).not_to be_ok
+        expect(resultset.count).to eq(1)
+        expect(resultset.first).not_to be_ok
+        expect(resultset.first.error_hash['msg']).to match(/Resources failed to apply for #{uri}/)
+      end
+
+      it 'includes failed resource events for all failing nodes when errored' do
+        resources = {
+          '/tmp/does/not/exist' => [{ 'status' => 'failure', 'message' => 'It failed.' }],
+          'C:/does/not/exist' => [{ 'status' => 'failure', 'message' => 'It failed.' }],
+          '/tmp/sure' => []
+        }.map { |name, events| { "File[#{name}]" => { 'failed' => !events.empty?, 'events' => events } } }
+
+        targets = [Bolt::Target.new('node1'), Bolt::Target.new('node2'), Bolt::Target.new('node3')]
+        results = targets.zip(resources, %w[failed failed success]).map do |target, res, status|
+          Bolt::Result.new(target, value: { 'status' => status, 'resource_statuses' => res, 'metrics' => {} })
+        end
+
+        allow(applicator).to receive(:future_compile).and_return(ast)
+        allow_any_instance_of(Bolt::Transport::SSH).to receive(:batch_task).and_return(*results)
+
+        expect {
+          applicator.apply([targets], :body, scope)
+        }.to raise_error(Bolt::ApplyFailure, <<~MSG.chomp)
+          Resources failed to apply for node1
+            File[/tmp/does/not/exist]: It failed.
+          Resources failed to apply for node2
+            File[C:/does/not/exist]: It failed.
+        MSG
+      end
+
+      it "only creates 2 threads" do
+        running = Concurrent::AtomicFixnum.new
+        promises = Concurrent::Array.new
+        allow(applicator).to receive(:future_compile) do
+          count = running.increment
+          if count <= 2
+            # Only first two will block, simplifying cleanup at the end
+            delay = Concurrent::Promise.new { ast }
+            promises << delay
+            delay.value
+          else
+            ast
+          end
+        end
+
+        targets = [Bolt::Target.new('node1'), Bolt::Target.new('node2'), Bolt::Target.new('node3')]
+        allow_any_instance_of(Bolt::Transport::SSH).to receive(:batch_task) do |_, batch|
+          Bolt::Result.new(batch.first, value: report)
+        end
+
+        t = Thread.new {
+          applicator.apply([targets], :body, scope)
+        }
+        sleep(0.2)
+
+        expect(running.value).to eq(2)
+
+        # execute all the promises to release the threads
+        expect(promises.count).to eq(2)
+        promises.each(&:execute)
+        t.join
+      end
     end
   end
 end

--- a/spec/bolt/catalog_spec.rb
+++ b/spec/bolt/catalog_spec.rb
@@ -23,14 +23,14 @@ describe Bolt::Catalog do
   let(:catalog) { Bolt::Catalog.new('warning') }
   let(:notify) { "notify { \"trusted ${trusted}\": }" }
   let(:files) {
-    <<-CODE
-file { '/root/test/':
-  ensure => directory,
-} -> file { '/root/test/hello.txt':
-  ensure  => file,
-  content => "hi there I'm ${$facts['os']['family']}\n"
-}
-CODE
+    <<~CODE
+      file { '/root/test/':
+        ensure => directory,
+      } -> file { '/root/test/hello.txt':
+        ensure  => file,
+        content => "hi there I'm ${$facts['os']['family']}\n"
+      }
+    CODE
   }
 
   let(:plan) { File.join(__FILE__, '../../fixtures/apply/basic/plans/trusted.pp') }

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -54,6 +54,13 @@ describe "Bolt::CLI" do
     allow(Bolt::Util).to receive(:read_config_file).and_return(file_content)
   end
 
+  # These tests may pick up local config that includes `future = true`
+  after :each do
+    # rubocop:disable Style/GlobalVars
+    $future = nil
+    # rubocop:enable Style/GlobalVars
+  end
+
   context "without a config file" do
     let(:boltdir) { Bolt::Boltdir.new('.') }
     before(:each) do

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -85,9 +85,9 @@ describe "Bolt::Outputter::Human" do
 
   it "formats a table" do
     outputter.print_table([%w[a b], %w[c1 d]])
-    expect(output.string).to eq(<<-TABLE)
-a    b
-c1   d
+    expect(output.string).to eq(<<~TABLE)
+      a    b
+      c1   d
     TABLE
   end
 
@@ -109,19 +109,19 @@ c1   d
       }
     }
     outputter.print_task_info(task)
-    expect(output.string).to eq(<<-TASK_OUTPUT)
+    expect(output.string).to eq(<<~TASK_OUTPUT)
 
-cinnamon_roll - A delicious sweet bun
+      cinnamon_roll - A delicious sweet bun
 
-USAGE:
-bolt task run --targets <node-name> cinnamon_roll icing=<value>
+      USAGE:
+      bolt task run --targets <node-name> cinnamon_roll icing=<value>
 
-PARAMETERS:
-- icing: Cream cheese
-    Rich, tangy, sweet
+      PARAMETERS:
+      - icing: Cream cheese
+          Rich, tangy, sweet
 
-MODULE:
-/path/to/cinnamony/goodness
+      MODULE:
+      /path/to/cinnamony/goodness
     TASK_OUTPUT
   end
 
@@ -147,21 +147,21 @@ MODULE:
       }
     }
     outputter.print_task_info(task)
-    expect(output.string).to eq(<<-TASK_OUTPUT)
+    expect(output.string).to eq(<<~TASK_OUTPUT)
 
-sticky_bun - A delicious sweet bun with nuts
+      sticky_bun - A delicious sweet bun with nuts
 
-USAGE:
-bolt task run --targets <node-name> sticky_bun glaze=<value> pecans=<value>
+      USAGE:
+      bolt task run --targets <node-name> sticky_bun glaze=<value> pecans=<value>
 
-PARAMETERS:
-- glaze: Sticky
-    Sweet
-- pecans: Data
-    The best kind of nut
+      PARAMETERS:
+      - glaze: Sticky
+          Sweet
+      - pecans: Data
+          The best kind of nut
 
-MODULE:
-/this/test/is/making/me/hungry
+      MODULE:
+      /this/test/is/making/me/hungry
     TASK_OUTPUT
   end
 
@@ -173,15 +173,15 @@ MODULE:
       'metadata' => {}
     }
     outputter.print_task_info(task)
-    expect(output.string).to eq(<<-TASK_OUTPUT)
+    expect(output.string).to eq(<<~TASK_OUTPUT)
 
-monkey_bread
+      monkey_bread
 
-USAGE:
-bolt task run --targets <node-name> monkey_bread
+      USAGE:
+      bolt task run --targets <node-name> monkey_bread
 
-MODULE:
-built-in module
+      MODULE:
+      built-in module
     TASK_OUTPUT
   end
 
@@ -211,19 +211,19 @@ built-in module
       }
     }
     outputter.print_plan_info(plan)
-    expect(output.string).to eq(<<-PLAN_OUTPUT)
+    expect(output.string).to eq(<<~PLAN_OUTPUT)
 
-planity_plan
+      planity_plan
 
-USAGE:
-bolt plan run planity_plan foo=<value> [baz=<value>]
+      USAGE:
+      bolt plan run planity_plan foo=<value> [baz=<value>]
 
-PARAMETERS:
-- foo: Bar
-- baz: Bar
+      PARAMETERS:
+      - foo: Bar
+      - baz: Bar
 
-MODULE:
-plans/plans/plans/plans
+      MODULE:
+      plans/plans/plans/plans
     PLAN_OUTPUT
   end
 

--- a/spec/fixtures/apply/puppet_types/plans/applyresult.pp
+++ b/spec/fixtures/apply/puppet_types/plans/applyresult.pp
@@ -1,0 +1,18 @@
+plan puppet_types::applyresult (
+  TargetSpec $targets
+) {
+  $first = get_target($targets)
+  $first.apply_prep
+  run_command('rm -rf /home/bolt/tmp', $first)
+
+  $result = apply($first) {
+    file { '/home/bolt/tmp':
+      ensure  => file,
+    }
+  }.first
+
+  return apply($first) {
+    $file = $result.report['catalog']['resources'].filter |$r| { $r['type'] == 'File' }
+    notify { "ApplyResult resource: ${$file[0]['title']}": }
+  }
+}

--- a/spec/fixtures/apply/puppet_types/plans/error.pp
+++ b/spec/fixtures/apply/puppet_types/plans/error.pp
@@ -1,0 +1,11 @@
+plan puppet_types::error(
+  TargetSpec $targets
+) {
+  $first = get_target($targets)
+  $first.apply_prep
+
+  $error = run_command("not real", $targets, _catch_errors => true)
+  return apply($first) {
+    notify { "ApplyResult resource: ${$error[0].error.message}": }
+  }
+}

--- a/spec/fixtures/apply/puppet_types/plans/get_target.pp
+++ b/spec/fixtures/apply/puppet_types/plans/get_target.pp
@@ -1,0 +1,11 @@
+plan puppet_types::get_target(
+  TargetSpec $targets
+) {
+  $first = get_target($targets)
+  $first.apply_prep
+
+  return apply($first) {
+    $name = get_target($targets).name
+    notify { $name: }
+  }
+}

--- a/spec/fixtures/apply/puppet_types/plans/get_targets.pp
+++ b/spec/fixtures/apply/puppet_types/plans/get_targets.pp
@@ -1,0 +1,13 @@
+plan puppet_types::get_targets(
+  TargetSpec $targets
+) {
+  $first = get_target($targets)
+  $first.apply_prep
+
+  return apply($first) {
+    $names = get_targets($targets).map |$t| {
+      $t.name
+    }
+    notify { $names.join(","): }
+  }
+}

--- a/spec/fixtures/apply/puppet_types/plans/result.pp
+++ b/spec/fixtures/apply/puppet_types/plans/result.pp
@@ -1,0 +1,13 @@
+plan puppet_types::result (
+  TargetSpec $targets
+) {
+  $target = get_target($targets)
+  $target.apply_prep
+
+  $result = run_command('whoami', $target).first
+
+  return apply($target) {
+    notify { "Result value: ${$result.value['stdout']}": }
+    notify { "Result target name: ${$result.target.name}": }
+  }
+}

--- a/spec/fixtures/apply/puppet_types/plans/resultset.pp
+++ b/spec/fixtures/apply/puppet_types/plans/resultset.pp
@@ -1,0 +1,12 @@
+plan puppet_types::resultset (
+  TargetSpec $targets
+) {
+  $first = get_targets($targets)[0]
+  $first.apply_prep
+
+  $result = run_command('whoami', $targets)
+
+  return apply($first) {
+    notify { "ResultSet target names: ${$result.names}": }
+  }
+}

--- a/spec/fixtures/apply/puppet_types/plans/target.pp
+++ b/spec/fixtures/apply/puppet_types/plans/target.pp
@@ -1,0 +1,10 @@
+plan puppet_types::target (
+  TargetSpec $targets
+) {
+  $first = get_target($targets)
+  $first.apply_prep
+
+  return apply($first) {
+    notify { "ApplyTarget protocol: ${$first.protocol}": }
+  }
+}

--- a/spec/fixtures/apply/puppet_types/plans/target_new.pp
+++ b/spec/fixtures/apply/puppet_types/plans/target_new.pp
@@ -1,0 +1,10 @@
+plan puppet_types::target_new(
+  TargetSpec $targets
+) {
+  $first = get_target($targets)
+  $first.apply_prep
+
+  return apply($first) {
+    $t = Target.new('localhost')
+  }
+}

--- a/spec/integration/apply_error_spec.rb
+++ b/spec/integration/apply_error_spec.rb
@@ -18,6 +18,9 @@ describe "errors gracefully attempting to apply a manifest block" do
     let(:tflags) { %w[--no-host-key-check] }
 
     it 'prints a helpful error if Puppet is not present' do
+      uninstall = '/opt/puppetlabs/bin/puppet resource package puppet-agent ensure=absent'
+      run_cli_json(%W[command run #{uninstall} --run-as root --sudo-password #{password}] + config_flags)
+
       result = run_cli_json(%w[plan run basic::class] + config_flags)
       error = result['details']['result_set'][0]['result']['_error']
       expect(error['kind']).to eq('bolt/apply-error')


### PR DESCRIPTION
There are 4 custom types in the Bolt plan language that we want to make
available inside apply blocks: Target, Result, ResultSet, ApplyResult.
For each of the \*Result\* objects this is accomplished by serializing the
plan variables to the apply block as pcore instead of as json. We also
needed to add pcore_init methods to the implementation classes of the
objects, because the pcore deserializer will by default call
`initialize` on the class and pass in the values of the attributes of
the type, which doesn't match the signature of the actual
implementations. Using `_pcore_init_hash` and `_pcore_init_from_hash`
lets us define what data gets serialized and how it gets deserialized
for those types.

Target objects are trickier for a few reasons:
1. They must have an associate inventory
2. They should not be modified or created inside an apply block

Instead of trying to create the right guard rails around using Target
objects in apply blocks and pass around an inventory, it's easier to
think of (and implement) targets-in-apply as their own class, an
ApplyTarget. When creating the catalog compiler we set the inventory to
a bare string, then look for that in the Target object. When a Target
object is instantiated while the inventory is in 'apply mode', it will
create an ApplyTarget instead of a Target. For now this is only ever
done by the deserializer when target objects are deserialized. This
protects the inventory within apply blocks, and clearly separates the
concept of Targets in plans, and Targets in apply blocks.

Closes #1244