### PR TITLE
(maint) Validate inventory more efficiently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Bolt Next
+
+### Bug fixes
+
+* **Fixed performance regression with large inventory files** ([#1627](https://github.com/puppetlabs/bolt/pull/1627))
+
+  Large inventory groups were taking a long time to validate and should now be faster.
+
 ## Bolt 2.0.1
 
 ### Deprecations and removals
@@ -9,7 +17,7 @@
 
 ### Bug fixes
 
-* **Fixed a performance regression with large inventory files** ([#1625](https://github.com/puppetlabs/bolt/pull/1607))
+* **Fixed a performance regression with large inventory files** ([#1625](https://github.com/puppetlabs/bolt/pull/1625))
 
   Large inventory groups were taking a long time to load and should now be faster.
 
@@ -17,6 +25,12 @@
 
   The `project migrate` command now correctly replaces all `nodes` keys in an inventory file with `targets`. 
   Previously, only the first group in an array of groups was having its `nodes` key replaced.
+
+* **Modifications to an inventory when using `run_plan` are validated correctly** ([#1627](https://github.com/puppetlabs/bolt/pull/1627))
+
+  When using `run_plan(..., _catch_errors => true)` and making invalid modifications to the inventory, errors would
+  be caught but the modifications would still be made to the inventory. Modifications to the inventory are now
+  validated prior to applying them to the inventory.
 
 ## Bolt 2.0.0
 

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -326,8 +326,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
       plan = ['plan', 'run', 'add_group::x_fail_group_name_exists', '--targets', 'add_me'] + config_flags
       result = run_cli_json(plan)
       expect(result['kind']).to eq('bolt.inventory/validation-error')
-      expect(result['msg']).to match(/Group foo conflicts with target of the same name for group/)
-      expect(result['details']).to eq("path" => ["foo"])
+      expect(result['msg']).to match(/Target name foo conflicts with group of the same name/)
     end
   end
 


### PR DESCRIPTION
This updates the inventory to only validate groups once all targets have
been expanded. Previously, when calling `get_targets` and creating each
target, the inventory would add that target to the necessary group and
then validate all groups with `@groups.validate`. This resulted in large
inventories taking an exponentially long time to load. Now, groups are
only validated once all targets have been created and added to groups.