### PR TITLE
(GH-1792) Ignore local project.yaml and expand ssh key fixture path

### DIFF
--- a/spec/integration/transport/winrm_spec.rb
+++ b/spec/integration/transport/winrm_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'bolt_spec/config'
 require 'bolt_spec/conn'
 require 'bolt_spec/errors'
 require 'bolt_spec/files'
@@ -12,6 +13,7 @@ require 'bolt/inventory'
 require 'winrm'
 
 describe Bolt::Transport::WinRM do
+  include BoltSpec::Config
   include BoltSpec::Conn
   include BoltSpec::Errors
   include BoltSpec::Files
@@ -27,7 +29,7 @@ describe Bolt::Transport::WinRM do
   let(:password)    { conn_info('winrm')[:password] }
   let(:command)     { "[Environment]::UserName" }
   let(:config)      { mk_config(ssl: false, user: user, password: password) }
-  let(:cacert_path) { 'spec/fixtures/ssl/ca.pem' }
+  let(:cacert_path) { fixture_path('ssl', 'ca.pem') }
   let(:ssl_config)  { mk_config(cacert: cacert_path, user: user, password: password) }
   let(:winrm)       { Bolt::Transport::WinRM.new }
   let(:winrm_ssl)   { Bolt::Transport::WinRM.new }

--- a/spec/lib/bolt_spec/conn.rb
+++ b/spec/lib/bolt_spec/conn.rb
@@ -11,7 +11,7 @@ module BoltSpec
       default_password = 'bolt'
       default_second_user = 'test'
       default_second_pw = 'test'
-      default_key = Dir["spec/fixtures/keys/id_rsa"][0]
+      default_key = File.expand_path(File.join(__dir__, '..', '..', 'fixtures/keys/id_rsa'))
       default_port = 0
 
       tu = transport.upcase

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,6 +53,9 @@ RSpec.configure do |config|
   config.before :each do
     # Disable analytics while running tests
     ENV['BOLT_DISABLE_ANALYTICS'] = 'true'
+    allow(Bolt::Project).to receive(:new).and_call_original
+    allow(Bolt::Project).to receive(:new).with('.')
+      .and_return(Bolt::Project.new(Dir.mktmpdir))
   end
 
   # This will be default in future rspec, leave it on

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@
 require 'bolt'
 require 'bolt/logger'
 require 'logging'
+require 'net/ssh'
 require 'rspec/logging_helper'
 # Make sure puppet is required for the 'reset puppet settings' context
 require 'puppet_pal'
@@ -53,9 +54,15 @@ RSpec.configure do |config|
   config.before :each do
     # Disable analytics while running tests
     ENV['BOLT_DISABLE_ANALYTICS'] = 'true'
+
+    # Ignore local project.yaml files
     allow(Bolt::Project).to receive(:new).and_call_original
     allow(Bolt::Project).to receive(:new).with('.')
-      .and_return(Bolt::Project.new(Dir.mktmpdir))
+                                         .and_return(Bolt::Project.new(Dir.mktmpdir))
+
+    # Ignore user's known hosts and ssh config files
+    conf = { user_known_hosts_file: '/dev/null/', global_known_hosts_file: '/dev/null' }
+    allow(Net::SSH::Config).to receive(:for).and_return(conf)
   end
 
   # This will be default in future rspec, leave it on


### PR DESCRIPTION
Bolt still read some local files while running spec tests, which would cause several tests to fail locally but pass in CI. This makes two changes to fix failing tests:
* Don't load local `project.yaml` file. This is accomplished by adding a stub in `spec_helper.rb` that will return an empty project when Bolt tries to load a project from the local path. This is a different pattern from the one we use for ignoring bolt.yaml, which is stubbed in `BoltSpec::Integration` helper. This works because the config object is typically stubbed in unit tests, and integration tests use the helper. Plus, the config object is initialized with its data, making it easy to pass in empty data. Passing data to initialize the project object is possible, but it's instantiated in multiple places in Bolt and would be cumbersome to load YAML before each time. All of this makes not loading the project file in both unit tests and integration tests necessary and makes spec_helper.rb the best place to stub it.
* Expand key fixture path. Previously, integration tests were failing to get the correct path for the key fixture from the `BoltSpec::Conn` helper. This expands the path in the helper now, so it's absolute and can be loaded from any spec tests.

Closes #1792 

!no-release-note