### PR TITLE
(GH-1779) Warn when Bolt is installed as a gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 # Disable analytics when running in development
 ENV['BOLT_DISABLE_ANALYTICS'] = 'true'
 
+# Disable warning that Bolt may be installed as a gem
+ENV['BOLT_GEM'] = 'true'
+
 gemspec
 
 # Bolt server gems are managed here not in the gemspec

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -804,6 +804,20 @@ module Bolt
     end
 
     def bundled_content
+      # If the bundled content directory is empty, Bolt is likely installed as a gem.
+      if ENV['BOLT_GEM'] != 'false' && gem_install?
+        msg = <<~MSG.chomp
+          Bolt may be installed as a gem. To use Bolt reliably and with all of its
+          dependencies, uninstall the 'bolt' gem and install Bolt as a package:
+          https://puppet.com/docs/bolt/latest/bolt_installing.html
+
+          If you meant to install Bolt as a gem and want to disable this warning,
+          set the BOLT_GEM environment variable to 'false'.
+        MSG
+
+        @logger.warn(msg)
+      end
+
       # We only need to enumerate bundled content when running a task or plan
       content = { 'Plan' => [],
                   'Task' => [],
@@ -826,6 +840,12 @@ module Bolt
         Loaded configuration from: '#{config.config_files.join("', '")}'
       MSG
       @logger.debug(msg)
+    end
+
+    # Gem installs include the aggregate, canary, and puppetdb_fact modules, while
+    # package installs include modules listed in the Bolt repo Puppetfile
+    def gem_install?
+      (Dir.children(Bolt::PAL::MODULES_PATH) - %w[aggregate canary puppetdb_fact]).empty?
     end
   end
 end

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -805,14 +805,14 @@ module Bolt
 
     def bundled_content
       # If the bundled content directory is empty, Bolt is likely installed as a gem.
-      if ENV['BOLT_GEM'] != 'false' && gem_install?
+      if ENV['BOLT_GEM'].nil? && incomplete_install?
         msg = <<~MSG.chomp
           Bolt may be installed as a gem. To use Bolt reliably and with all of its
           dependencies, uninstall the 'bolt' gem and install Bolt as a package:
           https://puppet.com/docs/bolt/latest/bolt_installing.html
 
           If you meant to install Bolt as a gem and want to disable this warning,
-          set the BOLT_GEM environment variable to 'false'.
+          set the BOLT_GEM environment variable.
         MSG
 
         @logger.warn(msg)
@@ -844,7 +844,7 @@ module Bolt
 
     # Gem installs include the aggregate, canary, and puppetdb_fact modules, while
     # package installs include modules listed in the Bolt repo Puppetfile
-    def gem_install?
+    def incomplete_install?
       (Dir.children(Bolt::PAL::MODULES_PATH) - %w[aggregate canary puppetdb_fact]).empty?
     end
   end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -57,9 +57,18 @@ describe "Bolt::CLI" do
   end
 
   context 'gem install' do
+    around(:each) do |example|
+      original_value = ENV['BOLT_GEM']
+      example.run
+    ensure
+      ENV['BOLT_GEM'] = original_value
+    end
+
     it 'displays a warning when Bolt is installed as a gem' do
+      ENV.delete('BOLT_GEM')
+
       cli = Bolt::CLI.new(%w[task show])
-      allow(cli).to receive(:gem_install?).and_return(true)
+      allow(cli).to receive(:incomplete_install?).and_return(true)
       cli.execute(cli.parse)
 
       output = @log_output.readlines.join
@@ -67,17 +76,14 @@ describe "Bolt::CLI" do
     end
 
     it 'does not display a warning when BOLT_GEM is set' do
-      original_env = ENV['BOLT_GEM']
-      ENV['BOLT_GEM'] = 'false'
+      ENV['BOLT_GEM'] = 'true'
 
       cli = Bolt::CLI.new(%w[task show])
-      allow(cli).to receive(:gem_install?).and_return(true)
+      allow(cli).to receive(:incomplete_install?).and_return(true)
       cli.execute(cli.parse)
 
       output = @log_output.readlines.join
       expect(output).not_to match(/Bolt may be installed as a gem/)
-    ensure
-      ENV['BOLT_GEM'] = original_env
     end
   end
 

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -56,6 +56,31 @@ describe "Bolt::CLI" do
     allow(Bolt::Util).to receive(:read_optional_yaml_hash).and_return(file_content)
   end
 
+  context 'gem install' do
+    it 'displays a warning when Bolt is installed as a gem' do
+      cli = Bolt::CLI.new(%w[task show])
+      allow(cli).to receive(:gem_install?).and_return(true)
+      cli.execute(cli.parse)
+
+      output = @log_output.readlines.join
+      expect(output).to match(/Bolt may be installed as a gem/)
+    end
+
+    it 'does not display a warning when BOLT_GEM is set' do
+      original_env = ENV['BOLT_GEM']
+      ENV['BOLT_GEM'] = 'false'
+
+      cli = Bolt::CLI.new(%w[task show])
+      allow(cli).to receive(:gem_install?).and_return(true)
+      cli.execute(cli.parse)
+
+      output = @log_output.readlines.join
+      expect(output).not_to match(/Bolt may be installed as a gem/)
+    ensure
+      ENV['BOLT_GEM'] = original_env
+    end
+  end
+
   context "without a config file" do
     let(:project) { Bolt::Project.new('.') }
     before(:each) do


### PR DESCRIPTION
This adds a warning that Bolt may be installed as a gem when bundled
content is missing. Bolt checks if any modules other than `aggregate`,
`canary`, and `puppetdb_fact` are installed at `Bolt::PAL::MODULES_PATH`
to determine if it may be a gem install.

This warning can be disabled by setting the `BOLT_GEM` environment
variable.

Closes #1779 

!feature

* **Warn when Bolt is installed as a gem**
  ([#1779](https://github.com/puppetlabs/bolt/issues/1779))

  Bolt now issues a warning when it detects that it may have been
  installed as a gem. This warning can be disabled by setting the
  `BOLT_GEM` environment variable.

  To install Bolt reliably and with all of its dependencies, it should
  be [installed as a package](https://puppet.com/docs/bolt/latest/bolt_installing.html).