### PR TITLE
(GH-1894) Do not load projects from world-writable directories

### DIFF
--- a/documentation/bolt_project_directories.md
+++ b/documentation/bolt_project_directories.md
@@ -98,6 +98,8 @@ if you have a single set of Bolt code and data that you use across all projects.
 
 Bolt uses these methods, in order, to choose a project directory.
 
+1. **Environment variable:** You can specify a path to a project using the
+   `BOLT_PROJECT` environment variable.
 1. **Manually specified:** You can specify on the command line what directory
    Bolt to use with `--project <DIRECTORY_PATH>`. There is not an equivalent
    configuration setting because the project directory must be known in order to
@@ -108,6 +110,39 @@ Bolt uses these methods, in order, to choose a project directory.
 1. **User project directory:** If no directory is specified manually or found in
    a parent directory, the user project directory is used.
 
+## World-writable project directories
+
+On **Unix-like systems**, Bolt will not load a project from a world-writable
+directory by default, as loading from a world-writable directory presents a
+potential security risk. If you attempt to load a project from a
+world-writable directory, Bolt will not load any content and will raise an
+exception.
+
+If you wish to override this behavior and force Bolt to load a project from a
+world-writable directory, you can set the `BOLT_PROJECT` environment variable
+to the project directory path.
+
+For example, if you wanted to load a project named `my_project` from the
+world-writable directory at `~/project/`, you would set the `BOLT_PROJECT`
+environment variable as:
+
+```bash
+export BOLT_PROJECT='~/project/world_writable'
+```
+
+> **Note:** Exported environment variables expire at the end of the current
+> session. If you need a more permanent solution, add the `export` line to your
+> `~/.bashrc` or the relevant profile for the shell you're using.
+
+If you want to use a world-writable directory for a single Bolt execution, set the
+environment variable before the Bolt command:
+
+```bash
+BOLT_PROJECT='~/project/world_writable' bolt command run uptime -t target1
+```
+
+> **Note:** The `BOLT_PROJECT` environment variable takes precedence over the
+> `--configfile` CLI option. 
 
 ## Project directory structure
 

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -111,7 +111,10 @@ module Bolt
 
       validate(options)
 
-      @config = if options[:configfile]
+      @config = if ENV['BOLT_PROJECT']
+                  project = Bolt::Project.create_project(ENV['BOLT_PROJECT'], 'environment')
+                  Bolt::Config.from_project(project, options)
+                elsif options[:configfile]
                   Bolt::Config.from_file(options[:configfile], options)
                 else
                   project = if options[:boltdir]

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -46,7 +46,7 @@ module Bolt
     DEFAULT_DEFAULT_CONCURRENCY = 100
 
     def self.default
-      new(Bolt::Project.create_project('.'), {})
+      new(Bolt::Project.default_project, {})
     end
 
     def self.from_project(project, overrides = {})

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -2100,6 +2100,30 @@ describe "Bolt::CLI" do
     end
   end
 
+  describe 'BOLT_PROJECT' do
+    let(:bolt_project) { '/bolt/project' }
+    let(:pathname)     { Pathname.new(bolt_project).expand_path }
+
+    around(:each) do |example|
+      original = ENV['BOLT_PROJECT']
+      ENV['BOLT_PROJECT'] = bolt_project
+      example.run
+    ensure
+      ENV['BOLT_PROJECT'] = original
+    end
+
+    before(:each) do
+      allow(Bolt::Util).to receive(:validate_file).and_return(true)
+    end
+
+    it 'loads from BOLT_PROJECT environment variable over --configfile' do
+      cli = Bolt::CLI.new(%w[command run uptime --configfile /foo/bar --targets foo])
+      cli.parse
+
+      expect(cli.config.project.path).to eq(pathname)
+    end
+  end
+
   describe 'configfile' do
     let(:configdir) { File.join(__dir__, '..', 'fixtures', 'configs') }
     let(:modulepath) { [File.expand_path('/foo/bar'), File.expand_path('/baz/qux')] }

--- a/spec/bolt/project_spec.rb
+++ b/spec/bolt/project_spec.rb
@@ -183,4 +183,24 @@ describe Bolt::Project do
       expect(Bolt::Project.find_boltdir(pwd)).to eq(Bolt::Project.default_project)
     end
   end
+
+  describe "::create_project" do
+    let(:path)     { 'world_writable' }
+    let(:pathname) { Pathname.new(path) }
+
+    before(:each) do
+      allow(Pathname).to receive(:new).and_call_original
+      allow(Pathname).to receive(:new).with(path).and_return(pathname)
+      allow(pathname).to receive(:expand_path).and_return(pathname)
+      allow(pathname).to receive(:world_writable?).and_return(true)
+    end
+
+    it 'errors when loading from a world-writable directory', :bash do
+      expect { Bolt::Project.create_project(path) }.to raise_error(/Project directory '#{pathname}' is world-writable/)
+    end
+
+    it 'loads from a world-writable directory when project is from environment variable' do
+      expect { Bolt::Project.create_project(path, 'environment') }.not_to raise_error
+    end
+  end
 end

--- a/spec/lib/bolt_spec/files.rb
+++ b/spec/lib/bolt_spec/files.rb
@@ -10,7 +10,7 @@ module BoltSpec
                else
                  name
                end
-      Tempfile.open(params) do |file|
+      Tempfile.open(params, Dir.pwd) do |file|
         file.binmode # Stop Ruby implicitly doing CRLF translations and breaking tests
         file.write(contents)
         file.flush


### PR DESCRIPTION
This updates the `Bolt::Project` class to raise an error if the
specified project directory is world-writable. This change is meant to
prevent malicious users from modifying project content that could alter
how Bolt runs and any secure information it might use.

Users who wish to override this behavior and force Bolt to load a
project from a world-writable directory can set the `BOLT_PROJECT`
environment variable to the project directory path.

Closes #1894 

!feature

* **Do not load projects from world-writable directories**
  ([#1894](https://github.com/puppetlabs/bolt/issues/1894))

  Bolt now raises an error when attempting to load a project from a
  world-writable directory. Users who wish to override this behavior and
  run a project from a world-writable directory should can set the
  `BOLT_PROJECT` environment variable to the project directory path.