### PR TITLE
(GH-1782) Build and ship Bolt for Ubuntu 20.04

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,7 +6,7 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '1.2.0'
-mod 'puppetlabs-puppet_agent', '3.0.2'
+mod 'puppetlabs-puppet_agent', '3.2.0'
 mod 'puppetlabs-facts', '1.0.0'
 
 # Core types and providers for Puppet 6

--- a/documentation/bolt_installing.md
+++ b/documentation/bolt_installing.md
@@ -200,6 +200,14 @@ The Puppet Tools repository for the APT package management system is [https://ap
         sudo apt-get install puppet-bolt
         ```
 
+    -   Ubuntu 20.04
+        ```shell script
+        wget https://apt.puppet.com/puppet-tools-release-focal.deb
+        sudo dpkg -i puppet-tools-release-focal.deb
+        sudo apt-get update 
+        sudo apt-get install puppet-bolt
+        ```
+
 2.  Run a Bolt command and get started.
     ```
     bolt --help


### PR DESCRIPTION
This adds documentation for installing Bolt on Ubuntu 20.04.

Closes #1782 

### TODO

- [x] Review and merge https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/491
- [x] Release `puppet_agent` module 3.2.0 and update Puppetfile
- [x] Review and merge puppetlabs/puppet-runtime#335
- [x] Review and merge puppetlabs/bolt-vanagon#136
- [x] Review and merge puppetlabs/ci-job-configs#7036
- [x] Build and ship `puppet-tools-release-focal`
  **NOTE:** The download link in the docs won't work until the puppet-tools-release-focal repo is available, which won't be published until at least one package is available for distribution.

!feature

* **Packages for Ubuntu 20.04 now available**
  ([#1782](https://github.com/puppetlabs/bolt/issues/1782))

  Bolt packages are now available for Ubuntu 20.04.