### PR TITLE
(GH-1848) Load project-level content during apply compilation

### DIFF
--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -14,7 +14,8 @@ require 'open3'
 
 module Bolt
   class Applicator
-    def initialize(inventory, executor, modulepath, plugin_dirs, pdb_client, hiera_config, max_compiles, apply_settings)
+    def initialize(inventory, executor, modulepath, plugin_dirs, project,
+                   pdb_client, hiera_config, max_compiles, apply_settings)
       # lazy-load expensive gem code
       require 'concurrent'
 
@@ -22,6 +23,7 @@ module Bolt
       @executor = executor
       @modulepath = modulepath
       @plugin_dirs = plugin_dirs
+      @project = project
       @pdb_client = pdb_client
       @hiera_config = hiera_config ? validate_hiera_config(hiera_config) : nil
       @apply_settings = apply_settings || {}
@@ -188,6 +190,7 @@ module Bolt
       scope = {
         code_ast: ast,
         modulepath: @modulepath,
+        project: @project.to_h,
         pdb_config: @pdb_client.config.to_hash,
         hiera_config: @hiera_config,
         plan_vars: plan_vars,

--- a/lib/bolt/catalog.rb
+++ b/lib/bolt/catalog.rb
@@ -58,6 +58,8 @@ module Bolt
       target = request['target']
       pdb_client = Bolt::PuppetDB::Client.new(Bolt::PuppetDB::Config.new(request['pdb_config']))
       options = request['puppet_config'] || {}
+      project = request['project'] || {}
+      bolt_project = Struct.new(:name, :path).new(project['name'], project['path']) unless project.empty?
       with_puppet_settings(request['hiera_config']) do
         Puppet[:rich_data] = true
         Puppet[:node_name_value] = target['name']
@@ -67,7 +69,8 @@ module Bolt
         Puppet::Pal.in_tmp_environment('bolt_catalog', env_conf) do |pal|
           inv = Bolt::ApplyInventory.new(request['config'])
           Puppet.override(bolt_pdb_client: pdb_client,
-                          bolt_inventory: inv) do
+                          bolt_inventory: inv,
+                          bolt_project: bolt_project) do
             Puppet.lookup(:pal_current_node).trusted_data = target['trusted']
             pal.with_catalog_compiler do |compiler|
               # Deserializing needs to happen inside the catalog compiler so

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -190,6 +190,7 @@ module Bolt
           # versions of "core" types, which are already present on the agent,
           # but may cause issues on Puppet 5 agents.
           @original_modulepath,
+          @project,
           pdb_client,
           @hiera_config,
           @max_compiles,

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -20,7 +20,7 @@ describe Bolt::Applicator do
   end
   let(:pdb_client) { Bolt::PuppetDB::Client.new(config) }
   let(:modulepath) { [Bolt::PAL::BOLTLIB_PATH, Bolt::PAL::MODULES_PATH] }
-  let(:applicator) { Bolt::Applicator.new(inventory, executor, modulepath, [], pdb_client, nil, 2, {}) }
+  let(:applicator) { Bolt::Applicator.new(inventory, executor, modulepath, [], nil, pdb_client, nil, 2, {}) }
   let(:ast) { { 'resources' => [] } }
 
   let(:report) {

--- a/spec/fixtures/projects/named/manifests/notify.pp
+++ b/spec/fixtures/projects/named/manifests/notify.pp
@@ -1,0 +1,3 @@
+class test_project::notify {
+  notify { "project notify": }
+}

--- a/spec/fixtures/projects/named/plans/apply.pp
+++ b/spec/fixtures/projects/named/plans/apply.pp
@@ -1,0 +1,9 @@
+plan test_project::apply(
+  TargetSpec $targets
+) {
+  return apply($targets) {
+    include test_project::notify
+  }
+}
+
+

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -292,6 +292,16 @@ describe "passes parsed AST to the apply_catalog task" do
       end
     end
 
+    context 'when using project-level content' do
+      let(:project) { File.join(__dir__, '../fixtures/projects/named') }
+
+      it 'applies a class contained in a project-level manifest' do
+        result = run_cli_json(%W[plan run test_project::apply --boltdir #{project}] + config_flags)
+        notify = get_notifies(result)
+        expect(notify[0]['title']).to eq('project notify')
+      end
+    end
+
     context 'with inventoryfile stubbed' do
       let(:inventory) {
         {


### PR DESCRIPTION
Previously, we failed to thread the project context through to the
applicator and on to the catalog compiler. This meant that project-level
classes, defines, functions, types, etc couldn't be used in an apply
block or with `bolt apply`.

!bug

* **Project-level content can now be used in apply blocks**
  ([#1836](https://github.com/puppetlabs/bolt/issues/1836))

  Project-level classes and defines can now be used in `apply` blocks
  and `bolt apply`.