### PR TITLE
(maint) Fix formatting for missing keys in apply report

### DIFF
--- a/lib/bolt/apply_result.rb
+++ b/lib/bolt/apply_result.rb
@@ -57,7 +57,7 @@ module Bolt
           msg = "Report result contains an '_output' key. Catalog application may have printed extraneous output to stdout: #{result['_output']}"
           # rubocop:enable Layout/LineLength
         else
-          msg = "Report did not contain all expected keys missing: #{missing_keys.join(' ,')}"
+          msg = "Report did not contain all expected keys missing: #{missing_keys.join(', ')}"
         end
 
         { 'msg' => msg,


### PR DESCRIPTION
This commit updates the missing keys error for an ApplyResult to format the list of missing keys with the correct separator.

!no-release-note