### PR TITLE
(maint) Clear gem cache when bolt.gemspec changes

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,10 +3,10 @@ name: Linting
 on:
   push:
     branches: [master]
-    paths-ignore: ['*.md']
+    paths-ignore: ['*.md', '*.erb']
   pull_request:
     type: [opened, reopened, edited]
-    paths-ignore: ['*.md']
+    paths-ignore: ['*.md', '*.erb']
 
 jobs:
 

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3
@@ -68,7 +68,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -3,10 +3,10 @@ name: Linux
 on:
   push:
     branches: [master]
-    paths-ignore: ['*.md']
+    paths-ignore: ['*.md', '*.erb']
   pull_request:
     type: [opened, reopened, edited]
-    paths-ignore: ['*.md']
+    paths-ignore: ['*.md', '*.erb']
 
 env:
   BOLT_SUDO_USER: true

--- a/.github/workflows/modules.yaml
+++ b/.github/workflows/modules.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3
@@ -60,7 +60,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3

--- a/.github/workflows/modules.yaml
+++ b/.github/workflows/modules.yaml
@@ -3,10 +3,10 @@ name: Modules
 on:
   push:
     branches: [master]
-    paths-ignore: ['*.md']
+    paths-ignore: ['*.md', '*.erb']
   pull_request:
     type: [opened, reopened, edited]
-    paths-ignore: ['*.md']
+    paths-ignore: ['*.md', '*.erb']
 
 env:
   BOLT_SUDO_USER: true

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: .bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
       - name: Cache modules
         id: modules
         uses: actions/cache@v1
@@ -78,7 +78,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: .bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
       - name: Cache modules
         id: modules
         uses: actions/cache@v1

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -3,10 +3,10 @@ name: Windows
 on:
   push:
     branches: [master]
-    paths-ignore: ['*.md']
+    paths-ignore: ['*.md', '*.erb']
   pull_request:
     type: [opened, reopened, edited]
-    paths-ignore: ['*.md']
+    paths-ignore: ['*.md', '*.erb']
 
 env:
   BOLT_WINRM_USER: roddypiper


### PR DESCRIPTION
As this file is where we actually specify our gem dependencies, we need to
include it in the cache key calculation or we will use a bundle that 
doesn't include all the gems we need.

This also includes a change to not run tests on .erb-only changes. We will
still run the docs workflow on .erb-only changes, as those could introduce
invalid syntax that would cause a build failure which we want to detect.