### PR TITLE
(maint) Warning instead of exceptiong whith invalid @param metadata

### DIFF
--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -336,11 +336,16 @@ module Bolt
                       end
 
         defaults = plan.parameters.reject { |_, value| value.nil? }.to_h
+        signature_params = Set.new(plan.parameters.map(&:first))
         parameters = plan.tags(:param).each_with_object({}) do |param, params|
           name = param.name
-          params[name] = { 'type' => param.types.first }
-          params[name]['default_value'] = defaults[name] if defaults.key?(name)
-          params[name]['description'] = param.text unless param.text.empty?
+          if signature_params.include?(name)
+            params[name] = { 'type' => param.types.first }
+            params[name]['default_value'] = defaults[name] if defaults.key?(name)
+            params[name]['description'] = param.text unless param.text.empty?
+          else
+            @logger.warn("The documented parameter '#{name}' does not exist in plan signature")
+          end
         end
 
         {

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1179,6 +1179,30 @@ describe "Bolt::CLI" do
           )
         end
 
+        it "warns when yard doc parameters do not match the plan signature parameters" do
+          plan_name = 'sample::documented_param_typo'
+          options = {
+            subcommand: 'plan',
+            action: 'show',
+            object: plan_name
+          }
+          cli.execute(options)
+          json = JSON.parse(output.string)
+          expect(json).to eq(
+            "name" => plan_name,
+            "module_dir" => File.absolute_path(File.join(__dir__, "..", "fixtures", "modules", "sample")),
+            "description" => nil,
+            "parameters" => {
+              "oops" => {
+                "type" => "String",
+                "default_value" => "typo"
+              }
+            }
+          )
+          expected_log = /The documented parameter 'not_oops' does not exist in plan signature/m
+          expect(@log_output.readlines.join).to match(expected_log)
+        end
+
         it "shows an individual yaml plan data" do
           plan_name = 'sample::yaml'
           options = {

--- a/spec/fixtures/modules/sample/plans/documented_param_typo.pp
+++ b/spec/fixtures/modules/sample/plans/documented_param_typo.pp
@@ -1,0 +1,3 @@
+# @param not_oops
+#   Accidentally typoed the param name such that it does not match plan signature
+plan sample::documented_param_typo(String $oops = typo){}


### PR DESCRIPTION
Previously if there was a descrepency between the @param descriptions in plan metadata and the actual parameters in the plan signature there would be an unhandled exception trying to extract parameter descriptions. With this commit if there is a @param description that describes a parameter that is not in the plan function signature a warning is raised and the @param metadata is ignored.