### PR TITLE
(GH-1842) Load config from bolt-project.yaml

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -107,6 +107,8 @@ namespace :docs do
     @puppetfile = { options: Bolt::Config::PUPPETFILE_OPTIONS }
     @apply = { options: Bolt::Config::APPLY_SETTINGS, defaults: Bolt::Config::DEFAULT_APPLY_SETTINGS }
     @project = { options: Bolt::Project::PROJECT_SETTINGS, defaults: {} }
+    @transport_option = { options: Bolt::Config::TRANSPORT_OPTION,
+                          defaults: Bolt::Config::DEFAULT_TRANSPORT_OPTION }
 
     Bolt::Config::TRANSPORT_CONFIG.each do |name, transport|
       @transports[:options][name] = transport::OPTIONS

--- a/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/apply_prep_spec.rb
@@ -148,7 +148,7 @@ describe 'apply_prep' do
         }
       }
 
-      let(:config)    { Bolt::Config.new(Bolt::Project.new('.'), {}) }
+      let(:config)    { Bolt::Config.default }
       let(:pal)       { nil }
       let(:plugins)   { Bolt::Plugin.setup(config, pal) }
       let(:inventory) { Bolt::Inventory.create_version(data, config.transport, config.transports, plugins) }

--- a/bolt-modules/boltlib/spec/functions/remove_from_group_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/remove_from_group_spec.rb
@@ -3,7 +3,7 @@
 describe 'remove_from_group' do
   include PuppetlabsSpec::Fixtures
   let(:executor)      { Bolt::Executor.new }
-  let(:config)        { Bolt::Config.new(Bolt::Project.new('.'), {}) }
+  let(:config)        { Bolt::Config.default }
   let(:pal)           { nil }
   let(:plugins)       { Bolt::Plugin.setup(config, pal) }
   let(:inventory)     { Bolt::Inventory.create_version(data, config.transport, config.transports, plugins) }

--- a/bolt-modules/boltlib/spec/functions/resolve_references_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/resolve_references_spec.rb
@@ -5,7 +5,7 @@ require 'bolt/plugin'
 
 describe 'resolve_references' do
   include PuppetlabsSpec::Fixtures
-  let(:project)       { Bolt::Project.new('./spec/fixtures') }
+  let(:project)       { Bolt::Project.create_project('./spec/fixtures') }
   let(:config)        { Bolt::Config.new(project, {}) }
   let(:pal)           { Bolt::PAL.new(config.modulepath, config.hiera_config, config.project.resource_types) }
   let(:plugins)       { Bolt::Plugin.setup(config, pal) }

--- a/documentation/bolt_configuration_reference.md.erb
+++ b/documentation/bolt_configuration_reference.md.erb
@@ -116,7 +116,14 @@ The `puppetfile` section of the configuration file configures how to retrieve mo
 
 ## Transport configuration options
 
-Transport configuration options can be set in both the configuration file and inventory file.
+Transport configuration options can be set in the inventory file. Options at
+the inventory's top level will apply to all targets.
+
+### The transport option
+
+<% @transport_option[:options].each do |option, desc| -%>
+| `<%= option %>` | <%= desc %> | <%= @transport_option[:defaults][option].to_s %> |
+<% end %>
 
 <% @transports[:options].each do |transport, options| %>
 ### <%= transport %>

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -37,14 +37,10 @@ Before your begin, make sure you've [updated Bolt to version 2.8.0 or
 higher](./bolt_installing.md).
 
 To get started with a Bolt project:
-1. Create a Bolt project:
-   - To create a fresh project directory, use the command `bolt project init
-   <PROJECT_NAME>`
-   - To turn an existing directory into a Bolt project directory, run `Bolt
-     project init` from the root of the directory.   
-2. Create a `bolt-project.yaml` file in the root of your Bolt project directory.
-3. Develop your Bolt plans and tasks in `plans` and `tasks` directories
-   in the root of the project directory.
+1. Create a `bolt-project.yaml` file in the root of your Bolt project directory. This can be an
+   existing directory, or a new one you make.
+1. Develop your Bolt plans and tasks in `plans` and `tasks` directories
+   in the root of the project directory, next to `bolt-project.yaml`.
 
 If `bolt-project.yaml` exists at the root of a project directory, Bolt loads the
 project as a module. Bolt loads tasks and plans from the `tasks` and `plans`
@@ -53,7 +49,6 @@ directories and namespaces them to the project name.
 Here is an example of a project using a simplified directory structure:
 ```console
 .
-├── bolt.yaml
 ├── bolt-project.yaml
 ├── inventory.yaml
 ├── plans
@@ -62,7 +57,29 @@ Here is an example of a project using a simplified directory structure:
     └── mytask.yaml
 ```
 
-### Naming your project
+### Project configuration
+
+As of Bolt 2.13.0 `bolt-project.yaml` contains both project configuration and [Bolt
+configuration](bolt_configuration_reference.md), excluding [transport configuration
+options](bolt_configuration_reference.md#transport-configuration-options). If your project contains
+both `bolt.yaml` and `bolt-project.yaml` files and `bolt-project.yaml` contains valid bolt config
+data, `bolt.yaml` will be ignored and `bolt-project.yaml` will be preferred for loading Bolt
+configuration. If using `bolt-project.yaml`, set transport configuration in your [inventory.yaml
+file](inventory_file_v2.md).
+
+For example, this `bolt-project.yaml` configures logging and modulepath for Bolt:
+```yaml
+# bolt-project.yaml
+modulepath: ['modules','site-modules','/home/user/mymodules']
+
+log:
+  console:
+    level: notice
+  ~/.puppetlabs/bolt/debug.log
+    level: debug
+```
+
+#### Naming your project
 
 If you want to set a name for your project that is different from the name of
 the Bolt project directory, add a `name` key to `bolt-project.yaml` with the project
@@ -79,7 +96,7 @@ lowercase letter.
 
 > **Note:** Projects take precedence over installed modules of the same name.
 
-### Whitelisting plans and tasks
+#### Whitelisting plans and tasks
 
 To control what tasks and plans appear when your users run `bolt plan
 show` or `bolt task show`, add `tasks` and `plans`

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -115,7 +115,7 @@ module Bolt
                   Bolt::Config.from_file(options[:configfile], options)
                 else
                   project = if options[:boltdir]
-                              Bolt::Project.new(options[:boltdir])
+                              Bolt::Project.create_project(options[:boltdir])
                             else
                               Bolt::Project.find_boltdir(Dir.pwd)
                             end
@@ -771,7 +771,7 @@ module Bolt
     end
 
     def pal
-      project = config.project.load_as_module? ? config.project : nil
+      project = config.project.project_file? ? config.project : nil
       @pal ||= Bolt::PAL.new(config.modulepath,
                              config.hiera_config,
                              config.project.resource_types,

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -34,6 +34,13 @@ module Bolt
       'remote' => Bolt::Config::Transport::Remote
     }.freeze
 
+    TRANSPORT_OPTION = { 'transport' => 'The default transport to use when the '\
+                         'transport for a target is not specified in the URL.' }.freeze
+
+    DEFAULT_TRANSPORT_OPTION = { 'transport' => 'ssh' }.freeze
+
+    CONFIG_IN_INVENTORY = TRANSPORT_CONFIG.merge(TRANSPORT_OPTION)
+
     # NOTE: All configuration options should have a corresponding schema property
     #       in schemas/bolt-config.schema.json
     OPTIONS = {
@@ -57,8 +64,8 @@ module Bolt
       "save-rerun"               => "Whether to update `.rerun.json` in the Bolt project directory. If "\
                                     "your target names include passwords, set this value to `false` to avoid "\
                                     "writing passwords to disk.",
-      "transport"                => "The default transport to use when the transport for a target is not "\
-                                    "specified in the URL or inventory.",
+      "transport"                => "The default transport to use when the transport for a target is not specified "\
+                                    "in the URL or inventory.",
       "trusted-external-command" => "The path to an executable on the Bolt controller that can produce "\
                                     "external trusted facts. **External trusted facts are experimental in both "\
                                     "Puppet and Bolt and this API may change or be removed.**"
@@ -106,14 +113,17 @@ module Bolt
     DEFAULT_DEFAULT_CONCURRENCY = 100
 
     def self.default
-      new(Bolt::Project.new('.'), {})
+      new(Bolt::Project.create_project('.'), {})
     end
 
     def self.from_project(project, overrides = {})
-      data = {
-        filepath: project.config_file,
-        data: Bolt::Util.read_optional_yaml_hash(project.config_file, 'config')
-      }
+      conf = if project.project_file == project.config_file
+               project.data
+             else
+               Bolt::Util.read_optional_yaml_hash(project.config_file, 'config')
+             end
+
+      data = { filepath: project.config_file, data: conf }
 
       data = load_defaults(project).push(data).select { |config| config[:data]&.any? }
 
@@ -121,12 +131,13 @@ module Bolt
     end
 
     def self.from_file(configfile, overrides = {})
-      project = Bolt::Project.new(Pathname.new(configfile).expand_path.dirname)
-
-      data = {
-        filepath: project.config_file,
-        data: Bolt::Util.read_yaml_hash(configfile, 'config')
-      }
+      project = Bolt::Project.create_project(Pathname.new(configfile).expand_path.dirname)
+      conf = if project.project_file == project.config_file
+               project.data
+             else
+               Bolt::Util.read_yaml_hash(configfile, 'config')
+             end
+      data = { filepath: project.config_file, data: conf }
       data = load_defaults(project).push(data).select { |config| config[:data]&.any? }
 
       new(project, data, overrides)
@@ -160,8 +171,8 @@ module Bolt
       end
 
       @logger = Logging.logger[self]
-      @warnings = []
       @project = project
+      @warnings = @project.warnings.dup
       @transports = {}
       @config_files = []
 

--- a/lib/bolt/inventory/group.rb
+++ b/lib/bolt/inventory/group.rb
@@ -16,7 +16,7 @@ module Bolt
       DATA_KEYS = %w[config facts vars features plugin_hooks].freeze
       TARGET_KEYS = DATA_KEYS + %w[name alias uri]
       GROUP_KEYS = DATA_KEYS + %w[name groups targets]
-      CONFIG_KEYS = Bolt::Config::TRANSPORT_CONFIG.keys + ['transport']
+      CONFIG_KEYS = Bolt::Config::CONFIG_IN_INVENTORY.keys
 
       def initialize(input, plugins)
         @logger = Logging.logger[self]

--- a/lib/bolt_spec/bolt_context.rb
+++ b/lib/bolt_spec/bolt_context.rb
@@ -138,7 +138,7 @@ module BoltSpec
     # Override in your tests
     def config
       @config ||= begin
-                    conf = Bolt::Config.new(Bolt::Project.new('.'), {})
+                    conf = Bolt::Config.default
                     conf.modulepath = [modulepath].flatten
                     conf
                   end

--- a/lib/bolt_spec/run.rb
+++ b/lib/bolt_spec/run.rb
@@ -144,7 +144,7 @@ module BoltSpec
       end
 
       def config
-        @config ||= Bolt::Config.new(Bolt::Project.new(@project_path), @config_data)
+        @config ||= Bolt::Config.new(Bolt::Project.create_project(@project_path), @config_data)
       end
 
       def inventory

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -4,6 +4,84 @@
   "description": "Bolt Project bolt-project.yaml Schema",
   "type": "object",
   "properties": {
+    "apply_settings": {
+      "description": "A map of Puppet settings to use when applying Puppet code.",
+      "type": "object",
+      "properties": {
+        "show_diff": {
+          "description": "Whether to log and report a contextual diff when files are being replaced.",
+          "type": "boolean"
+        }
+      }
+    },
+    "color": {
+      "description": "Whether to use colored output when printing messages to the console.",
+      "type": "boolean"
+    },
+    "compile-concurrency": {
+      "description": "The maximum number of simultaneous manifest block compiles.",
+      "type": "integer",
+      "min": 1
+    },
+    "concurrency": {
+      "description": "The number of threads to use when executing on remote targets.",
+      "type": "integer",
+      "min": 1
+    },
+    "format": {
+      "description": "The format to use when printing results.",
+      "type": "string",
+      "enum": ["human", "json"]
+    },
+    "hiera-config": {
+      "description": "The path to your Hiera config.",
+      "type": "string"
+    },
+    "inventoryfile": {
+      "description": "The path to your inventory file.",
+      "type": "string"
+    },
+    "log": {
+      "description": "The configuration of the logfile output. Configuration can be set for console and the path to a log file, such as ~/.puppetlabs/bolt/debug.log.",
+      "type": "object",
+      "properties": {
+        "console": {
+          "description": "Configuration for logs output to the console.",
+          "type": "object",
+          "properties": {
+            "level": {
+              "description": "The type of information in the log.",
+              "type": "string",
+              "enum": ["debug", "error", "info", "notice", "warn"]
+            }
+          }
+        }
+      },
+      "additionalProperties": {
+        "description": "Configuration for logs output to a file.",
+        "type": "object",
+        "properties": {
+          "append": {
+            "description": "Add output to an existing log file.",
+            "type": "boolean"
+          },
+          "level": {
+            "description": "The type of information in the log.",
+            "type": "string",
+            "enum": ["debug", "error", "info", "notice", "warn"]
+          }
+        }
+      }
+    },
+    "modulepath": {
+      "description": "The module path for loading tasks and plan code. This is either an array of directories or a string containing a list of directories separated by the OS-specific PATH separator.",
+      "type": ["array", "string"],
+      "items": {
+        "description": "Module path.",
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
     "name": {
       "description": "The Bolt project name.",
       "type": "string",
@@ -19,6 +97,84 @@
       },
       "uniqueItems": true
     },
+    "plugin_hooks": {
+      "description": "Which plugins a specific hook should use.",
+      "type": "object",
+      "properties": {
+        "puppet_library": {
+          "description": "Specify which plugin should be used to ensure the Puppet library is installed on a target.",
+          "type": "object"
+        }
+      }
+    },
+    "plugins": {
+      "description": "A map of plugins and their configuration data.",
+      "type": "object",
+      "patternProperties": {
+        "^[a-z][a-z0-9_]*$": { 
+          "type": "object"
+        }
+      }
+    },
+    "puppetdb": {
+      "description": "A map containing options for configuring the Bolt PuppetDB client.",
+      "type": "object",
+      "properties": {
+        "cacert": {
+          "description": "The path to the ca certificate for PuppetDB.",
+          "type": "string"
+        },
+        "cert": {
+          "description": "The path to the client certificate file to use for authentication.",
+          "type": "string"
+        },
+        "key": {
+          "description": "The path to the private key for the certificate.",
+          "type": "string"
+        },
+        "server_urls": {
+          "description": "An array containing the PuppetDB host to connect to. Include the protocol https and the port, which is usually 8081. For example, https://my-master.example.com:8081.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "description": "A PuppetDB host.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "puppetfile": {
+      "description": "A map containing options for the 'bolt puppetfile install' command.",
+      "type": "object",
+      "properties": {
+        "forge": {
+          "description": "A subsection that can have its own proxy setting to set an HTTP proxy for Forge operations only, and a baseurl setting to specify a different Forge host.",
+          "type": "object",
+          "properties": {
+            "baseurl": {
+              "description": "The URI for the Forge host.",
+              "type": "string",
+              "format": "uri"
+            },
+            "proxy": {
+              "description": "The HTTP proxy to use for Forge operations.",
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        "proxy": {
+          "description": "The HTTP proxy to use for Git and Forge operations.",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "save-rerun": {
+      "description": "Whether to update .rerun.json in the Bolt project directory. If your target names include passwords, set this value to false to avoid writing passwords to disk.",
+      "type": "boolean"
+    },
     "tasks": {
       "description": "The list of whitelisted tasks.",
       "type": "array",
@@ -28,6 +184,10 @@
         "pattern": "^[a-z][a-z0-9_]*(::[a-z][a-z0-9_]*)*$"
       },
       "uniqueItems": true
+    },
+    "trusted-external-command": {
+      "description": "The path to an executable on the Bolt controller that can produce external trusted facts.",
+      "type": "string"
     }
   }
 }

--- a/spec/bolt/inventory/inventory_spec.rb
+++ b/spec/bolt/inventory/inventory_spec.rb
@@ -240,7 +240,7 @@ describe Bolt::Inventory::Inventory do
           }
         }
       end
-      let(:config)    { Bolt::Config.new(Bolt::Project.new('.'), data) }
+      let(:config)    { Bolt::Config.new(Bolt::Project.new({}, '.'), data) }
       let(:inventory) { Bolt::Inventory::Inventory.new({}, config.transport, config.transports, plugins) }
       let(:target)    { inventory.get_targets('notarget')[0] }
 

--- a/spec/bolt/rerun_spec.rb
+++ b/spec/bolt/rerun_spec.rb
@@ -11,7 +11,7 @@ require 'bolt/util'
 describe 'rerun' do
   around(:each) do |example|
     Dir.mktmpdir do |project|
-      @project = Bolt::Project.new(project)
+      @project = Bolt::Project.new({}, project)
       example.run
     end
   end

--- a/spec/integration/project_spec.rb
+++ b/spec/integration/project_spec.rb
@@ -8,7 +8,7 @@ describe "When loading content", ssh: true do
   include BoltSpec::Conn
   include BoltSpec::Integration
 
-  let(:local) { Bolt::Project.new(File.join(__dir__, '../fixtures/projects/local'), 'local') }
+  let(:local) { Bolt::Project.create_project(File.join(__dir__, '../fixtures/projects/local'), 'local') }
   let(:target) { conn_uri('ssh') }
   let(:config_flags) { %W[--no-host-key-check --password #{conn_info('ssh')[:password]}] }
 
@@ -28,13 +28,13 @@ describe "When loading content", ssh: true do
   end
 
   it "runs plans namespaced with embedded project type" do
-    embedded = Bolt::Project.new(File.join(__dir__, '../fixtures/projects/embedded/Boltdir'), 'embedded')
+    embedded = Bolt::Project.create_project(File.join(__dir__, '../fixtures/projects/embedded/Boltdir'), 'embedded')
     result = run_cli_json(%W[plan run embedded -t #{target}] + config_flags, project: embedded)
     expect(result[0]['value']['stdout'].strip).to eq('polo')
   end
 
   it "runs plans namespaced to configured project name" do
-    named = Bolt::Project.new(File.join(__dir__, '../fixtures/projects/named'), 'local')
+    named = Bolt::Project.create_project(File.join(__dir__, '../fixtures/projects/named'), 'local')
     result = run_cli_json(%W[plan run test_project -t #{target}] + config_flags, project: named)
     expect(result[0]['value']['stdout'].strip).to eq('polo')
   end

--- a/spec/integration/transport/local_spec.rb
+++ b/spec/integration/transport/local_spec.rb
@@ -20,7 +20,7 @@ describe Bolt::Transport::Local do
   let(:password)      { 'runner' }
   let(:os_context)    { Bolt::Util.windows? ? windows_context : posix_context }
   let(:config)        { make_config }
-  let(:project)       { Bolt::Project.new('.') }
+  let(:project)       { Bolt::Project.new({}, '.') }
   let(:plugins)       { Bolt::Plugin.setup(config, nil) }
   let(:inventory)     { Bolt::Inventory.create_version({}, config.transport, config.transports, plugins) }
   let(:target)        { make_target }

--- a/spec/integration/transport/ssh_spec.rb
+++ b/spec/integration/transport/ssh_spec.rb
@@ -48,7 +48,7 @@ describe Bolt::Transport::SSH, ssh: true do
   let(:env_task)          { "#!/bin/sh\necho $PT_data" }
 
   let(:config)            { make_config }
-  let(:project)           { Bolt::Project.new('.') }
+  let(:project)           { Bolt::Project.new({}, '.') }
   let(:plugins)           { Bolt::Plugin.setup(config, nil) }
   let(:inventory)         { Bolt::Inventory.create_version({}, config.transport, config.transports, plugins) }
   let(:target)            { make_target }

--- a/spec/integration/transport/winrm_spec.rb
+++ b/spec/integration/transport/winrm_spec.rb
@@ -20,7 +20,7 @@ describe Bolt::Transport::WinRM do
   include BoltSpec::Sensitive
   include BoltSpec::Task
 
-  let(:project)     { Bolt::Project.new('.') }
+  let(:project)     { Bolt::Project.new({}, '.') }
   let(:host)        { conn_info('winrm')[:host] }
   let(:port)        { conn_info('winrm')[:port] }
   let(:ssl_port)    { ENV['BOLT_WINRM_SSL_PORT'].to_i || 25986 }

--- a/spec/lib/bolt_spec/config.rb
+++ b/spec/lib/bolt_spec/config.rb
@@ -14,7 +14,7 @@ module BoltSpec
       empty = {
         'inventoryfile' => fixture_path('inventory', 'empty.yml')
       }
-      Bolt::Config.new(Bolt::Project.new('.'), empty.merge(overrides))
+      Bolt::Config.new(Bolt::Project.new({}, '.'), empty.merge(overrides))
     end
 
     def conn_config(overrides = {})

--- a/spec/lib/bolt_spec/integration.rb
+++ b/spec/lib/bolt_spec/integration.rb
@@ -8,7 +8,7 @@ module BoltSpec
     include BoltSpec::PuppetDB
 
     def run_cli(arguments, rescue_exec: false, outputter: Bolt::Outputter::JSON,
-                project: Bolt::Project.new(Dir.mktmpdir))
+                project: Bolt::Project.new({}, Dir.mktmpdir))
       cli = Bolt::CLI.new(arguments)
 
       # prevent tests from reading users config

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,9 +62,11 @@ RSpec.configure do |config|
     ENV['BOLT_DISABLE_ANALYTICS'] = 'true'
 
     # Ignore local bolt-project.yaml files
-    allow(Bolt::Project).to receive(:new).and_call_original
-    allow(Bolt::Project).to receive(:new).with('.')
-                                         .and_return(Bolt::Project.new(Dir.mktmpdir))
+    allow(Bolt::Project).to receive(:create_project)
+      .and_call_original
+    allow(Bolt::Project).to receive(:create_project)
+      .with('.')
+      .and_return(Bolt::Project.create_project(Dir.mktmpdir))
 
     # Ignore user's known hosts and ssh config files
     conf = { user_known_hosts_file: '/dev/null/', global_known_hosts_file: '/dev/null' }


### PR DESCRIPTION
This makes several changes to how Bolt loads config. We now load bolt
configuration options (eg. concurrency), excluding transport config
options, from `bolt-project.yaml` if that file is present in the project
directory and has non-project config keys (e.g. 'format'). If both
`bolt-project.yaml` and `bolt.yaml` are present in the root of the
project directory and `bolt-project.yaml` has config keys `bolt.yaml`
will be ignored, regardless of how bolt determines the project
directory. This means that users can specify `--configfile
path/to/bolt.yaml`, and if there's a `bolt-project.yaml` with config
next to it it will not be loaded. If only `bolt.yaml` is present, it
will be loaded normally including transport config. Users using
`bolt-project.yaml` should specify transport configuration in
`inventory.yaml`.

Closes #1842

!feature

* **Load config from bolt-project.yaml** ([#1842](#1842))

  Bolt configuration options, excluding transport config, can now be
  loaded from `bolt-project.yaml`. If both `bolt-project.yaml` and
  `bolt.yaml` are present in the project and `bolt-project.yaml` has
  bolt config keys (e.g. 'format'), `bolt.yaml` will be ignored.