### PR TITLE
(maint) Configure new default Rubocop cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,6 +60,9 @@ Layout/ClosingHeredocIndentation:
 Layout/LineLength:
   Max: 120
 
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
 Style/GuardClause:
   Enabled: false
 
@@ -70,6 +73,9 @@ Style/DoubleNegation:
   Enabled: false
 
 Style/SafeNavigation:
+  Enabled: false
+
+Style/SlicingWithRange:
   Enabled: false
 
 # Disable nearly all Metrics checks. These seem better off left to judgement.

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -594,6 +594,7 @@ module Bolt
     HELP
 
     attr_reader :warnings
+
     def initialize(options)
       super()
 

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -15,6 +15,7 @@ module Bolt
 
     class ValidationError < Bolt::Error
       attr_accessor :path
+
       def initialize(message, offending_group)
         super(message, 'bolt.inventory/validation-error')
         @_message = message

--- a/lib/bolt/inventory/inventory.rb
+++ b/lib/bolt/inventory/inventory.rb
@@ -7,6 +7,7 @@ module Bolt
   class Inventory
     class Inventory
       attr_reader :targets, :plugins, :config, :transport
+
       class WildcardError < Bolt::Error
         def initialize(target)
           super("Found 0 targets matching wildcard pattern #{target}", 'bolt.inventory/wildcard-error')

--- a/lib/bolt/pal/yaml_plan.rb
+++ b/lib/bolt/pal/yaml_plan.rb
@@ -99,6 +99,7 @@ module Bolt
       # logic.
       class EvaluableString
         attr_reader :value
+
         def initialize(value)
           @value = value
         end

--- a/lib/bolt_spec/plans/mock_executor.rb
+++ b/lib/bolt_spec/plans/mock_executor.rb
@@ -230,6 +230,7 @@ module BoltSpec
       def transport(_protocol)
         Class.new do
           attr_reader :provided_features
+
           def initialize(features)
             @provided_features = features
           end

--- a/spec/integration/plugin/task_spec.rb
+++ b/spec/integration/plugin/task_spec.rb
@@ -40,6 +40,7 @@ describe 'using the task plugin' do
   end
 
   attr_reader :project
+
   around(:each) do |example|
     with_project(inventory: inventory, config: config, plan: plan) do |project|
       @project = project


### PR DESCRIPTION
This adds a couple new cops that are now enabled by default in Rubocop
to the Rubocop config file.

!no-release-note