### PR TITLE
(GH-1373) Package Bolt for Fedora 31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Bolt Next
+
+### New features
+
+* **Packages for Fedora 31** ([#1373](https://github.com/puppetlabs/bolt/issues/1373))
+
+  Bolt packages are now available for Fedora 31.
+
 ## Bolt 1.44.0
 
 ### New features

--- a/acceptance/tests/apply_plan_ssh.rb
+++ b/acceptance/tests/apply_plan_ssh.rb
@@ -7,7 +7,7 @@ test_name "bolt plan run should apply manifest block on remote hosts via ssh" do
   extend Acceptance::BoltCommandHelper
 
   ssh_nodes = select_hosts(roles: ['ssh'])
-  skip_targets = select_hosts(platform: [/osx-10.11/])
+  skip_targets = select_hosts(platform: [/osx-10.11/, /fedora-31/])
   targets = "ssh_nodes"
   if skip_targets.any?
     ssh_nodes -= skip_targets

--- a/acceptance/tests/bolt_apply.rb
+++ b/acceptance/tests/bolt_apply.rb
@@ -11,7 +11,7 @@ test_name "bolt apply should apply manifest block on remote hosts via ssh and wi
   targets = ssh_nodes + winrm_nodes
 
   # Puppet 6 doesn't support OSX 10.11, so skip those hosts if present
-  targets -= select_hosts(platform: [/osx-10.11/])
+  targets -= select_hosts(platform: [/osx-10.11/, /fedora-31/])
 
   skip_test('no applicable nodes to test on') if targets.empty?
 

--- a/documentation/bolt_installing.md
+++ b/documentation/bolt_installing.md
@@ -216,6 +216,11 @@ The Puppet Tools repository for the YUM package management system is [http://yum
         sudo rpm -Uvh https://yum.puppet.com/puppet-tools-release-fedora-30.noarch.rpm
         sudo dnf install puppet-bolt
         ```
+    -   Fedora 31
+        ```shell script
+        sudo rpm -Uvh https://yum.puppet.com/puppet-tools-release-fedora-31.noarch.rpm
+        sudo dnf install puppet-bolt
+        ```
 1.  Run a Bolt command and get started.
     ```
     bolt --help


### PR DESCRIPTION
This updates the installation docs for installing Bolt on Fedora 31.

The following PRs should be merged first:
- [ ] puppetlabs/ci-job-configs#6594
- [ ] puppetlabs/bolt-vanagon#130