### PR TITLE
(GH-1867) Document how privilege escalation works in Bolt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,6 @@ locales/
 documentation/plan_functions.md
 documentation/bolt_command_reference.md
 documentation/bolt_configuration_reference.md
+documentation/privilege_escalation.md
 tasks/
 plans/

--- a/Rakefile
+++ b/Rakefile
@@ -138,6 +138,25 @@ namespace :docs do
     File.write('documentation/bolt_configuration_reference.md', renderer.result)
   end
 
+  desc 'Generate privilege escalation document'
+  task :privilege_escalation do
+    @run_as = stringify_types(Bolt::Config::Transport::Options::TRANSPORT_OPTIONS
+      .slice(*Bolt::Config::Transport::Options::RUN_AS_OPTIONS))
+    parser = Bolt::BoltOptionParser.new({})
+    @run_as_options = Bolt::BoltOptionParser::OPTIONS[:escalation].map do |option|
+      switch = parser.top.long[option]
+
+      {
+        long: switch.long.first,
+        arg: switch.arg,
+        desc: switch.desc.map { |d| d.gsub("<", "&lt;") }.join("<br>")
+      }
+    end
+
+    renderer = ERB.new(File.read('documentation/templates/privilege_escalation.md.erb'), nil, '-')
+    File.write('documentation/privilege_escalation.md', renderer.result)
+  end
+
   desc 'Generate markdown docs for bolt-project.yaml'
   task :project_reference do
     @opts    = stringify_types(Bolt::Config::OPTIONS.slice(*Bolt::Config::BOLT_PROJECT_OPTIONS))
@@ -306,6 +325,7 @@ namespace :docs do
     cli_reference
     function_reference
     config_reference
+    privilege_escalation
     project_reference
     defaults_reference
     transports_reference

--- a/documentation/bolt.ditamap
+++ b/documentation/bolt.ditamap
@@ -17,6 +17,7 @@
             <topicref href="using_plugins.md" format="markdown"/>
             <topicref href="writing_plugins.md" format="markdown"/>
         </topicref>
+        <topicref href="privilege_escalation.md" format="markdown"/>
     </topicref>
     <topicref href="running_bolt_commands.md" format="markdown" linking="targetonly"/>
     <topicref href="plans.md" format="markdown">

--- a/documentation/templates/privilege_escalation.md.erb
+++ b/documentation/templates/privilege_escalation.md.erb
@@ -1,0 +1,86 @@
+# Escalating privilege with Bolt
+
+By default, Bolt connects to, and executes on, remote systems as the same user.
+Sometimes, connection and execution need to be done as separate users. For
+example, you might need to install a package as the root user on a system that
+doesn't allow incoming connections as the root user.  Bolt has several
+configuration options for setting which user to execute as, how to escalate to
+that user, and how to run commands as that user.
+
+### Limitations
+
+Bolt will only use the `run-as` user if:
+
+* The target shell is Bash
+* The transport is Local or SSH
+* The configured `run-as` user is different than the connecting `user`
+
+## Configuring `run-as`
+
+You can use privilege escalation from the command-line, or set it up using Bolt's configuration files.
+
+### Command-line options
+
+<% @run_as_options.each do |option| -%>
+
+#### `<%= option[:long] -%><%= option[:arg] %>`
+
+<%= option[:desc] %>
+<% end %>
+
+### Configuration file options
+
+You can configure escalation privilege in your `inventory.yaml` or
+`bolt-defaults.yaml` files. For more information on which file to use, see
+[Configuring Bolt](configuring_bolt.html).
+
+<% @run_as.each do |option, data| -%>
+### `<%= option %>`
+
+<%= data[:desc] %>
+
+<% if data.key?(:type) -%>
+- **Type:** <%= data[:type] %>
+<% end -%>
+<% if data.key?(:def) -%>
+- **Default:** <%= data[:def] %>
+<% end -%>
+
+<% if data.key?(:exmp) -%>
+```yaml
+<%= { option => data[:exmp] }.to_yaml(indentation: 2).split("\n").drop(1).join("\n") %>
+```
+<% end %>
+<% end %>
+
+## How `run-as` works
+
+Each time Bolt executes, it builds a command string to run on the remote
+system. The command is built from many configuration options, including
+interpreters, task input method, and the `run-as` configuration. When `run-as`
+is set, the following is prepended to the command:
+
+```
+<sudo-executable> -S -H -u <run-as> -p '[sudo] Bolt needs to run as another user, password:'
+```
+
+The default `sudo-executable` is `sudo`. If you're running a task that
+reads parameters from environment variables, `-E` will be appended.
+
+> **Note:** The command is shell escaped, so each value is interpreted
+> literally. This means you can't set sudo flags in the `run-as` configuration.
+> Use the `run-as-command` option to specify your own sudo command and flags.
+
+You can replace this command wholesale by specifying `run-as-command`, which
+will prepend the following to the command being run:
+
+```
+<run-as-command> <run-as>
+```
+
+This enables using any executable and flags to change users. Keep in mind that:
+- The `run-as-command` is non-interactive. If you set `run-as-command` and the
+  system prompts for a password, Bolt will error instead of supplying the password.
+- Bolt always appends the specified `run-as` user to the specified `run-as-command`,
+  which can be limiting for some escalating commands.
+- Bolt will not use the `run-as-command` option if `run-as` is not set.

--- a/lib/bolt/config/transport/local.rb
+++ b/lib/bolt/config/transport/local.rb
@@ -7,21 +7,13 @@ module Bolt
   class Config
     module Transport
       class Local < Base
-        OPTIONS = %w[
-          cleanup
-          interpreters
-          run-as
-          run-as-command
-          sudo-executable
-          sudo-password
-          tmpdir
-        ].freeze
-
         WINDOWS_OPTIONS = %w[
           cleanup
           interpreters
           tmpdir
         ].freeze
+
+        OPTIONS = WINDOWS_OPTIONS.dup.concat(RUN_AS_OPTIONS).sort.freeze
 
         DEFAULTS = {
           'cleanup' => true

--- a/lib/bolt/config/transport/options.rb
+++ b/lib/bolt/config/transport/options.rb
@@ -292,6 +292,13 @@ module Bolt
             exmp: "bolt"
           }
         }.freeze
+
+        RUN_AS_OPTIONS = %w[
+          run-as
+          run-as-command
+          sudo-executable
+          sudo-password
+        ].freeze
       end
     end
   end

--- a/lib/bolt/config/transport/ssh.rb
+++ b/lib/bolt/config/transport/ssh.rb
@@ -26,15 +26,11 @@ module Bolt
           port
           private-key
           proxyjump
-          run-as
-          run-as-command
           script-dir
-          sudo-executable
-          sudo-password
           tmpdir
           tty
           user
-        ].freeze
+        ].concat(RUN_AS_OPTIONS).sort.freeze
 
         # Options available when using the external ssh transport
         EXTERNAL_OPTIONS = %w[
@@ -45,15 +41,11 @@ module Bolt
           interpreters
           port
           private-key
-          run-as
-          run-as-command
           script-dir
           ssh-command
-          sudo-executable
-          sudo-password
           tmpdir
           user
-        ].freeze
+        ].concat(RUN_AS_OPTIONS).sort.freeze
 
         DEFAULTS = {
           "cleanup"            => true,

--- a/lib/bolt/shell/bash.rb
+++ b/lib/bolt/shell/bash.rb
@@ -332,14 +332,14 @@ module Bolt
         end
 
         if escalate
-          if use_sudo
-            sudo_exec = target.options['sudo-executable'] || "sudo"
-            sudo_flags = [sudo_exec, "-S", "-H", "-u", run_as, "-p", sudo_prompt]
-            sudo_flags += ["-E"] if options[:environment]
-            sudo_str = Shellwords.shelljoin(sudo_flags)
-          else
-            sudo_str = Shellwords.shelljoin(@target.options['run-as-command'] + [run_as])
-          end
+          sudo_str = if use_sudo
+                       sudo_exec = target.options['sudo-executable'] || "sudo"
+                       sudo_flags = [sudo_exec, "-S", "-H", "-u", run_as, "-p", sudo_prompt]
+                       sudo_flags += ["-E"] if options[:environment]
+                       Shellwords.shelljoin(sudo_flags)
+                     else
+                       Shellwords.shelljoin(@target.options['run-as-command'] + [run_as])
+                     end
           command_str = build_sudoable_command_str(command_str, sudo_str, @sudo_id, options)
         end
 


### PR DESCRIPTION
This adds a net new page to the docs titled `Escalating privilege with
Bolt` which details how Bolt builds the command to change users, how to
configure that command, and what limitations Bolt has with respect to
escalating privilege.

The page also includes a list of escalation-related configuration
options and command line flags, which are generated from Bolt itself the
same way the command line reference and configuration reference pages
are generated. The generation of the options on that page is done as
part of the `docs:config_reference` rake task. In order for this to
work, the run-as configuration options stored in
`Bolt::Config::Transport::SSH::OPTIONS` and
`Bolt::Config::Transport::Local::OPTIONS` had to be moved from those
constants to `Bolt::Config::Transport::Base::RUN_AS_OPTIONS` to be read
in the Rakefile. Those options are now merged into the other transport
options defined in those constants when the constant is instantiated.

!no-release-note

Closes #1867