### PR TITLE
(GH-1780) Allow users to shell out to SSH

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -43,6 +43,7 @@ jobs:
           sudo sh -c "echo 'runner  ALL=(ALL) PASSWD:ALL' >> /etc/sudoers"
           docker-compose -f spec/docker-compose.yml build --parallel ubuntu_node puppet_5_node puppet_6_node
           docker-compose -f spec/docker-compose.yml up -d ubuntu_node puppet_5_node puppet_6_node
+          chmod 0600 spec/fixtures/keys/id_rsa
           bundle exec r10k puppetfile install
       - name: Run tests with minimal container infrastructure
         run: bundle exec rake ci:fast

--- a/documentation/bolt_configuration_reference.md.erb
+++ b/documentation/bolt_configuration_reference.md.erb
@@ -121,11 +121,19 @@ Transport configuration options can be set in both the configuration file and in
 <% @transports[:options].each do |transport, options| %>
 ### <%= transport %>
 
+<% if transport == 'ssh' %>
+| Option | Description | External SSH | Type | Default |
+| ------ | ----------- | :----------: | ---- | ------- |
+<% options.each do |option, data| -%>
+  | `<%= option %>` | <%= data[:desc] %> | <%= data[:external] == true ? '&#10004;' : '' %> | <%= data[:type] == TrueClass ? 'Boolean' : data[:type] %> | <%= @transports[:defaults][transport][option].to_s || "" %> |
+<% end %>
+<% else %>
 | Option | Description | Type | Default |
 | ------ | ----------- | ---- | ------- |
 <% options.each do |option, data| -%>
 | `<%= option %>` | <%= data[:desc] %> | <%= data[:type] == TrueClass ? 'Boolean' : data[:type] %> | <%= @transports[:defaults][transport][option].to_s || "" %> |
 <% end %>
+<%end%>
 
 <% if transport == 'ssh' %>
 #### OpenSSH

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -281,4 +281,36 @@ $results = $targets.get_resources([Package, User])
 $results.each |$result| {
   $result.target.set_resources($result['resources'])
 }
+
+## External SSH transport
+
+Bolt's SSH transport uses the ruby library `net-ssh`, which is a pure ruby implementation of the
+SSH2 client protocol. While robust, the library lacks support for some features and algorithms that
+are available in native SSH. When you use the external SSH transport, Bolt uses the SSH executable
+you've specified instead of using `net-ssh`. Essentially, using the external SSH transport is the
+same as running SSH on your command line, but with Bolt managing the connections.
+
+To use the external SSH transport, set `ssh-command: <SSH>` in [bolt.yaml](configuring_bolt.md),
+where <SSH> is the SSH command to run. For example:
+
+```
+ssh:
+  ssh-command: 'ssh'
+```
+
+The value of `ssh-command` can be either a string or an array, and you can provide any flags to the
+command. Bolt will append Bolt-configuration settings to the command, as well as the specified
+target, when connecting. Not all Bolt configuration options are supported using the external SSH
+transport, but you can configure most options in your OpenSSH Config. See [bolt configuration
+reference](bolt_configuration_reference.md) for the list of supported Bolt SSH options.
+
+Bolt transports have two main functions: executing remotely, and copying files to the remote targets.
+`ssh-command` is what configures the remote execution, and `copy-command` configures the copy
+command. The default is `scp -r`, and `rsync` is not supported at this time.
+
+For example:
+```
+ssh:
+  ssh-command: 'ssh'
+  copy-command: 'scp -r -F ~/ssh-config/myconf'
 ```

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -11,7 +11,7 @@ module Bolt
                 escalation: %w[run-as sudo-password sudo-password-prompt sudo-executable],
                 run_context: %w[concurrency inventoryfile save-rerun cleanup],
                 global_config_setters: %w[modulepath boltdir configfile],
-                transports: %w[transport connect-timeout tty],
+                transports: %w[transport connect-timeout tty ssh-command copy-command],
                 display: %w[format color verbose trace],
                 global: %w[help version debug] }.freeze
 
@@ -741,6 +741,14 @@ module Bolt
       define('--transport TRANSPORT', TRANSPORTS.keys.map(&:to_s),
              "Specify a default transport: #{TRANSPORTS.keys.join(', ')}") do |t|
         @options[:transport] = t
+      end
+      define('--ssh-command EXEC', "Executable to use instead of the net-ssh ruby library. ",
+             "This option is experimental.") do |exec|
+        @options[:'ssh-command'] = exec
+      end
+      define('--copy-command EXEC', "Command to copy files to remote hosts if using external SSH. ",
+             "This option is experimental.") do |exec|
+        @options[:'copy-command'] = exec
       end
       define('--connect-timeout TIMEOUT', Integer, 'Connection timeout (defaults vary)') do |timeout|
         @options[:'connect-timeout'] = timeout

--- a/lib/bolt/node/output.rb
+++ b/lib/bolt/node/output.rb
@@ -12,7 +12,7 @@ module Bolt
       def initialize
         @stdout = StringIO.new
         @stderr = StringIO.new
-        @exit_code = 'unkown'
+        @exit_code = 'unknown'
       end
     end
   end

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -16,13 +16,16 @@ module Bolt
         rescue LoadError
           logger.debug("Authentication method 'gssapi-with-mic' (Kerberos) is not available.")
         end
-
         @transport_logger = Logging.logger[Net::SSH]
         @transport_logger.level = :warn
       end
 
       def with_connection(target)
-        conn = Connection.new(target, @transport_logger)
+        conn = if target.transport_config['ssh-command']
+                 ExecConnection.new(target)
+               else
+                 Connection.new(target, @transport_logger)
+               end
         conn.connect
         yield conn
       ensure
@@ -37,3 +40,4 @@ module Bolt
 end
 
 require 'bolt/transport/ssh/connection'
+require 'bolt/transport/ssh/exec_connection'

--- a/lib/bolt/transport/ssh/exec_connection.rb
+++ b/lib/bolt/transport/ssh/exec_connection.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+module Bolt
+  module Transport
+    class SSH < Simple
+      class ExecConnection
+        attr_reader :user, :target
+
+        def initialize(target)
+          raise Bolt::ValidationError, "Target #{target.safe_name} does not have a host" unless target.host
+
+          @target = target
+          ssh_config = Net::SSH::Config.for(target.host)
+          @user = @target.user || ssh_config[:user] || Etc.getlogin
+          @logger = Logging.logger[self]
+        end
+
+        # This is used to verify we can connect to targets with `connected?`
+        def connect
+          cmd = build_ssh_command('exit')
+          _, err, stat = Open3.capture3(*cmd)
+          unless stat.success?
+            raise Bolt::Node::ConnectError.new(
+              "Failed to connect to #{@target.safe_name}: #{err}",
+              'CONNECT_ERROR'
+            )
+          end
+        end
+
+        def disconnect; end
+
+        def shell
+          Bolt::Shell::Bash.new(@target, self)
+        end
+
+        def userhost
+          "#{@user}@#{@target.host}"
+        end
+
+        def ssh_opts
+          cmd = []
+          # BatchMode is SSH's noninteractive option: if key authentication
+          # fails it will error out instead of falling back to password prompt
+          cmd += %w[-o BatchMode=yes]
+          cmd += %W[-o Port=#{@target.port}] if @target.port
+
+          if @target.transport_config.key?('host-key-check')
+            hkc = @target.transport_config['host-key-check'] ? 'yes' : 'no'
+            cmd += %W[-o StrictHostKeyChecking=#{hkc}]
+          end
+
+          if (key = target.transport_config['private-key'])
+            cmd += ['-i', key]
+          end
+          cmd
+        end
+
+        def build_ssh_command(command)
+          ssh_conf = @target.transport_config['ssh-command']
+          ssh_cmd = Array(ssh_conf)
+          ssh_cmd += ssh_opts
+          ssh_cmd << userhost
+          ssh_cmd << command
+        end
+
+        def copy_file(source, dest)
+          @logger.debug { "Uploading #{source}, to #{userhost}:#{dest}" } unless source.is_a?(StringIO)
+
+          cp_conf = @target.transport_config['copy-command'] || ["scp", "-r"]
+          cp_cmd = Array(cp_conf)
+          cp_cmd += ssh_opts
+
+          _, err, stat = if source.is_a?(StringIO)
+                           Tempfile.create(File.basename(dest)) do |f|
+                             f.write(source.read)
+                             f.close
+                             cp_cmd << f.path
+                             cp_cmd << "#{userhost}:#{Shellwords.escape(dest)}"
+                             Open3.capture3(*cp_cmd)
+                           end
+                         else
+                           cp_cmd << source
+                           cp_cmd << "#{userhost}:#{Shellwords.escape(dest)}"
+                           Open3.capture3(*cp_cmd)
+                         end
+
+          if stat.success?
+            @logger.debug "Successfully uploaded #{source} to #{dest}"
+          else
+            message = "Could not copy file to #{dest}: #{err}"
+            raise Bolt::Node::FileError.new(message, 'COPY_ERROR')
+          end
+        end
+
+        def execute(command)
+          cmd_array = build_ssh_command(command)
+          Open3.popen3(*cmd_array)
+        end
+
+        # This is used by the Bash shell to decide whether to `cd` before
+        # executing commands as a run-as user
+        def reset_cwd?
+          true
+        end
+      end
+    end
+  end
+end

--- a/schemas/bolt-transport-definitions.json
+++ b/schemas/bolt-transport-definitions.json
@@ -49,8 +49,9 @@
     "description": "Configuration for the ssh transport.",
     "type": "object",
     "properties": {
-      "cleanup": { "$ref": "#/definitions/cleanup" },
-      "connect-timeout": { "$ref": "#/definitions/connect-timeout" },
+      "cleanup":            { "$ref": "#/definitions/cleanup" },
+      "connect-timeout":    { "$ref": "#/definitions/connect-timeout" },
+      "copy-command":       { "$ref": "#/definitions/copy-command" },
       "disconnect-timeout": { "$ref": "#/definitions/disconnect-timeout" },
       "host":               { "$ref": "#/definitions/host" },
       "host-key-check":     { "$ref": "#/definitions/host-key-check" },
@@ -65,6 +66,7 @@
       "run-as":             { "$ref": "#/definitions/run-as" },
       "run-as-command":     { "$ref": "#/definitions/run-as-command" },
       "script-dir":         { "$ref": "#/definitions/script-dir" },
+      "ssh-command":        { "$ref": "#/definitions/ssh-command" },
       "sudo-executable":    { "$ref": "#/definitions/sudo-executable" },
       "sudo-password":      { "$ref": "#/definitions/sudo-password" },
       "tmpdir":             { "$ref": "#/definitions/tmpdir" },
@@ -109,6 +111,11 @@
       "type": "integer",
       "min": 1
     },
+    "copy-command": {
+      "description": "Array of command and flags to use when copying files using ssh-command. Bolt runs `<copy-command> <src> <dest>`.",
+      "type": ["array", "string"]
+    },
+
     "disconnect-timeout": {
       "description": "How long to wait in seconds before force-closing a connection.",
       "type": "integer",
@@ -230,6 +237,10 @@
       "description": "The port to establish a connection on when using the smb file protocol.",
       "type": "integer",
       "min": 0
+    },
+    "ssh-command": {
+      "description": "Array of command and flags to use when SSHing. This enables the external SSH transport which shells out to the specified command.",
+      "type": ["array", "string"]
     },
     "ssl": {
       "description": "Whether to use a secure https connection.",

--- a/spec/Dockerfile
+++ b/spec/Dockerfile
@@ -19,7 +19,11 @@ RUN chown -R bolt:sudo /home/bolt
 # Add test user without authorized key and different login shell
 RUN useradd test && echo "test:test" | chpasswd && adduser test sudo
 RUN echo test | chsh -s /bin/bash test
-RUN mkdir -p /home/test/
+RUN mkdir -p /home/test/.ssh
+COPY fixtures/keys/id_rsa.pub /home/test/.ssh/id_rsa.pub
+COPY fixtures/keys/id_rsa.pub /home/test/.ssh/authorized_keys
+RUN chmod 700 /home/test/.ssh/
+RUN chmod 600 /home/test/.ssh/authorized_keys
 RUN chown -R test:sudo /home/test
 
 CMD ["/usr/sbin/sshd", "-D"]

--- a/spec/bolt/transport/ssh/exec_connection_spec.rb
+++ b/spec/bolt/transport/ssh/exec_connection_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'net/ssh'
+require 'bolt/inventory'
+require 'bolt/transport/ssh/exec_connection'
+require 'bolt_spec/files'
+
+describe Bolt::Transport::SSH::ExecConnection do
+  include BoltSpec::Files
+
+  let(:uri) { 'ssh://foo.example.com' }
+  let(:inventory) { Bolt::Inventory.empty }
+  let(:target) { inventory.get_target(uri) }
+  let(:subject) { described_class.new(target) }
+
+  before :each do
+    allow(Net::SSH::Config).to receive(:for).and_return(user: 'sshuser')
+    inventory.set_config(target, 'ssh', {})
+  end
+
+  context 'when copying files' do
+    it 'uses configured copy-command' do
+      inventory.set_config(target, %w[ssh copy-command], ['scp', '-o', 'Port=21'])
+
+      expect(Open3).to receive(:capture3)
+        .with("scp", "-o", "Port=21", "-o", "BatchMode=yes", "good", "sshuser@foo.example.com:afternoon")
+        .and_return(['{}', '', double(:status, success?: true)])
+      subject.copy_file('good', 'afternoon')
+    end
+
+    it 'rejects invalid copy-command' do
+      inventory.set_config(target, %w[ssh copy-command], 3)
+
+      expect { subject.copy_file('good', 'evening') }
+        .to raise_error(/copy-command must be a String or Array, received Integer 3/)
+    end
+
+    it 'builds scp command with port' do
+      inventory.set_config(target, %w[ssh port], 24)
+
+      expect(Open3).to receive(:capture3)
+        .with("scp", "-r", "-o", "BatchMode=yes", "-o", "Port=24", "good", "sshuser@foo.example.com:night")
+        .and_return(['{}', '', double(:status, success?: true)])
+      subject.copy_file('good', 'night')
+    end
+  end
+
+  context 'when executing' do
+    it 'builds ssh command' do
+      inventory.set_config(target, %w[ssh ssh-command], ['good', '-morning'])
+
+      expect(Open3).to receive(:popen3)
+        .with("good", "-morning", "-o", "BatchMode=yes", "sshuser@foo.example.com", "is it Friday?")
+      subject.execute('is it Friday?')
+    end
+
+    it 'builds ssh command with port' do
+      inventory.set_config(target, %w[ssh ssh-command], ['ssh'])
+      inventory.set_config(target, %w[ssh port], 23)
+
+      expect(Open3).to receive(:popen3)
+        .with("ssh", "-o", "BatchMode=yes", "-o", "Port=23", "sshuser@foo.example.com", "I don't know")
+      subject.execute("I don't know")
+    end
+
+    it 'builds ssh command with key' do
+      keypath = fixtures_path('keys', 'id_rsa')
+      inventory.set_config(target, %w[ssh ssh-command], ['ssh'])
+      inventory.set_config(target, %w[ssh private-key], keypath)
+
+      expect(Open3).to receive(:popen3)
+        .with("ssh", "-o", "BatchMode=yes", "-i", keypath, "sshuser@foo.example.com", "what is time?")
+      subject.execute('what is time?')
+    end
+
+    it 'fails if key is not a string' do
+      inventory.set_config(target, %w[ssh ssh-command], ['ssh'])
+      inventory.set_config(target, %w[ssh private-key], 'key-data' => 'beepboop')
+
+      expect { subject.execute('ls') }
+        .to raise_error(/private-key must be a filepath when using ssh-command/)
+    end
+
+    it 'errors with invalid ssh-command' do
+      inventory.set_config(target, %w[ssh ssh-command], 3)
+
+      expect { subject.execute('ls') }
+        .to raise_error(/ssh-command must be a String or Array, received Integer 3/)
+    end
+  end
+end


### PR DESCRIPTION
The SSH transport uses the net-ssh ruby library to establish an SSH
connection. While robust, the library is limited in it's OpenSSH
configuration and key exchange algorithm support. Users can now specify
an SSH command to run and Bolt will shell out to SSH, allowing users to
use all local OpenSSH configuration to connect.

This creates 2 new configuration options: `ssh-command` and
`copy-command`, which can be set in confg files, inventory files, or
specified on the CLI. Each option is an array which defines the command
to use when executing commands or copying files respectively.
`ssh-command` additionally enables using the 'external ssh' connection,
while `copy-command` does nothing if `ssh-command` is not set. Both
options accept either a string or array.

The external ssh connection does not support using Powershell.

The external ssh connection does not support the following configuration
options:
* connect-timeout
* disconnect-timeout
* host-key-check
* extensions
* load-config
* login-shell
* password
* proxyjump
* tty

These options should be specified in OpenSSH config.

Closes #1780

!feature

* **Allow users to shell out to SSH** ([#1780](https://github.com/puppetlabs/bolt/issues/1780))

  Users can now specify an SSH command, which Bolt will shell out to
  when using the SSH transport. This allows users to run SSH as if it were
  run locally without worrying about ruby library feature support.