### PR TITLE
(maint) Bump gcloud_inventory module to 0.1.1

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -32,7 +32,7 @@ mod 'puppetlabs-ruby_plugin_helper', '0.1.0'
 # Plugin modules
 mod 'puppetlabs-aws_inventory', '0.5.0'
 mod 'puppetlabs-azure_inventory', '0.3.0'
-mod 'puppetlabs-gcloud_inventory', '0.1.0'
+mod 'puppetlabs-gcloud_inventory', '0.1.1'
 mod 'puppetlabs-pkcs7', '0.1.0'
 mod 'puppetlabs-terraform', '0.5.0'
 mod 'puppetlabs-vault', '0.3.0'


### PR DESCRIPTION
This bumps the `gcloud_inventory` module to 0.1.1, which includes a bug
fix that makes the `resolve_reference` task private.

!bug

* **Set `gcloud_inventory::resolve_reference` task to private** (#1783)

  The `gcloud_inventory::resolve_reference` task has been set to private
  and will no longer appear when using `bolt task show`.