### PR TITLE
(PE-28373) Always return a result-like error result

### DIFF
--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -57,10 +57,17 @@ module BoltServer
     end
 
     def scrub_stack_trace(result)
-      if result.dig(:result, '_error', 'details', 'stack_trace')
-        result[:result]['_error']['details'].reject! { |k| k == 'stack_trace' }
+      if result.dig(:value, '_error', 'details', 'stack_trace')
+        result[:value]['_error']['details'].reject! { |k| k == 'stack_trace' }
       end
       result
+    end
+
+    def error_result(error)
+      {
+        'status' => 'failure',
+        'value' => { '_error' => error.to_h }
+      }
     end
 
     def validate_schema(schema, body)
@@ -280,7 +287,7 @@ module BoltServer
       body = JSON.parse(request.body.read)
 
       error = validate_schema(@schemas["transport-ssh"], body)
-      return [400, error.to_json] unless error.nil?
+      return [400, error_result(error).to_json] unless error.nil?
 
       targets = (body['targets'] || [body['target']]).map do |target|
         make_ssh_target(target)
@@ -320,7 +327,7 @@ module BoltServer
       body = JSON.parse(request.body.read)
 
       error = validate_schema(@schemas["transport-winrm"], body)
-      return [400, error.to_json] unless error.nil?
+      return [400, error_result(error).to_json] unless error.nil?
 
       targets = (body['targets'] || [body['target']]).map do |target|
         make_winrm_target(target)

--- a/spec/bolt_server/transport_app_spec.rb
+++ b/spec/bolt_server/transport_app_spec.rb
@@ -206,7 +206,8 @@ describe "BoltServer::TransportApp" do
 
         result = JSON.parse(last_response.body)
         regex = %r{The property '#/target' of type object matched more than one of the required schemas}
-        expect(result['details'].join).to match(regex)
+        expect(result['value']['_error']['details'].join).to match(regex)
+        expect(result['status']).to eq('failure')
       end
 
       it 'fails if no authorization is present' do


### PR DESCRIPTION
As part of the push to get orchestrator on 2.x it is expected that a bolt-server request will always expects a `status` and `value` key in the response. In most cases the Bolt::Result will have these keys. In the case where there is an error that is not target/action execution specific (in this case with a request schema validation error), return an error that has the `status` and `value` keys.

This commit also updates a stray `result` key to `value` in the scrub_stack_trace method.