### PR TITLE
(maint) Update paths-ignore for CI workflows

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,10 +3,10 @@ name: Docs
 on:
   push:
     branches: [master]
-    paths-ignore: ['*.md']
+    paths-ignore: ['**/*.md']
   pull_request:
     type: [opened, reopened, edited]
-    paths-ignore: ['*.md']
+    paths-ignore: ['**/*.md']
 
 jobs:
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,10 +3,10 @@ name: Linting
 on:
   push:
     branches: [master]
-    paths-ignore: ['*.md', '*.erb']
+    paths-ignore: ['**/*.md', '**/*.erb']
   pull_request:
     type: [opened, reopened, edited]
-    paths-ignore: ['*.md', '*.erb']
+    paths-ignore: ['**/*.md', '**/*.erb']
 
 jobs:
 

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -3,10 +3,10 @@ name: Linux
 on:
   push:
     branches: [master]
-    paths-ignore: ['*.md', '*.erb']
+    paths-ignore: ['**/*.md', '**/*.erb']
   pull_request:
     type: [opened, reopened, edited]
-    paths-ignore: ['*.md', '*.erb']
+    paths-ignore: ['**/*.md', '**/*.erb']
 
 env:
   BOLT_SUDO_USER: true

--- a/.github/workflows/modules.yaml
+++ b/.github/workflows/modules.yaml
@@ -3,10 +3,10 @@ name: Modules
 on:
   push:
     branches: [master]
-    paths-ignore: ['*.md', '*.erb']
+    paths-ignore: ['**/*.md', '**/*.erb']
   pull_request:
     type: [opened, reopened, edited]
-    paths-ignore: ['*.md', '*.erb']
+    paths-ignore: ['**/*.md', '**/*.erb']
 
 env:
   BOLT_SUDO_USER: true

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -3,10 +3,10 @@ name: Windows
 on:
   push:
     branches: [master]
-    paths-ignore: ['*.md', '*.erb']
+    paths-ignore: ['**/*.md', '**/*.erb']
   pull_request:
     type: [opened, reopened, edited]
-    paths-ignore: ['*.md', '*.erb']
+    paths-ignore: ['**/*.md', '**/*.erb']
 
 env:
   BOLT_WINRM_USER: roddypiper


### PR DESCRIPTION
This updates the `paths-ignore` list to ignore changes to any markdown
or erb templates from any directory.