### PR TITLE
(GH-1338) Support node definitions when applying manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
   The new plan function, `file::join`, allows you to join file paths using the separator `/`.
 
+* **Node definitions are supported when applying manifest code** ([#1338](https://github.com/puppetlabs/bolt/issues/1338))
+
+  Node definitions can now be used with `bolt apply` and within apply blocks in plans. This makes it easier to reuse existing Puppet codebases with Bolt.
+
 ### Bug fixes
 
 * **The ssh configuration option `key-data` was not compatible with the `future` flag** ([#1504](https://github.com/puppetlabs/bolt/issues/1504))

--- a/lib/bolt/catalog.rb
+++ b/lib/bolt/catalog.rb
@@ -97,6 +97,7 @@ module Bolt
               Puppet[:strict_variables] = options['strict_variables'] || false
               ast = Puppet::Pops::Serialization::FromDataConverter.convert(pal_main)
               compiler.evaluate(ast)
+              compiler.instance_variable_get(:@internal_compiler).send(:evaluate_ast_node)
               compiler.compile_additions
               compiler.with_json_encoding(&:encode)
             end

--- a/lib/bolt/catalog.rb
+++ b/lib/bolt/catalog.rb
@@ -96,6 +96,24 @@ module Bolt
               Puppet[:strict] = options['strict'] || :warning
               Puppet[:strict_variables] = options['strict_variables'] || false
               ast = Puppet::Pops::Serialization::FromDataConverter.convert(pal_main)
+              # This will be a Program when running via `bolt apply`, but will
+              # only be a subset of the AST when compiling an apply block in a
+              # plan. In that case, we need to discover the definitions (which
+              # would ordinarily be stored on the Program) and construct a Program object.
+              unless ast.is_a?(Puppet::Pops::Model::Program)
+                # Node definitions must be at the top level of the apply block.
+                # That means the apply body either a) consists of just a
+                # NodeDefinition, b) consists of a BlockExpression which may
+                # contain NodeDefinitions, or c) doesn't contain NodeDefinitions.
+                definitions = if ast.is_a?(Puppet::Pops::Model::BlockExpression)
+                                ast.statements.select { |st| st.is_a?(Puppet::Pops::Model::NodeDefinition) }
+                              elsif ast.is_a?(Puppet::Pops::Model::NodeDefinition)
+                                [ast]
+                              else
+                                []
+                              end
+                ast = Puppet::Pops::Model::Factory.PROGRAM(ast, definitions, ast.locator).model
+              end
               compiler.evaluate(ast)
               compiler.instance_variable_get(:@internal_compiler).send(:evaluate_ast_node)
               compiler.compile_additions

--- a/spec/fixtures/apply/basic/plans/node_default.pp
+++ b/spec/fixtures/apply/basic/plans/node_default.pp
@@ -1,0 +1,8 @@
+plan basic::node_default(TargetSpec $nodes) {
+  return apply($nodes) {
+    node default {
+      warn { "default node definition": }
+    }
+  }
+}
+

--- a/spec/fixtures/apply/basic/plans/node_definition.pp
+++ b/spec/fixtures/apply/basic/plans/node_definition.pp
@@ -1,0 +1,9 @@
+plan basic::node_definition(TargetSpec $nodes) {
+  return apply($nodes) {
+    # We don't know the node name that will be used in the test, so we have to
+    # just match everything
+    node /.+/ {
+      warn { "named node definition": }
+    }
+  }
+}

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -111,6 +111,22 @@ describe "passes parsed AST to the apply_catalog task" do
       expect(warn.count).to eq(1)
     end
 
+    it 'evaluates a node definition matching the node name' do
+      pending "puppet does not allow node definitions in plans"
+      result = run_cli_json(%w[plan run basic::node_definition] + config_flags)
+      report = result[0]['result']['report']
+      warn = report['catalog']['resources'].select { |r| r['type'] == 'Warn' }
+      expect(warn.count).to eq(1)
+    end
+
+    it 'evaluates a default node definition if none matches the node name' do
+      pending "puppet does not allow node definitions in plans"
+      result = run_cli_json(%w[plan run basic::node_default] + config_flags)
+      report = result[0]['result']['report']
+      warn = report['catalog']['resources'].select { |r| r['type'] == 'Warn' }
+      expect(warn.count).to eq(1)
+    end
+
     it 'logs messages emitted during compilation' do
       result = run_cli_json(%w[plan run basic::error] + config_flags)
       expect(result[0]['status']).to eq('success')

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -365,6 +365,14 @@ describe "apply", expensive: true do
           expect(result['report']['resource_statuses']).to include('Notify[hello world]')
         end
 
+        it "applies a node definition" do
+          results = run_cli_json(['apply', '-e', 'node default { notify { "hello world": } }'] + config_flags)
+          result = results[0]['result']
+          expect(result).not_to include('kind')
+          expect(result['report']).to include('status' => 'changed')
+          expect(result['report']['resource_statuses']).to include('Notify[hello world]')
+        end
+
         it "fails if the manifest doesn't parse" do
           expect { run_cli_json(['apply', '-e', 'include(basic'] + config_flags) }
             .to raise_error(/Syntax error/)


### PR DESCRIPTION
This adds support for node definitions from both `bolt apply` and within
apply blocks in a plan. Node definitions are still not allowed directly
in plans outside an apply block however, as there is no meaningful
behavior for them.

Supporting node definitions in apply blocks (vs `bolt apply`) depends on
https://github.com/puppetlabs/puppet/pull/7909 and the corresponding tests are
marked `pending` accordingly.

Closed #1338