### PR TITLE
(GH-1873) Add `[]` function to ResourceInstance data type

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/datatypes/resourceinstance.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/resourceinstance.rb
@@ -16,7 +16,8 @@ Puppet::DataTypes.create_type('ResourceInstance') do
       overwrite_state         => Callable[[Hash[String[1], Data]], Hash[String[1], Data]],
       set_desired_state       => Callable[[Hash[String[1], Data]], Hash[String[1], Data]],
       overwrite_desired_state => Callable[[Hash[String[1], Data]], Hash[String[1], Data]],
-      reference               => Callable[[], String]
+      reference               => Callable[[], String],
+      '[]'                    => Callable[[String[1]], Data]
     }
   PUPPET
 

--- a/documentation/bolt_types_reference.md
+++ b/documentation/bolt_types_reference.md
@@ -39,6 +39,7 @@ The following functions are available to `ResourceInstance` objects.
 
 | Function | Type returned | Description |
 |---|---|---|
+| `[]` | `Data` | Accesses the `state` hash directly and returns the value for the specified attribute. This function does not use dot notation. Call the function directly on the `ResourceInstance`. For example, `$resource['ensure']`. |
 | `add_event` | `Array[Hash]` | Add an event for the resource. |
 | `desired_state` | `Hash` | [Attributes](https://puppet.com/docs/puppet/latest/lang_resources.html#attributes) describing the desired state of the resource. |
 | `events` | `Array[Hash]` | Events for the resource. |

--- a/lib/bolt/resource_instance.rb
+++ b/lib/bolt/resource_instance.rb
@@ -89,6 +89,10 @@ module Bolt
     end
     alias to_s reference
 
+    def [](attribute)
+      @state[attribute]
+    end
+
     def add_event(event)
       @events << event
     end

--- a/spec/bolt/resource_instance_spec.rb
+++ b/spec/bolt/resource_instance_spec.rb
@@ -150,4 +150,14 @@ describe Bolt::ResourceInstance do
       expect { resource.overwrite_desired_state('present') }.to raise_error(Bolt::ValidationError)
     end
   end
+
+  context '#[]' do
+    it 'returns an attribute from state' do
+      expect(resource['ensure']).to eq('present')
+    end
+
+    it 'returns nil for a missing attribute' do
+      expect(resource['foo']).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
This adds a `[]` function to the `ResourceInstance` data type that
directly accesses the `state` hash and returns the value for the
specified attribute. If the attribute is missing, the function will
return `nil`.

Closes #1873 

!feature

* **Added `[]` function to the `ResourceInstance` data type**
  ([#1873](https://github.com/puppetlabs/bolt/issues/1873))

  The `[]` function can be used to directly access the `state` hash for
  a `ResourceInstance` object and return the specified attribute.