### PR TITLE
(GH-1768) Add 'optional' and 'default' opts

### DIFF
--- a/documentation/using_plugins.md
+++ b/documentation/using_plugins.md
@@ -49,7 +49,9 @@ The following fields are available to the `env_var` plugin.
 
 | Key | Description | Type | Default |
 | --- | ----------- | ---- | ------- |
-| `var` | The name of the environment variable to read from. | `String` | None |
+| **`var`** | The name of the environment variable to read from. | `String` | None |
+| **`default_value`** | (Optional) A value to use if the environment variable `var` isn't set | `String` | None |
+| **`optional`** | (Optional) Unless `true`, env_var will raise an error when the environment variable `var` does not exist.  When `optional` is `true` and `var` does not exist, env_var returns `nil` | `Boolean` | `false` |
 
 #### Example usage
 

--- a/documentation/using_plugins.md
+++ b/documentation/using_plugins.md
@@ -51,7 +51,7 @@ The following fields are available to the `env_var` plugin.
 | --- | ----------- | ---- | ------- |
 | **`var`** | The name of the environment variable to read from. **Required.** | `String` | None |
 | **`default_value`** | (Optional) A value to use if the environment variable `var` isn't set | `String` | None |
-| **`optional`** | (Optional) Unless `true`, env_var will raise an error when the environment variable `var` does not exist.  When `optional` is `true` and `var` does not exist, env_var returns `nil` | `Boolean` | `false` |
+| **`optional`** | Unless `true`, env_var will raise an error when the environment variable `var` does not exist.  When `optional` is `true` and `var` does not exist, env_var returns `nil` | `Boolean` | `false` |
 
 #### Example usage
 

--- a/documentation/using_plugins.md
+++ b/documentation/using_plugins.md
@@ -50,7 +50,7 @@ The following fields are available to the `env_var` plugin.
 | Key | Description | Type | Default |
 | --- | ----------- | ---- | ------- |
 | **`var`** | The name of the environment variable to read from. **Required.** | `String` | None |
-| **`default_value`** | (Optional) A value to use if the environment variable `var` isn't set | `String` | None |
+| **`default`** | A value to use if the environment variable `var` isn't set | `String` | None |
 | **`optional`** | Unless `true`, env_var will raise an error when the environment variable `var` does not exist.  When `optional` is `true` and `var` does not exist, env_var returns `nil` | `Boolean` | `false` |
 
 #### Example usage

--- a/documentation/using_plugins.md
+++ b/documentation/using_plugins.md
@@ -49,7 +49,7 @@ The following fields are available to the `env_var` plugin.
 
 | Key | Description | Type | Default |
 | --- | ----------- | ---- | ------- |
-| **`var`** | The name of the environment variable to read from. | `String` | None |
+| **`var`** | The name of the environment variable to read from. **Required.** | `String` | None |
 | **`default_value`** | (Optional) A value to use if the environment variable `var` isn't set | `String` | None |
 | **`optional`** | (Optional) Unless `true`, env_var will raise an error when the environment variable `var` does not exist.  When `optional` is `true` and `var` does not exist, env_var returns `nil` | `Boolean` | `false` |
 

--- a/lib/bolt/plugin/env_var.rb
+++ b/lib/bolt/plugin/env_var.rb
@@ -17,6 +17,7 @@ module Bolt
         unless opts['var']
           raise Bolt::ValidationError, "env_var plugin requires that the 'var' is specified"
         end
+        return if opts['optional']
         unless ENV[opts['var']]
           raise Bolt::ValidationError, "env_var plugin requires that the var '#{opts['var']}' be set"
         end

--- a/lib/bolt/plugin/env_var.rb
+++ b/lib/bolt/plugin/env_var.rb
@@ -24,7 +24,7 @@ module Bolt
       end
 
       def resolve_reference(opts)
-        ENV[opts['var']] || opts['default_value']
+        ENV[opts['var']] || opts['default']
       end
     end
   end

--- a/lib/bolt/plugin/env_var.rb
+++ b/lib/bolt/plugin/env_var.rb
@@ -17,7 +17,7 @@ module Bolt
         unless opts['var']
           raise Bolt::ValidationError, "env_var plugin requires that the 'var' is specified"
         end
-        return if opts['optional']
+        return if opts['optional'] || opts['default']
         unless ENV[opts['var']]
           raise Bolt::ValidationError, "env_var plugin requires that the var '#{opts['var']}' be set"
         end

--- a/lib/bolt/plugin/env_var.rb
+++ b/lib/bolt/plugin/env_var.rb
@@ -24,7 +24,7 @@ module Bolt
       end
 
       def resolve_reference(opts)
-        ENV[opts['var']]
+        ENV[opts['var']] || opts['default_value']
       end
     end
   end

--- a/spec/bolt/plugin/env_var_spec.rb
+++ b/spec/bolt/plugin/env_var_spec.rb
@@ -39,4 +39,18 @@ describe Bolt::Plugin::EnvVar do
       expect { subject.validate_resolve_reference(env_var_data).to be_nil }
     end
   end
+
+  describe 'when default_value is provided' do
+    let(:env_var_data) { super().merge({ 'default_value' => 'DEFAULT_STRING' }) }
+    it 'raises a validation error when no var is provided' do
+      env_var_data.delete('var')
+      expect { subject.validate_resolve_reference(env_var_data) }
+        .to raise_error(Bolt::ValidationError, /env_var plugin requires that the 'var' is specified/)
+    end
+
+    it 'returns the default value when no var is provided' do
+      ENV.delete('BOLT_ENV_VAR')
+      expect(subject.resolve_reference(env_var_data)).to eq 'DEFAULT_STRING'
+    end
+  end
 end

--- a/spec/bolt/plugin/env_var_spec.rb
+++ b/spec/bolt/plugin/env_var_spec.rb
@@ -40,8 +40,8 @@ describe Bolt::Plugin::EnvVar do
     end
   end
 
-  describe 'when default_value is provided' do
-    let(:env_var_data) { super().merge({ 'default_value' => 'DEFAULT_STRING' }) }
+  describe 'when default is provided' do
+    let(:env_var_data) { super().merge({ 'default' => 'DEFAULT_STRING' }) }
     it 'raises a validation error when no var is provided' do
       env_var_data.delete('var')
       expect { subject.validate_resolve_reference(env_var_data) }

--- a/spec/bolt/plugin/env_var_spec.rb
+++ b/spec/bolt/plugin/env_var_spec.rb
@@ -25,4 +25,18 @@ describe Bolt::Plugin::EnvVar do
   it 'returns the value of the environment variable' do
     expect(subject.resolve_reference(env_var_data)).to eq('bolt')
   end
+
+  describe 'when optional is true' do
+    let(:env_var_data) { super().merge({ 'optional' => true }) }
+    it 'raises a validation error when no var is provided' do
+      env_var_data.delete('var')
+      expect { subject.validate_resolve_reference(env_var_data) }
+        .to raise_error(Bolt::ValidationError, /env_var plugin requires that the 'var' is specified/)
+    end
+
+    it 'returns undef when the var is not set' do
+      ENV.delete('BOLT_ENV_VAR')
+      expect { subject.validate_resolve_reference(env_var_data).to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
This patch adds two (optional) opts for the `env_var` plugin:
* `default` provides a value to use when the environment variable `var` isn't set
* `optional` allows the env_var to return nil instead of failing when the environment variable `var` isn't set