### PR TITLE
(GH-1568) Require message in prompt plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@
   setting](https://puppet.com/docs/puppet/latest/configuration.html#showdiff) in their Bolt
   configuration file, which will be respected when applying Puppet code via Bolt.
 
+### Bug fixes
+
+* **Require a message when using the prompt plugin** ([#1568](https://github.com/puppetlabs/bolt/issue/1568))
+
+  The `prompt` plugin now requires a `message` option.
+
 ## Bolt 1.47.0
 
 ### Deprecations and removals

--- a/lib/bolt/plugin/prompt.rb
+++ b/lib/bolt/plugin/prompt.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'concurrent/delay'
 module Bolt
   class Plugin
     class Prompt
@@ -11,7 +10,7 @@ module Bolt
       end
 
       def hooks
-        [:resolve_reference]
+        %i[resolve_reference validate_resolve_reference]
       end
 
       def validate_resolve_reference(opts)


### PR DESCRIPTION
This updates the `prompt` plugin to require a `message` option.
Previously, the plugin was not requiring a message, as
`validate_resolve_reference` was not recognized as a valid hook. This
hook has been added, so options are now validated as intended.