### PR TITLE
(GH-1480) Add deprecation message for v1 inventory files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * **Support for the `bolt-inventory-pdb` command will be dropped in Bolt 2.0.** Users can use the [puppetdb inventory plugin](https://puppet.com/docs/bolt/latest/using_plugins.html#puppetdb) with a v2 inventory file to lookup targets from PuppetDB.
 
+* **Support for the v1 inventory files will be dropped in Bolt 2.0.** Inventory files [can be migrated](https://puppet.com/docs/bolt/latest/migrating_inventory_files.html) automatically using the `bolt project migrate` command.
+
 ### New features
 
 * **Packages for Fedora 31** ([#1373](https://github.com/puppetlabs/bolt/issues/1373))

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -90,6 +90,8 @@ module Bolt
 
       @groups.resolve_aliases(@groups.node_aliases)
       collect_groups
+
+      deprecation unless @data.empty?
     end
 
     def validate
@@ -99,6 +101,17 @@ module Bolt
     def version
       1
     end
+
+    def deprecation
+      msg = <<~MSG
+        Deprecation Warning: Starting with Bolt 2.0, inventory file v1 will no longer
+        be supported. v1 inventory files can be automatically migrated to v2 using
+        'bolt project migrate'. Inventory files are modified in place and will not
+        preserve formatting or comments.
+      MSG
+      @logger.warn(msg)
+    end
+    private :deprecation
 
     def collect_groups
       # Provide a lookup map for finding a group by name


### PR DESCRIPTION
This adds a deprecation message for when a v1 inventory file is loaded
and how to migrate to a v2 inventory file.

This change should be shipped with the planned changes to the inventory docs: #1464

Closes #1480 