### PR TITLE
(GH-1871) Don't infer project name from directory name

### DIFF
--- a/documentation/bolt_running_plans.md
+++ b/documentation/bolt_running_plans.md
@@ -35,9 +35,9 @@ path. By default, Bolt looks for downloaded module plans in
 `<PROJECT_NAME>/modules/plans/` and local plans in
 `<PROJECT_NAME>/site-modules/plans/`.
 
-Using a Bolt project, you can create an empty `<PROJECT_NAME>/bolt-project.yaml`
-file, develop your plan in `<PROJECT_NAME>/plans/`, and run Bolt from the root
-of your Bolt project directory to test the plan.
+Using a Bolt project, you can create a `<PROJECT_NAME>/bolt-project.yaml` file,
+develop your plan in `<PROJECT_NAME>/plans/`, and run Bolt from the root of
+your Bolt project directory to test the plan.
 
 > **Note**: The `bolt-project.yaml` file is part of an experimental feature. For
 > more information, see [Bolt

--- a/documentation/bolt_running_tasks.md
+++ b/documentation/bolt_running_tasks.md
@@ -78,9 +78,9 @@ directory>/site-modules]`.
 
 The current [Bolt project](./experimental_features.md#bolt-projects) is loaded
 as a standalone module at the front of the module path.  If you are developing a
-new task, you can create an empty `<PROJECT_NAME>/bolt-project.yaml` file,
-develop your task in `<PROJECT_NAME>/tasks/`, and run Bolt from the root of your
-Bolt project directory to test the task. 
+new task, you can create a `<PROJECT_NAME>/bolt-project.yaml` file, develop
+your task in `<PROJECT_NAME>/tasks/`, and run Bolt from the root of your Bolt
+project directory to test the task.
 
 > **Note:** The `bolt-project.yaml` file is part of an experimental feature. For
 > more information, see [Bolt

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -86,9 +86,8 @@ log:
 
 #### Naming your project
 
-If you want to set a name for your project that is different from the name of
-the Bolt project directory, add a `name` key to `bolt-project.yaml` with the
-project name. 
+The project must have a name in order to load content. To set the project name,
+add a `name` key to `bolt-project.yaml` with the project name.
 
 For example:
   ```yaml

--- a/documentation/module_structure.md
+++ b/documentation/module_structure.md
@@ -6,10 +6,9 @@ module directories on the module path.
 
 By default, the module path includes the `modules` and `site-modules`
 directories in the [Bolt project directory](bolt_project_directories.md#). If
-`bolt-project.yaml` exists at the root of the project directory, the project
-itself is also loaded as a module and namespaced to either `name` in
-`bolt-project.yaml` if it's set, or the name of the directory if `name` is not
-set. 
+`bolt-project.yaml` exists at the root of the project directory and contains a
+`name` key, the project itself is also loaded as a module and namespaced to the
+value of `name`.
 
 > **Note:** The `bolt-project.yaml` file is part of an experimental feature. For
 > more information, see [Bolt

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -196,10 +196,11 @@ module Bolt
                                                                        type_by_reference: true,
                                                                        local_reference: true)
 
+      bolt_project = @project if @project&.name
       scope = {
         code_ast: ast,
         modulepath: @modulepath,
-        project: @project.to_h,
+        project: bolt_project.to_h,
         pdb_config: @pdb_client.config.to_hash,
         hiera_config: @hiera_config,
         plan_vars: plan_vars,

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -771,14 +771,13 @@ module Bolt
     end
 
     def pal
-      project = config.project.project_file? ? config.project : nil
       @pal ||= Bolt::PAL.new(config.modulepath,
                              config.hiera_config,
                              config.project.resource_types,
                              config.compile_concurrency,
                              config.trusted_external,
                              config.apply_settings,
-                             project)
+                             config.project)
     end
 
     def convert_plan(plan)

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -137,7 +137,9 @@ module Bolt
       # TODO: If we always call this inside a bolt_executor we can remove this here
       setup
       r = Puppet::Pal.in_tmp_environment('bolt', modulepath: @modulepath, facts: {}) do |pal|
-        Puppet.override(bolt_project: @project,
+        # Only load the project if it a) exists, b) has a name it can be loaded with
+        bolt_project = @project if @project&.name
+        Puppet.override(bolt_project: bolt_project,
                         yaml_plan_instantiator: Bolt::PAL::YamlPlan::Loader) do
           pal.with_script_compiler do |compiler|
             alias_types(compiler)

--- a/spec/bolt/pal_spec.rb
+++ b/spec/bolt/pal_spec.rb
@@ -142,4 +142,22 @@ describe Bolt::PAL do
       expect(parsed).to eq('string' => 'foo', 'bool' => true)
     end
   end
+
+  describe :in_bolt_compiler do
+    it "sets the bolt_project in the context if it has a name" do
+      project = Bolt::Project.new({ 'name' => 'mytestproject' }, Dir.getwd)
+      pal = Bolt::PAL.new(nil, nil, nil, 1, nil, {}, project)
+      pal.in_bolt_compiler do
+        expect(Puppet.lookup(:bolt_project).name).to eq('mytestproject')
+      end
+    end
+
+    it "doesn't set bolt_project in the context if it doesn't have a name" do
+      project = Bolt::Project.new({}, Dir.getwd)
+      pal = Bolt::PAL.new(nil, nil, nil, 1, nil, {}, project)
+      pal.in_bolt_compiler do
+        expect(Puppet.lookup(:bolt_project)).to be_nil
+      end
+    end
+  end
 end

--- a/spec/bolt/project_spec.rb
+++ b/spec/bolt/project_spec.rb
@@ -78,9 +78,9 @@ describe Bolt::Project do
     describe "with namespaced project names" do
       let(:config) { { 'name' => 'puppetlabs-foo' } }
 
-      it "strips namespace and hyphen" do
-        project = Bolt::Project.new(config, pwd)
-        expect(project.name).to eq('foo')
+      it "raises an error" do
+        expect { Bolt::Project.new(config, pwd).validate }
+          .to raise_error(/Invalid project name 'puppetlabs-foo' in bolt-project.yaml/)
       end
     end
   end

--- a/spec/fixtures/projects/embedded/Boltdir/bolt-project.yaml
+++ b/spec/fixtures/projects/embedded/Boltdir/bolt-project.yaml
@@ -1,0 +1,1 @@
+name: embedded

--- a/spec/fixtures/projects/local/bolt-project.yaml
+++ b/spec/fixtures/projects/local/bolt-project.yaml
@@ -1,0 +1,1 @@
+name: local


### PR DESCRIPTION
Previously, we would infer the project name from the directory name if
no name was specified in the bolt-project.yaml. This behavior proved to
be confusing for users, so we now require `name` to be specified
in bolt-project.yaml and otherwise will warn and not load project
content.

We previously recognized `<author>-<name>` directory names as valid
project names (using only the `<name>` portion) as that is a common
repo naming scheme for modules. As the project name must now be
specified explicitly, we instead require it be simply the name portion.

!deprecation

  * **Project names must be explicitly specified** ([#1871](https://github.com/puppetlabs/bolt/issues/1871))

    Proejct names must now be specified in `bolt-project.yaml` in order
    for project-level content to be loaded, rather than the name being
    inferred by the name of the project directory.