### PR TITLE
(maint) Refactor/rename Bolt::Util#read_config_file

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -277,15 +277,13 @@ module Bolt
                            Bolt::Inventory::ENVIRONMENT_VAR
                          elsif @config.inventoryfile && Bolt::Util.file_stat(@config.inventoryfile)
                            @config.inventoryfile
-                         elsif (inventory_file = @config.default_inventoryfile.find do |file|
-                                  begin
-                                    Bolt::Util.file_stat(file)
-                                  rescue Errno::ENOENT
-                                    false
-                                  end
-                                end
-                               )
-                           inventory_file
+                         else
+                           begin
+                             Bolt::Util.file_stat(@config.default_inventoryfile)
+                             @config.default_inventoryfile
+                           rescue Errno::ENOENT
+                             nil
+                           end
                          end
 
       inventory_cli_opts = %i[authentication escalation transports].each_with_object([]) do |key, acc|

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -116,7 +116,7 @@ module Bolt
     def self.from_boltdir(boltdir, overrides = {})
       data = {
         filepath: boltdir.config_file,
-        data: Bolt::Util.read_config_file(nil, [boltdir.config_file], 'config')
+        data: Bolt::Util.read_optional_yaml_hash(boltdir.config_file, 'config')
       }
 
       data = load_defaults.push(data).select { |config| config[:data]&.any? }
@@ -129,9 +129,8 @@ module Bolt
 
       data = {
         filepath: boltdir.config_file,
-        data: Bolt::Util.read_config_file(configfile, [], 'config')
+        data: Bolt::Util.read_yaml_hash(configfile, 'config')
       }
-
       data = load_defaults.push(data).select { |config| config[:data]&.any? }
 
       new(boltdir, data, overrides)
@@ -148,8 +147,8 @@ module Bolt
                     end
       user_path = Pathname.new(File.expand_path(File.join('~', '.puppetlabs', 'etc', 'bolt', 'bolt.yaml')))
 
-      [{ filepath: system_path, data: Bolt::Util.read_config_file(nil, [system_path], 'config') },
-       { filepath: user_path, data: Bolt::Util.read_config_file(nil, [user_path], 'config') }]
+      [{ filepath: system_path, data: Bolt::Util.read_optional_yaml_hash(system_path, 'config') },
+       { filepath: user_path, data: Bolt::Util.read_optional_yaml_hash(user_path, 'config') }]
     end
 
     def initialize(boltdir, config_data, overrides = {})
@@ -182,7 +181,6 @@ module Bolt
       end
 
       @config_files = config_data.map { |config| config[:filepath] }
-
       config_data = merge_config_data(config_data)
       update_from_file(config_data)
 
@@ -376,7 +374,7 @@ module Bolt
     end
 
     def default_inventoryfile
-      [@boltdir.inventory_file]
+      @boltdir.inventory_file
     end
 
     def rerunfile

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -52,7 +52,11 @@ module Bolt
           raise Bolt::ParseError, "Could not parse inventory from $#{ENVIRONMENT_VAR}"
         end
       else
-        data = Bolt::Util.read_config_file(config.inventoryfile, config.default_inventoryfile, 'inventory')
+        data = if config.inventoryfile
+                 Bolt::Util.read_yaml_hash(config.inventoryfile, 'inventory')
+               else
+                 Bolt::Util.read_optional_yaml_hash(config.default_inventoryfile, 'inventory')
+               end
       end
 
       inventory = create_version(data, config, plugins)

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -51,7 +51,8 @@ describe "Bolt::CLI" do
   end
 
   def stub_config(file_content = {})
-    allow(Bolt::Util).to receive(:read_config_file).and_return(file_content)
+    allow(Bolt::Util).to receive(:read_yaml_hash).and_return(file_content)
+    allow(Bolt::Util).to receive(:read_optional_yaml_hash).and_return(file_content)
   end
 
   # These tests may pick up local config that includes `future = true`
@@ -66,7 +67,8 @@ describe "Bolt::CLI" do
     before(:each) do
       allow(Bolt::Boltdir).to receive(:find_boltdir).and_return(boltdir)
       allow_any_instance_of(Bolt::Boltdir).to receive(:resource_types)
-      allow(Bolt::Util).to receive(:read_config_file).and_return({})
+      allow(Bolt::Util).to receive(:read_yaml_hash).and_return({})
+      allow(Bolt::Util).to receive(:read_optional_yaml_hash).and_return({})
     end
 
     it "generates an error message if an unknown argument is given" do

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -76,12 +76,10 @@ describe Bolt::Config do
   end
 
   describe "::from_boltdir" do
-    let(:default_path) { File.expand_path(File.join('~', '.puppetlabs', 'bolt.yaml')) }
-
     it "loads from the boltdir config file if present" do
-      expect(Bolt::Util).to receive(:read_config_file).with(nil, [boltdir.config_file], 'config')
-      expect(Bolt::Util).to receive(:read_config_file).with(nil, [system_path], 'config')
-      expect(Bolt::Util).to receive(:read_config_file).with(nil, [user_path], 'config')
+      expect(Bolt::Util).to receive(:read_optional_yaml_hash).with(boltdir.config_file, 'config')
+      expect(Bolt::Util).to receive(:read_optional_yaml_hash).with(system_path, 'config')
+      expect(Bolt::Util).to receive(:read_optional_yaml_hash).with(user_path, 'config')
 
       Bolt::Config.from_boltdir(boltdir)
     end
@@ -91,9 +89,9 @@ describe Bolt::Config do
     let(:path) { File.expand_path('/path/to/config') }
 
     it 'loads from the specified config file' do
-      expect(Bolt::Util).to receive(:read_config_file).with(path, [], 'config')
-      expect(Bolt::Util).to receive(:read_config_file).with(nil, [system_path], 'config')
-      expect(Bolt::Util).to receive(:read_config_file).with(nil, [user_path], 'config')
+      expect(Bolt::Util).to receive(:read_yaml_hash).with(path, 'config')
+      expect(Bolt::Util).to receive(:read_optional_yaml_hash).with(system_path, 'config')
+      expect(Bolt::Util).to receive(:read_optional_yaml_hash).with(user_path, 'config')
 
       Bolt::Config.from_file(path)
     end


### PR DESCRIPTION
All config (inventory.yaml, bolt.yaml, etc...) should have a hash type (or be empty). It is possible to have valid YAML that is not a hash type. This commit re-names the `Bolt::Util#read_config_file` method to `read_yaml_hash`. This change also removes some of the complexity in the method by no longer accepting a list of "default" paths to check. Previously if a list of defaults was passed in actually finding a file to read became optional. Now a second util method `read_optional_yaml_hash` has been added which will return the results of `read_yaml_hash` if the file exists and an empty hash otherwise. This allows the caller to choose the appropriate method based on if the file is expected to exist or not.