### PR TITLE
(MAINT) Remove whitelist terminology from bolt documentation

### DIFF
--- a/documentation/bolt_project_directories.md
+++ b/documentation/bolt_project_directories.md
@@ -119,7 +119,7 @@ module path.
 |[`bolt.yaml`](bolt_configuration_reference.md)|Contains configuration options for Bolt.|
 |`hiera.yaml`|Contains the Hiera config to use for target-specific data when using `apply`.|
 |[`inventory.yaml`](inventory_file_v2.md)|Contains a list of known targets and target specific data.|
-|[`bolt-project.yaml`](bolt_configuration_reference.md#project_configuration_options)|Contains configuration for the Bolt project.  The `bolt-project.yaml` file contains a whitelist of tasks and plans that you can use to limit the output from the `bolt plan show` and `bolt task show` commands. This is an experimental feature. For more information, see [Bolt projects](./experimental_features.md#bolt-projects).|
+|[`bolt-project.yaml`](bolt_configuration_reference.md#project_configuration_options)|Contains configuration for the Bolt project.  The `bolt-project.yaml` file can contain a list of tasks and plans to limit the output from the `bolt plan show` and `bolt task show` commands. This is an experimental feature. For more information, see [Bolt projects](./experimental_features.md#bolt-projects).|
 |[`Puppetfile`](bolt_installing_modules.md#)|Specifies which modules to install for the project.|
 |[`modules/`](bolt_installing_modules.md#)|The directory where modules from the `Puppetfile` are installed. In most cases, do not edit these modules locally.|
 |[`site-modules`](bolt_installing_modules.md)|Local modules that are edited and versioned with the project directory.|

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -28,10 +28,10 @@ where you're looking to share orchestration that is specific to your
 infrastructure, it's not always necessary, and can be cumbersome to get going
 quickly. 
 
-We also needed a way for content authors to whitelist the plans and tasks that
-they've created, so that when they share the content with other users, those
-users can run `bolt plan show` or `bolt task show` from the project directory
-and be presented with a list of only the content they need to see. 
+We also needed a way for content authors to display a subset of plans and tasks
+that they've created, so that when they share the content with other users,
+those users can run `bolt plan show` or `bolt task show` from the project
+directory and be presented with a list of only the content they need to see.
 
 ### Using Bolt projects
 
@@ -100,11 +100,11 @@ lowercase letter.
 
 > **Note:** Projects take precedence over installed modules of the same name.
 
-#### Whitelisting plans and tasks
+#### Limiting displayed plans and tasks
 
-To control what tasks and plans appear when your users run `bolt plan show` or
-`bolt task show`, add `tasks` and `plans` keys to your `bolt-project.yaml` and
-include an array of task and plan names. 
+To control what plans and tasks appear when your users run `bolt plan show` or
+`bolt task show`, add `plans` and `tasks` keys to your `bolt-project.yaml` and
+include an array of plan and task names.
 
 For example, if you wanted to surface a plan named `myproject::myplan`, and a
 task named `myproject::mytask`, you would use the following `bolt-project.yaml`

--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -9,8 +9,10 @@ module Bolt
     BOLTDIR_NAME = 'Boltdir'
     PROJECT_SETTINGS = {
       "name"  => "The name of the project",
-      "plans" => "An array of plan names to whitelist. Whitelisted plans are included in `bolt plan show` output",
-      "tasks" => "An array of task names to whitelist. Whitelisted plans are included in `bolt task show` output"
+      "plans" => "An array of plan names to show, if they exist in the project."\
+                 "These plans are included in `bolt plan show` output",
+      "tasks" => "An array of task names to show, if they exist in the project."\
+                 "These tasks are included in `bolt task show` output"
     }.freeze
 
     attr_reader :path, :data, :config_file, :inventory_file, :modulepath, :hiera_config,


### PR DESCRIPTION
This rewords our documentation to not use the phrase 'whitelist',
preferring just 'list' and rewording to describe what the list does
rather than using the term 'whitelist'.

!no-release-note