### PR TITLE
(GH-1567) Error when using a v1 inventory

### DIFF
--- a/lib/bolt/inventory/group.rb
+++ b/lib/bolt/inventory/group.rb
@@ -239,6 +239,15 @@ module Bolt
           raise ValidationError.new(msg, @name)
         end
 
+        if input.key?('nodes')
+          msg = <<~MSG.chomp
+                Found 'nodes' key in group #{@name}. This looks like a v1 inventory file, which is
+                no longer supported by Bolt. Migrate to a v2 inventory file automatically using
+                'bolt project migrate'.
+                MSG
+          raise ValidationError.new(msg, nil)
+        end
+
         unless (unexpected_keys = input.keys - GROUP_KEYS).empty?
           msg = "Found unexpected key(s) #{unexpected_keys.join(', ')} in group #{@name}"
           @logger.warn(msg)

--- a/spec/bolt/inventory/group_spec.rb
+++ b/spec/bolt/inventory/group_spec.rb
@@ -751,6 +751,12 @@ describe Bolt::Inventory::Group do
         Bolt::Inventory::Group.new({ 'name' => 'foo', 'unexpected' => 1 }, plugins)
       end
 
+      it 'errors on deprecated nodes key' do
+        expect {
+          Bolt::Inventory::Group.new({ 'name' => 'foo', 'nodes' => [{ 'uri' => 'example.com' }] }, plugins)
+        }.to raise_error(/Found 'nodes' key/)
+      end
+
       it 'logs unexpected group config keys' do
         expect(mock_logger).to receive(:warn).with(/in config for group foo/)
         Bolt::Inventory::Group.new({ 'name' => 'foo', 'config' => { 'unexpected' => 1 } }, plugins)

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -14,7 +14,7 @@ describe Bolt::Inventory do
 
   context 'with BOLT_INVENTORY set' do
     let(:inventory) { Bolt::Inventory.from_config(config, plugins) }
-    let(:target) { inventory.get_targets('node1')[0] }
+    let(:target) { inventory.get_targets('target1')[0] }
 
     before(:each) do
       ENV['BOLT_INVENTORY'] = inventory_env.to_yaml
@@ -25,7 +25,7 @@ describe Bolt::Inventory do
     context 'with valid config' do
       let(:inventory_env) {
         {
-          'nodes' => ['node1'],
+          'targets' => ['target1'],
           'config' => {
             'transport' => 'winrm'
           }

--- a/spec/pal/vars_spec.rb
+++ b/spec/pal/vars_spec.rb
@@ -18,7 +18,7 @@ describe 'Vars function' do
 
   let(:data) {
     {
-      'nodes' => %w[example],
+      'targets' => %w[example],
       'vars' => { 'pb' => 'jelly', 'mac' => 'cheese' }
     }
   }


### PR DESCRIPTION
This adds an error when Bolt detects that a v1 inventory file is being
used. A v1 inventory file is identified by the use of a `nodes` key at
the group level, which is deprecated in v2 inventory files.