### PR TITLE
(GH-1899) Accept env_vars for commands and scripts

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
@@ -13,6 +13,7 @@ Puppet::Functions.create_function(:run_command) do
   # @param options A hash of additional options.
   # @option options [Boolean] _catch_errors Whether to catch raised errors.
   # @option options [String] _run_as User to run as using privilege escalation.
+  # @option options [Hash] _env_vars Map of environment variables to set
   # @return A list of results, one entry per target.
   # @example Run a command on targets
   #   run_command('hostname', $targets, '_catch_errors' => true)
@@ -30,6 +31,7 @@ Puppet::Functions.create_function(:run_command) do
   # @param options A hash of additional options.
   # @option options [Boolean] _catch_errors Whether to catch raised errors.
   # @option options [String] _run_as User to run as using privilege escalation.
+  # @option options [Hash] _env_vars Map of environment variables to set
   # @return A list of results, one entry per target.
   # @example Run a command on targets
   #   run_command('hostname', $targets, 'Get hostname')

--- a/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
@@ -11,8 +11,9 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
   # @param targets A pattern identifying zero or more targets. See {get_targets} for accepted patterns.
   # @param options A hash of additional options.
   # @option options [Array[String]] arguments An array of arguments to be passed to the script.
-  # @option args [Boolean] _catch_errors Whether to catch raised errors.
-  # @option args [String] _run_as User to run as using privilege escalation.
+  # @option options [Boolean] _catch_errors Whether to catch raised errors.
+  # @option options [String] _run_as User to run as using privilege escalation.
+  # @option options [Hash] _env_vars Map of environment variables to set
   # @return A list of results, one entry per target.
   # @example Run a local script on Linux targets as 'root'
   #   run_script('/var/tmp/myscript', $targets, '_run_as' => 'root')
@@ -33,8 +34,9 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
   # @param description A description to be output when calling this function.
   # @param options A hash of additional options.
   # @option options [Array[String]] arguments An array of arguments to be passed to the script.
-  # @option args [Boolean] _catch_errors Whether to catch raised errors.
-  # @option args [String] _run_as User to run as using privilege escalation.
+  # @option options [Boolean] _catch_errors Whether to catch raised errors.
+  # @option options [String] _run_as User to run as using privilege escalation.
+  # @option options [Hash] _env_vars Map of environment variables to set
   # @return A list of results, one entry per target.
   # @example Run a script
   #   run_script('/var/tmp/myscript', $targets, 'Downloading my application')

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -82,6 +82,10 @@ module Bolt
       end
 
       def batch_command(targets, command, options = {}, &callback)
+        if options[:env_vars] && !options[:env_vars].empty?
+          raise NotImplementedError, "pcp transport does not support setting environment variables"
+        end
+
         params = {
           'command' => command
         }
@@ -98,6 +102,10 @@ module Bolt
       end
 
       def batch_script(targets, script, arguments, options = {}, &callback)
+        if options[:env_vars] && !options[:env_vars].empty?
+          raise NotImplementedError, "pcp transport does not support setting environment variables"
+        end
+
         content = File.open(script, &:read)
         content = Base64.encode64(content)
         params = {

--- a/spec/bolt/shell/bash_spec.rb
+++ b/spec/bolt/shell/bash_spec.rb
@@ -129,6 +129,12 @@ describe Bolt::Shell::Bash do
 
       shell.run_command('whoami', run_as: 'suchandsuch')
     end
+
+    it "sets environment variables if requested" do
+      expect(connection).to receive(:execute).with('FOO=bar sh -c echo\\ \\$FOO')
+
+      shell.run_command('echo $FOO', env_vars: { 'FOO' => 'bar' })
+    end
   end
 
   describe "#execute" do


### PR DESCRIPTION
Previously, we had no way to specify environment variables when running
commands or scripts. There are many reasons a user might need to set
environment variables:

* To set up the execution context for a command
* To pass arguments to scripts that expect them as env vars
* To pass secrets to commands rather than passing them as args

We now support passing `_env_vars` to `run_command()` and `run_script()`
which will set the passed variables when running the command or script.

!feature

* **Set environment variables for commands and scripts** ([#1899](https://github.com/puppetlabs/bolt/issues/1899))

  The `run_command()` and `run_script()` plan functions now support an
  `_env_vars` argument which accepts a Hash of environment variable
  declarations to set when running the command/script.