### PR TITLE
(GH-1724) Fix bug in remote transport from nil results

### DIFF
--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -302,12 +302,12 @@ module Bolt
         batch_execute(targets) do |transport, batch|
           with_node_logging('Waiting until available', batch) do
             wait_until(wait_time, retry_interval) { transport.batch_connected?(batch) }
-            batch.map { |target| Result.new(target) }
+            batch.map { |target| Result.new(target, action: 'wait_until_available', object: description) }
           rescue TimeoutError => e
             available, unavailable = batch.partition { |target| transport.batch_connected?([target]) }
             (
-              available.map { |target| Result.new(target) } +
-              unavailable.map { |target| Result.from_exception(target, e) }
+              available.map { |target| Result.new(target, action: 'wait_until_available', object: description) } +
+              unavailable.map { |target| Result.from_exception(target, e, action: 'wait_until_available') }
             )
           end
         end

--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -7,7 +7,7 @@ module Bolt
   class Result
     attr_reader :target, :value, :action, :object
 
-    def self.from_exception(target, exception)
+    def self.from_exception(target, exception, action: 'action')
       if exception.is_a?(Bolt::Error)
         error = exception.to_h
       else
@@ -19,7 +19,7 @@ module Bolt
         }
         error['details']['stack_trace'] = exception.backtrace.join('\n') if exception.backtrace
       end
-      Result.new(target, error: error)
+      Result.new(target, error: error, action: action)
     end
 
     def self.for_command(target, stdout, stderr, exit_code, action, command)
@@ -90,7 +90,7 @@ module Bolt
         'object' => @object }
     end
 
-    def initialize(target, error: nil, message: nil, value: nil, action: nil, object: nil)
+    def initialize(target, error: nil, message: nil, value: nil, action: 'action', object: nil)
       @target = target
       @value = value || {}
       @action = action

--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -46,13 +46,13 @@ module Bolt
         @logger = Logging.logger[self]
       end
 
-      def with_events(target, callback)
+      def with_events(target, callback, action)
         callback&.call(type: :node_start, target: target)
 
         result = begin
                    yield
                  rescue StandardError, NotImplementedError => e
-                   Bolt::Result.from_exception(target, e)
+                   Bolt::Result.from_exception(target, e, action: action)
                  end
 
         callback&.call(type: :node_result, result: result)
@@ -106,7 +106,7 @@ module Bolt
       def batch_task(targets, task, arguments, options = {}, &callback)
         assert_batch_size_one("batch_task()", targets)
         target = targets.first
-        with_events(target, callback) do
+        with_events(target, callback, 'task') do
           @logger.debug { "Running task run '#{task}' on #{target.safe_name}" }
           run_task(target, task, arguments, options)
         end
@@ -120,7 +120,7 @@ module Bolt
       def batch_command(targets, command, options = {}, &callback)
         assert_batch_size_one("batch_command()", targets)
         target = targets.first
-        with_events(target, callback) do
+        with_events(target, callback, 'command') do
           @logger.debug("Running command '#{command}' on #{target.safe_name}")
           run_command(target, command, options)
         end
@@ -134,7 +134,7 @@ module Bolt
       def batch_script(targets, script, arguments, options = {}, &callback)
         assert_batch_size_one("batch_script()", targets)
         target = targets.first
-        with_events(target, callback) do
+        with_events(target, callback, 'script') do
           @logger.debug { "Running script '#{script}' on #{target.safe_name}" }
           run_script(target, script, arguments, options)
         end
@@ -148,7 +148,7 @@ module Bolt
       def batch_upload(targets, source, destination, options = {}, &callback)
         assert_batch_size_one("batch_upload()", targets)
         target = targets.first
-        with_events(target, callback) do
+        with_events(target, callback, 'upload') do
           @logger.debug { "Uploading: '#{source}' to #{destination} on #{target.safe_name}" }
           upload(target, source, destination, options)
         end

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -197,7 +197,7 @@ module Bolt
           end
         rescue StandardError => e
           targets.map do |target|
-            Bolt::Result.from_exception(target, e)
+            Bolt::Result.from_exception(target, e, 'task')
           end
         end
       end

--- a/lib/bolt/transport/remote.rb
+++ b/lib/bolt/transport/remote.rb
@@ -34,7 +34,7 @@ module Bolt
         remote_task = task.remote_instance
 
         result = transport.run_task(proxy_target, remote_task, arguments, options)
-        Bolt::Result.new(target, value: result.value)
+        Bolt::Result.new(target, value: result.value, action: 'task', object: task.name)
       end
     end
   end

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -277,6 +277,7 @@ describe "Bolt::Executor" do
       results = executor.wait_until_available(targets)
       results.each do |result|
         expect(result).to be_instance_of(Bolt::Result)
+        expect(result.action).to eq('wait_until_available')
       end
     end
 
@@ -285,6 +286,7 @@ describe "Bolt::Executor" do
 
       results = executor.wait_until_available(targets, wait_time: 0, retry_interval: 0)
       results.each do |result|
+        expect(result.action).to eq('wait_until_available')
         expect(result.error_hash['msg']).to eq('Timed out waiting for target')
         expect(result.error_hash['kind']).to eq('puppetlabs.tasks/exception-error')
       end
@@ -297,6 +299,7 @@ describe "Bolt::Executor" do
 
       results = executor.wait_until_available([targets[0]], wait_time: 2, retry_interval: 1)
       results.each do |result|
+        expect(result.action).to eq('wait_until_available')
         expect(result.error_hash['msg']).to eq('Timed out waiting for target')
         expect(result.error_hash['kind']).to eq('puppetlabs.tasks/exception-error')
       end
@@ -308,6 +311,7 @@ describe "Bolt::Executor" do
 
       results = executor.wait_until_available([targets[0]])
       results.each do |result|
+        expect(result.action).to eq('wait_until_available')
         expect(result.error_hash['msg']).to eq('Timed out waiting for target')
         expect(result.error_hash['kind']).to eq('puppetlabs.tasks/exception-error')
       end

--- a/spec/bolt/result_set_spec.rb
+++ b/spec/bolt/result_set_spec.rb
@@ -19,12 +19,12 @@ describe Bolt::Result do
   end
   let(:expected) {
     [{ "target" => "target1",
-       "action" => nil,
+       "action" => 'action',
        "object" => nil,
        "status" => "success",
        "value" => { "key" => "val1" } },
      { "target" => "target1",
-       "action" => nil,
+       "action" => 'action',
        "object" => nil,
        "status" => "failure",
        "value" => { "key" => "val2", "_error" => { "kind" => "bolt/oops" } } }]

--- a/spec/bolt/result_spec.rb
+++ b/spec/bolt/result_spec.rb
@@ -8,6 +8,33 @@ require 'bolt/result'
 describe Bolt::Result do
   let(:target) { "foo" }
 
+  describe :initialize do
+    it 'sets default values' do
+      result = Bolt::Result.new(target)
+      expect(result.target).to eq('foo')
+      expect(result.value).to eq({})
+      expect(result.action).to eq('action')
+      expect(result.object).to eq(nil)
+    end
+
+    it 'sets error' do
+      result = Bolt::Result.new(target, error: { 'This' => 'is an error' })
+      expect(result.error_hash).to eq('This' => 'is an error')
+      expect(result.value['_error']).to eq('This' => 'is an error')
+    end
+
+    it 'errors if error is not a hash' do
+      expect { Bolt::Result.new(target, error: 'This is an error') }
+        .to raise_error(RuntimeError, 'TODO: how did we get a string error')
+    end
+
+    it 'sets message' do
+      result = Bolt::Result.new(target, message: 'This is a message')
+      expect(result.message).to eq('This is a message')
+      expect(result.value['_output']).to eq('This is a message')
+    end
+  end
+
   describe :from_exception do
     let(:result) do
       ex = RuntimeError.new("oops")
@@ -29,6 +56,17 @@ describe Bolt::Result do
 
     it 'has an _error in value' do
       expect(result.value['_error']['msg']).to eq("oops")
+    end
+
+    it 'sets default action' do
+      expect(result.action).to eq('action')
+    end
+
+    it 'sets action when specified as an argument' do
+      ex = RuntimeError.new("oops")
+      ex.set_backtrace('/path/to/bolt/node.rb:42')
+      result = Bolt::Result.from_exception(target, ex, action: 'custom_action')
+      expect(result.action).to eq('custom_action')
     end
   end
 


### PR DESCRIPTION
Closes #1724, #1718 

Seems that sometimes Results are created without actions, causing exceptions to be thrown when referenced from the Human outputter.

**TODO**
- Should i put a guard in the human outputter to check for `nil` actions? https://github.com/puppetlabs/bolt/blob/master/lib/bolt/outputter/human.rb#L101
- Need to add tests for the `remote` transport. There doesn't seem to be any. I'm thinking the easiest course of action would be to write some unit tests that mock out the executor.  **Does this sound right?**
- Integration tests i could probably write based off of the `local` transport. **Does this sound right?**