### PR TITLE
(maint) Create user homedir for acceptance tests

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -10,7 +10,7 @@ extend Acceptance::BoltSetupHelper
 desc "Generate Beaker Host config"
 rototiller_task :host_config do |task|
   unless ENV['BEAKER_HOSTS']
-    task.add_env(name: 'BOLT_CONTROLLER', default: 'debian9-64')
+    task.add_env(name: 'BOLT_CONTROLLER', default: 'debian10-64')
     task.add_env(name: 'BOLT_NODES',
                  default: 'centos7-64,osx1012-64,windows10ent-64')
     ns = [ENV['BOLT_CONTROLLER'], ENV['BOLT_NODES']].join(',')

--- a/acceptance/tests/apply_plan_ssh.rb
+++ b/acceptance/tests/apply_plan_ssh.rb
@@ -124,9 +124,12 @@ test_name "bolt plan run should apply manifest block on remote hosts via ssh" do
     user = 'apply_nonroot'
 
     step 'create nonroot user on targets' do
+      # managehome fails here, so we manage the homedir seprately
       on(ssh_nodes, "/opt/puppetlabs/bin/puppet resource user #{user} ensure=present")
+      on(ssh_nodes, "/opt/puppetlabs/bin/puppet resource file $(echo ~#{user}) ensure=directory")
 
       teardown do
+        on(ssh_nodes, "/opt/puppetlabs/bin/puppet resource file $(echo ~#{user}) ensure=absent")
         on(ssh_nodes, "/opt/puppetlabs/bin/puppet resource user #{user} ensure=absent")
       end
     end


### PR DESCRIPTION
With #1518, we now execute `cd` before running any command when `run_as`
is specified, which changes into the `run_as` users home directory. In
the acceptance tests we create a user `apply_nonroot` using Puppet, which doesn't create
a homedir for that user. When Bolt tried to change into
apply_nonroot's home directory it would error, which wasn't what we were
trying to test.

Additionally, using `managehome=true` when creating the Puppet user
fails on OSX (I tried with 12 and 14). We now create the user's home
directory using Puppet so that there's a directory for the user to
change into. This uses the platform agnostic `$(echo ~apply_nonroot)`
which will get the homedir for the apply_nonroot user on both OSX and
Linux platforms (`/Users/apply_nonroot` and `/home/apply_nonroot`
respectively).

Lastly this updates the default Bolt controller for local testing to be
Debian 10 instead of Debian 9. The default ruby version on Debian 9 is
2.3.3, and some of our gems require ruby 2.4 or greater. The default
ruby for Debian 10 is 2.5.7, so updating the OS version ensures we
don't need to use a ruby environment manager to get the right version.