### PR TITLE
(maint) Only show descriptions and usages on command reference page

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -117,6 +117,7 @@ namespace :docs do
       actions.each do |action|
         command = [subcommand, action].compact.join(' ')
         help_text = parser.get_help_text(subcommand, action)
+        matches = help_text[:banner].match(/USAGE(?<usage>.+?)DESCRIPTION(?<desc>.+?)(EXAMPLES|\z)/m)
 
         options = help_text[:flags].map do |option|
           switch = parser.top.long[option]
@@ -129,8 +130,12 @@ namespace :docs do
           }
         end
 
+        desc  = matches[:desc].split("\n").map(&:strip).join("\n")
+        usage = matches[:usage].strip
+
         @commands[command] = {
-          banner: help_text[:banner],
+          usage: usage,
+          desc: desc,
           options: options
         }
       end

--- a/documentation/bolt_command_reference.md.erb
+++ b/documentation/bolt_command_reference.md.erb
@@ -6,8 +6,12 @@ These subcommands, actions, and options are available for Bolt.
 <% @commands.each do |key, val| %>
 ## <%= key %>
 
-```plain
-<%= val[:banner] -%>
+<%= val[:desc] %>
+
+**Usage**
+
+```bash
+<%= val[:usage] %>
 ```
 
 | Option | Description |

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -564,7 +564,7 @@ module Bolt
       DESCRIPTION
           Run a task on the specified targets.
 
-          Parameters take the form <parameter>=<value>.
+          Parameters take the form parameter=value.
 
       EXAMPLES
           bolt task run package --targets target1,target2 action=status name=bash


### PR DESCRIPTION
This updates the command reference page to only show the description and
usage for each command. Previously, the entire help text banner was
displayed.

The rake task that generates the reference uses named capture groups to
extract the relevant data from the help text banner.

!no-release-note