### PR TITLE
(ORCH-2290) Allow `deep_clone` to handle Jruby/Java objects

### DIFF
--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -169,7 +169,7 @@ module Bolt
       # references to the same object and prevents endless recursion.
       # Credit to Jan Molic via https://github.com/rubyworks/facets/blob/master/LICENSE.txt
       def deep_clone(obj, cloned = {})
-        cloned[obj.object_id] if cloned.include?(obj.object_id)
+        return cloned[obj.object_id] if cloned.include?(obj.object_id)
 
         begin
           cl = obj.clone


### PR DESCRIPTION
When attempting to `deep_clone` an instance of a `Bolt::Config` class with a custom Logging appender that references a Jruby/Clojure logger as an instance variable an exception (`Java::JavaLang::CloneNotSupportedException`) is raised that is not handled by rescuing `TypeError`. This commit updates the method to handle `CloneNotSupportedException`s the same way `TypeError` exceptions are handled.

Stack trace
```
java.lang.Object.clone(Native Method)
java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)
org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:440)
org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:304)
RUBY.deep_clone(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/util.rb:175)
RUBY.deep_clone(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/util.rb:194)
org.jruby.RubyArray.each(org/jruby/RubyArray.java:1800)
org.jruby.RubyArray$INVOKER$i$0$0$each.call(org/jruby/RubyArray$INVOKER$i$0$0$each.gen)
RUBY.deep_clone(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/util.rb:192)
RUBY.deep_clone(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/util.rb:187)
org.jruby.RubyArray.collectBang(org/jruby/RubyArray.java:2597)
org.jruby.RubyArray.collect!(org/jruby/RubyArray.java:2608)
org.jruby.RubyArray$INVOKER$i$0$0$collect_bang.call(org/jruby/RubyArray$INVOKER$i$0$0$collect_bang.gen)
RUBY.deep_clone(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/util.rb:187)
RUBY.deep_clone(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/util.rb:194)
org.jruby.RubyArray.each(org/jruby/RubyArray.java:1800)
org.jruby.RubyArray$INVOKER$i$0$0$each.call(org/jruby/RubyArray$INVOKER$i$0$0$each.gen)
RUBY.deep_clone(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/util.rb:192)
RUBY.deep_clone(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/util.rb:194)
org.jruby.RubyArray.each(org/jruby/RubyArray.java:1800)
org.jruby.RubyArray$INVOKER$i$0$0$each.call(org/jruby/RubyArray$INVOKER$i$0$0$each.gen)
RUBY.deep_clone(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/util.rb:192)
RUBY.deep_clone(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/util.rb:194)
org.jruby.RubyArray.each(org/jruby/RubyArray.java:1800)
org.jruby.RubyArray$INVOKER$i$0$0$each.call(org/jruby/RubyArray$INVOKER$i$0$0$each.gen)
RUBY.deep_clone(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/util.rb:192)
RUBY.deep_clone(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/config.rb:101)
RUBY.transport_config_cache(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/inventory/target.rb:114)
RUBY.transport(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/inventory/target.rb:151)
RUBY.validate(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/inventory/target.rb:133)
RUBY.initialize(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/inventory/target.rb:43)
org.jruby.RubyClass.newInstance(org/jruby/RubyClass.java:901)
org.jruby.RubyClass$INVOKER$i$newInstance.call(org/jruby/RubyClass$INVOKER$i$newInstance.gen)
RUBY.create_target_from_inventory(uri:classloader:/bolt-plan-executor-lib/bolt_plan_executor/pe_inventory2.rb:158)
RUBY.expand_targets(uri:classloader:/bolt-plan-executor-lib/bolt_plan_executor/pe_inventory2.rb:91)
org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2570)
org.jruby.RubyArray.map(org/jruby/RubyArray.java:2584)
org.jruby.RubyArray$INVOKER$i$0$0$map19.call(org/jruby/RubyArray$INVOKER$i$0$0$map19.gen)
RUBY.expand_targets(uri:classloader:/bolt-plan-executor-lib/bolt_plan_executor/pe_inventory2.rb:81)
org.jruby.RubyArray.collect(org/jruby/RubyArray.java:2570)
org.jruby.RubyArray.map(org/jruby/RubyArray.java:2584)
org.jruby.RubyArray$INVOKER$i$0$0$map19.call(org/jruby/RubyArray$INVOKER$i$0$0$map19.gen)
RUBY.expand_targets(uri:classloader:/bolt-plan-executor-lib/bolt_plan_executor/pe_inventory2.rb:79)
RUBY.get_targets(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/inventory/inventory2.rb:59)
RUBY.get_target(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/inventory/inventory2.rb:68)
RUBY.get_target(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/bolt-modules/boltlib/lib/puppet/functions/get_target.rb:33)
org.jruby.RubyClass.finvoke(org/jruby/RubyClass.java:505)
org.jruby.RubyBasicObject.send(org/jruby/RubyBasicObject.java:1741)
org.jruby.RubyKernel.send(org/jruby/RubyKernel.java:2193)
org.jruby.RubyKernel$INVOKER$s$send.call(org/jruby/RubyKernel$INVOKER$s$send.gen)
RUBY.invoke(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/functions/dispatch.rb:60)
RUBY.dispatch(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/functions/dispatcher.rb:43)
org.jruby.RubyKernel.rbCatch19Common(org/jruby/RubyKernel.java:1197)
org.jruby.RubyKernel.catch(org/jruby/RubyKernel.java:1193)
org.jruby.RubyKernel$INVOKER$s$rbCatch19.call(org/jruby/RubyKernel$INVOKER$s$rbCatch19.gen)
RUBY.dispatch(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/functions/dispatcher.rb:42)
RUBY.call(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/functions/function.rb:46)
org.jruby.RubyKernel.rbCatch19Common(org/jruby/RubyKernel.java:1197)
org.jruby.RubyKernel.catch(org/jruby/RubyKernel.java:1193)
org.jruby.RubyKernel$INVOKER$s$rbCatch19.call(org/jruby/RubyKernel$INVOKER$s$rbCatch19.gen)
RUBY.call(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/functions/function.rb:45)
org.jruby.RubyClass.finvoke(org/jruby/RubyClass.java:505)
org.jruby.RubyBasicObject.send(org/jruby/RubyBasicObject.java:1741)
org.jruby.RubyKernel.send(org/jruby/RubyKernel.java:2193)
org.jruby.RubyKernel$INVOKER$s$send.call(org/jruby/RubyKernel$INVOKER$s$send.gen)
RUBY.stack(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/puppet_stack.rb:42)
RUBY.call_function(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/evaluator/runtime3_support.rb:305)
RUBY.profile(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/profiler/around_profiler.rb:58)
RUBY.profile(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/profiler.rb:51)
RUBY.call_function(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/evaluator/runtime3_support.rb:303)
RUBY.call_function_with_block(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/evaluator/evaluator_impl.rb:976)
RUBY.eval_CallNamedFunctionExpression(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/evaluator/evaluator_impl.rb:945)
org.jruby.RubyClass.finvoke(org/jruby/RubyClass.java:505)
org.jruby.RubyBasicObject.send(org/jruby/RubyBasicObject.java:1741)
org.jruby.RubyKernel.send(org/jruby/RubyKernel.java:2193)
org.jruby.RubyKernel$INVOKER$s$send.call(org/jruby/RubyKernel$INVOKER$s$send.gen)
opt.puppetlabs.puppet.lib.ruby.vendor_ruby.puppet.pops.visitor.invokeOther11:send(opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops//opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/visitor.rb:49)
opt.puppetlabs.puppet.lib.ruby.vendor_ruby.puppet.pops.visitor.visit_this(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/visitor.rb:49)
org.jruby.RubyArray.each(org/jruby/RubyArray.java:1800)
org.jruby.RubyArray$INVOKER$i$0$0$each.call(org/jruby/RubyArray$INVOKER$i$0$0$each.gen)
opt.puppetlabs.puppet.lib.ruby.vendor_ruby.puppet.pops.visitor.invokeOther33:each(opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops//opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/visitor.rb:43)
opt.puppetlabs.puppet.lib.ruby.vendor_ruby.puppet.pops.visitor.visit_this(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/visitor.rb:43)
opt.puppetlabs.puppet.lib.ruby.vendor_ruby.puppet.pops.visitor.invokeOther4:visit_this(opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops//opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/visitor.rb:96)
opt.puppetlabs.puppet.lib.ruby.vendor_ruby.puppet.pops.visitor.visit_this_1(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/visitor.rb:96)
opt.puppetlabs.puppet.lib.ruby.vendor_ruby.puppet.pops.visitor.RUBY$method$visit_this_1$0$__VARARGS__(opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops//opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/visitor.rb)
RUBY.evaluate(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/evaluator/evaluator_impl.rb:81)
RUBY.eval_BlockExpression(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/evaluator/evaluator_impl.rb:660)
org.jruby.RubyEnumerable$27.call(org/jruby/RubyEnumerable.java:1077)
org.jruby.RubyArray.each(org/jruby/RubyArray.java:1800)
org.jruby.RubyArray$INVOKER$i$0$0$each.call(org/jruby/RubyArray$INVOKER$i$0$0$each.gen)
org.jruby.RubyClass.finvoke(org/jruby/RubyClass.java:493)
org.jruby.RubyEnumerable.callEach(org/jruby/RubyEnumerable.java:103)
org.jruby.RubyEnumerable.injectCommon(org/jruby/RubyEnumerable.java:1072)
org.jruby.RubyEnumerable.inject(org/jruby/RubyEnumerable.java:1093)
org.jruby.RubyEnumerable$INVOKER$s$inject.call(org/jruby/RubyEnumerable$INVOKER$s$inject.gen)
RUBY.eval_BlockExpression(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/evaluator/evaluator_impl.rb:660)
org.jruby.RubyClass.finvoke(org/jruby/RubyClass.java:505)
org.jruby.RubyBasicObject.send(org/jruby/RubyBasicObject.java:1741)
org.jruby.RubyKernel.send(org/jruby/RubyKernel.java:2193)
org.jruby.RubyKernel$INVOKER$s$send.call(org/jruby/RubyKernel$INVOKER$s$send.gen)
opt.puppetlabs.puppet.lib.ruby.vendor_ruby.puppet.pops.visitor.invokeOther11:send(opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops//opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/visitor.rb:49)
opt.puppetlabs.puppet.lib.ruby.vendor_ruby.puppet.pops.visitor.visit_this(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/visitor.rb:49)
org.jruby.RubyArray.each(org/jruby/RubyArray.java:1800)
org.jruby.RubyArray$INVOKER$i$0$0$each.call(org/jruby/RubyArray$INVOKER$i$0$0$each.gen)
opt.puppetlabs.puppet.lib.ruby.vendor_ruby.puppet.pops.visitor.invokeOther33:each(opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops//opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/visitor.rb:43)
opt.puppetlabs.puppet.lib.ruby.vendor_ruby.puppet.pops.visitor.visit_this(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/visitor.rb:43)
opt.puppetlabs.puppet.lib.ruby.vendor_ruby.puppet.pops.visitor.invokeOther4:visit_this(opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops//opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/visitor.rb:96)
opt.puppetlabs.puppet.lib.ruby.vendor_ruby.puppet.pops.visitor.visit_this_1(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/visitor.rb:96)
opt.puppetlabs.puppet.lib.ruby.vendor_ruby.puppet.pops.visitor.RUBY$method$visit_this_1$0$__VARARGS__(opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops//opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/visitor.rb)
RUBY.evaluate(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/evaluator/evaluator_impl.rb:81)
RUBY.evaluate_block_with_bindings(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/evaluator/evaluator_impl.rb:177)
RUBY.with_guarded_scope(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/parser/scope.rb:984)
RUBY.evaluate_block_with_bindings(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/evaluator/evaluator_impl.rb:173)
RUBY.call_by_name_internal(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/evaluator/closure.rb:113)
org.jruby.RubyKernel.rbCatch19Common(org/jruby/RubyKernel.java:1197)
org.jruby.RubyKernel.catch(org/jruby/RubyKernel.java:1193)
org.jruby.RubyKernel$INVOKER$s$rbCatch19.call(org/jruby/RubyKernel$INVOKER$s$rbCatch19.gen)
RUBY.call_by_name_internal(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/evaluator/closure.rb:112)
RUBY.call_by_name_with_scope(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/evaluator/closure.rb:82)
RUBY.run_inner_plan(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb:121)
RUBY.without_ephemeral_scopes(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/parser/scope.rb:957)
RUBY.with_global_scope(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/parser/scope.rb:934)
RUBY.run_inner_plan(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb:120)
org.jruby.RubyKernel.rbCatch19Common(org/jruby/RubyKernel.java:1197)
org.jruby.RubyKernel.catch(org/jruby/RubyKernel.java:1193)
org.jruby.RubyKernel$INVOKER$s$rbCatch19.call(org/jruby/RubyKernel$INVOKER$s$rbCatch19.gen)
RUBY.run_inner_plan(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb:119)
RUBY.log_plan(uri:classloader:/bolt-plan-executor-lib/bolt_plan_executor/executor.rb:109)
RUBY.run_inner_plan(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb:114)
RUBY.run_plan(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb:51)
org.jruby.RubyClass.finvoke(org/jruby/RubyClass.java:505)
org.jruby.RubyBasicObject.send(org/jruby/RubyBasicObject.java:1741)
org.jruby.RubyKernel.send(org/jruby/RubyKernel.java:2193)
org.jruby.RubyKernel$INVOKER$s$send.call(org/jruby/RubyKernel$INVOKER$s$send.gen)
RUBY.invoke(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/functions/dispatch.rb:60)
RUBY.dispatch(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/functions/dispatcher.rb:43)
org.jruby.RubyKernel.rbCatch19Common(org/jruby/RubyKernel.java:1197)
org.jruby.RubyKernel.catch(org/jruby/RubyKernel.java:1193)
org.jruby.RubyKernel$INVOKER$s$rbCatch19.call(org/jruby/RubyKernel$INVOKER$s$rbCatch19.gen)
RUBY.dispatch(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/functions/dispatcher.rb:42)
RUBY.call(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/functions/function.rb:46)
org.jruby.RubyKernel.rbCatch19Common(org/jruby/RubyKernel.java:1197)
org.jruby.RubyKernel.catch(org/jruby/RubyKernel.java:1193)
org.jruby.RubyKernel$INVOKER$s$rbCatch19.call(org/jruby/RubyKernel$INVOKER$s$rbCatch19.gen)
RUBY.call(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/functions/function.rb:45)
RUBY.external_call_function(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/evaluator/runtime3_support.rb:283)
RUBY.profile(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/profiler/around_profiler.rb:58)
RUBY.profile(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/profiler.rb:51)
RUBY.external_call_function(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pops/evaluator/runtime3_support.rb:282)
RUBY.call_function(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pal/compiler.rb:29)
RUBY.run_plan(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/pal.rb:433)
org.jruby.RubyProc.call(org/jruby/RubyProc.java:295)
org.jruby.RubyProc.call(org/jruby/RubyProc.java:274)
org.jruby.RubyProc.call(org/jruby/RubyProc.java:266)
org.jruby.RubyProc$INVOKER$i$0$0$call.call(org/jruby/RubyProc$INVOKER$i$0$0$call.gen)
RUBY.in_plan_compiler(uri:classloader:/bolt-plan-executor-lib/bolt_plan_executor/pe_pal.rb:133)
RUBY.in_plan_compiler(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/pal.rb:190)
RUBY.in_bolt_compiler(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/pal.rb:142)
RUBY.override(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/context.rb:62)
RUBY.override(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet.rb:274)
RUBY.in_bolt_compiler(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/pal.rb:141)
RUBY.main(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pal/pal_impl.rb:473)
RUBY.compile(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/parser/script_compiler.rb:47)
RUBY.override(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/context.rb:62)
RUBY.override(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet.rb:274)
RUBY.compile(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/parser/script_compiler.rb:42)
RUBY.main(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pal/pal_impl.rb:470)
RUBY.override(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/context.rb:62)
RUBY.override(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet.rb:274)
RUBY.main(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pal/pal_impl.rb:469)
RUBY.override(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/context.rb:62)
RUBY.override(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet.rb:274)
RUBY.main(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pal/pal_impl.rb:423)
RUBY.with_script_compiler(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pal/pal_impl.rb:94)
RUBY.in_bolt_compiler(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/pal.rb:137)
org.jruby.RubyProc.call(org/jruby/RubyProc.java:295)
org.jruby.RubyProc.call(org/jruby/RubyProc.java:274)
org.jruby.RubyProc.call(org/jruby/RubyProc.java:266)
org.jruby.RubyProc$INVOKER$i$0$0$call.call(org/jruby/RubyProc$INVOKER$i$0$0$call.gen)
RUBY.in_environment_context(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pal/pal_impl.rb:335)
RUBY.override(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/context.rb:62)
RUBY.override(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet.rb:274)
RUBY.in_environment_context(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pal/pal_impl.rb:327)
RUBY.in_tmp_environment(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/pal/pal_impl.rb:229)
RUBY.in_bolt_compiler(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/pal.rb:136)
RUBY.in_plan_compiler(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/pal.rb:189)
RUBY.with_puppet_settings(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/pal.rb:215)
RUBY.mktmpdir(uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/tmpdir.rb:89)
RUBY.with_puppet_settings(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/pal.rb:206)
RUBY.in_plan_compiler(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/pal.rb:188)
RUBY.override(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/context.rb:62)
RUBY.override(/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet.rb:274)
RUBY.with_bolt_executor(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/pal.rb:180)
RUBY.in_plan_compiler(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/pal.rb:184)
RUBY.in_plan_compiler(uri:classloader:/bolt-plan-executor-lib/bolt_plan_executor/pe_pal.rb:104)
RUBY.run_plan(/opt/puppetlabs/server/apps/bolt-server/lib/ruby/gems/bolt-1.43.0/lib/bolt/pal.rb:432)
RUBY.runPlan(uri:classloader:/bolt-plan-executor-lib/bolt_plan_executor/jruby_plan_executor.rb:57)
java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)
clojure.lang.Reflector.invokeMatchingMethod(clojure/lang/Reflector.java:167)
clojure.lang.Reflector.invokeInstanceMethod(clojure/lang/Reflector.java:102)
puppetlabs.orchestrator.bolt.plan_executor$run_plan.invokeStatic(puppetlabs/orchestrator/bolt/plan_executor.clj:29)
puppetlabs.orchestrator.bolt.plan_executor$run_plan.invoke(puppetlabs/orchestrator/bolt/plan_executor.clj:18)
puppetlabs.orchestrator.bolt.plan_executor.JRubyPlanExecutor$fn__60363.invoke(puppetlabs/orchestrator/bolt/plan_executor/plan_executor.clj:73)
clojure.lang.AFn.call(clojure/lang/AFn.java:18)
java.util.concurrent.FutureTask.run(java/util/concurrent/FutureTask.java:266)
java.util.concurrent.Executors$RunnableAdapter.call(java/util/concurrent/Executors.java:511)
java.util.concurrent.FutureTask.run(java/util/concurrent/FutureTask.java:266)
java.util.concurrent.ThreadPoolExecutor.runWorker(java/util/concurrent/ThreadPoolExecutor.java:1149)
java.util.concurrent.ThreadPoolExecutor$Worker.run(java/util/concurrent/ThreadPoolExecutor.java:624)
java.lang.Thread.run(java/lang/Thread.java:748)
```