### PR TITLE
(bug) Fix --transport bug

### DIFF
--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -243,8 +243,9 @@ module Bolt
     def normalize_overrides(options)
       opts = options.transform_keys(&:to_s)
 
-      # Pull out config options
-      overrides = opts.slice(*OPTIONS.keys)
+      # Pull out config options. We need to add 'transport' as it's not part of the
+      # OPTIONS hash but is a valid option that can be set with the --transport CLI option
+      overrides = opts.slice(*OPTIONS.keys, 'transport')
 
       # Pull out transport config options
       TRANSPORT_CONFIG.each do |transport, config|

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -51,6 +51,11 @@ describe Bolt::Config do
       expect(config.modified_concurrency).to eq(true)
       expect(config.concurrency).to eq(36)
     end
+
+    it 'sets the default transport from an override' do
+      config = Bolt::Config.new(project, {}, transport: 'winrm')
+      expect(config.transport).to eq('winrm')
+    end
   end
 
   describe "::from_project" do

--- a/spec/fixtures/modules/inventory/plans/transport.pp
+++ b/spec/fixtures/modules/inventory/plans/transport.pp
@@ -1,0 +1,6 @@
+plan inventory::transport (
+  TargetSpec $targets
+) {
+  $target = get_target($targets)
+  return $target.transport.chomp
+}

--- a/spec/integration/target_spec.rb
+++ b/spec/integration/target_spec.rb
@@ -35,6 +35,11 @@ describe "when running a plan that creates targets", ssh: true do
       )
     end
 
+    it 'sets the default transport' do
+      output = run_cli(%w[plan run inventory::transport -t foo --transport winrm] + config_flags)
+      expect(JSON.parse(output)).to eq('winrm')
+    end
+
     it 'only prints necessary info' do
       params = { user: info[:user],
                  password: info[:password],


### PR DESCRIPTION
This fixes a bug introduced by #1923 that would not set the
default transport when using the `--transport` CLI option. Previously,
when normalizing the CLI overrides during config initialization, the
`OPTIONS` hash was used to slice out potential config options from the
CLI overrides hash. However, the `OPTIONS` hash does not include the
`transport` option, so the transport override would not be picked up.
This adds `transport` as an additional key to slice out of the overrides
hash.

!no-release-note