### PR TITLE
(GH-1725) Target facts should take precedence in apply

### DIFF
--- a/spec/fixtures/apply/basic/plans/fact_merge.pp
+++ b/spec/fixtures/apply/basic/plans/fact_merge.pp
@@ -1,0 +1,17 @@
+plan basic::fact_merge(
+  TargetSpec $targets,
+) {
+  $targetspec = get_targets($targets)
+
+  $fresh = 'air'
+  $os = 'mosis'
+  $targetspec.each |$t| { $t.set_var('fresh', 'start') }
+  $targetspec.each |$t| {
+    add_facts($t, { 'fresh' => 'strawberries' })
+  }
+
+  return apply($targetspec) {
+    notify { "Fresh ${$fresh}": }
+    notify { "${$os}": }
+  }
+}

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -101,6 +101,15 @@ describe "passes parsed AST to the apply_catalog task" do
       expect(logs).to include(/Plan vars set to undef:/)
     end
 
+    it 'facts override plan vars and target vars' do
+      result = run_cli_json(%w[plan run basic::fact_merge] + config_flags)
+      notify = get_notifies(result)
+      expect(notify[0]['title']).to eq('Fresh strawberries')
+      logs = @log_output.readlines
+      expect(logs).to include(/Plan variable \$fresh will be overridden by fact/)
+      expect(logs).to include(/Target variable \$fresh will be overridden by fact/)
+    end
+
     it 'applies a class from the modulepath' do
       result = run_cli_json(%w[plan run basic::class] + config_flags)
       notify = get_notifies(result)


### PR DESCRIPTION
If a target has a fact that shares a name with a plan variable, a
target variable, or both, then the fact should take precedence when
passed in to apply. Previously, defining a fact with the same name as
another variable would cause a redefinition error in the apply block,
where now referencing the variable will refer to the fact value.

Closes #1725

!bug

* **Target facts with the same name as a plan or Target variable should
  not raise an error** ([#1725](https://github.com/puppetlabs/bolt/issues/1725))

  Previously, defining a fact with the same name as
  another variable would cause a redefinition error in the apply block,
  where now referencing the variable will refer to the fact value.