### PR TITLE
(maint) Support arbitrary URI schemes for remote targets in v2 inventory

### DIFF
--- a/lib/bolt/inventory/target.rb
+++ b/lib/bolt/inventory/target.rb
@@ -143,12 +143,26 @@ module Bolt
         @uri_obj.port || transport_config['port']
       end
 
+      # For remote targets, protocol is the value of the URI scheme. For
+      # non-remote targets, there is no protocol.
       def protocol
-        transport
+        if remote?
+          @uri_obj.scheme
+        end
       end
 
+      # For remote targets, the transport is always 'remote'. Otherwise, it
+      # will be either the URI scheme or set explicitly.
       def transport
-        @uri_obj.scheme || transport_config_cache['transport']
+        if remote?
+          'remote'
+        else
+          @uri_obj.scheme || transport_config_cache['transport']
+        end
+      end
+
+      def remote?
+        @uri_obj.scheme == 'remote' || transport_config_cache['transport'] == 'remote'
       end
 
       def user

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -118,11 +118,11 @@ module Bolt
     end
 
     def transport
-      inventory_target.protocol
+      inventory_target.transport
     end
 
     def protocol
-      inventory_target.protocol
+      inventory_target.protocol || inventory_target.transport
     end
 
     def user

--- a/lib/bolt/transport/remote.rb
+++ b/lib/bolt/transport/remote.rb
@@ -48,7 +48,7 @@ module Bolt
       # Cannot batch because arugments differ
       def run_task(target, task, arguments, options = {})
         proxy_target = get_proxy(target)
-        transport = @executor.transport(proxy_target.protocol)
+        transport = @executor.transport(proxy_target.transport)
         arguments = arguments.merge('_target' => target.to_h.reject { |_, v| v.nil? })
 
         remote_task = task.remote_instance

--- a/spec/bolt/inventory/inventory2_spec.rb
+++ b/spec/bolt/inventory/inventory2_spec.rb
@@ -231,8 +231,8 @@ describe Bolt::Inventory::Inventory2 do
         expect(inventory.get_targets('all')).to eq([])
       end
 
-      it 'should have the default protocol' do
-        expect(target.protocol).to eq('ssh')
+      it 'should have the default transport' do
+        expect(target.transport).to eq('ssh')
       end
     end
 
@@ -247,8 +247,8 @@ describe Bolt::Inventory::Inventory2 do
       }
       let(:target) { inventory.get_targets('notarget')[0] }
 
-      it 'should have use protocol' do
-        expect(target.protocol).to eq('winrm')
+      it 'should have the correct transport' do
+        expect(target.transport).to eq('winrm')
       end
 
       it 'should not use ssl' do
@@ -298,7 +298,7 @@ describe Bolt::Inventory::Inventory2 do
           expect(targets).to eq(ts)
         end
 
-        it 'should fail for unknown protocols' do
+        it 'should fail for unknown URI schemes' do
           expect {
             inventory.get_targets('z://foo')
           }.to raise_error(Bolt::UnknownTransportError, %r{Unknown transport z found for z://foo})
@@ -633,12 +633,12 @@ describe Bolt::Inventory::Inventory2 do
 
         it 'uses the configured transport' do
           target = get_target(inventory, 'target')
-          expect(target.protocol).to eq('winrm')
+          expect(target.transport).to eq('winrm')
         end
 
         it 'only uses configured options for ssh' do
           target = get_target(inventory, 'ssh://target')
-          expect(target.protocol).to eq('ssh')
+          expect(target.transport).to eq('ssh')
           expect(target.user).to eq('messh')
           expect(target.password).to eq('youssh')
           expect(target.port).to eq('12345ssh')
@@ -660,7 +660,7 @@ describe Bolt::Inventory::Inventory2 do
 
         it 'only uses configured options for winrm' do
           target = get_target(inventory, 'winrm://target')
-          expect(target.protocol).to eq('winrm')
+          expect(target.transport).to eq('winrm')
           expect(target.user).to eq('mewinrm')
           expect(target.password).to eq('youwinrm')
           expect(target.port).to eq('12345winrm')
@@ -680,7 +680,7 @@ describe Bolt::Inventory::Inventory2 do
 
         it 'only uses configured options for pcp' do
           target = get_target(inventory, 'pcp://target')
-          expect(target.protocol).to eq('pcp')
+          expect(target.transport).to eq('pcp')
           expect(target.user).to be nil
           expect(target.password).to be nil
           expect(target.port).to be nil
@@ -711,7 +711,7 @@ describe Bolt::Inventory::Inventory2 do
           }.to raise_error(Bolt::Inventory::ValidationError, "'#{names}' refers to 3 targets")
         end
 
-        it 'should fail for unknown protocols' do
+        it 'should fail for unknown URI schemes' do
           expect {
             inventory.get_target('z://foo')
           }.to raise_error(Bolt::UnknownTransportError, %r{Unknown transport z found for z://foo})
@@ -952,13 +952,13 @@ describe Bolt::Inventory::Inventory2 do
 
         it 'uses the configured transport' do
           target = inventory.get_target('target')
-          expect(target.protocol).to eq('winrm')
+          expect(target.transport).to eq('winrm')
           expect(target.config).to eq(data['config'])
         end
 
         it 'only uses configured options for ssh' do
           target = inventory.get_target('ssh://target')
-          expect(target.protocol).to eq('ssh')
+          expect(target.transport).to eq('ssh')
           expect(target.user).to eq('messh')
           expect(target.password).to eq('youssh')
           expect(target.port).to eq('12345ssh')
@@ -980,7 +980,7 @@ describe Bolt::Inventory::Inventory2 do
 
         it 'only uses configured options for winrm' do
           target = inventory.get_target('winrm://target')
-          expect(target.protocol).to eq('winrm')
+          expect(target.transport).to eq('winrm')
           expect(target.user).to eq('mewinrm')
           expect(target.password).to eq('youwinrm')
           expect(target.port).to eq('12345winrm')
@@ -1000,7 +1000,7 @@ describe Bolt::Inventory::Inventory2 do
 
         it 'only uses configured options for pcp' do
           target = inventory.get_target('pcp://target')
-          expect(target.protocol).to eq('pcp')
+          expect(target.transport).to eq('pcp')
           expect(target.user).to be nil
           expect(target.password).to be nil
           expect(target.port).to be nil
@@ -1025,7 +1025,7 @@ describe Bolt::Inventory::Inventory2 do
 
       it 'adds magic config options' do
         target = get_target(inventory, 'localhost')
-        expect(target.protocol).to eq('local')
+        expect(target.transport).to eq('local')
         expect(target.options['interpreters']).to include('.rb' => RbConfig.ruby)
         expect(target.features).to include('puppet-agent')
       end
@@ -1046,7 +1046,7 @@ describe Bolt::Inventory::Inventory2 do
 
       it 'does not override config options' do
         target = get_target(inventory, 'localhost')
-        expect(target.protocol).to eq('local')
+        expect(target.transport).to eq('local')
         expect(target.options['interpreters']).to include('.rb' => '/foo/ruby')
         expect(target.features).to include('puppet-agent')
       end
@@ -1067,7 +1067,7 @@ describe Bolt::Inventory::Inventory2 do
       let(:inventory) { Bolt::Inventory::Inventory2.new(data, plugins: plugins) }
       it 'does not set magic config' do
         target = get_target(inventory, 'localhost')
-        expect(target.protocol).to eq('ssh')
+        expect(target.transport).to eq('ssh')
         expect(target.options['interpreters']).to include('.rb' => '/foo/ruby')
         expect(target.features).to include('puppet-agent')
       end
@@ -1114,11 +1114,11 @@ describe Bolt::Inventory::Inventory2 do
 
       it 'sets config on a target' do
         target = inventory.get_target('target')
-        expect(target.protocol).to eq('ssh')
+        expect(target.transport).to eq('ssh')
         expect(target.password).to eq('sshpass')
         expect(target.config).to eq(expected_config)
         inventory.set_config(target, 'transport', 'local')
-        expect(target.protocol).to eq('local')
+        expect(target.transport).to eq('local')
         expect(target.config).to eq(expected_config.merge('transport' => 'local'))
       end
 
@@ -1147,7 +1147,7 @@ describe Bolt::Inventory::Inventory2 do
         expect(target.options).to eq(expected_options)
         expect(target.config).to eq(expected_config)
         inventory.set_config(target, '', 'transport' => 'winrm', 'winrm' => { 'password' => 'winrmpass' })
-        expect(target.protocol).to eq('winrm')
+        expect(target.transport).to eq('winrm')
         expect(target.password).to eq('winrmpass')
         winrm_conf = { "password" => "winrmpass",
                        "ssl" => true,
@@ -1206,7 +1206,7 @@ describe Bolt::Inventory::Inventory2 do
 
       it 'adds target to a group and inherets config' do
         target = inventory.get_target('new-target')
-        expect(target.protocol).to eq('ssh')
+        expect(target.transport).to eq('ssh')
         expect(target.options).to include('disconnect-timeout' => 5)
         expect(target.config).to eq({})
         inventory.add_to_group([target], 'test')

--- a/spec/bolt/target_spec.rb
+++ b/spec/bolt/target_spec.rb
@@ -235,7 +235,7 @@ describe Bolt::Target2 do
       expect(target.password).to eq(password)
     end
 
-    it "accepts userinfo when using the default protocol" do
+    it "accepts userinfo when not specifying a scheme" do
       target = inventory.get_target("#{user}:#{password}@neptune")
       expect(target.user).to eq(user)
       expect(target.password).to eq(password)
@@ -312,7 +312,7 @@ describe Bolt::Target2 do
       expect(target.password).to eq(unencoded)
     end
 
-    it "does not default the port without a protocol" do
+    it "does not default the port without a scheme" do
       target = inventory.get_target('pluto')
       expect(target.host).to eq('pluto')
       expect(target.port).to be_nil
@@ -326,7 +326,7 @@ describe Bolt::Target2 do
     describe "with winrm" do
       it "accepts 'winrm://host:port'" do
         target = inventory.get_target('winrm://neptune:55985')
-        expect(target.protocol).to eq('winrm')
+        expect(target.transport).to eq('winrm')
         expect(target.host).to eq('neptune')
         expect(target.port).to eq(55985)
       end
@@ -335,21 +335,21 @@ describe Bolt::Target2 do
     describe "with ssh" do
       it "accepts 'ssh://host:port'" do
         target = inventory.get_target('ssh://pluto:2224')
-        expect(target.protocol).to eq('ssh')
+        expect(target.transport).to eq('ssh')
         expect(target.host).to eq('pluto')
         expect(target.port).to eq(2224)
       end
 
       it "does not default the ssh port" do
         target = inventory.get_target('ssh://pluto')
-        expect(target.protocol).to eq('ssh')
+        expect(target.transport).to eq('ssh')
         expect(target.host).to eq('pluto')
         expect(target.port).to be_nil
       end
 
-      it "accepts 'host:port' without a protocol" do
+      it "accepts 'host:port' without a scheme" do
         target = inventory.get_target('pluto:2224')
-        expect(target.protocol).to eq('ssh')
+        expect(target.transport).to eq('ssh')
         expect(target.host).to eq('pluto')
         expect(target.port).to eq(2224)
       end
@@ -358,14 +358,14 @@ describe Bolt::Target2 do
     describe "with pcp" do
       it "accepts 'pcp://pluto:666'" do
         target = inventory.get_target('pcp://pluto:666')
-        expect(target.protocol).to eq('pcp')
+        expect(target.transport).to eq('pcp')
         expect(target.host).to eq('pluto')
         expect(target.port).to eq(666)
       end
 
       it "accepts 'pcp://pluto' without a port" do
         target = inventory.get_target('pcp://pluto')
-        expect(target.protocol).to eq('pcp')
+        expect(target.transport).to eq('pcp')
         expect(target.host).to eq('pluto')
         expect(target.port).to be_nil
       end


### PR DESCRIPTION
In both the v1 and v2 inventory formats, we use the URI scheme as the
transport for the target. In v1 however, that was only true if the
target did not also separately have transport specified as "remote". In
that case, the URI scheme was used as simply a URI scheme (called
`protocol` when running a task) allowing it to therefore be arbitrary.
With the v2 inventory, we didn't respect that distinction and would a) fail
if the URI scheme did not correspond to a valid transport, and b)
override the "remote" transport specification with the one derived from
the scheme, preventing the use of remote targets with specific URI schemes.

We now vary the behavior of protocol and transport for v2 targets based
on whether or not they are remote. For remote targets, `transport` will
always be "remote" and `protocol` will be the URI scheme if specified.
For ordinary targets, the URI scheme will be used to set the `transport`
if specified and there will be no `protocol`.

On the Target datatype that is exposed to Puppet, we continue to
implement the `protocol` method for backward compatibility, returning
the value of `transport` for non-remote targets (which have no
protocol).