### PR TITLE
(maint) Log task name with debug logging

### DIFF
--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -104,7 +104,7 @@ module Bolt
         assert_batch_size_one("batch_task()", targets)
         target = targets.first
         with_events(target, callback, 'task') do
-          @logger.debug { "Running task run '#{task}' on #{target.safe_name}" }
+          @logger.debug { "Running task '#{task.name}' on #{target.safe_name}" }
           run_task(target, task, arguments, options)
         end
       end
@@ -120,7 +120,7 @@ module Bolt
         arguments = target_mapping[target]
 
         with_events(target, callback, 'task') do
-          @logger.debug { "Running task run '#{task}' on #{target.safe_name} with '#{arguments.to_json}'" }
+          @logger.debug { "Running task '#{task.name}' on #{target.safe_name} with '#{arguments.to_json}'" }
           run_task(target, task, arguments, options)
         end
       end


### PR DESCRIPTION
Previously the debug logging in the base transport class would attept to interpolate a task object into a string instead of using the Task#name method. This resulted in difficult to read debug logs. This commit updates the debug logging to use the task name.

!no-release-note