### PR TITLE
(maint) Bump puppetlabs-reboot module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   The `puppetfile install` command now supports a `--puppetfile` option that accepts a relative or absolute path
   to a Puppetfile.
 
-* **Update reboot plan parameter `nodes` to `targets`** ([puppetlabs-reboot#223](https://github.com/puppetlabs/reboot/pulls/223)
+* **Update reboot plan parameter `nodes` to `targets`** ([puppetlabs-reboot#223](https://github.com/puppetlabs/puppetlabs-reboot/pull/223))
 
   Users who explicitly set the `nodes` parameter will need to update the parameter name to
   `targets`. Calling the `reboot` plan with `-t` or `run_plan('reboot', $mytargets)` behaves the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
   The `puppetfile install` command now supports a `--puppetfile` option that accepts a relative or absolute path
   to a Puppetfile.
 
+* **Update reboot plan parameter `nodes` to `targets`** ([puppetlabs-reboot#223](https://github.com/puppetlabs/reboot/pulls/223)
+
+  Users who explicitly set the `nodes` parameter will need to update the parameter name to
+  `targets`. Calling the `reboot` plan with `-t` or `run_plan('reboot', $mytargets)` behaves the same
+  as before and does not require an update.
+
 ### Bug fixes
 
 * **Fixed performance regression with large inventory files** ([#1627](https://github.com/puppetlabs/bolt/pull/1627))

--- a/Puppetfile
+++ b/Puppetfile
@@ -25,7 +25,7 @@ mod 'puppetlabs-zone_core', '1.0.3'
 mod 'puppetlabs-package', '0.7.0'
 mod 'puppetlabs-puppet_conf', '0.4.0'
 mod 'puppetlabs-python_task_helper', '0.3.0'
-mod 'puppetlabs-reboot', '2.2.0'
+mod 'puppetlabs-reboot', '3.0.0'
 mod 'puppetlabs-ruby_task_helper', '0.4.0'
 mod 'puppetlabs-ruby_plugin_helper', '0.1.0'
 


### PR DESCRIPTION
The latest puppetlabs-reboot version updates the deprecated `nodes`
parameter to `targets`. This is a breaking change for users who
explicitly set the parameter, either in the `run_plan` plan function or
on the CLI. Users will need to update the `nodes` parameter to be
`targets` instead. Calling the plan using `-t` or with
`run_plan('reboot', $mytargets)` will both behave the same and do not
need to be updated.