### PR TITLE
(maint) Do not set an exception instance variable on Bolt::Result

### DIFF
--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -8,9 +8,8 @@ module Bolt
     attr_reader :target, :value, :action, :object
 
     def self.from_exception(target, exception)
-      @exception = exception
-      if @exception.is_a?(Bolt::Error)
-        error = @exception.to_h
+      if exception.is_a?(Bolt::Error)
+        error = exception.to_h
       else
         error = {
           'kind' => 'puppetlabs.tasks/exception-error',


### PR DESCRIPTION
Previously an `@exception` instance variable was set on a `Bolt::Result` object when constructed with the `from_exception` class method. The instance variable does not appear to be used by the `Bolt::Result` class and there is no `attr_reader` for it. This commit removes the instance variable.