### PR TITLE
(PE-27794) add a puma status endpoint

### DIFF
--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -188,6 +188,11 @@ module BoltServer
       [200, GC.stat.to_json]
     end
 
+    get '/admin/status' do
+      stats = Puma.stats
+      [200, stats.is_a?(Hash) ? stats.to_json : stats]
+    end
+
     get '/500_error' do
       raise 'Unexpected error'
     end


### PR DESCRIPTION
With this commit, a puma status endpoint is added to our app.
(We already implement the gc_stats endpoint.)

Since this endpoint is served by our app, there will always be one
thread in use in the result: that thread is the status request itself.

This is not true with the default puma status endpoint,
as it runs within a separate server ... as per puma/lib/puma/runner.rb.