### PR TITLE
(GH-1785) Warn when applying a manifest that only contains definitions

### DIFF
--- a/documentation/bolt.ditamap
+++ b/documentation/bolt.ditamap
@@ -39,7 +39,6 @@
             <topicmeta>
                 <shortdesc>Plans allow you to run more than one task with a single command, compute values for the input to a task, process the results of tasks, or make decisions based on the result of running a task.</shortdesc>
             </topicmeta>
-            <topicref href="applying_manifest_blocks.md" format="markdown"/>
         </topicref>       
     </topicref>    
     <topicref href="tasks.md" format="markdown">
@@ -58,7 +57,8 @@
             </topicmeta>
         </topicref>
     </topicref>
-    
+    <topicref href="applying_manifest_blocks.md" format="markdown"/>
+
     <topichead navtitle="Modules">
         <topicref href="bolt_installing_modules.md" format="markdown" />
         <topicref href="module_structure.md" format="markdown" />

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -20,7 +20,7 @@ module Bolt
     def get_help_text(subcommand, action = nil)
       case subcommand
       when 'apply'
-        { flags: ACTION_OPTS + %w[noop execute compile-concurrency],
+        { flags: ACTION_OPTS + %w[noop execute compile-concurrency hiera-config],
           banner: APPLY_HELP }
       when 'command'
         case action
@@ -172,13 +172,14 @@ module Bolt
           apply
 
       USAGE
-          bolt apply <manifest.pp> [options]
+          bolt apply [manifest.pp] [options]
 
       DESCRIPTION
           Apply Puppet manifest code on the specified targets.
 
       EXAMPLES
-          bolt apply manifest.pp --targets target1,target2
+          bolt apply manifest.pp -t target
+          bolt apply -e "file { '/etc/puppetlabs': ensure => present }" -t target
     HELP
 
     COMMAND_HELP = <<~HELP

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -537,6 +537,17 @@ module Bolt
       Puppet[:tasks] = false
       ast = pal.parse_manifest(code, filename)
 
+      if defined?(ast.body) &&
+         (ast.body.is_a?(Puppet::Pops::Model::HostClassDefinition) ||
+         ast.body.is_a?(Puppet::Pops::Model::ResourceTypeDefinition))
+        message = "Manifest only contains definitions and will result in no changes on the targets. "\
+                  "Definitions must be declared for their resources to be applied. You can read more "\
+                  "about defining and declaring classes and types in the Puppet documentation at "\
+                  "https://puppet.com/docs/puppet/latest/lang_classes.html and "\
+                  "https://puppet.com/docs/puppet/latest/lang_defined_types.html"
+        @logger.warn(message)
+      end
+
       executor = Bolt::Executor.new(config.concurrency, analytics, noop)
       executor.subscribe(outputter) if options.fetch(:format, 'human') == 'human'
       executor.subscribe(log_outputter)

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -238,7 +238,7 @@ describe "Bolt::CLI" do
             expect {
               cli.parse
             }.to raise_error(Bolt::CLIExit)
-          }.to output(/USAGE.*bolt apply <manifest.pp>/m).to_stdout
+          }.to output(/USAGE.*bolt apply \[manifest.pp\]/m).to_stdout
         end
       end
     end


### PR DESCRIPTION
This updates the `bolt apply` command to warn a user when they are
applying a manifest that only consists of definitions without declaring
anything.

This also updates the 'Applying manifest blocks' documentation to document
using the `bolt apply` command. It also reorganizes the structure of the
page to create separate sections for the `bolt apply` command and the
`apply` plan function.

Lastly, this adds support for the `--hiera-config` option to the 
`bolt apply` command.

Closes #1785

!feature

* **Warn when applying manifests that only contain definitions** (#1785)

  Applying a manifest that only contains definitions with the `bolt apply`
  command will now display a warning that no changes will be applied to
  the targets.

!feature

* **Support `--hiera-config` option when using `bolt apply`** (#1839)

  The `--hiera-config` option can now be used with the `bolt apply`
  command to specify the path to a Hiera configuration file.