### PR TITLE
(GH-1433) Expose show_diff option for applying Puppet code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
   even when a version of the agent is already installed. If the specified version of the agent cannot be installed, 
   then `apply_prep` will error.
 
+* **Add show_diff configuration option** ([#1433](https://github.com/puppetlabs/bolt/issue/1433))
+
+  Users can now configure the `show_diff` [Puppet
+  setting](https://puppet.com/docs/puppet/latest/configuration.html#showdiff) in their Bolt
+  configuration file, which will be respected when applying Puppet code via Bolt.
+
 ## Bolt 1.47.0
 
 ### Deprecations and removals

--- a/Rakefile
+++ b/Rakefile
@@ -95,6 +95,7 @@ namespace :docs do
     @global = { options: Bolt::Config::OPTIONS, defaults: Bolt::Config::DEFAULT_OPTIONS }
     @log = { options: Bolt::Config::LOG_OPTIONS, defaults: Bolt::Config::DEFAULT_LOG_OPTIONS }
     @puppetfile = { options: Bolt::Config::PUPPETFILE_OPTIONS }
+    @apply = { options: Bolt::Config::APPLY_SETTINGS, defaults: Bolt::Config::DEFAULT_APPLY_SETTINGS }
 
     Bolt::TRANSPORTS.each do |name, transport|
       @transports[:options][name.to_s] = transport::OPTIONS

--- a/documentation/bolt_configuration_reference.md.erb
+++ b/documentation/bolt_configuration_reference.md.erb
@@ -80,6 +80,17 @@ plugin_hooks:
       message: "Which version of Puppet do you want to install?"
 ```
 
+## Apply options
+
+Apply options are a subset of [Puppet configuration settings](https://puppet.com/docs/puppet/latest/configuration.html) which are set when Bolt applies Puppet code on remote targets. Users can define values for the following Puppet settings:
+
+| Option | Description | Default |
+| ------ | ----------- | ------- |
+<% @apply[:options].each do |option, desc| -%>
+| `<%= option %>` | <%= desc %> | <%= @apply[:defaults][option].to_s %> |
+<% end %>
+
+
 ## Puppetfile configuration options
 
 The `puppetfile` section of the configuration file configures how to retrieve modules when running `bolt puppetfile install`.

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -127,7 +127,7 @@ module Bolt
       when 'task'
         case action
         when 'run'
-          { flags: ACTION_OPTS + %w[params tmpdir],
+          { flags: ACTION_OPTS + %w[params tmpdir noop],
             banner: TASK_RUN_HELP }
         when 'show'
           { flags: OPTIONS[:global] + OPTIONS[:global_config_setters],
@@ -627,7 +627,7 @@ module Bolt
              "'success' nodes that succeeded in the last run.") do |rerun|
         @options[:rerun] = rerun
       end
-      define('--noop', 'Execute a task that supports it in noop mode') do |_|
+      define('--noop', 'See what changes Bolt will make without actually executing the changes') do |_|
         @options[:noop] = true
       end
       define('--description DESCRIPTION',

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -665,7 +665,8 @@ module Bolt
                              config.hiera_config,
                              config.boltdir.resource_types,
                              config.compile_concurrency,
-                             config.trusted_external)
+                             config.trusted_external,
+                             config.apply_settings)
     end
 
     def convert_plan(plan)

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -39,7 +39,8 @@ module Bolt
 
     attr_reader :modulepath
 
-    def initialize(modulepath, hiera_config, resource_types, max_compiles = Etc.nprocessors, trusted_external = nil)
+    def initialize(modulepath, hiera_config, resource_types, max_compiles = Etc.nprocessors,
+                   trusted_external = nil, apply_settings = {})
       # Nothing works without initialized this global state. Reinitializing
       # is safe and in practice only happens in tests
       self.class.load_puppet
@@ -48,6 +49,7 @@ module Bolt
       @modulepath = [BOLTLIB_PATH, *modulepath, MODULES_PATH]
       @hiera_config = hiera_config
       @trusted_external = trusted_external
+      @apply_settings = apply_settings
       @max_compiles = max_compiles
       @resource_types = resource_types
 
@@ -175,7 +177,8 @@ module Bolt
           @original_modulepath,
           pdb_client,
           @hiera_config,
-          @max_compiles
+          @max_compiles,
+          @apply_settings
         )
       }
       Puppet.override(opts, &block)

--- a/libexec/apply_catalog.rb
+++ b/libexec/apply_catalog.rb
@@ -28,6 +28,9 @@ Puppet[:report] = false
 
 # Make sure to apply the catalog
 Puppet[:noop] = args['_noop'] || false
+args['apply_settings'].each do |setting, value|
+  Puppet[setting.to_sym] = value
+end
 
 Puppet[:default_file_terminus] = :file_server
 

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -20,7 +20,7 @@ describe Bolt::Applicator do
   end
   let(:pdb_client) { Bolt::PuppetDB::Client.new(config) }
   let(:modulepath) { [Bolt::PAL::BOLTLIB_PATH, Bolt::PAL::MODULES_PATH] }
-  let(:applicator) { Bolt::Applicator.new(inventory, executor, modulepath, [], pdb_client, nil, 2) }
+  let(:applicator) { Bolt::Applicator.new(inventory, executor, modulepath, [], pdb_client, nil, 2, {}) }
   let(:ast) { { 'resources' => [] } }
 
   let(:report) {

--- a/spec/fixtures/apply/settings/plans/show_diff.pp
+++ b/spec/fixtures/apply/settings/plans/show_diff.pp
@@ -1,0 +1,23 @@
+plan settings::show_diff(
+  TargetSpec $targets
+) {
+  $targets.apply_prep
+
+  apply($targets) {
+    file { '/root/settings/':
+      ensure => directory,
+    } -> file { '/root/settings/show_diff.txt':
+        ensure  => file,
+        content => "Silly string",
+    }
+  }
+
+  return apply($targets) {
+    file { '/root/settings/':
+      ensure => directory,
+    } -> file { '/root/settings/show_diff.txt':
+        ensure  => file,
+        content => "Silly string (get it?)",
+    }
+  }
+}


### PR DESCRIPTION
Bolt creates it's own Puppet context when applying Puppet code, which
doesn't inherit config from the system it's running on. Thus, when
applying Puppet code using Bolt users are limited to the default Puppet
settings.

This makes the `show_diff` [Puppet configuration
setting](https://puppet.com/docs/puppet/latest/configuration.html#showdiff)
to be configurable in Bolt's configuration file. When set, Bolt will set
the correspondent setting in it's Puppet context when applying Puppet
code, both from apply blocks in plans and from standalone manifests.

Additionally, this fixes a missing option in the help text, where `noop`
was not listed as a flag for `bolt task run`.

Closes #1433 