### PR TITLE
WIP (GH-1506) - Specify `run-as-command` without a `run-as` user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ group(:test) do
   gem "mocha", '~> 1.4.0'
   gem "rack-test", '~> 1.0'
   gem "rubocop", '~> 0.61', require: false
+  gem 'rb-readline'
+  gem 'pry'
 end
 
 group(:packaging) do

--- a/lib/bolt/transport/sudoable/connection.rb
+++ b/lib/bolt/transport/sudoable/connection.rb
@@ -87,9 +87,9 @@ module Bolt
         # using the wrapper or when the task does not require stdin data.
         def build_sudoable_command_str(command_str, sudo_str, sudo_id, options)
           if options[:stdin] && !options[:wrapper]
-            "#{sudo_str} #{prepend_sudo_success(sudo_id, command_str)}"
+            "#{sudo_str} #{prepend_sudo_success(sudo_id, command_str)}".lstrip
           else
-            "#{sudo_str} #{command_str}"
+            "#{sudo_str} #{command_str}".lstrip
           end
         end
 


### PR DESCRIPTION
  * previously if the run-as-command was specified the run-as user
    would always be appended causing the command to fail.

    Additionally, there was no way to disable without disabling
    other run-as-command option.

  * This fixes that situation where you want to login as a user
    but either:

      1. run a command as that logged in user without sudo
      2. run a command as a different user (run_as)
      3. run a command with sudo but without a run_as user