### PR TITLE
(GH-1789) Rescue EMFILE error with helpful message

### DIFF
--- a/documentation/bolt_known_issues.md
+++ b/documentation/bolt_known_issues.md
@@ -28,7 +28,10 @@ As a workaround, you can generate new keys with the ssh-keygen `-m PEM` flag. Fo
 
 ## Commands fail in remote Windows sessions
 
-Interactive tools fail when run in a remote PowerShell session. For example, using `--password` to prompt for a password when running Bolt triggers an error. As a workaround, consider putting the password in `bolt.yaml` or an inventory file, or passing the password on the command line. ([BOLT-1075](https://tickets.puppetlabs.com/browse/BOLT-1075))
+Interactive tools fail when run in a remote PowerShell session. For example, using
+`--password-prompt` to prompt for a password when running Bolt triggers an error. As a workaround,
+consider putting the password in `bolt.yaml` or an inventory file, or passing the password on the
+command line. ([BOLT-1075](https://tickets.puppetlabs.com/browse/BOLT-1075))
 
 ## Unable to authenticate with ed25519 keys over SSH transport on Windows
 
@@ -44,3 +47,23 @@ unsupported key type `ssh-ed25519'
 ## Limited Kerberos support
 
 Support for Kerberos over WinRM from a Linux host is currently experimental and requires the [MIT Kerberos library](https://web.mit.edu/Kerberos/www/krb5-latest/doc/admin/install_clients.html) to be installed. In the future, Bolt will support Kerberos when running on Windows ([BOLT-1323](https://tickets.puppet.com/browse/BOLT-1323)) and macOS ([BOLT-1471](https://tickets.puppet.com/browse/BOLT-1471)).
+
+## Errno::EMFILE Too many open files
+
+This error is raised when there are too many files open in Bolt's Ruby process. To see what
+your current limit is, run:
+
+```
+ulimit -n
+```
+
+To raise the limit, set the following in your shell configuration file (For example,
+`~/.bash_profile`):
+
+```
+ulimit -n 1024
+```
+
+You can also set Bolt's concurrency lower to have fewer file descriptors opened at once. The default
+is 100, and you can use `--concurrency` on the CLI, or set `concurrency: <CONCURRENCY>` in [Bolt
+config](configuring_bolt.md)

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -689,7 +689,7 @@ module Bolt
 
       separator "\nRUN CONTEXT OPTIONS"
       define('-c', '--concurrency CONCURRENCY', Integer,
-             'Maximum number of simultaneous connections (default: 100)') do |concurrency|
+             'Maximum number of simultaneous connections') do |concurrency|
         @options[:concurrency] = concurrency
       end
       define('--compile-concurrency CONCURRENCY', Integer,

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -67,6 +67,7 @@ module Bolt
     DEFAULT_OPTIONS = {
       "color" => true,
       "compile-concurrency" => "Number of cores",
+      "concurrency" => "100 or one-third of the ulimit, whichever is lower",
       "format" => "human",
       "hiera-config" => "Boltdir/hiera.yaml",
       "inventoryfile" => "Boltdir/inventory.yaml",

--- a/lib/bolt/shell/bash.rb
+++ b/lib/bolt/shell/bash.rb
@@ -353,9 +353,9 @@ module Bolt
         # Chunks of this size will be read in one iteration
         index = 0
         timeout = 0.1
+        result_output = Bolt::Node::Output.new
 
         inp, out, err, t = conn.execute(command_str)
-        result_output = Bolt::Node::Output.new
         read_streams = { out => String.new,
                          err => String.new }
         write_stream = in_buffer.empty? ? [] : [inp]

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -207,6 +207,10 @@ module Bolt
             err_wr.close
           end
           [in_wr, out_rd, err_rd, th]
+        rescue Errno::EMFILE => e
+          msg = "#{e.message}. This may be resolved by increasing your user limit "\
+            "with 'ulimit -n 1024'. See https://puppet.com/docs/bolt/latest/bolt_known_issues.html for details."
+          raise Bolt::Error.new(msg, 'bolt/too-many-files')
         end
 
         def copy_file(source, destination)

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -120,6 +120,10 @@ module Bolt
           end
 
           [inp, out_rd, err_rd, th]
+        rescue Errno::EMFILE => e
+          msg = "#{e.message}. This may be resolved by increasing your user limit "\
+            "with 'ulimit -n 1024'. See https://puppet.com/docs/bolt/latest/bolt_known_issues.html for details."
+          raise Bolt::Error.new(msg, 'bolt/too-many-files')
         rescue StandardError
           @logger.debug { "Command aborted" }
           raise

--- a/spec/bolt/config/transport/local_spec.rb
+++ b/spec/bolt/config/transport/local_spec.rb
@@ -30,7 +30,7 @@ describe Bolt::Config::Transport::Local do
     end
   end
 
-  context 'on *nix' do
+  context 'on *nix', :ssh do
     before(:each) do
       allow(Bolt::Util).to receive(:windows?).and_return(false)
     end

--- a/spec/integration/transport/ssh_spec.rb
+++ b/spec/integration/transport/ssh_spec.rb
@@ -121,6 +121,27 @@ describe Bolt::Transport::SSH, ssh: true do
     end
   end
 
+  context "when execution fails" do
+    let(:transport_config) do
+      {
+        'host-key-check' => false,
+        'private-key'    => key,
+        'user'           => user,
+        'port'           => port
+      }
+    end
+
+    it "catches EMFILE error and raises helpful message" do
+      allow(Thread).to receive(:new)
+        .and_raise(Errno::EMFILE)
+
+      expect_node_error(
+        Bolt::Error, nil,
+        /Too many open files. This may be resolved by increasing your user limit with 'ulimit -n 1024'/
+      ) { ssh.run_command(target, 'ls') }
+    end
+  end
+
   context "when executing with private key" do
     let(:transport_config) do
       {

--- a/spec/integration/transport/winrm_spec.rb
+++ b/spec/integration/transport/winrm_spec.rb
@@ -157,6 +157,22 @@ describe Bolt::Transport::WinRM do
     end
   end
 
+  context "when execution fails", winrm: true do
+    let(:target) { make_target(port_: ssl_port, conf: ssl_config) }
+
+    it "catches EMFILE error and raises helpful message" do
+      allow(Thread).to receive(:new)
+        .and_raise(Errno::EMFILE)
+
+      expect_node_error(
+        Bolt::Error, nil,
+        /Too many open files. This may be resolved by increasing your user limit with 'ulimit -n 1024'/
+      ) do
+        winrm.run_command(target, 'ls')
+      end
+    end
+  end
+
   context "connecting over SSL", winrm: true do
     # In order to run vagrant and docker targets simultaniously for local dev, use 4598{5,6} to avoid port conflict
     let(:target) { make_target(port_: ssl_port, conf: ssl_config) }


### PR DESCRIPTION
Since splitting the shell implementation from the transport connecting
to the shell, we now open a new thread with input, output, and error
streams for every connection. With concurrency defaulting to 100 this
often means 300+ file descriptors are open in Bolt's ruby process when
running against many targets, which exceeds the common FD limit of 256.
We now set concurrency to 1/3 the file descriptor limit if the limit is
below 300, otherwise it's set to 100. We also warn the user that
concurrency is set low, and provide instructions on how to increase the
ulimit or concurrency. We also raise a helpful error message when the
EMFILE error is thrown instructing the user on how to increase their FD
limit. Lastly this adds a section in the known issues documentation about
the error, also with instructions on increasing the FD limit and on
dialing back concurrency.

Closes #1789

!feature

* **Lower default concurrency when ulimit is low** ([1789](#1789))

  Concurrency defaults to 1/3 the ulimit if ulimit is below 300, and
  warns if lowered concurrency is used.