### PR TITLE
(GH-1598) Disallow config key in bolt_plugin.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
   Inventory v1 is no longer supported by Bolt and has been removed. The inventory now defaults to v2.
 
+* **Support for `config` key in a plugin's `bolt_plugin.json` has been removed** ([#1598](https://github.com/puppetlabs/bolt/issues/1598))
+
+  Plugins can no longer define config from the `bolt_plugin.json`. Plugins will now only infer config from task parameters
+  and pass config values as regular parameters.
+
 ## Bolt 1.48.0
 
 ### New features

--- a/spec/bolt/plugin_spec.rb
+++ b/spec/bolt/plugin_spec.rb
@@ -66,6 +66,10 @@ describe Bolt::Plugin do
 
       expect { plugins }.to raise_error(/The 'plugins' setting cannot be set by a plugin reference/)
     end
+
+    it 'fails if bolt_plugin.json has a config key' do
+      expect { plugins.add_module_plugin('conf_plug') }.to raise_error(/'config' key is not allowed/)
+    end
   end
 
   context 'loading plugin_hooks' do

--- a/spec/integration/plugin/module_spec.rb
+++ b/spec/integration/plugin/module_spec.rb
@@ -126,13 +126,6 @@ describe 'using module based plugins' do
   end
 
   context 'when a plugin requires config' do
-    let(:plugin) {
-      {
-        '_plugin' => 'conf_plug',
-        'value' => "ssshhh"
-      }
-    }
-
     let(:inventory) {
       { 'targets' => [
         { 'uri' => 'node1',
@@ -153,25 +146,6 @@ describe 'using module based plugins' do
       PLAN
     end
 
-    it 'fails when configuration is incorrect' do
-      result = run_cli_json(['plan', 'run', 'test_plan', '--boltdir', boltdir], rescue_exec: true)
-
-      expect(result).to include('kind' => "bolt/validation-error")
-      expect(result['msg']).to match(/conf_plug plugin expects a String for key required_key/)
-    end
-
-    context 'with correct config' do
-      let(:plugin_config) { { 'conf_plug' => { 'required_key' => 'foo' } } }
-
-      it 'passes _config to the task' do
-        result = run_cli_json(['plan', 'run', 'test_plan', '--boltdir', boltdir])
-
-        expect(result['remote']['data']).to include('_config' => plugin_config['conf_plug'])
-        expect(result['remote']['data']).to include('_boltdir' => boltdir)
-        expect(result['remote']['data']).to include('value' => 'ssshhh')
-      end
-    end
-
     context 'with values specified in both bolt.yaml and inventory.yaml' do
       context 'and merging config' do
         let(:plugin) { { '_plugin' => 'task_conf_plug', 'optional_key' => 'keep' } }
@@ -180,7 +154,6 @@ describe 'using module based plugins' do
         it 'merges parameters set in config and does not pass _config' do
           result = run_cli_json(['plan', 'run', 'test_plan', '--boltdir', boltdir])
 
-          expect(result['remote']['data']).not_to include('_config' => plugin_config['conf_plug'])
           expect(result['remote']['data']).to include('_boltdir' => boltdir)
           expect(result['remote']['data']).to include('required_key' => 'foo')
           expect(result['remote']['data']).to include('optional_key' => 'keep')
@@ -194,7 +167,6 @@ describe 'using module based plugins' do
         it 'treats all required values from task paramter metadata as optional' do
           result = run_cli_json(['plan', 'run', 'test_plan', '--boltdir', boltdir])
 
-          expect(result['remote']['data']).not_to include('_config' => plugin_config['conf_plug'])
           expect(result['remote']['data']).to include('_boltdir' => boltdir)
           expect(result['remote']['data']).to include('required_key' => 'foo')
           expect(result['remote']['data']).to include('optional_key' => 'bar')


### PR DESCRIPTION
This removes support for setting a plugin's configuration under the
`config` key in a `bolt_plugin.json` file. Plugins now will only infer
config from task parameters and pass any valid config as normal task
parameters.

Closes #1598 