### PR TITLE
(GH-1574) Initialize a Bolt project with modules

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -49,6 +49,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "puppet", [">= 6.11.0", "< 7"]
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "puppet-strings", "~> 2.3"
+  spec.add_dependency "puppetfile-resolver", "~> 0.1.0"
   spec.add_dependency "r10k", "~> 3.1"
   spec.add_dependency "ruby_smb", "~> 1.0"
   spec.add_dependency "terminal-table", "~> 1.8"

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -76,7 +76,7 @@ module Bolt
       when 'project'
         case action
         when 'init'
-          { flags: OPTIONS[:global],
+          { flags: OPTIONS[:global] + %w[modules],
             banner: PROJECT_INIT_HELP }
         when 'migrate'
           { flags: OPTIONS[:global] + %w[inventoryfile boltdir configfile],
@@ -391,6 +391,8 @@ module Bolt
             bolt project init
           Create a new Bolt project at a specified path.
             bolt project init ~/path/to/project
+          Create a new Bolt project with existing modules.
+            bolt project init --modules puppetlabs-apt,puppetlabs-ntp
     HELP
 
     PROJECT_MIGRATE_HELP = <<~HELP
@@ -761,6 +763,13 @@ module Bolt
       end
       define('--trace', 'Display error stack traces') do |_|
         @options[:trace] = true
+      end
+
+      separator "\nADDITIONAL OPTIONS"
+      define('--modules MODULES',
+             'A comma-separated list of modules to install from the Puppet Forge',
+             'when initializing a project. Resolves and installs all dependencies.') do |modules|
+        @options[:modules] = modules.split(',')
       end
 
       separator "\nGLOBAL OPTIONS"


### PR DESCRIPTION
This adds support for initializing a Bolt project with a set of
specified modules and their dependencies. A new CLI option `--modules`
accepts a comma-separated list of module names (e.g. `puppetlabs-apt`).

Bolt uses the `puppetfile-resolver` gem to parse the list of modules
provided at the CLI and then resolves a dependency graph for the
modules. If any of the specified modules or their dependencies are
missing, the command errors and the project directory is not created. If
the dependency graph is resolved successfully, the list of modules and
dependencies are written to a Puppetfile in the new project directory
and `bolt puppetfile install` is immediately run against this
Puppetfile.

### TODO

- [x] Update `puppet-runtime` with `puppetfile-resolver` and `monitillo` dependencies https://github.com/puppetlabs/puppet-runtime/pull/308

Closes #1574 