### PR TITLE
(GH-1847) Use task parameter default when parameter is `Undef`

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
@@ -88,8 +88,10 @@ Puppet::Functions.create_function(:run_task) do
 
       task = Bolt::Task.from_task_signature(task_signature)
 
-      # Set the default value for any params that have one and were not provided
-      params = task.parameter_defaults.merge(params)
+      # Set the default value for any params that have one and were not provided or are undef
+      params = task.parameter_defaults.merge(params) do |_, default, passed|
+        passed.nil? ? default : passed
+      end
 
       task_signature.runnable_with?(params) do |mismatch_message|
         raise with_stack(:TYPE_MISMATCH, mismatch_message)

--- a/bolt-modules/boltlib/lib/puppet/functions/run_task_with.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task_with.rb
@@ -124,7 +124,10 @@ Puppet::Functions.create_function(:run_task_with) do
       # If parameters are mismatched, create a failing result for the target that will later
       # be added to the ResultSet.
       unless pcp_only
-        params = task.parameter_defaults.merge(params)
+        # Set the default value for any params that have one and were not provided or are undef
+        params = task.parameter_defaults.merge(params) do |_, default, passed|
+          passed.nil? ? default : passed
+        end
 
         type_match = task_signature.runnable_with?(params) do |mismatch_message|
           exception = with_stack(:TYPE_MISMATCH, mismatch_message)
@@ -157,7 +160,10 @@ Puppet::Functions.create_function(:run_task_with) do
         end
       end
 
-      mapping[target] = task.parameter_defaults.merge(params)
+      # Set the default value for any params that have one and were not provided or are undef
+      mapping[target] = task.parameter_defaults.merge(params) do |_, default, passed|
+        passed.nil? ? default : passed
+      end
     end
 
     # Add a noop parameter if the function was called with the noop metaparameter.

--- a/bolt-modules/boltlib/spec/fixtures/modules/test/tasks/undef.json
+++ b/bolt-modules/boltlib/spec/fixtures/modules/test/tasks/undef.json
@@ -1,0 +1,15 @@
+{
+  "description": "undef task",
+  "input_method": "environment",
+  "parameters": {
+    "undef_default": {
+      "description": "parameter with default",
+      "type": "String",
+      "default": "foo"
+    },
+    "undef_no_default": {
+      "description": "parameter with no default",
+      "type": "Any"
+    }
+  }
+}

--- a/bolt-modules/boltlib/spec/fixtures/modules/test/tasks/undef.sh
+++ b/bolt-modules/boltlib/spec/fixtures/modules/test/tasks/undef.sh
@@ -1,0 +1,1 @@
+echo -n "$PT_undef_default"

--- a/bolt-modules/boltlib/spec/functions/run_task_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_spec.rb
@@ -128,6 +128,24 @@ describe 'run_task' do
       is_expected.to run.with_params('Test::Params', hostname, args)
     end
 
+    it 'uses the default if a parameter is specified as undef' do
+      executable = File.join(tasks_root, 'undef.sh')
+      args = {
+        'undef_default'    => nil,
+        'undef_no_default' => nil
+      }
+      expected_args = {
+        'undef_default'    => 'foo',
+        'undef_no_default' => nil
+      }
+
+      executor.expects(:run_task).with([target], mock_task(executable, 'environment'), expected_args, {})
+              .returns(result_set)
+      inventory.expects(:get_targets).with(hostname).returns([target])
+
+      is_expected.to run.with_params('test::undef', hostname, args).and_return(result_set)
+    end
+
     it 'when called with no destinations - does not invoke bolt' do
       executor.expects(:run_task).never
       inventory.expects(:get_targets).with([]).returns([])
@@ -333,8 +351,8 @@ describe 'run_task' do
 
     it 'errors when unknown parameters are specified' do
       task_params.merge!(
-        'foo' => nil,
-        'bar' => nil
+        'foo' => 'foo',
+        'bar' => 'bar'
       )
 
       is_expected.to run.with_params(task_name, hostname, task_params).and_raise_error(

--- a/bolt-modules/boltlib/spec/functions/run_task_with_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_with_spec.rb
@@ -149,6 +149,30 @@ describe 'run_task_with' do
         .with_lambda { |_| args })
     end
 
+    it 'uses the default if a parameter is specified as undef' do
+      executable = File.join(tasks_root, 'undef.sh')
+      args = {
+        'undef_default'    => nil,
+        'undef_no_default' => nil
+      }
+      expected_args = {
+        'undef_default'    => 'foo',
+        'undef_no_default' => nil
+      }
+      target_mapping = {
+        target  => expected_args,
+        target2 => expected_args
+      }
+
+      executor.expects(:run_task_with).with(target_mapping, mock_task(executable, 'environment'), {})
+              .returns(result_set)
+      inventory.expects(:get_targets).with(hosts).returns(targets)
+
+      is_expected.to(run
+        .with_params('test::undef', hosts)
+        .with_lambda { |_| args })
+    end
+
     it 'does not invoke Bolt when target list is empty' do
       executor.expects(:run_task).never
       inventory.expects(:get_targets).with([]).returns([])

--- a/documentation/writing_tasks.md
+++ b/documentation/writing_tasks.md
@@ -228,7 +228,9 @@ To define a parameter as sensitive within the JSON metadata, add the `"sensitive
 
 ### Setting default values
 
-You can set a default value for a parameter which will be used if the parameter isn't specified. The default value must be valid according to the parameter's `type`.
+You can set a default value for a parameter which will be used if the parameter isn't specified or if the
+parameter is specified and has a value of `Undef`. The default will be used even if the parameter
+type is optional. Default values must be valid according to the parameter's `type`.
 
 ```json
 {

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1603,8 +1603,8 @@ describe "Bolt::CLI" do
               # these are not legal parameters for the 'sample::params' task
               # according to the local task definition
               {
-                'foo' => nil,
-                'bar' => nil
+                'foo' => 'foo',
+                'bar' => 'bar'
               }
             }
 


### PR DESCRIPTION
This updates the `run_task` function to use a task parameter default
when a parameter is specified but has a value of `Undef`. Previously, if
a parameter was specified with a value of `Undef`, the default would not
be used and the `Undef` value would be passed to the task.

Closes #1847 

!feature

* **Use task parameter default when specified parameter is `Undef`**
  ([#1847](https://github.com/puppetlabs/issues/1847))

  Task parameters that are specified with a value of `Undef` will now
  use the default parameter value if one is defined in the task's
  metadata.