### PR TITLE
(GH-1598) Disallow config in bolt_plugin.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
   Inventory v1 is no longer supported by Bolt and has been removed. The inventory now defaults to v2.
 
+* **Support for `config` key in a plugin's `bolt_plugin.json` has been removed** ([#1598](https://github.com/puppetlabs/bolt/issues/1598))
+
+  Plugins can no longer set config in their `bolt_plugin.json`. Config is instead inferred from task
+  parameters, with config values passed as parameters to the task.
+
 ## Bolt 1.48.0
 
 ### New features

--- a/Puppetfile
+++ b/Puppetfile
@@ -6,7 +6,7 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '1.1.0'
-mod 'puppetlabs-puppet_agent', '3.0.1'
+mod 'puppetlabs-puppet_agent', '3.0.2'
 mod 'puppetlabs-facts', '1.0.0'
 
 # Core types and providers for Puppet 6

--- a/lib/bolt/plugin/module.rb
+++ b/lib/bolt/plugin/module.rb
@@ -6,7 +6,7 @@ module Bolt
   class Plugin
     class Module
       class InvalidPluginData < Bolt::Plugin::PluginError
-        def initialize(plugin, msg)
+        def initialize(msg, plugin)
           msg = "Invalid Plugin Data for #{plugin}: #{msg}"
           super(msg, 'bolt/invalid-plugin-data')
         end
@@ -36,17 +36,17 @@ module Bolt
       def setup
         @data = load_data
         @hook_map = find_hooks(@data['hooks'] || {})
-        # If there is a config section in bolt_plugin.json, validate against that and send
-        # validated values nested under `_config` key. Otherwise validate againsts the intersection
-        # of all task schemas.
-        # TODO: remove @send_config when deprecated
-        schema = if @data['config']
-                   @send_config = true
-                   @data['config']
-                 else
-                   extract_task_parameter_schema
-                 end
-        @config_schema = process_schema(schema)
+
+        if @data['config']
+          msg = <<~MSG.chomp
+            Found unsupported key 'config' in bolt_plugin.json. Config for a plugin is inferred
+            from task parameters, with config values passed as parameters.
+          MSG
+          raise InvalidPluginData.new(msg, name)
+        end
+
+        # Validate againsts the intersection of all task schemas.
+        @config_schema = process_schema(extract_task_parameter_schema)
 
         validate_config(@config, @config_schema)
       end
@@ -57,10 +57,6 @@ module Bolt
 
       def hooks
         (@hook_map.keys + [:validate_resolve_reference]).uniq
-      end
-
-      def config?
-        @data.include?('config') && !@data['config'].empty?
       end
 
       def load_data
@@ -159,17 +155,9 @@ module Bolt
         # handled previously. That may not always be the case so filter them
         # out now.
         meta, params = opts.partition { |key, _val| key.start_with?('_') }.map(&:to_h)
+        params = config.merge(params)
+        validate_params(task, params)
 
-        # Send config with `_config` when config is defined in bolt_plugin.json
-        # Otherwise, merge config with params
-        # TODO: remove @send_config when deprecated
-        if @send_config
-          validate_params(task, params)
-          params['_config'] = config if config?
-        else
-          params = @config ? config.merge(params) : params
-          validate_params(task, params)
-        end
         params['_boltdir'] = @context.boltdir.to_s
 
         [params, meta]
@@ -232,15 +220,10 @@ module Bolt
       end
 
       def validate_resolve_reference(opts)
-        # Send config with `_config` when config is defined in bolt_plugin.json
-        # Otherwise, merge config with params
-        # TODO: remove @send_config when deprecated
-        if @send_config
-          params = opts.reject { |k, _v| k.start_with?('_') }
-        else
-          merged = @config.merge(opts)
-          params = merged.reject { |k, _v| k.start_with?('_') }
-        end
+        # Merge config with params
+        merged = @config.merge(opts)
+        params = merged.reject { |k, _v| k.start_with?('_') }
+
         sig = @hook_map[:resolve_reference]['task']
         if sig
           validate_params(sig, params)

--- a/spec/fixtures/plugin_modules/my_plug/bolt_plugin.json
+++ b/spec/fixtures/plugin_modules/my_plug/bolt_plugin.json
@@ -1,2 +1,1 @@
-{ "hooks": {"createkeys": { "task": "my_plug::resolve_reference" } },
-  "config": { "optional_config": { "type": "Optional[String]" } } }
+{ "hooks": {"createkeys": { "task": "my_plug::resolve_reference" } } }

--- a/spec/fixtures/plugin_modules/my_plug/tasks/resolve_reference.json
+++ b/spec/fixtures/plugin_modules/my_plug/tasks/resolve_reference.json
@@ -1,0 +1,7 @@
+{
+    "parameters": {
+        "optional_config": {
+            "type": "Optional[String]"
+        }
+    }
+}

--- a/spec/integration/plugin/module_spec.rb
+++ b/spec/integration/plugin/module_spec.rb
@@ -153,23 +153,11 @@ describe 'using module based plugins' do
       PLAN
     end
 
-    it 'fails when configuration is incorrect' do
+    it 'fails when config key is present in bolt_plugin.json' do
       result = run_cli_json(['plan', 'run', 'test_plan', '--boltdir', boltdir], rescue_exec: true)
 
-      expect(result).to include('kind' => "bolt/validation-error")
-      expect(result['msg']).to match(/conf_plug plugin expects a String for key required_key/)
-    end
-
-    context 'with correct config' do
-      let(:plugin_config) { { 'conf_plug' => { 'required_key' => 'foo' } } }
-
-      it 'passes _config to the task' do
-        result = run_cli_json(['plan', 'run', 'test_plan', '--boltdir', boltdir])
-
-        expect(result['remote']['data']).to include('_config' => plugin_config['conf_plug'])
-        expect(result['remote']['data']).to include('_boltdir' => boltdir)
-        expect(result['remote']['data']).to include('value' => 'ssshhh')
-      end
+      expect(result).to include('kind' => "bolt/invalid-plugin-data")
+      expect(result['msg']).to match(/Found unsupported key 'config'/)
     end
 
     context 'with values specified in both bolt.yaml and inventory.yaml' do


### PR DESCRIPTION
This removes support for a `config` field in a plugin's
`bolt_plugin.json`. Plugins now infer config from task parameters and
pass config values as task parameters.

Blocked by https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/469
Closes #1598 