### PR TITLE
(GH-1862) Specify preferred  algorithms for SSH transport connections

### DIFF
--- a/documentation/bolt_configuration_reference.md.erb
+++ b/documentation/bolt_configuration_reference.md.erb
@@ -152,6 +152,7 @@ These are the options configurable in OpenSSH files:
 | `HostKeyAlias` | Use alias instead of real hostname when looking up or saving the host key in the host key database file. |
 | `HostName` | Host name to log. |
 | `IdentityFile` | File in which user's identity key is stored. |
+| `MACs` | Message authentication code algorithms that the client wants to use in order of preference. |
 | `Port` | SSH port. |
 | `StrictHostKeyChecking` | Prevents SSH from automatically adding host keys to the known hosts file, and refuses to connect to a host whose host key has changed. |
 | `User` | Login user. |

--- a/lib/bolt/config/transport/ssh.rb
+++ b/lib/bolt/config/transport/ssh.rb
@@ -12,94 +12,132 @@ module Bolt
         # NOTE: All transport configuration options should have a corresponding schema definition
         #       in schemas/bolt-transport-definitions.json
         OPTIONS = {
-          "cleanup"            => { type: TrueClass,
-                                    external: true,
-                                    desc: "Whether to clean up temporary files created on targets." },
-          "connect-timeout"    => { type: Integer,
-                                    desc: "How long to wait when establishing connections." },
-          "copy-command"       => { external: true,
-                                    desc: "Command to use when copying files using ssh-command. "\
-                                          "Bolt runs `<copy-command> <src> <dest>`. **This option is experimental.**" },
-          "disconnect-timeout" => { type: Integer,
-                                    desc: "How long to wait before force-closing a connection." },
-          "host"               => { type: String,
-                                    external: true,
-                                    desc: "Host name." },
-          "host-key-check"     => { type: TrueClass,
-                                    external: true,
-                                    desc: "Whether to perform host key validation when connecting." },
-          "extensions"         => { type: Array,
-                                    desc: "List of file extensions that are accepted for scripts or tasks on Windows. "\
-                                         "Scripts with these file extensions rely on the target's file type "\
-                                         "association to run. For example, if Python is installed on the system, "\
-                                         "a `.py` script runs with `python.exe`. The extensions `.ps1`, `.rb`, and "\
-                                         "`.pp` are always allowed and run via hard-coded executables." },
-          "interpreters"       => { type: Hash,
-                                    external: true,
-                                    desc: "A map of an extension name to the absolute path of an executable, "\
-                                          "enabling you to override the shebang defined in a task executable. The "\
-                                          "extension can optionally be specified with the `.` character (`.py` and "\
-                                          "`py` both map to a task executable `task.py`) and the extension is case "\
-                                          "sensitive. When a target's name is `localhost`, Ruby tasks run with the "\
-                                          "Bolt Ruby interpreter by default." },
-          "load-config"        => { type: TrueClass,
-                                    desc: "Whether to load system SSH configuration." },
-          "login-shell"        => { type: String,
-                                    desc: "Which login shell Bolt should expect on the target. "\
-                                          "Supported shells are #{LOGIN_SHELLS.join(', ')}. "\
-                                          "**This option is experimental.**" },
-          "password"           => { type: String,
-                                    desc: "Login password." },
-          "port"               => { type: Integer,
-                                    external: true,
-                                    desc: "Connection port." },
-          "private-key"        => { external: true,
-                                    desc: "Either the path to the private key file to use for authentication, or a "\
-                                          "hash with the key `key-data` and the contents of the private key." },
-          "proxyjump"          => { type: String,
-                                    desc: "A jump host to proxy connections through, and an optional user to "\
-                                          "connect with." },
-          "run-as"             => { type: String,
-                                    external: true,
-                                    desc: "A different user to run commands as after login." },
-          "run-as-command"     => { type: Array,
-                                    external: true,
-                                    desc: "The command to elevate permissions. Bolt appends the user and command "\
-                                          "strings to the configured `run-as-command` before running it on the "\
-                                          "target. This command must not require an interactive password prompt, "\
-                                          "and the `sudo-password` option is ignored when `run-as-command` is "\
-                                          "specified. The `run-as-command` must be specified as an array." },
-          "script-dir"         => { type: String,
-                                    external: true,
-                                    desc: "The subdirectory of the tmpdir to use in place of a randomized "\
-                                          "subdirectory for uploading and executing temporary files on the "\
-                                          "target. It's expected that this directory already exists as a subdir "\
-                                          "of tmpdir, which is either configured or defaults to `/tmp`." },
-          "ssh-command"        => { external: true,
-                                    desc: "Command and flags to use when SSHing. This enables the external "\
-                                          "SSH transport which shells out to the specified command. "\
-                                          "**This option is experimental.**" },
-          "sudo-executable"    => { type: String,
-                                    external: true,
-                                    desc: "The executable to use when escalating to the configured `run-as` "\
-                                          "user. This is useful when you want to escalate using the configured "\
-                                          "`sudo-password`, since `run-as-command` does not use `sudo-password` "\
-                                          "or support prompting. The command executed on the target is "\
-                                          "`<sudo-executable> -S -u <user> -p custom_bolt_prompt <command>`. "\
-                                          "**This option is experimental.**" },
-          "sudo-password"      => { type: String,
-                                    external: true,
-                                    desc: "Password to use when changing users via `run-as`." },
-          "tmpdir"             => { type: String,
-                                    external: true,
-                                    desc: "The directory to upload and execute temporary files on the target." },
-          "tty"                => { type: TrueClass,
-                                    desc: "Request a pseudo tty for the session. This option is generally "\
-                                          "only used in conjunction with the `run-as` option when the sudoers "\
-                                          "policy requires a `tty`." },
-          "user"               => { type: String,
-                                    external: true,
-                                    desc: "Login user." }
+          "cleanup"               => { type: TrueClass,
+                                       external: true,
+                                       desc: "Whether to clean up temporary files created on targets." },
+          "connect-timeout"       => { type: Integer,
+                                       desc: "How long to wait when establishing connections." },
+          "copy-command"          => { external: true,
+                                       desc: "Command to use when copying files using ssh-command. "\
+                                             "Bolt runs `<copy-command> <src> <dest>`. **This option is "\
+                                             "experimental.**" },
+          "disconnect-timeout"    => { type: Integer,
+                                       desc: "How long to wait before force-closing a connection." },
+          "encryption-algorithms" => { type: Array,
+                                       desc: "List of encryption algorithms to use when establishing a "\
+                                             "connection with a target. Supported algorithms are "\
+                                             "defined by the Ruby net-ssh library and can be viewed "\
+                                             "[here](https://github.com/net-ssh/net-ssh#supported-algorithms). "\
+                                             "All supported, non-deprecated algorithms are available by default when "\
+                                             "this option is not used. To reference all default algorithms "\
+                                             "when using this option, add 'defaults' to the list of supported "\
+                                             "algorithms." },
+          "extensions"            => { type: Array,
+                                       desc: "List of file extensions that are accepted for scripts or tasks on "\
+                                             "Windows. Scripts with these file extensions rely on the target's file "\
+                                             "type association to run. For example, if Python is installed on the "\
+                                             "system, a `.py` script runs with `python.exe`. The extensions `.ps1`, "\
+                                             "`.rb`, and `.pp` are always allowed and run via hard-coded "\
+                                             "executables." },
+          "host"                  => { type: String,
+                                       external: true,
+                                       desc: "Host name." },
+          "host-key-algorithms"   => { type: Array,
+                                       desc: "List of host key algorithms to use when establishing a connection "\
+                                             "with a target. Supported algorithms are defined by the Ruby net-ssh "\
+                                             "library "\
+                                             "([docs](https://github.com/net-ssh/net-ssh#supported-algorithms)). "\
+                                             "All supported, non-deprecated algorithms are available by default when "\
+                                             "this option is not used. To reference all default algorithms "\
+                                             "using this option, add 'defaults' to the list of supported "\
+                                             "algorithms." },
+          "host-key-check"        => { type: TrueClass,
+                                       external: true,
+                                       desc: "Whether to perform host key validation when connecting." },
+          "interpreters"          => { type: Hash,
+                                       external: true,
+                                       desc: "A map of an extension name to the absolute path of an executable, "\
+                                             "enabling you to override the shebang defined in a task executable. "\
+                                             "The extension can optionally be specified with the `.` character "\
+                                             "(`.py` and `py` both map to a task executable `task.py`) and the "\
+                                             "extension is case sensitive. When a target's name is `localhost`, "\
+                                             "Ruby tasks run with the Bolt Ruby interpreter by default." },
+          "kex-algorithms"        => { type: Array,
+                                       desc: "List of key exchange algorithms to use when establishing a "\
+                                             "connection to a target. Supported algorithms are defined by the "\
+                                             "Ruby net-ssh library "\
+                                             "([docs](https://github.com/net-ssh/net-ssh#supported-algorithms)). "\
+                                             "All supported, non-deprecated algorithms are available by default when "\
+                                             "this option is not used. To reference all default algorithms "\
+                                             "using this option, add 'defaults' to the list of supported "\
+                                             "algorithms." },
+          "load-config"           => { type: TrueClass,
+                                       desc: "Whether to load system SSH configuration." },
+          "login-shell"           => { type: String,
+                                       desc: "Which login shell Bolt should expect on the target. "\
+                                             "Supported shells are #{LOGIN_SHELLS.join(', ')}. "\
+                                             "**This option is experimental.**" },
+          "mac-algorithms"        => { type: Array,
+                                       desc: "List of message authentication code algorithms to use when "\
+                                             "establishing a connection to a target. Supported algorithms are "\
+                                             "defined by the Ruby net-ssh library "\
+                                             "([docs](https://github.com/net-ssh/net-ssh#supported-algorithms)). "\
+                                             "All supported, non-deprecated algorithms are available by default when "\
+                                             "this option is not used. To reference all default algorithms "\
+                                             "using this option, add 'defaults' to the list of supported "\
+                                             "algorithms." },
+          "password"              => { type: String,
+                                       desc: "Login password." },
+          "port"                  => { type: Integer,
+                                       external: true,
+                                       desc: "Connection port." },
+          "private-key"           => { external: true,
+                                       desc: "Either the path to the private key file to use for authentication, or "\
+                                             "a hash with the key `key-data` and the contents of the private key." },
+          "proxyjump"             => { type: String,
+                                       desc: "A jump host to proxy connections through, and an optional user to "\
+                                             "connect with." },
+          "run-as"                => { type: String,
+                                       external: true,
+                                       desc: "A different user to run commands as after login." },
+          "run-as-command"        => { type: Array,
+                                       external: true,
+                                       desc: "The command to elevate permissions. Bolt appends the user and command "\
+                                             "strings to the configured `run-as-command` before running it on the "\
+                                             "target. This command must not require an interactive password prompt, "\
+                                             "and the `sudo-password` option is ignored when `run-as-command` is "\
+                                             "specified. The `run-as-command` must be specified as an array." },
+          "script-dir"            => { type: String,
+                                       external: true,
+                                       desc: "The subdirectory of the tmpdir to use in place of a randomized "\
+                                             "subdirectory for uploading and executing temporary files on the "\
+                                             "target. It's expected that this directory already exists as a subdir "\
+                                             "of tmpdir, which is either configured or defaults to `/tmp`." },
+          "ssh-command"           => { external: true,
+                                       desc: "Command and flags to use when SSHing. This enables the external "\
+                                             "SSH transport which shells out to the specified command. "\
+                                             "**This option is experimental.**" },
+          "sudo-executable"       => { type: String,
+                                       external: true,
+                                       desc: "The executable to use when escalating to the configured `run-as` "\
+                                             "user. This is useful when you want to escalate using the configured "\
+                                             "`sudo-password`, since `run-as-command` does not use `sudo-password` "\
+                                             "or support prompting. The command executed on the target is "\
+                                             "`<sudo-executable> -S -u <user> -p custom_bolt_prompt <command>`. "\
+                                             "**This option is experimental.**" },
+          "sudo-password"         => { type: String,
+                                       external: true,
+                                       desc: "Password to use when changing users via `run-as`." },
+          "tmpdir"                => { type: String,
+                                       external: true,
+                                       desc: "The directory to upload and execute temporary files on the target." },
+          "tty"                   => { type: TrueClass,
+                                       desc: "Request a pseudo tty for the session. This option is generally "\
+                                             "only used in conjunction with the `run-as` option when the sudoers "\
+                                             "policy requires a `tty`." },
+          "user"                  => { type: String,
+                                       external: true,
+                                       desc: "Login user." }
         }.freeze
 
         DEFAULTS = {
@@ -142,10 +180,11 @@ module Bolt
                   "Unsupported login-shell #{@config['login-shell']}. Supported shells are #{LOGIN_SHELLS.join(', ')}"
           end
 
-          if (run_as_cmd = @config['run-as-command'])
-            unless run_as_cmd.all? { |n| n.is_a?(String) }
+          %w[encryption-algorithms host-key-algorithms kex-algorithms mac-algorithms run-as-command].each do |opt|
+            next unless @config.key?(opt)
+            unless @config[opt].all? { |n| n.is_a?(String) }
               raise Bolt::ValidationError,
-                    "run-as-command must be an Array of Strings, received #{run_as_cmd.class} #{run_as_cmd.inspect}"
+                    "#{opt} must be an Array of Strings, received #{@config[opt].inspect}"
             end
           end
 

--- a/schemas/bolt-transport-definitions.json
+++ b/schemas/bolt-transport-definitions.json
@@ -49,29 +49,33 @@
     "description": "Configuration for the ssh transport.",
     "type": "object",
     "properties": {
-      "cleanup":            { "$ref": "#/definitions/cleanup" },
-      "connect-timeout":    { "$ref": "#/definitions/connect-timeout" },
-      "copy-command":       { "$ref": "#/definitions/copy-command" },
-      "disconnect-timeout": { "$ref": "#/definitions/disconnect-timeout" },
-      "host":               { "$ref": "#/definitions/host" },
-      "host-key-check":     { "$ref": "#/definitions/host-key-check" },
-      "extensions":         { "$ref": "#/definitions/extensions" },
-      "interpreters":       { "$ref": "#/definitions/interpreters" },
-      "load-config":        { "$ref": "#/definitions/load-config" },
-      "login-shell":        { "$ref": "#/definitions/login-shell" },
-      "password":           { "$ref": "#/definitions/password" },
-      "port":               { "$ref": "#/definitions/port" },
-      "private-key":        { "$ref": "#/definitions/private-key" },
-      "proxyjump":          { "$ref": "#/definitions/proxyjump" },
-      "run-as":             { "$ref": "#/definitions/run-as" },
-      "run-as-command":     { "$ref": "#/definitions/run-as-command" },
-      "script-dir":         { "$ref": "#/definitions/script-dir" },
-      "ssh-command":        { "$ref": "#/definitions/ssh-command" },
-      "sudo-executable":    { "$ref": "#/definitions/sudo-executable" },
-      "sudo-password":      { "$ref": "#/definitions/sudo-password" },
-      "tmpdir":             { "$ref": "#/definitions/tmpdir" },
-      "tty":                { "$ref": "#/definitions/tty" },
-      "user":               { "$ref": "#/definitions/user" }
+      "cleanup":               { "$ref": "#/definitions/cleanup" },
+      "connect-timeout":       { "$ref": "#/definitions/connect-timeout" },
+      "copy-command":          { "$ref": "#/definitions/copy-command" },
+      "disconnect-timeout":    { "$ref": "#/definitions/disconnect-timeout" },
+      "encryption-algorithms": { "$ref": "#/definitions/encryption-algorithms" },
+      "host":                  { "$ref": "#/definitions/host" },
+      "host-key-algorithms":   { "$ref": "#/definitions/host-key-algorithms" },
+      "host-key-check":        { "$ref": "#/definitions/host-key-check" },
+      "extensions":            { "$ref": "#/definitions/extensions" },
+      "interpreters":          { "$ref": "#/definitions/interpreters" },
+      "kex-algorithms":        { "$ref": "#/definitions/kex-algorithms" },
+      "load-config":           { "$ref": "#/definitions/load-config" },
+      "login-shell":           { "$ref": "#/definitions/login-shell" },
+      "mac-algorithms":        { "$ref": "#/definitions/mac-algorithms" },
+      "password":              { "$ref": "#/definitions/password" },
+      "port":                  { "$ref": "#/definitions/port" },
+      "private-key":           { "$ref": "#/definitions/private-key" },
+      "proxyjump":             { "$ref": "#/definitions/proxyjump" },
+      "run-as":                { "$ref": "#/definitions/run-as" },
+      "run-as-command":        { "$ref": "#/definitions/run-as-command" },
+      "script-dir":            { "$ref": "#/definitions/script-dir" },
+      "ssh-command":           { "$ref": "#/definitions/ssh-command" },
+      "sudo-executable":       { "$ref": "#/definitions/sudo-executable" },
+      "sudo-password":         { "$ref": "#/definitions/sudo-password" },
+      "tmpdir":                { "$ref": "#/definitions/tmpdir" },
+      "tty":                   { "$ref": "#/definitions/tty" },
+      "user":                  { "$ref": "#/definitions/user" }
     }
   },
   "winrm": {
@@ -115,11 +119,17 @@
       "description": "Array of command and flags to use when copying files using ssh-command. Bolt runs `<copy-command> <src> <dest>`.",
       "type": ["array", "string"]
     },
-
     "disconnect-timeout": {
       "description": "How long to wait in seconds before force-closing a connection.",
       "type": "integer",
       "min": 1
+    },
+    "encryption-algorithms": {
+      "description": "List of encryption algorithms to use when establishing a connection with a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed at https://github.com/net-ssh/net-ssh#supported-algorithms . All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms when using this option, add 'defaults' to the list of supported algorithms.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "cleanup": {
       "description": "Whether to clean up temporary files created on targets.",
@@ -141,6 +151,13 @@
     "host": {
       "description": "The host's name.",
       "type": "string"
+    },
+    "host-key-algorithms": {
+      "description": "List of host key algorithms to use when establishing a connection with a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed at https://github.com/net-ssh/net-ssh#supported-algorithms . All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms when using this option, add 'defaults' to the list of supported algorithms.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "host-key-check": {
       "description": "Whether to perform host key validation when connecting.",
@@ -166,6 +183,13 @@
       "type": "integer",
       "min": 1
     },
+    "kex-algorithms": {
+      "description": "List of key exchange algorithms to use when establishing a connection with a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed at https://github.com/net-ssh/net-ssh#supported-algorithms . All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms when using this option, add 'defaults' to the list of supported algorithms.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "load-config": {
       "description": "Whether to load system SSH configuration.",
       "type": "boolean"
@@ -174,6 +198,13 @@
       "description": "Which login shell Bolt should expect on the target.",
       "type": "string",
       "enum": ["sh", "bash", "zsh", "dash", "ksh", "powershell"]
+    },
+    "mac-algorithms": {
+      "description": "List of message authentication code algorithms to use when establishing a connection with a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed at https://github.com/net-ssh/net-ssh#supported-algorithms . All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms when using this option, add 'defaults' to the list of supported algorithms.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "password": {
       "description": "Login password.",

--- a/spec/bolt/config/transport/ssh_spec.rb
+++ b/spec/bolt/config/transport/ssh_spec.rb
@@ -44,6 +44,18 @@ describe Bolt::Config::Transport::SSH do
       end
     end
 
+    %w[encryption-algorithms host-key-algorithms kex-algorithms mac-algorithms].each do |opt|
+      it "#{opt} errors with wrong type" do
+        data[opt] = 'foo'
+        expect { transport.new(data) }.to raise_error(Bolt::ValidationError)
+      end
+
+      it "#{opt} errors with wrong array element type" do
+        data[opt] = ['foo', 3]
+        expect { transport.new(data) }.to raise_error(Bolt::ValidationError)
+      end
+    end
+
     context 'private-key' do
       it 'errors with wrong type' do
         data['private-key'] = ['/path/to/key']

--- a/spec/bolt/transport/ssh/connection_spec.rb
+++ b/spec/bolt/transport/ssh/connection_spec.rb
@@ -48,6 +48,86 @@ describe Bolt::Transport::SSH::Connection do
       allow_any_instance_of(described_class).to receive(:validate_ssh_version)
     end
 
+    it "passes filtered encryption algorithms" do
+      inventory.set_config(target, 'ssh', 'encryption-algorithms' => %w[aes256-ctr fake])
+
+      allow(Net::SSH).to receive(:start) do |_, _, options|
+        expect(options[:encryption]).to match_array(['aes256-ctr'])
+      end
+
+      subject.connect
+    end
+
+    it "expands default encryption algorithms" do
+      inventory.set_config(target, 'ssh', 'encryption-algorithms' => ['defaults'])
+
+      allow(Net::SSH).to receive(:start) do |_, _, options|
+        expect(options[:encryption]).to match_array(Net::SSH::Transport::Algorithms::DEFAULT_ALGORITHMS[:encryption])
+      end
+
+      subject.connect
+    end
+
+    it "passes filtered host_key algorithms" do
+      inventory.set_config(target, 'ssh', 'host-key-algorithms' => %w[ssh-rsa fake])
+
+      allow(Net::SSH).to receive(:start) do |_, _, options|
+        expect(options[:host_key]).to match_array(['ssh-rsa'])
+      end
+
+      subject.connect
+    end
+
+    it "expands default host_key algorithms" do
+      inventory.set_config(target, 'ssh', 'host-key-algorithms' => ['defaults'])
+
+      allow(Net::SSH).to receive(:start) do |_, _, options|
+        expect(options[:host_key]).to match_array(Net::SSH::Transport::Algorithms::DEFAULT_ALGORITHMS[:host_key])
+      end
+
+      subject.connect
+    end
+
+    it "passes filtered kex algorithms" do
+      inventory.set_config(target, 'ssh', 'kex-algorithms' => %w[diffie-hellman-group14-sha1 fake])
+
+      allow(Net::SSH).to receive(:start) do |_, _, options|
+        expect(options[:kex]).to match_array(['diffie-hellman-group14-sha1'])
+      end
+
+      subject.connect
+    end
+
+    it "expands default kex algorithms" do
+      inventory.set_config(target, 'ssh', 'kex-algorithms' => ['defaults'])
+
+      allow(Net::SSH).to receive(:start) do |_, _, options|
+        expect(options[:kex]).to match_array(Net::SSH::Transport::Algorithms::DEFAULT_ALGORITHMS[:kex])
+      end
+
+      subject.connect
+    end
+
+    it "passes filtered mac algorithms" do
+      inventory.set_config(target, 'ssh', 'mac-algorithms' => %w[hmac-sha1 fake])
+
+      allow(Net::SSH).to receive(:start) do |_, _, options|
+        expect(options[:hmac]).to match_array(['hmac-sha1'])
+      end
+
+      subject.connect
+    end
+
+    it "expands default mac algorithms" do
+      inventory.set_config(target, 'ssh', 'mac-algorithms' => ['defaults'])
+
+      allow(Net::SSH).to receive(:start) do |_, _, options|
+        expect(options[:hmac]).to match_array(Net::SSH::Transport::Algorithms::DEFAULT_ALGORITHMS[:hmac])
+      end
+
+      subject.connect
+    end
+
     it "passes proxyjump options" do
       inventory.set_config(target, 'ssh', 'proxyjump' => 'jump.example.com')
 


### PR DESCRIPTION
This adds the following SSH transport configuration options:

- `encryption-algorithms`
- `host-key-algorithms`
- `kex-algorithms`
- `mac-algorithms`

Each of these options accepts an array of preferred algorithms to use when
establishing a connection using the SSH transport. When a `*-algorithms`
option is set, `net-ssh` is configured to only attempt to establish a
connection to the target using algorithms in the list.

Each `*-algorithms` option accepts a special `defaults` item, which will
automatically add all of default, supported algorithms for `net-ssh` to
the list. For example, the following config:

```yaml
ssh:
  encryption-algorithms:
    - defaults
```

Would expand to the following:

```yaml
ssh:
  encryption-algorithms:
    - aes-256-ctr
    - aes-192-ctr
    - aes-128-ctr
```

Starting with the release of `net-ssh` 6.0, several algorithms were
deprecated and disabled by default. This prevented users from using
these algorithms when establishing connections with targets. These
options allow users to enable these deprecated algorithms.

!feature

* **Specify preferred algorithms for SSH transport connections**
  ([#1862](https://github.com/puppetlabs/bolt/issues/1862))

  Users can now specify a list of preferred algorithms to use when
  establishing connections with targets using the SSH transport with the
  `encryption-algorithms`, `host-key-algorithms`, `kex-algorithms`, and
  `mac-algorithms` config options. Each option accepts an array of
  algorithms and overrides the default list of preferred algorithms.
  You can read more about these options in the [Bolt configuration
  reference](https://puppet.com/docs/bolt/latest/bolt_configuration_reference.html#ssh).