### PR TITLE
(maint) Fix bolt_server file_cache spec test

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,3 +3,4 @@
 
 /documentation @hestonhoffman @puppetlabs/bolt
 /lib/bolt_server @puppetlabs/skeletor
+/spec/bolt_server @puppetlabs/skeletor

--- a/spec/bolt_server/file_cache_spec.rb
+++ b/spec/bolt_server/file_cache_spec.rb
@@ -149,7 +149,7 @@ describe BoltServer::FileCache, puppetserver: true do
     it 'will create and run the purge timer' do
       expect(file_cache.instance_variable_get(:@purge)).to be_a(Concurrent::TimerTask)
       expect(file_cache.instance_variable_get(:@cache_dir_mutex)).to eq(other_mutex)
-      expect(other_mutex).to receive(:with_write_lock)
+      expect(other_mutex).to receive(:with_write_lock).at_most(2).times
 
       file_cache
       sleep 2 # allow time for the purge timer to fire


### PR DESCRIPTION
The file cache test sets a purge timeout/interval to 1 second, then sleeps for 2 seconds to allow enough time for the purge timer to fire. In most cases this is enough time for the mocked mutex to recieve `with_write_lock` one time. In some cases the timer fires twice. Given the interval is 1 second and we wait for 2 this is not unreasonable. This commit expects the timer to fire at most 2 times in the 2 seconds.