### PR TITLE
(GH-1843) Load analytics config from user-level config directory

### DIFF
--- a/documentation/bolt_installing.md
+++ b/documentation/bolt_installing.md
@@ -366,7 +366,8 @@ Bolt collects data to help us understand how it's being used and make decisions 
 
 ### How can I opt out of Bolt data collection?
 
-To disable the collection of analytics data add the following line to `~/.puppetlabs/bolt/analytics.yaml`:
+To disable the collection of analytics data add the following line to `~/.puppetlabs/etc/bolt/analytics.yaml`:
+
 ```yaml
 disabled: true
 ```


### PR DESCRIPTION
This updates the analytics client to load its configuration from
`~/.puppetlabs/etc/bolt/analytics.yaml` by default instead of
`~/.puppetlabs/bolt/analytics.yaml`.

By default, Bolt will first look for the config file at the new
location and load it if it exists. If it does not exist, Bolt will fall
back to the old location and load it if it exists. If it does not exist
at either location, Bolt will write the config file to the new location.

If a user has a config file at both the old and new locations, it will
display a helpful warning that the old location is deprecated.

Closes #1843 

!feature

* **Analytics configuration loaded from user-level config directory** (#1843)

  Analytics configuration is now written to and loaded from
  `~/.puppetlabs/etc/bolt/analytics.yaml` by default. Bolt will fall
  back to loading analytics config from
  `~/.puppetlabs/bolt/analytics.yaml` when the file does not exist in
  the user-level config directory.