### PR TITLE
(GH-1537) Add support for `_description` parameter in apply blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   Human formatted results no longer show empty strings or JSON objects. When a result only has an `_options` key, and the value
   is an empty string or whitespace, a message will be displayed saying the action completed successfully with no result.
 
+- **Support `_description` parameter for `apply` blocks** ([#1537](https://github.com/puppetlabs/bolt/issues/1537))
+
+  `apply` blocks in plans now support a `_description` parameter that gives the block a description that is displayed in plan output.
+
 ## Bolt 1.46.0
 
 ### Deprecations and removals

--- a/documentation/applying_manifest_blocks.md
+++ b/documentation/applying_manifest_blocks.md
@@ -35,6 +35,7 @@ After the catalog compiles and is executed successfully on all targets, `apply` 
 The `apply` action supports the following options:
 
 -   `_catch_errors => true` returns a `ResultSet` including failed results, rather than failing the plan.
+-   `_description => <DESCRIPTION>` adds a description to the apply block, allowing you to distinguish apply blocks.
 -   `_noop => true` applies the manifest block in Puppet no-operation mode, returning a report of the changes it would make, but takes no action.
 -   `_run_as => <USER>` applies the manifest block as the specified user. (This option is for transports that allow a user to run commands under a different username.)
     ```

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -250,7 +250,9 @@ module Bolt
       end
       # rubocop:enable Style/GlobalVars
 
-      r = @executor.log_action('apply catalog', targets) do
+      description = options[:description] || 'apply catalog'
+
+      r = @executor.log_action(description, targets) do
         futures = targets.map do |target|
           Concurrent::Future.execute(executor: @pool) do
             @executor.with_node_logging("Compiling manifest block", [target]) do


### PR DESCRIPTION
This adds a `_description` parameter in `apply` blocks that gives an
apply block a description that is displayed in plan output.

Closes #1537 