### PR TITLE
(GH-1439) Add sudo-executable transport config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
 
   If `sudo-password` is not set when using `run-as`, Bolt will set the value of `sudo-password` to match the value of `password`. This behavior is gated on the future config option, and will be available by default in Bolt 2.0.
   
+* **Add `sudo-executable` transport configuration option** ([#1200](https://github.com/puppetlabs/bolt/issues/1200))
+
+  When using `run-as`, the `sudo-executable` transport configuration option can be used to specify an executable to use to run as another user. This option can be set in a `local` or `ssh` config map or with the `--sudo-executable` flag on the CLI. This feature is experimental.
+
 ### Bug fixes
 
 * **Default PuppetDB config lookup used hardcoded path in Windows** ([#1427](https://github.com/puppetlabs/bolt/pull/1427))

--- a/documentation/bolt_configuration_options.md
+++ b/documentation/bolt_configuration_options.md
@@ -50,6 +50,7 @@ ssh:
 -   `proxyjump`: A jump host to proxy SSH connections through, and an optional user to connect with, for example: jump.example.com or user1@jump.example.com.
 -   `run-as`: A different user to run commands as after login.
 -   `run-as-command`: The command to elevate permissions. Bolt appends the user and command strings to the configured run as a command before running it on the target. This command must not require an interactive password prompt, and the `sudo-password` option is ignored when `run-as-command` is specified. The run-as command must be specified as an array.
+-   `sudo-executable`: The executable to use when escalating to the configured `run-as` user. This is useful when you want to escalate using the configured `sudo-password`, since `run-as-command` does not use `sudo-password` or support prompting. The command executed on the target is `<sudo-executable> -S -u <user> -p custom_bolt_prompt <command>`. **Note:** This option is experimental.
 -   `sudo-password`: Password to use when changing users via `run-as`.
 -   `tmpdir`: The directory to upload and execute temporary files on the target.
 -   `script-dir`: The subdirectory of the tmpdir to use in place of a randomized subdirectory for
@@ -161,6 +162,7 @@ When using the SSH transport, Bolt also interacts with the ssh-agent for SSH key
 
 -   `run-as`: A different user to run commands as after login.
 -   `run-as-command`: The command to elevate permissions. Bolt appends the user and command strings to the configured run as a command before running it on the target. This command must not require an interactive password prompt, and the `sudo-password` option is ignored when `run-as-command` is specified. The run-as command must be specified as an array.
+-   `sudo-executable`: The executable to use when escalating to the configured `run-as` user. This is useful when you want to escalate using the configured `sudo-password`, since `run-as-command` does not use `sudo-password` or support prompting. The command executed on the target is `<sudo-executable> -S -u <user> -p custom_bolt_prompt <command>`. **Note:** This option is experimental.
 -   `sudo-password`: Password to use when changing users via `run-as`.
 -   `tmpdir`: The directory to copy and execute temporary files.
 

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -8,7 +8,7 @@ module Bolt
   class BoltOptionParser < OptionParser
     OPTIONS = { inventory: %w[nodes targets query rerun description],
                 authentication: %w[user password password-prompt private-key host-key-check ssl ssl-verify],
-                escalation: %w[run-as sudo-password sudo-password-prompt],
+                escalation: %w[run-as sudo-password sudo-password-prompt sudo-executable],
                 run_context: %w[concurrency inventoryfile save-rerun],
                 global_config_setters: %w[modulepath boltdir configfile],
                 transports: %w[transport connect-timeout tty],
@@ -702,6 +702,10 @@ module Bolt
         STDERR.print "Please enter your privilege escalation password: "
         @options[:'sudo-password'] = STDIN.noecho(&:gets).chomp
         STDERR.puts
+      end
+      define('--sudo-executable EXEC', "Specify an executable for running as another user.",
+             "This option is experimental.") do |exec|
+        @options[:'sudo-executable'] = exec
       end
 
       separator "\nRUN CONTEXT OPTIONS"

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -36,7 +36,7 @@ module Bolt
                   :puppetfile_config, :plugins, :plugin_hooks, :future
     attr_writer :modulepath
 
-    TRANSPORT_OPTIONS = %i[password run-as sudo-password extensions
+    TRANSPORT_OPTIONS = %i[password run-as sudo-password extensions sudo-executable
                            private-key tty tmpdir user connect-timeout disconnect-timeout
                            cacert token-file service-url interpreters file-protocol smb-port realm].freeze
 

--- a/lib/bolt/transport/local.rb
+++ b/lib/bolt/transport/local.rb
@@ -4,7 +4,7 @@ module Bolt
   module Transport
     class Local < Sudoable
       def self.options
-        %w[tmpdir interpreters sudo-password run-as run-as-command]
+        %w[tmpdir interpreters sudo-password run-as run-as-command sudo-executable]
       end
 
       def provided_features

--- a/lib/bolt/transport/local/shell.rb
+++ b/lib/bolt/transport/local/shell.rb
@@ -126,7 +126,8 @@ module Bolt
 
           if escalate
             if use_sudo
-              sudo_flags = ["sudo", "-k", "-S", "-u", run_as, "-p", Sudoable.sudo_prompt]
+              sudo_exec = target.options['sudo-executable'] || "sudo"
+              sudo_flags = [sudo_exec, "-k", "-S", "-u", run_as, "-p", Sudoable.sudo_prompt]
               sudo_flags += ["-E"] if options[:environment]
               sudo_str = Shellwords.shelljoin(sudo_flags)
             else

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -9,7 +9,7 @@ module Bolt
   module Transport
     class SSH < Sudoable
       def self.options
-        %w[host port user password sudo-password private-key host-key-check
+        %w[host port user password sudo-password private-key host-key-check sudo-executable
            connect-timeout disconnect-timeout tmpdir script-dir run-as tty run-as-command proxyjump interpreters]
       end
 

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -194,10 +194,10 @@ module Bolt
           use_sudo = escalate && @target.options['run-as-command'].nil?
 
           command_str = inject_interpreter(options[:interpreter], command)
-
           if escalate
             if use_sudo
-              sudo_flags = ["sudo", "-S", "-u", run_as, "-p", Sudoable.sudo_prompt]
+              sudo_exec = target.options['sudo-executable'] || "sudo"
+              sudo_flags = [sudo_exec, "-S", "-u", run_as, "-p", Sudoable.sudo_prompt]
               sudo_flags += ["-E"] if options[:environment]
               sudo_str = Shellwords.shelljoin(sudo_flags)
             else

--- a/spec/integration/transport/ssh_spec.rb
+++ b/spec/integration/transport/ssh_spec.rb
@@ -337,6 +337,23 @@ describe Bolt::Transport::SSH do
     end
   end
 
+  context "with non-sudo executable", sudo: true do
+    let(:config) {
+      mk_config('host-key-check' => false, 'sudo-executable' => 'fake',
+                'run-as' => user, user: bash_user, password: bash_password)
+    }
+    let(:target) { make_target }
+
+    it 'uses the correct executable' do
+      allow_any_instance_of(Net::SSH::Connection::Channel).to receive(:wait).and_return('')
+      expect_any_instance_of(Net::SSH::Connection::Channel).to receive(:exec)
+        .with("fake -S -u bolt -p \\[sudo\\]\\ Bolt\\ needs\\ to\\ run\\ as\\ another\\ "\
+              "user,\\ password:\\  whoami")
+
+      ssh.run_command(target, 'whoami')
+    end
+  end
+
   context "with sudo with task interpreter set", sudo: true, ssh: true do
     let(:config) {
       mk_config('host-key-check' => false, 'sudo-password' => password, 'run-as' => 'root',


### PR DESCRIPTION
This adds support for a `sudo-executable` transport config
option. When using `run-as`, the `sudo-executable` option will specify
the executable to use when running as another user. It will run the
executable with the same options as sudo.

This feature is experimental.

Closes #1439 