### PR TITLE
(GH-1771) Use plugins to set PuppetDB config

### DIFF
--- a/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
@@ -15,7 +15,7 @@ describe 'apply_prep' do
   let(:applicator)    { mock('Bolt::Applicator') }
   let(:config)        { Bolt::Config.default }
   let(:executor)      { Bolt::Executor.new(1, Bolt::Analytics::NoopClient.new) }
-  let(:plugins)       { Bolt::Plugin.setup(config, nil, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins)       { Bolt::Plugin.setup(config, nil, Bolt::Analytics::NoopClient.new) }
   let(:plugin_result) { {} }
   let(:task_hook)     { proc { |_opts, target, _fun| proc { Bolt::Result.new(target, value: plugin_result) } } }
   let(:inventory)     { Bolt::Inventory.create_version({}, config.transport, config.transports, plugins) }
@@ -150,7 +150,7 @@ describe 'apply_prep' do
 
       let(:config)    { Bolt::Config.new(Bolt::Project.new('.'), {}) }
       let(:pal)       { nil }
-      let(:plugins)   { Bolt::Plugin.setup(config, pal, nil, Bolt::Analytics::NoopClient.new) }
+      let(:plugins)   { Bolt::Plugin.setup(config, pal, Bolt::Analytics::NoopClient.new) }
       let(:inventory) { Bolt::Inventory.create_version(data, config.transport, config.transports, plugins) }
       let(:target)    { inventory.get_target(hostname) }
       let(:targets)   { inventory.get_targets(hostname) }

--- a/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
@@ -14,8 +14,8 @@ describe 'apply_prep' do
   include PuppetlabsSpec::Fixtures
   let(:applicator)    { mock('Bolt::Applicator') }
   let(:config)        { Bolt::Config.default }
-  let(:executor)      { Bolt::Executor.new(1, Bolt::Analytics::NoopClient.new) }
-  let(:plugins)       { Bolt::Plugin.setup(config, nil, Bolt::Analytics::NoopClient.new) }
+  let(:executor)      { Bolt::Executor.new }
+  let(:plugins)       { Bolt::Plugin.setup(config, nil) }
   let(:plugin_result) { {} }
   let(:task_hook)     { proc { |_opts, target, _fun| proc { Bolt::Result.new(target, value: plugin_result) } } }
   let(:inventory)     { Bolt::Inventory.create_version({}, config.transport, config.transports, plugins) }
@@ -150,7 +150,7 @@ describe 'apply_prep' do
 
       let(:config)    { Bolt::Config.new(Bolt::Project.new('.'), {}) }
       let(:pal)       { nil }
-      let(:plugins)   { Bolt::Plugin.setup(config, pal, Bolt::Analytics::NoopClient.new) }
+      let(:plugins)   { Bolt::Plugin.setup(config, pal) }
       let(:inventory) { Bolt::Inventory.create_version(data, config.transport, config.transports, plugins) }
       let(:target)    { inventory.get_target(hostname) }
       let(:targets)   { inventory.get_targets(hostname) }

--- a/bolt-modules/boltlib/spec/functions/remove_from_group_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/remove_from_group_spec.rb
@@ -5,7 +5,7 @@ describe 'remove_from_group' do
   let(:executor)      { Bolt::Executor.new }
   let(:config)        { Bolt::Config.new(Bolt::Project.new('.'), {}) }
   let(:pal)           { nil }
-  let(:plugins)       { Bolt::Plugin.setup(config, pal, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins)       { Bolt::Plugin.setup(config, pal, Bolt::Analytics::NoopClient.new) }
   let(:inventory)     { Bolt::Inventory.create_version(data, config.transport, config.transports, plugins) }
   let(:tasks_enabled) { true }
   let(:target1)       { 'target1' }

--- a/bolt-modules/boltlib/spec/functions/remove_from_group_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/remove_from_group_spec.rb
@@ -5,7 +5,7 @@ describe 'remove_from_group' do
   let(:executor)      { Bolt::Executor.new }
   let(:config)        { Bolt::Config.new(Bolt::Project.new('.'), {}) }
   let(:pal)           { nil }
-  let(:plugins)       { Bolt::Plugin.setup(config, pal, Bolt::Analytics::NoopClient.new) }
+  let(:plugins)       { Bolt::Plugin.setup(config, pal) }
   let(:inventory)     { Bolt::Inventory.create_version(data, config.transport, config.transports, plugins) }
   let(:tasks_enabled) { true }
   let(:target1)       { 'target1' }

--- a/bolt-modules/boltlib/spec/functions/resolve_references_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/resolve_references_spec.rb
@@ -8,8 +8,7 @@ describe 'resolve_references' do
   let(:project)       { Bolt::Project.new('./spec/fixtures') }
   let(:config)        { Bolt::Config.new(project, {}) }
   let(:pal)           { Bolt::PAL.new(config.modulepath, config.hiera_config, config.project.resource_types) }
-  let(:analytics)     { Bolt::Analytics::NoopClient.new }
-  let(:plugins)       { Bolt::Plugin.setup(config, pal, analytics) }
+  let(:plugins)       { Bolt::Plugin.setup(config, pal) }
   let(:executor)      { Bolt::Executor.new }
   let(:inventory)     { Bolt::Inventory.create_version({}, config.transport, config.transports, plugins) }
   let(:tasks_enabled) { true }

--- a/bolt-modules/boltlib/spec/functions/resolve_references_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/resolve_references_spec.rb
@@ -8,9 +8,8 @@ describe 'resolve_references' do
   let(:project)       { Bolt::Project.new('./spec/fixtures') }
   let(:config)        { Bolt::Config.new(project, {}) }
   let(:pal)           { Bolt::PAL.new(config.modulepath, config.hiera_config, config.project.resource_types) }
-  let(:pdb_client)    { Bolt::PuppetDB::Client.new({}) }
   let(:analytics)     { Bolt::Analytics::NoopClient.new }
-  let(:plugins)       { Bolt::Plugin.setup(config, pal, pdb_client, analytics) }
+  let(:plugins)       { Bolt::Plugin.setup(config, pal, analytics) }
   let(:executor)      { Bolt::Executor.new }
   let(:inventory)     { Bolt::Inventory.create_version({}, config.transport, config.transports, plugins) }
   let(:tasks_enabled) { true }

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -257,13 +257,11 @@ module Bolt
     end
 
     def puppetdb_client
-      return @puppetdb_client if @puppetdb_client
-      puppetdb_config = Bolt::PuppetDB::Config.load_config(config.puppetdb, config.project.path)
-      @puppetdb_client = Bolt::PuppetDB::Client.new(puppetdb_config)
+      plugins.by_name('puppetdb').puppetdb_client
     end
 
     def plugins
-      @plugins ||= Bolt::Plugin.setup(config, pal, puppetdb_client, analytics)
+      @plugins ||= Bolt::Plugin.setup(config, pal, analytics)
     end
 
     def query_puppetdb_nodes(query)

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -258,7 +258,7 @@ module Bolt
 
     def puppetdb_client
       return @puppetdb_client if @puppetdb_client
-      puppetdb_config = Bolt::PuppetDB::Config.load_config(nil, config.puppetdb, config.project.path)
+      puppetdb_config = Bolt::PuppetDB::Config.load_config(config.puppetdb, config.project.path)
       @puppetdb_client = Bolt::PuppetDB::Client.new(puppetdb_config)
     end
 

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -257,7 +257,7 @@ module Bolt
     end
 
     def puppetdb_client
-      plugins.by_name('puppetdb').puppetdb_client
+      plugins.puppetdb_client
     end
 
     def plugins

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -312,10 +312,10 @@ module Bolt
         @warnings << { option: 'future', msg: msg }
       end
 
-      keys = OPTIONS.keys - %w[plugins plugin_hooks]
+      keys = OPTIONS.keys - %w[plugins plugin_hooks puppetdb]
       keys.each do |key|
         next unless Bolt::Util.references?(@data[key])
-        valid_keys = TRANSPORT_CONFIG.keys + %w[plugins plugin_hooks]
+        valid_keys = TRANSPORT_CONFIG.keys + %w[plugins plugin_hooks puppetdb]
         raise Bolt::ValidationError,
               "Found unsupported key _plugin in config setting #{key}. Plugins are only available in "\
               "#{valid_keys.join(', ')}."

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -83,7 +83,7 @@ module Bolt
 
     def self.empty
       config  = Bolt::Config.default
-      plugins = Bolt::Plugin.setup(config, nil, Bolt::Analytics::NoopClient)
+      plugins = Bolt::Plugin.setup(config, nil)
 
       create_version({}, config.transport, config.transports, plugins)
     end

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -83,7 +83,7 @@ module Bolt
 
     def self.empty
       config  = Bolt::Config.default
-      plugins = Bolt::Plugin.setup(config, nil, nil, Bolt::Analytics::NoopClient)
+      plugins = Bolt::Plugin.setup(config, nil, Bolt::Analytics::NoopClient)
 
       create_version({}, config.transport, config.transports, plugins)
     end

--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -159,6 +159,10 @@ module Bolt
       @unresolved_plugin_configs = config.plugins.dup
       # The puppetdb plugin config comes from the puppetdb section, not from
       # the plugins section
+      if @unresolved_plugin_configs.key?('puppetdb')
+        msg = "Configuration for the PuppetDB plugin must be in the 'puppetdb' config section, not 'plugins'"
+        raise Bolt::Error.new(msg, 'bolt/plugin-error')
+      end
       @unresolved_plugin_configs['puppetdb'] = config.puppetdb if config.puppetdb
       @plugin_hooks = DEFAULT_PLUGIN_HOOKS.dup
     end

--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -119,12 +119,8 @@ module Bolt
       end
     end
 
-    def self.setup(config, pal, pdb_client, analytics)
+    def self.setup(config, pal, analytics = Bolt::Analytics::NoopClient.new)
       plugins = new(config, pal, analytics)
-
-      # PDB is special because it needs the PDB client. Since it has no config,
-      # we can just add it first.
-      plugins.add_plugin(Bolt::Plugin::Puppetdb.new(pdb_client))
 
       # Initialize any plugins referenced in plugin config. This will also indirectly
       # initialize any plugins they depend on.
@@ -142,7 +138,7 @@ module Bolt
       plugins
     end
 
-    RUBY_PLUGINS = %w[task prompt env_var].freeze
+    RUBY_PLUGINS = %w[task prompt env_var puppetdb].freeze
     BUILTIN_PLUGINS = %w[task terraform pkcs7 prompt vault aws_inventory puppetdb azure_inventory
                          yaml env_var gcloud_inventory].freeze
     DEFAULT_PLUGIN_HOOKS = { 'puppet_library' => { 'plugin' => 'puppet_agent', 'stop_service' => true } }.freeze
@@ -161,6 +157,9 @@ module Bolt
       @unknown = Set.new
       @resolution_stack = []
       @unresolved_plugin_configs = config.plugins.dup
+      # The puppetdb plugin config comes from the puppetdb section, not from
+      # the plugins section
+      @unresolved_plugin_configs['puppetdb'] = config.puppetdb if config.puppetdb
       @plugin_hooks = DEFAULT_PLUGIN_HOOKS.dup
     end
 
@@ -168,7 +167,6 @@ module Bolt
       @modules ||= Bolt::Module.discover(@pal.modulepath)
     end
 
-    # Generally this is private. Puppetdb is special though
     def add_plugin(plugin)
       @plugins[plugin.name] = plugin
     end

--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -233,6 +233,10 @@ module Bolt
       end
     end
 
+    def puppetdb_client
+      by_name('puppetdb').puppetdb_client
+    end
+
     # Evaluate all _plugin references in a data structure. Leaves are
     # evaluated and then their parents are evaluated with references replaced
     # by their values. If the result of a reference contains more references,

--- a/lib/bolt/plugin/puppetdb.rb
+++ b/lib/bolt/plugin/puppetdb.rb
@@ -14,8 +14,11 @@ module Bolt
       TEMPLATE_OPTS = %w[alias config facts features name uri vars].freeze
       PLUGIN_OPTS = %w[_plugin query target_mapping].freeze
 
-      def initialize(pdb_client)
-        @puppetdb_client = pdb_client
+      attr_reader :puppetdb_client
+
+      def initialize(config:, context:)
+        pdb_config = Bolt::PuppetDB::Config.load_config(config, context.boltdir)
+        @puppetdb_client = Bolt::PuppetDB::Client.new(pdb_config)
         @logger = Logging.logger[self]
       end
 

--- a/lib/bolt_spec/bolt_context.rb
+++ b/lib/bolt_spec/bolt_context.rb
@@ -145,9 +145,7 @@ module BoltSpec
     end
 
     def plugins
-      @plugins ||= Bolt::Plugin.setup(config,
-                                      pal,
-                                      Bolt::Analytics::NoopClient.new)
+      @plugins ||= Bolt::Plugin.setup(config, pal)
     end
 
     def pal

--- a/lib/bolt_spec/bolt_context.rb
+++ b/lib/bolt_spec/bolt_context.rb
@@ -147,7 +147,6 @@ module BoltSpec
     def plugins
       @plugins ||= Bolt::Plugin.setup(config,
                                       pal,
-                                      nil,
                                       Bolt::Analytics::NoopClient.new)
     end
 

--- a/lib/bolt_spec/run.rb
+++ b/lib/bolt_spec/run.rb
@@ -156,7 +156,7 @@ module BoltSpec
       end
 
       def puppetdb_client
-        @puppetdb_client ||= plugins.by_name('puppetdb').puppetdb_client
+        plugins.puppetdb_client
       end
 
       def pal

--- a/lib/bolt_spec/run.rb
+++ b/lib/bolt_spec/run.rb
@@ -157,7 +157,7 @@ module BoltSpec
 
       def puppetdb_client
         @puppetdb_client ||= begin
-                               puppetdb_config = Bolt::PuppetDB::Config.load_config(nil, config.puppetdb)
+                               puppetdb_config = Bolt::PuppetDB::Config.load_config(config.puppetdb)
                                Bolt::PuppetDB::Client.new(puppetdb_config)
                              end
       end

--- a/lib/bolt_spec/run.rb
+++ b/lib/bolt_spec/run.rb
@@ -152,7 +152,7 @@ module BoltSpec
       end
 
       def plugins
-        @plugins ||= Bolt::Plugin.setup(config, pal, @analytics)
+        @plugins ||= Bolt::Plugin.setup(config, pal)
       end
 
       def puppetdb_client

--- a/lib/bolt_spec/run.rb
+++ b/lib/bolt_spec/run.rb
@@ -152,14 +152,11 @@ module BoltSpec
       end
 
       def plugins
-        @plugins ||= Bolt::Plugin.setup(config, pal, puppetdb_client, @analytics)
+        @plugins ||= Bolt::Plugin.setup(config, pal, @analytics)
       end
 
       def puppetdb_client
-        @puppetdb_client ||= begin
-                               puppetdb_config = Bolt::PuppetDB::Config.load_config(config.puppetdb)
-                               Bolt::PuppetDB::Client.new(puppetdb_config)
-                             end
+        @puppetdb_client ||= plugins.by_name('puppetdb').puppetdb_client
       end
 
       def pal

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1909,7 +1909,7 @@ describe "Bolt::CLI" do
                                                      anything,
                                                      true).and_return(executor)
 
-        plugins = Bolt::Plugin.setup(Bolt::Config.default, nil, nil, nil)
+        plugins = Bolt::Plugin.setup(Bolt::Config.default, nil, nil)
         allow(cli).to receive(:plugins).and_return(plugins)
 
         outputter = Bolt::Outputter::JSON.new(false, false, false, output)

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1909,7 +1909,7 @@ describe "Bolt::CLI" do
                                                      anything,
                                                      true).and_return(executor)
 
-        plugins = Bolt::Plugin.setup(Bolt::Config.default, nil, nil)
+        plugins = Bolt::Plugin.setup(Bolt::Config.default, nil)
         allow(cli).to receive(:plugins).and_return(plugins)
 
         outputter = Bolt::Outputter::JSON.new(false, false, false, output)

--- a/spec/bolt/inventory/group_spec.rb
+++ b/spec/bolt/inventory/group_spec.rb
@@ -13,7 +13,7 @@ describe Bolt::Inventory::Group do
 
   let(:data) { { 'name' => 'all' } }
   let(:pal) { nil } # Not used
-  let(:plugins) { Bolt::Plugin.setup(config, nil, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config, nil, Bolt::Analytics::NoopClient.new) }
   let(:group) {
     # Inventory always resolves unknown labels to names or aliases from the top-down when constructed,
     # passing the collection of all aliases in it. Do that manually here to ensure plain target strings
@@ -798,7 +798,7 @@ describe Bolt::Inventory::Group do
     let(:pal) { Bolt::PAL.new(modulepath, nil, nil) }
 
     let(:plugins) do
-      plugins = Bolt::Plugin.setup(config, pal, nil, Bolt::Analytics::NoopClient.new)
+      plugins = Bolt::Plugin.setup(config, pal, Bolt::Analytics::NoopClient.new)
       plugins.add_plugin(BoltSpec::Plugins::Constant.new)
       plugins.add_plugin(BoltSpec::Plugins::Error.new)
       plugins.add_plugin(BoltSpec::Plugins::TestLookup.new(lookup_data))

--- a/spec/bolt/inventory/group_spec.rb
+++ b/spec/bolt/inventory/group_spec.rb
@@ -13,7 +13,7 @@ describe Bolt::Inventory::Group do
 
   let(:data) { { 'name' => 'all' } }
   let(:pal) { nil } # Not used
-  let(:plugins) { Bolt::Plugin.setup(config, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config, nil) }
   let(:group) {
     # Inventory always resolves unknown labels to names or aliases from the top-down when constructed,
     # passing the collection of all aliases in it. Do that manually here to ensure plain target strings
@@ -798,7 +798,7 @@ describe Bolt::Inventory::Group do
     let(:pal) { Bolt::PAL.new(modulepath, nil, nil) }
 
     let(:plugins) do
-      plugins = Bolt::Plugin.setup(config, pal, Bolt::Analytics::NoopClient.new)
+      plugins = Bolt::Plugin.setup(config, pal)
       plugins.add_plugin(BoltSpec::Plugins::Constant.new)
       plugins.add_plugin(BoltSpec::Plugins::Error.new)
       plugins.add_plugin(BoltSpec::Plugins::TestLookup.new(lookup_data))

--- a/spec/bolt/inventory/inventory_spec.rb
+++ b/spec/bolt/inventory/inventory_spec.rb
@@ -16,7 +16,7 @@ describe Bolt::Inventory::Inventory do
   end
 
   let(:pal)          { nil }
-  let(:plugins)      { Bolt::Plugin.setup(config, pal, Bolt::Analytics::NoopClient.new) }
+  let(:plugins)      { Bolt::Plugin.setup(config, pal) }
   let(:target_name)  { "example.com" }
   let(:target_entry) { target_name }
   let(:targets)      { [target_entry] }
@@ -1278,7 +1278,7 @@ describe Bolt::Inventory::Inventory do
     }
 
     let(:plugins) do
-      plugins = Bolt::Plugin.setup(config, pal, Bolt::Analytics::NoopClient.new)
+      plugins = Bolt::Plugin.setup(config, pal)
       plugin = double('plugin')
       allow(plugin).to receive(:name).and_return('test_plugin')
       allow(plugin).to receive(:hooks).and_return([:resolve_reference])

--- a/spec/bolt/inventory/inventory_spec.rb
+++ b/spec/bolt/inventory/inventory_spec.rb
@@ -16,7 +16,7 @@ describe Bolt::Inventory::Inventory do
   end
 
   let(:pal)          { nil }
-  let(:plugins)      { Bolt::Plugin.setup(config, pal, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins)      { Bolt::Plugin.setup(config, pal, Bolt::Analytics::NoopClient.new) }
   let(:target_name)  { "example.com" }
   let(:target_entry) { target_name }
   let(:targets)      { [target_entry] }
@@ -1278,7 +1278,7 @@ describe Bolt::Inventory::Inventory do
     }
 
     let(:plugins) do
-      plugins = Bolt::Plugin.setup(config, pal, nil, Bolt::Analytics::NoopClient.new)
+      plugins = Bolt::Plugin.setup(config, pal, Bolt::Analytics::NoopClient.new)
       plugin = double('plugin')
       allow(plugin).to receive(:name).and_return('test_plugin')
       allow(plugin).to receive(:hooks).and_return([:resolve_reference])

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -10,7 +10,7 @@ describe Bolt::Inventory do
   include BoltSpec::Config
 
   let(:pal)     { nil } # Not used
-  let(:plugins) { Bolt::Plugin.setup(config, pal, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config, pal, Bolt::Analytics::NoopClient.new) }
 
   context 'with BOLT_INVENTORY set' do
     let(:inventory) { Bolt::Inventory.from_config(config, plugins) }

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -10,7 +10,7 @@ describe Bolt::Inventory do
   include BoltSpec::Config
 
   let(:pal)     { nil } # Not used
-  let(:plugins) { Bolt::Plugin.setup(config, pal, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config, pal) }
 
   context 'with BOLT_INVENTORY set' do
     let(:inventory) { Bolt::Inventory.from_config(config, plugins) }

--- a/spec/bolt/plugin/module_spec.rb
+++ b/spec/bolt/plugin/module_spec.rb
@@ -15,7 +15,7 @@ describe Bolt::Plugin::Module do
   let(:config_data) { { 'modulepath' => modulepath, 'plugins' => plugin_config } }
 
   let(:pal) { Bolt::PAL.new(modulepath, {}, nil) }
-  let(:plugins) { Bolt::Plugin.setup(config(config_data), pal, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config(config_data), pal) }
 
   let(:module_name) { 'empty_plug' }
   let(:mod) { Bolt::Module.new(module_name, fixtures_path('plugin_modules', module_name)) }

--- a/spec/bolt/plugin/module_spec.rb
+++ b/spec/bolt/plugin/module_spec.rb
@@ -15,7 +15,7 @@ describe Bolt::Plugin::Module do
   let(:config_data) { { 'modulepath' => modulepath, 'plugins' => plugin_config } }
 
   let(:pal) { Bolt::PAL.new(modulepath, {}, nil) }
-  let(:plugins) { Bolt::Plugin.setup(config(config_data), pal, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config(config_data), pal, Bolt::Analytics::NoopClient.new) }
 
   let(:module_name) { 'empty_plug' }
   let(:mod) { Bolt::Module.new(module_name, fixtures_path('plugin_modules', module_name)) }

--- a/spec/bolt/plugin/puppetdb_spec.rb
+++ b/spec/bolt/plugin/puppetdb_spec.rb
@@ -5,14 +5,12 @@ require 'bolt/plugin/puppetdb'
 
 describe Bolt::Plugin::Puppetdb do
   let(:config) do
-    Bolt::PuppetDB::Config.new('server_urls' => 'https://localhost:8081',
-                               'cacert' => '/path/to/cacert',
-                               'token' => 'token')
+    { 'server_urls' => 'https://localhost:8081',
+      'cacert' => '/path/to/cacert',
+      'token' => 'token' }
   end
-  let(:pdb_client) { Bolt::PuppetDB::Client.new(config) }
-  let(:plugin) { Bolt::Plugin::Puppetdb.new(pdb_client) }
-  let(:opts) do
-  end
+  let(:context) { double('context', boltdir: nil) }
+  let(:plugin) { Bolt::Plugin::Puppetdb.new(config: config, context: context) }
 
   context "#fact_path" do
     it "converts a valid dot-notation fact to an array" do
@@ -40,8 +38,8 @@ describe Bolt::Plugin::Puppetdb do
       }] }
     end
     before(:each) do
-      allow(pdb_client).to receive(:query_certnames).and_return([certname])
-      allow(pdb_client).to receive(:fact_values).and_return(values_hash)
+      allow(plugin.puppetdb_client).to receive(:query_certnames).and_return([certname])
+      allow(plugin.puppetdb_client).to receive(:fact_values).and_return(values_hash)
     end
 
     it "sets uri to certname if uri and name are not configured" do

--- a/spec/bolt/plugin_spec.rb
+++ b/spec/bolt/plugin_spec.rb
@@ -16,7 +16,7 @@ describe Bolt::Plugin do
   let(:config_data) { { 'modulepath' => modulepath, 'plugins' => plugin_config } }
   let(:pal) { Bolt::PAL.new(modulepath, nil, nil) }
 
-  let(:plugins) { Bolt::Plugin.setup(config(config_data), pal, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config(config_data), pal) }
 
   def identity(value)
     {

--- a/spec/bolt/plugin_spec.rb
+++ b/spec/bolt/plugin_spec.rb
@@ -15,9 +15,8 @@ describe Bolt::Plugin do
   let(:plugin_config) { {} }
   let(:config_data) { { 'modulepath' => modulepath, 'plugins' => plugin_config } }
   let(:pal) { Bolt::PAL.new(modulepath, nil, nil) }
-  let(:pdb_client) { double('pdb_client') }
 
-  let(:plugins) { Bolt::Plugin.setup(config(config_data), pal, pdb_client, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config(config_data), pal, Bolt::Analytics::NoopClient.new) }
 
   def identity(value)
     {

--- a/spec/bolt/puppetdb/config_spec.rb
+++ b/spec/bolt/puppetdb/config_spec.rb
@@ -180,25 +180,18 @@ describe Bolt::PuppetDB::Config do
   end
 
   context "::load_config" do
-    let(:user_supplied) { File.join('test', 'file') }
-
-    it "loads from specified filename when given" do
-      expect(File).to receive(:exist?).with(user_supplied)
-      expect { Bolt::PuppetDB::Config.load_config(user_supplied, {}) }.to raise_error(/does not exist/)
-    end
-
-    it "on non-windows OS loads from default location when filename is nil" do
+    it "on non-windows OS loads from default location" do
       allow(Bolt::Util).to receive(:windows?).and_return(false)
       expect(File).to receive(:exist?).with(Bolt::PuppetDB::Config::DEFAULT_CONFIG[:user])
       expect(File).to receive(:exist?).with(Bolt::PuppetDB::Config::DEFAULT_CONFIG[:global])
-      Bolt::PuppetDB::Config.load_config(nil, {})
+      Bolt::PuppetDB::Config.load_config({})
     end
 
-    it "on windows OS loads from default location when filename is nil", :winrm do
+    it "on windows OS loads from default location", :winrm do
       allow(Bolt::Util).to receive(:windows?).and_return(true)
       expect(File).to receive(:exist?).with(Bolt::PuppetDB::Config::DEFAULT_CONFIG[:user])
       expect(File).to receive(:exist?).with(Bolt::PuppetDB::Config.default_windows_config)
-      Bolt::PuppetDB::Config.load_config(nil, {})
+      Bolt::PuppetDB::Config.load_config({})
     end
 
     it "Does not error if puppetdb.conf fails to load" do
@@ -206,7 +199,7 @@ describe Bolt::PuppetDB::Config do
       expect(File).to receive(:exist?).with(Bolt::PuppetDB::Config::DEFAULT_CONFIG[:user]).and_return true
       expect(File).to receive(:read).with(Bolt::PuppetDB::Config::DEFAULT_CONFIG[:user]).and_return 'bad"json'
       expect(JSON).to receive(:parse).and_raise(JSON::ParserError.new("unexpected token"))
-      Bolt::PuppetDB::Config.load_config(nil, {})
+      Bolt::PuppetDB::Config.load_config({})
     end
   end
 end

--- a/spec/bolt/transport/remote_spec.rb
+++ b/spec/bolt/transport/remote_spec.rb
@@ -8,7 +8,7 @@ require 'bolt/plugin'
 
 describe Bolt::Transport::Remote do
   let(:config) { Bolt::Config.default }
-  let(:plugins) { Bolt::Plugin.setup(config, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config, nil) }
   let(:data) {
     {
       'targets' => [

--- a/spec/bolt/transport/remote_spec.rb
+++ b/spec/bolt/transport/remote_spec.rb
@@ -8,7 +8,7 @@ require 'bolt/plugin'
 
 describe Bolt::Transport::Remote do
   let(:config) { Bolt::Config.default }
-  let(:plugins) { Bolt::Plugin.setup(config, nil, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config, nil, Bolt::Analytics::NoopClient.new) }
   let(:data) {
     {
       'targets' => [

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -476,7 +476,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
     let(:facts) { {} }
 
     before(:each) do
-      allow_any_instance_of(Bolt::CLI).to receive(:puppetdb_client).and_return(pdb_client)
+      allow_any_instance_of(Bolt::Config).to receive(:puppetdb).and_return(pdb_conf)
 
       push_facts(facts)
     end

--- a/spec/integration/transport/local_spec.rb
+++ b/spec/integration/transport/local_spec.rb
@@ -21,7 +21,7 @@ describe Bolt::Transport::Local do
   let(:os_context)    { Bolt::Util.windows? ? windows_context : posix_context }
   let(:config)        { make_config }
   let(:project)       { Bolt::Project.new('.') }
-  let(:plugins)       { Bolt::Plugin.setup(config, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins)       { Bolt::Plugin.setup(config, nil) }
   let(:inventory)     { Bolt::Inventory.create_version({}, config.transport, config.transports, plugins) }
   let(:target)        { make_target }
 

--- a/spec/integration/transport/local_spec.rb
+++ b/spec/integration/transport/local_spec.rb
@@ -21,7 +21,7 @@ describe Bolt::Transport::Local do
   let(:os_context)    { Bolt::Util.windows? ? windows_context : posix_context }
   let(:config)        { make_config }
   let(:project)       { Bolt::Project.new('.') }
-  let(:plugins)       { Bolt::Plugin.setup(config, nil, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins)       { Bolt::Plugin.setup(config, nil, Bolt::Analytics::NoopClient.new) }
   let(:inventory)     { Bolt::Inventory.create_version({}, config.transport, config.transports, plugins) }
   let(:target)        { make_target }
 

--- a/spec/integration/transport/ssh_spec.rb
+++ b/spec/integration/transport/ssh_spec.rb
@@ -43,7 +43,7 @@ describe Bolt::Transport::SSH, ssh: true do
 
   let(:config)            { make_config }
   let(:project)           { Bolt::Project.new('.') }
-  let(:plugins)           { Bolt::Plugin.setup(config, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins)           { Bolt::Plugin.setup(config, nil) }
   let(:inventory)         { Bolt::Inventory.create_version({}, config.transport, config.transports, plugins) }
   let(:target)            { make_target }
 

--- a/spec/integration/transport/ssh_spec.rb
+++ b/spec/integration/transport/ssh_spec.rb
@@ -43,7 +43,7 @@ describe Bolt::Transport::SSH, ssh: true do
 
   let(:config)            { make_config }
   let(:project)           { Bolt::Project.new('.') }
-  let(:plugins)           { Bolt::Plugin.setup(config, nil, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins)           { Bolt::Plugin.setup(config, nil, Bolt::Analytics::NoopClient.new) }
   let(:inventory)         { Bolt::Inventory.create_version({}, config.transport, config.transports, plugins) }
   let(:target)            { make_target }
 

--- a/spec/integration/transport/winrm_spec.rb
+++ b/spec/integration/transport/winrm_spec.rb
@@ -31,7 +31,7 @@ describe Bolt::Transport::WinRM do
   let(:ssl_config)  { mk_config(cacert: cacert_path, user: user, password: password) }
   let(:winrm)       { Bolt::Transport::WinRM.new }
   let(:winrm_ssl)   { Bolt::Transport::WinRM.new }
-  let(:plugins)     { Bolt::Plugin.setup(config, nil, Bolt::Analytics::NoopClient) }
+  let(:plugins)     { Bolt::Plugin.setup(config, nil) }
   let(:transport)   { 'winrm' }
   let(:inventory)   { Bolt::Inventory.empty }
   let(:target)      { make_target }

--- a/spec/integration/transport/winrm_spec.rb
+++ b/spec/integration/transport/winrm_spec.rb
@@ -31,7 +31,7 @@ describe Bolt::Transport::WinRM do
   let(:ssl_config)  { mk_config(cacert: cacert_path, user: user, password: password) }
   let(:winrm)       { Bolt::Transport::WinRM.new }
   let(:winrm_ssl)   { Bolt::Transport::WinRM.new }
-  let(:plugins)     { Bolt::Plugin.setup(config, nil, nil, Bolt::Analytics::NoopClient) }
+  let(:plugins)     { Bolt::Plugin.setup(config, nil, Bolt::Analytics::NoopClient) }
   let(:transport)   { 'winrm' }
   let(:inventory)   { Bolt::Inventory.empty }
   let(:target)      { make_target }

--- a/spec/pal/apply_result_spec.rb
+++ b/spec/pal/apply_result_spec.rb
@@ -18,7 +18,7 @@ describe 'ApplyResult DataType' do
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
   let(:pal)     { Bolt::PAL.new(modulepath, nil, nil) }
-  let(:plugins) { Bolt::Plugin.setup(config, nil, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config, nil, Bolt::Analytics::NoopClient.new) }
 
   let(:result_code) do
     <<~PUPPET

--- a/spec/pal/apply_result_spec.rb
+++ b/spec/pal/apply_result_spec.rb
@@ -18,7 +18,7 @@ describe 'ApplyResult DataType' do
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
   let(:pal)     { Bolt::PAL.new(modulepath, nil, nil) }
-  let(:plugins) { Bolt::Plugin.setup(config, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config, nil) }
 
   let(:result_code) do
     <<~PUPPET

--- a/spec/pal/facts_spec.rb
+++ b/spec/pal/facts_spec.rb
@@ -25,11 +25,10 @@ describe 'Facts functions' do
     }
   }
   let(:pal)     { Bolt::PAL.new(modulepath, nil, nil) }
-  let(:plugins) { Bolt::Plugin.setup(config, nil, analytics) }
+  let(:plugins) { Bolt::Plugin.setup(config, nil) }
   let(:inv)     { Bolt::Inventory::Inventory.new(data, config.transport, config.transports, plugins) }
 
-  let(:analytics) { Bolt::Analytics::NoopClient.new }
-  let(:executor)  { Bolt::Executor.new(1, analytics) }
+  let(:executor)  { Bolt::Executor.new }
 
   let(:target_string) { "$t = get_targets(#{target})[0]\n" }
   let(:facts)         { "facts($t)\n" }

--- a/spec/pal/facts_spec.rb
+++ b/spec/pal/facts_spec.rb
@@ -25,7 +25,7 @@ describe 'Facts functions' do
     }
   }
   let(:pal)     { Bolt::PAL.new(modulepath, nil, nil) }
-  let(:plugins) { Bolt::Plugin.setup(config, nil, nil, analytics) }
+  let(:plugins) { Bolt::Plugin.setup(config, nil, analytics) }
   let(:inv)     { Bolt::Inventory::Inventory.new(data, config.transport, config.transports, plugins) }
 
   let(:analytics) { Bolt::Analytics::NoopClient.new }

--- a/spec/pal/features_spec.rb
+++ b/spec/pal/features_spec.rb
@@ -16,8 +16,7 @@ describe 'set_features function' do
   before(:all) { Bolt::PAL.load_puppet }
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
-  let(:analytics) { Bolt::Analytics::NoopClient.new }
-  let(:executor) { Bolt::Executor.new(1, analytics) }
+  let(:executor) { Bolt::Executor.new(1) }
 
   let(:pal) { Bolt::PAL.new(modulepath, nil, nil) }
   let(:inventory) { Bolt::Inventory.empty }

--- a/spec/pal/result_set_spec.rb
+++ b/spec/pal/result_set_spec.rb
@@ -18,7 +18,7 @@ describe 'ResultSet DataType' do
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
   let(:pal)     { Bolt::PAL.new(modulepath, nil, nil) }
-  let(:plugins) { Bolt::Plugin.setup(config, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config, nil) }
 
   let(:result_code) do
     <<~PUPPET

--- a/spec/pal/result_set_spec.rb
+++ b/spec/pal/result_set_spec.rb
@@ -18,7 +18,7 @@ describe 'ResultSet DataType' do
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
   let(:pal)     { Bolt::PAL.new(modulepath, nil, nil) }
-  let(:plugins) { Bolt::Plugin.setup(config, nil, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config, nil, Bolt::Analytics::NoopClient.new) }
 
   let(:result_code) do
     <<~PUPPET

--- a/spec/pal/result_spec.rb
+++ b/spec/pal/result_spec.rb
@@ -18,7 +18,7 @@ describe 'Result DataType' do
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
   let(:pal)     { Bolt::PAL.new(modulepath, nil, nil) }
-  let(:plugins) { Bolt::Plugin.setup(config, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config, nil) }
 
   let(:result_code) do
     <<~PUPPET

--- a/spec/pal/result_spec.rb
+++ b/spec/pal/result_spec.rb
@@ -18,7 +18,7 @@ describe 'Result DataType' do
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
   let(:pal)     { Bolt::PAL.new(modulepath, nil, nil) }
-  let(:plugins) { Bolt::Plugin.setup(config, nil, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config, nil, Bolt::Analytics::NoopClient.new) }
 
   let(:result_code) do
     <<~PUPPET

--- a/spec/pal/target_spec.rb
+++ b/spec/pal/target_spec.rb
@@ -18,7 +18,7 @@ describe 'Target DataType' do
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
   let(:pal)     { Bolt::PAL.new(modulepath, nil, nil) }
-  let(:plugins) { Bolt::Plugin.setup(config, nil, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config, nil, Bolt::Analytics::NoopClient.new) }
 
   let(:target_code) { "$target = Target('pcp://user1:pass1@example.com:33')\n" }
 

--- a/spec/pal/target_spec.rb
+++ b/spec/pal/target_spec.rb
@@ -18,7 +18,7 @@ describe 'Target DataType' do
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
   let(:pal)     { Bolt::PAL.new(modulepath, nil, nil) }
-  let(:plugins) { Bolt::Plugin.setup(config, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(config, nil) }
 
   let(:target_code) { "$target = Target('pcp://user1:pass1@example.com:33')\n" }
 

--- a/spec/pal/vars_spec.rb
+++ b/spec/pal/vars_spec.rb
@@ -25,10 +25,9 @@ describe 'Vars function' do
 
   let(:inventory) { Bolt::Inventory::Inventory.new(data, config.transport, config.transports, plugins) }
   let(:pal)       { Bolt::PAL.new(modulepath, nil, nil) }
-  let(:plugins)   { Bolt::Plugin.setup(config, nil, analytics) }
+  let(:plugins)   { Bolt::Plugin.setup(config, nil) }
 
-  let(:analytics) { Bolt::Analytics::NoopClient.new }
-  let(:executor)  { Bolt::Executor.new(1, analytics) }
+  let(:executor)  { Bolt::Executor.new }
 
   let(:target)     { "$t = get_targets('example')[0]\n" }
   let(:vars)       { "$t.vars\n" }

--- a/spec/pal/vars_spec.rb
+++ b/spec/pal/vars_spec.rb
@@ -25,7 +25,7 @@ describe 'Vars function' do
 
   let(:inventory) { Bolt::Inventory::Inventory.new(data, config.transport, config.transports, plugins) }
   let(:pal)       { Bolt::PAL.new(modulepath, nil, nil) }
-  let(:plugins)   { Bolt::Plugin.setup(config, nil, nil, analytics) }
+  let(:plugins)   { Bolt::Plugin.setup(config, nil, analytics) }
 
   let(:analytics) { Bolt::Analytics::NoopClient.new }
   let(:executor)  { Bolt::Executor.new(1, analytics) }

--- a/spec/shared_examples/transport_config.rb
+++ b/spec/shared_examples/transport_config.rb
@@ -44,7 +44,7 @@ shared_examples 'filters options' do
 end
 
 shared_examples 'plugins' do
-  let(:plugins) { Bolt::Plugin.setup(Bolt::Config.default, nil, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(Bolt::Config.default, nil, Bolt::Analytics::NoopClient.new) }
 
   it 'accepts plugin references' do
     expect { transport.new(plugin_data) }.not_to raise_error

--- a/spec/shared_examples/transport_config.rb
+++ b/spec/shared_examples/transport_config.rb
@@ -44,7 +44,7 @@ shared_examples 'filters options' do
 end
 
 shared_examples 'plugins' do
-  let(:plugins) { Bolt::Plugin.setup(Bolt::Config.default, nil, Bolt::Analytics::NoopClient.new) }
+  let(:plugins) { Bolt::Plugin.setup(Bolt::Config.default, nil) }
 
   it 'accepts plugin references' do
     expect { transport.new(plugin_data) }.not_to raise_error


### PR DESCRIPTION
Previously, PuppetDB config was not able to be set using plugins. This was
due to the fact that PuppetDB config is used to configure the PuppetDB
plugin which can then be used to configure other plugins. We already have
logic that handles incrementally resolving data in the
`plugins` section of the config, but that couldn't accomodate PuppetDB 
which was handled specially.

We used to construct the PuppetDB client and pass it to Bolt::Plugin during 
plugin setup, where it would be used to construct the PuppetDB plugin and
then other plugins would be resolved thereafter. This commit flips that
dependency so that Bolt::Plugin takes the unresolved PuppetDB config,
merges it with the rest of the plugin config, and uses that to construct
the PuppetDB plugin. The CLI then takes a reference to the PuppetDB client
from the PuppetDB plugin, rather than the plugin taking a reference to the
CLI's client. This allows us to still have a single PuppetDB client, but
for that client to be configurable using plugins.

!feature

  * **Use plugins to set PuppetDB config** ([#1771](https://github.com/puppetlabs/bolt/issues/1795))

    Plugin references can now be used to set configuration options for
    the PuppetDB client used by Bolt, in the `puppetdb` section of the
    config.