### PR TITLE
(GH-1614) Deep copy config and inventory for the BoltSpec Runner

### DIFF
--- a/lib/bolt_spec/run.rb
+++ b/lib/bolt_spec/run.rb
@@ -131,7 +131,7 @@ module BoltSpec
       # still be loaded
       def self.with_runner(config_data, inventory_data)
         Dir.mktmpdir do |boltdir_path|
-          runner = new(config_data, inventory_data, boltdir_path)
+          runner = new(Bolt::Util.deep_clone(config_data), Bolt::Util.deep_clone(inventory_data), boltdir_path)
           yield runner
         end
       end


### PR DESCRIPTION
Inventory can be huge when read from a file and so the Inventory deletes
the version key to avoid copying the whole inventory. This will cause
BoltSpec to copy the inventory before creating an Inventory instance to
avoid mutating the callers inventory hash.