### PR TITLE
(GH-1555) Automatically generate changelog from commit notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,19 @@ License Agreement before we can accept your pull request: https://cla.puppet.com
 1. Add the puppetlabs repo as an upstream - `git remote add upstream git@github.com:puppetlabs/bolt`
 1. Make a new branch off of master - `git checkout -b mybranchname`
 1. Commit your changes and add a useful commit message, including what specifically you changed and why - `git commit`
+    * If your changes are user-facing, add a release note to the end of a commit message. Release notes should begin
+      with a label indicating what kind of change you are making. Valid labels include `!feature`, `!bug`, `!deprecation`,
+      and `!removal`. 
+      
+      Release notes should follow this format:
+
+      ```
+      !label
+
+      * **Descriptive title of changes** ([#issue_number](issue_url))
+
+        Descriptive summary of changes.
+      ```
 1. Push your changes to your branch on your fork - `git push origin mybranchname`
 1. Open a PR against master at https://github.com/puppetlabs/bolt
 

--- a/Rakefile
+++ b/Rakefile
@@ -263,5 +263,10 @@ namespace :integration do
   end
 end
 
+desc 'Generate changelog'
+task :changelog, [:version] do |_t, args|
+  sh "./scripts/generate_changelog.rb #{args[:version]}"
+end
+
 spec = Gem::Specification.find_by_name 'gettext-setup'
 load "#{spec.gem_dir}/lib/tasks/gettext.rake"

--- a/developer-docs/releasing-bolt.md
+++ b/developer-docs/releasing-bolt.md
@@ -1,9 +1,9 @@
 # Releasing Bolt 
 
-Hello, fearless reader! This document details the release process for Bolt. Our current release cadence is weekly for both the bolt gem and bolt system package, usually on Wednesdays. Here's how we do it: 
+Hello, fearless reader! This document details the release process for Bolt. Our current release cadence is weekly for both the bolt gem and bolt system package, usually on Mondays. Here's how we do it: 
 
-1. Ensure the [CHANGELOG](https://github.com/puppetlabs/bolt/blob/master/CHANGELOG.md) has been updated to include all of the relevant changes included in the release under the new version header and has been merged in to the master branch.
+1. Generate the changelog using the rake task `rake 'changelog[VERSION]'`, where `VERSION` is the new tag, and merge the changes into `master`.
 2. Build and stage bolt packages with the [init_bolt-release job](https://jenkins-master-prod-1.delivery.puppetlabs.net/view/bolt/job/platform_bolt-vanagon_bolt-release-init_bolt-release/) using all defaults except the new tag for Bolt. The version specified will be the new tag in the github repo.
 3. Once step 2 is done and you are ready to push the packages to public repositories, run the [release job](https://jenkins-master-prod-1.delivery.puppetlabs.net/view/bolt/job/platform_ship-bolt_stage-foss-artifacts-all-repos/) with all default parameters except the new tag. This will also kick off the [docs publishing job](https://jenkins-master-prod-1.delivery.puppetlabs.net/view/bolt/job/platform_ship-bolt_publish_docs/) which will build and publish the docs based on the new tag. Note that this job can be run against any REF as a stand-alone pipeline in the case where a change is needed outside of a tagged version. 
 4. After packages are made public update the [Homebrew tap](https://github.com/puppetlabs/homebrew-puppet) with the new version of bolt. This can be accomplished by running the rake task `rake 'brew:cask[puppet-bolt]'` and opening a PR with the changes. Make sure the PR passes the Travis integration tests and merge the PR. 
-5. Once packages are public alert the docs team in `#docs-edu-bolt` that a release announcement is ready to be published.
+5. Once packages are public, send an email to the internal-puppet-products-update group.

--- a/scripts/generate_changelog.rb
+++ b/scripts/generate_changelog.rb
@@ -1,0 +1,99 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'open3'
+
+# Parses individual notes by searching for a !label, normalizing it to a
+# valid entry key, and returning both the normalized label and the changelog
+# entry
+def parse_commit(labels, commit)
+  regex   = /!(?<label>#{labels.join('|')})(?<entry>[\s\S]*)\z/
+  matches = commit.match(regex)
+  [matches[:label], matches[:entry].strip] if matches
+end
+
+# Map of valid labels to their full name and list of entries.
+# Any notes that do not have a valid label are ignored and not added
+# to the changelog.
+entries = {
+  'feature'     => { name: 'New features', entries: [] },
+  'bug'         => { name: 'Bug fixes',    entries: [] },
+  'deprecation' => { name: 'Deprecations', entries: [] },
+  'removal'     => { name: 'Removals',     entries: [] }
+}
+
+version    = ARGV.first
+changelog  = File.expand_path('CHANGELOG.md', Dir.pwd)
+
+unless version
+  warn "Usage: generate_changelog.rb VERSION"
+  exit 1
+end
+
+unless File.file?(changelog)
+  warn "Could not find changelog at #{changelog}"
+  exit 1
+end
+
+# Get the latest tag
+latest = `git describe --abbrev=0`.chomp
+
+# Read the git log between master and the most recent tagged release
+# The log is formatted to only include the body of a commit and are
+# terminated with a null terminator. These entries are then filtered
+# to only include those that have a valid LABEL (e.g. !feature, !bug)
+stdout_str, stderr_str, status = Open3.capture3(
+  "git log -z HEAD...#{latest} "\
+  "--pretty=format:'%b' "\
+  "--grep='!(#{entries.keys.join('|')})' -E"
+)
+
+if status.success?
+  # Create an array of commit messages
+  commits = stdout_str.split("\u0000")
+
+  if commits.empty?
+    warn "Did not find any changelog entries"
+    exit 0
+  end
+
+  # Parse the notes and map them to the correct list of entries
+  commits.each do |commit|
+    label, entry = parse_commit(entries.keys, commit)
+
+    if entries.key?(label)
+      entries[label][:entries] << entry
+    end
+  end
+else
+  warn stderr_str
+  exit 1
+end
+
+# Build the new changelog content from the list of valid notes
+new_content = <<~CONTENT
+  # Changelog
+
+  ## Bolt #{version} (#{Time.now.strftime '%Y-%m-%d'})
+
+CONTENT
+
+entries.each_value do |entry|
+  next unless entry[:entries].any?
+  new_content += <<~CONTENT
+    ### #{entry[:name]}
+
+    #{entry[:entries].join("\n\n")}
+  CONTENT
+end
+
+content = new_content + File.read(changelog)
+                            .split("\n")[1..-1]
+                            .join("\n")
+
+if File.write(changelog, content)
+  puts "Successfully wrote entries to #{changelog}"
+else
+  warn "Unable to write entries to #{changelog}"
+  exit 1
+end


### PR DESCRIPTION
This adds a rake task that executes a script to generate changelog
entries from commit messages. To execute the rake task, run `rake
'changelog[VERSION]'`, where `VERSION` is the new tag.

The script filters commits listed by the `git log` command and parses
them based on valid `!` labels. The list of valid labels are `feature`,
`bug`, `removal`, and `deprecation`. The label is followed by the
formatted changelog entry.

Closes #1555 

### Example

A commit message with a changelog entry would look like this:

```
<commit message>

!feature

* **Added a rake task to generate changelog entries** ([#1555](https://github.com/puppetlabs/bolt/issues/1555))

  Added a rake task that generates changelog entries from commit messages.
```