### PR TITLE
(maint) Mark node definition in plan tests as unpending

### DIFF
--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -131,7 +131,6 @@ describe "passes parsed AST to the apply_catalog task" do
     end
 
     it 'evaluates a node definition matching the node name' do
-      pending "puppet does not allow node definitions in plans"
       result = run_cli_json(%w[plan run basic::node_definition] + config_flags)
       report = result[0]['value']['report']
       warn = report['catalog']['resources'].select { |r| r['type'] == 'Warn' }
@@ -139,7 +138,6 @@ describe "passes parsed AST to the apply_catalog task" do
     end
 
     it 'evaluates a default node definition if none matches the node name' do
-      pending "puppet does not allow node definitions in plans"
       result = run_cli_json(%w[plan run basic::node_default] + config_flags)
       report = result[0]['value']['report']
       warn = report['catalog']['resources'].select { |r| r['type'] == 'Warn' }


### PR DESCRIPTION
The version of Puppet that supports this feature has been released so
these tests now pass.