### PR TITLE
(maint) Make external SSH column content valid

### DIFF
--- a/documentation/bolt_configuration_reference.md.erb
+++ b/documentation/bolt_configuration_reference.md.erb
@@ -125,7 +125,7 @@ Transport configuration options can be set in both the configuration file and in
 | Option | Description | External SSH | Type | Default |
 | ------ | ----------- | :----------: | ---- | ------- |
 <% options.each do |option, data| -%>
-  | `<%= option %>` | <%= data[:desc] %> | <%= data[:external] == true ? '&#10004;' : '' %> | <%= data[:type] == TrueClass ? 'Boolean' : data[:type] %> | <%= @transports[:defaults][transport][option].to_s || "" %> |
+  | `<%= option %>` | <%= data[:desc] %> | <%= data[:external] == true ? 'Yes' : '' %> | <%= data[:type] == TrueClass ? 'Boolean' : data[:type] %> | <%= @transports[:defaults][transport][option].to_s || "" %> |
 <% end %>
 <% else %>
 | Option | Description | Type | Default |


### PR DESCRIPTION
This updates the external SSH column in the bolt configuration reference
page to have 'yes' in stead of a check mark in the column for options
that are supported by the external ssh transport