### PR TITLE
(GH-1795) Add JSON schemas for Bolt configuration files

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,10 +3,10 @@ name: Docs
 on:
   push:
     branches: [master]
-    paths-ignore: ['**.md']
+    paths-ignore: ['**.md', 'schemas/*']
   pull_request:
     type: [opened, reopened, edited]
-    paths-ignore: ['**.md']
+    paths-ignore: ['**.md', 'schemas/*']
 
 jobs:
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,10 +3,10 @@ name: Linting
 on:
   push:
     branches: [master]
-    paths-ignore: ['**.md', '**.erb']
+    paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
     type: [opened, reopened, edited]
-    paths-ignore: ['**.md', '**.erb']
+    paths-ignore: ['**.md', '**.erb', 'schemas/*']
 
 jobs:
 

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -3,10 +3,10 @@ name: Linux
 on:
   push:
     branches: [master]
-    paths-ignore: ['**.md', '**.erb']
+    paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
     type: [opened, reopened, edited]
-    paths-ignore: ['**.md', '**.erb']
+    paths-ignore: ['**.md', '**.erb', 'schemas/*']
 
 env:
   BOLT_SUDO_USER: true

--- a/.github/workflows/modules.yaml
+++ b/.github/workflows/modules.yaml
@@ -3,10 +3,10 @@ name: Modules
 on:
   push:
     branches: [master]
-    paths-ignore: ['**.md', '**.erb']
+    paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
     type: [opened, reopened, edited]
-    paths-ignore: ['**.md', '**.erb']
+    paths-ignore: ['**.md', '**.erb', 'schemas/*']
 
 env:
   BOLT_SUDO_USER: true

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -3,10 +3,10 @@ name: Windows
 on:
   push:
     branches: [master]
-    paths-ignore: ['**.md', '**.erb']
+    paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
     type: [opened, reopened, edited]
-    paths-ignore: ['**.md', '**.erb']
+    paths-ignore: ['**.md', '**.erb', 'schemas/*']
 
 env:
   BOLT_WINRM_USER: roddypiper

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -34,6 +34,8 @@ module Bolt
       'remote' => Bolt::Config::Transport::Remote
     }.freeze
 
+    # NOTE: All configuration options should have a corresponding schema property
+    #       in schemas/bolt-config.schema.json
     OPTIONS = {
       "apply_settings"           => "A map of Puppet settings to use when applying Puppet code",
       "color"                    => "Whether to use colored output when printing messages to the console.",

--- a/lib/bolt/config/transport/docker.rb
+++ b/lib/bolt/config/transport/docker.rb
@@ -7,6 +7,8 @@ module Bolt
   class Config
     module Transport
       class Docker < Base
+        # NOTE: All transport configuration options should have a corresponding schema definition
+        #       in schemas/bolt-transport-definitions.json
         OPTIONS = {
           "cleanup"       => { type: TrueClass,
                                desc: "Whether to clean up temporary files created on targets." },

--- a/lib/bolt/config/transport/local.rb
+++ b/lib/bolt/config/transport/local.rb
@@ -7,6 +7,8 @@ module Bolt
   class Config
     module Transport
       class Local < Base
+        # NOTE: All transport configuration options should have a corresponding schema definition
+        #       in schemas/bolt-transport-definitions.json
         OPTIONS = {
           "cleanup"         => { type: TrueClass,
                                  desc: "Whether to clean up temporary files created on targets." },

--- a/lib/bolt/config/transport/orch.rb
+++ b/lib/bolt/config/transport/orch.rb
@@ -7,6 +7,8 @@ module Bolt
   class Config
     module Transport
       class Orch < Base
+        # NOTE: All transport configuration options should have a corresponding schema definition
+        #       in schemas/bolt-transport-definitions.json
         OPTIONS = {
           "cacert"            => { type: String,
                                    desc: "The path to the CA certificate." },

--- a/lib/bolt/config/transport/remote.rb
+++ b/lib/bolt/config/transport/remote.rb
@@ -7,6 +7,8 @@ module Bolt
   class Config
     module Transport
       class Remote < Base
+        # NOTE: All transport configuration options should have a corresponding schema definition
+        #       in schemas/bolt-transport-definitions.json
         OPTIONS = {
           "run-on" => { type: String,
                         desc: "The proxy target that the task executes on." }

--- a/lib/bolt/config/transport/ssh.rb
+++ b/lib/bolt/config/transport/ssh.rb
@@ -8,6 +8,9 @@ module Bolt
     module Transport
       class SSH < Base
         LOGIN_SHELLS = %w[sh bash zsh dash ksh powershell].freeze
+
+        # NOTE: All transport configuration options should have a corresponding schema definition
+        #       in schemas/bolt-transport-definitions.json
         OPTIONS = {
           "cleanup"            => { type: TrueClass,
                                     desc: "Whether to clean up temporary files created on targets." },

--- a/lib/bolt/config/transport/winrm.rb
+++ b/lib/bolt/config/transport/winrm.rb
@@ -7,6 +7,8 @@ module Bolt
   class Config
     module Transport
       class WinRM < Base
+        # NOTE: All transport configuration options should have a corresponding schema definition
+        #       in schemas/bolt-transport-definitions.json
         OPTIONS = {
           "basic-auth-only" => { type: TrueClass,
                                  desc: "Force basic authentication. This option is only available when using SSL." },

--- a/lib/bolt/inventory/group.rb
+++ b/lib/bolt/inventory/group.rb
@@ -12,6 +12,7 @@ module Bolt
       # Regex used to validate group names and target aliases.
       NAME_REGEX = /\A[a-z0-9_][a-z0-9_-]*\Z/.freeze
 
+      # NOTE: All keys should have a corresponding schema property in schemas/bolt-inventory.schema.json
       DATA_KEYS = %w[config facts vars features plugin_hooks].freeze
       TARGET_KEYS = DATA_KEYS + %w[name alias uri]
       GROUP_KEYS = DATA_KEYS + %w[name groups targets]

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,35 @@
+# Bolt schemas
+
+This directory includes several JSON schemas that can be used to validate
+Bolt configuration files, including `bolt.yaml`, `inventory.yaml`, and
+`project.yaml`.
+
+## Using schemas with Visual Studio Code
+
+### Prerequisites
+
+- Install [Visual Studio Code](https://code.visualstudio.com/)
+
+- Install the [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
+
+### Enabling schemas
+
+1. Download and save each of the JSON files in this directory.
+
+1. Open the [user or workspace settings file](https://code.visualstudio.com/docs/getstarted/settings).
+
+1. Add the following content as a top-level key in the settings file:
+
+    ```json
+    "yaml.schemas": {
+      "<path to bolt-project.schema.json>": [
+        "project.yaml"
+      ],
+      "<path to bolt-config.schema.json>": [
+        "bolt.yaml"
+      ],
+      "<path to bolt-inventory.schema.json>": [
+        "inventory.yaml"
+      ]
+    }
+    ```

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -1,0 +1,191 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Bolt Config",
+  "description": "Bolt Config bolt.yaml Schema",
+  "type": "object",
+  "properties": {
+    "apply_settings": {
+      "description": "A map of Puppet settings to use when applying Puppet code.",
+      "type": "object",
+      "properties": {
+        "show_diff": {
+          "description": "Whether to log and report a contextual diff when files are being replaced.",
+          "type": "boolean"
+        }
+      }
+    },
+    "color": {
+      "description": "Whether to use colored output when printing messages to the console.",
+      "type": "boolean"
+    },
+    "compile-concurrency": {
+      "description": "The maximum number of simultaneous manifest block compiles.",
+      "type": "integer",
+      "min": 1
+    },
+    "concurrency": {
+      "description": "The number of threads to use when executing on remote targets.",
+      "type": "integer",
+      "min": 1
+    },
+    "format": {
+      "description": "The format to use when printing results.",
+      "type": "string",
+      "enum": ["human", "json"]
+    },
+    "hiera-config": {
+      "description": "The path to your Hiera config.",
+      "type": "string"
+    },
+    "inventoryfile": {
+      "description": "The path to your inventory file.",
+      "type": "string"
+    },
+    "log": {
+      "description": "The configuration of the logfile output. Configuration can be set for console and the path to a log file, such as ~/.puppetlabs/bolt/debug.log.",
+      "type": "object",
+      "properties": {
+        "console": {
+          "description": "Configuration for logs output to the console.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "description": "The type of information in the log.",
+              "type": "string",
+              "enum": ["debug", "error", "info", "notice", "warn"]
+            }
+          }
+        }
+      },
+      "additionalProperties": {
+        "description": "Configuration for logs output to a file.",
+        "type": "object",
+        "properties": {
+          "append": {
+            "description": "Add output to an existing log file.",
+            "type": "boolean"
+          },
+          "level": {
+            "description": "The type of information in the log.",
+            "type": "string",
+            "enum": ["debug", "error", "info", "notice", "warn"]
+          }
+        }
+      }
+    },
+    "modulepath": {
+      "description": "The module path for loading tasks and plan code. This is either an array of directories or a string containing a list of directories separated by the OS-specific PATH separator.",
+      "type": ["array", "string"],
+      "items": {
+        "description": "Module path.",
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "plugin_hooks": {
+      "description": "Which plugins a specific hook should use.",
+      "type": "object",
+      "properties": {
+        "puppet_library": {
+          "description": "Specify which plugin should be used to ensure the Puppet library is installed on a target.",
+          "type": "object"
+        }
+      }
+    },
+    "plugins": {
+      "description": "A map of plugins and their configuration data.",
+      "type": "object",
+      "patternProperties": {
+        "^[a-z][a-z0-9_]*$": { 
+          "type": "object"
+        }
+      }
+    },
+    "puppetdb": {
+      "description": "A map containing options for configuring the Bolt PuppetDB client.",
+      "type": "object",
+      "properties": {
+        "cacert": {
+          "description": "The path to the ca certificate for PuppetDB.",
+          "type": "string"
+        },
+        "cert": {
+          "description": "The path to the client certificate file to use for authentication.",
+          "type": "string"
+        },
+        "key": {
+          "description": "The path to the private key for the certificate.",
+          "type": "string"
+        },
+        "server_urls": {
+          "description": "An array containing the PuppetDB host to connect to. Include the protocol https and the port, which is usually 8081. For example, https://my-master.example.com:8081.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "description": "A PuppetDB host.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "puppetfile": {
+      "description": "A map containing options for the 'bolt puppetfile install' command.",
+      "type": "object",
+      "properties": {
+        "forge": {
+          "description": "A subsection that can have its own proxy setting to set an HTTP proxy for Forge operations only, and a baseurl setting to specify a different Forge host.",
+          "type": "object",
+          "properties": {
+            "baseurl": {
+              "description": "The URI for the Forge host.",
+              "type": "string",
+              "format": "uri"
+            },
+            "proxy": {
+              "description": "The HTTP proxy to use for Forge operations.",
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        "proxy": {
+          "description": "The HTTP proxy to use for Git and Forge operations.",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "save-rerun": {
+      "description": "Whether to update .rerun.json in the Bolt project directory. If your target names include passwords, set this value to false to avoid writing passwords to disk.",
+      "type": "boolean"
+    },
+    "transport": {
+      "description": "The default transport to use when the transport for a target is not specified in the URL or inventory.",
+      "type": "string",
+      "enum": ["docker", "local", "pcp", "remote", "ssh", "winrm"]
+    },
+    "trusted-external-command": {
+      "description": "The path to an executable on the Bolt controller that can produce external trusted facts.",
+      "type": "string"
+    },
+    "docker": {
+      "$ref": "bolt-transport-definitions.json#/docker"
+    },
+    "local": {
+      "$ref": "bolt-transport-definitions.json#/local"
+    },
+    "pcp": {
+      "$ref": "bolt-transport-definitions.json#/pcp"
+    },
+    "remote": {
+      "$ref": "bolt-transport-definitions.json#/remote"
+    },
+    "ssh": {
+      "$ref": "bolt-transport-definitions.json#/ssh"
+    },
+    "winrm": {
+      "$ref": "bolt-transport-definitions.json#/winrm"
+    }
+  }
+}

--- a/schemas/bolt-inventory.schema.json
+++ b/schemas/bolt-inventory.schema.json
@@ -1,0 +1,163 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Bolt Inventory",
+  "description": "Bolt Inventory inventory.yaml Schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "config": {
+      "$ref": "#/definitions/config"
+    },
+    "facts": {
+      "$ref": "#/definitions/facts"
+    },
+    "features": {
+      "$ref": "#/definitions/features"
+    },
+    "groups": {
+      "$ref": "#/definitions/groups"
+    },
+    "targets": {
+      "$ref": "#/definitions/targets"
+    },
+    "vars": {
+      "$ref": "#/definitions/vars"
+    },
+    "version": {
+      "description": "The version of the inventory file.",
+      "type": "integer"
+    }
+  },
+  "definitions": {
+    "config": {
+      "description": "The configuration for a target.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "transport": {
+          "description": "The transport used to connect to a target.",
+          "type": "string",
+          "enum": ["docker", "local", "pcp", "remote", "ssh", "winrm"]
+        },
+        "docker": {
+          "$ref": "bolt-transport-definitions.json#/docker"
+        },
+        "local": {
+          "$ref": "bolt-transport-definitions.json#/local"
+        },
+        "pcp": {
+          "$ref": "bolt-transport-definitions.json#/pcp"
+        },
+        "remote": {
+          "$ref": "bolt-transport-definitions.json#/remote"
+        },
+        "ssh": {
+          "$ref": "bolt-transport-definitions.json#/ssh"
+        },
+        "winrm": {
+          "$ref": "bolt-transport-definitions.json#/winrm"
+        }
+      }
+    },
+    "facts": {
+      "description": "The facts for a target.",
+      "type": "object"
+    },
+    "features": {
+      "description": "The features for a target.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "groups": {
+      "description": "A list of target groups.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/group"
+      }
+    },
+    "group": {
+      "description": "A group of targets.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "config": {
+          "$ref": "#/definitions/config"
+        },
+        "facts": {
+          "$ref": "#/definitions/facts"
+        },
+        "features": {
+          "$ref": "#/definitions/features"
+        },
+        "groups": {
+          "$ref": "#/definitions/groups"
+        },
+        "name": {
+          "description": "The group's name.",
+          "type": "string",
+          "pattern": "^[a-z0-9_][a-z0-9_-]*$"
+        },
+        "targets": {
+          "$ref": "#/definitions/targets"
+        },
+        "vars": {
+          "$ref": "#/definitions/vars"
+        }
+      },
+      "required": ["name"]
+    },
+    "targets": {
+      "description": "A list of targets. Targets can be defined by either a string representation of its URI, or a map of its attributes and configuration.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/target"
+      }
+    },
+    "target": {
+      "description": "A target definition.",
+      "type": ["object", "string"],
+      "additionalProperties": false,
+      "properties": {
+        "alias": {
+          "description": "A unique alias to refer to the target.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z0-9_][a-z0-9_-]*$"
+          }
+        },
+        "config": {
+          "$ref": "#/definitions/config"
+        },
+        "facts": {
+          "$ref": "#/definitions/facts"
+        },
+        "features": {
+          "$ref": "#/definitions/features"
+        },
+        "name": {
+          "description": "A human-readable name for a target.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of the target.",
+          "type": "string",
+          "format": "uri"
+        },
+        "vars": {
+          "$ref": "#/definitions/vars"
+        }
+      },
+      "anyOf": [
+        { "required": ["uri"] },
+        { "required": ["name"] }
+      ]
+    },
+    "vars": {
+      "description": "The vars for a target.",
+      "type": "object"
+    }
+  }
+}

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Bolt Project",
+  "description": "Bolt Project project.yaml Schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "The Bolt project name.",
+      "type": "string",
+      "pattern": "^([a-zA-Z0-9]+[-])?[a-z][a-z0-9_]*$"
+    },
+    "plans": {
+      "description": "The list of whitelisted plans.",
+      "type": "array",
+      "items": {
+        "description": "Whitelisted plan.",
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9_]*(::[a-z][a-z0-9_]*)*$"
+      },
+      "uniqueItems": true
+    },
+    "tasks": {
+      "description": "The list of whitelisted tasks.",
+      "type": "array",
+      "items": {
+        "description": "Whitelisted task.",
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9_]*(::[a-z][a-z0-9_]*)*$"
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/schemas/bolt-transport-definitions.json
+++ b/schemas/bolt-transport-definitions.json
@@ -1,0 +1,271 @@
+{
+  "docker": {
+    "description": "Configuration for the docker transport.",
+    "type": "object",
+    "properties": {
+      "cleanup":       { "$ref": "#/definitions/cleanup" },
+      "host":          { "$ref": "#/definitions/host" },
+      "interpreters":  { "$ref": "#/definitions/interpreters" },
+      "service-url":   { "$ref": "#/definitions/service-url" },
+      "shell-command": { "$ref": "#/definitions/shell-command" },
+      "tmpdir":        { "$ref": "#/definitions/tmpdir" },
+      "tty":           { "$ref": "#/definitions/tty" }
+    }
+  },
+  "local": {
+    "description": "Configuration for the local transport.",
+    "type": "object",
+    "properties": {
+      "cleanup":         { "$ref": "#/definitions/cleanup" },
+      "interpreters":    { "$ref": "#/definitions/interpreters" },
+      "run-as":          { "$ref": "#/definitions/run-as" },
+      "run-as-command":  { "$ref": "#/definitions/run-as-command" },
+      "sudo-executable": { "$ref": "#/definitions/sudo-executable" },
+      "sudo-password":   { "$ref": "#/definitions/sudo-password" },
+      "tmpdir":          { "$ref": "#/definitions/tmpdir" }
+    }
+  },
+  "pcp": {
+    "description": "Configuration for the pcp transport.",
+    "type": "object",
+    "properties": {
+      "cacert":            { "$ref": "#/definitions/cacert" },
+      "host":              { "$ref": "#/definitions/host" },
+      "job-poll-interval": { "$ref": "#/definitions/job-poll-interval" },
+      "job-poll-timeout":  { "$ref": "#/definitions/job-poll-timeout" },
+      "service-url":       { "$ref": "#/definitions/service-url" },
+      "task-environment":  { "$ref": "#/definitions/task-environment" },
+      "token-file":        { "$ref": "#/definitions/token-file" }
+    }
+  },
+  "remote": {
+    "description": "Configuration for the remote transport.",
+    "type": "object",
+    "properties": {
+      "run-on": { "$ref": "#/definitions/run-on" }
+    }
+  },
+  "ssh": {
+    "description": "Configuration for the ssh transport.",
+    "type": "object",
+    "properties": {
+      "cleanup": { "$ref": "#/definitions/cleanup" },
+      "connect-timeout": { "$ref": "#/definitions/connect-timeout" },
+      "disconnect-timeout": { "$ref": "#/definitions/disconnect-timeout" },
+      "host":               { "$ref": "#/definitions/host" },
+      "host-key-check":     { "$ref": "#/definitions/host-key-check" },
+      "extensions":         { "$ref": "#/definitions/extensions" },
+      "interpreters":       { "$ref": "#/definitions/interpreters" },
+      "load-config":        { "$ref": "#/definitions/load-config" },
+      "login-shell":        { "$ref": "#/definitions/login-shell" },
+      "password":           { "$ref": "#/definitions/password" },
+      "port":               { "$ref": "#/definitions/port" },
+      "private-key":        { "$ref": "#/definitions/private-key" },
+      "proxyjump":          { "$ref": "#/definitions/proxyjump" },
+      "run-as":             { "$ref": "#/definitions/run-as" },
+      "run-as-command":     { "$ref": "#/definitions/run-as-command" },
+      "script-dir":         { "$ref": "#/definitions/script-dir" },
+      "sudo-executable":    { "$ref": "#/definitions/sudo-executable" },
+      "sudo-password":      { "$ref": "#/definitions/sudo-password" },
+      "tmpdir":             { "$ref": "#/definitions/tmpdir" },
+      "tty":                { "$ref": "#/definitions/tty" },
+      "user":               { "$ref": "#/definitions/user" }
+    }
+  },
+  "winrm": {
+    "description": "Configuration for the winrm transport.",
+    "type": "object",
+    "properties": {
+      "basic-auth-only": { "$ref": "#/definitions/basic-auth-only" },
+      "cacert":          { "$ref": "#/definitions/cacert" },
+      "cleanup":         { "$ref": "#/definitions/cleanup" },
+      "connect-timeout": { "$ref": "#/definitions/connect-timeout" },
+      "extensions":      { "$ref": "#/definitions/extensions" },
+      "file-protocol":   { "$ref": "#/definitions/file-protocol" },
+      "host":            { "$ref": "#/definitions/host" },
+      "interpreters":    { "$ref": "#/definitions/interpreters" },
+      "password":        { "$ref": "#/definitions/password" },
+      "port":            { "$ref": "#/definitions/port" },
+      "realm":           { "$ref": "#/definitions/realm" },
+      "smb-port":        { "$ref": "#/definitions/smb-port" },
+      "ssl":             { "$ref": "#/definitions/ssl" },
+      "ssl-verify":      { "$ref": "#/definitions/ssl-verify" },
+      "tmpdir":          { "$ref": "#/definitions/tmpdir" },
+      "user":            { "$ref": "#/definitions/user" }
+    }
+  },
+
+  "definitions": {
+    "basic-auth-only": {
+      "description": "Force basic authentication. This option is only available when using SSL.",
+      "type": "boolean"
+    },
+    "cacert": {
+      "description": "The path to the CA certificate.",
+      "type": "string"
+    },
+    "connect-timeout": {
+      "description": "How long to wait in seconds when establishing connections.",
+      "type": "integer",
+      "min": 1
+    },
+    "disconnect-timeout": {
+      "description": "How long to wait in seconds before force-closing a connection.",
+      "type": "integer",
+      "min": 1
+    },
+    "cleanup": {
+      "description": "Whether to clean up temporary files created on targets.",
+      "type": "boolean"
+    },
+    "extensions": {
+      "description": "A list of file extensions that are accepted for scripts or tasks.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "file-protocol": {
+      "description": "Which file transfer protocol to use. 'smb' is recommended for large file transfers.",
+      "type": "string",
+      "enum": ["smb", "winrm"]
+    },
+    "host": {
+      "description": "The host's name.",
+      "type": "string"
+    },
+    "host-key-check": {
+      "description": "Whether to perform host key validation when connecting.",
+      "type": "boolean"
+    },
+    "interpreters": {
+      "description": "A map of extension names to the absolute path of an executable, enabling you to override the shebang defined in a task executable.",
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^.?[a-zA-Z0-9]+$": {
+          "type": "string"
+        }
+      }
+    },
+    "job-poll-interval": {
+      "description": "The interval to poll orchestrator for job status.",
+      "type": "integer",
+      "min": 1
+    },
+    "job-poll-timeout": {
+      "description": "The time to wait for orchestrator job status.",
+      "type": "integer",
+      "min": 1
+    },
+    "load-config": {
+      "description": "Whether to load system SSH configuration.",
+      "type": "boolean"
+    },
+    "login-shell": {
+      "description": "Which login shell Bolt should expect on the target.",
+      "type": "string",
+      "enum": ["sh", "bash", "zsh", "dash", "ksh", "powershell"]
+    },
+    "password": {
+      "description": "Login password.",
+      "type": "string"
+    },
+    "port": {
+      "description": "Connection port.",
+      "type": "integer",
+      "min": 0
+    },
+    "private-key": {
+      "description": "Either the path to the private key file to use for authentication, or a hash with the key 'key-data' and the contents of the private key.",
+      "type": ["object", "string"],
+      "required": ["key-data"],
+      "properties": {
+        "key-data": {
+          "description": "The private key content.",
+          "type": "string"
+        }
+      }
+    },
+    "proxyjump": {
+      "description": "A jump host to proxy connections through, and an optional user to connect with.",
+      "type": "string",
+      "format": "uri"
+    },
+    "realm": {
+      "description": "Kerberos realm (Active Directory domain) to authenticate against.",
+      "type": "string"
+    },
+    "run-as": {
+      "description": "The user to run commands as after login.",
+      "type": "string"
+    },
+    "run-as-command": {
+      "description": "The command to elevate permissions. Bolt appends the user and command strings to the configured 'run-as-command' before running it on the target.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "run-on": {
+      "description": "The proxy target that the task executes on.",
+      "type": "string",
+      "format": "uri"
+    },
+    "script-dir": {
+      "description": "The subdirectory of the tmpdir to use in place of a randomized subdirectory for uploading and executing temporary fileson the target.",
+      "type": "string"
+    },
+    "service-url": {
+      "description": "URL of the host used for API requests.",
+      "type": "string",
+      "format": "uri"
+    },
+    "shell-command": {
+      "description": "A shell command to wrap any Docker exec commands in, such as `bash -lc`.",
+      "type": "string"
+    },
+    "smb-port": {
+      "description": "The port to establish a connection on when using the smb file protocol.",
+      "type": "integer",
+      "min": 0
+    },
+    "ssl": {
+      "description": "Whether to use a secure https connection.",
+      "type": "boolean"
+    },
+    "ssl-verify": {
+      "description": "Whether to verify the target certificate matches the cacert.",
+      "type": "boolean"
+    },
+    "sudo-executable": {
+      "description": "The executable to use when escalating to the configured 'run-as' user.",
+      "type": "string"
+    },
+    "sudo-password": {
+      "description": "The password to use when changing users via 'run-as'.",
+      "type": "string"
+    },
+    "task-environment": {
+      "description": "The environment the orchestrator loads task code from",
+      "type": "string"
+    },
+    "tmpdir": {
+      "description": "The directory to upload and execute temporary files on the target.",
+      "type": "string"
+    },
+    "token-file": {
+      "description": "The path to the token file.",
+      "type": "string"
+    },
+    "tty": {
+      "description": "Whether to enable tty on exec commands.",
+      "type": "boolean"
+    },
+    "user": {
+      "description": "Login user.",
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
This adds JSON schemas that can be used to validate `bolt.yaml`,
`inventory.yaml`, and `project.yaml` files.

Closes #1795 

!feature

* **Added JSON schemas for validating Bolt configuration files**
  ([#1795](https://github.com/puppetlabs/bolt/issues/1795))

  JSON schemas are now available for validating `bolt.yaml`,
  `inventory.yaml`, and `project.yaml` files.