### PR TITLE
(GH-1612) Add --puppetfile CLI option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,22 @@
 
   The new plan function, `write_file`, allows you to write content to a file on the given targets.
 
+* **Add `--puppetfile` option for `puppetfile install` command** ([#1612](https://github.com/puppetlabs/bolt/issues/1612))
+
+  The `puppetfile install` command now supports a `--puppetfile` option that accepts a relative or absolute path
+  to a Puppetfile.
+
 ### Bug fixes
 
 * **Fixed performance regression with large inventory files** ([#1627](https://github.com/puppetlabs/bolt/pull/1627))
 
   Large inventory groups were taking a long time to validate and should now be faster.
+
+* **Modifications to an inventory when using `run_plan` are validated correctly** ([#1627](https://github.com/puppetlabs/bolt/pull/1627))
+
+  When using `run_plan(..., _catch_errors => true)` and making invalid modifications to the inventory, errors would
+  be caught but the modifications would still be made to the inventory. Modifications to the inventory are now
+  validated prior to applying them to the inventory.
 
 ## Bolt 2.0.1
 
@@ -31,12 +42,6 @@
 
   The `project migrate` command now correctly replaces all `nodes` keys in an inventory file with `targets`. 
   Previously, only the first group in an array of groups was having its `nodes` key replaced.
-
-* **Modifications to an inventory when using `run_plan` are validated correctly** ([#1627](https://github.com/puppetlabs/bolt/pull/1627))
-
-  When using `run_plan(..., _catch_errors => true)` and making invalid modifications to the inventory, errors would
-  be caught but the modifications would still be made to the inventory. Modifications to the inventory are now
-  validated prior to applying them to the inventory.
 
 ## Bolt 2.0.0
 

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -88,7 +88,7 @@ module Bolt
       when 'puppetfile'
         case action
         when 'install'
-          { flags: OPTIONS[:global] + OPTIONS[:global_config_setters],
+          { flags: OPTIONS[:global] + OPTIONS[:global_config_setters] + %w[puppetfile],
             banner: PUPPETFILE_INSTALL_HELP }
         when 'show-modules'
           { flags: OPTIONS[:global] + OPTIONS[:global_config_setters],
@@ -706,7 +706,7 @@ module Bolt
         @options[:boltdir] = path
       end
       define('--configfile FILEPATH',
-             'Specify where to load config from (default: ~/.puppetlabs/bolt/bolt.yaml). ' \
+             'Specify where to load config from (default: ~/.puppetlabs/bolt/bolt.yaml).',
              'Directory containing bolt.yaml will be used as the Boltdir.') do |path|
         @options[:configfile] = path
       end
@@ -715,7 +715,12 @@ module Bolt
         if ENV.include?(Bolt::Inventory::ENVIRONMENT_VAR)
           raise Bolt::CLIError, "Cannot pass inventory file when #{Bolt::Inventory::ENVIRONMENT_VAR} is set"
         end
-        @options[:inventoryfile] = File.expand_path(path)
+        @options[:inventoryfile] = Pathname.new(File.expand_path(path))
+      end
+      define('--puppetfile FILEPATH',
+             'Specify a Puppetfile to use when installing modules. (default: ~/.puppetlabs/bolt/Puppetfile)',
+             'Modules are installed in the current Boltdir.') do |path|
+        @options[:puppetfile] = Pathname.new(File.expand_path(path))
       end
       define('--[no-]save-rerun', 'Whether to update the rerun file after this command.') do |save|
         @options[:'save-rerun'] = save

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -302,6 +302,8 @@ module Bolt
         send("#{key}=", options[key]) if options.key?(key)
       end
 
+      @puppetfile = options[:puppetfile] if options.key?(:puppetfile)
+
       @save_rerun = options[:'save-rerun'] if options.key?(:'save-rerun')
 
       if options[:debug]
@@ -386,7 +388,7 @@ module Bolt
     end
 
     def puppetfile
-      @boltdir.puppetfile
+      @puppetfile || @boltdir.puppetfile
     end
 
     def modulepath

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -517,6 +517,16 @@ describe "Bolt::CLI" do
       end
     end
 
+    describe "puppetfile" do
+      let(:puppetfile) { File.expand_path('/path/to/Puppetfile') }
+      let(:cli) { Bolt::CLI.new(%W[puppetfile install --puppetfile #{puppetfile}]) }
+
+      it 'uses a specified Puppetfile' do
+        cli.parse
+        expect(cli.config.puppetfile.to_s).to eq(puppetfile)
+      end
+    end
+
     describe "sudo" do
       it "supports running as a user" do
         cli = Bolt::CLI.new(%w[command run --targets foo whoami --run-as root])


### PR DESCRIPTION
This adds support for a `--puppetfile` CLI option which accepts a
relative or absolute path to a Puppetfile to use when installing
modules with `bolt puppetfile install`. When using this flag, modules
will be installed to the current Boltdir. If a relative path is passed
to the option, it will be relative to the current Boltdir.

Closes #1612 