### PR TITLE
(maint) Add workflow for release note labels on commits

### DIFF
--- a/.github/rulesets.yaml
+++ b/.github/rulesets.yaml
@@ -1,0 +1,24 @@
+rulesets:
+  commits:
+    message-matches:
+      range: once
+      params:
+        pattern: '!(feature|bug|deprecation|removal|no-release-note)'
+      error: |
+        At least one commit in a pull request must have a valid release note label.
+        Valid release note labels are:
+
+          !feature    !bug    !deprecation    !removal    !no-release-note
+
+        A commit with a release note label should also have a release note immediately 
+        following the label. If a release note is not needed, then the !no-release-note
+        label should be used and the release note should be omitted.
+
+        Release notes should follow the format set out in the CHANGELOG.md. A commit
+        with a valid release note label and release note would look like this:
+
+          !feature
+
+          * **Added a new feature** ([#1000](https://github.com/puppetlabs/bolt/issues/1000))
+
+            A brief summary of the new feature.

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -1,0 +1,19 @@
+name: Release Notes
+
+on:
+  pull_request:
+    type: [opened, reopened, edited]
+    paths-ignore: ['*.md', '**.md', '**.erb']
+
+jobs:
+
+  release-notes:
+    name: Release Notes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Check for release notes
+        uses: rulesets/rulesets@v1.0.0-beta
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds a workflow that checks that at least one commit in a pull
request has a valid release note label. It uses the `rulesets` action to
match each commit's message against a regex, ensuring that at least one
commit matches the regex. This is used to ensure that release notes are
added to pull requests where needed and can be picked up by the
changelog rake task.

!no-release-note