### PR TITLE
(GH-1836) Add PuppetObject interface to Bolt data types

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/datatypes/applyresult.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/applyresult.rb
@@ -17,5 +17,7 @@ Puppet::DataTypes.create_type('ApplyResult') do
 
   load_file('bolt/apply_result')
 
+  # Needed for Puppet to recognize Bolt::ApplyResult as a Puppet object when deserializing
+  Bolt::ApplyResult.include(Puppet::Pops::Types::PuppetObject)
   implementation_class Bolt::ApplyResult
 end

--- a/bolt-modules/boltlib/lib/puppet/datatypes/result.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/result.rb
@@ -19,5 +19,7 @@ Puppet::DataTypes.create_type('Result') do
 
   load_file('bolt/result')
 
+  # Needed for Puppet to recognize Bolt::Result as a Puppet object when deserializing
+  Bolt::Result.include(Puppet::Pops::Types::PuppetObject)
   implementation_class Bolt::Result
 end

--- a/bolt-modules/boltlib/lib/puppet/datatypes/resultset.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/resultset.rb
@@ -25,5 +25,7 @@ Puppet::DataTypes.create_type('ResultSet') do
 
   load_file('bolt/result_set')
 
+  # Needed for Puppet to recognize Bolt::ResultSet as a Puppet object when deserializing
+  Bolt::ResultSet.include(Puppet::Pops::Types::PuppetObject)
   implementation_class Bolt::ResultSet
 end

--- a/bolt-modules/boltlib/lib/puppet/datatypes/target.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/target.rb
@@ -8,8 +8,6 @@ Puppet::DataTypes.create_type('Target') do
     target_implementation_class = Bolt::Target
   end
 
-  require 'bolt/target'
-
   interface <<-PUPPET
     attributes => {
       uri => { type => Optional[String[1]], kind => given_or_derived },
@@ -34,5 +32,7 @@ Puppet::DataTypes.create_type('Target') do
     }
   PUPPET
 
+  # Needed for Puppet to recognize targets as Puppet objects when deserializing
+  target_implementation_class.include(Puppet::Pops::Types::PuppetObject)
   implementation_class target_implementation_class
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,12 @@ require 'ruby_smb'
 ENV['RACK_ENV'] = 'test'
 $LOAD_PATH.unshift File.join(__dir__, 'lib')
 
+# Disables internationalized strings, which shouldn't be needed for tests.
+# This gets around an issue where Puppet::Environment and GettextSetup in
+# r10k are fighting over the same text domain within the FastGettext domain.
+# https://github.com/voxpupuli/ra10ke/issues/39
+Puppet[:disable_i18n] = true
+
 RSpec.shared_context 'reset puppet settings' do
   after :each do
     # reset puppet settings so that they can be initialized again


### PR DESCRIPTION
This adds the `Puppet::Pops::Types::PuppetObject` interface to Bolt data
types and their associated classes. Previously, Bolt's data types were
missing this interface, which could lead to Puppet attempting to access
already-deserialized objects with the `[]` operator during the
deserialization process when local references are present. Since Bolt's
implementation classes do not implement the `[]` operator, and doing so
is undesirable, adding the `PuppetObject` interface is needed for
deserialization.

Closes #1836 

!bug

* **Add `PuppetObject` interface to Bolt data types**
  ([#1836](https://github.com/puppetlabs/bolt/issues/1836))

  Bolt data types would sometimes not be deserialized correctly when
  using `apply` blocks in plans. All Bolt data types now implement the
  `PuppetObject` interface so they can be deserialized correctly.