### PR TITLE
(bug-fix) Prefer Etc.getpwuid.name to Etc.getlogin when available

### DIFF
--- a/acceptance/files/example_apply/plans/init.pp
+++ b/acceptance/files/example_apply/plans/init.pp
@@ -1,12 +1,12 @@
 plan example_apply (
-  TargetSpec $nodes,
+  TargetSpec $targets,
   String $filepath,
   Boolean $noop = false,
   Optional[String] $run_as = undef,
 ) {
-  $nodes.apply_prep
+  $targets.apply_prep
 
-  return apply($nodes, _noop => $noop, _run_as => $run_as, _catch_errors => true) {
+  return apply($targets, _noop => $noop, _run_as => $run_as, _catch_errors => true) {
     file { $filepath:
       ensure => directory,
     } -> file { "${filepath}/hello.txt":

--- a/acceptance/tests/apply_plan_winrm.rb
+++ b/acceptance/tests/apply_plan_winrm.rb
@@ -21,10 +21,11 @@ test_name "bolt plan run should apply manifest block on remote hosts via winrm" 
     scp_to(bolt, File.join(fixtures, 'example_apply'), "#{dir}/modules/example_apply")
   end
 
-  bolt_command = "bolt plan run example_apply filepath=#{filepath} nodes=winrm_nodes"
+  bolt_command = "bolt plan run example_apply filepath=#{filepath}"
   flags = {
     '--modulepath' => modulepath(File.join(dir, 'modules')),
-    '--format' => 'json'
+    '--format' => 'json',
+    '-t' => "winrm_nodes"
   }
 
   teardown do
@@ -90,10 +91,11 @@ test_name "bolt plan run should apply manifest block on remote hosts via winrm" 
   end
 
   step "puppet service should be stopped" do
-    service_command = 'bolt plan run example_apply::puppet_status -n winrm_nodes'
+    service_command = 'bolt plan run example_apply::puppet_status'
     flags = {
       '--modulepath' => modulepath(File.join(dir, 'modules')),
-      '--format' => 'json'
+      '--format' => 'json',
+      '-t' => "winrm_nodes"
     }
 
     result = bolt_command_on(bolt, service_command, flags)

--- a/libexec/apply_catalog.rb
+++ b/libexec/apply_catalog.rb
@@ -39,7 +39,8 @@ begin
 
   Tempfile.open('plugins.tar.gz') do |plugins|
     File.binwrite(plugins, Base64.decode64(args['plugins']))
-    Puppet::ModuleTool::Tar.instance.unpack(plugins, moduledir, Etc.getlogin || Etc.getpwuid.name)
+    user = Etc.getpwuid.nil? ? Etc.getlogin : Etc.getpwuid.name
+    Puppet::ModuleTool::Tar.instance.unpack(plugins, moduledir, user)
   end
 
   env = Puppet.lookup(:environments).get('production')

--- a/libexec/custom_facts.rb
+++ b/libexec/custom_facts.rb
@@ -21,7 +21,8 @@ Dir.mktmpdir do |puppet_root|
 
   Tempfile.open('plugins.tar.gz') do |plugins|
     File.binwrite(plugins, Base64.decode64(args['plugins']))
-    Puppet::ModuleTool::Tar.instance.unpack(plugins, moduledir, Etc.getlogin || Etc.getpwuid.name)
+    user = Etc.getpwuid.nil? ? Etc.getlogin : Etc.getpwuid.name
+    Puppet::ModuleTool::Tar.instance.unpack(plugins, moduledir, user)
   end
 
   env = Puppet.lookup(:environments).get('production')

--- a/libexec/query_resources.rb
+++ b/libexec/query_resources.rb
@@ -28,7 +28,8 @@ Dir.mktmpdir do |puppet_root|
 
   Tempfile.open('plugins.tar.gz') do |plugins|
     File.binwrite(plugins, Base64.decode64(args['plugins']))
-    Puppet::ModuleTool::Tar.instance.unpack(plugins, moduledir, Etc.getlogin || Etc.getpwuid.name)
+    user = Etc.getpwuid.nil? ? Etc.getlogin : Etc.getpwuid.name
+    Puppet::ModuleTool::Tar.instance.unpack(plugins, moduledir, user)
   end
 
   env = Puppet.lookup(:environments).get('production')


### PR DESCRIPTION
There are 3 tasks defined in `libexec` that are used internally by Bolt
to perform tasks on remote hosts (when you have a hammer...). Each of
these tasks takes a 'plugins' argument which is the contents of a
tarball of plugins from modules that are available to Bolt, in order to
load custom facts. The 'plugins' argument contents are written to a tar
file, then unpacked by `Puppet::ModuleTool::Tar` into a tempdir. The
last step of the unpacking is to `chown -R` the untarred directory to
the user who is executing the task.

Previously we figured out which user to `chown` the directory to using
`Etc.getlogin`, because it works on both *nix and Windows platforms.
However when any task was run as a different user than the one Bolt
connected to the host with (using `run-as`), `Etc.getlogin` would return
the user Bolt had *connected* as, rather than the user the task was
*executing* as (the `run-as` user). This is acceptable in cases where the
user is escalating to root because the plugins would be unpacked as the
non-root user then `chown -R non-root .` by root, which would succeed, and
root can still access the files if they are owned by another user.
When `run-as` is de-escalating privileges this causes a permissions
error, because the task tries to run `chown -R root .` as a non-root
user.

To fix the issue we now use the more accurate `Etc.getpwuid.name` on
platforms where it's available, and fall back to `Etc.getlogin` on
platforms where `Etc.getpwuid` returns nil. Since `Etc.getpwuid` returns
nil on Windows and the WinRM transport doesn't support `run-as`,
*and* Windows is tightly coupled with the WinRM transport, this isn't
expected to cause issues for users executing on Windows. However, if we ever
support `run-as` for Windows hosts, we may need a
more robust solution.

This bug was missed by our acceptance tests because they intended to
verify that a file in the apply block couldn't be created, and verified
this by checking that `Permission denied` was in the output and that the
file wasn't created. Both of these were true, but the *reason* they were
true was because of an issue described in #1319 instead of because the
apply block executed as the correct user. This PR modifies
the acceptance tests to verify that a file is successfully created by
the `run_as` user by verifying that it's owned by the expected user when
created. This ensures that the apply block succeeds as expected and
that further unintended errors don't slip through in the future.