### PR TITLE
(GH-1931) Add '--project' as an alias for '--boltdir'

### DIFF
--- a/documentation/bolt_installing.md
+++ b/documentation/bolt_installing.md
@@ -409,7 +409,7 @@ Bolt collects data about how you use it. You can opt out of providing this data.
 -   The number of targets targeted with a Bolt command
 -   The output format selected (human-readable, JSON)
 -   Whether the Bolt project directory was determined from the location of a
-    `bolt.yaml` file or with the `--boltdir` flag
+    `bolt.yaml` file or with the `--project` flag
 -   The number of times Bolt tasks and plans are run (not including user-defined
     tasks or plans.)
 -   The number of statements in a manifest block, and how many resources that

--- a/documentation/bolt_project_directories.md
+++ b/documentation/bolt_project_directories.md
@@ -99,7 +99,7 @@ if you have a single set of Bolt code and data that you use across all projects.
 Bolt uses these methods, in order, to choose a project directory.
 
 1. **Manually specified:** You can specify on the command line what directory
-   Bolt to use with `--boltdir <DIRECTORY_PATH>`. There is not an equivalent
+   Bolt to use with `--project <DIRECTORY_PATH>`. There is not an equivalent
    configuration setting because the project directory must be known in order to
    load configuration.
 1. **Parent directory:** Bolt traverses parents of the current directory until

--- a/documentation/migrating_inventory_files.md
+++ b/documentation/migrating_inventory_files.md
@@ -25,7 +25,7 @@ of the keys in the inventory file, or automatically using a Bolt command.
 To automatically migrate a Version 1 inventory file to Version 2, use the `bolt
 project migrate` command. Bolt will locate the inventory file for the current
 Bolt project and migrate it in place. You can specify the projects and inventory
-files you want to migrate using the `--boltdir` and `--inventoryfile` options.
+files you want to migrate using the `--project` and `--inventoryfile` options.
 
 > **Note:** The `bolt project migrate` command modifies an inventory file in
 > place and does not preserve comments or formatting. Before using the command,

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -10,7 +10,7 @@ module Bolt
                 authentication: %w[user password password-prompt private-key host-key-check ssl ssl-verify],
                 escalation: %w[run-as sudo-password sudo-password-prompt sudo-executable],
                 run_context: %w[concurrency inventoryfile save-rerun cleanup],
-                global_config_setters: %w[modulepath boltdir configfile],
+                global_config_setters: %w[modulepath project configfile],
                 transports: %w[transport connect-timeout tty ssh-command copy-command],
                 display: %w[format color verbose trace],
                 global: %w[help version debug] }.freeze
@@ -422,7 +422,7 @@ module Bolt
 
       ACTIONS
           generate-types        Generate type references to register in plans
-          install               Install modules from a Puppetfile into a Boltdir
+          install               Install modules from a Puppetfile into a project
           show-modules          List modules available to the Bolt project
     HELP
 
@@ -445,7 +445,7 @@ module Bolt
           bolt puppetfile install [options]
 
       DESCRIPTION
-          Install modules from a Puppetfile into a Boltdir
+          Install modules from a Puppetfile into a project
     HELP
 
     PUPPETFILE_SHOWMODULES_HELP = <<~HELP
@@ -709,13 +709,13 @@ module Bolt
           File.expand_path(moduledir)
         end
       end
-      define('--boltdir FILEPATH',
-             'Specify what Boltdir to load config from (default: autodiscovered from current working dir)') do |path|
+      define('--project FILEPATH', '--boltdir FILEPATH',
+             'Specify what project to load config from (default: autodiscovered from current working dir)') do |path|
         @options[:boltdir] = path
       end
       define('--configfile FILEPATH',
              'Specify where to load config from (default: ~/.puppetlabs/bolt/bolt.yaml).',
-             'Directory containing bolt.yaml will be used as the Boltdir.') do |path|
+             'Directory containing bolt.yaml will be used as the project directory.') do |path|
         @options[:configfile] = path
       end
       define('--hiera-config FILEPATH',
@@ -731,7 +731,7 @@ module Bolt
       end
       define('--puppetfile FILEPATH',
              'Specify a Puppetfile to use when installing modules. (default: ~/.puppetlabs/bolt/Puppetfile)',
-             'Modules are installed in the current Boltdir.') do |path|
+             'Modules are installed in the current project.') do |path|
         @options[:puppetfile_path] = Pathname.new(File.expand_path(path))
       end
       define('--[no-]save-rerun', 'Whether to update the rerun file after this command.') do |save|

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -219,7 +219,7 @@ module Bolt
       end
 
       if options[:boltdir] && options[:configfile]
-        raise Bolt::CLIError, "Only one of '--boltdir' or '--configfile' may be specified"
+        raise Bolt::CLIError, "Only one of '--boltdir', '--project', or '--configfile' may be specified"
       end
 
       if options[:noop] &&

--- a/spec/integration/project_spec.rb
+++ b/spec/integration/project_spec.rb
@@ -17,6 +17,11 @@ describe "When loading content", ssh: true do
     expect(result[0]['value']['stdout'].strip).to eq('polo')
   end
 
+  it "loads plans from project when specified with --project" do
+    result = run_cli_json(%W[plan run local -t #{target} --project #{local.path}] + config_flags)
+    expect(result[0]['value']['stdout'].strip).to eq('polo')
+  end
+
   it "project level content can reference other modules" do
     result = run_cli_json(%W[task run local -t #{target}] + config_flags, project: local)
     expect(result["items"][0]["value"]["_output"].strip).to eq('polo')


### PR DESCRIPTION
This adds a `--project` CLI flag as an alias for `--boltdir`. If both
options are specified on the command line the rightmost option will be
used. `--project` behaves exactly like `--boltdir`. It also updates
documentation to use `--project` in place of `--boltdir`, since we
consistently refer to the concept as a 'project' in the documentation
and don't often use 'Boltdir'.

This additionally replaces `Boltdir` with `project` for all Bolt CLI flag descriptions.

Closes #1931

!feature

* **Add --project as an alias for the --boltdir CLI flag** ([1931](https://github.com/puppetlabs/bolt/issues/1931))

  New CLI flag `--project` can be used in place of `--boltdir`.