### PR TITLE
(GH-1431) Add support for trusted external facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 
   The new plan function, `file::join`, allows you to join file paths using the separator `/`.
 
+* **Support trusted external facts** ([#1431](https://github.com/puppetlabs/bolt/issues/1431))
+
+  A new Bolt configuration option `trusted-external-command` configures the path to the executable
+  on the Bolt controller to run to retrieve trusted external facts. If configured, trusted external
+  facts are available when running Bolt. This feature is experimental in both Puppet and Bolt, and
+  this API may change or be removed.
+
 ### Bug fixes
 
 * **The ssh configuration option `key-data` was not compatible with the `future` flag** ([#1504](https://github.com/puppetlabs/bolt/issues/1504))

--- a/documentation/bolt_configuration_options.md
+++ b/documentation/bolt_configuration_options.md
@@ -25,6 +25,7 @@ ssh:
 -   `concurrency`: The number of threads to use when executing on remote targets. Default is `100`.
 -   `format`: The format to use when printing results. Options are `human` and `json`. Default is `human`.
 -   `hiera-config`: Specify the path to your Hiera config. The default path is `hiera.yaml` inside the [Bolt project directory](bolt_project_directories.md#).
+-   `trusted-external-command`: Specify the path to an executable on the Bolt controller that can produce [external trusted facts](https://puppet.com/docs/puppet/latest/release_notes_puppet.html#puppet-new-features-x.10.1). **Note:** external trusted facts are experimental in both Puppet and Bolt, and this API may change or be removed.
 -   `interpreters`: A map of an extension name to the absolute path of an executable, enabling you to override the shebang defined in a task executable. The extension can optionally be specified with the `.` character (`.py` and `py` both map to a task executable `task.py`) and the extension is case sensitive. The transports that support interpreter configuration are `docker`, `local`, `ssh`, and `winrm`. When a target's name is `localhost`, Ruby tasks run with the Bolt Ruby interpreter by default. This example demonstrates configuring Python tasks to run with a `python3` interpreter:
     ```yaml
     interpreters:

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -82,7 +82,11 @@ module Bolt
     end
 
     def compile(target, ast, plan_vars)
-      trusted = Puppet::Context::TrustedInformation.new('local', target.name, {})
+      # This simplified Puppet node object is what .local uses to determine the
+      # certname of the target
+      node = Puppet::Node.from_data_hash('name' => target.name,
+                                         'parameters' => { 'clientcert' => target.name })
+      trusted = Puppet::Context::TrustedInformation.local(node)
       facts = @inventory.facts(target).merge('bolt' => true)
 
       catalog_input = {
@@ -131,7 +135,11 @@ module Bolt
     end
 
     def future_compile(target, catalog_input)
-      trusted = Puppet::Context::TrustedInformation.new('local', target.name, {})
+      # This simplified Puppet node object is what .local uses to determine the
+      # certname of the target
+      node = Puppet::Node.from_data_hash('name' => target.name,
+                                         'parameters' => { 'clientcert' => target.name })
+      trusted = Puppet::Context::TrustedInformation.local(node)
       catalog_input[:target] = {
         name: target.name,
         facts: @inventory.facts(target).merge('bolt' => true),

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -664,7 +664,8 @@ module Bolt
       @pal ||= Bolt::PAL.new(config.modulepath,
                              config.hiera_config,
                              config.boltdir.resource_types,
-                             config.compile_concurrency)
+                             config.compile_concurrency,
+                             config.trusted_external)
     end
 
     def convert_plan(plan)

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -33,7 +33,7 @@ module Bolt
   class Config
     attr_accessor :concurrency, :format, :trace, :log, :puppetdb, :color, :save_rerun,
                   :transport, :transports, :inventoryfile, :compile_concurrency, :boltdir,
-                  :puppetfile_config, :plugins, :plugin_hooks, :future
+                  :puppetfile_config, :plugins, :plugin_hooks, :future, :trusted_external
     attr_writer :modulepath
 
     TRANSPORT_OPTIONS = %i[password run-as sudo-password extensions sudo-executable
@@ -162,6 +162,9 @@ module Bolt
       end
 
       @hiera_config = File.expand_path(data['hiera-config'], @boltdir.path) if data.key?('hiera-config')
+      @trusted_external = if data.key?('trusted-external-command')
+                            File.expand_path(data['trusted-external-command'], @boltdir.path)
+                          end
       @compile_concurrency = data['compile-concurrency'] if data.key?('compile-concurrency')
 
       @save_rerun = data['save-rerun'] if data.key?('save-rerun')
@@ -291,6 +294,7 @@ module Bolt
       end
 
       Bolt::Util.validate_file('hiera-config', @hiera_config) if @hiera_config
+      Bolt::Util.validate_file('trusted-external-command', @trusted_external) if @trusted_external
 
       unless @transport.nil? || Bolt::TRANSPORTS.include?(@transport.to_sym)
         raise UnknownTransportError, @transport

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -39,7 +39,7 @@ module Bolt
 
     attr_reader :modulepath
 
-    def initialize(modulepath, hiera_config, resource_types, max_compiles = Etc.nprocessors)
+    def initialize(modulepath, hiera_config, resource_types, max_compiles = Etc.nprocessors, trusted_external = nil)
       # Nothing works without initialized this global state. Reinitializing
       # is safe and in practice only happens in tests
       self.class.load_puppet
@@ -47,6 +47,7 @@ module Bolt
       @original_modulepath = modulepath
       @modulepath = [BOLTLIB_PATH, *modulepath, MODULES_PATH]
       @hiera_config = hiera_config
+      @trusted_external = trusted_external
       @max_compiles = max_compiles
       @resource_types = resource_types
 
@@ -211,6 +212,7 @@ module Bolt
         Puppet.settings.send(:clear_everything_for_tests)
         Puppet.initialize_settings(cli)
         Puppet::GettextConfig.create_default_text_domain
+        Puppet[:trusted_external_command] = @trusted_external
         self.class.configure_logging
         yield
       end

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -81,7 +81,7 @@ module Bolt
               target,
               value: { '_error' => {
                 'kind' => 'puppetlabs.tasks/skipped-node',
-                'msg' => "Node #{target.safe_name} was skipped",
+                'msg' => "Target #{target.safe_name} was skipped",
                 'details' => {}
               } },
               action: 'task', object: task_name

--- a/spec/fixtures/scripts/trusted_external_facts.sh
+++ b/spec/fixtures/scripts/trusted_external_facts.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "{\"hot\": \"cocoa\", \"pepper\": \"mint\"}"

--- a/spec/integration/transport/orch_spec.rb
+++ b/spec/integration/transport/orch_spec.rb
@@ -189,7 +189,7 @@ describe Bolt::Transport::Orch, orchestrator: true do
 
         expect(node_results[1].error_hash).to eq(
           'kind' => 'puppetlabs.tasks/skipped-node',
-          'msg' => "Node node2 was skipped",
+          'msg' => "Target node2 was skipped",
           'details' => {}
         )
       end


### PR DESCRIPTION
This adds support for the new trusted external facts command. It adds a
configuration option `trusted-external-command` where users can
configure a path to their trusted external facts executable. We pass that
value through to the Puppet settings config of the same name. This
allows users to access trusted external facts in `$trusted['external']`.

Closes #1431