### PR TITLE
Add x25519 gem dependency

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -56,6 +56,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "terminal-table", "~> 1.8"
   spec.add_dependency "winrm", "~> 2.0"
   spec.add_dependency "winrm-fs", "~> 1.3"
+  spec.add_dependency "x25519", "~> 1.0"
 
   # there is a bug in puppetlabs_spec_helper for modules without fixtures
   spec.add_development_dependency "bundler", ">= 1.14"


### PR DESCRIPTION
This adds the `x25519` gem as a dependency, which is required for using
the `curve25519sha256 ` kex algorithm with `net-ssh`.

!bug

* **Support curve25519sha256 key exchange algorithm**

  A missing gem dependency caused Bolt to error when using the
  curve25519sha256 key exchange algorithm.

### TODO

- [x] Approval for third-party gem from RE
- [x] Review and merge https://github.com/puppetlabs/puppet-runtime/pull/330