### PR TITLE
(GH-1623) Replace all 'nodes' keys with 'project migrate' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 
   Large inventory groups were taking a long time to load and should now be much faster.
 
+* **`project migrate` command correctly migrates version 1 inventory files** ([#1623](https://github.com/puppetlabs/bolt/issues/1623))
+
+  The `project migrate` command now correctly replaces all `nodes` keys in an inventory file with `targets`. 
+  Previously, only the first group in an array of groups was having its `nodes` key replaced.
+
 ## Bolt 2.0.0
 
 ### Deprecations and removals

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -583,7 +583,10 @@ module Bolt
       inventory_file = config.inventoryfile || config.default_inventoryfile
       data = Bolt::Util.read_yaml_hash(inventory_file, 'inventory')
 
+      data.delete('version') if data['version'] != 2
+
       migrated = migrate_group(data)
+
       ok = File.write(inventory_file, data.to_yaml) if migrated
 
       result = if migrated && ok
@@ -613,7 +616,8 @@ module Bolt
         group['targets'] = targets
       end
       (group['groups'] || []).each do |subgroup|
-        migrated ||= migrate_group(subgroup)
+        migrated_group = migrate_group(subgroup)
+        migrated ||= migrated_group
       end
       migrated
     end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -2192,30 +2192,55 @@ describe "Bolt::CLI" do
     context 'migrate' do
       let(:inventory_v1) do
         {
+          "version" => 1,
           "name" => "all",
-          "groups" => [{
-            "name" => "group1",
-            "nodes" => [{
-              "name" => "target1",
-              "facts" => {
-                "name" => "foo"
-              }
-            }]
-          }]
+          "groups" => [
+            {
+              "name" => "group1",
+              "nodes" => [
+                {
+                  "name" => "target1",
+                  "facts" => {
+                    "name" => "foo"
+                  }
+                }
+              ]
+            },
+            {
+              "name" => "group2",
+              "nodes" => [
+                {
+                  "name" => "target2"
+                }
+              ]
+            }
+          ]
         }
       end
       let(:inventory_v2) do
         {
           "name" => "all",
-          "groups" => [{
-            "name" => "group1",
-            "targets" => [{
-              "uri" => "target1",
-              "facts" => {
-                "name" => "foo"
-              }
-            }]
-          }]
+          "groups" => [
+            {
+              "name" => "group1",
+              "targets" => [
+                {
+                  "uri" => "target1",
+                  "facts" => {
+                    "name" => "foo"
+                  }
+                }
+              ]
+            },
+            {
+              "name" => "group2",
+              "targets" => [
+                {
+                  "uri" => "target2"
+                }
+              ]
+            }
+          ]
         }
       end
 


### PR DESCRIPTION
This fixes a bug in the `project migrate` command that resulted in only
the first group in an array of groups having its `nodes` key replaced
with `targets`. The command now replaces `nodes` keys with `targets` in
*all* groups.

This also updates the `project migrate` command to remove any `version`
field that does not have a value of `2` from the inventory file.

Fixes #1623 