### PR TITLE
(GH-1781) Add ResourceInstance data type

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/datatypes/resourceinstance.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/resourceinstance.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+Puppet::DataTypes.create_type('ResourceInstance') do
+  interface <<-PUPPET
+    attributes => {
+      'target'        => Target,
+      'type'          => Variant[String[1], Type[Resource]],
+      'title'         => String[1],
+      'state'         => Optional[Hash[String[1], Data]],
+      'desired_state' => Optional[Hash[String[1], Data]],
+      'events'        => Optional[Array[Hash[String[1], Data]]]
+    },
+    functions => {
+      add_event               => Callable[[Hash[String[1], Data]], [Hash[String[1], Data]]],
+      set_state               => Callable[[Hash[String[1], Data]], Hash[String[1], Data]],
+      overwrite_state         => Callable[[Hash[String[1], Data]], Hash[String[1], Data]],
+      set_desired_state       => Callable[[Hash[String[1], Data]], Hash[String[1], Data]],
+      overwrite_desired_state => Callable[[Hash[String[1], Data]], Hash[String[1], Data]],
+      reference               => Callable[[], String]
+    }
+  PUPPET
+
+  load_file('bolt/resource_instance')
+  # Needed for Puppet to recognize Bolt::ResourceInstance as a Puppet object when deserializing
+  Bolt::ResourceInstance.include(Puppet::Pops::Types::PuppetObject)
+  implementation_class Bolt::ResourceInstance
+end

--- a/bolt-modules/boltlib/lib/puppet/datatypes/target.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/target.rb
@@ -20,7 +20,8 @@ Puppet::DataTypes.create_type('Target') do
       vars => { type => Optional[Hash[String[1], Data]], kind => given_or_derived },
       facts => { type => Optional[Hash[String[1], Data]], kind => given_or_derived },
       features => { type => Optional[Array[String[1]]], kind => given_or_derived },
-      plugin_hooks => { type => Optional[Hash[String[1], Data]], kind => given_or_derived }
+      plugin_hooks => { type => Optional[Hash[String[1], Data]], kind => given_or_derived },
+      resources => { type => Optional[Hash[String[1], ResourceInstance]], kind => given_or_derived }
     },
     functions => {
       host => Callable[[], Optional[String]],

--- a/bolt-modules/boltlib/lib/puppet/functions/set_resources.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_resources.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'bolt/error'
+
+# Sets one or more resources on a target.
+# For more information about resources, see: https://puppet.com/docs/puppet/latest/lang_resources.html
+#
+# > **Note:** Not available in apply block
+Puppet::Functions.create_function(:set_resources) do
+  # @param target The `Target` object to add resources to. See {get_targets}.
+  # @param resources The resources to set on the target.
+  # @return The added `ResourceInstance` objects.
+  # @example Add multiple resources to a target with an array of `ResourceInstance` objects.
+  #   $resource1 = ResourceInstance.new(
+  #     'target' => $target,
+  #     'type'   => 'file',
+  #     'title'  => '/etc/puppetlabs',
+  #     'state'  => { 'ensure' => 'present' }
+  #   )
+  #   $resource2 = ResourceInstance.new(
+  #     'target' => $target,
+  #     'type'   => 'package',
+  #     'title'  => 'openssl',
+  #     'state'  => { 'ensure' => 'installed' }
+  #   )
+  #   $target.set_resources([$resource1, $resource2])
+  # @example Add resources retrieved with [`get_resources`](#get_resources) to a target.
+  #   $target.apply_prep
+  #   $resources = $target.get_resources(Package).first['resources']
+  #   $target.set_resources($resources)
+  dispatch :set_resources do
+    param 'Target', :target
+    param 'Array[Variant[Hash, ResourceInstance]]', :resources
+    return_type 'Array[ResourceInstance]'
+  end
+
+  # @param target The `Target` object to add resources to. See {get_targets}.
+  # @param resource The resource to set on the target.
+  # @return The added `ResourceInstance` object.
+  # @example Add a single resource to a target with a resource data hash.
+  #   $resource = {
+  #     'type'  => 'file',
+  #     'title' => '/etc/puppetlabs',
+  #     'state' => { 'ensure' => 'present' }
+  #   }
+  #   $target.set_resources($resource)
+  dispatch :set_resource do
+    param 'Target', :target
+    param 'Variant[Hash, ResourceInstance]', :resource
+    return_type 'Array[ResourceInstance]'
+  end
+
+  def set_resources(target, resources)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(
+          Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING,
+          action: 'set_resources'
+        )
+    end
+
+    inventory = Puppet.lookup(:bolt_inventory)
+    executor  = Puppet.lookup(:bolt_executor)
+    executor.report_function_call(self.class.name)
+
+    inventory_target = inventory.get_target(target)
+
+    resources.uniq.map do |resource|
+      if resource.is_a?(Hash)
+        # ResourceInstance expects a Target object, so either get a specified target from
+        # the inventory or use the target this function was called on.
+        resource_target = if resource.key?('target')
+                            inventory.get_target(resource['target'])
+                          else
+                            inventory_target
+                          end
+
+        # Observed state from get_resources() is under the 'parameters' key
+        resource_state = resource['state'] || resource['parameters']
+
+        init_hash = {
+          'target'        => resource_target,
+          'type'          => resource['type'],
+          'title'         => resource['title'],
+          'state'         => resource_state,
+          'desired_state' => resource['desired_state'],
+          'events'        => resource['events']
+        }
+
+        # Calling Bolt::ResourceInstance.new or Bolt::ResourceInstance.from_asserted_hash
+        # will not perform any validation on the parameters. Instead, we need to use the
+        # Puppet constructor to initialize the object, which will first validate the parameters
+        # and then call Bolt::ResourceInstance.from_asserted_hash internally. To do this we
+        # first need to get the Puppet datatype and then call the new function on that type.
+        type = Puppet::Pops::Types::TypeParser.singleton.parse('ResourceInstance')
+        resource = call_function('new', type, init_hash)
+      end
+
+      unless resource.target == inventory_target
+        file, line = Puppet::Pops::PuppetStack.top_of_stack
+        raise Bolt::ValidationError, "Cannot set resource #{resource.reference} for target "\
+                                     "#{resource.target} on target #{inventory_target}. "\
+                                     "#{Puppet::Util::Errors.error_location(file, line)}"
+      end
+
+      inventory_target.set_resource(resource)
+    end
+  end
+
+  def set_resource(target, resource)
+    set_resources(target, [resource])
+  end
+end

--- a/bolt-modules/boltlib/lib/puppet/functions/set_resources.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_resources.rb
@@ -2,7 +2,8 @@
 
 require 'bolt/error'
 
-# Sets one or more resources on a target.
+# Sets one or more ResourceInstances on a Target. This function does not apply or modify
+# resources on a target.
 #
 # For more information about resources see [the
 # documentation](https://puppet.com/docs/puppet/latest/lang_resources.html).
@@ -13,6 +14,7 @@ require 'bolt/error'
 #
 # > **Note:** Not available in apply block
 Puppet::Functions.create_function(:set_resources) do
+  # Set multiple resources
   # @param target The `Target` object to add resources to. See {get_targets}.
   # @param resources The resources to set on the target.
   # @return The added `ResourceInstance` objects.
@@ -40,6 +42,7 @@ Puppet::Functions.create_function(:set_resources) do
     return_type 'Array[ResourceInstance]'
   end
 
+  # Set a single resource
   # @param target The `Target` object to add resources to. See {get_targets}.
   # @param resource The resource to set on the target.
   # @return The added `ResourceInstance` object.

--- a/bolt-modules/boltlib/lib/puppet/functions/set_resources.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_resources.rb
@@ -3,7 +3,13 @@
 require 'bolt/error'
 
 # Sets one or more resources on a target.
-# For more information about resources, see: https://puppet.com/docs/puppet/latest/lang_resources.html
+#
+# For more information about resources see [the
+# documentation](https://puppet.com/docs/puppet/latest/lang_resources.html).
+#
+# > **Note:** The `ResourceInstance` data type is under active development and is subject to
+#   change. You can read more about the data type in the [experimental features
+#   documentation](experimental_features.md#resourceinstance-data-type).
 #
 # > **Note:** Not available in apply block
 Puppet::Functions.create_function(:set_resources) do

--- a/bolt-modules/boltlib/spec/functions/set_resources_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/set_resources_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/executor'
+require 'bolt/inventory'
+
+describe 'set_resources' do
+  let(:executor)      { Bolt::Executor.new }
+  let(:inventory)     { Bolt::Inventory.empty }
+  let(:tasks_enabled) { true }
+
+  around(:each) do |example|
+    Puppet[:tasks] = tasks_enabled
+    Puppet.override(bolt_executor: executor, bolt_inventory: inventory) do
+      example.run
+    end
+  end
+
+  let(:target)    { inventory.get_target('foo') }
+  let(:target2)   { inventory.get_target('bar') }
+  let(:resource)  { Bolt::ResourceInstance.new(resource_data) }
+  let(:resource2) { Bolt::ResourceInstance.new(resource2_data) }
+
+  let(:resource_data) do
+    {
+      'target' => target,
+      'type'   => 'File',
+      'title'  => '/etc/puppetlabs',
+      'state'  => { 'ensure' => 'present' }
+    }
+  end
+
+  let(:resource2_data) do
+    {
+      'target' => target2,
+      'type'   => 'Package',
+      'title'  => 'mysql',
+      'state'  => { 'ensure' => 'installed' }
+    }
+  end
+
+  it 'sets a single resource data hash' do
+    is_expected.to run.with_params(target, resource_data).and_return([resource])
+  end
+
+  it 'sets multiple resource data hashes' do
+    resource2_data['target'] = target
+    is_expected.to run.with_params(target, [resource_data, resource2_data])
+                      .and_return([resource, resource2])
+  end
+
+  it 'sets a single ResourceInstance' do
+    is_expected.to run.with_params(target, resource).and_return([resource])
+  end
+
+  it 'sets multiple ResourceInstances' do
+    resource2_data['target'] = target
+    is_expected.to run.with_params(target, [resource, resource2])
+                      .and_return([resource, resource2])
+  end
+
+  it 'sets multiple resource data hashes and ResourceInstances' do
+    resource2_data['target'] = target
+    is_expected.to run.with_params(target, [resource, resource2_data])
+                      .and_return([resource, resource2])
+  end
+
+  it 'errors on unknown types' do
+    is_expected.to run.with_params(mock('anything')).and_raise_error(ArgumentError)
+  end
+
+  it 'errors when setting a resource for one target on another' do
+    is_expected.to run.with_params(target, resource2).and_raise_error(Bolt::ValidationError)
+  end
+
+  it 'calls Target#set_resource' do
+    target.expects(:set_resource).with(resource).returns(resource)
+    is_expected.to run.with_params(target, resource).and_return([resource])
+  end
+
+  it 'reports the call to analytics' do
+    executor.expects(:report_function_call).with('set_resources')
+    is_expected.to run.with_params(target, resource).and_return([resource])
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+    it 'fails and reports that set_resources is not available' do
+      is_expected.to run.with_params(target, resource)
+                        .and_raise_error(/Plan language function 'set_resources' cannot be used/)
+    end
+  end
+end

--- a/bolt-modules/boltlib/types/planresult.pp
+++ b/bolt-modules/boltlib/types/planresult.pp
@@ -11,5 +11,6 @@ type Boltlib::PlanResult = Variant[Boolean,
                                    ApplyResult,
                                    ResultSet,
                                    Target,
+                                   ResourceInstance,
                                    Array[Boltlib::PlanResult],
                                    Hash[String, Boltlib::PlanResult]]

--- a/documentation/bolt_types_reference.md
+++ b/documentation/bolt_types_reference.md
@@ -23,6 +23,31 @@ The following functions are available to `ApplyResult` objects.
 | `target` | `Target` | The target the result is from. |
 | `to_data` | `Hash` | A serialized representation of `ApplyResult`. |
 
+## `ResourceInstance`
+
+`ResourceInstance` objects are used to store the observed and desired state of a target's resource and to track events for the resource. These objects do not modify or interact with a target's resources.
+
+> **Note:** The `ResourceInstance` data type is under active development and is subject to change.
+
+You can access `ResourceInstance` functions with dot notation, using the syntax: `$resource.function`.
+
+The following functions are available to `ResourceInstance` objects.
+
+| Function | Type returned | Description |
+|---|---|---|
+| `add_event` | `Array[Hash]` | Add an event for the resource. |
+| `desired_state` | `Hash` | [Attributes](https://puppet.com/docs/puppet/latest/lang_resources.html#attributes) describing the desired state of the resource. |
+| `events` | `Array[Hash]` | Events for the resource. |
+| `overwrite_desired_state` | `Hash` | Overwrites the desired state of the resource. |
+| `overwrite_state` | `Hash` | Overwrites the observed state of the resource. |
+| `reference` | `String` | The resource's reference string, e.g. `File[/etc/puppetlabs]` |
+| `set_desired_state` | `Hash` | Sets attributes describing the desired state of the resource. Performs a shallow merge with existing desired state. |
+| `set_state` | `Hash` | Sets attributes describing the observed state of the resource. Performs a shallow merge with existing state. |
+| `state` | `Hash` | [Attributes](https://puppet.com/docs/puppet/latest/lang_resources.html#attributes) describing the observed state of the resource. |
+| `target` | `Target` | The resource's target. |
+| `title` | `String` | The [resource title](https://puppet.com/docs/puppet/latest/lang_resources.html#title).
+| `type` | `String` | The [resource type](https://puppet.com/docs/puppet/latest/lang_resources.html#resource-types). |
+
 ## `Result`
 
 For each target that you execute an action on, Bolt returns a `Result` object and adds the 
@@ -83,7 +108,7 @@ The following functions are available to `Target` objects:
 | Function | Type returned | Description | Note |
 |---|---|---|---|
 | `config` | `Hash[String, Data]` | The inventory configuration for the target. | This function returns the configuration set directly on the target in `inventory.yaml` or set in a plan using `Target.new` or `set_config()`. It does not return default configuration values or configuration set in `bolt.yaml`.  |
-| `facts` | `Hash[String, Data]` | The target's facts. | This function does not lookup facts for a target and only returns the facts specified in an `inventory.yaml` file or set on a target during a plan run. |
+| `facts` | `Hash[String, Data]` | The target's facts. | This function does not look up facts for a target and only returns the facts specified in an `inventory.yaml` file or set on a target during a plan run. |
 | `features` | `Array[String]` | The target's features. ||
 | `host` | `String` | The target's hostname. ||
 | `name` | `String` | The target's human-readable name, or its URI if a name was not given. ||
@@ -91,6 +116,7 @@ The following functions are available to `Target` objects:
 | `plugin_hooks` | `Hash[String, Data]` | The target's `plugin_hooks` [configuration options](bolt_configuration_reference.md#plugin-hooks-configuration-options). ||
 | `port` | `Integer` | The target's connection port. ||
 | `protocol` | `String` | The protocol used to connect to the target. | This is equivalent to the target's `transport`, except for targets using the `remote` transport. For example, a target with the URI `http://example.com` using the `remote` transport would return `http` for the `protocol`. |
+| `resources` | `Hash[String, ResourceInstance]` | The target's resources. | This function does not look up resources for a target and only returns resources set on a target during a plan run. |
 | `safe_name` | `String` | The target's safe name. Equivalent to `name` if a name was given, or the target's `uri` with any password omitted. ||
 | `target_alias` | `Variant[String, Array[String]]` | The target's aliases. ||
 | `transport` | `String` | The transport used to connect to the target. ||

--- a/documentation/bolt_types_reference.md
+++ b/documentation/bolt_types_reference.md
@@ -25,9 +25,13 @@ The following functions are available to `ApplyResult` objects.
 
 ## `ResourceInstance`
 
-`ResourceInstance` objects are used to store the observed and desired state of a target's resource and to track events for the resource. These objects do not modify or interact with a target's resources.
+`ResourceInstance` objects are used to store the observed and desired state of a target's resource
+and to track events for the resource. These objects do not modify or interact with a target's
+resources.
 
 > **Note:** The `ResourceInstance` data type is under active development and is subject to change.
+  You can learn more about this data type and how to use it in the [experimental features
+  documentation](experimental_features.md#resourceinstance-data-type).
 
 You can access `ResourceInstance` functions with dot notation, using the syntax: `$resource.function`.
 

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -7,9 +7,6 @@ releases. While a feature is experimental, its API may change, requiring the use
 update their code or configuration. The Bolt team attempts to make these changes painless
 by providing useful warnings around breaking behavior where possible. 
 
-Experimental features are subject to possible breaking changes between minor Bolt
-releases.
-
 - [Bolt projects](#bolt-projects)
 - [`ResourceInstance` data type](#resourceinstance-data-type)
 
@@ -121,13 +118,13 @@ Use `bolt plan show <plan-name>` to view details and parameters for a specific p
 This feature was introduced in [Bolt
 2.10.0](https://github.com/puppetlabs/bolt/blob/master/CHANGELOG.md#bolt-2100-2020-05-18).
 
-Bolt has had a limited ability to interact with Puppet's Resource Abstraction Layer. Users
+Bolt has had a limited ability to interact with Puppet's Resource Abstraction Layer. You
 could use the `apply` function to generate catalogs and return events, and the `get_resources`
-plan function can be used to query resources on target. The `ResourceInstance` data type is
+plan function can be used to query resources on a target. The `ResourceInstance` data type is
 the first step in enabling plan authors to build resource-based logic into their plans to
 enable a discover-inspect-execute workflow for interacting with resources on remote systems.
 
-The `ResourceInstance` data type is used to store information about a single resource on a
+Use the `ResourceInstance` data type is used to store information about a single resource on a
 target, including its observed state, desired state, and any related events.
 
 > **Note::** The `ResourceInstance` data type does not interact with or modify resources in
@@ -138,9 +135,9 @@ target, including its observed state, desired state, and any related events.
 #### `Target.set_resources()`
 
 The recommended way to create `ResourceInstance` objects is by setting them directly on
-a `Target` object using the `Target.set_resources` function. This function can be used to 
-set one or more resources on a target at a time. You can read more about this function in
-the [Bolt plan functions reference documentation](plan_functions.md#set_resources).
+a `Target` object using the `Target.set_resources` function. Use the function to set one or
+more resources on a target at a time. You can read more about this function in
+[Bolt plan functions](plan_functions.md#set_resources).
 
 The `Target.set_resources` function can set existing `ResourceInstance` objects on a target,
 or take hashes of parameters to create new `ResourceInstance` objects and automatically set
@@ -148,13 +145,6 @@ them on a target.
 
 When setting resources using a hash of parameters, you can pass either a single hash or an
 array of hashes:
-
-> **Note:** When passing a data hash to `Target.set_resources`, the `target` parameter
-  is **optional**. If the `target` parameter is not specified, the function automatically
-  sets the target to the target the function is called on.
-
-> **Note:** If the `target` parameter is any target other than the one you are setting the
-  resource on, Bolt will raise an error.
 
 ```ruby
 $init_hash = {
@@ -171,11 +161,15 @@ $target.set_resources(
 )
 ```
 
-When setting resources using existing `ResourceInstance`s, you can pass either a single
-`ResourceInstance` or an array of `ResourceInstance`s.
+> **Note:** When passing a data hash to `Target.set_resources`, the `target` parameter
+  is **optional**. If the `target` parameter is not specified, the function automatically
+  sets the target to the target the function is called on.
 
-> **Note:** If the target for a `ResourceInstance` does not match the target it is being set
-  on, Bolt will raise an error.
+> **Note:** If the `target` parameter is any target other than the one you are setting the
+  resource on, Bolt will raise an error.
+
+When setting resources using existing `ResourceInstance` objects, you can pass either a single
+`ResourceInstance` or an array of `ResourceInstance` objects.
 
 ```ruby
 $resource = ResourceInstance.new(...)
@@ -185,10 +179,13 @@ $target.set_resources(
 )
 ```
 
-A target can only have a single instance of a given resource. If a duplicate resource is set
-on a target, the `state` and `desired_state` of the duplicate resource will be shallow merged
-with that of the existing resource, while any `events` for the duplicate resource will be
-added to the events for the existing resource.
+> **Note:** If the target for a `ResourceInstance` does not match the target it is being set
+  on, Bolt will raise an error.
+
+A target can only have a single instance of a given resource. If you set a duplicate resource 
+on a target, Bolt shallow merges the `state` and `desired_state` of the duplicate resource 
+with the `state` and `desired_state` of the existing resource and adds any `events` for the
+duplicate resource to the existing resource.
 
 #### `ResourceInstance.new()`
 
@@ -244,17 +241,16 @@ immutable. Since `Target.set_resources` will automatically set the `target` when
 a hash of parameters, the `target` parameter can be ommitted.
 
 The `state`, `desired_state`, and `events` parameters are optional when creating a
-`ResourceInstance`. If `state` and `desired_state` are not specified they will default to
-empty hashes, while `events` will default to an empty array. Each of these attributes can
-be modified during the lifetime of the `ResourceInstance` using [the data type's
+`ResourceInstance`. If you do not specify `state` and `desired_state`, they default to empty
+hashes, while `events` defaults to an empty array. You can modify each of these attributes
+during the lifetime of the `ResourceInstance` using [the data type's
 functions](bolt_types_reference.md#resourceinstance).
 
 ### Functions
 
 The `ResourceInstance` data type has several built-in functions. These range from accessing
-the object's attributes to modifying and overwriting state. A full list of the available
-functions can be found in the [data type reference 
-documentation](bolt_types_reference.md#resourceinstance).
+the object's attributes to modifying and overwriting state. For a full list of the available
+functions, see [Bolt data types](bolt_types_reference.md#resourceinstance).
 
 ### Example usage
 

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -181,7 +181,7 @@ module Bolt
                                                                        rich_data: true,
                                                                        symbol_as_string: true,
                                                                        type_by_reference: true,
-                                                                       local_reference: false)
+                                                                       local_reference: true)
 
       scope = {
         code_ast: ast,

--- a/lib/bolt/apply_target.rb
+++ b/lib/bolt/apply_target.rb
@@ -3,7 +3,7 @@
 module Bolt
   class ApplyTarget
     ATTRIBUTES = %i[uri name target_alias config vars facts features
-                    plugin_hooks safe_name].freeze
+                    plugin_hooks resources safe_name].freeze
     COMPUTED = %i[host password port protocol user].freeze
 
     attr_reader(*ATTRIBUTES)
@@ -24,7 +24,8 @@ module Bolt
                                 facts = nil,
                                 vars = nil,
                                 features = nil,
-                                plugin_hooks = nil)
+                                plugin_hooks = nil,
+                                resources = nil)
       raise Bolt::Error.new("Target objects cannot be instantiated inside apply blocks", 'bolt/apply-error')
     end
     # rubocop:enable Lint/UnusedMethodArgument

--- a/lib/bolt/inventory/inventory.rb
+++ b/lib/bolt/inventory/inventory.rb
@@ -318,6 +318,10 @@ module Bolt
       def target_config(target)
         @targets[target.name].config
       end
+
+      def resources(target)
+        @targets[target.name].resources
+      end
     end
   end
 end

--- a/lib/bolt/resource_instance.rb
+++ b/lib/bolt/resource_instance.rb
@@ -42,7 +42,7 @@ module Bolt
       new(resource_hash)
     end
 
-    # Creates a ResourceINstance from positional arguments in a plan when
+    # Creates a ResourceInstance from positional arguments in a plan when
     # calling ResourceInstance.new(target, type, title, ...)
     def self.from_asserted_args(target,
                                 type,

--- a/lib/bolt/resource_instance.rb
+++ b/lib/bolt/resource_instance.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Bolt
+  class ResourceInstance
+    attr_reader :target, :type, :title, :state, :desired_state
+    attr_accessor :events
+
+    # Needed by Puppet to recognize Bolt::ResourceInstance as a Puppet object when deserializing
+    def self._pcore_type
+      ResourceInstance
+    end
+
+    # Needed by Puppet to serialize with _pcore_init_hash instead of the object's attributes
+    def self._pcore_init_from_hash(_init_hash)
+      raise "ResourceInstance shouldn't be instantiated from a pcore_init class method. "\
+            "How did this get called?"
+    end
+
+    def _pcore_init_from_hash(init_hash)
+      initialize(init_hash)
+    end
+
+    # Parameters will already be validated when calling ResourceInstance.new or
+    # set_resources() from a plan. We don't perform any validation in the class
+    # itself since Puppet will pass an empty hash to the initializer as part of
+    # the deserialization process before passing the _pcore_init_hash.
+    def initialize(resource_hash)
+      @target        = resource_hash['target']
+      @type          = resource_hash['type'].to_s.capitalize
+      @title         = resource_hash['title']
+      # get_resources() returns observed state under the 'parameters' key
+      @state         = resource_hash['state'] || resource_hash['parameters'] || {}
+      @desired_state = resource_hash['desired_state'] || {}
+      @events        = resource_hash['events'] || []
+    end
+
+    # Creates a ResourceInstance from a data hash in a plan when calling
+    # ResourceInstance.new($resource_hash) or $target.set_resources($resource_hash)
+    def self.from_asserted_hash(resource_hash)
+      new(resource_hash)
+    end
+
+    # Creates a ResourceINstance from positional arguments in a plan when
+    # calling ResourceInstance.new(target, type, title, ...)
+    def self.from_asserted_args(target,
+                                type,
+                                title,
+                                state         = nil,
+                                desired_state = nil,
+                                events        = nil)
+      new(
+        'target'        => target,
+        'type'          => type,
+        'title'         => title,
+        'state'         => state,
+        'desired_state' => desired_state,
+        'events'        => events
+      )
+    end
+
+    def eql?(other)
+      self.class.equal?(other.class) &&
+        target == other.target &&
+        type   == other.type &&
+        title  == other.title
+    end
+    alias == eql?
+
+    def to_hash
+      {
+        'target'        => target,
+        'type'          => type,
+        'title'         => title,
+        'state'         => state,
+        'desired_state' => desired_state,
+        'events'        => events
+      }
+    end
+    alias _pcore_init_hash to_hash
+
+    def to_json(opts = nil)
+      to_hash.to_json(opts)
+    end
+
+    def reference
+      "#{type}[#{title}]"
+    end
+    alias to_s reference
+
+    def add_event(event)
+      @events << event
+    end
+
+    # rubocop:disable Naming/AccessorMethodName
+    def set_state(state)
+      assert_hash('state', state)
+      @state.merge!(state)
+    end
+    # rubocop:enable Naming/AccessorMethodName
+
+    def overwrite_state(state)
+      assert_hash('state', state)
+      @state = state
+    end
+
+    # rubocop:disable Naming/AccessorMethodName
+    def set_desired_state(desired_state)
+      assert_hash('desired_state', desired_state)
+      @desired_state.merge!(desired_state)
+    end
+    # rubocop:enable Naming/AccessorMethodName
+
+    def overwrite_desired_state(desired_state)
+      assert_hash('desired_state', desired_state)
+      @desired_state = desired_state
+    end
+
+    def assert_hash(loc, value)
+      unless value.is_a?(Hash)
+        raise Bolt::ValidationError, "#{loc} must be of type Hash; got #{value.class}"
+      end
+    end
+  end
+end

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -31,7 +31,8 @@ module Bolt
                                 facts = nil,
                                 vars = nil,
                                 features = nil,
-                                plugin_hooks = nil)
+                                plugin_hooks = nil,
+                                resources = nil)
       from_asserted_hash('uri' => uri)
     end
     # rubocop:enable Lint/UnusedMethodArgument
@@ -74,6 +75,16 @@ module Bolt
     def target_alias
       inventory_target.target_alias
     end
+
+    def resources
+      inventory_target.resources
+    end
+
+    # rubocop:disable Naming/AccessorMethodName
+    def set_resource(resource)
+      inventory_target.set_resource(resource)
+    end
+    # rubocop:enable Naming/AccessorMethodName
 
     def to_h
       options.to_h.merge(

--- a/spec/bolt/resource_instance_spec.rb
+++ b/spec/bolt/resource_instance_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/resource_instance'
+require 'bolt/target'
+require 'bolt/inventory'
+require 'bolt/plugin'
+require 'bolt/config'
+
+describe Bolt::ResourceInstance do
+  let(:target)  { Bolt::Target.new('target1') }
+  let(:target2) { Bolt::Target.new('target2') }
+
+  let(:resource) do
+    Bolt::ResourceInstance.new(resource_data)
+  end
+
+  let(:resource2) do
+    Bolt::ResourceInstance.new(resource2_data)
+  end
+
+  let(:resource_data) do
+    {
+      'target'        => target,
+      'type'          => 'File',
+      'title'         => '/etc/puppetlabs/',
+      'state'         => { 'ensure' => 'present' },
+      'desired_state' => { 'ensure' => 'absent' },
+      'events'        => [{ 'audited' => false }]
+    }
+  end
+
+  let(:resource2_data) do
+    {
+      'target'        => target2,
+      'type'          => 'File',
+      'title'         => '/etc/ssh/',
+      'state'         => { 'ensure' => 'present' },
+      'desired_state' => { 'ensure' => 'absent' },
+      'events'        => [{ 'audited' => false }]
+    }
+  end
+
+  context '#eql?' do
+    it 'returns true if the resources match' do
+      expect(resource.eql?(resource)).to eq(true)
+    end
+
+    it 'returns false if the resources do not match' do
+      expect(resource.eql?(resource2)).to eq(false)
+    end
+  end
+
+  context '#reference' do
+    it 'returns the resource reference' do
+      expect(resource.reference).to eq('File[/etc/puppetlabs/]')
+    end
+  end
+
+  context '#to_s' do
+    it 'returns the resource reference' do
+      expect(resource.to_s).to eq(resource.reference)
+    end
+  end
+
+  context '#to_hash' do
+    it 'returns the resource data' do
+      expect(resource.to_hash).to eq(resource_data)
+    end
+  end
+
+  context '#set_state' do
+    it 'shallow merges with existing state' do
+      resource_data['state'] = {
+        'ensure' => 'present',
+        'source' => '/etc/puppetlabs/bolt/bolt.yaml',
+        'foo'    => { 'bar' => true }
+      }
+
+      resource.set_state(
+        'source' => '/Users/.puppetlabs/bolt/bolt.yaml',
+        'foo'    => { 'baz' => false }
+      )
+
+      expect(resource.state).to eq(
+        'ensure' => 'present',
+        'source' => '/Users/.puppetlabs/bolt/bolt.yaml',
+        'foo'    => { 'baz' => false }
+      )
+    end
+
+    it 'errors when state is not a Hash' do
+      expect { resource.set_state('present') }.to raise_error(Bolt::ValidationError)
+    end
+  end
+
+  context '#overwrite_state' do
+    it 'overwrites existing state' do
+      resource.overwrite_state(
+        'source' => '/Users/.puppetlabs/bolt/bolt.yaml'
+      )
+
+      expect(resource.state).to eq(
+        'source' => '/Users/.puppetlabs/bolt/bolt.yaml'
+      )
+    end
+
+    it 'errors when state is not a Hash' do
+      expect { resource.overwrite_state('present') }.to raise_error(Bolt::ValidationError)
+    end
+  end
+
+  context '#set_desired_state' do
+    it 'shallow merges with existing desired state' do
+      resource_data['desired_state'] = {
+        'ensure' => 'present',
+        'source' => '/etc/puppetlabs/bolt/bolt.yaml',
+        'foo'    => { 'bar' => true }
+      }
+
+      resource.set_desired_state(
+        'source' => '/Users/.puppetlabs/bolt/bolt.yaml',
+        'foo'    => { 'baz' => false }
+      )
+
+      expect(resource.desired_state).to eq(
+        'ensure' => 'present',
+        'source' => '/Users/.puppetlabs/bolt/bolt.yaml',
+        'foo'    => { 'baz' => false }
+      )
+    end
+
+    it 'errors when desired state is not a Hash' do
+      expect { resource.set_desired_state('present') }.to raise_error(Bolt::ValidationError)
+    end
+  end
+
+  context '#overwrite_desired_state' do
+    it 'overwrites existing desired state' do
+      resource.overwrite_desired_state(
+        'source' => '/Users/.puppetlabs/bolt/bolt.yaml'
+      )
+
+      expect(resource.desired_state).to eq(
+        'source' => '/Users/.puppetlabs/bolt/bolt.yaml'
+      )
+    end
+
+    it 'errors when desired state is not a Hash' do
+      expect { resource.overwrite_desired_state('present') }.to raise_error(Bolt::ValidationError)
+    end
+  end
+end


### PR DESCRIPTION
This adds a new `ResourceInstance` data type to the plan language and a
corresponding `Bolt::ResourceInstance` implementation class.

The `ResourceInstance` data type stores observed state, desired state  and
events for a single resource on a target. Resources are identified by a
combination of their target, type, and title, and can have their observed
state, desired state, and events set and overwritten.

This data type does not modify or interact with resources on a target in
any way.

Closes #1781 

!feature

* **Added `ResourceInstance` data type**
  ([#1781](#1781))

  The new `ResourceInstance` data type is available for use in plans and
  can be used to store the observed state, desired state, and events for
  a target's resource.

!feature

* **Added `set_resources` plan function**
  ([#1781](#1781))

  The `set_resources` plan function can be used to set
  `ResourceInstance`s on a `Target`.

!feature

* **Added `resources` function to `Target` data type**
  ([#1781](#1781))

  `Target` objects have a new `resources` function that can be used to
  return a map of `ResourceInstance`s for the target.