### PR TITLE
(GH-1319) Execute in run-as user's home dir when using run-as with SSH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Bolt NEXT
+
+### Bug fixes
+
+* **SSH commands will run from the home directory of the run-as user, not the connected user** ([#1518](https://github.com/puppetlabs/bolt/pull/1518))
+
+  Connecting via SSH and then switching users will now run as though it had
+  connected as the new user in the first place, using that user's home
+  directory as the working directory.
+
 ## Bolt 1.45.0
 
 ### Deprecations

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -197,13 +197,13 @@ module Bolt
           if escalate
             if use_sudo
               sudo_exec = target.options['sudo-executable'] || "sudo"
-              sudo_flags = [sudo_exec, "-S", "-u", run_as, "-p", Sudoable.sudo_prompt]
+              sudo_flags = [sudo_exec, "-S", "-H", "-u", run_as, "-p", Sudoable.sudo_prompt]
               sudo_flags += ["-E"] if options[:environment]
               sudo_str = Shellwords.shelljoin(sudo_flags)
             else
               sudo_str = Shellwords.shelljoin(@target.options['run-as-command'] + [run_as])
             end
-            command_str = build_sudoable_command_str(command_str, sudo_str, @sudo_id, options)
+            command_str = build_sudoable_command_str(command_str, sudo_str, @sudo_id, options.merge(reset_cwd: true))
           end
 
           # Including the environment declarations in the shelljoin will escape

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -36,7 +36,7 @@ module Bolt
 
           @sudo_password = @target.options['sudo-password']
           # rubocop:disable Style/GlobalVars
-          @sudo_password ||= @target.options['password'] if $future
+          @sudo_password ||= @target.password if $future
           # rubocop:enable Style/GlobalVars
 
           if target.options['private-key']&.instance_of?(String)

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -376,7 +376,7 @@ describe "passes parsed AST to the apply_catalog task" do
       it 'serializes Error objects in apply blocks' do
         result = run_cli_json(%w[plan run puppet_types::error] + config_flags)
         notify = get_notifies(result, true)
-        expect(notify[0]['title']).to eq("ApplyResult resource: The command failed with exit code 1")
+        expect(notify[0]['title']).to eq("ApplyResult resource: The command failed with exit code 127")
       end
 
       context 'when calling invalid functions in apply' do


### PR DESCRIPTION
Previously, connecting as one user and running as a different user via 
run-as would cause the operation to execute in the home directory of the 
connected user instead of the run-as user. This difference doesn't usually
matter because the common run-as case involves escalating to root, in which
case root can read the directory anyway. However, when connecting as root
and then *dropping* to a less-privileged user, this would leave the process
in a situation where it might not have read access to its working
directory. This problem also arises when using NFS with the standard root
squash configuration, whereby root still can't read the home directories of
non-root users.

We now prepend a `cd` command with no argument before every command we 
execute when using run-as. This form of `cd` implicitly changes to the 
value of $HOME. We also now run with `sudo -H` which instructs sudo to 
reset $HOME to the home directory of the user we're switching to.

This issue caused particular problems for the libexec tasks used to apply
Puppet code. Those tasks use Puppet::ModuleTool::Tar which in some cases
will use `Dir.chdir` with a block while extracting files. This form of
`Dir.chdir` will change to a temporary directory to do its work, and then
will attempt to change back to the directory it was in previously. In cases
where that directory is unreadable by the current user, it would fail to
switch back and the task would error. We now ensure that those tasks will
be running from a current working directory where they are allowed read
access.

Also fixed an unrelated issue with defaulting sudo-password to the value of
password. It will now use the password value even if the password was set via
the URI, not just with the --password flag or the `password` field in the
inventory.

Fixes #1319 