### PR TITLE
(GH-1446) Use second positional argument of run_plan function to spec…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Bolt Next
+
+### New features
+
+* **`run_plan` plan function will specify a plan's `$targets` parameter using the second positional argument** ([#1446](https://github.com/puppetlabs/bolt/issues/1446))
+
+  When running a plan with a `$targets` parameter with the `run_plan` plan function, the second positional argument can be used to specify the `$targets` parameter. If a plan has a `$nodes` parameter, the second positional argument will only specify the `$nodes` parameter.
+
 ## Bolt 1.42.0
 
 ### New features

--- a/bolt-modules/boltlib/spec/fixtures/modules/test/plans/run_me_nodes_and_targets.pp
+++ b/bolt-modules/boltlib/spec/fixtures/modules/test/plans/run_me_nodes_and_targets.pp
@@ -1,0 +1,6 @@
+plan test::run_me_nodes_and_targets(
+  BoltLib::TargetSpec $nodes,
+  BoltLib::TargetSpec $targets,
+) {
+  return $nodes
+}

--- a/bolt-modules/boltlib/spec/fixtures/modules/test/plans/run_me_targets.pp
+++ b/bolt-modules/boltlib/spec/fixtures/modules/test/plans/run_me_targets.pp
@@ -1,0 +1,5 @@
+plan test::run_me_targets(
+  BoltLib::TargetSpec $targets,
+) {
+  return $targets
+}

--- a/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
@@ -131,4 +131,41 @@ describe 'run_plan' do
       is_expected.to run.with_params('test::targetspec_params', params).and_return(expected_targets)
     end
   end
+
+  context 'with a plan with a $targets parameter' do
+    it 'fails when given positional argument and targets named argument' do
+      is_expected.to run.with_params('test::run_me_targets', 'target1', 'targets' => 'target2')
+                        .and_raise_error(ArgumentError)
+    end
+
+    it 'specifies the $targets parameter using the second positional argument' do
+      is_expected.to run.with_params('test::run_me_targets', 'target1')
+                        .and_return('target1')
+    end
+  end
+
+  context 'with a plan with both a $nodes and $targets parameter' do
+    context 'with $future set' do
+      after(:each) do
+        # rubocop:disable Style/GlobalVars
+        $future = nil
+        # rubocop:enable Style/GlobalVars
+      end
+
+      it 'fails when using the second positional argument' do
+        # rubocop:disable Style/GlobalVars
+        $future = true
+        # rubocop:enable Style/GlobalVars
+        is_expected.to run.with_params('test::run_me_nodes_and_targets', 'target1')
+                          .and_raise_error(ArgumentError)
+      end
+    end
+
+    context 'with $future unset' do
+      it 'specifies the $nodes parameter using the second positional argument' do
+        is_expected.to run.with_params('test::run_me_nodes_and_targets', 'target1', 'targets' => 'target2')
+                          .and_return('target1')
+      end
+    end
+  end
 end

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -338,5 +338,9 @@ module Bolt
     ensure
       publish_event(type: :enable_default_output)
     end
+
+    def deprecation(msg)
+      @logger.warn msg
+    end
   end
 end


### PR DESCRIPTION
…ify $targets parameter

This adds support for using the second positional argument of the
`run_plan` plan function to specify a plan's `TargetSpec $targets`
parameter.

When a plan has both a `$nodes` and `$targets` parameter, the
`run_plan` plan function will do the following.

 * If `future` is set, the plan will fail when there is a `$nodes`
    and `$targets` parameter and the second positional argument is used.
 * If `future` is unset, the second positional argument will specify
    the `$nodes` parameter. A deprecation warning will also be logged.

 When a plan has only one of `$nodes` or `$targets` as parameters, then
 the second positional argument will specify that parameter. The plan
 will also fail if the second positional argument is used to specify one
 of these parameters and the arguments hash specifies the same
 parameter.

Closes #1446 