### PR TITLE
(GH-1481) Add deprecation message for Target.new(<uri>, <options>)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 * **Support for the v1 inventory files will be dropped in Bolt 2.0.** Inventory files [can be migrated](https://puppet.com/docs/bolt/latest/migrating_inventory_files.html) automatically using the `bolt project migrate` command.
 
+* **Support for plan method `Target.new(<uri>, <options>)` will be dropped in Bolt 2.0.** The plan method `Target.new(<options>)`, where `options` is a hash of target data and config, should be used instead. See [the docs](https://puppet.com/docs/bolt/latest/writing_plans.html#creating-target-objects) for more information and examples.
+
 ### New features
 
 * **Packages for Fedora 31** ([#1373](https://github.com/puppetlabs/bolt/issues/1373))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@
   deprecated in version 1.35 in favor of the `puppet_agent` plugin, and is now removed. The plugins
   have the exact same behavior.
 
+* **Support for plan method `Target.new(<uri>, <options>)` will be dropped in Bolt 2.0.** Use 
+  `Target.new(<config>)`, where `config` is a hash with the same structure used to define targets in 
+  the inventory V2 file. See [the docs](https://puppet.com/docs/bolt/latest/writing_plans.html#creating-target-objects) 
+  for more information and examples.
+
+* **Support for `options` key in the hash parameter for `Target.new()` plan function will be dropped in Bolt 2.0.** Use 
+  `Target.new(<config>)`, where `config` is a hash with the same structure used to define targets in 
+  the inventory V2 file. See [the docs](https://puppet.com/docs/bolt/latest/writing_plans.html#creating-target-objects) 
+  for more information and examples.
+
 ### Bug fixes
 
 * **SSH commands will run from the home directory of the run-as user, not the connected user** ([#1518](https://github.com/puppetlabs/bolt/pull/1518))
@@ -23,8 +33,6 @@
 * **Support for the `bolt-inventory-pdb` command will be dropped in Bolt 2.0.** Users can use the [puppetdb inventory plugin](https://puppet.com/docs/bolt/latest/using_plugins.html#puppetdb) with a v2 inventory file to lookup targets from PuppetDB.
 
 * **Support for the v1 inventory files will be dropped in Bolt 2.0.** Inventory files [can be migrated](https://puppet.com/docs/bolt/latest/migrating_inventory_files.html) automatically using the `bolt project migrate` command.
-
-* **Support for plan method `Target.new(<uri>, <options>)` will be dropped in Bolt 2.0.** The plan method `Target.new(<options>)`, where `options` is a hash of target data and config, should be used instead. See [the docs](https://puppet.com/docs/bolt/latest/writing_plans.html#creating-target-objects) for more information and examples.
 
 ### New features
 

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -72,7 +72,8 @@ module Bolt
       end
     end
 
-    attr_reader :plugins, :config
+    attr_reader :plugins, :config, :logger
+    attr_accessor :hash_deprecation_issued, :args_deprecation_issued
 
     def initialize(data, config = nil, plugins: nil, target_vars: {},
                    target_facts: {}, target_features: {}, target_plugin_hooks: {})

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -435,5 +435,17 @@ module Bolt
       @target_plugin_hooks.delete(target.name)
     end
     private :invalidate_group_cache!
+
+    # Logs deprecation warning for Target.new(<uri>, <options>)
+    def target_deprecation
+      return if @deprecation_issued
+
+      @deprecation_issued = true
+      msg = <<~MSG
+        Deprecation Warning: Starting with Bolt 2.0, 'Target.new(<uri>, <options>)' will no
+        longer be supported. Use 'Target.new(<options>)' instead.
+      MSG
+      @logger.warn(msg)
+    end
   end
 end

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -72,8 +72,7 @@ module Bolt
       end
     end
 
-    attr_reader :plugins, :config, :logger
-    attr_accessor :hash_deprecation_issued, :args_deprecation_issued
+    attr_reader :plugins, :config
 
     def initialize(data, config = nil, plugins: nil, target_vars: {},
                    target_facts: {}, target_features: {}, target_plugin_hooks: {})
@@ -435,17 +434,5 @@ module Bolt
       @target_plugin_hooks.delete(target.name)
     end
     private :invalidate_group_cache!
-
-    # Logs deprecation warning for Target.new(<uri>, <options>)
-    def target_deprecation
-      return if @deprecation_issued
-
-      @deprecation_issued = true
-      msg = <<~MSG
-        Deprecation Warning: Starting with Bolt 2.0, 'Target.new(<uri>, <options>)' will no
-        longer be supported. Use 'Target.new(<options>)' instead.
-      MSG
-      @logger.warn(msg)
-    end
   end
 end

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -157,34 +157,32 @@ module Bolt
 
     # Satisfies the Puppet datatypes API
     def self.from_asserted_hash(hash)
-      inv = Puppet.lookup(:bolt_inventory)
-
-      if hash['uri'] && hash['options'] && inv.hash_deprecation_issued.nil?
-        inv.hash_deprecation_issued = true
+      if hash['uri'] && hash['options']
+        logger = Logging.logger[self]
         msg = <<~MSG
-          Deprecation Warning: Starting with Bolt 2.0, using 'Target.new' with an 'options' hash key will no
-          will no longer be supported. Use 'Target.new(<config>)', where 'config' is a hash with the same
-          structure used to define targets in the inventory V2 file. For more information see 
-          https://puppet.com/docs/bolt/latest/writing_plans.html#creating-target-objects
+          #{Puppet::Pops::PuppetStack.top_of_stack.join(':')}
+            Deprecation Warning: Starting with Bolt 2.0, using 'Target.new' with an 'options' hash key will no
+            will no longer be supported. Use 'Target.new(<config>)', where 'config' is a hash with the same
+            structure used to define targets in the inventory V2 file. For more information see
+            https://puppet.com/docs/bolt/latest/writing_plans.html#creating-target-objects
         MSG
-        inv.logger.warn(msg)
+        logger.warn(msg)
       end
-      
+
       new(hash['uri'], hash['options'])
     end
 
     def self.from_asserted_args(uri, options = nil)
-      inv = Puppet.lookup(:bolt_inventory)
-      
-      if options && inv.args_deprecation_issued.nil?
-        inv.args_deprecation_issued = true
+      if options
+        logger = Logging.logger[self]
         msg = <<~MSG
-          Deprecation Warning: Starting with Bolt 2.0, 'Target.new(<uri>, <options>)' will no
-          longer be supported. Use 'Target.new(<config>)', where 'config' is a hash with the same 
-          structure used to define targets in the inventory V2 file. For more information see 
-          https://puppet.com/docs/bolt/latest/writing_plans.html#creating-target-objects
+          #{Puppet::Pops::PuppetStack.top_of_stack.join(':')}
+            Deprecation Warning: Starting with Bolt 2.0, 'Target.new(<uri>, <options>)' will no
+            longer be supported. Use 'Target.new(<config>)', where 'config' is a hash with the same
+            structure used to define targets in the inventory V2 file. For more information see
+            https://puppet.com/docs/bolt/latest/writing_plans.html#creating-target-objects
         MSG
-        inv.logger.warn(msg)
+        logger.warn(msg)
       end
 
       new(uri, options)

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -157,7 +157,37 @@ module Bolt
 
     # Satisfies the Puppet datatypes API
     def self.from_asserted_hash(hash)
+      inv = Puppet.lookup(:bolt_inventory)
+
+      if hash['uri'] && hash['options'] && inv.hash_deprecation_issued.nil?
+        inv.hash_deprecation_issued = true
+        msg = <<~MSG
+          Deprecation Warning: Starting with Bolt 2.0, using 'Target.new' with an 'options' hash key will no
+          will no longer be supported. Use 'Target.new(<config>)', where 'config' is a hash with the same
+          structure used to define targets in the inventory V2 file. For more information see 
+          https://puppet.com/docs/bolt/latest/writing_plans.html#creating-target-objects
+        MSG
+        inv.logger.warn(msg)
+      end
+      
       new(hash['uri'], hash['options'])
+    end
+
+    def self.from_asserted_args(uri, options = nil)
+      inv = Puppet.lookup(:bolt_inventory)
+      
+      if options && inv.args_deprecation_issued.nil?
+        inv.args_deprecation_issued = true
+        msg = <<~MSG
+          Deprecation Warning: Starting with Bolt 2.0, 'Target.new(<uri>, <options>)' will no
+          longer be supported. Use 'Target.new(<config>)', where 'config' is a hash with the same 
+          structure used to define targets in the inventory V2 file. For more information see 
+          https://puppet.com/docs/bolt/latest/writing_plans.html#creating-target-objects
+        MSG
+        inv.logger.warn(msg)
+      end
+
+      new(uri, options)
     end
 
     # URI can be passes as nil


### PR DESCRIPTION
This adds a deprecation message for when `Target.new(<uri>, <options>)`
is used in a plan. It also notifies the user to use `Target.new(<uri>)`
instead.

Closes #1481 