### PR TITLE
(maint) Add `resolve_reference` powershell implementation for tests

### DIFF
--- a/spec/fixtures/plugin_modules/identity/tasks/resolve_reference.json
+++ b/spec/fixtures/plugin_modules/identity/tasks/resolve_reference.json
@@ -1,5 +1,10 @@
 {
   "parameters": {
     "value": { "type": "Any" }
-  }
+  },
+  "input_method": "stdin",
+  "implementations": [
+    {"name": "resolve_reference.ps1", "requirements": ["powershell"]},
+    {"name": "resolve_reference.sh", "requirements": ["shell"]}
+  ]
 }

--- a/spec/fixtures/plugin_modules/identity/tasks/resolve_reference.ps1
+++ b/spec/fixtures/plugin_modules/identity/tasks/resolve_reference.ps1
@@ -1,0 +1,2 @@
+$line = [Console]::In.ReadLine()
+Write-Output "$line"


### PR DESCRIPTION
This adds a powershell implementation for the `resolve_reference` task
used by some unit tests. Previously, a handful of tests would fail on
Windows since the tests would attempt to use a shell implementation of
the task.