### PR TITLE
(maint) Pin net-ssh to 5.2.0

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "logging", "~> 2.2"
   spec.add_dependency "minitar", "~> 0.6"
   spec.add_dependency "net-scp", "~> 1.2"
-  spec.add_dependency "net-ssh", ">= 4.0"
+  spec.add_dependency "net-ssh", [">= 4", "< 6"]
   spec.add_dependency "net-ssh-krb", "~> 0.5"
   spec.add_dependency "orchestrator_client", "~> 0.4"
   spec.add_dependency "puppet", [">= 6.11.0", "< 7"]


### PR DESCRIPTION
The recent release of net-ssh 6.0 has caused issues with corrupted
HMACs, resulting in some tests occasionally failing. This pins net-ssh
to the most recent working version.

Related issue: https://github.com/net-ssh/net-ssh/issues/728

!no-release-note