### PR TITLE
(GH-1755) Add `prompt` plan function

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -79,7 +79,7 @@ namespace :ci do
   task :modules do
     success = true
     # Test core modules
-    %w[boltlib ctrl file out system].each do |mod|
+    %w[boltlib ctrl file out prompt system].each do |mod|
       Dir.chdir("#{__dir__}/bolt-modules/#{mod}") do
         sh 'rake spec' do |ok, _|
           success = false unless ok
@@ -169,6 +169,7 @@ namespace :docs do
                                        'bolt-modules/ctrl',
                                        'bolt-modules/file',
                                        'bolt-modules/out',
+                                       'bolt-modules/prompt',
                                        'bolt-modules/system'])
     json = JSON.parse(File.read(tmpfile))
     funcs = json.delete('puppet_functions')

--- a/bolt-modules/prompt/Rakefile
+++ b/bolt-modules/prompt/Rakefile
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'puppetlabs_spec_helper/rake_tasks'

--- a/bolt-modules/prompt/lib/puppet/functions/prompt.rb
+++ b/bolt-modules/prompt/lib/puppet/functions/prompt.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'bolt/error'
+
+# Display a prompt and wait for a response.
+#
+# > **Note:** Not available in apply block
+Puppet::Functions.create_function(:prompt) do
+  # @param prompt The prompt to display.
+  # @param options A hash of additional options.
+  # @option options [Boolean] sensitive Disable echo back and mark the response as sensitive.
+  # @return The response to the prompt.
+  # @example Prompt the user if plan execution should continue
+  #   $response = prompt('Continue executing plan? [Y\N]')
+  # @example Prompt the user for sensitive information
+  #   $password = prompt('Enter your password', 'sensitive' => true)
+  dispatch :prompt do
+    param 'String', :prompt
+    optional_param 'Hash[String[1], Any]', :options
+    return_type 'Variant[String, Sensitive]'
+  end
+
+  def prompt(prompt, options = {})
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING,
+                              action: 'prompt')
+    end
+
+    options = options.transform_keys(&:to_sym)
+
+    executor = Puppet.lookup(:bolt_executor)
+    executor.report_function_call(self.class.name)
+
+    response = executor.prompt(prompt, options)
+
+    if options[:sensitive]
+      Puppet::Pops::Types::PSensitiveType::Sensitive.new(response)
+    else
+      response
+    end
+  end
+end

--- a/bolt-modules/prompt/spec/functions/prompt_spec.rb
+++ b/bolt-modules/prompt/spec/functions/prompt_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/executor'
+
+describe 'prompt' do
+  let(:executor)      { Bolt::Executor.new }
+  let(:prompt)        { 'prompt' }
+  let(:response)      { 'response' }
+  let(:tasks_enabled) { true }
+
+  around(:each) do |example|
+    Puppet[:tasks] = tasks_enabled
+    Puppet.override(bolt_executor: executor) { example.run }
+  end
+
+  it 'returns a String value' do
+    executor.expects(:prompt).with(prompt, {}).returns(response)
+    is_expected.to run.with_params(prompt).and_return(response)
+  end
+
+  it 'returns a Sensitive value' do
+    executor.expects(:prompt).with(prompt, sensitive: true).returns(response)
+
+    result = subject.execute(prompt, 'sensitive' => true)
+
+    expect(result.class).to be(Puppet::Pops::Types::PSensitiveType::Sensitive)
+    expect(result.unwrap).to eq(response)
+  end
+
+  it 'errors when passed invalid data types' do
+    is_expected.to run.with_params(1)
+                      .and_raise_error(ArgumentError,
+                                       "'prompt' parameter 'prompt' expects a String value, got Integer")
+  end
+
+  it 'reports the call to analytics' do
+    executor.expects(:report_function_call).with('prompt')
+    executor.expects(:prompt).with(prompt, {}).returns(response)
+    is_expected.to run.with_params(prompt)
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+
+    it 'fails and reports that prompt is not available' do
+      is_expected.to run.with_params(prompt)
+                        .and_raise_error(/Plan language function 'prompt' cannot be used/)
+    end
+  end
+end

--- a/bolt-modules/prompt/spec/spec_helper.rb
+++ b/bolt-modules/prompt/spec/spec_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'puppet_pal'
+require 'bolt/pal'
+
+# Ensure tasks are enabled when rspec-puppet sets up an environment
+# so we get task loaders.
+Puppet[:tasks] = true
+Bolt::PAL.load_puppet
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -326,6 +326,23 @@ module Bolt
       end
     end
 
+    def prompt(prompt, options)
+      unless STDIN.tty?
+        raise Bolt::Error.new('STDIN is not a tty, unable to prompt', 'bolt/no-tty-error')
+      end
+
+      STDERR.print("#{prompt}: ")
+      value = if options[:sensitive]
+                STDIN.noecho(&:gets).chomp
+              else
+                STDIN.gets.chomp
+              end
+
+      STDERR.puts if options[:sensitive]
+
+      value
+    end
+
     # Plan context doesn't make sense for most transports but it is tightly
     # coupled with the orchestrator transport since the transport behaves
     # differently when a plan is running. In order to limit how much this

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -332,10 +332,11 @@ module Bolt
       end
 
       STDERR.print("#{prompt}: ")
+
       value = if options[:sensitive]
-                STDIN.noecho(&:gets).chomp
+                STDIN.noecho(&:gets).to_s.chomp
               else
-                STDIN.gets.chomp
+                STDIN.gets.to_s.chomp
               end
 
       STDERR.puts if options[:sensitive]

--- a/lib/bolt/plugin/prompt.rb
+++ b/lib/bolt/plugin/prompt.rb
@@ -19,7 +19,7 @@ module Bolt
 
       def resolve_reference(opts)
         STDERR.print("#{opts['message']}: ")
-        value = STDIN.noecho(&:gets).chomp
+        value = STDIN.noecho(&:gets).to_s.chomp
         STDERR.puts
 
         value

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -335,6 +335,33 @@ describe "Bolt::Executor" do
     end
   end
 
+  context 'prompting' do
+    let(:prompt)   { 'prompt' }
+    let(:response) { 'response' }
+
+    it 'prompts for data on STDERR when executed' do
+      allow(STDIN).to receive(:tty?).and_return(true)
+      allow(STDIN).to receive(:gets).and_return(response)
+      expect(STDERR).to receive(:print).with("#{prompt}: ")
+
+      executor.prompt(prompt, {})
+    end
+
+    it 'does not show input when sensitive' do
+      allow(STDIN).to receive(:tty?).and_return(true)
+      allow(STDERR).to receive(:puts)
+      allow(STDERR).to receive(:print).with("#{prompt}: ")
+      expect(STDIN).to receive(:noecho).and_return(prompt)
+
+      executor.prompt(prompt, sensitive: true)
+    end
+
+    it 'errors if STDIN is not a tty' do
+      allow(STDIN).to receive(:tty?).and_return(false)
+      expect { executor.prompt(prompt, {}) }.to raise_error(Bolt::Error, /STDIN is not a tty, unable to prompt/)
+    end
+  end
+
   it "returns and notifies an error result" do
     node_results.each_key do |_target|
       expect(ssh)


### PR DESCRIPTION
This adds a `prompt` plan function that displays a user-specified prompt
message and accepts a response from `STDIN`. The function pauses
execution of a plan until a response is provided and returns the
response as a `String`, or a `Sensitive` type if the `sensitive => true`
option is set.

Closes #1755 

!feature

* **Add `prompt` plan function**
  ([#1755](https://github.com/puppetlabs/bolt/issues/1755))

  The new `prompt` plan function lets you pause plan execution and
  prompt the user for input.