### PR TITLE
(maint) Periodically expire gem cache

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
+          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
+          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3
@@ -68,7 +68,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
+          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3

--- a/.github/workflows/modules.yaml
+++ b/.github/workflows/modules.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
+          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3
@@ -60,7 +60,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
+          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -30,25 +30,25 @@ jobs:
         uses: actions/setup-ruby@v1
         with:
           ruby-version: 2.5.x
+      - name: Install bundler
+        run: |
+          gem install bundler
+          bundle config path vendor/bundle
       - name: Cache gems
-        id: gems
+        id: cache
         uses: actions/cache@v1
         with:
-          path: .bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
+      - name: Install gems
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: bundle install --jobs 4 --retry 3
       - name: Cache modules
         id: modules
         uses: actions/cache@v1
         with:
           path: modules
           key: ${{ runner.os }}-modules-${{ hashFiles('**/Puppetfile') }}
-      - name: Install bundler
-        run: |
-          gem install bundler
-          bundle config --local path .bundle
-      - name: Install gems
-        if: steps.gems.outputs.cache-hit != 'true'
-        run: bundle install --jobs 4 --retry 3
       - name: Install modules
         if: steps.modules.outputs.cache-hit != 'true'
         run: bundle exec r10k puppetfile install
@@ -73,25 +73,25 @@ jobs:
         uses: actions/setup-ruby@v1
         with:
           ruby-version: 2.5.x
+      - name: Install bundler
+        run: |
+          gem install bundler
+          bundle config path vendor/bundle
       - name: Cache gems
-        id: gems
+        id: cache
         uses: actions/cache@v1
         with:
-          path: .bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
+      - name: Install gems
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: bundle install --jobs 4 --retry 3
       - name: Cache modules
         id: modules
         uses: actions/cache@v1
         with:
           path: modules
           key: ${{ runner.os }}-modules-${{ hashFiles('**/Puppetfile') }}
-      - name: Install bundler
-        run: |
-          gem install bundler
-          bundle config --local path .bundle
-      - name: Install gems
-        if: steps.gems.outputs.cache-hit != 'true'
-        run: bundle install --jobs 4 --retry 3
       - name: Install modules
         if: steps.modules.outputs.cache-hit != 'true'
         run: bundle exec r10k puppetfile install


### PR DESCRIPTION
Previously, the gem caches for jobs run through github actions were
based purely on a hash of the Gemfile and bolt.gemspec. This meant the
caches were only refreshed when we explicitly changed a dependency of
Bolt. Given that we do so relatively infrequently, that meant we could
miss updated versions of our gem dependencies. We now tie the gem cache
to the content of lib/bolt/version.rb, which changes every release. That
ensures we will update the gems we're testing against at least once a
week or so.

This also standardizes the way we handle installing bundler and caching
gems. The location we use for the bundler cache varied by job as did the
order in which we handled installing bundler and unpacking gems. We now
always follow the order a) install bundler, b) try to download the gem
cache, c) install gems if necessary.

!no-release-note