### PR TITLE
(maint) Fix title capitalization in Bolt functions reference doc

### DIFF
--- a/documentation/reference.md.erb
+++ b/documentation/reference.md.erb
@@ -1,4 +1,4 @@
-# Bolt Functions
+# Bolt functions
 
 <% for func in @functions %>
 ## `<%= func['name'] %>`


### PR DESCRIPTION
This fixes the title in the Bolt functions reference doc to follow the
standard sentence case format.