### PR TITLE
(fun) Add rainbow output format

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -47,6 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-ssh", ">= 4.0"
   spec.add_dependency "net-ssh-krb", "~> 0.5"
   spec.add_dependency "orchestrator_client", "~> 0.4"
+  spec.add_dependency "paint", "~> 2.2"
   spec.add_dependency "puppet", [">= 6.16.0", "< 7"]
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "puppet-strings", "~> 2.3"

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -356,7 +356,7 @@ module Bolt
         raise Bolt::ValidationError, "Compilation is CPU-intensive, set concurrency less than #{compile_limit}"
       end
 
-      unless %w[human json].include? format
+      if (format == 'rainbow' && Bolt::Util.windows?) || !(%w[human json rainbow].include? format)
         raise Bolt::ValidationError, "Unsupported format: '#{format}'"
       end
 

--- a/lib/bolt/outputter.rb
+++ b/lib/bolt/outputter.rb
@@ -8,6 +8,8 @@ module Bolt
         Bolt::Outputter::Human.new(color, verbose, trace)
       when 'json'
         Bolt::Outputter::JSON.new(color, verbose, trace)
+      when 'rainbow'
+        Bolt::Outputter::Rainbow.new(color, verbose, trace)
       when nil
         raise "Cannot use outputter before parsing."
       end
@@ -24,4 +26,5 @@ end
 
 require 'bolt/outputter/human'
 require 'bolt/outputter/json'
+require 'bolt/outputter/rainbow'
 require 'bolt/outputter/logger'

--- a/lib/bolt/outputter/rainbow.rb
+++ b/lib/bolt/outputter/rainbow.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'bolt/pal'
+require 'paint'
+
+module Bolt
+  class Outputter
+    class Rainbow < Bolt::Outputter::Human
+      def initialize(color, verbose, trace, stream = $stdout)
+        super
+        @line_color = 0
+        @color = 0
+        @state = :normal
+      end
+
+      # The algorithm is from lolcat (https://github.com/busyloop/lolcat)
+      # lolcat is released with WTFPL
+      def rainbow
+        red = Math.sin(0.3 * @color + 0) * 127 + 128
+        green = Math.sin(0.3 * @color + 2 * Math::PI / 3) * 127 + 128
+        blue  = Math.sin(0.3 * @color + 4 * Math::PI / 3) * 127 + 128
+        @color += 1 / 8.0
+        format("%<red>02X%<green>02X%<blue>02X", red: red, green: green, blue: blue)
+      end
+
+      def colorize(color, string)
+        if @color && @stream.isatty
+          if %i[green rainbow].include?(color)
+            a = string.chars.map do |c|
+              case @state
+              when :normal
+                if c == "\e"
+                  @state = :ansi
+                elsif c == "\n"
+                  @line_color += 1
+                  @color = @line_color
+                  c
+                else
+                  Paint[c, rainbow]
+                end
+              when :ansi
+                @state = :normal if c == 'm'
+              end
+            end
+            a.join('')
+          else
+            "\033[#{COLORS[color]}m#{string}\033[0m"
+          end
+        else
+          string
+        end
+      end
+
+      def print_summary(results, elapsed_time = nil)
+        ok_set = results.ok_set
+        unless ok_set.empty?
+          @stream.puts colorize(:rainbow, format('Successful on %<size>d target%<plural>s: %<names>s',
+                                                 size: ok_set.size,
+                                                 plural: ok_set.size == 1 ? '' : 's',
+                                                 names: ok_set.targets.map(&:safe_name).join(',')))
+        end
+
+        error_set = results.error_set
+        unless error_set.empty?
+          @stream.puts colorize(:red,
+                                format('Failed on %<size>d target%<plural>s: %<names>s',
+                                       size: error_set.size,
+                                       plural: error_set.size == 1 ? '' : 's',
+                                       names: error_set.targets.map(&:safe_name).join(',')))
+        end
+
+        total_msg = format('Ran on %<size>d target%<plural>s',
+                           size: results.size,
+                           plural: results.size == 1 ? '' : 's')
+        total_msg << " in #{duration_to_string(elapsed_time)}" unless elapsed_time.nil?
+        @stream.puts colorize(:rainbow, total_msg)
+      end
+    end
+  end
+end

--- a/spec/bolt/outputter/rainbow_spec.rb
+++ b/spec/bolt/outputter/rainbow_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/outputter'
+require 'bolt/cli'
+require 'bolt/plan_result'
+
+describe "Bolt::Outputter::Rainbow" do
+  let(:output) { StringIO.new }
+  let(:outputter) { Bolt::Outputter::Rainbow.new(false, false, false, output) }
+  let(:inventory) { Bolt::Inventory.empty }
+  let(:target) { inventory.get_target('target1') }
+  let(:target2) { inventory.get_target('target2') }
+  let(:results) {
+    Bolt::ResultSet.new(
+      [
+        Bolt::Result.new(target, message: "ok", action: 'action'),
+        Bolt::Result.new(target2, error: { 'msg' => 'oops' }, action: 'action')
+      ]
+    )
+  }
+
+  it "colorizes output with empty results" do
+    expect(outputter).to receive(:colorize).with(:rainbow, "Ran on 0 targets in 2.0 sec")
+    outputter.print_head
+    outputter.print_summary(Bolt::ResultSet.new([]), 2.0)
+  end
+
+  it "colorizes status output" do
+    outputter.print_head
+    results.each do |result|
+      outputter.print_result(result)
+    end
+    expect(outputter).to receive(:colorize).with(:red, 'Failed on 1 target: target2').and_call_original
+    # Because there's no tty this won't actually print color, so the best we
+    # can test is that the right parameters are passed in
+    expect(outputter).to receive(:colorize)
+      .with(:rainbow, 'Successful on 1 target: target1')
+      .and_call_original
+    expect(outputter).to receive(:colorize)
+      .with(:rainbow, 'Ran on 2 targets in 10.0 sec')
+      .and_call_original
+    outputter.print_summary(results, 10.0)
+    lines = output.string
+    summary = lines.split("\n")[-3..-1]
+    expect(summary[0]).to eq('Successful on 1 target: target1')
+    expect(summary[1]).to eq('Failed on 1 target: target2')
+    expect(summary[2]).to eq('Ran on 2 targets in 10.0 sec')
+  end
+end


### PR DESCRIPTION
This adds a new output format option `rainbow` which behaves like the
human outputt except that it will colorize success messages with rainbow
colors instead of green if the system supports it. This works by adding
a new outputter class `Bolt::Outputter::Rainbow` that inherits from the
`Bolt::Outputter::Human` class and overrides the `colorize` and
`print_summary` functions. The colorize function in the rainbow class
will color messages labelled as `:green` or `:rainbow` with rainbow
colors using an algorithm copied from the [lolcat
project](https://github.com/busyloop/lolcat) (which is licensed for free
modification and reuse). The `print_summary` function is overridden to
colorize success messages that aren't colorized in the Human class.

This option can be configured on the cli with `--format rainbow` or in
config with `format: rainbow`.

This option is not available on Windows, and will throw a validation error.

!feature

* **Add rainbow output format**

  This adds a new format option `rainbow` which will print success
  messages in rainbow colors. This option is not available on Windows.