### PR TITLE
(GH-1927) Fix powershell mkdir method

### DIFF
--- a/lib/bolt/shell/powershell.rb
+++ b/lib/bolt/shell/powershell.rb
@@ -111,7 +111,8 @@ module Bolt
       end
 
       def mkdirs(dirs)
-        mkdir_command = "mkdir -Force #{dirs.uniq.sort.join(',')}"
+        paths = dirs.uniq.sort.join('","')
+        mkdir_command = "mkdir -Force -Path (\"#{paths}\")"
         result = execute(mkdir_command)
         if result.exit_code != 0
           message = "Could not create directories: #{result.stderr.string}"


### PR DESCRIPTION
Fixes the powershell mkdir command to correctly handle paths with spaces in them. When passed to the command line, paths have to be quoted, the previous code did not handle this.

This uses double quotes instead of single quotes to allow string interpolation to happen when it is finally passed to PowerShell.

Closes #1927 
