### PR TITLE
(spike) Hide private plans from UI

### DIFF
--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -291,35 +291,17 @@ module Bolt
     end
 
     def list_plans
-      require 'puppet-strings'
-      require 'puppet-strings/yard'
       in_bolt_compiler do |compiler|
         errors = []
         plans = compiler.list_plans(nil, errors).map { |plan| [plan.name] }.sort
         errors.each do |error|
           @logger.warn(error.details['original_error'])
         end
-        plans.reject { |plan| private_plan?(plan.first) }
+        plans.reject { |plan| get_plan_info(plan.first)['private'] }
       end
     end
 
-    def private_plan?(plan_name)
-      pp_path = plan_location(plan_name)[:path]
-      if File.exist?(pp_path)
-        PuppetStrings::Yard.setup!
-        YARD::Logger.instance.level = :error
-        YARD.parse(pp_path)
-
-        plan = YARD::Registry.at("puppet_plans::#{plan_name}")
-
-        private_plan = plan.tag(:private) && plan.tag(:private).text == 'true'
-      else
-        private_plan = false
-      end
-      private_plan
-    end
-
-    def plan_location(plan_name)
+    def get_plan_info(plan_name)
       plan_sig = in_bolt_compiler do |compiler|
         compiler.plan_signature(plan_name)
       end
@@ -335,17 +317,13 @@ module Bolt
       plan_subpath = File.join(plan_name.split('::').drop(1))
       plan_subpath = 'init' if plan_subpath.empty?
 
-      { path: File.join(mod, 'plans', "#{plan_subpath}.pp"), mod: mod }
-    end
-
-    def get_plan_info(plan_name)
-      plan_loc = plan_location(plan_name)
-      if File.exist?(plan_loc[:path])
+      pp_path = File.join(mod, 'plans', "#{plan_subpath}.pp")
+      if File.exist?(pp_path)
         require 'puppet-strings'
         require 'puppet-strings/yard'
         PuppetStrings::Yard.setup!
         YARD::Logger.instance.level = :error
-        YARD.parse(plan_loc[:path])
+        YARD.parse(pp_path)
 
         plan = YARD::Registry.at("puppet_plans::#{plan_name}")
 
@@ -363,16 +341,19 @@ module Bolt
           params[name]['description'] = param.text unless param.text.empty?
         end
 
+        private_plan = plan.tag(:private) && plan.tag(:private).text == 'true'
+
         {
           'name' => plan_name,
           'description' => description,
           'parameters' => parameters,
-          'module' => plan_loc[:mod]
+          'private' => private_plan,
+          'module' => mod
         }
 
       # If it's a YAML plan, fall back to limited data
       else
-        yaml_path = plan_loc[:path].sub(/\.pp?/, '.yaml')
+        yaml_path = File.join(mod, 'plans', "#{plan_subpath}.yaml")
         plan_content = File.read(yaml_path)
         plan = Bolt::PAL::YamlPlan::Loader.from_string(plan_name, plan_content, yaml_path)
 
@@ -394,7 +375,8 @@ module Bolt
           'name' => plan_name,
           'description' => plan.description,
           'parameters' => parameters,
-          'module' => plan_loc[:mod]
+          'private' => false,
+          'module' => mod
         }
       end
     end


### PR DESCRIPTION
This commit is a spike for hiding plans with a @private yard tag from bolt plan show.

Questions:
1. Is Yard parsing every plan too much overhead just to get at that tag?
2. Is @private the correct tag name
3. Should we also ensure `@private true` or should just the existence of @private hide the plan.