### PR TITLE
(maint) Add Lint/DeprecatedOpenSSLConstant cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -117,6 +117,9 @@ Lint/RaiseException:
 Lint/StructNewOverride:
   Enabled: true
 
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
 # Enforce LF line endings, even when on Windows
 Layout/EndOfLine:
   EnforcedStyle: lf


### PR DESCRIPTION
In rubocop 0.84 a new cop, `Lint/DeprecatedOpenSSLConstant`, was added
that needed to be configured to either 'true' or 'false' in
`.rubocop.yml` otherwise rubocop would raise a warning. This adds the
cop and enables it.

!no-release-note