### PR TITLE
(GH-1928) Upload files to directories with the correct name

### DIFF
--- a/lib/bolt/shell/bash.rb
+++ b/lib/bolt/shell/bash.rb
@@ -35,7 +35,7 @@ module Bolt
       def upload(source, destination, options = {})
         running_as(options[:run_as]) do
           with_tmpdir do |dir|
-            basename = File.basename(destination)
+            basename = File.basename(source)
             tmpfile = File.join(dir.to_s, basename)
             conn.copy_file(source, tmpfile)
             # pass over file ownership if we're using run-as to be a different user

--- a/lib/bolt/transport/docker.rb
+++ b/lib/bolt/transport/docker.rb
@@ -20,7 +20,7 @@ module Bolt
       def upload(target, source, destination, _options = {})
         with_connection(target) do |conn|
           conn.with_remote_tmpdir do |dir|
-            basename = File.basename(destination)
+            basename = File.basename(source)
             tmpfile = "#{dir}/#{basename}"
             if File.directory?(source)
               conn.write_remote_directory(source, tmpfile)

--- a/spec/shared_examples/transport.rb
+++ b/spec/shared_examples/transport.rb
@@ -141,6 +141,23 @@ shared_examples 'transport api' do
       end
     end
 
+    it "can upload a file to a directory on a host" do
+      contents = "kljhdfg"
+      with_tempfile_containing('upload-test', contents) do |file|
+        remote_path = File.join(os_context[:destination_dir], File.basename(file.path))
+        result = runner.upload(target, file.path, os_context[:destination_dir])
+        expect(result.message).to eq("Uploaded '#{file.path}' to '#{target.host}:#{os_context[:destination_dir]}'")
+        expect(result.action).to eq('upload')
+        expect(result.object).to eq(file.path)
+
+        expect(
+          runner.run_command(target, "#{os_context[:cat_cmd]} #{remote_path}").value['stdout'].chomp
+        ).to eq(contents)
+
+        runner.run_command(target, "#{os_context[:rm_cmd]} #{remote_path}")
+      end
+    end
+
     it "can upload a directory to a host" do
       Dir.mktmpdir do |dir|
         subdir = File.join(dir, 'subdir')


### PR DESCRIPTION
Previously, uploading a file to a directory on some transports would
cause the file to be renamed to match the name of the directory, ie.
`bolt file upload file.txt /dir` would result in a file called
`/dir/dir`. This happened because we create a tempfile that we move into
place, and we computed the name of the tempfile using the basename of
the destination, assuming it was always a file. We now use the basename
of the source file as the name of the tempfile, which preserves the name
when the destination is a directory and still causes the file to be
written with the propery destination name if the destination is a file.

!bug

* **Upload files with the correct name when destination is a directory** ([#1928](https://github.com/puppetlabs/bolt/issues/1928))

  Files uploaded to directories will now retain the name of the original
  source file rather than changing their name to the same name as the
  destination directory. This also fixes the case where the destination
  was `.`