### PR TITLE
(GH-1686) Add transport and transport_config functions to Target type

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/datatypes/target.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/target.rb
@@ -27,7 +27,9 @@ Puppet::DataTypes.create_type('Target') do
       password => Callable[[], Optional[String[1]]],
       port => Callable[[], Optional[Integer]],
       protocol => Callable[[], Optional[String[1]]],
-      user => Callable[[], Optional[String[1]]],
+      transport => Callable[[], Optional[String[1]]],
+      transport_config => Callable[[], Optional[Hash[String[1], Data]]],
+      user => Callable[[], Optional[String[1]]]
     }
   PUPPET
 

--- a/bolt-modules/boltlib/lib/puppet/datatypes/target.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/target.rb
@@ -27,8 +27,8 @@ Puppet::DataTypes.create_type('Target') do
       password => Callable[[], Optional[String[1]]],
       port => Callable[[], Optional[Integer]],
       protocol => Callable[[], Optional[String[1]]],
-      transport => Callable[[], Optional[String[1]]],
-      transport_config => Callable[[], Optional[Hash[String[1], Data]]],
+      transport => Callable[[], String[1]],
+      transport_config => Callable[[], Hash[String[1], Data]],
       user => Callable[[], Optional[String[1]]]
     }
   PUPPET

--- a/documentation/bolt_types_reference.md
+++ b/documentation/bolt_types_reference.md
@@ -82,7 +82,7 @@ The following functions are available to `Target` objects:
 
 | Function | Type returned | Description | Note |
 |---|---|---|---|
-| `config` | `Hash[String, Data]` | The inventory configuration for the target. | This function does not return default configuration values or configuration set in a `bolt.yaml` file. It only returns the configuration set in an `inventory.yaml` file or set in a plan using the `Target.new` or `set_config()` functions. |
+| `config` | `Hash[String, Data]` | The inventory configuration for the target. | This function returns the configuration set directly on the target in `inventory.yaml` or set in a plan using `Target.new` or `set_config()`. It does not return default configuration values or configuration set in `bolt.yaml`.  |
 | `facts` | `Hash[String, Data]` | The target's facts. | This function does not lookup facts for a target and only returns the facts specified in an `inventory.yaml` file or set on a target during a plan run. |
 | `features` | `Array[String]` | The target's features. ||
 | `host` | `String` | The target's hostname. ||

--- a/documentation/bolt_types_reference.md
+++ b/documentation/bolt_types_reference.md
@@ -94,7 +94,7 @@ The following functions are available to `Target` objects:
 | `safe_name` | `String` | The target's safe name. Equivalent to `name` if a name was given, or the target's `uri` with any password omitted. ||
 | `target_alias` | `Variant[String, Array[String]]` | The target's aliases. ||
 | `transport` | `String` | The transport used to connect to the target. ||
-| `transport_config` | `Hash[String, Data]` | The merged configuration for the target's `transport`. | This function returns the merged configuration for a target's `transport`, including defaults, configuration set in a `bolt.yaml`, and configuration set in an `inventory.yaml` file or set in a plan using the `Target.new` or `set_config()` functions. |
+| `transport_config` | `Hash[String, Data]` | The merged configuration for the target's `transport`. | This function returns the merged configuration for a target's transport. This includes defaults, configuration set in a `bolt.yaml`, configuration set `inventory.yaml`, and configuration set in a plan using `set_config()`.|
 | `uri` | `String` | The target's URI. ||
 | `user` | `String` | The user to connect to the target. ||
 | `vars` | `Hash[String, Data]` | The target's variables. ||

--- a/documentation/bolt_types_reference.md
+++ b/documentation/bolt_types_reference.md
@@ -82,7 +82,7 @@ The following functions are available to `Target` objects:
 
 | Function | Type returned | Description | Note |
 |---|---|---|---|
-| `config` | `Hash[String, Data]` | The inventory configuration for the target. | This function does not return default configuration values or configuration set in a `bolt.yaml` file. It only returns the configuration set in an `inventory.yaml` file or the configuration set during a plan using the `Target.new` or `set_config()` functions. |
+| `config` | `Hash[String, Data]` | The inventory configuration for the target. | This function does not return default configuration values or configuration set in a `bolt.yaml` file. It only returns the configuration set in an `inventory.yaml` file or set in a plan using the `Target.new` or `set_config()` functions. |
 | `facts` | `Hash[String, Data]` | The target's facts. | This function does not lookup facts for a target and only returns the facts specified in an `inventory.yaml` file or set on a target during a plan run. |
 | `features` | `Array[String]` | The target's features. ||
 | `host` | `String` | The target's hostname. ||

--- a/documentation/bolt_types_reference.md
+++ b/documentation/bolt_types_reference.md
@@ -93,6 +93,8 @@ The following functions are available to `Target` objects:
 | `protocol` | `String` | The protocol used to connect to the target. | This is equivalent to the target's `transport`, except for targets using the `remote` transport. For example, a target with the URI `http://example.com` using the `remote` transport would return `http` for the `protocol`. |
 | `safe_name` | `String` | The target's safe name. Equivalent to `name` if a name was given, or the target's `uri` with any password omitted. ||
 | `target_alias` | `Variant[String, Array[String]]` | The target's aliases. ||
+| `transport` | `String` | The transport used to connect to the target. ||
+| `transport_config` | `Hash[String, Data]` | The merged configuration for the target's `transport`. | This function returns the merged configuration for a target's `transport`, including defaults, configuration set in a `bolt.yaml`, and configuration set in an `inventory.yaml` file or set in a plan using the `Target.new` or `set_config()` functions. |
 | `uri` | `String` | The target's URI. ||
 | `user` | `String` | The user to connect to the target. ||
 | `vars` | `Hash[String, Data]` | The target's variables. ||

--- a/documentation/writing_plans.md
+++ b/documentation/writing_plans.md
@@ -432,6 +432,39 @@ target objects, as well as add or remove objects from existing [inventory
 groups](https://puppet.com/docs/bolt/latest/inventory_file.html). Targets are modified in-memory
 for the life cycle of the plan and are not saved between plan runs.
 
+### Temporarily modifying target objects
+
+Target objects can be temporarily modified during a plan run. For example, you can store a target's
+configuration in a temporary variable, modify the target's configuration using the 
+[`set_config`](plan_functions.md#set-config) function, and then restore the target's original
+configuration.
+
+Temporarily modify a target's configuration:
+
+```
+plan test(String $host) {
+  $target = get_target($host)
+
+  # Store the target's original configuration
+  $original_config = $target.config['ssh']
+
+  # Modify the target's configuration
+  $config =  {
+    'user'     => 'bolt',
+    'password' => 'secret'
+  }
+
+  set_config($target, 'ssh', $config)
+
+  ...
+
+  # Restore the target's original configuration
+  set_config($target, 'ssh', $original_config)
+
+  ...
+}
+```
+
 ### Variables and facts on targets
 
 When Bolt runs, it loads transport configuration values, variables, and facts from the inventory. These can be accessed with the `$target.facts()` and `$target.vars()` functions. During the course of a plan, you can update the facts or variables for any target. Facts usually come from running `facter` or another fact collection application on the target, or from a fact store like PuppetDB. Variables are computed externally or assigned directly.

--- a/lib/bolt/inventory/target.rb
+++ b/lib/bolt/inventory/target.rb
@@ -32,7 +32,6 @@ module Bolt
         @vars = target_data['vars'] || {}
         @facts = target_data['facts'] || {}
         @features = target_data['features'] || Set.new
-        @options = target_data['options'] || {}
         @plugin_hooks = target_data['plugin_hooks'] || {}
         # When alias is specified in a plan, the key will be `target_alias`, when
         # alias is specified in inventory the key will be `alias`.
@@ -166,10 +165,6 @@ module Bolt
         Addressable::URI.unencode_component(@uri_obj.password) || transport_config['password']
       end
 
-      def options
-        transport_config
-      end
-
       # We only want to look up transport config keys for the configured
       # transport
       def transport_config
@@ -199,7 +194,6 @@ module Bolt
             'vars' => {},
             'facts' => {},
             'features' => Set.new,
-            'options' => {},
             'plugin_hooks' => {},
             'target_alias' => []
           }

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -129,6 +129,10 @@ module Bolt
       inventory_target.transport
     end
 
+    def transport_config
+      inventory_target.transport_config.to_h
+    end
+
     def protocol
       inventory_target.protocol || inventory_target.transport
     end

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -132,6 +132,7 @@ module Bolt
     def transport_config
       inventory_target.transport_config.to_h
     end
+    alias options transport_config
 
     def protocol
       inventory_target.protocol || inventory_target.transport
@@ -143,10 +144,6 @@ module Bolt
 
     def password
       inventory_target.password
-    end
-
-    def options
-      inventory_target.options
     end
 
     def plugin_hooks

--- a/spec/bolt/target_spec.rb
+++ b/spec/bolt/target_spec.rb
@@ -114,6 +114,17 @@ describe Bolt::Target do
       expect(target.to_s).to eq("ssh://#{user}@neptune:2222")
     end
 
+    it "returns the transport" do
+      target = inventory.get_target('ssh://jupiter')
+      expect(target.transport).to eq('ssh')
+    end
+
+    it "returns the transport config" do
+      transport_config = Bolt::Config::Transport::SSH.new
+      target = inventory.get_target('ssh://jupiter')
+      expect(target.transport_config).to eq(transport_config.to_h)
+    end
+
     describe "with winrm" do
       it "accepts 'winrm://host:port'" do
         target = inventory.get_target('winrm://neptune:55985')

--- a/spec/pal/target_spec.rb
+++ b/spec/pal/target_spec.rb
@@ -22,6 +22,8 @@ describe 'Target DataType' do
 
   let(:target_code) { "$target = Target('pcp://user1:pass1@example.com:33')\n" }
 
+  let(:default_config) { config.transports['pcp'].to_h }
+
   def target(attr)
     code = target_code + attr
     peval(code, pal, nil, Bolt::Inventory::Inventory.new({}, config.transport, config.transports, plugins))
@@ -53,5 +55,13 @@ describe 'Target DataType' do
 
   it 'should expose password' do
     expect(target('$target.password')).to eq('pass1')
+  end
+
+  it 'should expose transport' do
+    expect(target('$target.transport')).to eq('pcp')
+  end
+
+  it 'should expose transport_config' do
+    expect(target('$target.transport_config')).to eq(default_config)
   end
 end


### PR DESCRIPTION
This adds two functions to the `Target` data type in plans:

- `transport`

  Returns the transport used to connect to the target.

 - `transport_config`

   Returns a hash of the merged transport config for the target,
   including defaults, config set in a `bolt.yaml`, and config set at
   the group and target level in an `inventory.yaml` or plan.

Closes #1686 

!feature

* **Added `transport` and `transport_config` functions to `Target` data
  type** ([#1686](#1686))

  The `Target` data type now supports a `transport` function, which
  returns the transport used to connect to the target, and a
  `transport_config` function, which returns a hash of merged
  configuration for the target's transport.