### PR TITLE
(maint) Fix exit code test

### DIFF
--- a/spec/integration/local_spec.rb
+++ b/spec/integration/local_spec.rb
@@ -34,8 +34,8 @@ describe "when running over the local transport" do
     end
 
     it 'returns correct exit code', :reset_puppet_settings do
-      cmd = 'puppet apply --trace --detailed-exitcodes -e "notify {foo:}"'
-      result = run_failed_nodes(%W[command run #{cmd} -t #{uri}]).first
+      cmd = "puppet apply --trace --detailed-exitcodes -e 'notify {foo:}'"
+      result = run_failed_nodes(%W[command run #{cmd} -t localhost]).first
       expect(result['_error']['msg']).to eq('The command failed with exit code 2')
       expect(result['_error']['details']['exit_code']).to eq(2)
     end


### PR DESCRIPTION
Windows tests for the local transport were failing with the command
`bolt command run 'puppet apply --trace --detailed-exitcodes -e "notify
{foo: }"'` with `Unknown argument(s) {foo:, }`. This switches the quotes
so that powershell properly parses the command. It also only runs the
test on a single valid host, 'localhost', to avoid unexpected errors running on host `local://foo`.

!no-release-note