### PR TITLE
(GH-1729) Add option to skip clean up of tmpdir

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -9,7 +9,7 @@ module Bolt
     OPTIONS = { inventory: %w[targets query rerun description],
                 authentication: %w[user password password-prompt private-key host-key-check ssl ssl-verify],
                 escalation: %w[run-as sudo-password sudo-password-prompt sudo-executable],
-                run_context: %w[concurrency inventoryfile save-rerun],
+                run_context: %w[concurrency inventoryfile save-rerun cleanup],
                 global_config_setters: %w[modulepath boltdir configfile],
                 transports: %w[transport connect-timeout tty],
                 display: %w[format color verbose trace],
@@ -694,6 +694,10 @@ module Bolt
       define('--compile-concurrency CONCURRENCY', Integer,
              'Maximum number of simultaneous manifest block compiles (default: number of cores)') do |concurrency|
         @options[:'compile-concurrency'] = concurrency
+      end
+      define('--[no-]cleanup',
+             'Whether to clean up temporary files created on targets') do |cleanup|
+        @options[:cleanup] = cleanup
       end
       define('-m', '--modulepath MODULES',
              "List of directories containing modules, separated by '#{File::PATH_SEPARATOR}'",

--- a/lib/bolt/config/transport/docker.rb
+++ b/lib/bolt/config/transport/docker.rb
@@ -8,6 +8,8 @@ module Bolt
     module Transport
       class Docker < Base
         OPTIONS = {
+          "cleanup"       => { type: TrueClass,
+                               desc: "Whether to clean up temporary files created on targets." },
           "host"          => { type: String,
                                desc: "Host name." },
           "interpreters"  => { type: Hash,
@@ -27,7 +29,9 @@ module Bolt
                                desc: "Whether to enable tty on exec commands." }
         }.freeze
 
-        DEFAULTS = {}.freeze
+        DEFAULTS = {
+          'cleanup' => true
+        }.freeze
 
         private def validate
           super

--- a/lib/bolt/config/transport/local.rb
+++ b/lib/bolt/config/transport/local.rb
@@ -8,6 +8,8 @@ module Bolt
     module Transport
       class Local < Base
         OPTIONS = {
+          "cleanup"         => { type: TrueClass,
+                                 desc: "Whether to clean up temporary files created on targets." },
           "interpreters"    => { type: Hash,
                                  desc: "A map of an extension name to the absolute path of an executable, "\
                                       "enabling you to override the shebang defined in a task executable. The "\
@@ -36,6 +38,8 @@ module Bolt
         }.freeze
 
         WINDOWS_OPTIONS = {
+          "cleanup"      => { type: TrueClass,
+                              desc: "Whether to clean up temporary files created on targets." },
           "interpreters" => { type: Hash,
                               desc: "A map of an extension name to the absolute path of an executable, "\
                                     "enabling you to override the shebang defined in a task executable. The "\
@@ -47,7 +51,9 @@ module Bolt
                               desc: "The directory to copy and execute temporary files." }
         }.freeze
 
-        DEFAULTS = {}.freeze
+        DEFAULTS = {
+          'cleanup' => true
+        }.freeze
 
         def self.options
           Bolt::Util.windows? ? WINDOWS_OPTIONS : OPTIONS

--- a/lib/bolt/config/transport/ssh.rb
+++ b/lib/bolt/config/transport/ssh.rb
@@ -9,6 +9,8 @@ module Bolt
       class SSH < Base
         LOGIN_SHELLS = %w[sh bash zsh dash ksh powershell].freeze
         OPTIONS = {
+          "cleanup"            => { type: TrueClass,
+                                    desc: "Whether to clean up temporary files created on targets." },
           "connect-timeout"    => { type: Integer,
                                     desc: "How long to wait when establishing connections." },
           "disconnect-timeout" => { type: Integer,
@@ -78,6 +80,7 @@ module Bolt
         }.freeze
 
         DEFAULTS = {
+          "cleanup"            => true,
           "connect-timeout"    => 10,
           "tty"                => false,
           "load-config"        => true,

--- a/lib/bolt/config/transport/winrm.rb
+++ b/lib/bolt/config/transport/winrm.rb
@@ -12,6 +12,8 @@ module Bolt
                                  desc: "Force basic authentication. This option is only available when using SSL." },
           "cacert"          => { type: String,
                                  desc: "The path to the CA certificate." },
+          "cleanup"         => { type: TrueClass,
+                                 desc: "Whether to clean up temporary files created on targets." },
           "connect-timeout" => { type: Integer,
                                  desc: "How long Bolt should wait when establishing connections." },
           "extensions"      => { type: Array,
@@ -53,6 +55,7 @@ module Bolt
 
         DEFAULTS = {
           "basic-auth-only" => false,
+          "cleanup"         => true,
           "connect-timeout" => 10,
           "ssl"             => true,
           "ssl-verify"      => true,

--- a/lib/bolt/shell/bash.rb
+++ b/lib/bolt/shell/bash.rb
@@ -262,7 +262,13 @@ module Bolt
         dir = make_tempdir
         yield dir
       ensure
-        dir&.delete
+        if dir
+          if target.options['cleanup']
+            dir.delete
+          else
+            @logger.warn("Skipping cleanup of tmpdir #{dir}")
+          end
+        end
       end
 
       # In the case where a task is run with elevated privilege and needs stdin

--- a/lib/bolt/shell/bash/tmpdir.rb
+++ b/lib/bolt/shell/bash/tmpdir.rb
@@ -48,7 +48,7 @@ module Bolt
         def delete
           result = @shell.execute(['rm', '-rf', @path], sudoable: true, run_as: @owner)
           if result.exit_code != 0
-            @logger.warn("Failed to clean up tempdir '#{@path}': #{result.stderr.string}")
+            @logger.warn("Failed to clean up tmpdir '#{@path}': #{result.stderr.string}")
           end
           # For testing
           result.stderr.string

--- a/lib/bolt/shell/powershell.rb
+++ b/lib/bolt/shell/powershell.rb
@@ -140,7 +140,13 @@ module Bolt
         end
         yield @tempdir
       ensure
-        rmdir(@tempdir) if owner
+        if owner && @tempdir
+          if target.options['cleanup']
+            rmdir(@tempdir)
+          else
+            @logger.warn("Skipping cleanup of tmpdir '#{@tempdir}'")
+          end
+        end
       end
 
       def run_ps_task(task_path, arguments, input_method)

--- a/lib/bolt/shell/powershell/snippets.rb
+++ b/lib/bolt/shell/powershell/snippets.rb
@@ -20,7 +20,7 @@ module Bolt
             PS
           end
 
-          def make_tempdir(parent)
+          def make_tmpdir(parent)
             <<~PS
             $parent = #{parent}
             $name = [System.IO.Path]::GetRandomFileName()

--- a/lib/bolt/transport/docker.rb
+++ b/lib/bolt/transport/docker.rb
@@ -19,7 +19,7 @@ module Bolt
 
       def upload(target, source, destination, _options = {})
         with_connection(target) do |conn|
-          conn.with_remote_tempdir do |dir|
+          conn.with_remote_tmpdir do |dir|
             basename = File.basename(destination)
             tmpfile = "#{dir}/#{basename}"
             if File.directory?(source)
@@ -57,7 +57,7 @@ module Bolt
         arguments = unwrap_sensitive_args(arguments)
 
         with_connection(target) do |conn|
-          conn.with_remote_tempdir do |dir|
+          conn.with_remote_tmpdir do |dir|
             remote_path = conn.write_remote_executable(dir, script)
             stdout, stderr, exitcode = conn.execute(remote_path, *arguments, {})
             Bolt::Result.for_command(target, stdout, stderr, exitcode, 'script', script)
@@ -77,7 +77,7 @@ module Bolt
         with_connection(target) do |conn|
           execute_options = {}
           execute_options[:interpreter] = select_interpreter(executable, target.options['interpreters'])
-          conn.with_remote_tempdir do |dir|
+          conn.with_remote_tmpdir do |dir|
             if extra_files.empty?
               task_dir = dir
             else

--- a/lib/bolt/transport/docker/connection.rb
+++ b/lib/bolt/transport/docker/connection.rb
@@ -103,29 +103,29 @@ module Bolt
           end
         end
 
-        def make_tempdir
+        def make_tmpdir
           tmpdir = @target.options.fetch('tmpdir', container_tmpdir)
           tmppath = "#{tmpdir}/#{SecureRandom.uuid}"
 
           stdout, stderr, exitcode = execute('mkdir', '-m', '700', tmppath, {})
           if exitcode != 0
-            raise Bolt::Node::FileError.new("Could not make tempdir: #{stderr}", 'TEMPDIR_ERROR')
+            raise Bolt::Node::FileError.new("Could not make tmpdir: #{stderr}", 'TMPDIR_ERROR')
           end
           tmppath || stdout.first
         end
 
-        def with_remote_tempdir
-          dir = make_tempdir
+        def with_remote_tmpdir
+          dir = make_tmpdir
           yield dir
         ensure
           if dir
             if @target.options['cleanup']
               _, stderr, exitcode = execute('rm', '-rf', dir, {})
               if exitcode != 0
-                @logger.warn("Failed to clean up tempdir '#{dir}': #{stderr}")
+                @logger.warn("Failed to clean up tmpdir '#{dir}': #{stderr}")
               end
             else
-              @logger.warn("Skipping cleanup of tempdir '#{dir}'")
+              @logger.warn("Skipping cleanup of tmpdir '#{dir}'")
             end
           end
         end

--- a/lib/bolt/transport/docker/connection.rb
+++ b/lib/bolt/transport/docker/connection.rb
@@ -119,9 +119,13 @@ module Bolt
           yield dir
         ensure
           if dir
-            _, stderr, exitcode = execute('rm', '-rf', dir, {})
-            if exitcode != 0
-              @logger.warn("Failed to clean up tempdir '#{dir}': #{stderr}")
+            if @target.options['cleanup']
+              _, stderr, exitcode = execute('rm', '-rf', dir, {})
+              if exitcode != 0
+                @logger.warn("Failed to clean up tempdir '#{dir}': #{stderr}")
+              end
+            else
+              @logger.warn("Skipping cleanup of tempdir '#{dir}'")
             end
           end
         end

--- a/spec/bolt/inventory/inventory_spec.rb
+++ b/spec/bolt/inventory/inventory_spec.rb
@@ -1118,6 +1118,7 @@ describe Bolt::Inventory::Inventory do
           "load-config" => true,
           "disconnect-timeout" => 11,
           'login-shell' => 'bash',
+          'cleanup' => true,
           "password" => 'sshpass',
           "interpreters" => { ".rb" => "/foo/ruby" } }
       }
@@ -1330,7 +1331,8 @@ describe Bolt::Inventory::Inventory do
             'tty' => false,
             'load-config' => true,
             'disconnect-timeout' => 100,
-            'login-shell' => 'bash'
+            'login-shell' => 'bash',
+            'cleanup' => true
           }
         },
         'vars' => {},

--- a/spec/integration/transport/ssh_spec.rb
+++ b/spec/integration/transport/ssh_spec.rb
@@ -376,7 +376,7 @@ describe Bolt::Transport::SSH, ssh: true do
     end
   end
 
-  context "with specific tempdir using script-dir option" do
+  context "with specific tmpdir using script-dir option" do
     let(:script_dir) { "123456" }
     let(:transport_config) do
       {

--- a/spec/shared_examples/transport.rb
+++ b/spec/shared_examples/transport.rb
@@ -466,7 +466,7 @@ shared_examples 'transport api' do
   end
 
   context 'when tmpdir is specified' do
-    let(:tmpdir) { File.join(os_context[:destination_dir], 'mytempdir') }
+    let(:tmpdir) { File.join(os_context[:destination_dir], 'mytmpdir') }
 
     it "errors when tmpdir doesn't exist" do
       skip "Windows will create the directory anyway" if Bolt::Util.windows?
@@ -475,7 +475,7 @@ shared_examples 'transport api' do
       with_tempfile_containing('script dir', 'dummy script', os_context[:extension]) do |file|
         expect {
           runner.run_script(target, file.path, [])
-        }.to raise_error(Bolt::Node::FileError, /Could not make tempdir.*#{Regexp.escape(tmpdir)}/)
+        }.to raise_error(Bolt::Node::FileError, /Could not make tmpdir.*#{Regexp.escape(tmpdir)}/)
       end
     end
 
@@ -498,7 +498,7 @@ shared_examples 'transport api' do
         end
 
         runner.run_command(target, mkdir)
-        # Once the tempdir is created the target can be configured to upload scripts to it
+        # Once the tmpdir is created the target can be configured to upload scripts to it
         set_config(target, 'tmpdir' => tmpdir)
         example.run
         # Required because the Local transport changes to the tmpdir before running commands


### PR DESCRIPTION
!feature

* **`--no-cleanup` option to leave behind temporary files**
  ([#1729](https://github.com/puppetlabs/bolt/issues/1729))

  The `--no-cleanup` flag or `cleanup: false` transport option can now
  be set to instruct Bolt not to clean up on a target after it's
  finished. This is useful for debugging what Bolt is doing on a system.