### PR TITLE
(maint) Ignore markdown files in root for CI

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,10 +3,10 @@ name: Docs
 on:
   push:
     branches: [master]
-    paths-ignore: ['**/*.md']
+    paths-ignore: ['**.md']
   pull_request:
     type: [opened, reopened, edited]
-    paths-ignore: ['**/*.md']
+    paths-ignore: ['**.md']
 
 jobs:
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,10 +3,10 @@ name: Linting
 on:
   push:
     branches: [master]
-    paths-ignore: ['**/*.md', '**/*.erb']
+    paths-ignore: ['**.md', '**.erb']
   pull_request:
     type: [opened, reopened, edited]
-    paths-ignore: ['**/*.md', '**/*.erb']
+    paths-ignore: ['**.md', '**.erb']
 
 jobs:
 

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -3,10 +3,10 @@ name: Linux
 on:
   push:
     branches: [master]
-    paths-ignore: ['**/*.md', '**/*.erb']
+    paths-ignore: ['**.md', '**.erb']
   pull_request:
     type: [opened, reopened, edited]
-    paths-ignore: ['**/*.md', '**/*.erb']
+    paths-ignore: ['**.md', '**.erb']
 
 env:
   BOLT_SUDO_USER: true

--- a/.github/workflows/modules.yaml
+++ b/.github/workflows/modules.yaml
@@ -3,10 +3,10 @@ name: Modules
 on:
   push:
     branches: [master]
-    paths-ignore: ['**/*.md', '**/*.erb']
+    paths-ignore: ['**.md', '**.erb']
   pull_request:
     type: [opened, reopened, edited]
-    paths-ignore: ['**/*.md', '**/*.erb']
+    paths-ignore: ['**.md', '**.erb']
 
 env:
   BOLT_SUDO_USER: true

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -3,10 +3,10 @@ name: Windows
 on:
   push:
     branches: [master]
-    paths-ignore: ['**/*.md', '**/*.erb']
+    paths-ignore: ['**.md', '**.erb']
   pull_request:
     type: [opened, reopened, edited]
-    paths-ignore: ['**/*.md', '**/*.erb']
+    paths-ignore: ['**.md', '**.erb']
 
 env:
   BOLT_WINRM_USER: roddypiper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
 
   Large inventory groups were taking a long time to validate and should now be faster.
 
+* **Modifications to an inventory when using `run_plan` are validated correctly** ([#1627](https://github.com/puppetlabs/bolt/pull/1627))
+
+  When using `run_plan(..., _catch_errors => true)` and making invalid modifications to the inventory, errors would
+  be caught but the modifications would still be made to the inventory. Modifications to the inventory are now
+  validated prior to applying them to the inventory.
+
 ## Bolt 2.0.1
 
 ### Deprecations and removals
@@ -31,12 +37,6 @@
 
   The `project migrate` command now correctly replaces all `nodes` keys in an inventory file with `targets`. 
   Previously, only the first group in an array of groups was having its `nodes` key replaced.
-
-* **Modifications to an inventory when using `run_plan` are validated correctly** ([#1627](https://github.com/puppetlabs/bolt/pull/1627))
-
-  When using `run_plan(..., _catch_errors => true)` and making invalid modifications to the inventory, errors would
-  be caught but the modifications would still be made to the inventory. Modifications to the inventory are now
-  validated prior to applying them to the inventory.
 
 ## Bolt 2.0.0
 


### PR DESCRIPTION
This updates the GitHub workflows to ignore markdown files at the root
of the repository, which were not caught by the glob pattern in the
`paths-ignore` field.