### PR TITLE
(maint) Support Kerberos authentication with SSH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### New features
 
+* **Add Kerberos support for SSH transport**
+
+  Users can now authenticate with Kerberos when using the SSH transport.
+
 * **Warning when task metadata has unknown keys** ([#1542](https://github.com/puppetlabs/bolt/pull/1542))
 
   Unexpected keys in task metadata may signal either a typo or a task that

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "minitar", "~> 0.6"
   spec.add_dependency "net-scp", "~> 1.2"
   spec.add_dependency "net-ssh", ">= 4.0"
+  spec.add_dependency "net-ssh-krb", "~> 0.5"
   spec.add_dependency "orchestrator_client", "~> 0.4"
   spec.add_dependency "puppet", [">= 6.11.0", "< 7"]
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"

--- a/documentation/bolt_known_issues.md
+++ b/documentation/bolt_known_issues.md
@@ -43,6 +43,4 @@ unsupported key type `ssh-ed25519'
 
 ## Limited Kerberos support
 
-A license incompatibility with other components distributed with Bolt prevents authenticating with Kerberos over SSH using the net-ssh-krb gem. ([BOLT-980](https://tickets.puppetlabs.com/browse/BOLT-980))
-
 Support for Kerberos over WinRM from a Linux host is currently experimental and requires the [MIT Kerberos library](https://web.mit.edu/Kerberos/www/krb5-latest/doc/admin/install_clients.html) to be installed. In the future, Bolt will support Kerberos when running on Windows ([BOLT-1323](https://tickets.puppet.com/browse/BOLT-1323)) and macOS ([BOLT-1471](https://tickets.puppet.com/browse/BOLT-1471)).

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -101,11 +101,6 @@ module Bolt
 
         require 'net/ssh'
         require 'net/scp'
-        begin
-          require 'net/ssh/krb'
-        rescue LoadError
-          logger.debug("Authentication method 'gssapi-with-mic' (Kerberos) is not available.")
-        end
 
         @transport_logger = Logging.logger[Net::SSH]
         @transport_logger.level = :warn


### PR DESCRIPTION
The net-ssh-krb gem was previously licensed with an incompatible license
for use in Bolt, in addition to a dependency version conflict. The gem
was recently relicensed and updated, so can now be shipped out of the
box with Bolt and documented. This allows users to use Kerberos
authentication when connecting to targets over SSH by specifying
`gssapi-with-mic` as a `PreferredAuthenticationMethod` in their OpenSSH
config (typically `~/.ssh/config`).