### PR TITLE
Bolt::Util.deep_clone fails with frozen hashes

### DIFF
--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -170,7 +170,22 @@ module Bolt
         error_types << Java::JavaLang::CloneNotSupportedException if RUBY_PLATFORM == 'java'
 
         begin
-          cl = obj.clone
+          # We can't recurse on frozen objects to populate them with cloned
+          # data. Instead we store the freeze-state of the original object,
+          # deep_clone, then set the cloned object to frozen if the original
+          # object was frozen
+          frozen = obj.frozen?
+          cl = begin
+                 obj.clone(freeze: false)
+                 # Some datatypes, such as FalseClass, can't be unfrozen. These
+                 # aren't the types we recurse on, so we can leave them frozen
+               rescue ArgumentError => e
+                 if e.message =~ /can't unfreeze/
+                   obj.clone
+                 else
+                   raise e
+                 end
+               end
         rescue *error_types
           cloned[obj.object_id] = obj
           obj
@@ -192,6 +207,7 @@ module Bolt
             cl.instance_variable_set(var, v_cl)
           end
 
+          cl.freeze if frozen
           cl
         end
       end

--- a/spec/bolt/util_spec.rb
+++ b/spec/bolt/util_spec.rb
@@ -110,4 +110,12 @@ describe Bolt::Util do
       expect(Bolt::Util.read_optional_yaml_hash('does-not-exist', 'config')).to eq({})
     end
   end
+
+  describe '#deep_clone' do
+    it 'works with frozen hashes' do
+      hash = { key: 'value', boolean: true }
+      hash.freeze
+      expect(Bolt::Util.deep_clone(hash)).to eq(hash)
+    end
+  end
 end


### PR DESCRIPTION
The internet suggests replacing `clone` with `dup` to avoid copying the `frozen?` bit.