### PR TITLE
(maint) Use --no-document instead of --no-rdoc

### DIFF
--- a/acceptance/setup/common/pre-suite/010_install_ruby.rb
+++ b/acceptance/setup/common/pre-suite/010_install_ruby.rb
@@ -47,7 +47,7 @@ PS
       result = on(bolt, 'ruby --version')
     when /osx/
       # System ruby for osx is 2.3. winrm-fs and its dependencies require > 2.3.
-      on(bolt, 'gem install winrm-fs -v 1.3.3 --no-rdoc --no-ri')
+      on(bolt, 'gem install winrm-fs -v 1.3.3 --no-document')
       result = on(bolt, 'ruby --version')
     else
       fail_test("#{bolt['platform']} not currently a supported bolt controller")


### PR DESCRIPTION
`--no-rdoc` and `--no-ri` were removed in favor of `--no-document` in
ruby 2.6, which is default on OSX 15. This updates our acceptance test
suite setup script to use --no-document when installing gems on OSX. The
`--no-document` option was added in Ruby 2.0, so should work for all
Bolt platforms.