### PR TITLE
(maint) Update Docker container to install apt-transport-https

### DIFF
--- a/spec/Dockerfile
+++ b/spec/Dockerfile
@@ -1,6 +1,6 @@
 # Travis not using 18.04 yet
 FROM rastasheep/ubuntu-sshd:16.04
-RUN apt-get update && apt-get -y install sudo tree && apt-get -y install locales
+RUN apt-get update && apt-get -y install sudo tree locales apt-transport-https
 RUN locale-gen en_US.UTF-8
 
 ENV LC_ALL="en_US.UTF-8"


### PR DESCRIPTION
This updates the Dockerfile for building images used in spec tests to
install the `apt-transport-https` package. The `puppet5` repo was
recently updated to pull packages from the `https` site, causing several
integration tests that installed packages from this collection to fail.
Adding the `apt-transport-https` package allows `apt` to download
packages from the `https` site.