### PR TITLE
(docs) Fix incorrect server-urls key in PuppetDB connect docs

### DIFF
--- a/documentation/bolt_connect_puppetdb.md
+++ b/documentation/bolt_connect_puppetdb.md
@@ -35,7 +35,7 @@ curl -X GET https://$SERVER_URL/pdb/query/v4 --data-urlencode 'query=nodes[certn
 
 To configure the Bolt PuppetDB client, add a `puppetdb` section to your [Bolt config](configuring_bolt.md) with the following values:
 
--   `server-urls`: An array containing the PuppetDB host to connect to. Include the protocol `https` and the port, which is usually `8081`. For example, `https://my-master.example.com:8081`.
+-   `server_urls`: An array containing the PuppetDB host to connect to. Include the protocol `https` and the port, which is usually `8081`. For example, `https://my-master.example.com:8081`.
 -   `cacert`: The path to the ca certificate for PuppetDB.
 
 If you are using certificate authentication also set:


### PR DESCRIPTION
This updates the PuppetDB docs to show the correct `server_urls` key
instead of `server-urls`.