### PR TITLE
(maint) Add new cops from RuboCop 0.85

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,6 +78,12 @@ Style/SafeNavigation:
 Style/SlicingWithRange:
   Enabled: false
 
+Style/RedundantRegexpCharacterClass:
+  Enabled: false
+
+Style/RedundantRegexpEscape:
+  Enabled: true
+
 # Disable nearly all Metrics checks. These seem better off left to judgement.
 
 Metrics/AbcSize:
@@ -119,6 +125,9 @@ Lint/StructNewOverride:
 
 Lint/DeprecatedOpenSSLConstant:
   Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: false
 
 # Enforce LF line endings, even when on Windows
 Layout/EndOfLine:

--- a/bolt-modules/boltlib/spec/functions/run_script_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_script_spec.rb
@@ -165,7 +165,7 @@ describe 'run_script' do
     it 'errors when script appoints a directory' do
       executor.expects(:run_script).never
 
-      is_expected.to run.with_params('test/uploads', []).and_raise_error(%r{.*\/uploads is not a file})
+      is_expected.to run.with_params('test/uploads', []).and_raise_error(%r{.*/uploads is not a file})
     end
   end
 

--- a/spec/bolt/pal/yaml_plan/loader_spec.rb
+++ b/spec/bolt/pal/yaml_plan/loader_spec.rb
@@ -36,7 +36,7 @@ describe Bolt::PAL::YamlPlan::Loader do
 
       expect { described_class.create(loader, plan_name, 'test.yaml', plan_body) }.to raise_error do |error|
         expect(error.to_s).to match(/Parse error in step number 1/)
-        expect(error.to_s).to match(/Error parsing \"command\": Illegal variable name/)
+        expect(error.to_s).to match(/Error parsing "command": Illegal variable name/)
       end
     end
 

--- a/spec/bolt/pal/yaml_plan_spec.rb
+++ b/spec/bolt/pal/yaml_plan_spec.rb
@@ -96,8 +96,8 @@ describe Bolt::PAL::YamlPlan do
 
         expect { plan }.to raise_error do |error|
           expect(error.kind).to eq('bolt/invalid-plan')
-          expect(error.message).to match(/Parse error in step \"foo\"/)
-          expect(error.message).to match(/Duplicate step name or parameter detected: \"foo\"/)
+          expect(error.message).to match(/Parse error in step "foo"/)
+          expect(error.message).to match(/Duplicate step name or parameter detected: "foo"/)
         end
       end
 
@@ -108,7 +108,7 @@ describe Bolt::PAL::YamlPlan do
           'foo' => 'bar'
         }
 
-        expect { plan }.to raise_error(Bolt::Error, /Plan contains illegal key\(s\) \[\"foo\"\]/)
+        expect { plan }.to raise_error(Bolt::Error, /Plan contains illegal key\(s\) \["foo"\]/)
       end
 
       it 'fails if two steps have the same name' do
@@ -123,8 +123,8 @@ describe Bolt::PAL::YamlPlan do
 
         expect { plan }.to raise_error do |error|
           expect(error.kind).to eq('bolt/invalid-plan')
-          expect(error.message).to match(/Parse error in step \"foo\"/)
-          expect(error.message).to match(/Duplicate step name or parameter detected: \"foo\"/)
+          expect(error.message).to match(/Parse error in step "foo"/)
+          expect(error.message).to match(/Duplicate step name or parameter detected: "foo"/)
         end
       end
 
@@ -138,8 +138,8 @@ describe Bolt::PAL::YamlPlan do
 
         expect { plan }.to raise_error do |error|
           expect(error.kind).to eq('bolt/invalid-plan')
-          expect(error.message).to match(/Parse error in step \"foo-bar\"/)
-          expect(error.message).to match(/Invalid step name: \"foo-bar\"/)
+          expect(error.message).to match(/Parse error in step "foo-bar"/)
+          expect(error.message).to match(/Invalid step name: "foo-bar"/)
         end
       end
 
@@ -154,8 +154,8 @@ describe Bolt::PAL::YamlPlan do
 
         expect { plan }.to raise_error do |error|
           expect(error.kind).to eq('bolt/invalid-plan')
-          expect(error.message).to match(/Parse error in step \"foo-bar\"/)
-          expect(error.message).to match(/Multiple action keys detected: \[\"task\", \"eval\"\]/)
+          expect(error.message).to match(/Parse error in step "foo-bar"/)
+          expect(error.message).to match(/Multiple action keys detected: \["task", "eval"\]/)
         end
       end
 
@@ -171,7 +171,7 @@ describe Bolt::PAL::YamlPlan do
         expect { plan }.to raise_error do |error|
           expect(error.kind).to eq('bolt/invalid-plan')
           expect(error.message).to match(/Parse error in step number 1/)
-          expect(error.message).to match(/The \"eval\" step does not support: \[\"bar\"\] key\(s\)/)
+          expect(error.message).to match(/The "eval" step does not support: \["bar"\] key\(s\)/)
         end
       end
 
@@ -186,8 +186,8 @@ describe Bolt::PAL::YamlPlan do
 
         expect { plan }.to raise_error do |error|
           expect(error.kind).to eq('bolt/invalid-plan')
-          expect(error.message).to match(/Parse error in step \"foo\"/)
-          expect(error.message).to match(/The \"task\" step requires: \[\"targets\"\] key\(s\)/)
+          expect(error.message).to match(/Parse error in step "foo"/)
+          expect(error.message).to match(/The "task" step requires: \["targets"\] key\(s\)/)
         end
       end
 

--- a/spec/integration/transport/docker_spec.rb
+++ b/spec/integration/transport/docker_spec.rb
@@ -44,7 +44,7 @@ describe Bolt::Transport::Docker, docker: true do
       # Test fails differently on Windows due to issues in the docker-api gem.
       expect {
         docker.with_connection(inventory.get_target('not_a_target')) {}
-      }.to raise_error(Bolt::Node::ConnectError, /Could not find a container with name or ID matching \'not_a_target\'/)
+      }.to raise_error(Bolt::Node::ConnectError, /Could not find a container with name or ID matching 'not_a_target'/)
     end
   end
 

--- a/spec/integration/transport/winrm_spec.rb
+++ b/spec/integration/transport/winrm_spec.rb
@@ -259,7 +259,7 @@ describe Bolt::Transport::WinRM do
     # verifies the local setup has already acquired the right Kerberos ticket
     it "has acquired a ticket granting ticket from the Samba AD / KDC" do
       esc_realm = Regexp.escape(@kerb_realm)
-      expect(`klist`).to match(%r{krbtgt\/#{esc_realm}@#{esc_realm}})
+      expect(`klist`).to match(%r{krbtgt/#{esc_realm}@#{esc_realm}})
     end
 
     it "executes a command on a host over HTTP" do

--- a/spec/integration/yaml_plan_spec.rb
+++ b/spec/integration/yaml_plan_spec.rb
@@ -130,7 +130,7 @@ describe "running YAML plans", ssh: true do
     result = run_plan('yaml::bad_puppet')
 
     expect(result['kind']).to eq("bolt/invalid-plan")
-    expect(result['msg']).to match(/Parse error in step \"x_fail\":/)
+    expect(result['msg']).to match(/Parse error in step "x_fail":/)
   end
 
   it 'passes information between steps' do


### PR DESCRIPTION
This adds a few new default cops introduced in Rubocop 0.85. The
`Lint/MixedRegexpCaptureTypes` and `Style/RedundantRegexpCharacterClass`
cops are disabled as they appear to be buggy.