### PR TITLE
(maint) Don't include OpenSSH config section in table of contents

### DIFF
--- a/documentation/bolt_configuration_reference.md.erb
+++ b/documentation/bolt_configuration_reference.md.erb
@@ -115,7 +115,7 @@ Transport configuration options can be set in both the configuration file and in
 <% end %>
 
 <% if transport == 'ssh' %>
-### OpenSSH
+#### OpenSSH
 
 In addition to the SSH transport options, some additional SSH options are read from OpenSSH configuration files, including `~/.ssh/config`, `/etc/ssh_config`, and `/etc/ssh/ssh_config`. Not all OpenSSH configuration values have equivalents in Bolt.
 


### PR DESCRIPTION
This was at the same level as the actual transports, causing it to show
up as an entry in the table of contents under "Transport configuration
options".