### PR TITLE
(PE-28674) No longer look for modulepath in bolt.yaml for PE plans

### DIFF
--- a/lib/bolt_server/pe/pal.rb
+++ b/lib/bolt_server/pe/pal.rb
@@ -6,98 +6,53 @@ require 'bolt/util'
 module BoltServer
   module PE
     class PAL < Bolt::PAL
+
       # PE_BOLTLIB_PATH is intended to function exactly like the BOLTLIB_PATH used
       # in Bolt::PAL. Paths and variable names are similar to what exists in
       # Bolt::PAL, but with a 'PE' prefix.
-      PE_BOLTLIB_PATH = '/opt/puppetlabs/server/apps/bolt-server/pe-bolt-modules'
+      PE_BOLTLIB_PATH = '/opt/puppetlabs/server/apps/bolt-server/pe-bolt-modules'.freeze
 
       # For now at least, we maintain an entirely separate codedir from
       # puppetserver by default, so that filesync can work properly. If filesync
       # is not used, this can instead match the usual puppetserver codedir.
       # See the `orchestrator.bolt.codedir` tk config setting.
-      DEFAULT_BOLT_CODEDIR = '/opt/puppetlabs/server/data/orchestration-services/code'
+      DEFAULT_BOLT_CODEDIR = '/opt/puppetlabs/server/data/orchestration-services/code'.freeze
 
-      # This function is nearly identical to Bolt::Pal's `with_puppet_settings` with the
-      # one difference that we set the codedir to point to actual code, rather than the
-      # tmpdir. We only use this funtion inside the PEBolt::PAL initializer so that Puppet
-      # is correctly configured to pull environment configuration correctly. If we don't
-      # set codedir in this way: when we try to load and interpolate the modulepath it
-      # won't correctly load.
-      def with_pe_pal_init_settings(codedir, environmentpath, basemodulepath)
-        Dir.mktmpdir('pe-bolt') do |dir|
-          cli = []
-          Puppet::Settings::REQUIRED_APP_SETTINGS.each do |setting|
-            dir = setting == :codedir ? codedir : dir
-            cli << "--#{setting}" << dir
-          end
-          cli << "--environmentpath" << environmentpath
-          cli << "--basemodulepath" << basemodulepath
-          Puppet.settings.send(:clear_everything_for_tests)
-          Puppet.initialize_settings(cli)
-          yield
-          # Ensure the puppet settings go back to what bolt expects after
-          # we finish with the settings we need for PEBolt::PAL init.
-          with_puppet_settings { |_| nil }
-        end
+      DATADIR = '/opt/puppetlabs/server/data/orchestration-services'.freeze
+
+      def self.loader_lock
+        @loader_lock
       end
 
-      def initialize(plan_executor_config, environment_name, hiera_config = nil, max_compiles = nil)
-        # Bolt::PAL#initialize takes the modulepath as its first argument, but we
-        # want to customize it later, so we pass an empty value:
-        super([], hiera_config, max_compiles)
-
-        codedir = plan_executor_config['codedir'] || DEFAULT_BOLT_CODEDIR
-        environmentpath = plan_executor_config['environmentpath'] || "#{codedir}/environments"
-        basemodulepath = plan_executor_config['basemodulepath'] || "#{codedir}/modules:/opt/puppetlabs/puppet/modules"
-
-        with_pe_pal_init_settings(codedir, environmentpath, basemodulepath) do
-          modulepath_dirs = []
-          modulepath_setting_from_bolt = nil
-          environment = Puppet.lookup(:environments).get!(environment_name)
-          path_to_env = environment.configuration.path_to_env
-
-          # In the instance where the environment is "production" but no production dir
-          # exists, the lookup will succeed, but the configuration will be mostly empty.
-          # For other environments the lookup will fail, but for production we don't
-          # want cryptic messages sent to the user about combining `nil` with a string.
-          # Thus if we do get here and `path_to_env` is empty, just assume it's the
-          # default production environment and continue.
-          #
-          # This should hopefully match puppet's behavior for the default 'production'
-          # environment: _technically_ that environment always exists, but if the dir
-          # isn't there it won't find the module and fail with "plan not found" rather
-          # than "environment doesn't exist"
-          if path_to_env
-            bolt_yaml = File.join(environment.configuration.path_to_env, 'bolt.yaml')
-            modulepath_setting_from_bolt = Bolt::Util.read_optional_yaml_hash(bolt_yaml, 'config')['modulepath']
-          end
-
-          # If we loaded a bolt.yaml in the environment root and it contained a modulepath setting:
-          # we will use that modulepath rather than the one loaded through puppet. modulepath will
-          # be the _only_ setting that will work from bolt.yaml in plans in PE.
-          if modulepath_setting_from_bolt
-            modulepath_setting_from_bolt.split(File::PATH_SEPARATOR).each do |path|
-              if Pathname.new(path).absolute? && File.exist?(path)
-                modulepath_dirs << path
-              elsif File.exist?(File.join(path_to_env, path))
-                modulepath_dirs << File.join(path_to_env, path)
-              end
-            end
-
-            # Append the basemodulepath to include "built-in" modules.
-            modulepath_dirs.concat(basemodulepath.split(File::PATH_SEPARATOR))
-          else
-            modulepath_dirs = environment.modulepath
-          end
-
-          # A new modulepath is created from scratch (rather than using super's @modulepath)
-          # so that we can have full control over all the entries in modulepath. In the future
-          # it's likely we will need to preceed _both_ Bolt::PAL::BOLTLIB_PATH _and_
-          # Bolt::PAL::MODULES_PATH which would be more complex if we tried to use @modulepath since
-          # we need to append our modulepaths and exclude modules shiped in bolt gem code
-          @original_modulepath = modulepath_dirs
-          @modulepath = [PE_BOLTLIB_PATH, Bolt::PAL::BOLTLIB_PATH, *modulepath_dirs]
+      def self.initialize_puppet(config)
+        cli = []
+        codedir = config['codedir'] || DEFAULT_BOLT_CODEDIR
+        environmentpath = config['environmentpath'] || "#{codedir}/environments"
+        basemodulepath = config['basemodulepath'] || "#{codedir}/modules:/opt/puppetlabs/puppet/modules"
+        Bolt::PAL.load_puppet()
+        Puppet::Settings::REQUIRED_APP_SETTINGS.each do |setting|
+          dir = setting == :codedir ? codedir : DATADIR
+          cli << "--#{setting}" << dir
         end
+        cli << "--environmentpath" << environmentpath
+        cli << "--basemodeulepath" << basemodulepath
+        Puppet.initialize_settings(cli)
+        Puppet[:tasks] = true
+        Bolt::PAL.configure_logging()
+        @loader_lock = Mutex.new()
+      end
+
+      # The only reason we need to subclass is to control the modulepath, specifically remove
+      # the path to Bolt::PAL::MODULES_PATH
+      def initialize(environment_name)
+        modulepath_dirs = []
+        modulepath_setting_from_bolt = nil
+        environment = Puppet.lookup(:environments).get!(environment_name)
+        path_to_env = environment.configuration.path_to_env
+        basemodulepath = Puppet[:basemodulepath]
+
+        modulepath_dirs = environment.modulepath
+        @modulepath = [PE_BOLTLIB_PATH, Bolt::PAL::BOLTLIB_PATH, *modulepath_dirs]
       end
     end
   end

--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -50,8 +50,7 @@ module BoltServer
 
       @file_cache = BoltServer::FileCache.new(@config).setup
 
-      # This is needed until the PAL is threadsafe.
-      @pal_mutex = Mutex.new
+      BoltServer::PE::PAL.initialize_puppet({})
 
       super(nil)
     end
@@ -193,8 +192,8 @@ module BoltServer
       if environment.nil?
         [400, '`environment` is a required argument']
       else
-        @pal_mutex.synchronize do
-          pal = BoltServer::PE::PAL.new({}, environment)
+        begin
+          pal = BoltServer::PE::PAL.new(environment)
           yield pal
         rescue Puppet::Environments::EnvironmentNotFound
           [400, {


### PR DESCRIPTION
Attempting to use a modulepath from `bolt.yaml` in PE plans has exposed some issues that we are not ready to tackle yet. For example there is no interpolation for `$basemodulepath`. This commit prevents bolt-server from attempting to load a modulepath from bolt.yaml in an environment. This commit also updates `BoltServer::PE::PAL` to take advantage of the work done in the PAL we use in orchestrator to leverage threadsafe Puppet features.