### PR TITLE
(GH-1749) Add external contributions to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@
   that returned `nil`, threw an exception. Returning from a plan with results 
   of `wait_until_available()`, threw an exception.
 
+  _Contributed by [Nick Maludy](https://github.com/nmaludy)_
+
 * **Fix a bug passing arguments to local shell transport**
   ([#1713](https://github.com/puppetlabs/bolt/1713))
 
@@ -100,6 +102,8 @@
   Previously, the `target_mapping` field only supported populating a target's `uri`,
   `name` and `config` values. All of a target's attributes can now be specified in
   the `target_mapping` field, including `facts`, `vars`, `features`, and `alias`.
+
+  _Contributed by [Nick Maludy](https://github.com/nmaludy)_
 
 ## Bolt 2.3.1 (2020-03-30)
 

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -59,6 +59,7 @@ Gem::Specification.new do |spec|
 
   # there is a bug in puppetlabs_spec_helper for modules without fixtures
   spec.add_development_dependency "bundler", ">= 1.14"
+  spec.add_development_dependency "octokit", "~> 4.0"
   spec.add_development_dependency "puppetlabs_spec_helper", "~> 2.7"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/developer-docs/releasing-bolt.md
+++ b/developer-docs/releasing-bolt.md
@@ -1,9 +1,44 @@
 # Releasing Bolt 
 
-Hello, fearless reader! This document details the release process for Bolt. Our current release cadence is weekly for both the bolt gem and bolt system package, usually on Mondays. Here's how we do it: 
+Hello, fearless reader! This document details the release process for Bolt. We have a weekly release cadence and
+aim to release new versions of Bolt on Mondays. 
 
-1. Generate the changelog using the rake task `rake 'changelog[VERSION]'`, where `VERSION` is the new tag, and merge the changes into `master`.
-2. Build and stage bolt packages with the [init_bolt-release job](https://jenkins-master-prod-1.delivery.puppetlabs.net/view/bolt/job/platform_bolt-vanagon_bolt-release-init_bolt-release/) using all defaults except the new tag for Bolt. The version specified will be the new tag in the github repo.
-3. Once step 2 is done and you are ready to push the packages to public repositories, run the [release job](https://jenkins-master-prod-1.delivery.puppetlabs.net/view/bolt/job/platform_ship-bolt_stage-foss-artifacts-all-repos/) with all default parameters except the new tag. This will also kick off the [docs publishing job](https://jenkins-master-prod-1.delivery.puppetlabs.net/view/bolt/job/platform_ship-bolt_publish_docs/) which will build and publish the docs based on the new tag. Note that this job can be run against any REF as a stand-alone pipeline in the case where a change is needed outside of a tagged version. 
-4. After packages are made public update the [Homebrew tap](https://github.com/puppetlabs/homebrew-puppet) with the new version of bolt. This can be accomplished by running the rake task `rake 'brew:cask[puppet-bolt]'` and opening a PR with the changes. Make sure the PR passes the Travis integration tests and merge the PR. 
-5. Once packages are public, send an email to the internal-puppet-products-update group.
+1. Generate the changelog using the changelog rake task, where `VERSION` is the next tagged version of Bolt.
+
+   ```bash
+   $ rake 'changelog[VERSION]'
+   ```
+   
+   Open a PR against `puppetlabs/bolt` and merge the changes into `master`.
+
+   > **Note:** To use the rake task you must be a member of the `puppetlabs` organization and set the environment
+     variable `GITHUB_TOKEN` with a [personal access token](https://github.com/settings/tokens) that has
+     `admin:read:org` permissions.
+
+1. Ensure that the [Bolt pipelines](https://jenkins-master-prod-1.delivery.puppetlabs.net/view/bolt/) are green.
+
+1. Build and stage packages with the 
+   [init_bolt-release job](https://jenkins-master-prod-1.delivery.puppetlabs.net/view/bolt/job/platform_bolt-vanagon_bolt-release-init_bolt-release/).
+   Click on _Build with Parameters_ and set `NEW_TAG` to the next tagged version of Bolt. Click _Build_.
+
+1. Once packages are staged and you are ready to push them to public repositories, run the
+   [release job](https://jenkins-master-prod-1.delivery.puppetlabs.net/view/bolt/job/platform_ship-bolt_stage-foss-artifacts-all-repos/).
+   Click on _Build with Parameters_ and set `REFS` to the next tagged version of Bolt. Click _Build_. 
+   
+   Once the release pipeline is complete it will kick off additional jobs, including the
+   [puppet-bolt docker job](https://jenkins-master-prod-1.delivery.puppetlabs.net/view/bolt/job/platform_ship-bolt_build_and_push_bolt_docker_image/)
+   and [docs publishing job](https://jenkins-master-prod-1.delivery.puppetlabs.net/view/bolt/job/platform_ship-bolt_publish_docs/).
+   If these jobs are not kicked off automatically, they can be triggered manually without affecting the release.
+
+1. After packages are made public, update the [Homebrew tap](https://github.com/puppetlabs/homebrew-puppet) with the
+   new version of Bolt. Checkout a new release branch and run the following rake task:
+
+   ```bash
+   $ rake 'brew:cask[puppet-bolt]'
+   ```
+
+   Open a PR against `puppetlabs/homebrew-puppet`, wait for the Travis CI tests to pass, and then merge to
+   `master`
+
+1. Once packages are public, send an email to the `internal-puppet-products-update` group with the release
+   notes and announce the new version in the `#bolt` channel on the community Slack.

--- a/scripts/generate_changelog.rb
+++ b/scripts/generate_changelog.rb
@@ -1,100 +1,146 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'open3'
+require 'octokit'
 
-# Parses individual notes by searching for a !label, normalizing it to a
-# valid entry key, and returning both the normalized label and the changelog
-# entry
-def parse_commit(labels, commit)
-  regex   = /!(?<label>#{labels.join('|')})(?<entry>[\s\S]*)\z/
-  matches = commit.match(regex)
-  [matches[:label], matches[:entry].strip] if matches
-end
+class ChangelogGenerator
+  attr_reader :version, :entries
 
-# Map of valid labels to their full name and list of entries.
-# Any notes that do not have a valid label are ignored and not added
-# to the changelog.
-entries = {
-  'feature'     => { name: 'New features', entries: [] },
-  'bug'         => { name: 'Bug fixes',    entries: [] },
-  'deprecation' => { name: 'Deprecations', entries: [] },
-  'removal'     => { name: 'Removals',     entries: [] }
-}
+  def initialize(version)
+    unless version
+      warn "Usage: generate_changelog.rb VERSION"
+      exit 1
+    end
 
-version    = ARGV.first
-changelog  = File.expand_path('CHANGELOG.md', Dir.pwd)
+    @version = version
+    @entries = {
+      'feature'     => { name: 'New features', entries: [] },
+      'bug'         => { name: 'Bug fixes',    entries: [] },
+      'deprecation' => { name: 'Deprecations', entries: [] },
+      'removal'     => { name: 'Removals',     entries: [] }
+    }
 
-unless version
-  warn "Usage: generate_changelog.rb VERSION"
-  exit 1
-end
-
-unless File.file?(changelog)
-  warn "Could not find changelog at #{changelog}"
-  exit 1
-end
-
-# Get the latest tag
-latest = `git describe --abbrev=0`.chomp
-
-# Read the git log between master and the most recent tagged release
-# The log is formatted to only include the body of a commit and are
-# terminated with a null terminator. These entries are then filtered
-# to only include those that have a valid LABEL (e.g. !feature, !bug)
-stdout_str, stderr_str, status = Open3.capture3(
-  "git log -z HEAD...#{latest} "\
-  "--pretty=format:'%B' "\
-  "--grep='!(#{entries.keys.join('|')})' -E"
-)
-
-if status.success?
-  # Create an array of commit messages
-  commits = stdout_str.split("\u0000")
-
-  if commits.empty?
-    warn "Did not find any changelog entries"
-    exit 0
+    # Setting the changelog path early lets us check that it exists
+    # before we spend time making API calls
+    changelog
   end
 
-  # Parse the notes and map them to the correct list of entries
-  commits.each do |commit|
-    label, entry = parse_commit(entries.keys, commit)
+  def labels
+    @entries.keys
+  end
 
-    if entries.key?(label)
-      entries[label][:entries] << entry
+  def client
+    unless @client
+      unless ENV['GITHUB_TOKEN']
+        warn "Missing GitHub personal access token. Set $GITHUB_TOKEN with a "\
+             "personal access token to use this script."
+        exit 1
+      end
+
+      Octokit.configure do |c|
+        c.auto_paginate = true
+      end
+
+      @client = Octokit::Client.new(access_token: ENV['GITHUB_TOKEN'])
+    end
+
+    @client
+  end
+
+  def latest
+    @latest ||= client.tags('puppetlabs/bolt').first.name
+  end
+
+  def commits
+    @commits ||= client.compare('puppetlabs/bolt', latest, 'master').commits
+  end
+
+  def org_members
+    @org_members ||= Set.new(client.org_members('puppetlabs').map(&:login))
+  end
+
+  def changelog
+    unless @changelog
+      @changelog = File.expand_path('CHANGELOG.md', Dir.pwd)
+
+      unless File.file?(@changelog)
+        warn "Unable to find changelog at #{@changelog}"
+        exit 1
+      end
+    end
+
+    @changelog
+  end
+
+  # Parses individual commits by searching for a !label, normalizing it to a
+  # valid entry key, and pulling out the changelog entry from the commit
+  def parse_commit(commit)
+    regex = /!(?<label>#{labels.join('|')})(?<entry>[\s\S]*)\z/
+    match = commit.commit.message.match(regex)
+
+    add_entry(match, commit) if match
+  end
+
+  # Adds valid entries to the list of entries, adding extra information about
+  # the author and whether it is an internal contribution
+  def add_entry(match, commit)
+    label = match[:label]
+
+    entries[label][:entries].push(
+      body:     match[:entry],
+      author:   commit.commit.author.name || commit.author.login,
+      profile:  commit.author.html_url,
+      internal: org_members.include?(commit.author.login)
+    )
+  end
+
+  def update_changelog
+    old_lines = File.read(changelog).split("\n")[2..-1]
+
+    new_lines = [
+      "# Changelog\n",
+      "## Bolt #{version} (#{Time.now.strftime '%Y-%m-%d'})\n"
+    ]
+
+    entries.each_value do |type|
+      next unless type[:entries].any?
+      new_lines << "### #{type[:name]}\n"
+
+      type[:entries].each do |entry|
+        new_lines << "#{entry[:body].strip}\n"
+
+        unless entry[:internal]
+          new_lines << "  _Contributed by [#{entry[:author]}](#{entry[:profile]})_\n"
+        end
+      end
+    end
+
+    content = (new_lines + old_lines).join("\n")
+
+    if File.write(changelog, content)
+      puts "Successfully wrote entries to #{changelog}"
+    else
+      warn "Unable to write entries to #{changelog}"
+      exit 1
     end
   end
-else
-  warn stderr_str
-  exit 1
+
+  def generate
+    puts "Loading and parsing commits for #{latest}..master"
+
+    commits.each do |commit|
+      parse_commit(commit)
+    end
+
+    if entries.each_value.all? { |type| type[:entries].empty? }
+      warn "No release notes for #{latest}..master"
+      exit 0
+    end
+
+    update_changelog
+  end
 end
 
-# Build the new changelog content from the list of valid notes
-new_content = <<~CONTENT
-  # Changelog
-
-  ## Bolt #{version} (#{Time.now.strftime '%Y-%m-%d'})
-
-CONTENT
-
-entries.each_value do |entry|
-  next unless entry[:entries].any?
-  new_content += <<~CONTENT
-    ### #{entry[:name]}
-
-    #{entry[:entries].join("\n\n")}
-
-  CONTENT
-end
-
-content = new_content + File.read(changelog)
-                            .split("\n")[1..-1]
-                            .join("\n")
-
-if File.write(changelog, content)
-  puts "Successfully wrote entries to #{changelog}"
-else
-  warn "Unable to write entries to #{changelog}"
-  exit 1
+if $PROGRAM_NAME == __FILE__
+  ChangelogGenerator.new(ARGV.first).generate
 end


### PR DESCRIPTION
This updates the `generate_changelog` script to add acknowledgements for
external contributors as part of the release note for the contribution.

Closes #1749 

!no-release-note