### PR TITLE
(GH-1881) Log STDERR when STDOUT from bolt_catalog is not JSON

### DIFF
--- a/spec/fixtures/apply/basic/lib/puppet/functions/load_error.rb
+++ b/spec/fixtures/apply/basic/lib/puppet/functions/load_error.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# This should raise a LoadError, as it's not a real gem
+require 'fake'
+
+Puppet::Functions.create_function(:load_error) do
+  def load_error
+    puts 'error'
+  end
+end


### PR DESCRIPTION
When compiling Bolt apply catalogs we only log the error message if the
error is a Puppet error or a ruby StandardError. If an error is raised
that isn't either of those types, it fails silently, and as there's
often not anything on stdout all that's raised is a JSON parse error.

Now, if the STDOUT of `bolt_catalog` is not valid JSON we log whatever
is on STDERR and include a helpful message for the ApplyError. This
should account for any case where `bolt_catalog` wasn't successful and
so didn't print JSON to STDOUT, and ensures we only print STDERR when
it's useful and not redundant with other error messages.

Closes #1881

!bug

* **Log error for unhandled catalog compilation errors** ([#1881](https://github.com/puppetlabs/bolt/issues/1881))

  We now log whatever is on STDERR when catalog compilation fails in a
  way that isn't already handled, and raise an ApplyError.