### PR TITLE
(maint) Expand filepaths passed on the CLI relative to cwd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ locales/
 documentation/plan_functions.md
 documentation/bolt_command_reference.md
 documentation/bolt_configuration_reference.md
+tasks/
+plans/

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -655,8 +655,8 @@ module Bolt
         @options[:password] = STDIN.noecho(&:gets).chomp
         STDERR.puts
       end
-      define('--private-key KEY', 'Private ssh key to authenticate with') do |key|
-        @options[:'private-key'] = key
+      define('--private-key KEY', 'Path to private ssh key to authenticate with') do |key|
+        @options[:'private-key'] = File.expand_path(key)
       end
       define('--[no-]host-key-check', 'Check host keys with SSH') do |host_key_check|
         @options[:'host-key-check'] = host_key_check
@@ -718,7 +718,7 @@ module Bolt
       end
       define('--hiera-config FILEPATH',
              'Specify where to load Hiera config from (default: ~/.puppetlabs/bolt/hiera.yaml)') do |path|
-        @options[:'hiera-config'] = path
+        @options[:'hiera-config'] = File.expand_path(path)
       end
       define('-i', '--inventoryfile FILEPATH',
              'Specify where to load inventory from (default: ~/.puppetlabs/bolt/inventory.yaml)') do |path|

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -422,11 +422,21 @@ describe "Bolt::CLI" do
     describe "key" do
       it "accepts a private key" do
         allow(Bolt::Util).to receive(:validate_file).and_return(true)
-        path = '~/.ssh/google_compute_engine'
+        path = File.expand_path('~/.ssh/google_compute_engine')
         cli = Bolt::CLI.new(%W[  command run uptime
                                  --private-key #{path}
                                  --targets foo])
         expect(cli.parse).to include('private-key': path)
+        expect(cli.config.transports['ssh']['private-key']).to eq(File.expand_path(path))
+      end
+
+      it "expands private key relative to cwd" do
+        allow(Bolt::Util).to receive(:validate_file).and_return(true)
+        path = './ssh/google_compute_engine'
+        cli = Bolt::CLI.new(%W[  command run uptime
+                                 --private-key #{path}
+                                 --targets foo])
+        expect(cli.parse).to include('private-key': File.expand_path(path))
         expect(cli.config.transports['ssh']['private-key']).to eq(File.expand_path(path))
       end
 

--- a/spec/integration/lookup_spec.rb
+++ b/spec/integration/lookup_spec.rb
@@ -11,7 +11,7 @@ describe "lookup() in plans" do
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
   let(:boltdir)      { fixture_path('hiera') }
-  let(:hiera_config) { 'hiera.yaml' }
+  let(:hiera_config) { File.join(boltdir, 'hiera.yaml') }
   let(:plan)         { 'test::lookup' }
 
   let(:cli_command) {
@@ -87,7 +87,7 @@ describe "lookup() in plans" do
   end
 
   context 'with interpolations' do
-    let(:hiera_config) { 'hiera_interpolations.yaml' }
+    let(:hiera_config) { File.join(boltdir, 'hiera_interpolations.yaml') }
 
     it 'returns an error' do
       result = run_cli_json(cli_command + %w[key=test::interpolations])
@@ -124,7 +124,7 @@ describe "lookup() in plans" do
   end
 
   context 'with a missing backend' do
-    let(:hiera_config) { 'hiera_missing_backend.yaml' }
+    let(:hiera_config) { File.join(boltdir, 'hiera_missing_backend.yaml') }
 
     it 'returns an error' do
       result = run_cli_json(cli_command + %w[key=test::backends])


### PR DESCRIPTION
As part of the [#1364](https://github.com/puppetlabs/bolt/pull/1364) work to
standardize how we expand configured paths we expand all paths
configured in files relative to the project directory, and stated that
all paths set on the CLI would be expanded relative to the directory
Bolt was run from. However, only some CLI paths (inventoryfile and 
puppetfile) were expanded this way, while others (hiera-config and 
private-key) were expanded relative to the project
directory. This standardizes paths passed on the CLI to be expanded
relative to the cwd. This is accomplished by expanding the path in our 
CLI option handler, so that the config object only sees the path as
absolute and does not try to expand it relative to the project.

!bug

* **Expand filepaths passed on the CLI relative to the current working directory**
  Config options hiera-config and private-key are now expanded relative
  to the directory Bolt was run from when specified on the CLI, inline
  with other CLI options.