### PR TITLE
(GH-1544) Remove empty strings and objects from results in human output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Bolt Next
+
+### New features
+
+* **Remove empty strings and objects from results in human output** ([#1544](https://github.com/puppetlabs/bolt/issues/1544))
+
+  Human formatted results no longer show empty strings or JSON objects. When a result only has an `_options` key, and the value
+  is an empty string or whitespace, a message will be displayed saying the action completed successfully with no result.
+
 ## Bolt 1.46.0
 
 ### Deprecations and removals

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -96,12 +96,15 @@ module Bolt
           end
         end
 
-        if result.message
-          @stream.puts(remove_trail(indent(2, result.message)))
-        end
+        # Only print results if there's something other than empty string and hash
+        if result.value.empty? || (result.value.keys == ['_output'] && !result.message?)
+          @stream.puts(indent(2, "#{result.action.capitalize} completed successfully with no result"))
+        else
+          # Only print messages that have something other than whitespace
+          if result.message?
+            @stream.puts(remove_trail(indent(2, result.message)))
+          end
 
-        # There is more information to output
-        if result.generic_value
           # Use special handling if the result looks like a command or script result
           if result.generic_value.keys == %w[stdout stderr exit_code]
             unless result['stdout'].strip.empty?
@@ -112,7 +115,7 @@ module Bolt
               @stream.puts(indent(2, "STDERR:"))
               @stream.puts(indent(4, result['stderr']))
             end
-          else
+          elsif result.generic_value.any?
             @stream.puts(indent(2, ::JSON.pretty_generate(result.generic_value)))
           end
         end

--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -95,7 +95,6 @@ module Bolt
       @value = value || {}
       @action = action
       @object = object
-      @value_set = !value.nil?
       if error && !error.is_a?(Hash)
         raise "TODO: how did we get a string error"
       end
@@ -105,6 +104,10 @@ module Bolt
 
     def message
       @value['_output']
+    end
+
+    def message?
+      message && !message.strip.empty?
     end
 
     def status_hash
@@ -121,9 +124,7 @@ module Bolt
     end
 
     def generic_value
-      if @value_set
-        value.reject { |k, _| %w[_error _output].include? k }
-      end
+      value.reject { |k, _| %w[_error _output].include? k }
     end
 
     def eql?(other)

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -13,8 +13,8 @@ describe "Bolt::Outputter::Human" do
   let(:results) {
     Bolt::ResultSet.new(
       [
-        Bolt::Result.new(target, message: "ok"),
-        Bolt::Result.new(target2, error: { 'msg' => 'oops' })
+        Bolt::Result.new(target, message: "ok", action: 'action'),
+        Bolt::Result.new(target2, error: { 'msg' => 'oops' }, action: 'action')
       ]
     )
   }


### PR DESCRIPTION
This changes the human outputter so that it does not display empty
strings or empty JSON objects. Previously, if a result only had an
`_output` key, the human outputter would dislay the value of `_output`,
even if it was an empty string or whitespace. If the only key present
was `_output`, the outputter would also display an empty JSON object
after the value of `_output`.

Now, if the result only contains an `_option` key and the value for that
key is an empty string or whitespace, the human outputter will display a
message stating the action completed successfully with no result.

Closes #1544 