### PR TITLE
(GH-1195) Update facts module to 1.0.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,8 +6,8 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '1.1.0'
-mod 'puppetlabs-facts', '0.6.0'
 mod 'puppetlabs-puppet_agent', '3.0.0'
+mod 'puppetlabs-facts', '1.0.0'
 
 # Core types and providers for Puppet 6
 mod 'puppetlabs-augeas_core', '1.0.5'

--- a/spec/fixtures/apply/basic/plans/init.pp
+++ b/spec/fixtures/apply/basic/plans/init.pp
@@ -1,10 +1,10 @@
-plan basic(TargetSpec $nodes) {
-  $result = run_plan('facts', nodes => $nodes)
+plan basic(TargetSpec $targets) {
+  $result = run_plan('facts', targets => $targets)
   if !$result.ok {
     return $result
   }
 
-  return apply($nodes) {
+  return apply($targets) {
     file { '/root/test/':
       ensure => directory,
     } -> file { '/root/test/hello.txt':

--- a/spec/integration/modules/facts_spec.rb
+++ b/spec/integration/modules/facts_spec.rb
@@ -20,7 +20,7 @@ describe "running the facts plan" do
 
   describe 'over ssh', ssh: true do
     it 'gathers os facts' do
-      result = run_plan('facts', { "nodes" => 'ssh' }, config: config_data, inventory: inventory)
+      result = run_plan('facts', { "targets" => 'ssh' }, config: config_data, inventory: inventory)
 
       expect(result['value'].size).to eq(1)
       data = result['value'][0]
@@ -35,7 +35,7 @@ describe "running the facts plan" do
 
   describe 'over winrm', winrm: true do
     it 'gathers os facts' do
-      result = run_plan('facts', { "nodes" => 'winrm' }, config: config_data, inventory: inventory)
+      result = run_plan('facts', { "targets" => 'winrm' }, config: config_data, inventory: inventory)
 
       expect(result['value'].size).to eq(1)
       data = result['value'][0]


### PR DESCRIPTION
The facts module now uses facter if it's available when running the
`facts` task. Plans in the facts module now use the `targets` parameter
instead of `nodes`.

Closes #1195 