### PR TITLE
(maint) Search plan subdirectories for plan filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 
   Bolt will now lookup the default PuppetDB config at `%COMMON_APPDATA%\PuppetLabs\client-tools\puppetdb.conf` instead of the hardcoded path `C:\ProgramData\PuppetLabs\client-tools\puppetdb.conf`.
 
+* **Bolt could not find plans in subdirectories of `plans` directory**
+
+  Bolt will now correctly search for subdir paths under the `plans` directory for plan names when determining if the plan is a Puppet plan or yaml plan.
+
 ## Bolt 1.41.0
 
 ### New features

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -312,8 +312,10 @@ module Bolt
 
       # If it's a Puppet language plan, use strings to extract data. The only
       # way to tell is to check which filename exists in the module.
-      plan_file = plan_name.split('::', 2)[1] || 'init'
-      pp_path = File.join(mod, 'plans', "#{plan_file}.pp")
+      plan_subpath = File.join(plan_name.split('::').drop(1))
+      plan_subpath = 'init' if plan_subpath.empty?
+
+      pp_path = File.join(mod, 'plans', "#{plan_subpath}.pp")
       if File.exist?(pp_path)
         require 'puppet-strings'
         require 'puppet-strings/yard'
@@ -346,7 +348,7 @@ module Bolt
 
       # If it's a YAML plan, fall back to limited data
       else
-        yaml_path = File.join(mod, 'plans', "#{plan_file}.yaml")
+        yaml_path = File.join(mod, 'plans', "#{plan_subpath}.yaml")
         plan_content = File.read(yaml_path)
         plan = Bolt::PAL::YamlPlan::Loader.from_string(plan_name, plan_content, yaml_path)
 

--- a/spec/fixtures/modules/sample/plans/subdir/command.pp
+++ b/spec/fixtures/modules/sample/plans/subdir/command.pp
@@ -1,0 +1,5 @@
+plan sample::subdir::command (
+  TargetSpec $targets
+) {
+  return run_command('echo From subdir', $targets)
+}

--- a/spec/fixtures/modules/yaml/plans/subdir/init.yaml
+++ b/spec/fixtures/modules/yaml/plans/subdir/init.yaml
@@ -1,0 +1,10 @@
+parameters:
+  targets:
+    type: TargetSpec
+
+steps:
+  - name: run_command
+    command: echo I am a yaml plan
+    target: $targets
+
+return: $run_command

--- a/spec/integration/plan_spec.rb
+++ b/spec/integration/plan_spec.rb
@@ -45,6 +45,22 @@ describe "When a plan succeeds" do
     expect(result).to match(/Ran on 1 node/)
   end
 
+  it 'runs a puppet plan from a subdir', ssh: true do
+    result = run_cli(%W[plan run sample::subdir::command --targets #{target}] + config_flags)
+
+    json = JSON.parse(result)[0]
+    expect(json['result']['stdout']).to eq("From subdir\n")
+  end
+
+  it 'runs a yaml plan from a subdir of plans', ssh: true do
+    result = run_cli(%W[plan run yaml::subdir::init --targets #{target}] + config_flags)
+
+    json = JSON.parse(result)[0]
+    expect(json['node']).to eq(target)
+    expect(json['status']).to eq('success')
+    expect(json['result']).to eq("stdout" => "I am a yaml plan\n", "stderr" => "", "exit_code" => 0)
+  end
+
   it 'runs a yaml plan', ssh: true do
     result = run_cli(['plan', 'run', 'sample::yaml', '--targets', target] + config_flags)
     expect(JSON.parse(result)).to eq('stdout' => "hello world\n", 'stderr' => '', 'exit_code' => 0)


### PR DESCRIPTION
We now have to discover the language a plan is written in based on it's
filename, which requires constructing the file path from the plan name
(i.e. `foo::bar::baz`) and testing if the file exists with either `.pp`
or `.yaml` extensions. This search falsely assumed that the plan path
could have at most 2 values: the module name and the plan filename.
Instead, it can have the module name, and a path relative to the `plans`
directory. This modifies the logic to correctly load nested plans.

Still needs testing