### PR TITLE
(maint) Remove outdated facts module from bolt puppetfile example

### DIFF
--- a/documentation/bolt_installing_modules.md
+++ b/documentation/bolt_installing_modules.md
@@ -72,7 +72,6 @@ For more details about specifying modules in a Puppetfile, see the [Puppetfile d
     mod 'puppetlabs-apache', '4.1.0'
     mod 'puppetlabs-postgresql', '5.12.0'
     mod 'puppetlabs-puppet_conf', '0.3.0'
-    mod 'puppetlabs-facts', '0.3.1'
     
     # Modules from a Git repository.
     mod 'puppetlabs-haproxy', git: 'https://github.com/puppetlabs/puppetlabs-haproxy.git', ref: 'master'


### PR DESCRIPTION
An example puppetfile used to demonstrate installing modules in a Bolt
project included an outdated version of the `puppetlabs-facts` module.
When users copy-paste the example the outdated module would override
versions that ship with Bolt and cause other tasks and plans (such as
puppet_agent::install) to fail. This removes the module from the example
Puppetfile.

I also verified there were no other conflicting modules in our documentation :+1: 