### PR TITLE
(maint) Enable new Hash cops in Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,15 @@ AllCops:
 
 # Checks for if and unless statements that would fit on one line if written as a
 # modifier if/unless.
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
 Style/IfUnlessModifier:
   Enabled: false
 

--- a/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
@@ -51,7 +51,7 @@ Puppet::Functions.create_function(:run_command) do
         .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'run_command')
     end
 
-    options = options.map { |k, v| [k.sub(/^_/, '').to_sym, v] }.to_h
+    options = options.transform_keys { |k| k.sub(/^_/, '').to_sym }
     options[:description] = description if description
 
     executor = Puppet.lookup(:bolt_executor)

--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -59,7 +59,7 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
     executor = Puppet.lookup(:bolt_executor)
 
     options, params = args.partition { |k, _v| k.start_with?('_') }.map(&:to_h)
-    options = options.map { |k, v| [k.sub(/^_/, '').to_sym, v] }.to_h
+    options = options.transform_keys { |k| k.sub(/^_/, '').to_sym }
 
     # Bolt calls this function internally to trigger plans from the CLI. We
     # don't want to count those invocations.

--- a/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
@@ -58,7 +58,7 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
     end
 
     arguments = options['arguments'] || []
-    options = options.select { |opt| opt.start_with?('_') }.map { |k, v| [k.sub(/^_/, '').to_sym, v] }.to_h
+    options = options.select { |opt| opt.start_with?('_') }.transform_keys { |k| k.sub(/^_/, '').to_sym }
     options[:description] = description if description
 
     executor = Puppet.lookup(:bolt_executor)

--- a/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
@@ -56,7 +56,7 @@ Puppet::Functions.create_function(:run_task) do
     end
 
     options, params = args.partition { |k, _v| k.start_with?('_') }.map(&:to_h)
-    options = options.map { |k, v| [k.sub(/^_/, '').to_sym, v] }.to_h
+    options = options.transform_keys { |k| k.sub(/^_/, '').to_sym }
 
     executor = Puppet.lookup(:bolt_executor)
     inventory = Puppet.lookup(:bolt_inventory)

--- a/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
@@ -61,7 +61,7 @@ Puppet::Functions.create_function(:upload_file, Puppet::Functions::InternalFunct
         .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'upload_file')
     end
 
-    options = options.select { |opt| opt.start_with?('_') }.map { |k, v| [k.sub(/^_/, '').to_sym, v] }.to_h
+    options = options.select { |opt| opt.start_with?('_') }.transform_keys { |k| k.sub(/^_/, '').to_sym }
     options[:description] = description if description
 
     executor = Puppet.lookup(:bolt_executor)

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -151,7 +151,7 @@ module Bolt
       if args.count > 1
         type1 = Puppet.lookup(:pal_script_compiler).type('Hash[String, Data]')
         Puppet::Pal.assert_type(type1, args[1], 'apply options')
-        options = args[1].map { |k, v| [k.sub(/^_/, '').to_sym, v] }.to_h
+        options = args[1].transform_keys { |k| k.sub(/^_/, '').to_sym }
       end
 
       plan_vars = scope.to_hash(true, true)

--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -133,7 +133,7 @@ module Bolt
         raise PluginError.new(msg, 'bolt/plugin-error')
       end
 
-      config.plugins.keys.each do |plugin|
+      config.plugins.each_key do |plugin|
         plugins.by_name(plugin)
       end
 
@@ -263,9 +263,9 @@ module Bolt
       if data.is_a?(Array)
         data.flat_map { |elem| resolve_top_level_references(elem) }
       elsif reference?(data)
-        partially_resolved = data.map do |k, v|
-          [k, resolve_references(v)]
-        end.to_h
+        partially_resolved = data.transform_values do |v|
+          resolve_references(v)
+        end
         fully_resolved = resolve_single_reference(partially_resolved)
         # The top-level reference may have returned more references, so repeat the process
         resolve_top_level_references(fully_resolved)

--- a/lib/bolt/plugin/module.rb
+++ b/lib/bolt/plugin/module.rb
@@ -91,7 +91,7 @@ module Bolt
       end
 
       def validate_config(config, config_schema)
-        config.keys.each do |key|
+        config.each_key do |key|
           msg = "Config for #{name} plugin contains unexpected key #{key}"
           raise Bolt::ValidationError, msg unless config_schema.include?(key)
         end

--- a/lib/bolt/plugin/pkcs7.rb
+++ b/lib/bolt/plugin/pkcs7.rb
@@ -14,7 +14,7 @@ module Bolt
           end
         end
 
-        config.keys.each do |key|
+        config.each_key do |key|
           unless known_keys.include?(key)
             raise Bolt::ValidationError, "Unpexpected key in pkcs7 plugin config: #{key}"
           end

--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -78,7 +78,7 @@ module Bolt
 
     def _pcore_init_from_hash(init_hash)
       opts = init_hash.reject { |k, _v| k == 'target' }
-      initialize(init_hash['target'], opts.map { |k, v| [k.to_sym, v] }.to_h)
+      initialize(init_hash['target'], opts.transform_keys(&:to_sym))
     end
 
     def _pcore_init_hash

--- a/lib/bolt_spec/plans/action_stubs/command_stub.rb
+++ b/lib/bolt_spec/plans/action_stubs/command_stub.rb
@@ -36,7 +36,7 @@ module BoltSpec
 
       def with_params(params)
         @invocation[:options] = params.select { |k, _v| k.start_with?('_') }
-                                      .map { |k, v| [k.sub(/^_/, '').to_sym, v] }.to_h
+                                      .transform_keys { |k| k.sub(/^_/, '').to_sym }
         self
       end
     end

--- a/lib/bolt_spec/plans/action_stubs/script_stub.rb
+++ b/lib/bolt_spec/plans/action_stubs/script_stub.rb
@@ -44,7 +44,7 @@ module BoltSpec
         @invocation[:params] = params
         @invocation[:arguments] = params['arguments']
         @invocation[:options] = params.select { |k, _v| k.start_with?('_') }
-                                      .map { |k, v| [k.sub(/^_/, '').to_sym, v] }.to_h
+                                      .transform_keys { |k| k.sub(/^_/, '').to_sym }
         self
       end
     end

--- a/lib/bolt_spec/plans/action_stubs/task_stub.rb
+++ b/lib/bolt_spec/plans/action_stubs/task_stub.rb
@@ -23,7 +23,7 @@ module BoltSpec
         @calls += 1
         if @return_block
           # Merge arguments and options into params to match puppet function signature.
-          params = options.map { |k, v| ["_#{k}", v] }.to_h
+          params = options.transform_keys { |k| "_#{k}" }
           params = params.merge(arguments)
 
           check_resultset(@return_block.call(targets: targets, task: task, params: params), task)
@@ -49,7 +49,7 @@ module BoltSpec
         @invocation[:params] = params
         @invocation[:arguments] = params.reject { |k, _v| k.start_with?('_') }
         @invocation[:options] = params.select { |k, _v| k.start_with?('_') }
-                                      .map { |k, v| [k.sub(/^_/, '').to_sym, v] }.to_h
+                                      .transform_keys { |k| k.sub(/^_/, '').to_sym }
         self
       end
     end

--- a/lib/bolt_spec/plans/action_stubs/upload_stub.rb
+++ b/lib/bolt_spec/plans/action_stubs/upload_stub.rb
@@ -57,7 +57,7 @@ module BoltSpec
 
       def with_params(params)
         @invocation[:options] = params.select { |k, _v| k.start_with?('_') }
-                                      .map { |k, v| [k.sub(/^_/, '').to_sym, v] }.to_h
+                                      .transform_keys { |k| k.sub(/^_/, '').to_sym }
         self
       end
     end

--- a/libexec/apply_catalog.rb
+++ b/libexec/apply_catalog.rb
@@ -68,7 +68,7 @@ begin
     end
 
     # Transport.connect will modify this hash!
-    transport_conn_info = conn_info.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
+    transport_conn_info = conn_info.transform_keys(&:to_sym)
 
     transport = Puppet::ResourceApi::Transport.connect(type, transport_conn_info)
     Puppet::ResourceApi::Transport.inject_device(type, transport)

--- a/libexec/custom_facts.rb
+++ b/libexec/custom_facts.rb
@@ -46,7 +46,7 @@ Dir.mktmpdir do |puppet_root|
     end
 
     # Transport.connect will modify this hash!
-    transport_conn_info = conn_info.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
+    transport_conn_info = conn_info.transform_keys(&:to_sym)
     transport = Puppet::ResourceApi::Transport.connect(type, transport_conn_info)
     Puppet::ResourceApi::Transport.inject_device(type, transport)
 

--- a/libexec/query_resources.rb
+++ b/libexec/query_resources.rb
@@ -53,7 +53,7 @@ Dir.mktmpdir do |puppet_root|
     end
 
     # Transport.connect will modify this hash!
-    transport_conn_info = conn_info.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
+    transport_conn_info = conn_info.transform_keys(&:to_sym)
 
     transport = Puppet::ResourceApi::Transport.connect(type, transport_conn_info)
     Puppet::ResourceApi::Transport.inject_device(type, transport)

--- a/spec/lib/bolt_spec/puppetdb.rb
+++ b/spec/lib/bolt_spec/puppetdb.rb
@@ -55,7 +55,7 @@ module BoltSpec
     end
 
     def clear_facts(facts_hash)
-      facts_hash.keys.each { |certname| deactivate_node(certname, wait: 30) }
+      facts_hash.each_key { |certname| deactivate_node(certname, wait: 30) }
     end
 
     def pdb_client


### PR DESCRIPTION
This enables the new Rubocop cops `Style/HashEachMethods`,
`Style/HashTransformKeys`, and `Style/HashTransformValues`.