### PR TITLE
(GH-1872) Accept `resource_type` key in `set_resources` plan function

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/set_resources.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/set_resources.rb
@@ -87,9 +87,12 @@ Puppet::Functions.create_function(:set_resources) do
         # Observed state from get_resources() is under the 'parameters' key
         resource_state = resource['state'] || resource['parameters']
 
+        # Type from apply results is under the 'resource_type' key
+        resource_type = resource['type'] || resource['resource_type']
+
         init_hash = {
           'target'        => resource_target,
-          'type'          => resource['type'],
+          'type'          => resource_type,
           'title'         => resource['title'],
           'state'         => resource_state,
           'desired_state' => resource['desired_state'],

--- a/bolt-modules/boltlib/spec/functions/set_resources_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/set_resources_spec.rb
@@ -65,6 +65,18 @@ describe 'set_resources' do
                       .and_return([resource, resource2])
   end
 
+  it 'accepts a resource_type key instead of type' do
+    resource_object = resource
+    resource_data['resource_type'] = resource_data.delete('type')
+    is_expected.to run.with_params(target, resource_data).and_return([resource_object])
+  end
+
+  it 'accepts a parameters key instead of state' do
+    resource_object = resource
+    resource_data['parameters'] = resource_data.delete('state')
+    is_expected.to run.with_params(target, resource_data).and_return([resource_object])
+  end
+
   it 'errors on unknown types' do
     is_expected.to run.with_params(mock('anything')).and_raise_error(ArgumentError)
   end

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -277,6 +277,24 @@ $results.each |$result| {
 }
 ```
 
+The `set_resources` function will return an array of `ResourceInstance` objects, which
+can be used to easily examine attributes for multiple resources and perform actions
+based on those attributes. For example, you can iterate over an array of resources to
+determine which users need to have their maxium password age modified:
+
+```ruby
+$results = $target.get_resources(User)
+
+$results.each |$result| {
+  $resources = $result.target.set_resources($result['resources'])
+
+  $users = $resources.filter |$resource| { $resource.state['password_max_age'] > 90 }
+                     .map |$resource| { $resource.title }
+
+  run_task('update_password_max_age', $result.target, 'users' => $users)
+}
+```
+
 Apply blocks will also return results with reports. These reports have resource data
 hashes that can be used to set resources on a target:
 

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -277,6 +277,24 @@ $results.each |$result| {
 }
 ```
 
+Apply blocks will also return results with reports. These reports have resource data
+hashes that can be used to set resources on a target:
+
+```ruby
+$apply_results = apply($targets) {
+  File { '/etc/puppetlabs':
+    ensure => present
+  }
+  Package { 'openssl':
+    ensure => installed
+  }
+}
+
+$apply_results.each |$result| {
+  $result.target.set_resources($result.report['resource_statuses'].values)
+}
+```
+
 ## External SSH transport
 
 This feature was introduced in [Bolt

--- a/lib/bolt/resource_instance.rb
+++ b/lib/bolt/resource_instance.rb
@@ -30,8 +30,7 @@ module Bolt
       @target        = resource_hash['target']
       @type          = resource_hash['type'].to_s.capitalize
       @title         = resource_hash['title']
-      # get_resources() returns observed state under the 'parameters' key
-      @state         = resource_hash['state'] || resource_hash['parameters'] || {}
+      @state         = resource_hash['state'] || {}
       @desired_state = resource_hash['desired_state'] || {}
       @events        = resource_hash['events'] || []
     end


### PR DESCRIPTION
This updates the `set_resources` plan function to accept a
`resource_type` key as part of the resource data hash, in addition to
`type`.

When creating a `ResourceInstance` object from a hash, a `type` key is
expected. However, when using resource data hashes returned from an
apply block, the resource's type is set under the `resource_type` key.
This made it impossible to directly use this hash to create a
`ResourceInstance` object, as the hash did not have the required `type`
key. The `set_resources` function now falls back to using the
`resource_type` key if the `type` key is not present.

It's important to note that calling `ResourceInstance.new` with a hash
that has a `resource_type` key instead of a `type` key will still raise
an exception.

To keep the behavior of `ResourceInstance.new` predictable, this also
removes the ability to use a `parameters` key instead of a `state` key
in the implementation class.

Lastly, this updates the `set_resources` function to have separate
dispatches instead of a `Variant` type for the `resources` parameter.

Closes #1872 

!feature

* **Accept `resource_type` key in resource data hash for `set_resources`
  plan function**
  ([#1872](#1872))

  The `set_resources` function now accepts resource data hashes that
  have a `resource_type` key instead of a `type` key. This allows users
  to set resources directly from reports from an apply block, which set
  a resource's type under the `resource_type` key.