### PR TITLE
(maint) Bump python-task-helper to 0.4.3

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -24,7 +24,7 @@ mod 'puppetlabs-zone_core', '1.0.3'
 # Useful additional modules
 mod 'puppetlabs-package', '1.1.0'
 mod 'puppetlabs-puppet_conf', '0.6.0'
-mod 'puppetlabs-python_task_helper', '0.4.0'
+mod 'puppetlabs-python_task_helper', '0.4.3'
 mod 'puppetlabs-reboot', '3.0.0'
 mod 'puppetlabs-ruby_task_helper', '0.5.1'
 mod 'puppetlabs-ruby_plugin_helper', '0.1.0'


### PR DESCRIPTION
We manually released a version of python-task-helper that contained a
virtual environment in it. We had to update the version of the helper to
republish to the forge. This bumps the version to the new module that
doesn't contain a venv.