### PR TITLE
(GH-1829) Use system project directory if homedir isn't defined

### DIFF
--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -16,7 +16,18 @@ module Bolt
                 :puppetfile, :rerunfile, :type, :resource_types
 
     def self.default_project
-      Project.new(File.join('~', '.puppetlabs', 'bolt'), 'user')
+      Project.new(File.expand_path(File.join('~', '.puppetlabs', 'bolt')), 'user')
+    # If homedir isn't defined use the system config path
+    rescue ArgumentError
+      Project.new(system_path, 'system')
+    end
+
+    def self.system_path
+      if Bolt::Util.windows?
+        File.join(Dir::COMMON_APPDATA, 'PuppetLabs', 'bolt', 'etc')
+      else
+        File.join('/etc', 'puppetlabs', 'bolt')
+      end
     end
 
     # Search recursively up the directory hierarchy for the Project. Look for a

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -5,13 +5,7 @@ require 'bolt/config'
 
 describe Bolt::Config do
   let(:project) { Bolt::Project.new(File.join(Dir.tmpdir, rand(1000).to_s)) }
-  let(:system_path) {
-    if Bolt::Util.windows?
-      Pathname.new(File.join(Dir::COMMON_APPDATA, 'PuppetLabs', 'bolt', 'etc', 'bolt.yaml'))
-    else
-      Pathname.new(File.join('/etc', 'puppetlabs', 'bolt', 'bolt.yaml'))
-    end
-  }
+  let(:system_path) { Pathname.new(File.join(Bolt::Project.system_path, 'bolt.yaml')) }
   let(:user_path) { Pathname.new(File.expand_path(File.join('~', '.puppetlabs', 'etc', 'bolt', 'bolt.yaml'))) }
 
   describe "when initializing" do

--- a/spec/bolt/project_spec.rb
+++ b/spec/bolt/project_spec.rb
@@ -4,6 +4,17 @@ require 'spec_helper'
 require 'bolt/project'
 
 describe Bolt::Project do
+  it "loads from system-wide config path if homedir expansion fails" do
+    allow(File).to receive(:expand_path).and_call_original
+    allow(File)
+      .to receive(:expand_path)
+      .with(File.join('~', '.puppetlabs', 'bolt'))
+      .and_raise(ArgumentError, "couldn't find login name -- expanding `~'")
+    project = Bolt::Project.default_project
+    # we have to call expand_path to ensure C:/ instead of C:\ on Windows
+    expect(project.path.to_s).to eq(File.expand_path(Bolt::Project.system_path))
+  end
+
   describe "configuration" do
     let(:pwd) { @tmpdir }
     let(:config) { { 'tasks' => ['facts'] } }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,7 +61,7 @@ RSpec.configure do |config|
     # Disable analytics while running tests
     ENV['BOLT_DISABLE_ANALYTICS'] = 'true'
 
-    # Ignore local project.yaml files
+    # Ignore local bolt-project.yaml files
     allow(Bolt::Project).to receive(:new).and_call_original
     allow(Bolt::Project).to receive(:new).with('.')
                                          .and_return(Bolt::Project.new(Dir.mktmpdir))


### PR DESCRIPTION
Bolt is sometimes run in processes where no homedir is defined, causing
the expansion of `~` to fail. This was previously taken care of in most
places in #1676 but missed the default project directory at
`~/.puppetlabs/bolt`. Now when we try to load the path if it fails it
will fall back to the system-wide configuration path at
`/etc/puppetlabs/bolt` as the default project directory.

!bug

* **Fall back to system-wide config path if homedir expansion fails**

  We now fall back to `/etc/puppetlabs/bolt` as the default project
  directory if expanding the homedir fails.