### PR TITLE
(GH-1807) Make an `ApplyResult` a valid `PlanResult`

### DIFF
--- a/bolt-modules/boltlib/types/planresult.pp
+++ b/bolt-modules/boltlib/types/planresult.pp
@@ -2,4 +2,14 @@
 # should be used as the return type of functions that run plans and return the
 # results.
 
-type Boltlib::PlanResult = Variant[Boolean, Numeric, String, Undef, Error, Result, ResultSet, Target, Array[Boltlib::PlanResult], Hash[String, Boltlib::PlanResult]]
+type Boltlib::PlanResult = Variant[Boolean, 
+                                   Numeric,
+                                   String,
+                                   Undef,
+                                   Error,
+                                   Result,
+                                   ApplyResult,
+                                   ResultSet,
+                                   Target,
+                                   Array[Boltlib::PlanResult],
+                                   Hash[String, Boltlib::PlanResult]]


### PR DESCRIPTION
This commit adds `ApplyResult` to the list of valid variants allowable as a `PlanResult`.

!bug

  * **Make an `ApplyResult` a valid `PlanResult`**
    ([#1807](#1807))

  Plans may now return `ApplyResult`s outside of a `ResultSet`.

closes https://github.com/puppetlabs/bolt/issues/1807