### PR TITLE
(GH-1769) Don't fail when writing stdin to a task that has exited

### DIFF
--- a/lib/bolt/shell/bash.rb
+++ b/lib/bolt/shell/bash.rb
@@ -150,8 +150,14 @@ module Bolt
           end
         elsif err =~ /^#{@sudo_id}/
           if sudo_stdin
-            stdin.write("#{sudo_stdin}\n")
-            stdin.close
+            begin
+              stdin.write("#{sudo_stdin}\n")
+              stdin.close
+            # If a task has stdin as an input_method but doesn't actually read
+            # from stdin, the task may return and close the input stream before
+            # we finish writing
+            rescue Errno::EPIPE
+            end
           end
           ''
         else
@@ -399,8 +405,9 @@ module Bolt
                 write_stream = []
               end
             end
-          # If a task has stdin as an input_method but doesn't actually
-          # read from stdin, the task may return and close the input stream
+          # If a task has stdin as an input_method but doesn't actually read
+          # from stdin, the task may return and close the input stream before
+          # we finish writing
           rescue Errno::EPIPE
             write_stream = []
           end


### PR DESCRIPTION
Previously, when using run-as with stdin, both the local and SSH
transports would fail with a "broken pipe" error if the task exited
before all of stdin could be written. This happens if stdin is larger
than the pipe buffer and the task doesn't read stdin. We now anticipate
that error and simply stop trying to write stdin if it's encountered.

!bug

* **Fixed 'broken pipe' errors with SSH and local transports**
  ([#1769](https://github.com/puppetlabs/bolt/issues/1769))

  The SSH and local transports could experience broken pipes when
  using run-as while running a task that accepted input on stdin but
  didn't read it.