### PR TITLE
(GH-1491) Add deprecation message for bolt-inventory-pdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Bolt Next
 
+### Deprecations
+
+* **Support for the `bolt-inventory-pdb` command will be dropped in Bolt 2.0.** Users can use the [puppetdb inventory plugin](https://puppet.com/docs/bolt/latest/using_plugins.html#puppetdb) with a v2 inventory file to lookup targets from PuppetDB.
+
 ### New features
 
 * **Packages for Fedora 31** ([#1373](https://github.com/puppetlabs/bolt/issues/1373))

--- a/lib/bolt_ext/puppetdb_inventory.rb
+++ b/lib/bolt_ext/puppetdb_inventory.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require 'bolt/puppetdb'
+require 'bolt/logger'
 require 'json'
 require 'optparse'
 require 'yaml'
@@ -10,6 +11,8 @@ module Bolt
   class PuppetDBInventory
     class CLI
       def initialize(args)
+        Bolt::Logger.initialize_logging
+        @logger = Logging.logger[self]
         @args = args
         @cli_opts = {}
         @parser = build_parser
@@ -66,6 +69,17 @@ query results.
       end
 
       def run
+        Bolt::Logger.configure({ "console" => {} }, true)
+        msg = <<~MSG
+          Deprecation Warning: Starting with Bolt 2.0, inventory file v1 and the
+          bolt-inventory-pdb command will no longer be supported. Use a v2 inventory
+          file instead with the PuppetDB plugin to lookup targets from PuppetDB.
+
+          v1 inventory files can be automatically migrated to v2 using 'bolt project migrate'.
+          Inventory files are modified in place and will not preserve formatting or comments.
+        MSG
+        @logger.warn(msg)
+
         positional_args = @parser.permute(@args)
 
         if @show_help


### PR DESCRIPTION
This adds a deprecation message to the `bolt-inventory-pdb` command
warning users about support for the command and inventory file v1 being
dropped in the future.

This change should be shipped with the planned changes to the inventory docs: #1464