### PR TITLE
(GH-1673) Add run_task_with plan function

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/run_task_with.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task_with.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+require 'bolt/error'
+require 'bolt/pal'
+require 'bolt/task'
+
+# Runs a given instance of a `Task` with target-specific parameters on the given set of targets and
+# returns the result from each. This function differs from {run_task} by accepting a block that returns
+# a `Hash` of target-specific parameters that are passed to the task. This can be used to send parameters
+# based on a target's attributes, such as its `facts`, or to use conditional logic to determine the
+# parameters a task should receive for a specific target.
+#
+# This function does nothing if the list of targets is empty.
+#
+# > **Note:** Not available in apply block
+#
+# > **Note:** Not available to targets using the pcp transport
+Puppet::Functions.create_function(:run_task_with) do
+  # Run a task with target-specific parameters.
+  # @param task_name The task to run.
+  # @param targets A pattern identifying zero or more targets. See {get_targets} for accepted patterns.
+  # @param options A hash of additional options.
+  # @option options [Boolean] _catch_errors Whether to catch raised errors.
+  # @option options [Boolean] _noop Run the task in noop mode if available.
+  # @option options [String] _run_as User to run as using privilege escalation.
+  # @param block A block that returns a `Hash` of target-specific parameters for the task.
+  # @return A list of results, one entry per target.
+  # @example Run a task with target-specific parameters as root
+  #   run_task_with('my_task', $targets, '_run_as' => 'root') |$t| {
+  #     { 'param1' => $t.vars['var1'],
+  #       'param2' => $t.vars['var2'] }
+  #   }
+  dispatch :run_task_with do
+    param 'String[1]', :task_name
+    param 'Boltlib::TargetSpec', :targets
+    optional_param 'Hash[String[1], Any]', :options
+    required_block_param 'Callable[Target]', :block
+    return_type 'ResultSet'
+  end
+
+  # Run a task with target-specific parameters, logging the provided description.
+  # @param task_name The task to run.
+  # @param targets A pattern identifying zero or more targets. See {get_targets} for accepted patterns.
+  # @param description A description to be output when calling this function.
+  # @param options A hash of additional options.
+  # @option options [Boolean] _catch_errors Whether to catch raised errors.
+  # @option options [Boolean] _noop Run the task in noop mode if available.
+  # @option options [String] _run_as User to run as using privilege escalation.
+  # @param block A block that returns a `Hash` of target-specific parameters for the task.
+  # @return A list of results, one entry per target.
+  # @example Run a task with target-specific parameters and a description
+  #   run_task_with('my_task', $targets, 'Update system packages') |$t| {
+  #     { 'param1' => $t.vars['var1'],
+  #       'param2' => $t.vars['var2'] }
+  #   }
+  dispatch :run_task_with_with_description do
+    param 'String[1]', :task_name
+    param 'Boltlib::TargetSpec', :targets
+    param 'Optional[String]', :description
+    optional_param 'Hash[String[1], Any]', :options
+    required_block_param 'Callable[Target]', :block
+    return_type 'ResultSet'
+  end
+
+  def run_task_with(task_name, targets, options = {}, &block)
+    run_task_with_with_description(task_name, targets, nil, options, &block)
+  end
+
+  def run_task_with_with_description(task_name, targets, description, options = {})
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(
+          Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING,
+          action: 'run_task_with'
+        )
+    end
+
+    executor  = Puppet.lookup(:bolt_executor)
+    inventory = Puppet.lookup(:bolt_inventory)
+    error_set = []
+
+    # Report to analytics
+    executor.report_function_call(self.class.name)
+    executor.report_bundled_content('Task', task_name)
+
+    # Keep valid metaparameters, discarding everything else
+    options = options.select { |k, _v| k.start_with?('_') }
+                     .transform_keys { |k| k.sub(/^_/, '').to_sym }
+
+    options[:description] = description if description
+
+    # Get all the targets
+    targets = Array(inventory.get_targets(targets))
+
+    # If all targets use the 'pcp' transport, use a fake task instead of loading the local definition
+    # Otherwise, load the local task definition
+    if (pcp_only = targets.any? && targets.all? { |t| t.transport == 'pcp' })
+      task = Bolt::Task.new(task_name, {}, [{ 'name' => '', 'path' => '' }])
+    else
+      task_signature = Puppet::Pal::ScriptCompiler.new(closure_scope.compiler).task_signature(task_name)
+
+      if task_signature.nil?
+        raise Bolt::Error.unknown_task(task_name)
+      end
+
+      task = Bolt::Task.from_task_signature(task_signature)
+    end
+
+    # Map the targets to their specific parameters and merge with the defaults
+    target_mapping = targets.each_with_object({}) do |target, mapping|
+      params = yield(target)
+
+      # Parameters returned from the block should be a Hash. If they're not, create a failing
+      # Result for the target that will later be added to the ResultSet.
+      unless params.is_a?(Hash)
+        exception = with_stack(
+          :TYPE_MISMATCH,
+          "Block must return a Hash of parameters, received #{params.class}"
+        )
+        error_set << Bolt::Result.from_exception(target, exception, action: 'task')
+        next
+      end
+
+      # If parameters are mismatched, create a failing result for the target that will later
+      # be added to the ResultSet.
+      unless pcp_only
+        params = task.parameter_defaults.merge(params)
+
+        type_match = task_signature.runnable_with?(params) do |mismatch_message|
+          exception = with_stack(:TYPE_MISMATCH, mismatch_message)
+          error_set << Bolt::Result.from_exception(target, exception, action: 'task')
+        end
+
+        next unless type_match
+      end
+
+      # If there is a type mismatch between the type Data and the type of the params, create
+      # a failing result for the target that will later be added to the ResultSet.
+      unless Puppet::Pops::Types::TypeFactory.data.instance?(params)
+        params_t = Puppet::Pops::Types::TypeCalculator.infer_set(params)
+        desc = Puppet::Pops::Types::TypeMismatchDescriber.singleton.describe_mismatch(
+          'Task parameters are not of type Data. run_task_with()',
+          Puppet::Pops::Types::TypeFactory.data, params_t
+        )
+        exception = with_stack(:TYPE_NOT_DATA, desc)
+        error_set << Bolt::Result.from_exception(target, exception, action: 'task')
+        next
+      end
+
+      # Wrap parameters marked with '"sensitive": true' in the task metadata with a
+      # Sensitive wrapper type. This way it's not shown in logs.
+      if (param_spec = task.parameters)
+        params.each do |k, v|
+          if param_spec[k] && param_spec[k]['sensitive']
+            params[k] = Puppet::Pops::Types::PSensitiveType::Sensitive.new(v)
+          end
+        end
+      end
+
+      mapping[target] = task.parameter_defaults.merge(params)
+    end
+
+    # Add a noop parameter if the function was called with the noop metaparameter.
+    if options[:noop]
+      if task.supports_noop
+        target_mapping.each_value { |params| params['_noop'] = true }
+      else
+        raise with_stack(:TASK_NO_NOOP, 'Task does not support noop')
+      end
+    end
+
+    if targets.empty?
+      Bolt::ResultSet.new([])
+    else
+      # Combine the results from the task run with any failing results that were
+      # generated earlier when creating the target mapping
+      task_result = executor.run_task_with(target_mapping, task, options)
+      result = Bolt::ResultSet.new(task_result.results + error_set)
+
+      if !result.ok && !options[:catch_errors]
+        raise Bolt::RunFailure.new(result, 'run_task', task_name)
+      end
+
+      result
+    end
+  end
+
+  def with_stack(kind, msg)
+    issue = Puppet::Pops::Issues.issue(kind) { msg }
+    Puppet::ParseErrorWithIssue.from_issue_and_stack(issue)
+  end
+end

--- a/bolt-modules/boltlib/spec/functions/run_task_with_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_with_spec.rb
@@ -1,0 +1,435 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/executor'
+require 'bolt/inventory'
+require 'bolt/result'
+require 'bolt/result_set'
+require 'puppet/pops/types/p_sensitive_type'
+
+Sensitive = Puppet::Pops::Types::PSensitiveType::Sensitive
+
+class TaskTypeMatcher < Mocha::ParameterMatchers::Equals
+  def initialize(executable, input_method)
+    super(nil)
+    @executable = Regexp.new(executable)
+    @input_method = input_method
+  end
+
+  def matches?(available_parameters)
+    other = available_parameters.shift
+    @executable =~ other.files.first['path'] && @input_method == other.metadata['input_method']
+  end
+end
+
+describe 'run_task_with' do
+  include PuppetlabsSpec::Fixtures
+  let(:executor)      { Bolt::Executor.new }
+  let(:inventory)     { Bolt::Inventory.empty }
+  let(:tasks_enabled) { true }
+
+  around(:each) do |example|
+    Puppet[:tasks] = tasks_enabled
+    executor.stubs(:noop).returns(false)
+
+    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
+      example.run
+    end
+  end
+
+  def mock_task(executable, input_method)
+    TaskTypeMatcher.new(executable, input_method)
+  end
+
+  context 'it calls bolt executor run_task_with' do
+    let(:hostname)       { 'a.b.com' }
+    let(:hostname2)      { 'x.y.com' }
+    let(:hosts)          { [hostname, hostname2] }
+    let(:message)        { 'the message' }
+    let(:target)         { inventory.get_target(hostname) }
+    let(:target2)        { inventory.get_target(hostname2) }
+    let(:targets)        { [target, target2] }
+    let(:target_mapping) { { target => task_params, target2 => task_params } }
+    let(:result)         { Bolt::Result.new(target, value: { '_output' => message }) }
+    let(:result2)        { Bolt::Result.new(target2, value: { '_output' => message }) }
+    let(:result_set)     { Bolt::ResultSet.new([result]) }
+    let(:tasks_root)     { File.expand_path(fixtures('modules', 'test', 'tasks')) }
+    let(:task_params)    { { 'message' => message } }
+
+    context 'without tasks enabled' do
+      let(:tasks_enabled) { false }
+
+      it 'fails and reports that run_task is not available' do
+        is_expected.to run
+          .with_params('Test::Echo', hostname)
+          .with_lambda { |_| {} }
+          .and_raise_error(/Plan language function 'run_task_with' cannot be used/)
+      end
+    end
+
+    it 'maps parameters to targets' do
+      executable = File.join(tasks_root, 'meta.sh')
+
+      target_mapping = {
+        target  => { 'message' => target.safe_name },
+        target2 => { 'message' => target2.safe_name }
+      }
+
+      executor.expects(:run_task_with)
+              .with(target_mapping, mock_task(executable, 'environment'), {})
+              .returns(result_set)
+
+      inventory.expects(:get_targets).with(hosts).returns(targets)
+
+      is_expected.to(run
+        .with_params('Test::Meta', hosts)
+        .with_lambda { |t| { 'message' => t.safe_name } })
+    end
+
+    it '_run_as is passed to the executor' do
+      executable = File.join(tasks_root, 'meta.sh')
+
+      executor.expects(:run_task_with)
+              .with(target_mapping, mock_task(executable, 'environment'), run_as: 'root')
+              .returns(result_set)
+
+      inventory.expects(:get_targets).with(hosts).returns(targets)
+
+      is_expected.to(run
+        .with_params('Test::Meta', hosts, { '_run_as' => 'root' })
+        .with_lambda { |_| task_params }
+        .and_return(result_set))
+    end
+
+    it 'uses the default if a parameter is not specified' do
+      executable = File.join(tasks_root, 'params.sh')
+
+      args = {
+        'mandatory_string'  => 'str',
+        'mandatory_integer' => 10,
+        'mandatory_boolean' => true
+      }
+
+      defaults = {
+        'default_string'          => 'hello',
+        'optional_default_string' => 'goodbye'
+      }
+
+      target_mapping = {
+        target  => args.merge(defaults),
+        target2 => args.merge(defaults)
+      }
+
+      executor.expects(:run_task_with).with(target_mapping, mock_task(executable, 'stdin'), {}).returns(result_set)
+      inventory.expects(:get_targets).with(hosts).returns(targets)
+
+      is_expected.to(run
+        .with_params('Test::Params', hosts)
+        .with_lambda { |_| args })
+    end
+
+    it 'does not use the default if a parameter is specified' do
+      executable = File.join(tasks_root, 'params.sh')
+
+      args = {
+        'mandatory_string'        => 'str',
+        'mandatory_integer'       => 10,
+        'mandatory_boolean'       => true,
+        'default_string'          => 'something',
+        'optional_default_string' => 'something else'
+      }
+
+      target_mapping = { target => args, target2 => args }
+
+      executor.expects(:run_task_with).with(target_mapping, mock_task(executable, 'stdin'), {}).returns(result_set)
+      inventory.expects(:get_targets).with(hosts).returns(targets)
+
+      is_expected.to(run
+        .with_params('Test::Params', hosts)
+        .with_lambda { |_| args })
+    end
+
+    it 'does not invoke Bolt when target list is empty' do
+      executor.expects(:run_task).never
+      inventory.expects(:get_targets).with([]).returns([])
+
+      is_expected.to(run
+        .with_params('Test::Yes', [])
+        .with_lambda { |_| {} }
+        .and_return(Bolt::ResultSet.new([])))
+    end
+
+    it 'reports the function call and task name to analytics' do
+      executor.expects(:report_function_call).with('run_task_with')
+      executor.expects(:report_bundled_content).with('Task', 'Test::Echo').once
+      executable = File.join(tasks_root, 'echo.sh')
+
+      executor.expects(:run_task_with).with(target_mapping, mock_task(executable, nil), {}).returns(result_set)
+      inventory.expects(:get_targets).with(hosts).returns(targets)
+
+      is_expected.to(run
+        .with_params('Test::Echo', hosts)
+        .with_lambda { |_| task_params }
+        .and_return(result_set))
+    end
+
+    context 'with description' do
+      let(:message) { 'test message' }
+
+      it 'passes the description through' do
+        executor.expects(:run_task_with).with(target_mapping, anything, description: message).returns(result_set)
+        inventory.expects(:get_targets).with(hosts).returns(targets)
+
+        is_expected.to(run
+          .with_params('test::yes', hosts, message)
+          .with_lambda { |_| task_params })
+      end
+    end
+
+    context 'without description' do
+      it 'ignores description if options are passed' do
+        executor.expects(:run_task_with).with(target_mapping, anything, {}).returns(result_set)
+        inventory.expects(:get_targets).with(hosts).returns(targets)
+
+        is_expected.to(run
+          .with_params('test::yes', hosts, {})
+          .with_lambda { |_| task_params })
+      end
+
+      it 'ignores description if no parameters are passed' do
+        executor.expects(:run_task_with).with(target_mapping, anything, {}).returns(result_set)
+        inventory.expects(:get_targets).with(hosts).returns(targets)
+
+        is_expected.to(run
+          .with_params('test::yes', hosts)
+          .with_lambda { |_| task_params })
+      end
+    end
+
+    context 'with multiple destinations' do
+      let(:result_set) { Bolt::ResultSet.new([result, result2]) }
+
+      it 'targets can be specified as repeated nested arrays and strings and combine into one list of targets' do
+        executable = File.join(tasks_root, 'meta.sh')
+
+        executor.expects(:run_task_with)
+                .with(target_mapping, mock_task(executable, 'environment'), {})
+                .returns(result_set)
+
+        inventory.expects(:get_targets).with([hostname, [[hostname2]], []]).returns(targets)
+
+        is_expected.to(run
+          .with_params('Test::Meta', [hostname, [[hostname2]], []])
+          .with_lambda { |_| task_params }
+          .and_return(result_set))
+      end
+
+      it 'targets can be specified as repeated nested arrays and Targets and combine into one list of targets' do
+        executable = File.join(tasks_root, 'meta.sh')
+
+        executor.expects(:run_task_with)
+                .with(target_mapping, mock_task(executable, 'environment'), {})
+                .returns(result_set)
+
+        inventory.expects(:get_targets).with([target, [[target2]], []]).returns(targets)
+
+        is_expected.to(run
+          .with_params('Test::Meta', [target, [[target2]], []])
+          .with_lambda { |_| task_params }
+          .and_return(result_set))
+      end
+
+      context 'when a command fails on one target' do
+        let(:failresult) { Bolt::Result.new(target2, error: { 'msg' => 'oops' }) }
+        let(:result_set) { Bolt::ResultSet.new([result, failresult]) }
+
+        it 'errors by default' do
+          executable = File.join(tasks_root, 'meta.sh')
+
+          executor.expects(:run_task_with)
+                  .with(target_mapping, mock_task(executable, 'environment'), {})
+                  .returns(result_set)
+
+          inventory.expects(:get_targets).with(hosts).returns(targets)
+
+          is_expected.to(run
+            .with_params('Test::Meta', hosts)
+            .with_lambda { |_| task_params }
+            .and_raise_error(Bolt::RunFailure))
+        end
+
+        it 'does not error with _catch_errors' do
+          executable = File.join(tasks_root, 'meta.sh')
+
+          executor.expects(:run_task_with)
+                  .with(target_mapping, mock_task(executable, 'environment'), catch_errors: true)
+                  .returns(result_set)
+
+          inventory.expects(:get_targets).with(hosts).returns(targets)
+
+          is_expected.to(run
+            .with_params('Test::Meta', [hostname, hostname2], '_catch_errors' => true)
+            .with_lambda { |_| task_params })
+        end
+      end
+    end
+
+    context 'when called on a module that contains manifests/init.pp' do
+      it 'the call does not load init.pp' do
+        executor.expects(:run_task).never
+        inventory.expects(:get_targets).with([]).returns([])
+
+        is_expected.to(run
+          .with_params('test::echo', [])
+          .with_lambda { |_| {} })
+      end
+    end
+
+    context 'when called on a module that contains tasks/init.sh' do
+      let(:target_mapping) { { target => task_params } }
+
+      it 'finds task named after the module' do
+        executable = File.join(tasks_root, 'init.sh')
+
+        executor.expects(:run_task_with).with(target_mapping, mock_task(executable, nil), {}).returns(result_set)
+        inventory.expects(:get_targets).with(hostname).returns([target])
+
+        is_expected.to run
+          .with_params('test', hostname)
+          .with_lambda { |_| task_params }
+          .and_return(result_set)
+      end
+    end
+
+    it 'when called with non existing task - reports an unknown task error' do
+      inventory.expects(:get_targets).with([]).returns([])
+
+      is_expected.to run
+        .with_params('test::nonesuch', [])
+        .with_lambda { |_| {} }
+        .and_raise_error(
+          /Could not find a task named "test::nonesuch"/
+        )
+    end
+
+    context 'with sensitive data parameters' do
+      let(:sensitive_string) { '$up3r$ecr3t!' }
+      let(:sensitive_array)  { [1, 2, 3] }
+      let(:sensitive_hash)   { { 'k' => 'v' } }
+      let(:sensitive_json)   { "#{sensitive_string}\n#{sensitive_array}\n{\"k\":\"v\"}\n" }
+      let(:result)           { Bolt::Result.new(target, value: { '_output' => sensitive_json }) }
+      let(:result_set)       { Bolt::ResultSet.new([result]) }
+      let(:task_params)      { {} }
+
+      it 'with Sensitive metadata - input parameters are wrapped in Sensitive' do
+        executable = File.join(tasks_root, 'sensitive_meta.sh')
+
+        input_params = {
+          'sensitive_string' => sensitive_string,
+          'sensitive_array'  => sensitive_array,
+          'sensitive_hash'   => sensitive_hash
+        }
+
+        expected_params = {
+          'sensitive_string' => Sensitive.new(sensitive_string),
+          'sensitive_array'  => Sensitive.new(sensitive_array),
+          'sensitive_hash'   => Sensitive.new(sensitive_hash)
+        }
+
+        target_mapping = { target => expected_params }
+
+        Sensitive.expects(:new).with(input_params['sensitive_string'])
+                 .returns(expected_params['sensitive_string'])
+        Sensitive.expects(:new).with(input_params['sensitive_array'])
+                 .returns(expected_params['sensitive_array'])
+        Sensitive.expects(:new).with(input_params['sensitive_hash'])
+                 .returns(expected_params['sensitive_hash'])
+
+        executor.expects(:run_task_with).with(target_mapping, mock_task(executable, nil), {}).returns(result_set)
+        inventory.expects(:get_targets).with(hostname).returns(target)
+
+        is_expected.to run
+          .with_params('Test::Sensitive_Meta', hostname)
+          .with_lambda { |_| input_params }
+          .and_return(result_set)
+      end
+    end
+  end
+
+  context 'it validates the task parameters' do
+    let(:task_name)   { 'Test::Params' }
+    let(:hostname)    { 'a.b.com' }
+    let(:target)      { inventory.get_target(hostname) }
+    let(:task_params) { {} }
+
+    it 'errors when the block does not return a Hash' do
+      is_expected.to run
+        .with_params(task_name, hostname)
+        .with_lambda { |_| [] }
+        .and_raise_error(Bolt::RunFailure)
+    end
+
+    it 'errors when unknown parameters are specified' do
+      task_params.merge!(
+        'foo' => nil,
+        'bar' => nil
+      )
+
+      is_expected.to run
+        .with_params(task_name, hostname)
+        .with_lambda { |_| task_params }
+        .and_raise_error(Bolt::RunFailure)
+    end
+
+    it 'errors when required parameters are not specified' do
+      task_params['mandatory_string'] = 'str'
+
+      is_expected.to run
+        .with_params(task_name, hostname)
+        .with_lambda { |_| task_params }
+        .and_raise_error(Bolt::RunFailure)
+    end
+
+    it 'errors when the specified parameter values do not match the expected data types' do
+      task_params.merge!(
+        'mandatory_string' => 'str',
+        'mandatory_integer' => 10,
+        'mandatory_boolean' => 'str',
+        'optional_string' => 10
+      )
+
+      is_expected.to run
+        .with_params(task_name, hostname)
+        .with_lambda { |_| task_params }
+        .and_raise_error(Bolt::RunFailure)
+    end
+
+    it 'errors when the specified parameter values are outside of the expected ranges' do
+      task_params.merge!(
+        'mandatory_string' => '0123456789a',
+        'mandatory_integer' => 10,
+        'mandatory_boolean' => true,
+        'optional_integer' => 10
+      )
+
+      is_expected.to run
+        .with_params(task_name, hostname)
+        .with_lambda { |_| task_params }
+        .and_raise_error(Bolt::RunFailure)
+    end
+
+    it 'errors when a specified parameter value is not Data' do
+      task_params.merge!(
+        'mandatory_string' => 'str',
+        'mandatory_integer' => 10,
+        'mandatory_boolean' => true,
+        'optional_hash' => { now: Time.now }
+      )
+
+      is_expected.to run
+        .with_params(task_name, hostname)
+        .with_lambda { |_| task_params }
+        .and_raise_error(Bolt::RunFailure)
+    end
+  end
+end

--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -32,7 +32,7 @@ module Bolt
     # Transports that need their own batching, like the Orch transport, can
     # instead override the batches() method to split Targets into sets that can
     # be executed together, and override the batch_task() and related methods
-    # to execute a batch of nodes. In that case, those Transports should accept
+    # to execute a batch of targets. In that case, those Transports should accept
     # a block argument and call it with a :node_start event for each Target
     # before executing, and a :node_result event for each Target after
     # execution.
@@ -90,12 +90,12 @@ module Bolt
       # case and raises an error if it's not.
       def assert_batch_size_one(method, targets)
         if targets.length > 1
-          message = "#{self.class.name} must implement #{method} to support batches (got #{targets.length} nodes)"
+          message = "#{self.class.name} must implement #{method} to support batches (got #{targets.length} targets)"
           raise NotImplementedError, message
         end
       end
 
-      # Runs the given task on a batch of nodes.
+      # Runs the given task on a batch of targets.
       #
       # The default implementation only supports batches of size 1 and will fail otherwise.
       #
@@ -109,7 +109,23 @@ module Bolt
         end
       end
 
-      # Runs the given command on a batch of nodes.
+      # Runs the given task on a batch of targets with variable parameters.
+      #
+      # The default implementation only supports batches of size 1 and will fail otherwise.
+      #
+      # Transports may override this method to implment their own batch processing.
+      def batch_task_with(targets, task, target_mapping, options = {}, &callback)
+        assert_batch_size_one("batch_task_with()", targets)
+        target = targets.first
+        arguments = target_mapping[target]
+
+        with_events(target, callback, 'task') do
+          @logger.debug { "Running task run '#{task}' on #{target.safe_name} with '#{arguments.to_json}'" }
+          run_task(target, task, arguments, options)
+        end
+      end
+
+      # Runs the given command on a batch of targets.
       #
       # The default implementation only supports batches of size 1 and will fail otherwise.
       #
@@ -123,7 +139,7 @@ module Bolt
         end
       end
 
-      # Runs the given script on a batch of nodes.
+      # Runs the given script on a batch of targets.
       #
       # The default implementation only supports batches of size 1 and will fail otherwise.
       #
@@ -137,7 +153,7 @@ module Bolt
         end
       end
 
-      # Uploads the given source file to the destination location on a batch of nodes.
+      # Uploads the given source file to the destination location on a batch of targets.
       #
       # The default implementation only supports batches of size 1 and will fail otherwise.
       #
@@ -157,7 +173,7 @@ module Bolt
       end
 
       # Split the given list of targets into a list of batches. The default
-      # implementation returns single-node batches.
+      # implementation returns single-target batches.
       #
       # Transports may override this method, and the corresponding batch_*
       # methods, to implement their own batch processing.

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -210,6 +210,10 @@ module Bolt
         end
       end
 
+      def batch_task_with(_targets, _task, _target_mapping, _options = {})
+        raise NotImplementedError, "pcp transport does not support run_task_with()"
+      end
+
       def batch_connected?(targets)
         resp = get_connection(targets.first.options).query_inventory(targets)
         resp['items'].all? { |node| node['connected'] }


### PR DESCRIPTION
This adds a new plan function `run_task_with` that runs a task on a set
of targets with target-specific parameters. It accepts a lambda that
returns a `Hash` of parameters to pass to the task run on a particular
target.

As an example, a task might expect a parameter with a value that is set
by a target's `facts`. The `run_task_with` function would have a lambda
that assigns this parameter with the appropriate fact:

```
$results = run_task_with('my_task', $targets) |$t| {
    { 'osfamily' => $t.facts['osfamily'] }
}
```

Similar to the `run_task` plan function, `run_task_with` also accepts
an optional `description` parameter, as well as three metaparameters:

- `_catch_errors`
- `_noop`
- `_run_as`

Closes #1673 

!feature

* **Added `run_task_with` plan function**
([#1673](https://github.com/puppetlabs/bolt/issues/1673))

  The new plan function `run_task_with` lets you run tasks on a set of
  targets with target-specific parameters. It accepts a lambda that
  returns a `Hash` of parameters for a particular target.