### PR TITLE
(GH-1445) Package Bolt for MacOS 10.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Bolt Next
+## Bolt 2.1.0
 
 ### New features
 
@@ -18,6 +18,10 @@
   Users who explicitly set the `nodes` parameter will need to update the parameter name to
   `targets`. Calling the `reboot` plan with `-t` or `run_plan('reboot', $mytargets)` behaves the same
   as before and does not require an update.
+
+* **Package Bolt for MacOS 10.15** ([#1445](https://github.com/puppetlabs/bolt/issues/1445))
+
+  Bolt packages are now available for MacOS 10.15.
 
 ### Bug fixes
 

--- a/documentation/bolt_installing.md
+++ b/documentation/bolt_installing.md
@@ -139,6 +139,7 @@ Use the Apple Disk Image (DMG) to install Bolt on macOS.
     
     **Tip:** To find the macOS version number on your Mac, go to the Apple () menu in the corner of your screen and choose **About This Mac**.
     - 10.14 (Mojave) [https://downloads.puppet.com/mac/puppet6/10.14/x86_64/puppet-bolt-latest.dmg](https://downloads.puppet.com/mac/puppet6/10.14/x86_64/puppet-bolt-latest.dmg)
+    - 10.15 (Catalina) [https://downloads.puppet.com/mac/puppet/10.15/x86_64/puppet-bolt-latest.dmg](https://https://downloads.puppet.com/mac/puppet/10.15/x86_64/puppet-bolt-latest.dmg)
 1.  Double-click the `puppet-bolt-latest.dmg` file to mount it and then double-click `puppet-bolt-[version]-installer.pkg` to run the installer.
 1.  Open Terminal and run a Bolt command and get started.
     ```


### PR DESCRIPTION
This adds documentation for installing Bolt on MacOS 10.15.

Related PRs:
- [x] [ci-job-configs](https://github.com/puppetlabs/ci-job-configs/pull/6834)
- [x] [bolt-vanagon](https://github.com/puppetlabs/bolt-vanagon/pull/133)

Closes #1445