### PR TITLE
(maint) Fix file plan function examples

### DIFF
--- a/bolt-modules/file/lib/puppet/functions/file/exists.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/exists.rb
@@ -9,7 +9,7 @@ Puppet::Functions.create_function(:'file::exists', Puppet::Functions::InternalFu
   # @example Check a file on disk
   #   file::exists('/tmp/i_dumped_this_here')
   # @example check a file from the modulepath
-  #   file::exists('example/files/VERSION')
+  #   file::exists('example/VERSION')
   dispatch :exists do
     scope_param
     required_param 'String', :filename

--- a/bolt-modules/file/lib/puppet/functions/file/readable.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/readable.rb
@@ -9,7 +9,7 @@ Puppet::Functions.create_function(:'file::readable', Puppet::Functions::Internal
   # @example Check a file on disk
   #   file::readable('/tmp/i_dumped_this_here')
   # @example check a file from the modulepath
-  #   file::readable('example/files/VERSION')
+  #   file::readable('example/VERSION')
   dispatch :readable do
     scope_param
     required_param 'String', :filename


### PR DESCRIPTION
The documented example for using file::readable and file::exists plan
functions to read a file from a module on the modulepath erroneously
included `/files/`. This changes the example from the path
`example/files/VERSION` to `example/VERSION`.

!no-release-note