### PR TITLE
(GH-1500) Support .yml for bolt config and inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
 
   Bolt no longer attempts to expand a `private-key` configuration `Hash` when `key-data` is being used in conjunction with the `future` setting.
 
+### New features
+
+* **Support .yml extension for Bolt config and inventory** ([#1500](https://github.com/puppetlabs/bolt/issues/1500))
+
+  Bolt will now read config and inventory from `bolt.yml` and `inventory.yml` in the Boltdir. Bolt
+  will also treat `bolt.yml` as the root of a local-type project directory. If both `.yaml` and `.yml`
+  extensions are present, `.yaml` is preferred.
+
 ## Bolt 1.43.0
 
 ### New features

--- a/documentation/bolt_project_directories.md
+++ b/documentation/bolt_project_directories.md
@@ -10,7 +10,8 @@ There are three types of project directories that you can use depending on how y
 
 ### Local project directory
 
-Bolt treats a directory containing a `bolt.yaml` file as a project directory. Use this type of directory to track and share management code in a dedicated repository.
+Bolt treats a directory containing a `bolt.yaml` or `bolt.yml` file as a project directory. Use this
+type of directory to track and share management code in a dedicated repository.
 
 **Tip:** You can use an existing control repo as a Bolt project directory by adding a `bolt.yaml` file to it and configuring the `modulepath` to match the `modulepath` in `environment.conf`.
 


### PR DESCRIPTION
This adds support for the `.yml` extension for bolt config and inventory
files. Bolt will recognize either `bolt.yaml` or `bolt.yml` as the root
of a local Boltdir, with `bolt.yml` following the same behavior as
`bolt.yaml` with respect to project directory type precedence. If both
`.yaml` and `.yml` files are present for config or inventory, `.yaml` is
preferred. Any yaml files generated by bolt still have the `.yaml`
extension.

Closes #1500 