### PR TITLE
(BOLT-1549) Add puppet data types to plugin tarbal

### DIFF
--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -34,6 +34,8 @@ module Bolt
           search_dirs << mod.plugins if mod.plugins?
           search_dirs << mod.pluginfacts if mod.pluginfacts?
           search_dirs << mod.files if mod.files?
+          type_files = "#{mod.path}/types"
+          search_dirs << type_files if File.exist?(type_files)
           search_dirs
         end
       end


### PR DESCRIPTION
Right now the plugin tarbal doesn't contain the puppet data types defined in the module directory `types` with extension `.pp`. As a result of that puppet code that requires these puppet data types not only for catalog compilation but also for run-time type checking, cannot run in a bolt apply block. 

This is related to  https://tickets.puppetlabs.com/browse/PUP-7197. 
 