### PR TITLE
(maint) Validate hiera-config setting

### DIFF
--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -339,7 +339,7 @@ module Bolt
         raise Bolt::ValidationError, "Unsupported format: '#{format}'"
       end
 
-      Bolt::Util.validate_file('hiera-config', @data['hiera_config']) if @data['hiera_config']
+      Bolt::Util.validate_file('hiera-config', @data['hiera-config']) if @data['hiera-config']
       Bolt::Util.validate_file('trusted-external-command', trusted_external) if trusted_external
 
       unless TRANSPORT_CONFIG.include?(transport)


### PR DESCRIPTION
This updates config validation to properly validate that a specified
Hiera config file exists. Previously, the config was accessing the wrong
value in the config data hash, preventing Bolt from validating that the
file exists.

!bug

* **Validate that a specified Hiera config file exists**
([#1692](https://github.com/puppetlabs/bolt/pulls/1692))

  Bolt was not properly validating that a Hiera config file specified
  with the `hiera-config` option in a `bolt.yaml` existed.