### PR TITLE
(BOLT-1550) Fix couldn't find login name error

### DIFF
--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'pathname'
+require 'etc'
 require 'bolt/pal'
 
 module Bolt
@@ -15,8 +16,16 @@ module Bolt
     attr_reader :path, :config_file, :inventory_file, :modulepath, :hiera_config,
                 :puppetfile, :rerunfile, :type, :resource_types
 
+    def self.home_dir
+      if Gem.win_platform?
+        Dir.home
+      else
+        Etc.getpwuid(Process.uid).dir
+      end
+    end
+
     def self.default_project
-      Project.new(File.join('~', '.puppetlabs', 'bolt'), 'user')
+      Project.new(File.join(home_dir, '.puppetlabs', 'bolt'), 'user')
     end
 
     # Search recursively up the directory hierarchy for the Project. Look for a


### PR DESCRIPTION
* **Fix couldn't find login name when running non-interactive** ([BOLT-1550](https://tickets.puppetlabs.com/browse/BOLT-1550))

When running bolt in a non-interactive process, Bolt has issue’s finding the home directory of the current process. This fix, makes sure the home directory is found regardless of mode the process is running in.

!lbug