### PR TITLE
(PUP-10476) Use updated PAL api for catalog compilation

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-ssh", ">= 4.0"
   spec.add_dependency "net-ssh-krb", "~> 0.5"
   spec.add_dependency "orchestrator_client", "~> 0.4"
-  spec.add_dependency "puppet", [">= 6.15.0", "< 7"]
+  spec.add_dependency "puppet", [">= 6.16.0", "< 7"]
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "puppet-strings", "~> 2.3"
   spec.add_dependency "puppetfile-resolver", "~> 0.1.0"

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -21,7 +21,7 @@ module Bolt
 
       @inventory = inventory
       @executor = executor
-      @modulepath = modulepath
+      @modulepath = modulepath || []
       @plugin_dirs = plugin_dirs
       @project = project
       @pdb_client = pdb_client

--- a/lib/bolt/catalog.rb
+++ b/lib/bolt/catalog.rb
@@ -19,7 +19,7 @@ module Bolt
       @log_level = log_level
     end
 
-    def with_puppet_settings(hiera_config = {})
+    def with_puppet_settings(overrides = {})
       Dir.mktmpdir('bolt') do |dir|
         cli = []
         Puppet::Settings::REQUIRED_APP_SETTINGS.each do |setting|
@@ -31,7 +31,9 @@ module Bolt
         Puppet.settings.override_default(:vendormoduledir, '')
 
         Puppet.initialize_settings(cli)
-        Puppet.settings[:hiera_config] = hiera_config
+        overrides.each do |setting, value|
+          Puppet.settings[setting] = value
+        end
 
         # Use a special logdest that serializes all log messages and their level to stderr.
         Puppet::Util::Log.newdestination(:stderr)
@@ -54,88 +56,99 @@ module Bolt
     end
 
     def compile_catalog(request)
-      pal_main = request['code_ast'] || request['code_string']
-      target = request['target']
       pdb_client = Bolt::PuppetDB::Client.new(Bolt::PuppetDB::Config.new(request['pdb_config']))
-      options = request['puppet_config'] || {}
       project = request['project'] || {}
       bolt_project = Struct.new(:name, :path).new(project['name'], project['path']) unless project.empty?
-      with_puppet_settings(request['hiera_config']) do
-        Puppet[:rich_data] = true
-        Puppet[:node_name_value] = target['name']
-        env_conf = { modulepath: request['modulepath'] || [],
-                     facts: target['facts'] || {} }
-        env_conf[:variables] = {}
+      inv = Bolt::ApplyInventory.new(request['config'])
+      puppet_overrides = {
+        bolt_pdb_client: pdb_client,
+        bolt_inventory: inv,
+        bolt_project: bolt_project
+      }
+
+      # Facts will be set by the catalog compiler, so we need to ensure
+      # that any plan or target variables with the same name are not
+      # passed into the apply block to avoid a redefinition error.
+      # Filter out plan and target vars separately and raise a Puppet
+      # warning if there are any collisions for either. Puppet warning
+      # is the only way to log a message that will make it back to Bolt
+      # to be printed.
+      target = request['target']
+      plan_vars = shadow_vars('plan', request['plan_vars'], target['facts'])
+      target_vars = shadow_vars('target', target['variables'], target['facts'])
+      topscope_vars = target_vars.merge(plan_vars)
+      env_conf = { modulepath: request['modulepath'],
+                   facts: target['facts'],
+                   variables: topscope_vars }
+
+      puppet_settings = {
+        node_name_value: target['name'],
+        # CODEREVIEW: Isnt this already the default?
+        # https://github.com/puppetlabs/puppet/blob/master/lib/puppet/parser/catalog_compiler.rb#L18
+        rich_data: true,
+        hiera_config: request['hiera_config']
+      }
+
+      with_puppet_settings(puppet_settings) do
         Puppet::Pal.in_tmp_environment('bolt_catalog', env_conf) do |pal|
-          inv = Bolt::ApplyInventory.new(request['config'])
-          Puppet.override(bolt_pdb_client: pdb_client,
-                          bolt_inventory: inv,
-                          bolt_project: bolt_project) do
+          Puppet.override(puppet_overrides) do
             Puppet.lookup(:pal_current_node).trusted_data = target['trusted']
             pal.with_catalog_compiler do |compiler|
-              # Deserializing needs to happen inside the catalog compiler so
-              # loaders are initialized for loading
-              plan_vars = Puppet::Pops::Serialization::FromDataConverter.convert(request['plan_vars'])
-
-              # Facts will be set by the catalog compiler, so we need to ensure
-              # that any plan or target variables with the same name are not
-              # passed into the apply block to avoid a redefinition error.
-              # Filter out plan and target vars separately and raise a Puppet
-              # warning if there are any collisions for either. Puppet warning
-              # is the only way to log a message that will make it back to Bolt
-              # to be printed.
-              pv_collisions, pv_filtered = plan_vars.partition do |k, _|
-                target['facts'].keys.include?(k)
-              end.map(&:to_h)
-              unless pv_collisions.empty?
-                print_pv = pv_collisions.keys.map { |k| "$#{k}" }.join(', ')
-                plural = pv_collisions.keys.length == 1 ? '' : 's'
-                Puppet.warning("Plan variable#{plural} #{print_pv} will be overridden by fact#{plural} " \
-                               "of the same name in the apply block")
-              end
-
-              tv_collisions, tv_filtered = target['variables'].partition do |k, _|
-                target['facts'].keys.include?(k)
-              end.map(&:to_h)
-              unless tv_collisions.empty?
-                print_tv = tv_collisions.keys.map { |k| "$#{k}" }.join(', ')
-                plural = tv_collisions.keys.length == 1 ? '' : 's'
-                Puppet.warning("Target variable#{plural} #{print_tv} " \
-                               "will be overridden by fact#{plural} of the same name in the apply block")
-              end
-
-              pal.send(:add_variables, compiler.send(:topscope), tv_filtered.merge(pv_filtered))
-
+              options = request['puppet_config'] || {}
               # Configure language strictness in the CatalogCompiler. We want Bolt to be able
               # to compile most Puppet 4+ manifests, so we default to allowing deprecated functions.
               Puppet[:strict] = options['strict'] || :warning
               Puppet[:strict_variables] = options['strict_variables'] || false
-              ast = Puppet::Pops::Serialization::FromDataConverter.convert(pal_main)
-              # This will be a Program when running via `bolt apply`, but will
-              # only be a subset of the AST when compiling an apply block in a
-              # plan. In that case, we need to discover the definitions (which
-              # would ordinarily be stored on the Program) and construct a Program object.
-              unless ast.is_a?(Puppet::Pops::Model::Program)
-                # Node definitions must be at the top level of the apply block.
-                # That means the apply body either a) consists of just a
-                # NodeDefinition, b) consists of a BlockExpression which may
-                # contain NodeDefinitions, or c) doesn't contain NodeDefinitions.
-                definitions = if ast.is_a?(Puppet::Pops::Model::BlockExpression)
-                                ast.statements.select { |st| st.is_a?(Puppet::Pops::Model::NodeDefinition) }
-                              elsif ast.is_a?(Puppet::Pops::Model::NodeDefinition)
-                                [ast]
-                              else
-                                []
-                              end
-                ast = Puppet::Pops::Model::Factory.PROGRAM(ast, definitions, ast.locator).model
-              end
+
+              pal_main = request['code_ast'] || request['code_string']
+              ast = build_program(pal_main)
               compiler.evaluate(ast)
-              compiler.instance_variable_get(:@internal_compiler).send(:evaluate_ast_node)
+              compiler.evaluate_ast_node
               compiler.compile_additions
               compiler.with_json_encoding(&:encode)
             end
           end
         end
+      end
+    end
+
+    # Warn and remove variables that will be shadowed by facts of the same
+    # name, which are set in scope earlier.
+    def shadow_vars(type, vars, facts)
+      collisions, valid = vars.partition do |k, _|
+        facts.include?(k)
+      end
+      if collisions.any?
+        names = collisions.map { |k, _| "$#{k}" }.join(', ')
+        plural = collisions.length == 1 ? '' : 's'
+        Puppet.warning("#{type.capitalize} variable#{plural} #{names} will be overridden by fact#{plural} " \
+                       "of the same name in the apply block")
+      end
+      valid.to_h
+    end
+
+    def build_program(code)
+      ast = Puppet::Pops::Serialization::FromDataConverter.convert(code)
+
+      # This will be a Program when running via `bolt apply`, but will
+      # only be a subset of the AST when compiling an apply block in a
+      # plan. In that case, we need to discover the definitions (which
+      # would ordinarily be stored on the Program) and construct a Program object.
+      if ast.is_a?(Puppet::Pops::Model::Program)
+        ast
+      else
+        # Node definitions must be at the top level of the apply block.
+        # That means the apply body either a) consists of just a
+        # NodeDefinition, b) consists of a BlockExpression which may
+        # contain NodeDefinitions, or c) doesn't contain NodeDefinitions.
+        definitions = if ast.is_a?(Puppet::Pops::Model::BlockExpression)
+                        ast.statements.select { |st| st.is_a?(Puppet::Pops::Model::NodeDefinition) }
+                      elsif ast.is_a?(Puppet::Pops::Model::NodeDefinition)
+                        [ast]
+                      else
+                        []
+                      end
+        Puppet::Pops::Model::Factory.PROGRAM(ast, definitions, ast.locator).model
       end
     end
   end

--- a/lib/bolt/catalog.rb
+++ b/lib/bolt/catalog.rb
@@ -83,9 +83,6 @@ module Bolt
 
       puppet_settings = {
         node_name_value: target['name'],
-        # CODEREVIEW: Isnt this already the default?
-        # https://github.com/puppetlabs/puppet/blob/master/lib/puppet/parser/catalog_compiler.rb#L18
-        rich_data: true,
         hiera_config: request['hiera_config']
       }
 


### PR DESCRIPTION
This commit updates the catalog compiler to use updates to PAL api to enable node definitions in plans and deserialized bolt types in apply blocks without relying on using public methods. This includes a refactor to clean up the compile_catalog method and make it more readable.