### PR TITLE
(maint) Metrics/LineLength cop is now Layout/LineLength

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,9 @@ Layout/HeredocIndentation:
 Layout/ClosingHeredocIndentation:
   Enabled: false
 
+Layout/LineLength:
+  Max: 120
+
 Style/GuardClause:
   Enabled: false
 
@@ -72,9 +75,6 @@ Metrics/ClassLength:
 
 Metrics/CyclomaticComplexity:
   Enabled: false
-
-Metrics/LineLength:
-  Max: 120
 
 Metrics/MethodLength:
   Enabled: false

--- a/bolt-modules/boltlib/lib/puppet/functions/puppetdb_query.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/puppetdb_query.rb
@@ -5,13 +5,13 @@ require 'bolt/error'
 # Makes a query to {https://puppet.com/docs/puppetdb/latest/index.html puppetdb}
 # using Bolt's PuppetDB client.
 Puppet::Functions.create_function(:puppetdb_query) do
-  # rubocop:disable Metrics/LineLength
+  # rubocop:disable Layout/LineLength
   # @param query A PQL query.
   #   {https://puppet.com/docs/puppetdb/latest/api/query/tutorial-pql.html Learn more about Puppet's query language, PQL}
   # @return Results of the PuppetDB query.
   # @example Request certnames for all nodes
   #   puppetdb_query('nodes[certname] {}')
-  # rubocop:enable Metrics/LineLength
+  # rubocop:enable Layout/LineLength
   dispatch :make_query do
     param 'Variant[String, Array[Data]]', :query
     return_type 'Array[Data]'

--- a/lib/bolt/apply_result.rb
+++ b/lib/bolt/apply_result.rb
@@ -53,9 +53,9 @@ module Bolt
 
       unless missing_keys.empty?
         if result['_output']
-          # rubocop:disable Metrics/LineLength
+          # rubocop:disable Layout/LineLength
           msg = "Report result contains an '_output' key. Catalog application may have printed extraneous output to stdout: #{result['_output']}"
-          # rubocop:enable Metrics/LineLength
+          # rubocop:enable Layout/LineLength
         else
           msg = "Report did not contain all expected keys missing: #{missing_keys.join(' ,')}"
         end

--- a/lib/bolt/inventory/group2.rb
+++ b/lib/bolt/inventory/group2.rb
@@ -235,7 +235,7 @@ module Bolt
 
         # DEPRECATION : remove this before finalization
         if input.key?('target-lookups')
-          msg = "'target-lookups' are no longer a separate key. Merge 'target-lookups' and 'targets' lists and replace 'plugin' with '_plugin'" # rubocop:disable Metrics/LineLength
+          msg = "'target-lookups' are no longer a separate key. Merge 'target-lookups' and 'targets' lists and replace 'plugin' with '_plugin'" # rubocop:disable Layout/LineLength
           raise ValidationError.new(msg, @name)
         end
 

--- a/lib/bolt/transport/docker/connection.rb
+++ b/lib/bolt/transport/docker/connection.rb
@@ -157,14 +157,14 @@ module Bolt
                        .map { |str| JSON.parse(str) }
         end
 
-        # rubocop:disable Metrics/LineLength
+        # rubocop:disable Layout/LineLength
         # Executes a Docker CLI command
         #
         # @param subcommand [String] The docker subcommand to run e.g. 'inspect' for `docker inspect`
         # @param command_options [Array] Additional command options e.g. ['--size'] for `docker inspect --size`
         # @param redir_stdin [IO] IO object which will be use to as STDIN in the docker command. Default is nil, which does not perform redirection
         # @return [String, String, Process::Status] The output of the command:  STDOUT, STDERR, Process Status
-        # rubocop:enable Metrics/LineLength
+        # rubocop:enable Layout/LineLength
         def execute_local_docker_command(subcommand, command_options = [], redir_stdin = nil)
           env_hash = {}
           # Set the DOCKER_HOST if we are using a non-default service-url


### PR DESCRIPTION
Rubocop updated the line length cop to be under the Layout section
rather than the Metrics section of their cops. This updates Bolt to
silence warnings about the name switch.