### PR TITLE
(GH-1151) Move rubocop and docs tasks to GitHub Actions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,50 @@
+name: Linting
+
+on:
+  pull_request_review:
+    types: [edited, submitted]
+
+jobs:
+
+  rubocop:
+    name: Rubocop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.5.x'
+      - name: Install rubocop
+        run: |
+          gem install rubocop
+          which rubocop
+      - name: Run rubocop
+        run: rubocop --display-cop-names --display-style-guide --parallel
+
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.5.x'
+      - name: Install bundler
+        run: |
+          gem install bundler
+          bundle config path vendor/bundle
+      - name: Cache gems
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+      - name: Install gems
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: bundle install --jobs 4 --retry 3
+      - name: Generate docs
+        run: bundle exec rake generate_docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,8 @@ env:
     - secure: Gk8LaACXYEVpv5LIWEMOuH3sJP4CzB2aSvE1BUcfDWkI+Hdgr2by3w/nGbKpyVD+v2H8r0zXyVrbCJ/qzx2gCRxqKJ2GKJEsrStT+8z3BXRRRzwkThIBVyWKk9b9bTt8AE0G94I3BE4gJyIPfbX5XxnKcg7nJZGOmubZpUPQX+2SXSfy9EbtY9iismwK7LGtWv6l90cK2eSLZGvdsSKPo7cylOldXfdYIyeBtvsIL1juBaiINX52Zgt371+nX53fDSYOKdIDLuhNqX3zpNOuIJ9DUj4E7IJA7+XhHy77zL98VjHtPo5H4fmKyZ2k+xbYqOydc5OPGguKequsnyDo5npktDrkbswnjWMXNDu+wImAd+IwHG2lTamsAnOGQ+E6g2oK0R5fUL26XJ3lBnTRrsLDnlrvqYqFxt3MCR+o5+DnTirSVQJfrRVsIKTucWHlYLTOUWkVDrLavJqIbWHytEbMf/BXUcovlQzSgfu5/Y1GkUJBnthtbiZfTImmBLcrqKDD4PnDmvC1v9Z5KR78MYu7lFTe5C4STj2aR6bwvqjiPKm6kYG5etOFEyRJ+CbqD2QsdF2N6Ww/RFWovqVqQIWuGdhumDUTdmQAiiPxl12M0+kIH6NugpBD3gt4RT0sni/T+booDw6b3Ts4WJ8FW1/LPWdy7gVo9yOCL4FhjOw=
 jobs:
   include:
-    - env: CHECK=rubocop
     - env: CHECK=unit
     - env: CHECK=modules
-    - env: CHECK=docs
     - env: CHECK=integration
 before_script:
 - eval `ssh-agent`

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,6 @@
 
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
-require "rubocop/rake_task"
 require "bolt/cli"
 
 require "puppet-strings"
@@ -42,12 +41,8 @@ RSpec::Core::RakeTask.new(:puppetserver) do |t|
   t.rspec_opts = '--tag puppetserver --tag puppetdb --tag expensive'
 end
 
-RuboCop::RakeTask.new(:rubocop) do |t|
-  t.options = ['--display-cop-names', '--display-style-guide', '--parallel']
-end
-
 desc "Run tests and style checker"
-task test: %w[spec rubocop]
+task test: %w[spec]
 
 task :default do
   system "rake --tasks"
@@ -58,7 +53,6 @@ def format_links(text)
 end
 
 namespace :travis do
-  task rubocop: :rubocop
   task :unit do
     sh "docker-compose -f spec/docker-compose.yml build --parallel ubuntu_node puppet_5_node puppet_6_node"
     sh "docker-compose -f spec/docker-compose.yml up -d ubuntu_node puppet_5_node puppet_6_node"


### PR DESCRIPTION
This removes the `rubocop` and `docs` rake tasks from TravisCI and moves
them to GitHub Actions.