### PR TITLE
(GH-1773) Implement hash() method for Target

### DIFF
--- a/lib/bolt/apply_target.rb
+++ b/lib/bolt/apply_target.rb
@@ -73,5 +73,9 @@ module Bolt
     rescue Addressable::URI::InvalidURIError => e
       raise Bolt::ParseError, "Could not parse target URI: #{e.message}"
     end
+
+    def hash
+      @name.hash
+    end
   end
 end

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -155,5 +155,9 @@ module Bolt
       self.class.equal?(other.class) && @name == other.name
     end
     alias == eql?
+
+    def hash
+      @name.hash
+    end
   end
 end

--- a/spec/bolt/target_spec.rb
+++ b/spec/bolt/target_spec.rb
@@ -199,5 +199,23 @@ describe Bolt::Target do
       expect(target.eql?(target)).to eq(true)
       expect(target.eql?(other)).to eq(false)
     end
+
+    it 'treats two target with the same name as identical' do
+      target = inventory.get_target('target')
+      also_target = inventory.get_target('target')
+
+      expect(target).to be_eql(also_target)
+      expect([target, also_target].uniq).to eq([target])
+    end
+
+    it 'can use a target as a hash key' do
+      target = inventory.get_target('target')
+      also_target = inventory.get_target('target')
+
+      h = { target => "value" }
+      h[also_target] = "other value"
+
+      expect(h).to eq(target => "other value")
+    end
   end
 end


### PR DESCRIPTION
At a time in the past, Bolt::Target implemented both eql? and hash,
allowing Target objects to be uniqed and used as Hash keys. With the
switch over to inventory v2, Bolt::Target objects are generally considered
identical as long as they have the same name, so it makes even more
sense to be able to uniq them, etc. However, the current implementation
lacks the hash method that makes that behavior work.

We now implement hash() for both Bolt::Target and Bolt::ApplyTarget so
that plan authors can treat Target objects the same as target names.

!bug

* **Target objects of the same name are now identical** ([#1773](https://github.com/puppetlabs/bolt/issues/1773))

  Target objects will now be considered identical in all cases if they
  have the same name. This allows uniq to operate on arrays of Targets
  as well as Targets to be used as Hash keys.