### PR TITLE
(GH-1904) Localhost default config overrides group-level config

### DIFF
--- a/lib/bolt/inventory/inventory.rb
+++ b/lib/bolt/inventory/inventory.rb
@@ -78,20 +78,6 @@ module Bolt
         target_array.first
       end
 
-      def self.localhost_defaults(data)
-        defaults = {
-          'config' => {
-            'transport' => 'local',
-            'local' => { 'interpreters' => { '.rb' => RbConfig.ruby } }
-          },
-          'features' => ['puppet-agent']
-        }
-        data = Bolt::Util.deep_merge(defaults, data)
-        # If features is an empty array deep_merge won't add the puppet-agent
-        data['features'] += ['puppet-agent'] if data['features'].empty?
-        data
-      end
-
       #### PRIVATE ####
       def group_data_for(target_name)
         @groups.group_collect(target_name)

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -407,7 +407,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
           # Ensure that we try to connect to a *closed* port, to avoid spurious "success"
           port = TCPServer.open(0) { |socket| socket.addr[1] }
           config = { transport: 'ssh', ssh: { port: port } }
-          { targets: ['localhost'], config: config }
+          { targets: [{ uri: 'localhost', config: config }] }
         end
 
         it 'fails to connect' do
@@ -487,15 +487,22 @@ describe 'running with an inventory file', reset_puppet_settings: true do
 
     let(:inventory) do
       {
-        "targets" => [
+        targets: [
           {
             _plugin: 'puppetdb',
             query: 'inventory { facts.fact1 = true }',
             target_mapping: {
               config: {
+                transport: 'facts.transport',
                 ssh: ssh_config
               }
             }.merge(addtl_mapping)
+          },
+          {
+            name: conn[:host],
+            config: {
+              transport: conn[:protocol]
+            }
           }
         ],
         config: {
@@ -578,7 +585,8 @@ describe 'running with an inventory file', reset_puppet_settings: true do
       context 'when a fact is not set' do
         let(:facts) do
           { conn[:host] => {
-            'fact1' => true
+            'fact1' => true,
+            'transport' => 'ssh'
           } }
         end
 


### PR DESCRIPTION
Previously, the default config for 'localhost' was merged as part of the
group data collected for that target, making it effectively group-level
data. Because all targets are considered part of the 'all' group
top-level config would override localhost's default config, which made
it difficult to set defaults for all targets except localhost. This
modifies how we load localhost defaults to now merge them as part of
initializing the `Bolt::Inventory::Target` object, meaning that any time
a target with name 'localhost' is created (either via the inventory or
by `Target.new` in a plan) it will pick up the localhost defaults at the
target level. This means that now the only way to override the defaults
is to set that config at the target-level.

Closes #1904

!bug

* **Consider localhost default config target-level instead of group-level** (

  Previously the 'localhost' special default config was merged at the
  group-level, meaning that group-level config in the inventory would
  override it. The config is now target-level, and must be overridden at
  the target-level in inventory.