### PR TITLE
Add new 3rd party plugin list

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ AllCops:
 # modifier if/unless.
 Style/HashEachMethods:
   Enabled: true
-
+  
 Style/HashTransformKeys:
   Enabled: true
 
@@ -55,6 +55,8 @@ Layout/ClosingHeredocIndentation:
 
 Layout/LineLength:
   Max: 120
+  Exclude: 
+    - Rakefile
 
 Style/GuardClause:
   Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -263,6 +263,24 @@ namespace :integration do
   end
 end
 
+desc 'Generate Plugin List'
+task :plugin_list do
+  require 'yaml'
+  plugin_file = YAML.load_file(File.expand_path(File.join(__dir__, 'resources', 'plugins.yaml')))
+  table_header = plugin_file['plugin_table_header']
+  plugin_list = []
+  plugin_file['plugins'].each do |category, plugins|
+    plugin_list = plugins.map do |_name, plugin|
+      <<~LIST
+         |#{plugin['name']} |#{plugin['url']} |#{plugin['author']} |#{category} |#{plugin['desc']} |#{plugin['tags'].join(', ')} |#{plugin['requirements'].join(', ')}|
+
+         LIST
+    end
+  end
+  data = ["\n## Bolt Plugin Table"] + [table_header] + plugin_list.flatten
+  File.write(File.expand_path(File.join(__dir__, 'resources', 'plugins.md')), plugin_file['plugin_intro'] + data.join("\n"))
+end
+
 desc 'Generate changelog'
 task :changelog, [:version] do |_t, args|
   sh "./scripts/generate_changelog.rb #{args[:version]}"

--- a/resources/plugins.md
+++ b/resources/plugins.md
@@ -1,0 +1,10 @@
+# 3rd Party Bolt Plugin list
+
+Below is a plugin list of all documented 3rd party bolt plugins.  If you have created a plugin please add your plugin
+to the resources/plugins.yaml list and run the rake task `plugin_list` to regenerate the list with your info.  Submit a PR with the updated files so others can see your plugin information. 
+
+## Bolt Plugin Table
+|Name|Url|Author|Category|Description|Tags|Requirements|
+| --- | --- | --- | --- | --- | --- | --- |
+|AD Inventory |https://github.com/glennsarti/bolt_ad_inventory |glennsarti |inventory |Bolt Plugin for getting inventory from Active Directory |windows, Active Directory, Inventory |bolt 1.x|
+

--- a/resources/plugins.yaml
+++ b/resources/plugins.yaml
@@ -1,0 +1,21 @@
+plugin_intro: |
+  # 3rd Party Bolt Plugin list
+
+  Below is a plugin list of all documented 3rd party bolt plugins.  If you have created a plugin please add your plugin
+  to the resources/plugins.yaml list and run the rake task `plugin_list` to regenerate the list with your info.  Submit a PR with the updated files so others can see your plugin information. 
+
+plugin_table_header: "|Name|Url|Author|Category|Description|Tags|Requirements|\n| --- | --- | --- | --- | --- | --- | --- |"
+plugins:
+  inventory:
+    ad_inventory:
+      name: 'AD Inventory'
+      url: 'https://github.com/glennsarti/bolt_ad_inventory'
+      author:  glennsarti
+      desc: 'Bolt Plugin for getting inventory from Active Directory'
+      tags: 
+        - windows
+        - Active Directory
+        - Inventory
+      requirements:
+        - bolt 1.x
+  


### PR DESCRIPTION
 * This adds a yaml file with a list of plugins that generates a
 markdown file of plugins via the `plugin_list` rake task.

 * The markdown is generated dynamically via data from the plugins.yaml
 file.