### PR TITLE
(PE-27909) Return plan metadata for `init` plan

### DIFF
--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -305,7 +305,13 @@ module BoltServer
     # @param environment [String] the environment to fetch the plan from
     get '/plans/:module_name/:plan_name' do
       in_pe_pal_env(params['environment']) do |pal|
-        plan_info = pal.get_plan_info("#{params[:module_name]}::#{params[:plan_name]}")
+        # Handle case where plan name is simply module name with special `init.pp` plan
+        plan_name = if params[:plan_name] == 'init'
+                      params[:module_name]
+                    else
+                      "#{params[:module_name]}::#{params[:plan_name]}"
+                    end
+        plan_info = pal.get_plan_info(plan_name)
         [200, plan_info.to_json]
       end
     end

--- a/spec/bolt_server/transport_app_spec.rb
+++ b/spec/bolt_server/transport_app_spec.rb
@@ -71,15 +71,24 @@ describe "BoltServer::TransportApp" do
     end
 
     describe '/plans/:module_name/:plan_name' do
-      let(:path) { "/plans/foo/bar?environment=production" }
+      let(:path) { '/plans/foo/bar?environment=production' }
       let(:fake_pal) { instance_double('BoltServer::PE::PAL') }
+      let(:init_plan) { '/plans/foo/init?environment=production' }
 
-      it 'returns properly from /plans' do
+      it '/plans/:module_name/:plan_name handles module::plan_name' do
         expect(BoltServer::PE::PAL).to receive(:new).and_return(fake_pal)
         expect(fake_pal).to receive(:get_plan_info).with('foo::bar').and_return('name' => 'foo::bar')
         get(path)
         metadata = JSON.parse(last_response.body)
         expect(metadata).to eq('name' => 'foo::bar')
+      end
+
+      it '/plans/:module_name/:plan_name handles plan name = module name (init.pp) plan' do
+        expect(BoltServer::PE::PAL).to receive(:new).and_return(fake_pal)
+        expect(fake_pal).to receive(:get_plan_info).with('foo').and_return('name' => 'foo')
+        get(init_plan)
+        metadata = JSON.parse(last_response.body)
+        expect(metadata).to eq('name' => 'foo')
       end
 
       it 'returns 400 if an unknown plan error is thrown' do


### PR DESCRIPTION
Previously when the plan metadata is requested for the special `init.pp` plan (with the same name as its parent module) the metadata endpoint would not trim the `init` from the name before calling in to get_plan_info. With this commit the endpoint has been updated to handle plans referenced only by `[module name]::init`.