### PR TITLE
(maint) Handle WaitWritable errors on Windows

### DIFF
--- a/lib/bolt/shell/bash.rb
+++ b/lib/bolt/shell/bash.rb
@@ -378,22 +378,11 @@ module Bolt
                      else
                        !ready_write.nil?
                      end
-          retries = 0
 
           begin
             if writable && index < in_buffer.length
               to_print = in_buffer[index..-1]
-              begin
-                written = inp.write_nonblock to_print
-              rescue IO::WaitWritable, Errno::EINTR => e
-                IO.select(nil, [io])
-                retries += 1
-                if retries < 4
-                  retry
-                else
-                  raise e
-                end
-              end
+              written = inp.write_nonblock to_print
               index += written
 
               if index >= in_buffer.length && !write_stream.empty?

--- a/lib/bolt/shell/bash.rb
+++ b/lib/bolt/shell/bash.rb
@@ -382,16 +382,19 @@ module Bolt
           begin
             if writable && index < in_buffer.length
               to_print = in_buffer[index..-1]
-              written = inp.write_nonblock to_print
-              index += written
+              # On Windows, select marks the input stream as writable even if
+              # it's full. We need to check whether we received wait_writable
+              # and treat that as not having written anything.
+              written = inp.write_nonblock(to_print, exception: false)
+              index += written unless written == :wait_writable
 
               if index >= in_buffer.length && !write_stream.empty?
                 inp.close
                 write_stream = []
               end
             end
-            # If a task has stdin as an input_method but doesn't actually
-            # read from stdin, the task may return and close the input stream
+          # If a task has stdin as an input_method but doesn't actually
+          # read from stdin, the task may return and close the input stream
           rescue Errno::EPIPE
             write_stream = []
           end


### PR DESCRIPTION
The Bash shell was raising WaitWritable errors due to incorrect assumptions
about the behavior of select/wait_writable on Windows. Specifically, when
the IO buffer is full, IO.select will still indicate that the stream is
writable. Our subsequent call to write_nonblock will then raise
WaitWritable which we don't handle.

We now anticipate that condition by passing `exception: false` to 
write_nonblock, indicating that it should return a :wait_writable symbol 
rather than raise an error, and we treat that as having written 0 bytes, 
sending us back through our IO.select loop again.