### PR TITLE
(GH-1790) Wrap Sensitive plan parameters as Sensitive wrapper type

### DIFF
--- a/bolt-modules/boltlib/spec/fixtures/modules/sensitive/plans/complex.pp
+++ b/bolt-modules/boltlib/spec/fixtures/modules/sensitive/plans/complex.pp
@@ -1,0 +1,4 @@
+plan sensitive::complex (
+  Variant[Sensitive[String], Array[String]] $complex
+) {
+}

--- a/bolt-modules/boltlib/spec/fixtures/modules/sensitive/plans/init.pp
+++ b/bolt-modules/boltlib/spec/fixtures/modules/sensitive/plans/init.pp
@@ -1,0 +1,13 @@
+plan sensitive (
+  Sensitive $array,
+  Sensitive $hash,
+  Sensitive $string
+) {
+  $result = {
+    'array'  => $array.unwrap,
+    'hash'   => $hash.unwrap,
+    'string' => $string.unwrap
+  }
+
+  return $result
+}

--- a/bolt-modules/boltlib/spec/fixtures/modules/sensitive/plans/no_api.pp
+++ b/bolt-modules/boltlib/spec/fixtures/modules/sensitive/plans/no_api.pp
@@ -1,0 +1,4 @@
+plan sensitive::no_api (
+  Sensitive[String] $string
+) {
+}

--- a/bolt-modules/boltlib/spec/functions/run_task_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_spec.rb
@@ -9,8 +9,6 @@ require 'bolt/target'
 require 'puppet/pops/types/p_sensitive_type'
 require 'rspec/expectations'
 
-Sensitive = Puppet::Pops::Types::PSensitiveType::Sensitive
-
 class TaskTypeMatcher < Mocha::ParameterMatchers::Equals
   def initialize(executable, input_method)
     super(nil)
@@ -287,6 +285,7 @@ describe 'run_task' do
     end
 
     context 'with sensitive data parameters' do
+      let(:sensitive) { Puppet::Pops::Types::PSensitiveType::Sensitive }
       let(:sensitive_string) { '$up3r$ecr3t!' }
       let(:sensitive_array) { [1, 2, 3] }
       let(:sensitive_hash) { { 'k' => 'v' } }
@@ -304,16 +303,16 @@ describe 'run_task' do
         }
 
         expected_params = {
-          'sensitive_string' => Sensitive.new(sensitive_string),
-          'sensitive_array' => Sensitive.new(sensitive_array),
-          'sensitive_hash' => Sensitive.new(sensitive_hash)
+          'sensitive_string' => sensitive.new(sensitive_string),
+          'sensitive_array' => sensitive.new(sensitive_array),
+          'sensitive_hash' => sensitive.new(sensitive_hash)
         }
 
-        Sensitive.expects(:new).with(input_params['sensitive_string'])
+        sensitive.expects(:new).with(input_params['sensitive_string'])
                  .returns(expected_params['sensitive_string'])
-        Sensitive.expects(:new).with(input_params['sensitive_array'])
+        sensitive.expects(:new).with(input_params['sensitive_array'])
                  .returns(expected_params['sensitive_array'])
-        Sensitive.expects(:new).with(input_params['sensitive_hash'])
+        sensitive.expects(:new).with(input_params['sensitive_hash'])
                  .returns(expected_params['sensitive_hash'])
 
         executor.expects(:run_task).with([target], mock_task(executable, nil), expected_params, {})

--- a/bolt-modules/boltlib/spec/functions/run_task_with_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_with_spec.rb
@@ -7,8 +7,6 @@ require 'bolt/result'
 require 'bolt/result_set'
 require 'puppet/pops/types/p_sensitive_type'
 
-Sensitive = Puppet::Pops::Types::PSensitiveType::Sensitive
-
 class TaskTypeMatcher < Mocha::ParameterMatchers::Equals
   def initialize(executable, input_method)
     super(nil)
@@ -313,6 +311,7 @@ describe 'run_task_with' do
     end
 
     context 'with sensitive data parameters' do
+      let(:sensitive) { Puppet::Pops::Types::PSensitiveType::Sensitive }
       let(:sensitive_string) { '$up3r$ecr3t!' }
       let(:sensitive_array)  { [1, 2, 3] }
       let(:sensitive_hash)   { { 'k' => 'v' } }
@@ -331,18 +330,18 @@ describe 'run_task_with' do
         }
 
         expected_params = {
-          'sensitive_string' => Sensitive.new(sensitive_string),
-          'sensitive_array'  => Sensitive.new(sensitive_array),
-          'sensitive_hash'   => Sensitive.new(sensitive_hash)
+          'sensitive_string' => sensitive.new(sensitive_string),
+          'sensitive_array'  => sensitive.new(sensitive_array),
+          'sensitive_hash'   => sensitive.new(sensitive_hash)
         }
 
         target_mapping = { target => expected_params }
 
-        Sensitive.expects(:new).with(input_params['sensitive_string'])
+        sensitive.expects(:new).with(input_params['sensitive_string'])
                  .returns(expected_params['sensitive_string'])
-        Sensitive.expects(:new).with(input_params['sensitive_array'])
+        sensitive.expects(:new).with(input_params['sensitive_array'])
                  .returns(expected_params['sensitive_array'])
-        Sensitive.expects(:new).with(input_params['sensitive_hash'])
+        sensitive.expects(:new).with(input_params['sensitive_hash'])
                  .returns(expected_params['sensitive_hash'])
 
         executor.expects(:run_task_with).with(target_mapping, mock_task(executable, nil), {}).returns(result_set)

--- a/documentation/writing_plans.md
+++ b/documentation/writing_plans.md
@@ -126,6 +126,28 @@ Similarly, parameters are made available to the task as environment variables wh
 
 - [Task metadata types](writing_tasks.md#)
 
+### Sensitive parameters
+
+Use the `Sensitive` data type to mask parameters that should not be displayed in logs can be masked using the 
+`Sensitive` data type.
+
+When you pass a value to a `Sensitive` parameter, Bolt automatically masks the value before the plan is run.
+
+To access the unmasked value, call the `unwrap` function on the parameter.
+
+```
+plan sensitive_task(
+  Sensitive $password
+) {
+  $result = run_task('task_with_password', ..., 'password' => $password.unwrap)
+  return($result)
+}
+```
+
+Sensitive parameters are only masked if they use the un-parameterized or parameterized `Sensitive` type, such as
+`Sensitive` or `Sensitive[Hash]`. Other types, such as `Optional[Sensitive]` or `Hash[String, Sensitive]`, will
+not be automatically masked.
+
 ## Returning results from plans
 
 Use plans to return results that you can use in other plans or save for use outside of Bolt.

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -359,6 +359,7 @@ module Bolt
           name = param.name
           if signature_params.include?(name)
             params[name] = { 'type' => param.types.first }
+            params[name]['sensitive'] = param.types.first =~ /\ASensitive(\[.*\])?\z/ ? true : false
             params[name]['default_value'] = defaults[name] if defaults.key?(name)
             params[name]['description'] = param.text unless param.text.empty?
           else
@@ -390,6 +391,7 @@ module Bolt
                        param.type_expr
                      end
           params[name] = { 'type' => type_str }
+          params[name]['sensitive'] = param.type_expr.instance_of?(Puppet::Pops::Types::PSensitiveType)
           params[name]['default_value'] = param.value
           params[name]['description'] = param.description if param.description
         end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1239,16 +1239,19 @@ describe "Bolt::CLI" do
             "parameters" => {
               "param_mandatory" => {
                 "type" => "String",
-                "description" => "A mandatory parameter"
+                "description" => "A mandatory parameter",
+                "sensitive" => false
               },
               "param_optional" => {
                 "type" => "Optional[String]",
-                "description" => "An optional parameter"
+                "description" => "An optional parameter",
+                "sensitive" => false
               },
               "param_with_default_value" => {
                 "type" => "String",
                 "description" => "A parameter with a default value",
-                "default_value" => "'foo'"
+                "default_value" => "'foo'",
+                "sensitive" => false
               }
             }
           )
@@ -1270,7 +1273,8 @@ describe "Bolt::CLI" do
             "parameters" => {
               "oops" => {
                 "type" => "String",
-                "default_value" => "typo"
+                "default_value" => "typo",
+                "sensitive" => false
               }
             }
           )
@@ -1294,15 +1298,18 @@ describe "Bolt::CLI" do
             "parameters" => {
               "nodes" => {
                 "type" => "TargetSpec",
-                "default_value" => nil
+                "default_value" => nil,
+                "sensitive" => false
               },
               "param_optional" => {
                 "type" => "Optional[String]",
-                "default_value" => 'undef'
+                "default_value" => 'undef',
+                "sensitive" => false
               },
               "param_with_default_value" => {
                 "type" => "String",
-                "default_value" => 'hello'
+                "default_value" => 'hello',
+                "sensitive" => false
               }
             }
           )

--- a/spec/integration/parsing_spec.rb
+++ b/spec/integration/parsing_spec.rb
@@ -39,11 +39,11 @@ describe "CLI parses input" do
       "description" => nil,
       "module_dir" => File.absolute_path(File.join(__dir__, '..', 'fixtures', 'modules', 'parsing')),
       "parameters" => {
-        "string" => { "type" => "String" },
-        "string_bool" => { "type" => "Variant[String, Boolean]" },
-        "nodes" => { "type" => "TargetSpec" },
-        "array" => { "type" => "Optional[Array]", "default_value" => 'undef' },
-        "hash" => { "type" => "Optional[Hash]", "default_value" => 'undef' }
+        "string" => { "type" => "String", "sensitive" => false },
+        "string_bool" => { "type" => "Variant[String, Boolean]", "sensitive" => false },
+        "nodes" => { "type" => "TargetSpec", "sensitive" => false },
+        "array" => { "type" => "Optional[Array]", "default_value" => 'undef', "sensitive" => false },
+        "hash" => { "type" => "Optional[Hash]", "default_value" => 'undef', "sensitive" => false }
       }
     )
   end


### PR DESCRIPTION
This updates the `run_plan` function to wrap parameters marked as
`Sensitive` in the Sensitive wrapper type. Previously, indicating a plan
parameter as `Sensitive` would cause a plan to fail, as the parameter is
passed as a `String` type.

Plan authors could get around this limitation
by accepting `String` parameters and then wrapping them as `Sensitive`,
but GUIs that expose plan parameters would still display these
parameters as strings. Now, Bolt will check the type expression for each
parameter on plan startup and wrap any parameters marked as `Sensitive`
as such.

Only parameters with a parameterized or non-parameterized `Sensitive`
type are automatically wrapped. Additionally, these parameters will only
be automatically wrapped for plans run via an API call, as plans run
from another plan can already receive `Sensitive` parameters.

!feature

* **Use `Sensitive` plan parameters with `bolt plan run`**
  ([#1790](#1790))

  Plans now support parameters with the `Sensitive` wrapper type when
  run with the `bolt plan run` command. Parameters marked as `Sensitive`
  will be automatically wrapped with the `Sensitive` wrapper type upon
  plan startup.