### PR TITLE
(GH-1504) Do not try to expand a file path when ssh private-key key-data is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Bolt NEXT
+
+### Bug fixes
+
+* **The ssh configuration option `key-data` was not compatible with the `future` flag** ([#1504](https://github.com/puppetlabs/bolt/issues/1504))
+
+  Bolt no longer attempts to expand a `private-key` configuration `Hash` when `key-data` is being used in conjunction with the `future` setting.
+
 ## Bolt 1.43.0
 
 ### New features

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -223,7 +223,7 @@ module Bolt
           if @future
             to_expand = %w[private-key cacert token-file] & selected.keys
             to_expand.each do |opt|
-              selected[opt] = File.expand_path(selected[opt], @boltdir.path) if opt.is_a?(String)
+              selected[opt] = File.expand_path(selected[opt], @boltdir.path) if selected[opt].is_a?(String)
             end
           end
 

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -281,6 +281,20 @@ describe Bolt::Config do
         .to eq(File.expand_path('secret/key', boltdir.path))
     end
 
+    it "does not attempt to expand private-key when key-data is specified" do
+      key_data = { 'key-data' => 'key content' }
+      data = {
+        'ssh' => {
+          'private-key' => key_data
+        },
+        'future' => true
+      }
+
+      config = Bolt::Config.new(boltdir, data)
+      expect(config.transports[:ssh]['private-key'])
+        .to eq(key_data)
+    end
+
     it "expands inventoryfile relative to boltdir" do
       data = {
         'inventoryfile' => 'targets.yml',


### PR DESCRIPTION
When attempting to expand paths in config, only do so for the `ssh` transport setting `private-key` when it is not a `Hash` (indicating that `key-data` is being used.).

Closes https://github.com/puppetlabs/bolt/issues/1504