### PR TITLE
(GH-1920) Add --log-level CLI option

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -250,6 +250,10 @@ module Bolt
          !options[:object]
         raise Bolt::CLIError, "Must specify a value to #{options[:action]}"
       end
+
+      if options.key?(:debug) && options.key?(:log)
+        raise Bolt::CLIError, "Only one of '--debug' or '--log-level' may be specified"
+      end
     end
 
     def handle_parser_errors

--- a/lib/bolt/logger.rb
+++ b/lib/bolt/logger.rb
@@ -89,8 +89,10 @@ module Bolt
       :notice
     end
 
+    # Explicitly check the log level names instead of the log level number, as levels
+    # that are stringified integers (e.g. "level" => "42") will return a truthy value
     def self.valid_level?(level)
-      !Logging.level_num(level).nil?
+      Logging::LEVELS.include?(Logging.levelify(level))
     end
 
     def self.levels

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -499,6 +499,29 @@ describe "Bolt::CLI" do
         cli = Bolt::CLI.new(%w[command run uptime --targets foo --debug --verbose])
         cli.parse
       end
+
+      it "errors when debug and log-level are both set" do
+        cli = Bolt::CLI.new(%w[command run uptime --targets foo --debug --log-level notice])
+        expect { cli.parse }.to raise_error(Bolt::CLIError, /Only one of '--debug' or '--log-level' may be specified/)
+      end
+
+      it "warns when using debug" do
+        cli = Bolt::CLI.new(%w[command run uptime --targets foo --debug])
+        cli.parse
+        expect(@log_output.readlines).to include(/Command line option '--debug' is deprecated/)
+      end
+
+      it "log-level sets the log option" do
+        expect(Bolt::Logger).to receive(:configure).with({ 'console' => { level: 'notice' } }, true)
+
+        cli = Bolt::CLI.new(%w[command run uptime --targets foo --log-level notice])
+        cli.parse
+      end
+
+      it "raises a Bolt error when the level is a stringified integer" do
+        cli = Bolt::CLI.new(%w[command run uptime --targets foo --log-level 42])
+        expect { cli.parse }.to raise_error(Bolt::ValidationError, /level of log console must be one of/)
+      end
     end
 
     describe "host-key-check" do

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -393,5 +393,95 @@ describe "passes parsed AST to the apply_catalog task" do
         end
       end
     end
+
+    context 'setting log level' do
+      let(:lines) { @log_output.readlines }
+
+      after(:each) { @log_output.level = :all }
+
+      it 'logs debug messages' do
+        @log_output.level = :debug
+        run_cli(%w[plan run basic::error --log-level debug] + config_flags)
+
+        expect(lines).to include(/DEBUG.*Debugging/)
+        expect(lines).to include(/INFO.*Meh/)
+        expect(lines).to include(/NOTICE.*Helpful/)
+        expect(lines).to include(/WARN.*Warned/)
+        expect(lines).to include(/ERROR.*Fire/)
+        expect(lines).to include(/ERROR.*Stop/)
+        expect(lines).to include(/FATAL.*Drop/)
+        expect(lines).to include(/FATAL.*Roll/)
+      end
+
+      it 'logs info messages' do
+        @log_output.level = :info
+        run_cli(%w[plan run basic::error --log-level info] + config_flags)
+
+        expect(lines).not_to include(/DEBUG.*Debugging/)
+        expect(lines).to include(/INFO.*Meh/)
+        expect(lines).to include(/NOTICE.*Helpful/)
+        expect(lines).to include(/WARN.*Warned/)
+        expect(lines).to include(/ERROR.*Fire/)
+        expect(lines).to include(/ERROR.*Stop/)
+        expect(lines).to include(/FATAL.*Drop/)
+        expect(lines).to include(/FATAL.*Roll/)
+      end
+
+      it 'logs notice messages' do
+        @log_output.level = :notice
+        run_cli(%w[plan run basic::error --log-level notice] + config_flags)
+
+        expect(lines).not_to include(/DEBUG.*Debugging/)
+        expect(lines).not_to include(/INFO.*Meh/)
+        expect(lines).to include(/NOTICE.*Helpful/)
+        expect(lines).to include(/WARN.*Warned/)
+        expect(lines).to include(/ERROR.*Fire/)
+        expect(lines).to include(/ERROR.*Stop/)
+        expect(lines).to include(/FATAL.*Drop/)
+        expect(lines).to include(/FATAL.*Roll/)
+      end
+
+      it 'logs warn messages' do
+        @log_output.level = :warn
+        run_cli(%w[plan run basic::error --log-level warn] + config_flags)
+
+        expect(lines).not_to include(/DEBUG.*Debugging/)
+        expect(lines).not_to include(/INFO.*Meh/)
+        expect(lines).not_to include(/NOTICE.*Helpful/)
+        expect(lines).to include(/WARN.*Warned/)
+        expect(lines).to include(/ERROR.*Fire/)
+        expect(lines).to include(/ERROR.*Stop/)
+        expect(lines).to include(/FATAL.*Drop/)
+        expect(lines).to include(/FATAL.*Roll/)
+      end
+
+      it 'logs error messages' do
+        @log_output.level = :error
+        run_cli(%w[plan run basic::error --log-level error] + config_flags)
+
+        expect(lines).not_to include(/DEBUG.*Debugging/)
+        expect(lines).not_to include(/INFO.*Meh/)
+        expect(lines).not_to include(/NOTICE.*Helpful/)
+        expect(lines).not_to include(/WARN.*Warned/)
+        expect(lines).to include(/ERROR.*Fire/)
+        expect(lines).to include(/ERROR.*Stop/)
+        expect(lines).to include(/FATAL.*Drop/)
+        expect(lines).to include(/FATAL.*Roll/)
+      end
+
+      it 'logs fatal messages' do
+        @log_output.level = :fatal
+        run_cli(%w[plan run basic::error --log-level fatal] + config_flags)
+
+        expect(lines).not_to include(/DEBUG.*Debugging/)
+        expect(lines).not_to include(/INFO.*Meh/)
+        expect(lines).not_to include(/NOTICE.*Helpful/)
+        expect(lines).not_to include(/WARN.*Warned/)
+        expect(lines).not_to include(/ERROR.*Fire/)
+        expect(lines).not_to include(/ERROR.*Stop/)
+        expect(lines).to include(/FATAL.*Drop/)
+        expect(lines).to include(/FATAL.*Roll/)
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds a new `--log-level` CLI option that accepts a log level. When
using this option, any existing configuration for the console's log
level will be overridden with the specified level. The `--log-level`
option cannot be used in conjunction with the `--debug` option.

This also adds a warning that the `--debug` option is deprecated and
that Bolt will set `--log-level debug` instead.

Closes #1920 
Supersedes #1921 

!feature

* **Added `--log-level` CLI option** ([#1920](https://github.com/puppetlabs/bolt/issues/1920))

  The new `--log-level` CLI option can be used to override the console's
  log level. It accepts the following log levels: `debug`, `info`,
  `notice`, `warn`, `error`, `fatal`, `any`.