### PR TITLE
(GH-1597) Add write_file plan function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Bolt Next
 
+### New features
+
+* **New `write_file` plan function** ([#1597](https://github.com/puppetlabs/bolt/issues/1597))
+
+  The new plan function, `write_file`, allows you to write content to a file on the given targets.
+
 ### Bug fixes
 
 * **Fixed performance regression with large inventory files** ([#1627](https://github.com/puppetlabs/bolt/pull/1627))

--- a/bolt-modules/boltlib/lib/puppet/functions/write_file.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/write_file.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'tempfile'
+
+# Write contents to a file on the given set of targets.
+#
+# > **Note:** Not available in apply block
+Puppet::Functions.create_function(:write_file) do
+  # @param targets A pattern identifying zero or more targets. See {get_targets} for accepted patterns.
+  # @param content File content to write.
+  # @param destination An absolute path on the target(s).
+  # @option options [Boolean] _catch_errors Whether to catch raised errors.
+  # @option options [String] _run_as User to run as using privilege escalation.
+  # @return A list of results, one entry per target.
+  # @example Write a file to a target
+  #   $content = 'Hello, world!'
+  #   write_file($targets, $content, '/Users/me/hello.txt')
+  dispatch :write_file do
+    required_param 'String', :content
+    required_param 'String[1]', :destination
+    required_param 'Boltlib::TargetSpec', :targets
+    optional_param 'Hash[String[1], Any]', :options
+    return_type 'ResultSet'
+  end
+
+  def write_file(content, destination, target_spec, options = {})
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING,
+                              action: 'write_file')
+    end
+
+    executor = Puppet.lookup(:bolt_executor)
+    executor.report_function_call(self.class.name)
+
+    inventory = Puppet.lookup(:bolt_inventory)
+    targets = inventory.get_targets(target_spec)
+
+    executor.log_action("write file #{destination}", targets) do
+      executor.without_default_logging do
+        Tempfile.create do |tmp|
+          call_function('file::write', tmp.path, content)
+          call_function('upload_file', tmp.path, destination, targets, options)
+        end
+      end
+    end
+  end
+end

--- a/bolt-modules/boltlib/spec/functions/write_file_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/write_file_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/executor'
+require 'bolt/inventory'
+
+describe 'write_file' do
+  let(:executor) { Bolt::Executor.new }
+  let(:inventory) { Bolt::Inventory.empty }
+  let(:tasks_enabled) { true }
+
+  around(:each) do |example|
+    Puppet[:tasks] = tasks_enabled
+    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
+      example.run
+    end
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+
+    it 'fails and reports that write_file is not available' do
+      is_expected.to run.with_params('example.com', 'Hello, world!', 'hello.txt')
+                        .and_raise_error(/Plan language function 'write_file' cannot be used/)
+    end
+  end
+end

--- a/spec/fixtures/modules/write_file/plans/init.pp
+++ b/spec/fixtures/modules/write_file/plans/init.pp
@@ -1,0 +1,7 @@
+plan write_file(
+  TargetSpec $target,
+  String $content,
+  String $destination
+) {
+  return write_file($content, $destination, $target)
+}

--- a/spec/integration/modules/write_file_spec.rb
+++ b/spec/integration/modules/write_file_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/conn'
+require 'bolt_spec/files'
+require 'bolt_spec/integration'
+require 'bolt_spec/run'
+
+describe 'running a plan with write_file' do
+  include BoltSpec::Conn
+  include BoltSpec::Files
+  include BoltSpec::Integration
+  include BoltSpec::Run
+
+  let(:filename) { 'hello.txt' }
+  let(:content) { 'Hello, world!' }
+  let(:params) { %W[target=#{target} content=#{content} destination=#{filename}] }
+  let(:modulepath) { File.expand_path(File.join(__dir__, '../../fixtures/modules')) }
+  let(:inventory) { conn_inventory.merge(config) }
+  let(:config) do
+    {
+      'config' => {
+        'ssh' => { 'host-key-check' => false },
+        'winrm' => { 'ssl' => false }
+      }
+    }
+  end
+
+  shared_examples 'when writing a file from a plan' do
+    # Delete the uploaded file after each test
+    after(:each) do
+      result = run_command("#{remove_cmd} #{filename}", target, inventory: inventory)
+      expect(result.first['status']).to eq('success')
+    end
+
+    it 'writes a file to the destination' do
+      with_tempfile_containing('inventory', YAML.dump(inventory), '.yaml') do |inv|
+        # Check that a file is correctly uploaded
+        result = run_cli_json(%W[plan run write_file -i #{inv.path} -m #{modulepath}] + params)
+
+        expect(result.size).to eq(1)
+        data = result.first
+        expect(data['status']).to eq('success')
+        expect(data['value']['_output']).to match(/Uploaded .* to .*hello.txt/)
+
+        # Check that the created file has the correct content
+        result = run_command("#{print_cmd} #{filename}", target, inventory: inventory)
+
+        expect(result.size).to eq(1)
+        data = result.first
+        expect(data['status']).to eq('success')
+        expect(data['value']['stdout']).to match(/#{content}/)
+      end
+    end
+
+    it 'reports multiple function calls to analytics' do
+      with_tempfile_containing('inventory', YAML.dump(inventory), '.yaml') do |inv|
+        expect_any_instance_of(Bolt::Executor).to receive(:report_function_call).with('write_file')
+        expect_any_instance_of(Bolt::Executor).to receive(:report_function_call).with('file::write')
+        expect_any_instance_of(Bolt::Executor).to receive(:report_function_call).with('upload_file')
+        run_cli_json(%W[plan run write_file -i #{inv.path} -m #{modulepath}] + params)
+      end
+    end
+  end
+
+  describe 'over ssh', ssh: true do
+    let(:target) { 'ssh' }
+    let(:print_cmd) { 'cat' }
+    let(:remove_cmd) { 'rm' }
+
+    include_examples 'when writing a file from a plan'
+  end
+
+  describe 'over winrm', winrm: true do
+    let(:target) { 'winrm' }
+    let(:print_cmd) { 'type' }
+    let(:remove_cmd) { 'del' }
+
+    include_examples 'when writing a file from a plan'
+  end
+end


### PR DESCRIPTION
This adds a new `write_file` plan function that writes content to a
specified file on the given targets. Internally, the function uses the
`file::write` function to write content to a tempfile on `localhost` and
then uses the `upload_file` function to upload the tempfile to the
destination on the given targets.

Closes #1597 