### PR TITLE
(GH-1208) Ensure Puppet agent version with apply_prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
   depends on features that aren't in this version of Bolt, so Bolt will now
   print a warning if it sees such keys.
 
+* **`apply_prep` plan function ensures Puppet agent version** ([#1208](https://github.com/puppetlabs/bolt/issues/1208))
+
+  The `apply_prep` plan function now attempts to install the specified version of the Puppet agent on a target 
+  even when a version of the agent is already installed. If the specified version of the agent cannot be installed, 
+  then `apply_prep` will error.
+
 ## Bolt 1.47.0
 
 ### Deprecations and removals

--- a/Puppetfile
+++ b/Puppetfile
@@ -7,7 +7,7 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '1.1.0'
 mod 'puppetlabs-facts', '0.6.0'
-mod 'puppetlabs-puppet_agent', '2.2.2'
+mod 'puppetlabs-puppet_agent', '3.0.0'
 
 # Core types and providers for Puppet 6
 mod 'puppetlabs-augeas_core', '1.0.5'

--- a/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
@@ -7,12 +7,8 @@ require 'bolt/task'
 # installed using either the configured plugin or the `task` plugin with the
 # `puppet_agent::install` task.
 #
-# Agent detection will be skipped if the target includes the 'puppet-agent' feature, either as a
+# Agent installation will be skipped if the target includes the 'puppet-agent' feature, either as a
 # property of its transport (PCP) or by explicitly setting it as a feature in Bolt's inventory.
-#
-# If Bolt does not detect an agent on the target using the 'puppet_agent::version' task,
-# it will install the agent using either the configured plugin or the
-# task plugin.
 #
 # **NOTE:** Not available in apply block
 Puppet::Functions.create_function(:apply_prep) do
@@ -79,53 +75,40 @@ Puppet::Functions.create_function(:apply_prep) do
     executor.log_action('install puppet and gather facts', targets) do
       executor.without_default_logging do
         # Skip targets that include the puppet-agent feature, as we know an agent will be available.
-        agent_targets, unknown_targets = targets.partition { |target| agent?(target, executor, inventory) }
+        agent_targets, need_install_targets = targets.partition { |target| agent?(target, executor, inventory) }
         agent_targets.each { |target| Puppet.debug "Puppet Agent feature declared for #{target.name}" }
-        unless unknown_targets.empty?
-          # Ensure Puppet is installed
-          version_task = get_task('puppet_agent::version')
-          versions = run_task(unknown_targets, version_task)
-          raise Bolt::RunFailure.new(versions, 'run_task', 'puppet_agent::version') unless versions.ok?
-          need_install, installed = versions.partition { |r| r['version'].nil? }
-          installed.each do |r|
-            Puppet.debug "Puppet Agent #{r['version']} installed on #{r.target.name}"
-            set_agent_feature(r.target)
+        unless need_install_targets.empty?
+          # lazy-load expensive gem code
+          require 'concurrent'
+          pool = Concurrent::ThreadPoolExecutor.new
+
+          hooks = need_install_targets.map do |t|
+            begin
+              opts = t.plugin_hooks&.fetch('puppet_library').dup
+              plugin_name = opts.delete('plugin')
+              hook = inventory.plugins.get_hook(plugin_name, :puppet_library)
+              { 'target' => t,
+                'hook_proc' => hook.call(opts, t, self) }
+            rescue StandardError => e
+              Bolt::Result.from_exception(t, e)
+            end
           end
 
-          unless need_install.empty?
-            need_install_targets = need_install.map(&:target)
-            # lazy-load expensive gem code
-            require 'concurrent'
-            pool = Concurrent::ThreadPoolExecutor.new
+          hook_errors, ok_hooks = hooks.partition { |h| h.is_a?(Bolt::Result) }
 
-            hooks = need_install_targets.map do |t|
-              begin
-                opts = t.plugin_hooks&.fetch('puppet_library').dup
-                plugin_name = opts.delete('plugin')
-                hook = inventory.plugins.get_hook(plugin_name, :puppet_library)
-                { 'target' => t,
-                  'hook_proc' => hook.call(opts, t, self) }
-              rescue StandardError => e
-                Bolt::Result.from_exception(t, e)
-              end
+          futures = ok_hooks.map do |hash|
+            Concurrent::Future.execute(executor: pool) do
+              hash['hook_proc'].call
             end
-
-            hook_errors, ok_hooks = hooks.partition { |h| h.is_a?(Bolt::Result) }
-
-            futures = ok_hooks.map do |hash|
-              Concurrent::Future.execute(executor: pool) do
-                hash['hook_proc'].call
-              end
-            end
-
-            results = futures.zip(ok_hooks).map do |f, hash|
-              f.value || Bolt::Result.from_exception(hash['target'], f.reason)
-            end
-            set = Bolt::ResultSet.new(results + hook_errors)
-            raise Bolt::RunFailure.new(set.error_set, 'apply_prep') unless set.ok
-
-            need_install_targets.each { |target| set_agent_feature(target) }
           end
+
+          results = futures.zip(ok_hooks).map do |f, hash|
+            f.value || Bolt::Result.from_exception(hash['target'], f.reason)
+          end
+          set = Bolt::ResultSet.new(results + hook_errors)
+          raise Bolt::RunFailure.new(set.error_set, 'apply_prep') unless set.ok
+
+          need_install_targets.each { |target| set_agent_feature(target) }
         end
 
         # Gather facts, including custom facts

--- a/spec/bolt_spec/run_spec.rb
+++ b/spec/bolt_spec/run_spec.rb
@@ -107,18 +107,25 @@ describe "BoltSpec::Run", ssh: true do
       } }
     end
 
+    def agent_inventory
+      { 'groups' => conn_inventory['groups'],
+        'features' => ['puppet-agent'] }
+    end
+
+    let(:bolt_inventory) { agent_inventory }
+
     before(:all) do
-      result = run_task('puppet_agent::version', 'ssh', {}, inventory: conn_inventory, config: root_config)
+      result = run_task('puppet_agent::version', 'ssh', {}, inventory: agent_inventory, config: root_config)
       expect(result.first['status']).to eq('success')
       unless result.first['result']['version']
-        result = run_task('puppet_agent::install', 'ssh', {}, inventory: conn_inventory, config: root_config)
+        result = run_task('puppet_agent::install', 'ssh', {}, inventory: agent_inventory, config: root_config)
       end
       expect(result.first['status']).to eq('success')
     end
 
     after(:all) do
       uninstall = '/opt/puppetlabs/bin/puppet resource package puppet-agent ensure=absent'
-      run_command(uninstall, 'ssh', inventory: conn_inventory, config: root_config)
+      run_command(uninstall, 'ssh', inventory: agent_inventory, config: root_config)
     end
 
     describe 'apply_manifest' do

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -453,7 +453,7 @@ describe "apply", expensive: true do
     context "when running against puppet 6" do
       before(:all) do
         result = run_task('puppet_agent::install', conn_uri('winrm'),
-                          { 'collection' => 'puppet6' }, config: config)
+                          { 'collection' => 'puppet6', 'version' => 'latest' }, config: config)
         expect(result.count).to eq(1)
         expect(result[0]).to include('status' => 'success')
 


### PR DESCRIPTION
This updates the `apply_prep` plan function to ensure the specified
version of the Puppet agent is installed on the target. Previously, the
`apply_prep` function would only install the agent if the target did not
have any version of the agent installed and did not have the
`puppet-agent` feature set. Now, `apply_prep` will attempt to install
the agent on any target that does not have the `puppet-agent` feature
set, even if the install would cause an upgrade or downgrade to an
already-installed agent.

The following PR in puppetlabs/puppetlabs-puppet_agent should be merged in first:
https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/463

Closes #1208 