### PR TITLE
(feat) Add script-dir option to ssh transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
   When running a plan with a `$targets` parameter with the `run_plan` plan function, the second positional argument can be used to specify the `$targets` parameter. If a plan has a `$nodes` parameter, the second positional argument will only specify the `$nodes` parameter.
 
+* **Add `script-dir` option for specifying predictable subpath to the tmpdir**
+
+  When uploading files to remote targets, Bolt uploads them to a tmpdir which includes a randomized
+  directory name. The `script-dir` option sets a predictable subdirectory for `tmpdir` where files
+  will be uploaded.
+
 ## Bolt 1.42.0
 
 ### New features

--- a/documentation/bolt_configuration_options.md
+++ b/documentation/bolt_configuration_options.md
@@ -52,6 +52,9 @@ ssh:
 -   `run-as-command`: The command to elevate permissions. Bolt appends the user and command strings to the configured run as a command before running it on the target. This command must not require an interactive password prompt, and the `sudo-password` option is ignored when `run-as-command` is specified. The run-as command must be specified as an array.
 -   `sudo-password`: Password to use when changing users via `run-as`.
 -   `tmpdir`: The directory to upload and execute temporary files on the target.
+-   `script-dir`: The subdirectory of the tmpdir to use in place of a randomized subdirectory for
+    uploading and executing temporary files on the target. It's expected that this directory already
+    exists as a subdir of `tmpdir`, which is either configured or defaults to `/tmp`.
 -   `tty`: Request a pseudo tty for the SSH session. This option is generally only used in conjunction with the `run_as` option when the sudoers policy requires a `tty`. Default is `false`.
 -   `user`: Login user. Default is `root`.
 

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -48,6 +48,12 @@ module Bolt
             raise Bolt::ValidationError, error_msg
           end
         end
+
+        if (dir_opt = options['script-dir'])
+          unless dir_opt.is_a?(String) && !dir_opt.empty?
+            raise Bolt::ValidationError, "script-dir option must be a non-empty string"
+          end
+        end
       end
 
       def initialize

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -10,7 +10,7 @@ module Bolt
     class SSH < Sudoable
       def self.options
         %w[host port user password sudo-password private-key host-key-check
-           connect-timeout disconnect-timeout tmpdir run-as tty run-as-command proxyjump interpreters]
+           connect-timeout disconnect-timeout tmpdir script-dir run-as tty run-as-command proxyjump interpreters]
       end
 
       def self.default_options

--- a/lib/bolt/transport/sudoable/connection.rb
+++ b/lib/bolt/transport/sudoable/connection.rb
@@ -7,6 +7,7 @@ module Bolt
     class Sudoable < Base
       class Connection
         attr_accessor :target
+
         def initialize(target)
           @target = target
           @run_as = nil
@@ -38,7 +39,8 @@ module Bolt
 
         def make_tempdir
           tmpdir = @target.options.fetch('tmpdir', '/tmp')
-          tmppath = "#{tmpdir}/#{SecureRandom.uuid}"
+          script_dir = @target.options.fetch('script-dir', SecureRandom.uuid)
+          tmppath = File.join(tmpdir, script_dir)
           command = ['mkdir', '-m', 700, tmppath]
 
           result = execute(command)

--- a/spec/integration/transport/ssh_spec.rb
+++ b/spec/integration/transport/ssh_spec.rb
@@ -469,4 +469,15 @@ describe Bolt::Transport::SSH do
       expect { ssh.run_command(target, 'whoami') }.to raise_error(/does not have a host/)
     end
   end
+
+  context "user supplied script directory" do
+    let(:config) do
+      mk_config("host-key-check" => false, "sudo-password" => password, "run-as" => "root",
+                user: user, password: password, "script-dir" => "123456", interpreters: { sh: "/bin/sh" })
+    end
+    let(:target) { make_target }
+    it "executes a command on a host", ssh: true do
+      expect(ssh.run_command(target, "pwd")["stdout"]).to eq("/home/bolt\n")
+    end
+  end
 end


### PR DESCRIPTION
  * In some cases you need to be able to predict where bolt
    will write the script file to. Previously, this was dictated
    by the value of tmpdir and a SecureRandom id.

  * This adds a new script-dir option that allows the user to supply
    the directory where the script will be placed.

    ```
    ---
    ssh:
       script-dir: 'bolt_script_dir'
       tmpdir: /home/vagrant
    ```
    would end up creating the script file under
      /home/vagrant/bolt_script_dir

    By default the previous behavior of creating a unique directory
    per script run is preserved.