### PR TITLE
(GH-1585) Don't show apply result hash in human output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Bolt Next
+
+### Bug fixes
+
+* **Remove apply result hash from human output** ([#1585](https://github.com/puppetlabs/bolt/issues/1585))
+
+  Apply result hashes will no longer be displayed when using human output. Instead, a metrics message
+  will be shown.
+
 ## Bolt 1.48.0
 
 ### New features

--- a/lib/bolt/apply_result.rb
+++ b/lib/bolt/apply_result.rb
@@ -130,5 +130,9 @@ module Bolt
     def report
       @value['report']
     end
+
+    def generic_value
+      {}
+    end
   end
 end


### PR DESCRIPTION
This fixes a regression introduced in #1544 that would show an apply
result hash as a JSON object when using human output. Now, if a plan
returns only an apply result, human output will display a metrics
message instead of the apply result hash.

Fixes #1585 