### PR TITLE
(PE-28674) No longer look for modulepath in bolt.yaml for PE plans

### DIFF
--- a/lib/bolt_server/pe/pal.rb
+++ b/lib/bolt_server/pe/pal.rb
@@ -51,50 +51,13 @@ module BoltServer
         basemodulepath = plan_executor_config['basemodulepath'] || "#{codedir}/modules:/opt/puppetlabs/puppet/modules"
 
         with_pe_pal_init_settings(codedir, environmentpath, basemodulepath) do
-          modulepath_dirs = []
-          modulepath_setting_from_bolt = nil
           environment = Puppet.lookup(:environments).get!(environment_name)
-          path_to_env = environment.configuration.path_to_env
-
-          # In the instance where the environment is "production" but no production dir
-          # exists, the lookup will succeed, but the configuration will be mostly empty.
-          # For other environments the lookup will fail, but for production we don't
-          # want cryptic messages sent to the user about combining `nil` with a string.
-          # Thus if we do get here and `path_to_env` is empty, just assume it's the
-          # default production environment and continue.
-          #
-          # This should hopefully match puppet's behavior for the default 'production'
-          # environment: _technically_ that environment always exists, but if the dir
-          # isn't there it won't find the module and fail with "plan not found" rather
-          # than "environment doesn't exist"
-          if path_to_env
-            bolt_yaml = File.join(environment.configuration.path_to_env, 'bolt.yaml')
-            modulepath_setting_from_bolt = Bolt::Util.read_optional_yaml_hash(bolt_yaml, 'config')['modulepath']
-          end
-
-          # If we loaded a bolt.yaml in the environment root and it contained a modulepath setting:
-          # we will use that modulepath rather than the one loaded through puppet. modulepath will
-          # be the _only_ setting that will work from bolt.yaml in plans in PE.
-          if modulepath_setting_from_bolt
-            modulepath_setting_from_bolt.split(File::PATH_SEPARATOR).each do |path|
-              if Pathname.new(path).absolute? && File.exist?(path)
-                modulepath_dirs << path
-              elsif File.exist?(File.join(path_to_env, path))
-                modulepath_dirs << File.join(path_to_env, path)
-              end
-            end
-
-            # Append the basemodulepath to include "built-in" modules.
-            modulepath_dirs.concat(basemodulepath.split(File::PATH_SEPARATOR))
-          else
-            modulepath_dirs = environment.modulepath
-          end
-
           # A new modulepath is created from scratch (rather than using super's @modulepath)
           # so that we can have full control over all the entries in modulepath. In the future
           # it's likely we will need to preceed _both_ Bolt::PAL::BOLTLIB_PATH _and_
           # Bolt::PAL::MODULES_PATH which would be more complex if we tried to use @modulepath since
           # we need to append our modulepaths and exclude modules shiped in bolt gem code
+          modulepath_dirs = environment.modulepath
           @original_modulepath = modulepath_dirs
           @modulepath = [PE_BOLTLIB_PATH, Bolt::PAL::BOLTLIB_PATH, *modulepath_dirs]
         end


### PR DESCRIPTION
Attempting to use a modulepath from bolt.yaml in PE plans has exposed some issues that we are not ready to tackle yet. For example there is no interpolation for $basemodulepath. This commit prevents bolt-server from attempting to load a modulepath from bolt.yaml in an environment. Note this commit does not attempt to change BoltServer::PE::PAL to take advantage of the work done in the PAL we use in orchestrator to leverage threadsafe Puppet features.