### PR TITLE
Enable to use basic_auth_only option from winrm gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Bolt NEXT
+
+### New features
+
+* **Enable basic-auth-only option for WinRM when using SSL** ([#1658](https://github.com/puppetlabs/bolt/pulls/1658)
+
+  Users can now use WinRM Basic authentication when SSL is configured.
+
 ## Bolt 2.2.0
 
 ### New features

--- a/lib/bolt/config/transport/winrm.rb
+++ b/lib/bolt/config/transport/winrm.rb
@@ -8,6 +8,8 @@ module Bolt
     module Transport
       class WinRM < Base
         OPTIONS = {
+          "basic-auth-only" => { type: TrueClass,
+                                 desc: "Force basic authentication. This option is only available when using SSL." },
           "cacert"          => { type: String,
                                  desc: "The path to the CA certificate." },
           "connect-timeout" => { type: Integer,
@@ -50,6 +52,7 @@ module Bolt
         }.freeze
 
         DEFAULTS = {
+          "basic-auth-only" => false,
           "connect-timeout" => 10,
           "ssl"             => true,
           "ssl-verify"      => true,
@@ -68,6 +71,10 @@ module Bolt
               @config['cacert'] = File.expand_path(@config['cacert'], @boltdir)
               Bolt::Util.validate_file('cacert', @config['cacert'])
             end
+          end
+
+          if !@config['ssl'] && @config['basic-auth-only']
+            raise Bolt::ValidationError, "Basic auth is only allowed when using SSL"
           end
 
           if @config['interpreters']

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -63,7 +63,7 @@ module Bolt
         unless !!ssl_flag == ssl_flag
           raise Bolt::ValidationError, 'ssl option must be a Boolean true or false'
         end
-        
+
         basic_auth_only_flag = options['basic-auth-only']
         unless !!basic_auth_only_flag == basic_auth_only_flag
           raise Bolt::ValidationError, 'basic-auth-only option must be a Boolean true or false'

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -7,6 +7,48 @@ require 'bolt/transport/powershell'
 module Bolt
   module Transport
     class WinRM < Base
+      OPTIONS = {
+        "cacert"          => "The path to the CA certificate.",
+        "connect-timeout" => "How long Bolt should wait when establishing connections.",
+        "extensions"      => "List of file extensions that are accepted for scripts or tasks. "\
+                              "Scripts with these file extensions rely on the target's file type "\
+                              "association to run. For example, if Python is installed on the system, "\
+                              "a `.py` script runs with `python.exe`. The extensions `.ps1`, `.rb`, and "\
+                              "`.pp` are always allowed and run via hard-coded executables.",
+        "file-protocol"   => "Which file transfer protocol to use. Either `winrm` or `smb`. Using `smb` is "\
+                              "recommended for large file transfers.",
+        "host"            => "Host name.",
+        "interpreters"    => "A map of an extension name to the absolute path of an executable, "\
+                              "enabling you to override the shebang defined in a task executable. The "\
+                              "extension can optionally be specified with the `.` character (`.py` and "\
+                              "`py` both map to a task executable `task.py`) and the extension is case "\
+                              "sensitive. When a target's name is `localhost`, Ruby tasks run with the "\
+                              "Bolt Ruby interpreter by default.",
+        "password"        => "Login password. **Required unless using Kerberos.**",
+        "port"            => "Connection port.",
+        "realm"           => "Kerberos realm (Active Directory domain) to authenticate against.",
+        "smb-port"        => "With file-protocol set to smb, this is the port to establish a connection on.",
+        "ssl"             => "When true, Bolt uses secure https connections for WinRM.",
+        "ssl-verify"      => "When true, verifies the targets certificate matches the cacert.",
+        "tmpdir"          => "The directory to upload and execute temporary files on the target.",
+        "user"            => "Login user. **Required unless using Kerberos.**",
+        "basic-auth-only" => "Force basic authentication."
+      }.freeze
+
+      def self.options
+        OPTIONS.keys
+      end
+
+      def self.default_options
+        {
+          'connect-timeout' => 10,
+          'ssl' => true,
+          'ssl-verify' => true,
+          'file-protocol' => 'winrm'
+          'basic_auth_only' => false,
+        }
+      end
+
       def provided_features
         ['powershell']
       end
@@ -14,6 +56,37 @@ module Bolt
       def default_input_method(executable)
         input_method ||= Powershell.powershell_file?(executable) ? 'powershell' : 'both'
         input_method
+      end
+
+      def self.validate(options)
+        ssl_flag = options['ssl']
+        unless !!ssl_flag == ssl_flag
+          raise Bolt::ValidationError, 'ssl option must be a Boolean true or false'
+        end
+        
+        basic_auth_only_flag = options['basic-auth-only']
+        unless !!basic_auth_only_flag == basic_auth_only_flag
+          raise Bolt::ValidationError, 'basic-auth-only option must be a Boolean true or false'
+        end
+
+        if ssl_flag && (options['file-protocol'] == 'smb')
+          raise Bolt::ValidationError, 'SMB file transfers are not allowed with SSL enabled'
+        end
+
+        if ssl_flag && (ca_path = options['cacert'])
+          Bolt::Util.validate_file('cacert', ca_path)
+        end
+
+        ssl_verify_flag = options['ssl-verify']
+        unless !!ssl_verify_flag == ssl_verify_flag
+          raise Bolt::ValidationError, 'ssl-verify option must be a Boolean true or false'
+        end
+
+        timeout_value = options['connect-timeout']
+        unless timeout_value.is_a?(Integer) || timeout_value.nil?
+          error_msg = "connect-timeout value must be an Integer, received #{timeout_value}:#{timeout_value.class}"
+          raise Bolt::ValidationError, error_msg
+        end
       end
 
       def initialize

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -44,8 +44,8 @@ module Bolt
           'connect-timeout' => 10,
           'ssl' => true,
           'ssl-verify' => true,
-          'file-protocol' => 'winrm'
-          'basic_auth_only' => false,
+          'file-protocol' => 'winrm',
+          'basic-auth-only' => false
         }
       end
 

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -49,8 +49,8 @@ module Bolt
                       password: target.options['realm'] ? 'dummy' : target.password,
                       retry_limit: 1,
                       transport: transport,
-                      ca_trust_path: cacert,
                       basic_auth_only: target.options['basic-auth-only'],
+                      ca_trust_path: cacert,
                       realm: target.options['realm'],
                       no_ssl_peer_verification: !target.options['ssl-verify'] }
 

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -50,6 +50,7 @@ module Bolt
                       retry_limit: 1,
                       transport: transport,
                       ca_trust_path: cacert,
+                      basic_auth_only: target.options['basic-auth-only'],
                       realm: target.options['realm'],
                       no_ssl_peer_verification: !target.options['ssl-verify'] }
 

--- a/spec/bolt/config/transport/winrm_spec.rb
+++ b/spec/bolt/config/transport/winrm_spec.rb
@@ -29,7 +29,7 @@ describe Bolt::Config::Transport::WinRM do
       end
     end
 
-    %w[cacert file-protocol host password realm tmpdir user].each do |opt|
+    %w[cacert file-protocol host password realm tmpdir user basic-auth-only].each do |opt|
       it "#{opt} errors with wrong type" do
         data[opt] = 100
         expect { transport.new(data) }.to raise_error(Bolt::ValidationError)
@@ -50,6 +50,14 @@ describe Bolt::Config::Transport::WinRM do
       it 'errors when using smb with ssl enabled' do
         data['ssl'] = true
         data['file-protocol'] = 'smb'
+        expect { transport.new(data) }.to raise_error(Bolt::ValidationError)
+      end
+    end
+
+    context 'basic-auth-only' do
+      it 'errors when not using ssl' do
+        data['ssl'] = false
+        data['basic-auth-only'] = true
         expect { transport.new(data) }.to raise_error(Bolt::ValidationError)
       end
     end

--- a/spec/bolt/inventory/inventory_spec.rb
+++ b/spec/bolt/inventory/inventory_spec.rb
@@ -528,7 +528,7 @@ describe Bolt::Inventory::Inventory do
           let(:data) {
             {
               'targets' => ['target'],
-              'config' => { 'winrm' => { 'basic-auth-only' => 'true' } }
+              'config' => { 'transport' => 'winrm', 'winrm' => { 'basic-auth-only' => 'true' } }
             }
           }
 
@@ -610,7 +610,7 @@ describe Bolt::Inventory::Inventory do
             'password' => 'you' + transport,
             'port' => 12345,
             'private-key' => 'anything',
-            'ssl' => false,
+            'ssl' => true,
             'ssl-verify' => false,
             'host-key-check' => false,
             'connect-timeout' => transport.size,
@@ -649,10 +649,10 @@ describe Bolt::Inventory::Inventory do
         it 'should not modify existing config' do
           get_target(inventory, 'ssh://target')
           expect(conf.transport).to eq('ssh')
-          expect(conf.transports[:ssh]['host-key-check']).to be nil
-          expect(conf.transports[:winrm]['ssl']).to be true
-          expect(conf.transports[:winrm]['ssl-verify']).to be true
-          expect(conf.transports[:winrm]['basic-auth-only']).to be false
+          expect(conf.transports['ssh']['host-key-check']).to be nil
+          expect(conf.transports['winrm']['ssl']).to be true
+          expect(conf.transports['winrm']['ssl-verify']).to be true
+          expect(conf.transports['winrm']['basic-auth-only']).to be false
         end
 
         it 'uses the configured transport' do
@@ -690,7 +690,7 @@ describe Bolt::Inventory::Inventory do
           expect(target.port).to eq(12345)
           expect(target.options.to_h).to include(
             'connect-timeout' => 5,
-            'ssl' => false,
+            'ssl' => true,
             'ssl-verify' => false,
             'tmpdir' => "/winrm",
             'extensions' => [".py"],

--- a/spec/bolt/inventory/inventory_spec.rb
+++ b/spec/bolt/inventory/inventory_spec.rb
@@ -523,6 +523,19 @@ describe Bolt::Inventory::Inventory do
             expect { inventory.get_targets('target') }.to raise_error(Bolt::ValidationError)
           end
         end
+        
+        context 'basic-auth-only' do
+          let(:data) {
+            {
+              'targets' => ['target'],
+              'config' => { 'winrm' => { 'basic-auth-only' => 'true' } }
+            }
+          }
+
+          it 'fails validation' do
+            expect { inventory.get_targets('target') }.to raise_error(Bolt::ValidationError)
+          end
+        end
 
         context 'transport' do
           let(:data) {

--- a/spec/bolt/inventory/inventory_spec.rb
+++ b/spec/bolt/inventory/inventory_spec.rb
@@ -523,7 +523,7 @@ describe Bolt::Inventory::Inventory do
             expect { inventory.get_targets('target') }.to raise_error(Bolt::ValidationError)
           end
         end
-        
+
         context 'basic-auth-only' do
           let(:data) {
             {

--- a/spec/bolt/inventory/inventory_spec.rb
+++ b/spec/bolt/inventory/inventory_spec.rb
@@ -622,7 +622,8 @@ describe Bolt::Inventory::Inventory do
             'service-url' => 'https://master',
             'cacert' => transport + '.pem',
             'token-file' => 'token',
-            'task-environment' => 'prod'
+            'task-environment' => 'prod',
+            'basic-auth-only' => true
           }
         end
 
@@ -648,9 +649,10 @@ describe Bolt::Inventory::Inventory do
         it 'should not modify existing config' do
           get_target(inventory, 'ssh://target')
           expect(conf.transport).to eq('ssh')
-          expect(conf.transports['ssh']['host-key-check']).to be nil
-          expect(conf.transports['winrm']['ssl']).to be true
-          expect(conf.transports['winrm']['ssl-verify']).to be true
+          expect(conf.transports[:ssh]['host-key-check']).to be nil
+          expect(conf.transports[:winrm]['ssl']).to be true
+          expect(conf.transports[:winrm]['ssl-verify']).to be true
+          expect(conf.transports[:winrm]['basic-auth-only]).to be false
         end
 
         it 'uses the configured transport' do
@@ -696,7 +698,8 @@ describe Bolt::Inventory::Inventory do
             'port' => 12345,
             'user' => 'mewinrm',
             'file-protocol' => 'winrm',
-            'cacert' => /winrm.pem\z/
+            'cacert' => /winrm.pem\z/,
+            'basic-auth-only' => true
           )
         end
 

--- a/spec/bolt/inventory/inventory_spec.rb
+++ b/spec/bolt/inventory/inventory_spec.rb
@@ -652,7 +652,7 @@ describe Bolt::Inventory::Inventory do
           expect(conf.transports[:ssh]['host-key-check']).to be nil
           expect(conf.transports[:winrm]['ssl']).to be true
           expect(conf.transports[:winrm]['ssl-verify']).to be true
-          expect(conf.transports[:winrm]['basic-auth-only]).to be false
+          expect(conf.transports[:winrm]['basic-auth-only']).to be false
         end
 
         it 'uses the configured transport' do


### PR DESCRIPTION
This pull request adds an option for the winrm transport named `basic-auth-only`, which is by default set to false, but if set to true will force basic auth by passing the corresponding `basic_auth_only` option to the winrm gem.
If there is an easier solution to my issue than to force basic auth, I would gladly welcome any advice.

I set up winRM to use with basicAuth on a machine at our site. I was able to connect properly using plain winRM powershell commands where I can pass the auth method via `-Authentication Basic`. For bolt this was not possible, the connection failed with an `AUTH_ERROR` all the time.
I looked into the code and saw that bolt offers no option to enforce basic_auth, while the winrm gem offers this option via `basic_auth_only`.