### PR TITLE
(GH-1596) Filter tasks and plans by substring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Bolt Next
+
+### New features
+
+* **Filter tasks and plans by substring** ([#1596](https://github.com/puppetlabs/bolt/issues/1596))
+
+  Users can now filter available tasks and plans when using `bolt task show` and `bolt plan show` by
+  using the `--filter` CLI option. This option accepts a substring to match task and plan names against.
+
 ## Bolt 1.49.0
 
 ### New features

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -67,7 +67,7 @@ module Bolt
           { flags: ACTION_OPTS + %w[params compile-concurrency tmpdir],
             banner: PLAN_RUN_HELP }
         when 'show'
-          { flags: OPTIONS[:global] + OPTIONS[:global_config_setters],
+          { flags: OPTIONS[:global] + OPTIONS[:global_config_setters] + %w[filter format],
             banner: PLAN_SHOW_HELP }
         else
           { flags: OPTIONS[:global],
@@ -130,7 +130,7 @@ module Bolt
           { flags: ACTION_OPTS + %w[params tmpdir noop],
             banner: TASK_RUN_HELP }
         when 'show'
-          { flags: OPTIONS[:global] + OPTIONS[:global_config_setters],
+          { flags: OPTIONS[:global] + OPTIONS[:global_config_setters] + %w[filter format],
             banner: TASK_SHOW_HELP }
         else
           { flags: OPTIONS[:global],
@@ -761,6 +761,14 @@ module Bolt
       end
 
       separator "\nDISPLAY OPTIONS"
+      define('--filter FILTER', 'Filter tasks and plans by a matching substring') do |filter|
+        unless /^[a-z0-9_:]+$/.match(filter)
+          msg = "Illegal characters in filter string '#{filter}'. Filters must match a legal "\
+                "task or plan name."
+          raise Bolt::CLIError, msg
+        end
+        @options[:filter] = filter
+      end
       define('--format FORMAT', 'Output format to use: human or json') do |format|
         @options[:format] = format
       end

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -453,7 +453,9 @@ module Bolt
     end
 
     def list_tasks
-      outputter.print_tasks(pal.list_tasks, pal.list_modulepath)
+      tasks = pal.list_tasks
+      tasks.select! { |task| task.first.include?(options[:filter]) } if options[:filter]
+      outputter.print_tasks(tasks, pal.list_modulepath)
     end
 
     def show_plan(plan_name)
@@ -461,7 +463,9 @@ module Bolt
     end
 
     def list_plans
-      outputter.print_plans(pal.list_plans, pal.list_modulepath)
+      plans = pal.list_plans
+      plans.select! { |plan| plan.first.include?(options[:filter]) } if options[:filter]
+      outputter.print_plans(plans, pal.list_modulepath)
     end
 
     def list_targets

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -573,6 +573,13 @@ describe "Bolt::CLI" do
       end
     end
 
+    describe "filter" do
+      it "raises an error when a filter has illegal characters" do
+        cli = Bolt::CLI.new(%w[plan show --filter JSON])
+        expect { cli.parse }.to raise_error(Bolt::CLIError, /Illegal characters in filter string/)
+      end
+    end
+
     describe "transport" do
       it "defaults to 'ssh'" do
         cli = Bolt::CLI.new(%w[command run --targets foo whoami])


### PR DESCRIPTION
This adds support for a `--filter FILTER` option when using the `task show` and
`plan show` commands. When using the `--filter` option, the list of
tasks and plans displayed by the outputter will be filtered to tasks and
plans whose names include the provided substring.