### PR TITLE
(GH-1718) Give wait_until_available Result an action

### DIFF
--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -302,12 +302,12 @@ module Bolt
         batch_execute(targets) do |transport, batch|
           with_node_logging('Waiting until available', batch) do
             wait_until(wait_time, retry_interval) { transport.batch_connected?(batch) }
-            batch.map { |target| Result.new(target) }
+            batch.map { |target| Result.new(target, action: 'wait_until_available') }
           rescue TimeoutError => e
             available, unavailable = batch.partition { |target| transport.batch_connected?([target]) }
             (
-              available.map { |target| Result.new(target) } +
-              unavailable.map { |target| Result.from_exception(target, e) }
+              available.map { |target| Result.new(target, action: 'wait_until_available') } +
+              unavailable.map { |target| Result.from_exception(target, e, action: 'wait_until_available') }
             )
           end
         end

--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -7,7 +7,7 @@ module Bolt
   class Result
     attr_reader :target, :value, :action, :object
 
-    def self.from_exception(target, exception)
+    def self.from_exception(target, exception, action: nil)
       if exception.is_a?(Bolt::Error)
         error = exception.to_h
       else
@@ -19,7 +19,7 @@ module Bolt
         }
         error['details']['stack_trace'] = exception.backtrace.join('\n') if exception.backtrace
       end
-      Result.new(target, error: error)
+      action.nil? ? Result.new(target, error: error) : Result.new(target, error: error, action: action)
     end
 
     def self.for_command(target, stdout, stderr, exit_code, action, command)

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -277,6 +277,7 @@ describe "Bolt::Executor" do
       results = executor.wait_until_available(targets)
       results.each do |result|
         expect(result).to be_instance_of(Bolt::Result)
+        expect(result.action).to eq('wait_until_available')
       end
     end
 
@@ -285,6 +286,7 @@ describe "Bolt::Executor" do
 
       results = executor.wait_until_available(targets, wait_time: 0, retry_interval: 0)
       results.each do |result|
+        expect(result.action).to eq('wait_until_available')
         expect(result.error_hash['msg']).to eq('Timed out waiting for target')
         expect(result.error_hash['kind']).to eq('puppetlabs.tasks/exception-error')
       end

--- a/spec/bolt/puppetdb/client_spec.rb
+++ b/spec/bolt/puppetdb/client_spec.rb
@@ -28,7 +28,7 @@ describe Bolt::PuppetDB::Client do
   end
 
   describe "#query_certnames" do
-    let(:response) { double('response', code: 200, body: '[]') }
+    let(:response) { double('response', code: '200', body: '[]') }
     let(:http_client) { double('http_client', post: response) }
 
     before :each do
@@ -38,7 +38,6 @@ describe Bolt::PuppetDB::Client do
     it 'returns unique certnames' do
       body = [{ 'certname' => 'foo' }, { 'certname' => 'bar' }, { 'certname' => 'foo' }]
       allow(response).to receive(:body).and_return(body.to_json)
-
       expect(client.query_certnames('query')).to eq(%w[foo bar])
     end
 
@@ -54,7 +53,7 @@ describe Bolt::PuppetDB::Client do
     end
 
     it 'fails if the response from PuppetDB is an error' do
-      allow(response).to receive(:code).and_return(400)
+      allow(response).to receive(:code).and_return('400')
       allow(response).to receive(:body).and_return("something went wrong")
 
       expect { client.query_certnames('query') }.to raise_error(/Failed to query PuppetDB: something went wrong/)

--- a/spec/bolt/result_spec.rb
+++ b/spec/bolt/result_spec.rb
@@ -15,6 +15,12 @@ describe Bolt::Result do
       Bolt::Result.from_exception(target, ex)
     end
 
+    let(:result_with_action) do
+      ex = RuntimeError.new("oops")
+      ex.set_backtrace('/path/to/bolt/node.rb:42')
+      Bolt::Result.from_exception(target, ex, action: 'oops')
+    end
+
     it 'has an error' do
       expect(result.error_hash['msg']).to eq("oops")
     end
@@ -29,6 +35,10 @@ describe Bolt::Result do
 
     it 'has an _error in value' do
       expect(result.value['_error']['msg']).to eq("oops")
+    end
+
+    it 'sets action when requested' do
+      expect(result_with_action.action).to eq("oops")
     end
   end
 

--- a/spec/lib/bolt_spec/puppetdb.rb
+++ b/spec/lib/bolt_spec/puppetdb.rb
@@ -27,7 +27,7 @@ module BoltSpec
 
       headers = { "Content-Type" => "application/json" }
 
-      response = client.http_client.post(url, body: body, header: headers)
+      response = client.http_client.post(url, body, headers)
       response
     end
 


### PR DESCRIPTION
When constructing a `Result` for `wait_until_available`, add an `action` key so that the human outputter can print print a plan result.