### PR TITLE
(GH-1584) Add options to Bolt plan functions documentation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -182,7 +182,6 @@ namespace :docs do
       overloads = func['docstring']['tags'].select { |tag| tag['tag_name'] == 'overload' }
       sig_tags = overloads.map { |overload| overload['docstring']['tags'] }
       sig_tags = [func['docstring']['tags']] if sig_tags.empty?
-
       func['signatures'] = func['signatures'].zip(sig_tags).map do |sig, tags|
         sig['text'] = sig['docstring']['text']
         sects = sig['docstring']['tags'].group_by { |t| t['tag_name'] }
@@ -193,6 +192,12 @@ namespace :docs do
         sig['params'] = sects['param'].map do |param|
           param['text'] = format_links(param['text'])
           param
+        end
+        if sects['option']
+          sig['options'] = sects['option'].map do |option|
+            option['opt_text'] = format_links(option['opt_text'])
+            option
+          end
         end
 
         # get examples from overload docstring; puppet-strings should probably do this.

--- a/bolt-modules/boltlib/lib/puppet/functions/add_facts.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/add_facts.rb
@@ -4,7 +4,7 @@ require 'bolt/error'
 
 # Deep merges a hash of facts with the existing facts on a target.
 #
-# **NOTE:** Not available in apply block
+# > **Note:** Not available in apply block
 Puppet::Functions.create_function(:add_facts) do
   # @param target A target.
   # @param facts A hash of fact names to values that may include structured facts.

--- a/bolt-modules/boltlib/lib/puppet/functions/add_to_group.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/add_to_group.rb
@@ -4,7 +4,7 @@ require 'bolt/error'
 
 # Adds a target to specified inventory group.
 #
-# **NOTE:** Not available in apply block
+# > **Note:** Not available in apply block
 Puppet::Functions.create_function(:add_to_group) do
   # @param targets A pattern or array of patterns identifying a set of targets.
   # @param group The name of the group to add targets to.

--- a/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
@@ -2,15 +2,15 @@
 
 require 'bolt/task'
 
-# Installs the puppet-agent package on targets if needed, then collects facts,
+# Installs the `puppet-agent` package on targets if needed, then collects facts,
 # including any custom facts found in Bolt's modulepath. The package is
 # installed using either the configured plugin or the `task` plugin with the
 # `puppet_agent::install` task.
 #
-# Agent installation will be skipped if the target includes the 'puppet-agent' feature, either as a
+# Agent installation will be skipped if the target includes the `puppet-agent` feature, either as a
 # property of its transport (PCP) or by explicitly setting it as a feature in Bolt's inventory.
 #
-# **NOTE:** Not available in apply block
+# > **Note:** Not available in apply block
 Puppet::Functions.create_function(:apply_prep) do
   # @param targets A pattern or array of patterns identifying a set of targets.
   # @example Prepare targets by name.

--- a/bolt-modules/boltlib/lib/puppet/functions/catch_errors.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/catch_errors.rb
@@ -4,7 +4,7 @@
 # output of the block if no errors are raised. Accepts an optional list of
 # error kinds to catch.
 #
-# **NOTE:** Not available in apply block
+# > **Note:** Not available in apply block
 Puppet::Functions.create_function(:catch_errors) do
   # @param error_types An array of error types to catch
   # @param block The block of steps to catch errors on

--- a/bolt-modules/boltlib/lib/puppet/functions/fail_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/fail_plan.rb
@@ -2,12 +2,12 @@
 
 require 'bolt/error'
 
-# Raises a Bolt::PlanFailure exception to signal to callers that the plan failed.
+# Raises a `Bolt::PlanFailure` exception to signal to callers that the plan failed.
 #
 # Plan authors should call this function when their plan is not successful. The
-# error may then be caught by another plans run_plan function or in bolt itself
+# error may then be caught by another plans `run_plan` function or in Bolt itself
 #
-# **NOTE:** Not available in apply block
+# > **Note:** Not available in apply block
 Puppet::Functions.create_function(:fail_plan) do
   # Fail a plan, generating an exception from the parameters.
   # @param msg An error message.

--- a/bolt-modules/boltlib/lib/puppet/functions/get_resources.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/get_resources.rb
@@ -6,20 +6,21 @@ require 'bolt/task'
 # The results are returned as a list of hashes representing each resource.
 #
 # Requires the Puppet Agent be installed on the target, which can be accomplished with apply_prep
-# or by directly running the puppet_agent::install task. In order to be able to reference types without
-# string quoting (for example `get_resources($target, Package)` instead of `get_resources($target, 'Package')`)
+# or by directly running the `puppet_agent::install` task. In order to be able to reference types without
+# string quoting (for example `get_resources($target, Package)` instead of `get_resources($target, 'Package')`),
 # run the command `bolt puppetfile generate-types` to generate type references in `$Boldir/.resource_types`.
 #
-#
-# **NOTE:** Not available in apply block
+# > **Note:** Not available in apply block
 Puppet::Functions.create_function(:get_resources) do
   # @param targets A pattern or array of patterns identifying a set of targets.
   # @param resources A resource type or instance, or an array of such.
+  # @return A result set with a list of hashes representing each resource.
   # @example Collect resource states for packages and a file
   #   get_resources('target1,target2', [Package, File[/etc/puppetlabs]])
   dispatch :get_resources do
     param 'Boltlib::TargetSpec', :targets
     param 'Variant[String, Type[Resource], Array[Variant[String, Type[Resource]]]]', :resources
+    return_type 'ResultSet'
   end
 
   def script_compiler

--- a/bolt-modules/boltlib/lib/puppet/functions/get_target.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/get_target.rb
@@ -4,9 +4,11 @@ require 'bolt/error'
 
 # Get a single target from inventory if it exists, otherwise create a new Target.
 #
-# **NOTE:** Calling `get_target('all')` returns an empty array.
-# **NOTE:** Only compatible with inventory v2
-# **NOTE:** Not available in apply block when `future` is true
+# > **Note:** Calling `get_target('all')` returns an empty array.
+#
+# > **Note:** Only compatible with inventory v2
+#
+# > **Note:** Not available in apply block when `future` is true
 Puppet::Functions.create_function(:get_target) do
   # @param name A Target name.
   # @return A single target, either new or from inventory.

--- a/bolt-modules/boltlib/lib/puppet/functions/get_targets.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/get_targets.rb
@@ -5,7 +5,7 @@ require 'bolt/error'
 # Parses common ways of referring to targets and returns an array of Targets.
 # `get_targets('all')` returns an empty array.
 #
-# **NOTE:** Not available in apply block when `future` is true
+# > **Note:** Not available in apply block when `future` is true
 Puppet::Functions.create_function(:get_targets) do
   # @param names A pattern or array of patterns identifying a set of targets.
   # @return A list of unique Targets resolved from any target URIs and groups.

--- a/bolt-modules/boltlib/lib/puppet/functions/puppetdb_fact.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/puppetdb_fact.rb
@@ -4,8 +4,8 @@ require 'bolt/error'
 
 # Collects facts based on a list of certnames.
 #
-# * If a node is not found in PuppetDB, it's included in the returned hash with empty facts hash.
-# * Otherwise the node is included in the hash with a value that is a hash of it's facts.
+# If a node is not found in PuppetDB, it's included in the returned hash with an empty facts hash.
+# Otherwise, the node is included in the hash with a value that is a hash of its facts.
 Puppet::Functions.create_function(:puppetdb_fact) do
   # @param certnames Array of certnames.
   # @return A hash of certname to facts hash for each matched Target.

--- a/bolt-modules/boltlib/lib/puppet/functions/remove_from_group.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/remove_from_group.rb
@@ -5,9 +5,9 @@ require 'bolt/error'
 # Removes a target from the specified inventory group.
 #
 # The target is removed from all child groups and all parent groups where the target has
-# not been explicitly defined. A target cannot be removed from the 'all' group.
+# not been explicitly defined. A target cannot be removed from the `all` group.
 #
-# **NOTE:** Not available in apply block
+# > **Note:** Not available in apply block
 Puppet::Functions.create_function(:remove_from_group) do
   # @param target A pattern identifying a single target.
   # @param group The name of the group to remove the target from.

--- a/bolt-modules/boltlib/lib/puppet/functions/resolve_references.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/resolve_references.rb
@@ -2,7 +2,7 @@
 
 require 'bolt/error'
 
-# Evaulates all _plugin references in a hash and returns the resolved reference data.
+# Evaluates all `_plugin` references in a hash and returns the resolved reference data.
 Puppet::Functions.create_function(:resolve_references) do
   # Resolve references.
   # @param references A hash of reference data to resolve.

--- a/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
@@ -5,12 +5,14 @@ require 'bolt/error'
 # Runs a command on the given set of targets and returns the result from each command execution.
 # This function does nothing if the list of targets is empty.
 #
-# **NOTE:** Not available in apply block
+# > **Note:** Not available in apply block
 Puppet::Functions.create_function(:run_command) do
   # Run a command.
   # @param command A command to run on target.
   # @param targets A pattern identifying zero or more targets. See {get_targets} for accepted patterns.
-  # @param options Additional options: '_catch_errors', '_run_as'.
+  # @param options A hash of additional options.
+  # @option options [Boolean] _catch_errors Whether to catch raised errors.
+  # @option options [String] _run_as User to run as using privilege escalation.
   # @return A list of results, one entry per target.
   # @example Run a command on targets
   #   run_command('hostname', $targets, '_catch_errors' => true)
@@ -25,7 +27,9 @@ Puppet::Functions.create_function(:run_command) do
   # @param command A command to run on target.
   # @param targets A pattern identifying zero or more targets. See {get_targets} for accepted patterns.
   # @param description A description to be output when calling this function.
-  # @param options Additional options: '_catch_errors', '_run_as'.
+  # @param options A hash of additional options.
+  # @option options [Boolean] _catch_errors Whether to catch raised errors.
+  # @option options [String] _run_as User to run as using privilege escalation.
   # @return A list of results, one entry per target.
   # @example Run a command on targets
   #   run_command('hostname', $targets, 'Get hostname')

--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -4,11 +4,13 @@ require 'bolt/error'
 
 # Runs the `plan` referenced by its name. A plan is autoloaded from `$MODULEROOT/plans`.
 #
-# **NOTE:** Not available in apply block
+# > **Note:** Not available in apply block
 Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction) do
   # Run a plan
   # @param plan_name The plan to run.
-  # @param args Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.
+  # @param args A hash of arguments to the plan. Can also include additional options.
+  # @option args [Boolean] _catch_errors Whether to catch raised errors.
+  # @option args [String] _run_as User to run as using privilege escalation.
   # @return [PlanResult] The result of running the plan. Undef if plan does not explicitly return results.
   # @example Run a plan
   #   run_plan('canary', 'command' => 'false', 'targets' => $targets, '_catch_errors' => true)
@@ -19,19 +21,21 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
     return_type 'Boltlib::PlanResult'
   end
 
-  # Run a plan, specifying $nodes or $targets as a positional argument.
+  # Run a plan, specifying `$nodes` or `$targets` as a positional argument.
   #
-  # When running a plan with a $nodes parameter, the second positional argument will always specify
-  # the $nodes parameter. When running a plan with a $targets parameter and no $nodes parameter, the
-  # second positional argument specifies the $targets parameter.
+  # When running a plan with a `$nodes` parameter, the second positional argument will always specify
+  # the `$nodes` parameter. When running a plan with a `$targets `parameter and no `$nodes` parameter, the
+  # second positional argument specifies the `$targets` parameter.
   #
-  # Deprecation Warning: Starting with Bolt 2.0, a plan with both a $nodes and $targets parameter
-  # cannot specify either parameter using the second positional argument and will result in the plan
-  # failing to run.
+  # > **Deprecation Warning**: Starting with Bolt 2.0, a plan with both a `$nodes` and `$targets` parameter
+  # > cannot specify either parameter using the second positional argument and will result in the plan
+  # > failing to run.
   #
   # @param plan_name The plan to run.
-  # @param args Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as'.
   # @param targets A pattern identifying zero or more targets. See {get_targets} for accepted patterns.
+  # @param args A hash of arguments to the plan. Can also include additional options.
+  # @option args [Boolean] _catch_errors Whether to catch raised errors.
+  # @option args [String] _run_as User to run as using privilege escalation.
   # @return [PlanResult] The result of running the plan. Undef if plan does not explicitly return results.
   # @example Run a plan
   #   run_plan('canary', $targets, 'command' => 'false')

--- a/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
@@ -3,14 +3,16 @@
 # Uploads the given script to the given set of targets and returns the result of having each target execute the script.
 # This function does nothing if the list of targets is empty.
 #
-# **NOTE:** Not available in apply block
+# > **Note:** Not available in apply block
 Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFunction) do
   # Run a script.
   # @param script Path to a script to run on target. May be an absolute path or a modulename/filename selector for a
   #               file in $MODULEROOT/files.
   # @param targets A pattern identifying zero or more targets. See {get_targets} for accepted patterns.
-  # @param options Specify an array of arguments to the 'arguments' key to be passed to the script.
-  #                Additional options: '_catch_errors', '_run_as'.
+  # @param options A hash of additional options.
+  # @option options [Array[String]] arguments An array of arguments to be passed to the script.
+  # @option args [Boolean] _catch_errors Whether to catch raised errors.
+  # @option args [String] _run_as User to run as using privilege escalation.
   # @return A list of results, one entry per target.
   # @example Run a local script on Linux targets as 'root'
   #   run_script('/var/tmp/myscript', $targets, '_run_as' => 'root')
@@ -29,8 +31,10 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
   #               file in $MODULEROOT/files.
   # @param targets A pattern identifying zero or more targets. See {get_targets} for accepted patterns.
   # @param description A description to be output when calling this function.
-  # @param options Specify an array of arguments to the 'arguments' key to be passed to the script.
-  #                Additional options: '_catch_errors', '_run_as'.
+  # @param options A hash of additional options.
+  # @option options [Array[String]] arguments An array of arguments to be passed to the script.
+  # @option args [Boolean] _catch_errors Whether to catch raised errors.
+  # @option args [String] _run_as User to run as using privilege escalation.
   # @return A list of results, one entry per target.
   # @example Run a script
   #   run_script('/var/tmp/myscript', $targets, 'Downloading my application')

--- a/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
@@ -7,12 +7,15 @@ require 'bolt/task'
 # Runs a given instance of a `Task` on the given set of targets and returns the result from each.
 # This function does nothing if the list of targets is empty.
 #
-# **NOTE:** Not available in apply block
+# > **Note:** Not available in apply block
 Puppet::Functions.create_function(:run_task) do
   # Run a task.
   # @param task_name The task to run.
   # @param targets A pattern identifying zero or more targets. See {get_targets} for accepted patterns.
-  # @param args Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as', '_noop'.
+  # @param args A hash of arguments to the task. Can also include additional options.
+  # @option args [Boolean] _catch_errors Whether to catch raised errors.
+  # @option args [String] _run_as User to run as using privilege escalation.
+  # @option args [Boolean] _noop Run the task in noop mode if available.
   # @return A list of results, one entry per target.
   # @example Run a task as root
   #   run_task('facts', $targets, '_run_as' => 'root')
@@ -27,7 +30,10 @@ Puppet::Functions.create_function(:run_task) do
   # @param task_name The task to run.
   # @param targets A pattern identifying zero or more targets. See {get_targets} for accepted patterns.
   # @param description A description to be output when calling this function.
-  # @param args Arguments to the plan. Can also include additional options: '_catch_errors', '_run_as', '_noop'.
+  # @param args A hash of arguments to the task. Can also include additional options.
+  # @option args [Boolean] _catch_errors Whether to catch raised errors.
+  # @option args [String] _run_as User to run as using privilege escalation.
+  # @option args [Boolean] _noop Run the task in noop mode if available.
   # @return A list of results, one entry per target.
   # @example Run a task
   #   run_task('facts', $targets, 'Gather OS facts')

--- a/bolt-modules/boltlib/lib/puppet/functions/set_config.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_config.rb
@@ -2,10 +2,11 @@
 
 require 'bolt/error'
 
-# Set configuration options on a target
+# Set configuration options on a target.
 #
-# **NOTE:** Not available in apply block
-# **NOTE:** Only compatible with inventory v2
+# > **Note:** Not available in apply block
+#
+# > **Note:** Only compatible with inventory v2
 Puppet::Functions.create_function(:set_config) do
   # @param target The Target object to configure. See {get_targets}.
   # @param key_or_key_path The configuration setting to update.

--- a/bolt-modules/boltlib/lib/puppet/functions/set_feature.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_feature.rb
@@ -5,18 +5,18 @@ require 'bolt/error'
 # Sets a particular feature to present on a target.
 #
 # Features are used to determine what implementation of a task should be run.
-# Currently supported features are
-# - powershell
-# - shell
-# - puppet-agent
+# Supported features are:
+# - `powershell`
+# - `shell`
+# - `puppet-agent`
 #
-# **NOTE:** Not available in apply block
+# > **Note:** Not available in apply block
 Puppet::Functions.create_function(:set_feature) do
   # @param target The Target object to add features to. See {get_targets}.
   # @param feature The string identifying the feature.
   # @param value Whether the feature is supported.
   # @return The target with the updated feature
-  # @example Add the puppet-agent feature to a target
+  # @example Add the `puppet-agent` feature to a target
   #   set_feature($target, 'puppet-agent', true)
   dispatch :set_feature do
     param 'Target', :target

--- a/bolt-modules/boltlib/lib/puppet/functions/set_var.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_var.rb
@@ -2,9 +2,9 @@
 
 require 'bolt/error'
 
-# Sets a variable { key => value } for a target.
+# Sets a variable `{ key => value }` for a target.
 #
-# **NOTE:** Not available in apply block
+# > **Note:** Not available in apply block
 Puppet::Functions.create_function(:set_var) do
   # @param target The Target object to set the variable for. See {get_targets}.
   # @param key The key for the variable.

--- a/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
@@ -5,14 +5,16 @@ require 'bolt/error'
 # Uploads the given file or directory to the given set of targets and returns the result from each upload.
 # This function does nothing if the list of targets is empty.
 #
-# **NOTE:** Not available in apply block
+# > **Note:** Not available in apply block
 Puppet::Functions.create_function(:upload_file, Puppet::Functions::InternalFunction) do
   # Upload a file or directory.
   # @param source A source path, either an absolute path or a modulename/filename selector for a
   #               file or directory in $MODULEROOT/files.
   # @param destination An absolute path on the target(s).
   # @param targets A pattern identifying zero or more targets. See {get_targets} for accepted patterns.
-  # @param options Additional options: '_catch_errors', '_run_as'.
+  # @param options A hash of additional options.
+  # @option options [Boolean] _catch_errors Whether to catch raised errors.
+  # @option options [String] _run_as User to run as using privilege escalation.
   # @return A list of results, one entry per target.
   # @example Upload a local file to Linux targets and change owner to 'root'
   #   upload_file('/var/tmp/payload.tgz', '/tmp/payload.tgz', $targets, '_run_as' => 'root')
@@ -33,7 +35,9 @@ Puppet::Functions.create_function(:upload_file, Puppet::Functions::InternalFunct
   # @param destination An absolute path on the target(s).
   # @param targets A pattern identifying zero or more targets. See {get_targets} for accepted patterns.
   # @param description A description to be output when calling this function.
-  # @param options Additional options: '_catch_errors', '_run_as'.
+  # @param options A hash of additional options.
+  # @option options [Boolean] _catch_errors Whether to catch raised errors.
+  # @option options [String] _run_as User to run as using privilege escalation.
   # @return A list of results, one entry per target.
   # @example Upload a file
   #   upload_file('/var/tmp/payload.tgz', '/tmp/payload.tgz', $targets, 'Uploading payload to unpack')

--- a/bolt-modules/boltlib/lib/puppet/functions/wait_until_available.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/wait_until_available.rb
@@ -4,11 +4,15 @@ require 'bolt/util'
 
 # Wait until all targets accept connections.
 #
-# **NOTE:** Not available in apply block
+# > **Note:** Not available in apply block
 Puppet::Functions.create_function(:wait_until_available) do
   # Wait until targets are available.
   # @param targets A pattern identifying zero or more targets. See {get_targets} for accepted patterns.
-  # @param options Additional options: 'description', 'wait_time', 'retry_interval', '_catch_errors'.
+  # @param options A hash of additional options.
+  # @option options [String] description A description for logging. (default: 'wait until available')
+  # @option options [Numeric] wait_time The time to wait. (default: 120)
+  # @option options [Numeric] retry_interval The interval to wait before retrying. (default: 1)
+  # @option options [Boolean] _catch_errors Whether to catch raised errors.
   # @return A list of results, one entry per target. Successful results have no value.
   # @example Wait for targets
   #   wait_until_available($targets, wait_time => 300)

--- a/bolt-modules/boltlib/lib/puppet/functions/without_default_logging.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/without_default_logging.rb
@@ -3,10 +3,10 @@
 # Define a block where default logging is suppressed.
 #
 # Messages for actions within this block will be logged at `info` level instead
-# of `notice`, so they will not be seen normally but # will still be present
+# of `notice`, so they will not be seen normally but will still be present
 # when `verbose` logging is requested.
 #
-# **NOTE:** Not available in apply block
+# > **Note:** Not available in apply block
 Puppet::Functions.create_function(:without_default_logging) do
   # @param block The block where action logging is suppressed.
   # @return [Undef]

--- a/bolt-modules/ctrl/lib/puppet/functions/ctrl/do_until.rb
+++ b/bolt-modules/ctrl/lib/puppet/functions/ctrl/do_until.rb
@@ -2,7 +2,8 @@
 
 # Repeat the block until it returns a truthy value. Returns the value.
 Puppet::Functions.create_function(:'ctrl::do_until') do
-  # @param options Additional options: 'until'
+  # @param options A hash of additional options.
+  # @option options [Numeric] limit The number of times to repeat the block.
   # @example Run a task until it succeeds
   #   ctrl::do_until() || {
   #     run_task('test', $target, _catch_errors => true).ok()

--- a/bolt-modules/file/lib/puppet/functions/file/exists.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/exists.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
-# check if a file exists
+# Check if a file exists.
 Puppet::Functions.create_function(:'file::exists', Puppet::Functions::InternalFunction) do
   # @param filename Absolute path or Puppet file path.
+  # @return Whether the file exists.
   # @example Check a file on disk
   #   file::exists('/tmp/i_dumped_this_here')
   # @example check a file from the modulepath

--- a/bolt-modules/file/lib/puppet/functions/file/join.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/join.rb
@@ -3,6 +3,7 @@
 # Join file paths.
 Puppet::Functions.create_function(:'file::join') do
   # @param paths The paths to join.
+  # @return The joined file path.
   # @example Join file paths
   #   file::join('./path', 'to/files')
   dispatch :join do

--- a/bolt-modules/file/lib/puppet/functions/file/read.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/read.rb
@@ -3,6 +3,7 @@
 # Read a file and return its contents.
 Puppet::Functions.create_function(:'file::read', Puppet::Functions::InternalFunction) do
   # @param filename Absolute path or Puppet file path.
+  # @return The file's contents.
   # @example Read a file from disk
   #   file::read('/tmp/i_dumped_this_here')
   # @example Read a file from the modulepath

--- a/bolt-modules/file/lib/puppet/functions/file/readable.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/readable.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
-# check if a file is readable
+# Check if a file is readable.
 Puppet::Functions.create_function(:'file::readable', Puppet::Functions::InternalFunction) do
   # @param filename Absolute path or Puppet file path.
+  # @return Whether the file is readable.
   # @example Check a file on disk
   #   file::readable('/tmp/i_dumped_this_here')
   # @example check a file from the modulepath

--- a/bolt-modules/out/lib/puppet/functions/out/message.rb
+++ b/bolt-modules/out/lib/puppet/functions/out/message.rb
@@ -5,7 +5,7 @@
 # This will print a message to stdout when using the human output format,
 # and print to stderr when using the json output format
 #
-# **NOTE:** Not available in apply block
+# > **Note:** Not available in apply block
 Puppet::Functions.create_function(:'out::message') do
   # Output a message.
   # @param message The message to output.

--- a/bolt-modules/system/lib/puppet/functions/system/env.rb
+++ b/bolt-modules/system/lib/puppet/functions/system/env.rb
@@ -3,6 +3,7 @@
 # Get an environment variable.
 Puppet::Functions.create_function(:'system::env') do
   # @param name Environment variable name.
+  # @return The environment variable's value.
   # @example Get the USER environment variable
   #   system::env('USER')
   dispatch :env do

--- a/documentation/reference.md.erb
+++ b/documentation/reference.md.erb
@@ -14,19 +14,33 @@
 <%= sig['signature'] %>
 ```
 
+<% if sig['returns'] -%>
+#### Returns
 <% for ret in sig['returns'] -%>
-*Returns:* `<%= ret['types'].first %>` <%= ret['text'] %>
+`<%= ret['types'].first %>` <%= ret['text'] %>
+<% end -%>
 <% end -%>
 
+#### Parameters
 <% for param in sig['params'] -%>
 * **<%= param['name'] %>** `<%= param['types'].first %>` <%= param['text'] %>
 <% end -%>
 
+<% if sig['options'] -%>
+#### Additional options
+<% for option in sig['options'] -%>
+* **<%= option['opt_name'] %>** `<%= option['opt_types'].first %>` <%= option['opt_text'] %>
+<% end -%>
+<% end -%>
+
+<% if sig['examples'] -%>
+#### Examples
 <% for example in sig['examples'] -%>
-**Example:** <%= example['name'] %>
+<%= example['name'] %>
 ```
 <%= example['text'] %>
 ```
+<% end -%>
 <% end -%>
 <% end %>
 <% end %>


### PR DESCRIPTION
This adds documentation for the optional parameters and metaparameters
for Bolt's plan functions. It also updates the formatting of the plan
functions page to be more clear on what is a return value, parameter, or
additional option.

Closes #1584 