### PR TITLE
(maint) Update net-ssh to 6.0.2

### DIFF
--- a/documentation/bolt_configuration_reference.md.erb
+++ b/documentation/bolt_configuration_reference.md.erb
@@ -132,6 +132,7 @@ These are the options configurable in OpenSSH files:
 | `HostName` | Host name to log. |
 | `IdentityFile` | File in which user's identity key is stored. |
 | `Port` | SSH port. |
+| `StrictHostKeyChecking` | Prevents SSH from automatically adding host keys to the known hosts file, and refuses to connect to a host whose host key has changed. |
 | `User` | Login user. |
 | `UserKnownHostsFile` | Path to local user's host key database. |
 


### PR DESCRIPTION
The recent net-ssh gem release includes several Bolt-related changes,
including support for `StrictHostKeyChecking` option from OpenSSH
config, performance improvements, and support for ed25519 formatted ssh
keys.

Closes #733

!feature

* **OpenSSH config option StrictHostKeyChecking now honored**
  Setting `StrictHostKeyChecking` in your ssh config will now be loaded
  and merged with config along with other OpenSSH settings

!feature
* **Support for ed25519 SSH keys**
  Key exchange algorithm curve25519sha256 is now supported