### PR TITLE
(GH-1425) Set default value for sudo-password to value for password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
   Bolt packages are now available for Debian 10.
 
+* **SSH transport sets `sudo-password` to the same value as `password` by default** ([#1425](https://github.com/puppetlabs/bolt/issues/1425))
+
+  If `sudo-password` is not set when using `run-as`, Bolt will set the value of `sudo-password` to match the value of `password`. This behavior is gated on the future config option, and will be available by default in Bolt 2.0.
+  
 ### Bug fixes
 
 * **Default PuppetDB config lookup used hardcoded path in Windows** ([#1427](https://github.com/puppetlabs/bolt/pull/1427))

--- a/spec/integration/transport/ssh_spec.rb
+++ b/spec/integration/transport/ssh_spec.rb
@@ -377,6 +377,26 @@ describe Bolt::Transport::SSH do
     end
   end
 
+  context "with no sudo-password", sudo: true, ssh: true do
+    let(:config) {
+      mk_config('host-key-check' => false, 'password' => password, 'run-as' => 'root',
+                user: user, password: password)
+    }
+    let(:target) { make_target }
+    after(:each) {
+      # rubocop:disable Style/GlobalVars
+      $future = nil
+      # rubocop:enable Style/GlobalVars
+    }
+
+    it "uses password as sudo-password when future is set" do
+      # rubocop:disable Style/GlobalVars
+      $future = true
+      # rubocop:enable Style/GlobalVars
+      expect(ssh.run_command(target, 'whoami')['stdout'].strip).to eq('root')
+    end
+  end
+
   context "with a bad private-key option" do
     include BoltSpec::Logger
 


### PR DESCRIPTION
This sets the default value for `sudo-password` to the same value as
`password`. This feature is gated by `future`.