### PR TITLE
(GH-1433) Only pass apply_settings task param when set

### DIFF
--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -225,10 +225,11 @@ module Bolt
                 arguments = {
                   'catalog' => Puppet::Pops::Types::PSensitiveType::Sensitive.new(catalog),
                   'plugins' => Puppet::Pops::Types::PSensitiveType::Sensitive.new(plugins),
-                  'apply_settings' => @apply_settings,
                   '_task' => catalog_apply_task.name,
                   '_noop' => options[:noop]
                 }
+
+                arguments.merge!({ 'apply_settings' => @apply_settings }) unless @apply_settings.empty?
 
                 callback = proc do |event|
                   if event[:type] == :node_result

--- a/libexec/apply_catalog.rb
+++ b/libexec/apply_catalog.rb
@@ -28,7 +28,9 @@ Puppet[:report] = false
 
 # Make sure to apply the catalog
 Puppet[:noop] = args['_noop'] || false
-args['apply_settings'].each do |setting, value|
+
+apply_settings = args['apply_settings'] || {}
+apply_settings.each do |setting, value|
   Puppet[setting.to_sym] = value
 end
 


### PR DESCRIPTION
Previously the apply_setting task parameter to the apply_catalog task would always be passed even if there were no apply_settings. This is incompatible with the puppetlabs-apply_helpers 0.1.0 module. Specifically if the apply_settings task parameter is passed to the task the task metadata forbids that parameter. The 0.2.0 module supports the apply_settings argument. With this commit we maintain compatibility with both versions.