### PR TITLE
Allow boltdir to be found no matter the case

### DIFF
--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -25,8 +25,10 @@ module Bolt
     # hierarchy, falling back to the default if we reach the root.
     def self.find_boltdir(dir)
       dir = Pathname.new(dir)
-      if (dir + BOLTDIR_NAME).directory?
-        new(dir + BOLTDIR_NAME, 'embedded')
+      # allows for any case of Boltdir, BoltDir, boltdir, etc
+      boltdirs = dir.children.select { |c| c.directory? && c.basename.to_s.casecmp?(BOLTDIR_NAME)  }
+      if !boltdirs.empty?
+        new(boltdirs.first, 'embedded')
       elsif (dir + 'bolt.yaml').file? || (dir + 'bolt-project.yaml').file?
         new(dir, 'local')
       elsif dir.root?
@@ -73,7 +75,7 @@ module Bolt
 
     def name
       # If the project is in mymod/Boltdir/bolt-project.yaml, use mymod as the project name
-      dirname = @path.basename.to_s == 'Boltdir' ? @path.parent.basename.to_s : @path.basename.to_s
+      dirname = @path.basename.to_s.casecmp?('boltdir') ? @path.parent.basename.to_s : @path.basename.to_s
       pname = @data['name'] || dirname
       pname.include?('-') ? pname.split('-', 2)[1] : pname
     end

--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -26,7 +26,11 @@ module Bolt
     def self.find_boltdir(dir)
       dir = Pathname.new(dir)
       # allows for any case of Boltdir, BoltDir, boltdir, etc
-      boltdirs = dir.children.select { |c| c.directory? && c.basename.to_s.casecmp?(BOLTDIR_NAME)  }
+      # note: we're sorting the directories here so that we consistently pick the
+      #       same Boltdir between runs, and we always choose the lexicographical "less"
+      #       Boltdir name rather than whatever the first name we run into as returned by
+      #       the filesystem
+      boltdirs = dir.children.sort.select { |c| c.directory? && c.basename.to_s.casecmp?(BOLTDIR_NAME) }
       if !boltdirs.empty?
         new(boltdirs.first, 'embedded')
       elsif (dir + 'bolt.yaml').file? || (dir + 'bolt-project.yaml').file?
@@ -75,7 +79,7 @@ module Bolt
 
     def name
       # If the project is in mymod/Boltdir/bolt-project.yaml, use mymod as the project name
-      dirname = @path.basename.to_s.casecmp?('boltdir') ? @path.parent.basename.to_s : @path.basename.to_s
+      dirname = @path.basename.to_s.casecmp?(BOLTDIR_NAME) ? @path.parent.basename.to_s : @path.basename.to_s
       pname = @data['name'] || dirname
       pname.include?('-') ? pname.split('-', 2)[1] : pname
     end

--- a/spec/bolt/project_spec.rb
+++ b/spec/bolt/project_spec.rb
@@ -68,67 +68,38 @@ describe Bolt::Project do
       end
     end
 
-    describe "when the project directory is named Boltdir" do
-      it 'finds project from inside project' do
-        pwd = boltdir_path
-        expect(Bolt::Project.find_boltdir(pwd)).to eq(project)
-      end
+    %w[Boltdir boltdir BoltDir bOlTdIr].each do |boltdir|
+      describe "when the project directory is named #{boltdir}" do
+        let(:boltdir_path) { @tmpdir + 'foo' + boltdir }
 
-      it 'finds project from the parent directory' do
-        pwd = boltdir_path.parent
-        expect(Bolt::Project.find_boltdir(pwd)).to eq(project)
-      end
+        it 'finds project from inside project' do
+          pwd = boltdir_path
+          expect(Bolt::Project.find_boltdir(pwd)).to eq(project)
+        end
 
-      it 'does not find project from the grandparent directory' do
-        pwd = boltdir_path.parent.parent
-        expect(Bolt::Project.find_boltdir(pwd)).not_to eq(project)
-      end
+        it 'finds project from the parent directory' do
+          pwd = boltdir_path.parent
+          expect(Bolt::Project.find_boltdir(pwd)).to eq(project)
+        end
 
-      it 'finds the project from a sibling directory' do
-        pwd = boltdir_path.parent + 'bar'
-        FileUtils.mkdir_p(pwd)
+        it 'does not find project from the grandparent directory' do
+          pwd = boltdir_path.parent.parent
+          expect(Bolt::Project.find_boltdir(pwd)).not_to eq(project)
+        end
 
-        expect(Bolt::Project.find_boltdir(pwd)).to eq(project)
-      end
+        it 'finds the project from a sibling directory' do
+          pwd = boltdir_path.parent + 'bar'
+          FileUtils.mkdir_p(pwd)
 
-      it 'finds the project from a child directory' do
-        pwd = boltdir_path + 'baz'
-        FileUtils.mkdir_p(pwd)
+          expect(Bolt::Project.find_boltdir(pwd)).to eq(project)
+        end
 
-        expect(Bolt::Project.find_boltdir(pwd)).to eq(project)
-      end
-    end
+        it 'finds the project from a child directory' do
+          pwd = boltdir_path + 'baz'
+          FileUtils.mkdir_p(pwd)
 
-    describe "when the project directory is named boltdir" do
-      let(:boltdir_path) { @tmpdir + 'foo' + 'boltdir' }
-      
-      it 'finds project from inside project' do
-        pwd = boltdir_path
-        expect(Bolt::Project.find_boltdir(pwd)).to eq(project)
-      end
-
-      it 'finds project from the parent directory' do
-        pwd = boltdir_path.parent
-        expect(Bolt::Project.find_boltdir(pwd)).to eq(project)
-      end
-
-      it 'does not find project from the grandparent directory' do
-        pwd = boltdir_path.parent.parent
-        expect(Bolt::Project.find_boltdir(pwd)).not_to eq(project)
-      end
-
-      it 'finds the project from a sibling directory' do
-        pwd = boltdir_path.parent + 'bar'
-        FileUtils.mkdir_p(pwd)
-
-        expect(Bolt::Project.find_boltdir(pwd)).to eq(project)
-      end
-
-      it 'finds the project from a child directory' do
-        pwd = boltdir_path + 'baz'
-        FileUtils.mkdir_p(pwd)
-
-        expect(Bolt::Project.find_boltdir(pwd)).to eq(project)
+          expect(Bolt::Project.find_boltdir(pwd)).to eq(project)
+        end
       end
     end
 

--- a/spec/bolt/project_spec.rb
+++ b/spec/bolt/project_spec.rb
@@ -99,6 +99,39 @@ describe Bolt::Project do
       end
     end
 
+    describe "when the project directory is named boltdir" do
+      let(:boltdir_path) { @tmpdir + 'foo' + 'boltdir' }
+      
+      it 'finds project from inside project' do
+        pwd = boltdir_path
+        expect(Bolt::Project.find_boltdir(pwd)).to eq(project)
+      end
+
+      it 'finds project from the parent directory' do
+        pwd = boltdir_path.parent
+        expect(Bolt::Project.find_boltdir(pwd)).to eq(project)
+      end
+
+      it 'does not find project from the grandparent directory' do
+        pwd = boltdir_path.parent.parent
+        expect(Bolt::Project.find_boltdir(pwd)).not_to eq(project)
+      end
+
+      it 'finds the project from a sibling directory' do
+        pwd = boltdir_path.parent + 'bar'
+        FileUtils.mkdir_p(pwd)
+
+        expect(Bolt::Project.find_boltdir(pwd)).to eq(project)
+      end
+
+      it 'finds the project from a child directory' do
+        pwd = boltdir_path + 'baz'
+        FileUtils.mkdir_p(pwd)
+
+        expect(Bolt::Project.find_boltdir(pwd)).to eq(project)
+      end
+    end
+
     describe "when using a control repo-style project" do
       it 'uses the current directory if it has a bolt.yaml' do
         pwd = @tmpdir


### PR DESCRIPTION
In the current implementation Boltdir needs to match the case exactly on filesystems that care about case. Sticking with the Linux tradition i like to have my directories all lowercase and though it would be nice if Bolt was able to find `boltdir` or `Boltdir` whatever the user preferred.

This change allows `Boltdir` to be of any case and we will use the first `Boltdir` we find. 

I'm also sorting the `children` returned in the directory so the lexicographical "less" / "smallest" `Boltdir` variant will be chosen and this will be consistent across `bolt` runs. This is better than relying on whatever random ordering the filesystem will return the directory listings in.