### PR TITLE
(GH-1846) Exit with correct exit code when running on Windows with local transport

### DIFF
--- a/lib/bolt/shell/powershell/snippets.rb
+++ b/lib/bolt/shell/powershell/snippets.rb
@@ -20,6 +20,14 @@ module Bolt
             PS
           end
 
+          def exit_with_code(command)
+            <<~PS
+            #{command}
+            if (-not $? -and ($LASTEXITCODE -eq $null)) { exit 1 }
+            exit $LASTEXITCODE
+            PS
+          end
+
           def make_tmpdir(parent)
             <<~PS
             $parent = #{parent}

--- a/lib/bolt/transport/local/connection.rb
+++ b/lib/bolt/transport/local/connection.rb
@@ -50,7 +50,8 @@ module Bolt
             # If it's already a powershell command then invoke it normally.
             # Otherwise, wrap it in powershell.exe.
             unless command.start_with?('powershell.exe')
-              command = ['powershell.exe', *Bolt::Shell::Powershell::PS_ARGS, '-Command', command]
+              cmd = Bolt::Shell::Powershell::Snippets.exit_with_code(command)
+              command = ['powershell.exe', *Bolt::Shell::Powershell::PS_ARGS, '-Command', cmd]
             end
           end
 

--- a/spec/integration/local_spec.rb
+++ b/spec/integration/local_spec.rb
@@ -33,6 +33,13 @@ describe "when running over the local transport" do
       expect(result[0]['_error']).to be
     end
 
+    it 'returns correct exit code', :reset_puppet_settings do
+      cmd = 'puppet apply --trace --detailed-exitcodes -e "notify {foo:}"'
+      result = run_failed_nodes(%W[command run #{cmd} -t #{uri}]).first
+      expect(result['_error']['msg']).to eq('The command failed with exit code 2')
+      expect(result['_error']['details']['exit_code']).to eq(2)
+    end
+
     it 'runs a ruby task using bolt ruby', :reset_puppet_settings do
       result = run_one_node(%w[task run sample::bolt_ruby message=somemessage] + config_flags)
       expect(result['env']).to match(/somemessage/)


### PR DESCRIPTION
Powershell will [exit
1](PowerShell/PowerShell#11461) whenever the $LASTEXITCODE is greater
than 0, regardless of what the code is, whenever running a bare command.
Powershell exits with the correct exit code when executing files, or
when `exit $LASTEXITCODE` is appended to the command being run (as in
the [execute_process
snippet](https://github.com/puppetlabs/bolt/blob/0d44ce739d4dafcb6d27abd894e230894fdd50e0/lib/bolt/shell/powershell/snippets.rb#L19),
meaning this is only an issue when running commands through Bolt, and
not tasks or scripts. This appends a Powershell snippet to exit with
the correct exit code to commands running on Windows using the local
transport.

Closes #1846

!bug

* **Return correct exit code when running commands in powershell** ([1846](#1846))

  Bolt will now display the correct exit code when running commands in
  powershell that exit with code > 1.
