### PR TITLE
#1634 - Upgrade reboot module version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@
   When using `run_plan(..., _catch_errors => true)` and making invalid modifications to the inventory, errors would
   be caught but the modifications would still be made to the inventory. Modifications to the inventory are now
   validated prior to applying them to the inventory.
+  
+* **Upgrade reboot module** ([#1634](https://github.com/puppetlabs/bolt/issues/1634))
+
+  Bolt had pinned an old version of the `puppetlabs-reboot` module that was not compatible with
+  Bolt `2.0`. This fix upgrades the `puppetlabs-reboot` module to a version that is compatible.
 
 ## Bolt 2.0.1
 

--- a/Puppetfile
+++ b/Puppetfile
@@ -25,7 +25,7 @@ mod 'puppetlabs-zone_core', '1.0.3'
 mod 'puppetlabs-package', '0.7.0'
 mod 'puppetlabs-puppet_conf', '0.4.0'
 mod 'puppetlabs-python_task_helper', '0.3.0'
-mod 'puppetlabs-reboot', '2.2.0'
+mod 'puppetlabs-reboot', '3.0.0'
 mod 'puppetlabs-ruby_task_helper', '0.4.0'
 mod 'puppetlabs-ruby_plugin_helper', '0.1.0'
 


### PR DESCRIPTION
Closes #1634 

Pinning latest version of the `reboot` module with the new fixes for `nodes` to `targets` conversion in Bolt 2.0.