### PR TITLE
(GH-1671) Handle cases where loading paths with ~ fails

### DIFF
--- a/lib/bolt/analytics.rb
+++ b/lib/bolt/analytics.rb
@@ -28,8 +28,12 @@ module Bolt
 
     def self.build_client
       logger = Logging.logger[self]
-      config_file = File.expand_path('~/.puppetlabs/bolt/analytics.yaml')
-      config = load_config(config_file, logger)
+      begin
+        config_file = File.expand_path('~/.puppetlabs/bolt/analytics.yaml')
+        config = load_config(config_file, logger)
+      rescue ArgumentError
+        config = { 'disabled' => true }
+      end
 
       if config['disabled'] || ENV['BOLT_DISABLE_ANALYTICS']
         logger.debug "Analytics opt-out is set, analytics will be disabled"

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -137,10 +137,15 @@ module Bolt
                     else
                       Pathname.new(File.join('/etc', 'puppetlabs', 'bolt', 'bolt.yaml'))
                     end
-      user_path = Pathname.new(File.expand_path(File.join('~', '.puppetlabs', 'etc', 'bolt', 'bolt.yaml')))
+      user_path = begin
+                    Pathname.new(File.expand_path(File.join('~', '.puppetlabs', 'etc', 'bolt', 'bolt.yaml')))
+                  rescue ArgumentError
+                    nil
+                  end
 
-      [{ filepath: system_path, data: Bolt::Util.read_optional_yaml_hash(system_path, 'config') },
-       { filepath: user_path, data: Bolt::Util.read_optional_yaml_hash(user_path, 'config') }]
+      confs = [{ filepath: system_path, data: Bolt::Util.read_optional_yaml_hash(system_path, 'config') }]
+      confs << { filepath: user_path, data: Bolt::Util.read_optional_yaml_hash(user_path, 'config') } if user_path
+      confs
     end
 
     def initialize(boltdir, config_data, overrides = {})

--- a/spec/bolt/analytics_spec.rb
+++ b/spec/bolt/analytics_spec.rb
@@ -23,6 +23,17 @@ describe Bolt::Analytics do
     expect(subject.build_client).to be_instance_of(Bolt::Analytics::NoopClient)
   end
 
+  it 'creates a NoopClient if reading config fails' do
+    allow(File).to receive(:expand_path).and_call_original
+    allow(File)
+      .to receive(:expand_path)
+      .with('~/.puppetlabs/bolt/analytics.yaml')
+      .and_raise(ArgumentError, "couldn't find login name -- expanding `~'")
+    expect(subject).not_to receive(:write_config)
+
+    expect(subject.build_client).to be_instance_of(Bolt::Analytics::NoopClient)
+  end
+
   it 'creates a regular Client if analytics is not disabled' do
     expect(subject.build_client).to be_instance_of(Bolt::Analytics::Client)
   end

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -431,6 +431,7 @@ describe "apply", expensive: true do
       { 'modulepath' => File.join(__dir__, '../fixtures/apply'),
         'winrm' => {
           'ssl' => false,
+          'connect-timeout' => 30,
           'ssl-verify' => false,
           'user' => conn_info('winrm')[:user],
           'password' => conn_info('winrm')[:password]

--- a/spec/integration/transport/winrm_spec.rb
+++ b/spec/integration/transport/winrm_spec.rb
@@ -44,7 +44,7 @@ describe Bolt::Transport::WinRM do
 
   def mk_config(conf)
     conf = Bolt::Util.walk_keys(conf, &:to_s)
-    conf['connect-timeout'] ||= 20
+    conf['connect-timeout'] ||= 30
     conf
   end
 


### PR DESCRIPTION
By default Bolt has 3 configuration file locations that get merged
together: project level, user level, and global. Project level config is
configurable (yo dawg...) using the `--configfile` CLI flag, but the 
user level and global configs are hard coded to
`~/.puppetlabs/etc/bolt/bolt.yaml` and `/etc/puppetlabs/bolt/bolt.yaml`
respectively. When `getlogin` returns nil loading the user level config
file will fail and error out trying to load `~`. This change catches the 
error and doesn't try to load user level config.

We also try to load a hard coded `~` path for analytics, at
`~/.puppetlabs/bolt/analytics.yaml`. Because loading the homedir will
typically only fail if getlogin isn't set when running Bolt through the 
Orchestrator or in other automated environments, we opt to disable
analytics if the config file can't be loaded.

This doesn't account for other places where paths use the homedir as
part of the default path since other paths are configurable, or already
fallback to another path if `ENV['HOME']` isn't set.

This additionally extends the connect timeout for WinRM apply
integration tests to 30 seconds, since they were consistently timing out 
in Github Actions.

Closes #1671

!bug

* **Handle cases where loading hardcoded homedir paths fail** ([#1671](https://github.com/puppetlabs/bolt/issues/1671))

  Bolt's user level config and analytics config paths are hardcoded and 
  include `~`, which errors out when getlogin fails to return a user. We
  now skip loading user level config if loading the file fails, and 
  disable analytics if loading the analytics config fails.

