### PR TITLE
(Docs) Using a more generic password in the docs

### DIFF
--- a/documentation/writing_plans.md
+++ b/documentation/writing_plans.md
@@ -355,7 +355,7 @@ Task parameters defined as sensitive are masked when they appear in plans.
 You define a task parameter as sensitive with the metadata property `"sensitive": true`. When a task runs, the values for these sensitive parameters are masked.
 
 ```
-run_task('task_with_secrets', ..., password => '$ecret!')
+run_task('task_with_secrets', ..., password => 'hunter2')
 ```
 
 ### Working with the sensitive function
@@ -363,7 +363,7 @@ run_task('task_with_secrets', ..., password => '$ecret!')
 In Puppet you use the `Sensitive` function to mask data in output logs. Because plans are written in Puppet DSL, you can use this type freely. The `run_task()` function does not allow parameters of `Sensitive` function to be passed. When you need to pass a sensitive value to a task, you must unwrap it prior to calling `run_task()`.
 
 ```
-$pass = Sensitive('$ecret!')
+$pass = Sensitive('hunter2')
 run_task('task_with_secrets', ..., password => $pass.unwrap)
 ```
 


### PR DESCRIPTION
This is to address user feedback:
> While I definitely appreciate the cleverness of the “$ecret!” string in the “Passing sensitive data to tasks” section, it may be better to use a string that does not start with $ as that’s also how Puppet variable names start and this could be confusing for those less well-versed in Puppet.

FYI: `$ecret!` is also used a lot in the code, too. I figure the code isn't user-facing though.