### PR TITLE
(maint) Make inventory_config optional

### DIFF
--- a/lib/bolt/apply_inventory.rb
+++ b/lib/bolt/apply_inventory.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require 'bolt/project'
-require 'bolt/config'
 require 'bolt/error'
+require 'bolt/apply_target'
 
 module Bolt
   class ApplyInventory

--- a/lib/bolt/apply_target.rb
+++ b/lib/bolt/apply_target.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'addressable'
+
 module Bolt
   class ApplyTarget
     ATTRIBUTES = %i[uri name target_alias config vars facts features
@@ -48,7 +50,7 @@ module Bolt
       # Merge the config hash with inventory config
       config = Bolt::Util.deep_merge(config, @config || {})
       transport = config['transport'] || 'ssh'
-      t_conf = config['transports'][transport] || {}
+      t_conf = config.dig('transports', transport) || {}
       uri_obj = parse_uri(uri)
       @host = uri_obj.hostname || t_conf['host']
       @password = Addressable::URI.unencode_component(uri_obj.password) || t_conf['password']


### PR DESCRIPTION
The code in the constructor for an `ApplyTarget` seems to suggest that config can be an empty hash. Similarly most instance variable declarations provide defaults. The `t_conf` variable assumes that the config hash has a `transport` config section. In practice the defaults for a bolt inventory/config ensure there is always data for config. In the case where a plan runner explicitly does not want to expose target connection information is it reasonable to just provide an empty hash?