### PR TITLE
Fixed documentation for using the puppetdb plugin with certname fact

### DIFF
--- a/documentation/using_plugins.md
+++ b/documentation/using_plugins.md
@@ -125,7 +125,7 @@ targets:
   - _plugin: puppetdb
     query: "inventory[certname] { facts.osfamily = 'RedHat' }"
     target_mapping:
-      name: certname
+      name: facts.trusted.certname
       config:
         ssh:
           hostname: facts.networking.interfaces.en0.ipaddress

--- a/documentation/using_plugins.md
+++ b/documentation/using_plugins.md
@@ -116,16 +116,25 @@ The following fields are available to the `puppetdb` plugin.
 | **`query`** | A string containing a [PQL query](https://puppet.com/docs/puppetdb/latest/api/query/v4/pql.html) or an array containing a [PuppetDB AST format query](https://puppet.com/docs/puppetdb/latest/api/query/v4/ast.html).<br> **Required.** | `String` | None |
 | `target_mapping` | A hash of target attributes (`name`, `uri`, `config`) to populate with fact lookup values. | `Hash` | None |
 
+#### Available fact paths
+
+The following values/patterns are available to use for looking up facts in the `target_mapping` field:
+
+| Key | Description |
+| --- | ----------- |
+| `certname` | The certname of the node returned from PuppetDB. This is short hand for doing: `facts.trusted.certname`. |
+| `facts.*` | [PQL dot notation](https://puppet.com/docs/puppetdb/latest/api/query/v4/ast.html#dot-notation) facts string such as `facts.os.family` to reference fact value. Dot notation is required for both structured and unstructured facts. |
+
 #### Example usage
 
-Lookup targets with the fact `osfamily: RedHat`, and set the hostname with the fact `networking.interfaces.en0.ipaddress`:
+Lookup targets with the fact `osfamily: RedHat`, set the `name` with the fact `certname`, and set the hostname with the fact `networking.interfaces.en0.ipaddress`:
 
 ```yaml
 targets:
   - _plugin: puppetdb
     query: "inventory[certname] { facts.osfamily = 'RedHat' }"
     target_mapping:
-      name: facts.trusted.certname
+      name: certname
       config:
         ssh:
           hostname: facts.networking.interfaces.en0.ipaddress

--- a/lib/bolt/plugin/puppetdb.rb
+++ b/lib/bolt/plugin/puppetdb.rb
@@ -83,10 +83,14 @@ module Bolt
       def resolve_facts(config, certname, target_data)
         Bolt::Util.walk_vals(config) do |value|
           if value.is_a?(String)
-            data = target_data&.detect { |d| d['path'] == fact_path(value) }
-            warn_missing_fact(certname, value) if data.nil?
-            # If there's no fact data this will be nil
-            data&.fetch('value', nil)
+            if value == 'certname'
+              certname
+            else
+              data = target_data&.detect { |d| d['path'] == fact_path(value) }
+              warn_missing_fact(certname, value) if data.nil?
+              # If there's no fact data this will be nil
+              data&.fetch('value', nil)
+            end
           elsif value.is_a?(Array) || value.is_a?(Hash)
             value
           else

--- a/spec/bolt/plugin/puppetdb_spec.rb
+++ b/spec/bolt/plugin/puppetdb_spec.rb
@@ -61,6 +61,18 @@ describe Bolt::Plugin::Puppetdb do
       end
     end
 
+    context "when using 'certname' as a facts path" do
+      let(:opts) do
+        { "query" => '',
+          "target_mapping" => { "name" => 'certname' } }
+      end
+
+      it "sets the name to the certname" do
+        expect(plugin.resolve_reference(opts))
+          .to eq([{ "name" => "therealslimcertname" }])
+      end
+    end
+
     context "with misplaced config keys" do
       let(:opts) do
         { "query" => '',
@@ -101,6 +113,36 @@ describe Bolt::Plugin::Puppetdb do
       it "raises an error" do
         expect { plugin.resolve_facts(config, certname, data) }
           .to raise_error(Bolt::Plugin::Puppetdb::FactLookupError, /be a string/)
+      end
+    end
+
+    context "with 'certname' as fact path" do
+      let(:certname) { 'hostname.domain.tld' }
+      let(:config) do
+        { 'name' => 'certname' }
+      end
+
+      context " with no fact_values" do
+        let(:data) { nil }
+
+        it "returns the certname" do
+          expect(plugin.resolve_facts(config, certname, data))
+            .to eq({ 'name' => 'hostname.domain.tld' })
+        end
+      end
+
+      context " with fact_values" do
+        let(:data) do
+          { certname => [{
+            'path' => [1],
+            'value' => 'the loneliest number'
+          }] }
+        end
+
+        it "returns the certname" do
+          expect(plugin.resolve_facts(config, certname, data))
+            .to eq({ 'name' => 'hostname.domain.tld' })
+        end
       end
     end
 


### PR DESCRIPTION
When trying to implement some more complex inventory files using PuppetDB i ran into an issue when trying to use the `target_mapping` feature of the `puppetdb` plugin based on this example: https://puppet.com/docs/bolt/latest/using_plugins.html#example-usage-2

Running this as my inventory as shown in the example:
```yaml
version: 2
groups:
  - name: puppetdb_wsus
    targets:
      - _plugin: puppetdb
        query: "inventory[certname] { facts.osfamily = 'windows' }"
        target_mapping:
          name: certname
```

I kept getting an error: 
```
$ bolt inventory show --targets puppetdb_wsus
Could not find fact certname for node xxx
Could not find fact certname for node yyy
Could not find fact certname for node zzz
```

I dug into it a bit by querying the `fact-path` API in PuppetDB:
```bash
$ curl -s -k -X GET     --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem     --key /etc/puppetlabs/puppet/ssl/private_keys/$(hostname -f).pem     --cert /etc/puppetlabs/puppet/ssl/certs/$(hostname -f).pem 'https://127.0.0.1:8081/pdb/query/v4/fact-paths' | jq | grep -B4 -A3 certname
  {
    "type": "string",
    "path": [
      "trusted",
      "certname"
    ],
    "name": "trusted"
  },
```

Turns out that the path is actually `"trusted.certname"`.

My final inventory file that got the the results i wanted without errors was:

```yaml
version: 2
groups:
  - name: puppetdb_wsus
    targets:
      - _plugin: puppetdb
        query: "inventory[certname] { facts.osfamily = 'windows' }"
        target_mapping:
          name: facts.trusted.certname
```