### PR TITLE
(maint) Remove docker-compose download from linux CI

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -38,8 +38,6 @@ jobs:
         run: bundle install --jobs 4 --retry 3
       - name: Pre-test setup
         run: |
-          sudo curl -L https://github.com/docker/compose/releases/download/1.23.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
-          sudo chmod +x /usr/local/bin/docker-compose
           echo 'runner:runner' | sudo chpasswd
           sudo sh -c "echo 'Defaults authenticate' >> /etc/sudoers"
           sudo sh -c "echo 'runner  ALL=(ALL) PASSWD:ALL' >> /etc/sudoers"
@@ -74,8 +72,6 @@ jobs:
         run: bundle install --jobs 4 --retry 3
       - name: Pre-test setup
         run: |
-          sudo curl -L https://github.com/docker/compose/releases/download/1.23.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
-          sudo chmod +x /usr/local/bin/docker-compose
           docker-compose -f spec/docker-compose.yml build --parallel
           docker-compose -f spec/docker-compose.yml up -d
           bundle exec r10k puppetfile install


### PR DESCRIPTION
This removes the step to install docker-compose during pre-test setup
for the linux CI workflow. Previously, the linux virtual environment did
not have a version of docker-compose installed that supported the
`--parallel` flag. docker-compose has since been updated to a version
that does support this flag, so it's no longer necessary to download and
install docker-compose during pre-test setup.

!no-release-note