### PR TITLE
(maint) Fix formatting and regex in changelog script

### DIFF
--- a/scripts/generate_changelog.rb
+++ b/scripts/generate_changelog.rb
@@ -44,7 +44,7 @@ latest = `git describe --abbrev=0`.chomp
 # to only include those that have a valid LABEL (e.g. !feature, !bug)
 stdout_str, stderr_str, status = Open3.capture3(
   "git log -z HEAD...#{latest} "\
-  "--pretty=format:'%b' "\
+  "--pretty=format:'%B' "\
   "--grep='!(#{entries.keys.join('|')})' -E"
 )
 
@@ -84,6 +84,7 @@ entries.each_value do |entry|
     ### #{entry[:name]}
 
     #{entry[:entries].join("\n\n")}
+
   CONTENT
 end
 


### PR DESCRIPTION
This makes two trivial changes to the changelog script:

- Add an extra newline after the last changelog entry. Previously,
headers were printed on the line immediately after the last entry.

- Use the commit message's raw body in `git log` pretty formatting.
Previously, only the commit message's body was being used. This would
cause any commit messages that had a release note label as the subject
of the commit to pass CI but be skipped in the changelog script.

!no-release-note