### PR TITLE
Fix a bug passing arguments to local shell transport.

### DIFF
--- a/lib/bolt/transport/local/shell.rb
+++ b/lib/bolt/transport/local/shell.rb
@@ -184,7 +184,7 @@ module Bolt
 
             begin
               if writable && index < in_buffer.length
-                to_print = in_buffer[index..-1]
+                to_print = in_buffer.byteslice(index..-1)
                 written = inp.write_nonblock to_print
                 index += written
 


### PR DESCRIPTION
!bug

* **Fix a bug passing arguments to local shell transport.** ([#1713](https://github.com/puppetlabs/bolt/issues/1713))

  Local shell transport was not correctly slicing stdin when writing to the subprocess.