### PR TITLE
(maint) Bump checkout action to v2

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:

--- a/.github/workflows/modules.yaml
+++ b/.github/workflows/modules.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:
@@ -46,7 +46,7 @@ jobs:
       BOLT_WINDOWS: true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Check for release notes
         uses: rulesets/rulesets@v1.0.0-beta
         with:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -25,7 +25,7 @@ jobs:
       WINDOWS_AGENTS: true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:
@@ -68,7 +68,7 @@ jobs:
       BOLT_WINDOWS: true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:

--- a/Rakefile
+++ b/Rakefile
@@ -11,8 +11,11 @@ require "json"
 require "erb"
 
 # Needed for Vanagon component ship job
-require 'packaging'
-Pkg::Util::RakeUtils.load_packaging_tasks
+# Do not load in GitHub workflows
+unless ENV['GITHUB_WORKFLOW']
+  require 'packaging'
+  Pkg::Util::RakeUtils.load_packaging_tasks
+end
 
 desc "Run all RSpec tests"
 RSpec::Core::RakeTask.new(:spec)


### PR DESCRIPTION
This bumps the `checkout` action used in the CI workflows to `v2`.