### PR TITLE
(maint) Add a to_s method to ApplyTarget

### DIFF
--- a/lib/bolt/apply_target.rb
+++ b/lib/bolt/apply_target.rb
@@ -57,6 +57,10 @@ module Bolt
       @user = Addressable::URI.unencode_component(uri_obj.user) || t_conf['user']
     end
 
+    def to_s
+      @safe_name
+    end
+
     def parse_uri(string)
       require 'addressable/uri'
       if string.nil?

--- a/spec/fixtures/apply/puppet_types/plans/target.pp
+++ b/spec/fixtures/apply/puppet_types/plans/target.pp
@@ -5,6 +5,6 @@ plan puppet_types::target (
   $first.apply_prep
 
   return apply($first) {
-    notify { "ApplyTarget protocol: ${$first.protocol}": }
+    notify { "ApplyTarget $first protocol: ${first.protocol}": }
   }
 }

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -342,7 +342,7 @@ describe "passes parsed AST to the apply_catalog task" do
       it 'serializes Target objects as ApplyTargets in apply blocks' do
         result = run_cli_json(%w[plan run puppet_types::target] + config_flags)
         notify = get_notifies(result)
-        expect(notify[0]['title']).to eq("ApplyTarget protocol: ssh")
+        expect(notify[0]['title']).to eq("ApplyTarget ssh://bolt@localhost:20022 protocol: ssh")
       end
 
       it 'serializes Error objects in apply blocks' do


### PR DESCRIPTION
Add a to_s method to the ApplyTarget class that returns the safe name for coercing into a string in an apply block.