### PR TITLE
(GH-837) Add `file::join` plan function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Bolt NEXT
 
+### New features
+
+* **New `file::join` plan function** ([#837](https://github.com/puppetlabs/bolt/issues/837))
+
+  The new plan function, `file::join`, allows you to join file paths using the separator `/`.
+
 ### Bug fixes
 
 * **The ssh configuration option `key-data` was not compatible with the `future` flag** ([#1504](https://github.com/puppetlabs/bolt/issues/1504))

--- a/bolt-modules/file/lib/puppet/functions/file/join.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/join.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Join file paths.
+Puppet::Functions.create_function(:'file::join') do
+  # @param paths The paths to join.
+  # @example Join file paths
+  #   file::join('./path', 'to/files')
+  dispatch :join do
+    required_repeated_param 'String', :paths
+    return_type 'String'
+  end
+
+  def join(*paths)
+    Puppet.lookup(:bolt_executor) {}&.report_function_call(self.class.name)
+    File.join(paths)
+  end
+end

--- a/bolt-modules/file/spec/functions/file/join_spec.rb
+++ b/bolt-modules/file/spec/functions/file/join_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/executor'
+
+describe 'file::join' do
+  let(:executor) { Bolt::Executor.new }
+
+  around(:each) do |example|
+    Puppet[:tasks] = true
+    Puppet.override(bolt_executor: executor) { example.run }
+  end
+
+  it 'joins file paths' do
+    is_expected.to run.with_params('foo', 'bar', 'bak').and_return('foo/bar/bak')
+  end
+
+  it 'reports function call to analytics' do
+    executor.expects(:report_function_call).with('file::join')
+    is_expected.to run.with_params('foo', 'bar', 'bak')
+  end
+end


### PR DESCRIPTION
This adds a `file::join` plan function which joins paths using the
separator `/`. It accepts multiple parameters and returns a single
string that is the joined file path.

Closes #837 