### PR TITLE
(maint) Add details to file function descriptions

### DIFF
--- a/bolt-modules/file/lib/puppet/functions/file/exists.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/exists.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-# Check if a file exists.
+# Check if a local file exists using Puppet's
+# `Puppet::Parser::Files.find_file()` function. This will only check files that
+# are on the machine Bolt is run on.
 Puppet::Functions.create_function(:'file::exists', Puppet::Functions::InternalFunction) do
   # @param filename Absolute path or Puppet file path.
   # @return Whether the file exists.

--- a/bolt-modules/file/lib/puppet/functions/file/join.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/join.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Join file paths.
+# Join file paths using ruby's `File.join()` function.
 Puppet::Functions.create_function(:'file::join') do
   # @param paths The paths to join.
   # @return The joined file path.

--- a/bolt-modules/file/lib/puppet/functions/file/read.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/read.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-# Read a file and return its contents.
+# Read a file on localhost and return its contents using ruby's `File.read`. This will
+# only read files on the machine you run Bolt on.
 Puppet::Functions.create_function(:'file::read', Puppet::Functions::InternalFunction) do
   # @param filename Absolute path or Puppet file path.
   # @return The file's contents.

--- a/bolt-modules/file/lib/puppet/functions/file/readable.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/readable.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-# Check if a file is readable.
+# Check if a local file is readable using Puppet's
+# `Puppet::Parser::Files.find_file()` function. This will only check files on the
+# machine you run Bolt on.
 Puppet::Functions.create_function(:'file::readable', Puppet::Functions::InternalFunction) do
   # @param filename Absolute path or Puppet file path.
   # @return Whether the file is readable.

--- a/bolt-modules/file/lib/puppet/functions/file/write.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/write.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-# Write a string to a file.
+# Write a string to a file on localhost using ruby's `File.write`. This will
+# only write files to the machine you run Bolt on. Use `write_file()` to write
+# to remote targets.
 Puppet::Functions.create_function(:'file::write') do
   # @param filename Absolute path.
   # @param content File content to write.


### PR DESCRIPTION
The file module includes several helpful functions for interacting with
files locally. Previously the documentation didn't clearly specify that
the functions only act on disk and cannot be run against remote targets.
The function documentation now clarifies what exactly each function is
running "under the hood", and states that the functions are limited to
localhost.