### PR TITLE
Ensure library is loaded before referencing

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/add_facts.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/add_facts.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bolt/error'
+require 'bolt/pal/issues'
 
 # Deep merges a hash of facts with the existing facts on a target.
 #

--- a/bolt-modules/boltlib/lib/puppet/functions/add_to_group.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/add_to_group.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bolt/error'
+require 'bolt/pal/issues'
 
 # Adds a target to specified inventory group.
 #

--- a/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bolt/task'
+require 'bolt/pal/issues'
 
 # Installs the `puppet-agent` package on targets if needed, then collects facts,
 # including any custom facts found in Bolt's modulepath. The package is

--- a/bolt-modules/boltlib/lib/puppet/functions/catch_errors.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/catch_errors.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bolt/pal/issues'
+
 # Catches errors in a given block and returns them. This will return the
 # output of the block if no errors are raised. Accepts an optional list of
 # error kinds to catch.

--- a/bolt-modules/boltlib/lib/puppet/functions/fail_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/fail_plan.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bolt/error'
+require 'bolt/pal/issues'
 
 # Raises a `Bolt::PlanFailure` exception to signal to callers that the plan failed.
 #

--- a/bolt-modules/boltlib/lib/puppet/functions/get_resources.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/get_resources.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bolt/task'
+require 'bolt/pal/issues'
 
 # Query the state of resources on a list of targets using resource definitions in Bolt's modulepath.
 # The results are returned as a list of hashes representing each resource.

--- a/bolt-modules/boltlib/lib/puppet/functions/get_target.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/get_target.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bolt/error'
+require 'bolt/pal/issues'
 
 # Get a single target from inventory if it exists, otherwise create a new Target.
 #

--- a/bolt-modules/boltlib/lib/puppet/functions/remove_from_group.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/remove_from_group.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bolt/error'
+require 'bolt/pal/issues'
 
 # Removes a target from the specified inventory group.
 #

--- a/bolt-modules/boltlib/lib/puppet/functions/resolve_references.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/resolve_references.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bolt/error'
+require 'bolt/pal/issues'
 
 # Evaluates all `_plugin` references in a hash and returns the resolved reference data.
 Puppet::Functions.create_function(:resolve_references) do

--- a/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bolt/error'
+require 'bolt/pal/issues'
 
 # Runs a command on the given set of targets and returns the result from each command execution.
 # This function does nothing if the list of targets is empty.

--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bolt/error'
+require 'bolt/pal/issues'
 
 # Runs the `plan` referenced by its name. A plan is autoloaded from `$MODULEROOT/plans`.
 #

--- a/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bolt/pal/issues'
+
 # Uploads the given script to the given set of targets and returns the result of having each target execute the script.
 # This function does nothing if the list of targets is empty.
 #

--- a/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
@@ -3,6 +3,7 @@
 require 'bolt/error'
 require 'bolt/pal'
 require 'bolt/task'
+require 'bolt/pal/issues'
 
 # Runs a given instance of a `Task` on the given set of targets and returns the result from each.
 # This function does nothing if the list of targets is empty.

--- a/bolt-modules/boltlib/lib/puppet/functions/set_config.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bolt/error'
+require 'bolt/pal/issues'
 
 # Set configuration options on a target.
 #

--- a/bolt-modules/boltlib/lib/puppet/functions/set_feature.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_feature.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bolt/error'
+require 'bolt/pal/issues'
 
 # Sets a particular feature to present on a target.
 #

--- a/bolt-modules/boltlib/lib/puppet/functions/set_var.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_var.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bolt/error'
+require 'bolt/pal/issues'
 
 # Sets a variable `{ key => value }` for a target.
 #

--- a/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bolt/error'
+require 'bolt/pal/issues'
 
 # Uploads the given file or directory to the given set of targets and returns the result from each upload.
 # This function does nothing if the list of targets is empty.

--- a/bolt-modules/boltlib/lib/puppet/functions/wait_until_available.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/wait_until_available.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bolt/util'
+require 'bolt/pal/issues'
 
 # Wait until all targets accept connections.
 #

--- a/bolt-modules/boltlib/lib/puppet/functions/without_default_logging.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/without_default_logging.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bolt/pal/issues'
+
 # Define a block where default logging is suppressed.
 #
 # Messages for actions within this block will be logged at `info` level instead

--- a/bolt-modules/boltlib/lib/puppet/functions/write_file.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/write_file.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'tempfile'
+require 'bolt/pal/issues'
 
 # Write contents to a file on the given set of targets.
 #

--- a/bolt-modules/out/lib/puppet/functions/out/message.rb
+++ b/bolt-modules/out/lib/puppet/functions/out/message.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bolt/pal/issues'
+
 # Output a message for the user.
 #
 # This will print a message to stdout when using the human output format,


### PR DESCRIPTION
  * Previously some boltlib functions were using part of a bolt
    library from puppet without first loading that file.  This
    becomes a problem when Puppet is used in 3rd party tooling
    that parse Puppet code and also attempt to load the boltlib.

    This fixes the issue by requiring the bolt/pal/issues file
    so that it can be referenced without issue.