### PR TITLE
(GH-733) Document connecting with configuration not supported by net-ssh

### DIFF
--- a/documentation/bolt_known_issues.md
+++ b/documentation/bolt_known_issues.md
@@ -20,27 +20,6 @@ created with the `ConvertTo-Json` cmdlet) might require additional escaping. In
 some cases, you can use the PowerShell stop parsing symbol `--%` as a
 workaround. ([BOLT-1130](https://tickets.puppetlabs.com/browse/BOLT-1130))
 
-## SSH keys generated with ssh-keygen from OpenSSH 7.8+ fail
-
-OpenSSH 7.8 switched to generating private keys with its own format rather than
-the OpenSSL PEM format. The Bolt SSH implementation assumes any key using the
-OpenSSH format uses ed25519, resulting in false errors such as:
-
-```
- OpenSSH keys only supported if ED25519 is available net-ssh requires the following gems for ed25519 support: * ed25519 (>= 1.2, < 2.0) * bcrypt_pbkdf (>= 1.0, < 2.0) See https://github.com/net-ssh/net-ssh/issues/565 for more information Gem::LoadError : "ed25519 is not part of the bundle. Add it to your Gemfile."
-```
-
-or
-
-```
-Failed to connect to HOST: expected 64-byte String, got NUM
-```
-
-As a workaround, you can generate new keys with the ssh-keygen `-m PEM` flag.
-For existing keys, you can try exporting keys from the OpenSSH format using the
-`-e` option, although export is not implemented for all private key types.
-([BOLT-920](https://tickets.puppetlabs.com/browse/BOLT-920))
-
 ## Commands fail in remote Windows sessions
 
 Interactive tools fail when run in a remote PowerShell session. For example,

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -399,3 +399,40 @@ ssh:
   ssh-command: 'ssh'
   copy-command: 'scp -r -F ~/ssh-config/myconf'
 ```
+
+### Connecting with SSH configuration not supported by net-ssh
+
+You can use the external SSH transport to connect to targets using configuration that isn't
+supported by the Ruby net-ssh library, for example the encryption algorithm
+chacha20-poly1305@openssh.com. This example uses chacha20-poly1305@openssh.com to encrypt SSH
+connections:
+
+```
+# inventory.yaml
+config:
+  ssh:
+    ssh-command:
+      - 'ssh'
+      - '-o Ciphers=chacha20-poly1305@openssh.com'
+```
+
+You can also store this config in your SSH config at `~/.ssh/config` as:
+
+```
+Ciphers+=chacha20-poly1305@openssh.com
+```
+
+then configure Bolt to use the SSH shell command
+```
+# inventory.yaml
+config:
+  ssh:
+    ssh-command: 'ssh'
+```
+and it will pick up that config.
+
+> **Note**: While some OpenSSH config options are supported in net-ssh, such as Ciphers, the specific
+> algorithms you want to use may not be supported and you will still need to use the `ssh-command`
+> option to shell out to SSH. See [the net-ssh
+> README](https://github.com/net-ssh/net-ssh/#supported-algorithms) for a list of supported
+> algorithms.


### PR DESCRIPTION
This adds a section to the experimental features page under external SSH
about how to use the external SSH configuration option to enable SSH
configuration that isn't supported by the Ruby net-ssh library. It
includes an example of both defining the command to include the
configuration, and an example with configuration defined in
`~/.ssh/config`. It also removes the OpenSSH 7.8 key format known issue,
as it is no longer an issue since we ship Bolt with the gems to support
the new format.

Closes #733

!no-release-note