### PR TITLE
(Docs) Removing symlink for changelog

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -1,1 +1,0 @@
-../CHANGELOG.md


### PR DESCRIPTION
Removing the unused changelog symlink in /documentation