### PR TITLE
(maint) Fix add_event return type

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/datatypes/resourceinstance.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/resourceinstance.rb
@@ -11,7 +11,7 @@ Puppet::DataTypes.create_type('ResourceInstance') do
       'events'        => Optional[Array[Hash[String[1], Data]]]
     },
     functions => {
-      add_event               => Callable[[Hash[String[1], Data]], [Hash[String[1], Data]]],
+      add_event               => Callable[[Hash[String[1], Data]], Array[Hash[String[1], Data]]],
       set_state               => Callable[[Hash[String[1], Data]], Hash[String[1], Data]],
       overwrite_state         => Callable[[Hash[String[1], Data]], Hash[String[1], Data]],
       set_desired_state       => Callable[[Hash[String[1], Data]], Hash[String[1], Data]],

--- a/spec/fixtures/modules/resources/plans/add_event.pp
+++ b/spec/fixtures/modules/resources/plans/add_event.pp
@@ -1,0 +1,12 @@
+plan resources::add_event(
+  TargetSpec $targets
+) {
+  $t = get_target($targets)
+  $r = ResourceInstance.new({
+    'target' => $t,
+    'type' => Package,
+    'title' => 'openssl'
+  })
+  $r.add_event({'update' => { 'time' => 'warp' }})
+  return $r
+}

--- a/spec/integration/resource_instance_spec.rb
+++ b/spec/integration/resource_instance_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/integration'
+require 'bolt_spec/conn'
+
+describe "resource instance in plans", ssh: true do
+  include BoltSpec::Integration
+  include BoltSpec::Conn
+
+  let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
+  let(:config_flags) do
+    %W[--format json --targets #{conn_uri('ssh')}] +
+      %W[--password #{conn_info('ssh')[:password]}] +
+      %W[--modulepath #{modulepath} --no-host-key-check]
+  end
+
+  it 'can add an event' do
+    result = run_cli_json(%w[plan run resources::add_event] + config_flags)
+    expect(result).not_to include('kind')
+    expect(result['events']).to eq([{ "update" => { "time" => "warp" } }])
+  end
+end


### PR DESCRIPTION
The add_event function on the ResourceInstance datatype didn't correctly
wrap the events hash in an array, causing the function to fail. The
expected return type of the function is now `Array[Hash[String[1],
Data]]]`.

!bug
    
    * **Correct ResourceInstance.add_event return type**
    
      Previously the `add_event` function had a typo that prevented it from
      successfully returning. It now correctly expects an
      `Array[Hash[String[1], Data]]]`.