### PR TITLE
(maint) Fix plan show for project plans

### DIFF
--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -329,7 +329,8 @@ module Bolt
         raise Bolt::Error.unknown_plan(plan_name)
       end
 
-      mod = plan_sig.instance_variable_get(:@plan_func).loader.parent.path
+      # path may be a Pathname object, so make sure to stringify it
+      mod = plan_sig.instance_variable_get(:@plan_func).loader.parent.path.to_s
 
       # If it's a Puppet language plan, use strings to extract data. The only
       # way to tell is to check which filename exists in the module.


### PR DESCRIPTION
`bolt plan show <plan>` was failing when passed a project-level
plan due to the fact that the project path is a Pathname rather than a
string, unlike most modules. We now convert the path to a string in
`get_plan_info` so that any code interacting with the plan data can
treat it as if it came from any other module.

!bug

  * **Fix `bolt plan show <plan>` for project-level plans**
    ([#1799](https://github.com/puppetlabs/bolt/pull/1799))

  This command was throwing errors due to a type mismatch that is now
  resolved.