### PR TITLE
(bug-fix) Gate key change in JSON formatted output on future

### DIFF
--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -36,9 +36,17 @@ module Bolt
         @stream.puts "],\n"
         @preceding_item = false
         @items_open = false
-        @stream.puts format('"target_count": %<size>d, "elapsed_time": %<elapsed>d }',
-                            size: results.size,
-                            elapsed: elapsed_time)
+        # rubocop:disable Style/GlobalVars
+        if $future
+          @stream.puts format('"target_count": %<size>d, "elapsed_time": %<elapsed>d }',
+                              size: results.size,
+                              elapsed: elapsed_time)
+        else
+          @stream.puts format('"node_count": %<size>d, "elapsed_time": %<elapsed>d }',
+                              size: results.size,
+                              elapsed: elapsed_time)
+        end
+        # rubocop:enable Style/GlobalVars
       end
 
       def print_table(results)


### PR DESCRIPTION
We introduced a breaking change to JSON formatted output without gating
it on future. This restores the previous keys in the JSON output if
`future` is not configured.