### PR TITLE
(docs) Add env_var plugin documentation

### DIFF
--- a/documentation/inventory_file_v2.md
+++ b/documentation/inventory_file_v2.md
@@ -190,6 +190,7 @@ Bolt ships with several plugins.
 | ------ | ----------- | ---- |
 | `aws_inventory` | Generate targets from AWS EC2 instances. | [aws_inventory](https://forge.puppet.com/puppetlabs/aws_inventory) |
 | `azure_inventory` | Generate targets from Azure VMs and VM scale sets. | [azure_inventory](https://forge.puppet.com/puppetlabs/azure_inventory) |
+| `env_var` | Read a value from an environment variable. | [Using plugins](using_pugins.html#env_var) |
 | `pkcs7` | Use encrypted values for sensitive data. | [Using plugins](using_plugins.html#pkcs7) |
 | `prompt` | Prompt users to enter sensitive configuration information instead of storing it in a file. | [Using plugins](using_plugins.html#prompt) |
 | `puppetdb` | Query PuppetDB for a group of targets. | [Using plugins](using_plugins.html#puppetdb) |

--- a/documentation/using_plugins.md
+++ b/documentation/using_plugins.md
@@ -38,6 +38,35 @@ It is a module-based plugin available on the Puppet Forge and is installed with
 Bolt. [View the documentation on the forge](https://forge.puppet.com/puppetlabs/azure_inventory).
 
 
+### Environment variable
+
+The `env_var` plugin allows users to read values stored in environment variables and load
+them into an inventory or configuration file.
+
+#### Available fields
+
+The following fields are available to the `env_var` plugin.
+
+| Key | Description | Type | Default |
+| --- | ----------- | ---- | ------- |
+| `var` | The name of the environment variable to read from. | `String` | None |
+
+#### Example usage
+
+Looking up a value from an environment variable in an inventory file:
+
+```yaml
+version: 2
+targets:
+  - target1.example.com
+config:
+  ssh:
+    user: bolt
+    password:
+      _plugin: env_var
+      var: BOLT_PASSWORD
+```
+
 ### Prompt
 
 The `prompt` plugin allows users to interactively enter sensitive configuration


### PR DESCRIPTION
This adds documentation for the `env_var` plugin.