### PR TITLE
(GH-1880) Raise error for empty apply block 

### DIFF
--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -146,6 +146,7 @@ module Bolt
 
     def apply(args, apply_body, scope)
       raise(ArgumentError, 'apply requires a TargetSpec') if args.empty?
+      raise(ArgumentError, 'apply requires at least one statement in the apply block') if apply_body.nil?
       type0 = Puppet.lookup(:pal_script_compiler).type('TargetSpec')
       Puppet::Pal.assert_type(type0, args[0], 'apply targets')
 

--- a/lib/bolt/catalog.rb
+++ b/lib/bolt/catalog.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
+require 'bolt/apply_inventory'
 require 'bolt/apply_target'
 require 'bolt/config'
 require 'bolt/error'
 require 'bolt/inventory'
-require 'bolt/apply_inventory'
 require 'bolt/pal'
 require 'bolt/puppetdb'
 require 'bolt/util'

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -62,6 +62,11 @@ describe Bolt::Applicator do
     expect(applicator).to be
   end
 
+  it 'errors with an empty catalog' do
+    expect { applicator.apply([target], nil, nil) }
+      .to raise_error(ArgumentError, /apply requires at least one statement/)
+  end
+
   it 'passes catalog input' do
     expect(Open3).to receive(:capture3)
       .with('ruby', /bolt_catalog/, 'compile', stdin_data: input.merge(target_hash).to_json)


### PR DESCRIPTION
There's a [PR](puppetlabs/puppet#8193) to Puppet
to handle empty apply statements correctly. Until that's in, an empty
apply block will be considered unacceptable and an error will be raised,
since there's no use cases for empty apply blocks.

Closes #1880

!bug

* **Empty apply blocks now error correctly** ([#1880](#1880))

  This raises an appropriate error when an apply block is empty, instead
  of an undefined method error.