### PR TITLE
(maint) Fix file::read from module example

### DIFF
--- a/bolt-modules/file/lib/puppet/functions/file/read.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/read.rb
@@ -8,7 +8,7 @@ Puppet::Functions.create_function(:'file::read', Puppet::Functions::InternalFunc
   # @example Read a file from disk
   #   file::read('/tmp/i_dumped_this_here')
   # @example Read a file from the modulepath
-  #   file::read('example/files/VERSION')
+  #   file::read('example/VERSION')
   dispatch :read do
     scope_param
     required_param 'String', :filename


### PR DESCRIPTION
The documented example for using file::read plan function to read a file
from a module on the modulepath erroneously included `/files/`. This
changes the example from the path `example/files/VERSION` to
`example/VERSION`.

!no-release-note