### PR TITLE
(GH-1599) Set bundled resolve_reference tasks to private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
   Users can now filter available tasks and plans when using `bolt task show` and `bolt plan show` by
   using the `--filter` CLI option. This option accepts a substring to match task and plan names against.
 
+### Bug fixes
+
+* **Bundled `resolve_references` tasks set to private** ([#1599](https://github.com/puppetlabs/bolt/issues/1599))
+
+  `resolve_references` tasks in bundled content have been set to private and will no longer appear when
+  using `bolt task show`.
+
 ## Bolt 1.49.0
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@
 
 ### Bug fixes
 
-* **Bundled `resolve_references` tasks set to private** ([#1599](https://github.com/puppetlabs/bolt/issues/1599))
+* **Bundled `resolve_reference` tasks set to private** ([#1599](https://github.com/puppetlabs/bolt/issues/1599))
 
-  `resolve_references` tasks in bundled content have been set to private and will no longer appear when
+  `resolve_reference` tasks in bundled content have been set to private and will no longer appear when
   using `bolt task show`.
 
 ## Bolt 1.49.0

--- a/Puppetfile
+++ b/Puppetfile
@@ -30,11 +30,11 @@ mod 'puppetlabs-ruby_task_helper', '0.4.0'
 mod 'puppetlabs-ruby_plugin_helper', '0.1.0'
 
 # Plugin modules
-mod 'puppetlabs-azure_inventory', '0.2.0'
-mod 'puppetlabs-terraform', '0.3.0'
-mod 'puppetlabs-vault', '0.2.2'
-mod 'puppetlabs-aws_inventory', '0.3.0'
-mod 'puppetlabs-yaml', '0.1.0'
+mod 'puppetlabs-azure_inventory', '0.3.0'
+mod 'puppetlabs-terraform', '0.4.0'
+mod 'puppetlabs-vault', '0.3.0'
+mod 'puppetlabs-aws_inventory', '0.4.0'
+mod 'puppetlabs-yaml', '0.2.0'
 
 # If we don't list these modules explicitly, r10k will purge them
 mod 'canary', local: true


### PR DESCRIPTION
This bumps the versions of bundled modules with `resolve_reference`
tasks which are now set to private so they do not appear when using
`bolt task show`.

Closes #1599 