### PR TITLE
Do not check if unrecognized plan parameters are sensitive

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -187,7 +187,11 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
     params.each_with_object({}) do |(name, value), acc|
       model = models[name]
 
-      if sensitive_type?(model.type_expr)
+      # Parameters passed to a plan that the plan is not expecting don't have a model,
+      # so keep the parameter as-is.
+      if model.nil?
+        acc[name] = value
+      elsif sensitive_type?(model.type_expr)
         acc[name] = Puppet::Pops::Types::PSensitiveType::Sensitive.new(value)
       else
         if model.type_expr.to_s.include?('Sensitive')


### PR DESCRIPTION
This updates the `run_plan` function to not check if a plan parameter
has a `Sensitive` type if the parameter is not recognized by the plan.
Previously, if a parameter was passed to a plan that the plan was not
expecting, the `run_plan` function would attempt to check the
parameter's type expression to determine whether it should be wrapped as
`Sensitive`. Since the parameter is unrecognized, it would raise an
error when attempting to access its type expression.

!bug

* **Raise correct error when passing unknown plan parameters** (#1886)

  Bolt was raising an obscure error when a plan received an unknown
  parameter. It now raises the correct error indicating that the
  parameter is unknown.