### PR TITLE
(GH-1845) Add `bolt-defaults.yaml` configuration file

### DIFF
--- a/documentation/bolt.ditamap
+++ b/documentation/bolt.ditamap
@@ -75,5 +75,7 @@
         <topicref href="plan_functions.md" format="markdown"/>
         <topicref href="bolt_types_reference.md" format="markdown" />
         <topicref href="bolt_configuration_reference.md" format="markdown"/>
+        <topicref href="bolt_defaults_reference.md" format="markdown"/>
+        <topicref href="bolt_transports_reference.md" format="markdown"/>
     </topichead>
 </map>

--- a/documentation/bolt_configuration_reference.md.erb
+++ b/documentation/bolt_configuration_reference.md.erb
@@ -130,12 +130,6 @@ The `puppetfile` section of the configuration file configures how to retrieve mo
 Transport configuration options can be set in the inventory file. Options at
 the inventory's top level will apply to all targets.
 
-### The transport option
-
-<% @transport_option[:options].each do |option, desc| -%>
-| `<%= option %>` | <%= desc %> | <%= @transport_option[:defaults][option].to_s %> |
-<% end %>
-
 <% @transports[:options].each do |transport, options| %>
 ### <%= transport %>
 

--- a/documentation/bolt_defaults_reference.md.erb
+++ b/documentation/bolt_defaults_reference.md.erb
@@ -1,0 +1,88 @@
+# `bolt-defaults.yaml` options
+
+This page lists the configuration options that are available in the `bolt-defaults.yaml` configuration file,
+which is supported in both the [system-wide and user-level configuration directories](configuring_bolt.md).
+
+<% @opts[:options].each do |option, desc| -%>
+## `<%= option %>`
+
+<%= desc %>
+
+<% if @opts[:defaults][option] -%>
+- **Default:** <%= @opts[:defaults][option] %>
+<% end -%>
+
+<% if @opts[:suboptions][option] -%>
+### Options
+
+This option accepts a map of additional options.
+
+<% if option == 'inventory-config' %>
+<% @opts[:suboptions][option].each do |option, _| -%>
+- `<%= option %>`
+<% end -%>
+
+A detailed description of each option, their default values, and any available sub-options
+can be viewed in [Transport configuration reference](bolt_transports_reference.md).
+<% else %>
+<% @opts[:suboptions][option].each do |option, desc| -%>
+#### `<%= option %>`
+
+<%= desc %>
+<% if @transports.include?(option) -%>
+This option accepts a map of additional options. You can view the available options in [Transport configuration reference](bolt_transports_reference.md#<%= option %>).
+<% end %>
+
+<% if @opts[:defaults][option] -%>
+- **Default:** <%= @opts[:defaults][option] %>
+<% end %>
+<% end -%>
+<% end %>
+<% end -%>
+<% end -%>
+
+## Example file
+
+```yaml
+color: true
+compile-concurrency: 5
+concurrency: 50
+format: human
+inventory-config:
+  transport: winrm
+  docker:
+    service-url: https://docker-host.example.com
+    shell-command: bash -lc
+  local:
+    cleanup: false
+    tmpdir: /tmp/bolt
+  pcp:
+    job-poll-interval: 30
+    job-poll-timeout: 60
+  remote:
+    run-on: proxy_target
+  ssh:
+    user: bolt
+    password: hunter2!
+  winrm:
+    user: bolt
+    password: hunter2!
+plugin_hooks:
+  puppet_library:
+    plugin: puppet_agent
+    stop_service: true
+plugins:
+  pkcs7:
+    private_key: ~/.ssh/my_key.pem
+    public_key: ~/.ssh/my_key.pub
+puppetdb:
+  server_urls: ["https://puppet.example.com:8081"]
+  cacert: /etc/puppetlabs/puppet/ssl/certs/ca.pem
+  token: ~/.puppetlabs/token
+puppetfile:
+  forge:
+    proxy: https://forge-proxy.org.com
+    baseurl: https://forge.org.com
+  proxy: https://forge-proxy.org.com
+save-rerun: true
+```

--- a/documentation/bolt_transports_reference.md.erb
+++ b/documentation/bolt_transports_reference.md.erb
@@ -1,0 +1,34 @@
+# Transport configuration options
+
+This page lists the configuration options that are available to each transport used by Bolt to connect
+to targets. These options can be set in multiple locations:
+
+- Under a `config` key in an [inventory file](inventory_file_v2.md).
+- As top-level keys in a `bolt.yaml` file.
+- Under the `inventory-config` key in a [`bolt-defaults.yaml` file](bolt_defaults_reference.md).
+
+<% @opts[:options].each do |option, desc| -%>
+## `<%= option %>`
+
+<%= desc %>
+
+<% if @transports[:options].key?(option) -%>
+<% @transports[:options][option].each do |t_option, data| -%>
+### `<%= t_option %>`
+
+<%= data[:desc] %>
+
+<% if data[:type] -%>
+- **Type:** <%= data[:type] == TrueClass ? 'Boolean' : data[:type] %>
+<% end -%>
+<% if @transports[:defaults][option][t_option] -%>
+- **Default:** <%= @transports[:defaults][option][t_option] %>
+<% end -%>
+<% if option == 'ssh' -%>
+- **External SSH Support:** <%= data[:external] ? 'Yes' : 'No' %>
+<% end %>
+<% end %>
+<% elsif @opts[:defaults].key?(option) -%>
+- **Default:** <%= @opts[:defaults][option] %>
+<% end %>
+<% end %>

--- a/documentation/configuring_bolt.md
+++ b/documentation/configuring_bolt.md
@@ -1,59 +1,190 @@
 # Configuring Bolt
 
 You can configure Bolt's options and features at a project level, a user level,
-or a system-wide level. 
+or a system-wide level. Unless your use case requires setting user-specific or
+system-wide configurations, configure Bolt at the project level. 
 
-Some options and features you can configure include:
-- global options
-- transports 
-- plugins
-- PuppetDB connections
-- log files 
+## Project-level configuration
 
-For a complete list of Bolt settings, see the [configuration
-reference](bolt_configuration_reference.md).
+Most of the time, you'll only need to set configuration at the project level. 
+You can set all configurable options in Bolt at the project level, and any options
+you set within a project only apply to that project. 
 
-## Configuration files
+Bolt loads project-level configuration files from the root of your [Bolt project
+directory](bolt_project_directories.md). If it can't find a project directory,
+Bolt uses the default project directory: `~/.puppetlabs/bolt/`.
 
-To configure Bolt, create a Bolt configuration file named `bolt.yaml` in one of
-the locations listed below. If a configuration file is not located at the
-expected path, or the file is empty, Bolt does not load the file. 
+You can set project-level configuration in three files: 
+- For Bolt configuration, use `bolt-project.yaml`.
+- For inventory configuration, use `inventory.yaml`.
+- You can set all configuration in a `bolt.yaml` file at the root of your
+  project directory. **The project-level `bolt.yaml` file is on the path towards
+  deprecation and will be removed in a future version of Bolt.** Use
+  `bolt-project.yaml` and `inventory.yaml` files instead.
 
-You can place `bolt.yaml` configuration files at the following paths, from
-highest precedence to lowest:
+The preferred method for setting project-level configuration is to use a
+combination of `bolt-project.yaml` and `inventory.yaml` files. This maintains
+a clear distinction between Bolt configuration and inventory configuration.
 
-- **Project**
+### `bolt-project.yaml`
 
-  The `bolt.yaml` file in a project directory applies settings to that project
-  specifically. Matching settings at the project level override those at the
-  user and system-wide levels.
+> **Note:** The `bolt-project.yaml` file is experimental and is subject to
+> change. You can read more about Bolt projects in [Experimental
+> features](experimental_features.md).
 
-  `Boltdir/bolt.yaml` or `<MY_PROJECT_NAME>/bolt.yaml`
+**Filepath:** `<project-directory>/bolt-project.yaml`
 
-  > **Note:** The project configuration file is loaded from the [Bolt project
-  > directory](bolt_project_directories.md). The default project directory is
-  > `~/.puppetlabs/bolt/`.
+The project configuration file supports options that configure how Bolt behaves,
+such as how many threads it can use when running commands on targets. You can
+also use `bolt-project.yaml` to configure different components of the project,
+such as a list of plans and tasks that are visible to the user. Any directory
+containing a `bolt-project.yaml` file is automatically considered a [Project
+directory](bolt_project_directories.md).
 
-- **User**
+Project configuration files take precedence over `bolt.yaml` files. If a
+project directory contains both files, Bolt will only load and read
+configuration from `bolt-project.yaml`.
 
-  The `bolt.yaml` file at the user level applies settings only to that user.
-  Matching settings at the user level are overridden by project-level settings,
-  but take precedence over system-wide settings.  
+You can view a full list of the available options in [Bolt configuration
+options](bolt_configuration_reference.md).
 
-  `~/.puppetlabs/etc/bolt/bolt.yaml`
+### `inventory.yaml`
 
-- **System-wide**
+**Filepath:** `<project-directory>/inventory.yaml`
 
-  Settings in a system-wide config file apply to all users running Bolt,
-  regardless of the Bolt project directory. However, matching settings at the
-  project or user level override system-wide settings.
+The inventory file is a structured data file that contains groups of targets
+that you can run Bolt commands on, as well as configuration for the transports
+used to connect to the targets. Most projects will include an inventory file.
 
-  The `bolt.yaml` file at the system-wide level applies settings only to that
-  user.
+Inventory configuration can be set at multiple levels in an inventory file
+under a `config` option. You can set the following options under `config`:
 
-  \*nix: `/etc/puppetlabs/bolt/bolt.yaml`
+- `transport`
+- `docker`
+- `local`
+- `pcp`
+- `remote`
+- `ssh`
+- `winrm`
 
-  Windows: `%PROGRAMDATA%\PuppetLabs\bolt\etc\bolt.yaml`
+You can read more about inventory files and the available options in
+[Inventory files](inventory_file_v2.md).
+
+### `bolt.yaml`
+
+> **Note:** The project-level `bolt.yaml` file is on the path towards
+> deprecation and will be removed in a future version of Bolt. Use
+> `bolt-project.yaml` and `inventory.yaml` files instead.
+
+**Filepath:** `<project-directory>/bolt.yaml`
+
+The Bolt configuration file can be used to set all available configuration
+options, including default inventory configuration options. Any directory
+containing a `bolt.yaml` file is automatically considered a [Project
+directory](bolt_project_directories.md).
+
+You can view a full list of the available options in [Bolt configuration
+options](bolt_configuration_reference.md).
+
+## User-level configuration
+
+Use this level to set configuration that should apply to all projects for a
+particular user. Options that you might set at the user-level include paths to
+private keys, credentials for a plugin,
+or default inventory configuration that is common to all of your projects.
+You can set most configurable options in Bolt at the user level. 
+
+
+You can set user-level configuration in two files:
+- Use `bolt-defaults.yaml` for configuration that is
+not project-specific.
+- You can set all configuration in a `bolt.yaml` file. **The user-level `bolt.yaml` file is on the path towards
+  deprecation and will be removed in a future version of Bolt. Use
+  `bolt-defaults.yaml` instead.**
+
+The preferred method for setting user-level configuration is to use a
+`bolt-defaults.yaml` file. This file does not allow you to set project-specific
+configuration, such as the path to an inventory file, and is less likely
+to lead to errors where Bolt loads content from another project.
+
+### `bolt-defaults.yaml`
+
+**Filepath:** `~/.puppetlabs/etc/bolt/bolt-defaults.yaml`
+
+The defaults configuration file supports most of Bolt's configuration options,
+with the exception of options that are project-specific such as `inventoryfile`
+and `modulepath`.
+
+The `bolt-defaults.yaml` file takes precedence over a `bolt.yaml` file in the
+same directory. If the directory contains both files, Bolt will only load and 
+read configuration from `bolt-defaults.yaml`.
+
+You can view a full list of the available options in [`bolt-defaults.yaml`
+options](bolt_defaults_reference.md).
+
+### `bolt.yaml`
+
+> **Note:** The user-level `bolt.yaml` file is deprecated and will be removed
+> in a future version of Bolt. Use a `bolt-defaults.yaml` file instead.
+
+**Filepath:** `~/.puppetlabs/etc/bolt/bolt.yaml`
+
+The Bolt configuration file can be used to set all available configuration
+options, including project-specific configuration options.
+
+You can view a full list of the available options in [Bolt configuration
+options](bolt_configuration_reference.md).
+
+## System-wide configuration
+
+Use this level to set configuration that applies to all users and all projects.
+This might include configuration for connecting to an organization's Forge
+proxy, the number of threads Bolt should use when connecting to targets, or
+setting credentials for connecting to PuppetDB. You can set most configurable
+Bolt options at the system level. 
+
+System-wide configuration can be set in two files.
+- Use `bolt-defaults.yaml` for configuration that is not project-specific.
+- You can set all configuration in a `bolt.yaml` file. **The system-level
+  `bolt.yaml` file is on the path towards deprecation and will be removed in a
+  future version of Bolt. Use `bolt-defaults.yaml` instead.** 
+
+The preferred method for setting user-level configuration is to use a
+`bolt-defaults.yaml` file. This file does not allow you to set project-specific
+configuration, such as the path to an inventory file, and is less likely
+to lead to errors where content from another project is loaded.
+
+### `bolt-defaults.yaml`
+
+**\*nix Filepath:** `/etc/puppetlabs/bolt/bolt-defaults.yaml`
+
+**Windows Filepath:** `%PROGRAMDATA%\PuppetLabs\bolt\etc\bolt-defaults.yaml`
+
+The defaults configuration file supports most of Bolt's configuration options,
+with the exception of options that are project-specific such as `inventoryfile`
+and `modulepath`.
+
+The `bolt-defaults.yaml` file takes precedence over a `bolt.yaml` file in the
+same directory. If the directory contains both files, Bolt will only load and 
+read configuration from `bolt-defaults.yaml`.
+
+You can view a full list of the available options in [`bolt-defaults.yaml`
+options](bolt_defaults_reference.md).
+
+### `bolt.yaml`
+
+> **Note:** The system-wide `bolt.yaml` file is deprecated and will be removed
+> in a future version of Bolt. Use a `bolt-defaults.yaml` file instead.
+
+**\*nix Filepath:** `/etc/puppetlabs/bolt/bolt.yaml`
+
+**Windows Filepath:** `%PROGRAMDATA%\PuppetLabs\bolt\etc\bolt.yaml`
+
+You can set all available configuration
+options in `bolt.yaml`, including project-specific configuration options.
+
+You can view a full list of the available options in [Bolt configuration
+options](bolt_configuration_reference.md).
 
 ## Configuration precedence
 
@@ -63,8 +194,8 @@ from highest precedence to lowest:
   - Target URI (i.e. ssh://user:password@hostname:port)
   - [Inventory file](inventory_file_v2.md) options
   - [Command line flags](bolt_command_reference.md)
-  - Project configuration file
-  - User configuration file
+  - Project-level configuration file
+  - User-level configuration file
   - System-wide configuration file
   - SSH configuration file options (e.g. `~/.ssh/config`)
 
@@ -74,9 +205,7 @@ When merging configurations, Bolt's strategy is to shallow merge any options
 that accept hashes and to overwrite any options that do not accept hashes. There
 are two exceptions to this strategy:
 
-- [Transport
-  configuration](bolt_configuration_reference.md#transport-configuration-options)
-  (e.g. `ssh`, `winrm`) is deep-merged.
+- [Transport configuration](bolt_transports_reference.md) is deep-merged.
 
 - [Plugin configuration](using_plugins.md#configuring-plugins) is shallow-merged
   for _each individual plugin_.
@@ -85,22 +214,26 @@ are two exceptions to this strategy:
 
 Transport configuration is deep merged. 
 
-For example, given this SSH configuration in a project configuration file:
+For example, given this SSH configuration in an inventory file:
 
 ```yaml
-ssh:
-  user: bolt
-  password: bolt
-  host-key-check: false
+# ~/.puppetlabs/bolt/inventory.yaml
+config:
+  ssh:
+    user: bolt
+    password: bolt
+    host-key-check: false
 ```
 
 And this this SSH configuration in a user configuration file:
 
 ```yaml
-ssh:
-  user: puppet
-  password: puppet
-  private-key: ~/path/to/key/id_rsa
+# ~/.puppetlabs/etc/bolt/bolt-defaults.yaml
+inventory-config:
+  ssh:
+    user: puppet
+    password: puppet
+    private-key: ~/path/to/key/id_rsa
 ```
 The merged Bolt configuration would look like this:
 
@@ -110,7 +243,6 @@ ssh:
   password: bolt
   host-key-check: false
   private-key: ~/path/to/key/id_rsa
-  ...
 ```
 
 ### Plugin configuration merge strategy
@@ -126,6 +258,7 @@ configurations, the configuration for individual plugins is shallow merged.
 For example, given this plugin configuration in a project configuration file:
 
 ```yaml
+# ~/.puppetlabs/bolt/bolt-project.yaml
 plugins:
   vault:
     auth:
@@ -137,6 +270,7 @@ plugins:
 And this plugin configuration in a system-wide configuration file:
 
 ```yaml
+# /etc/puppetlabs/bolt/bolt-defaults.yaml
 plugins:
   aws_inventory:
     credentials: /etc/aws/credentials
@@ -161,24 +295,12 @@ plugins:
       pass: bolt
 ```
 
-## Additional documentation
+📖 **Related information**
 
-- **[Project directories](bolt_project_directories.md#)**  
-
-  Bolt runs in the context of a project directory or a `Boltdir`. This directory
-  contains all of the configuration, code, and data loaded by Bolt.
-
-- **[Bolt configuration options](bolt_configuration_reference.md)**  
-
-  Your Bolt configuration file can contain global and transport options.
-
-- **[Using Bolt with Puppet Enterprise](bolt_configure_orchestrator.md)**  
-
-  If you're a Puppet Enterprise (PE) customer, you can configure Bolt to use the
-  PE orchestrator and perform actions on managed targets. Pairing PE with Bolt
-  enables role-based access control, logging, and visual reports in the PE
-  console.
-
-- **[Connecting Bolt to PuppetDB](bolt_connect_puppetdb.md)**  
-
-  Configure Bolt to connect to PuppetDB.
+- [Project directories](bolt_project_directories.md#)
+- [Bolt configuration options](bolt_configuration_reference.md)
+- [bolt-defaults.yaml options](bolt_defaults_reference.md)
+- [bolt-project.yaml options](bolt_project_reference.md)
+- [Transport configuration options](bolt_transports_reference.md)
+- For information on using configuring Bolt for Puppet Enterprise, see [Using Bolt with Puppet Enterprise](bolt_configure_orchestrator.md)
+- For information on connecting Bolt to PuppetDB, see [Connecting Bolt to PuppetDB](bolt_connect_puppetdb.md)

--- a/lib/bolt/inventory/group.rb
+++ b/lib/bolt/inventory/group.rb
@@ -16,7 +16,7 @@ module Bolt
       DATA_KEYS = %w[config facts vars features plugin_hooks].freeze
       TARGET_KEYS = DATA_KEYS + %w[name alias uri]
       GROUP_KEYS = DATA_KEYS + %w[name groups targets]
-      CONFIG_KEYS = Bolt::Config::CONFIG_IN_INVENTORY.keys
+      CONFIG_KEYS = Bolt::Config::INVENTORY_CONFIG.keys
 
       def initialize(input, plugins)
         @logger = Logging.logger[self]

--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -2,6 +2,7 @@
 
 require 'pathname'
 require 'bolt/pal'
+require 'bolt/config'
 
 module Bolt
   class Project
@@ -19,15 +20,7 @@ module Bolt
       create_project(File.expand_path(File.join('~', '.puppetlabs', 'bolt')), 'user')
     # If homedir isn't defined use the system config path
     rescue ArgumentError
-      create_project(system_path, 'system')
-    end
-
-    def self.system_path
-      if Bolt::Util.windows?
-        File.join(Dir::COMMON_APPDATA, 'PuppetLabs', 'bolt', 'etc')
-      else
-        File.join('/etc', 'puppetlabs', 'bolt')
-      end
+      create_project(Bolt::Config.system_path, 'system')
     end
 
     # Search recursively up the directory hierarchy for the Project. Look for a
@@ -74,13 +67,13 @@ module Bolt
       @resource_types = @path + '.resource_types'
       @type = type
 
-      tc = Bolt::Config::CONFIG_IN_INVENTORY.keys & raw_data.keys
+      tc = Bolt::Config::INVENTORY_CONFIG.keys & raw_data.keys
       if tc.any?
         msg = "Transport configuration isn't supported in bolt-project.yaml. Ignoring keys #{tc}"
         @warnings << { msg: msg }
       end
 
-      @data = raw_data.reject { |k, _| Bolt::Config::CONFIG_IN_INVENTORY.keys.include?(k) }
+      @data = raw_data.reject { |k, _| Bolt::Config::INVENTORY_CONFIG.keys.include?(k) }
 
       # Once bolt.yaml deprecation is removed, this attribute should be removed
       # and replaced with .project_file in lib/bolt/config.rb

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Bolt Defaults",
+  "description": "Bolt Defaults bolt-defaults.yaml Schema",
+  "type": "object",
+  "properties": {
+    "color": {
+      "description": "Whether to use colored output when printing messages to the console.",
+      "type": "boolean"
+    },
+    "compile-concurrency": {
+      "description": "The maximum number of simultaneous manifest block compiles.",
+      "type": "integer",
+      "min": 1
+    },
+    "concurrency": {
+      "description": "The number of threads to use when executing on remote targets.",
+      "type": "integer",
+      "min": 1
+    },
+    "format": {
+      "description": "The format to use when printing results.",
+      "type": "string",
+      "enum": ["human", "json"]
+    },
+    "inventory-config": {
+      "description": "A map containing default configuration for each of Bolt's transports as well as the default transport to apply to targets that do not specify one in their URI or inventory configuration.",
+      "type": "object",
+      "parameters": {
+        "docker": {
+          "$ref": "bolt-transport-definitions.json#/docker"
+        },
+        "local": {
+          "$ref": "bolt-transport-definitions.json#/local"
+        },
+        "pcp": {
+          "$ref": "bolt-transport-definitions.json#/pcp"
+        },
+        "remote": {
+          "$ref": "bolt-transport-definitions.json#/remote"
+        },
+        "ssh": {
+          "$ref": "bolt-transport-definitions.json#/ssh"
+        },
+        "transport": {
+          "description": "The default transport to use when the transport for a target is not specified in the URI or inventory.",
+          "type": "string",
+          "enum": ["docker", "local", "pcp", "remote", "ssh", "winrm"]
+        },
+        "winrm": {
+          "$ref": "bolt-transport-definitions.json#/winrm"
+        }
+      }
+    },
+    "plugin_hooks": {
+      "description": "Which plugins a specific hook should use.",
+      "type": "object",
+      "properties": {
+        "puppet_library": {
+          "description": "Specify which plugin should be used to ensure the Puppet library is installed on a target.",
+          "type": "object"
+        }
+      }
+    },
+    "plugins": {
+      "description": "A map of plugins and their configuration data.",
+      "type": "object",
+      "patternProperties": {
+        "^[a-z][a-z0-9_]*$": { 
+          "type": "object"
+        }
+      }
+    },
+    "puppetdb": {
+      "description": "A map containing options for configuring the Bolt PuppetDB client.",
+      "type": "object",
+      "properties": {
+        "cacert": {
+          "description": "The path to the ca certificate for PuppetDB.",
+          "type": "string"
+        },
+        "cert": {
+          "description": "The path to the client certificate file to use for authentication.",
+          "type": "string"
+        },
+        "key": {
+          "description": "The path to the private key for the certificate.",
+          "type": "string"
+        },
+        "server_urls": {
+          "description": "An array containing the PuppetDB host to connect to. Include the protocol https and the port, which is usually 8081. For example, https://my-master.example.com:8081.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "description": "A PuppetDB host.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "puppetfile": {
+      "description": "A map containing options for the 'bolt puppetfile install' command.",
+      "type": "object",
+      "properties": {
+        "forge": {
+          "description": "A subsection that can have its own proxy setting to set an HTTP proxy for Forge operations only, and a baseurl setting to specify a different Forge host.",
+          "type": "object",
+          "properties": {
+            "baseurl": {
+              "description": "The URI for the Forge host.",
+              "type": "string",
+              "format": "uri"
+            },
+            "proxy": {
+              "description": "The HTTP proxy to use for Forge operations.",
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        "proxy": {
+          "description": "The HTTP proxy to use for Git and Forge operations.",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "save-rerun": {
+      "description": "Whether to update .rerun.json in the Bolt project directory. If your target names include passwords, set this value to false to avoid writing passwords to disk.",
+      "type": "boolean"
+    }
+  }
+}

--- a/spec/bolt/project_spec.rb
+++ b/spec/bolt/project_spec.rb
@@ -12,7 +12,7 @@ describe Bolt::Project do
       .and_raise(ArgumentError, "couldn't find login name -- expanding `~'")
     project = Bolt::Project.default_project
     # we have to call expand_path to ensure C:/ instead of C:\ on Windows
-    expect(project.path.to_s).to eq(File.expand_path(Bolt::Project.system_path))
+    expect(project.path.to_s).to eq(File.expand_path(Bolt::Config.system_path))
   end
 
   describe "configuration" do

--- a/spec/lib/bolt_spec/integration.rb
+++ b/spec/lib/bolt_spec/integration.rb
@@ -13,6 +13,7 @@ module BoltSpec
 
       # prevent tests from reading users config
       allow(Bolt::Project).to receive(:find_boltdir).and_return(project)
+      allow(Bolt::Config).to receive(:load_defaults).and_return([])
       allow(cli).to receive(:puppetdb_client).and_return(pdb_client)
       allow(cli).to receive(:analytics).and_return(Bolt::Analytics::NoopClient.new)
 


### PR DESCRIPTION
This adds support for a new config file named `bolt-defaults.yaml`. This
file is loaded from both the system-wide and user-level config
directories, and contains similar config options to a `bolt.yaml` file
(except for project-specific config such as `inventoryfile`).

When a user has a `bolt-defaults.yaml` file alongside a `bolt.yaml` file
in the system-wide or user-level directories, it is loaded instead of
the `bolt.yaml` file and warns the user that the `bolt.yaml` file has
been ignored.

If a user has a `bolt.yaml` file present in either the system-wide or
user-level directories, Bolt will issue a warning that the file is
deprecated and to use a `bolt-defaults.yaml` file instead.

Closes #1845 

!feature

* **Add `bolt-defaults.yaml` configuration file** ([#1845](#1845))

  Bolt now supports a new `bolt-defaults.yaml` configuration file in the
  [system-wide and user-level directories](https://puppet.com/docs/bolt/latest/configuring_bolt.html).
  This configuration file is intended to replace the `bolt.yaml`
  configuration file in the system-wide and user-level directories in
  a future version of Bolt. If a `bolt-defaults.yaml` file exists
  alongside a `bolt.yaml` file, Bolt will ignore the `bolt.yaml` file.

!deprecation

* **System-wide and user-level `bolt.yaml` is deprecated** ([#1845](#1845))

  The [system-wide and user-level](https://puppet.com/docs/bolt/latest/configuring_bolt.html)
  `bolt.yaml` files have been deprecated in favor of
  `bolt-defaults.yaml`.