### PR TITLE
(GH-1938) Add native-ssh config option and warn_once logging utility

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -214,8 +214,8 @@ namespace :docs do
   desc 'Generate markdown docs for transports configuration reference'
   task :transports_reference do
     @opts     = Bolt::Config::INVENTORY_OPTIONS.dup
-    @external = Bolt::Config::Transport::Options::TRANSPORT_OPTIONS.slice(
-      *Bolt::Config::Transport::SSH::EXTERNAL_OPTIONS
+    @nativessh = Bolt::Config::Transport::Options::TRANSPORT_OPTIONS.slice(
+      *Bolt::Config::Transport::SSH::NATIVE_OPTIONS
     )
 
     # Stringify data types
@@ -237,8 +237,8 @@ namespace :docs do
       win: Bolt::Config::Transport::Local::WINDOWS_OPTIONS
     }
 
-    # Stringify types for the external SSH transport
-    @external.transform_values! { |data| stringify_types(data) }
+    # Stringify types for the native SSH transport
+    @nativessh.transform_values! { |data| stringify_types(data) }
 
     # Generate YAML file examples
     @yaml = generate_yaml_file(@opts)

--- a/Rakefile
+++ b/Rakefile
@@ -213,7 +213,7 @@ namespace :docs do
 
   desc 'Generate markdown docs for transports configuration reference'
   task :transports_reference do
-    @opts     = Bolt::Config::INVENTORY_OPTIONS.dup
+    @opts = Bolt::Config::INVENTORY_OPTIONS.dup
     @nativessh = Bolt::Config::Transport::Options::TRANSPORT_OPTIONS.slice(
       *Bolt::Config::Transport::SSH::NATIVE_OPTIONS
     )

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -357,7 +357,7 @@ $apply_results.each |$result| {
 }
 ```
 
-## External SSH transport
+## Native SSH transport
 
 This feature was introduced in [Bolt
 2.10.0](https://github.com/puppetlabs/bolt/blob/master/CHANGELOG.md#bolt-2100-2020-05-18).
@@ -365,12 +365,12 @@ This feature was introduced in [Bolt
 Bolt's SSH transport uses the ruby library `net-ssh`, which is a pure ruby
 implementation of the SSH2 client protocol. While robust, the library lacks
 support for some features and algorithms that are available in native SSH. When
-you use the external SSH transport, Bolt uses the SSH executable you've
-specified instead of using `net-ssh`. Essentially, using the external SSH
+you use the native SSH transport, Bolt uses the SSH executable you've
+specified instead of using `net-ssh`. Essentially, using the native SSH
 transport is the same as running SSH on your command line, but with Bolt
 managing the connections.
 
-To use the external SSH transport, set `ssh-command: <SSH>` in
+To use the native SSH transport, set `ssh-command: <SSH>` in
 [bolt.yaml](configuring_bolt.md), where `<SSH>` is the SSH command to run. For
 example:
 
@@ -382,7 +382,7 @@ ssh:
 The value of `ssh-command` can be either a string or an array, and you can
 provide any flags to the command. Bolt will append Bolt-configuration settings
 to the command, as well as the specified target, when connecting. Not all Bolt
-configuration options are supported using the external SSH transport, but you
+configuration options are supported using the native SSH transport, but you
 can configure most options in your OpenSSH Config. See [bolt configuration
 reference](bolt_configuration_reference.md) for the list of supported Bolt SSH
 options.
@@ -401,7 +401,7 @@ ssh:
 
 ### Connecting with SSH configuration not supported by net-ssh
 
-You can use the external SSH transport to connect to targets using configuration
+You can use the native SSH transport to connect to targets using configuration
 that isn't supported by the Ruby net-ssh library. Configure the settings for the
 transport in your inventory file, or use your local SSH config. 
 

--- a/documentation/templates/bolt_transports_reference.md.erb
+++ b/documentation/templates/bolt_transports_reference.md.erb
@@ -42,28 +42,28 @@ to targets. These options can be set in multiple locations:
 <% end %>
 <% end %>
 <% if option == 'ssh' -%>
-## External `ssh`
+## Native `ssh`
 
 Bolt's SSH transport uses the Ruby library `net-ssh`, which is a pure Ruby
 implementation of the SSH2 client protocol. While robust, the library lacks
 support for some features and algorithms that are available in native SSH.
-When you use the external SSH transport, Bolt uses the SSH executable you've
+When you use the native SSH transport, Bolt uses the SSH executable you've
 specified instead of using `net-ssh`.
 
-To enable the external SSH transport, you must set the `ssh-command` option
-under the `ssh` configuration option. When using the external SSH transport,
-a more limited set of configuration options is available.
+Set the `native-ssh` config option or pass `--native-ssh` on the command line
+to enable native SSH. When using the native SSH transport, a more limited set
+of configuration options is available.
 
 ```yaml
 ssh:
-  ssh-command: ssh
+  native-ssh: true
 ```
 
-> **Note:** The external SSH transport is experimental and is subject to
-> breaking changes. To read more about the external SSH transport, see
-> [External SSH transport](experimental_features.md#external-ssh-transport).
+> **Note:** The native SSH transport is experimental and is subject to
+> breaking changes. To read more about the native SSH transport, see
+> [Native SSH transport](experimental-features.md#native-ssh-transport).
 
-<% @external.each do |transport_option, data| -%>
+<% @nativessh.each do |transport_option, data| -%>
 ### `<%= transport_option %>`
 
 <%= data[:description] %>

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -747,7 +747,7 @@ module Bolt
              "This option is experimental.") do |exec|
         @options[:'ssh-command'] = exec
       end
-      define('--copy-command EXEC', "Command to copy files to remote hosts if using external SSH. ",
+      define('--copy-command EXEC', "Command to copy files to remote hosts if using native SSH. ",
              "This option is experimental.") do |exec|
         @options[:'copy-command'] = exec
       end

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -11,7 +11,7 @@ module Bolt
                 escalation: %w[run-as sudo-password sudo-password-prompt sudo-executable],
                 run_context: %w[concurrency inventoryfile save-rerun cleanup],
                 global_config_setters: %w[modulepath project configfile],
-                transports: %w[transport connect-timeout tty ssh-command copy-command],
+                transports: %w[transport connect-timeout tty native-ssh ssh-command copy-command],
                 display: %w[format color verbose trace],
                 global: %w[help version debug log-level] }.freeze
 
@@ -743,7 +743,11 @@ module Bolt
              "Specify a default transport: #{TRANSPORTS.keys.join(', ')}") do |t|
         @options[:transport] = t
       end
-      define('--ssh-command EXEC', "Executable to use instead of the net-ssh ruby library. ",
+      define('--[no-]native-ssh', 'Whether to shell out to native SSH or use the net-ssh Ruby library.',
+             'This option is experimental') do |bool|
+        @options[:'native-ssh'] = bool
+      end
+      define('--ssh-command EXEC', "Executable to use instead of the net-ssh Ruby library. ",
              "This option is experimental.") do |exec|
         @options[:'ssh-command'] = exec
       end

--- a/lib/bolt/config/transport/options.rb
+++ b/lib/bolt/config/transport/options.rb
@@ -108,17 +108,16 @@ module Bolt
           },
           "copy-command" => {
             type: [Array, String],
-            description: "The command to use when copying files using ssh-command. Bolt runs `<copy-command> <src> "\
+            description: "The command to use when copying files using native SSH. Bolt runs `<copy-command> <src> "\
                          "<dest>`. This option is used when you need support for features or algorithms that are not "\
                          "supported by the net-ssh Ruby library. **This option is experimental.** You can read more "\
-                         "about this option in [External SSH "\
-                         "transport](experimental_features.md#external-ssh-transport).",
+                         "about this option in [Native SSH transport](experimental_features.md#native-ssh-transport).",
             items: {
               type: String
             },
             _plugin: true,
-            _default: "scp -r",
-            _example: "scp -r -F ~/ssh-config/myconf"
+            _default: %w[scp -r],
+            _example: %w[scp -r -F ~/ssh-config/myconf]
           },
           "disconnect-timeout" => {
             type: Integer,
@@ -270,6 +269,13 @@ module Bolt
             _plugin: true,
             _example: %w[defaults hmac-md5]
           },
+          "native-ssh" => {
+            type: [TrueClass, FalseClass],
+            description: "This enables the native SSH transport, which shells out to SSH instead of using the "\
+                         "net-ssh Ruby library",
+            _default: false,
+            _example: true,            
+          },
           "password" => {
             type: String,
             description: "The password to use to login.",
@@ -368,16 +374,16 @@ module Bolt
           },
           "ssh-command" => {
             type: [Array, String],
-            description: "The command and flags to use when SSHing. This enables the external SSH transport, which "\
-                         "shells out to the specified command. This option is used when you need support for "\
+            description: "The command and flags to use when SSHing. This option is used when you need support for "\
                          "features or algorithms that are not supported by the net-ssh Ruby library. **This option "\
-                         "is experimental.** You can read more about this  option in [External SSH "\
-                         "transport](experimental_features.md#external-ssh-transport).",
+                         "is experimental.** You can read more about this  option in [Native SSH "\
+                         "transport](experimental_features.md#native-ssh-transport).",
             items: {
               type: String
             },
             _plugin: true,
-            _example: "ssh"
+            _default: 'ssh',
+            _example: %w[ssh -o Ciphers=chacha20-poly1305@openssh.com]
           },
           "ssl" => {
             type: [TrueClass, FalseClass],

--- a/lib/bolt/config/transport/options.rb
+++ b/lib/bolt/config/transport/options.rb
@@ -274,7 +274,7 @@ module Bolt
             description: "This enables the native SSH transport, which shells out to SSH instead of using the "\
                          "net-ssh Ruby library",
             _default: false,
-            _example: true,            
+            _example: true
           },
           "password" => {
             type: String,

--- a/lib/bolt/config/transport/ssh.rb
+++ b/lib/bolt/config/transport/ssh.rb
@@ -32,8 +32,8 @@ module Bolt
           user
         ].concat(RUN_AS_OPTIONS).sort.freeze
 
-        # Options available when using the external ssh transport
-        EXTERNAL_OPTIONS = %w[
+        # Options available when using the native ssh transport
+        NATIVE_OPTIONS = %w[
           cleanup
           copy-command
           host
@@ -56,17 +56,17 @@ module Bolt
           "tty"                => false
         }.freeze
 
-        # The set of options available for the ssh and external ssh transports overlap, so we
+        # The set of options available for the ssh and native ssh transports overlap, so we
         # need to check which transport is used before fully initializing, otherwise options
         # may not be filtered correctly.
         def initialize(data = {}, project = nil)
           assert_hash_or_config(data)
-          @external = true if data['ssh-command']
+          @native = true if data['ssh-command']
           super(data, project)
         end
 
         private def filter(unfiltered)
-          @external ? unfiltered.slice(*EXTERNAL_OPTIONS) : unfiltered.slice(*OPTIONS)
+          @native ? unfiltered.slice(*NATIVE_OPTIONS) : unfiltered.slice(*OPTIONS)
         end
 
         private def validate
@@ -117,8 +117,8 @@ module Bolt
             end
           end
 
-          if @config['ssh-command'] && !@config['load-config']
-            msg = 'Cannot use external SSH transport with load-config set to false'
+          if @config['native-ssh'] && !@config['load-config']
+            msg = 'Cannot use native SSH transport with load-config set to false'
             raise Bolt::ValidationError, msg
           end
         end

--- a/lib/bolt/config/transport/ssh.rb
+++ b/lib/bolt/config/transport/ssh.rb
@@ -66,6 +66,9 @@ module Bolt
           super(data, project)
         end
 
+        # This method is used to filter CLI options in the Config class. This
+        # should include `ssh-command` so that we can later warn if the option
+        # is present without `native-ssh`
         def self.options
           %w[ssh-command native-ssh].concat(OPTIONS)
         end

--- a/lib/bolt/logger.rb
+++ b/lib/bolt/logger.rb
@@ -15,6 +15,7 @@ module Bolt
       return if Logging.initialized?
 
       Logging.init :debug, :info, :notice, :warn, :error, :fatal, :any
+      @mutex = Mutex.new
 
       Logging.color_scheme(
         'bolt',
@@ -101,6 +102,17 @@ module Bolt
 
     def self.reset_logging
       Logging.reset
+    end
+
+    def self.warn_once(type, msg)
+      @mutex.synchronize {
+        @warnings ||= []
+        @logger ||= Logging.logger[self]
+        unless @warnings.include?(type)
+          @logger.warn(msg)
+          @warnings << type
+        end
+      }
     end
   end
 end

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'bolt/logger'
 require 'bolt/node/errors'
 require 'bolt/transport/simple'
 
@@ -21,6 +22,11 @@ module Bolt
       end
 
       def with_connection(target)
+        if target.transport_config['ssh-command'] && !target.transport_config['native-ssh']
+          Bolt::Logger.warn_once("ssh-command and native-ssh conflict",
+                                 "native-ssh must be true to use ssh-command")
+        end
+
         conn = if target.transport_config['native-ssh']
                  ExecConnection.new(target)
                else

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -21,7 +21,7 @@ module Bolt
       end
 
       def with_connection(target)
-        conn = if target.transport_config['ssh-command']
+        conn = if target.transport_config['native-ssh']
                  ExecConnection.new(target)
                else
                  Connection.new(target, @transport_logger)

--- a/lib/bolt/transport/ssh/exec_connection.rb
+++ b/lib/bolt/transport/ssh/exec_connection.rb
@@ -58,7 +58,7 @@ module Bolt
         end
 
         def build_ssh_command(command)
-          ssh_conf = @target.transport_config['ssh-command']
+          ssh_conf = @target.transport_config['ssh-command'] || 'ssh'
           ssh_cmd = Array(ssh_conf)
           ssh_cmd += ssh_opts
           ssh_cmd << userhost

--- a/schemas/bolt-transport-definitions.json
+++ b/schemas/bolt-transport-definitions.json
@@ -446,7 +446,7 @@
       "min": 0
     },
     "ssh-command": {
-      "description": "Array of command and flags to use when SSHing. This enables the external SSH transport which shells out to the specified command.",
+      "description": "Array of command and flags to use when SSHing using native SSH.",
       "type": ["array", "string"]
     },
     "ssl": {

--- a/schemas/bolt-transport-definitions.json
+++ b/schemas/bolt-transport-definitions.json
@@ -62,6 +62,7 @@
       "kex-algorithms":        { "$ref": "#/definitions/kex-algorithms" },
       "load-config":           { "$ref": "#/definitions/load-config" },
       "login-shell":           { "$ref": "#/definitions/login-shell" },
+      "native-ssh":            { "$ref": "#/definitions/native-ssh" },
       "mac-algorithms":        { "$ref": "#/definitions/mac-algorithms" },
       "password":              { "$ref": "#/definitions/password" },
       "port":                  { "$ref": "#/definitions/port" },
@@ -149,7 +150,7 @@
       ]
     },
     "copy-command": {
-      "description": "Array of command and flags to use when copying files using ssh-command. Bolt runs `<copy-command> <src> <dest>`.",
+      "description": "Array of command and flags to use when copying files using native SSH. Bolt runs `<copy-command> <src> <dest>`.",
       "oneOf": [
         {
           "type": "array"
@@ -374,6 +375,10 @@
           "$ref": "#/definitions/_plugin"
         }
       ]
+    },
+    "native-ssh": {
+      "description": "Whether to shell out directly to SSH or use the Ruby net-ssh library.",
+      "type": "boolean"
     },
     "mac-algorithms": {
       "description": "List of message authentication code algorithms to use when establishing a connection with a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed at https://github.com/net-ssh/net-ssh#supported-algorithms . All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms when using this option, add 'defaults' to the list of supported algorithms.",

--- a/spec/integration/transport/ssh_spec.rb
+++ b/spec/integration/transport/ssh_spec.rb
@@ -456,7 +456,7 @@ describe Bolt::Transport::SSH, ssh: true do
 
       it "uses the configured ssh-command" do
         expect { ssh.run_command(target, command) }
-          .to raise_error(/Can't open user config file \/tmp\/fake/)
+          .to raise_error(%r{Can't open user config file /tmp/fake})
       end
     end
 

--- a/spec/integration/transport/ssh_spec.rb
+++ b/spec/integration/transport/ssh_spec.rb
@@ -37,7 +37,7 @@ describe Bolt::Transport::SSH, ssh: true do
   let(:ssh_exec)          {
     { 'host-key-check' => false,
       'user' => user,
-      'ssh-command' => 'ssh',
+      'native-ssh' => true,
       'private-key' => key }
   }
 
@@ -438,7 +438,7 @@ describe Bolt::Transport::SSH, ssh: true do
 
   context "with exec_connection" do
     let(:exec_config) {
-      { 'ssh-command' => 'ssh',
+      { 'native-ssh' => true,
         'private-key' => key,
         'sudo-password' => password,
         'host-key-check' => false,
@@ -449,6 +449,15 @@ describe Bolt::Transport::SSH, ssh: true do
 
     it "executes a command on a host" do
       expect(ssh.run_command(target, command).value['stdout']).to eq("/home/#{user}\n")
+    end
+
+    context "with ssh-command set" do
+      let(:transport_config) { exec_config.merge('ssh-command' => %w[ssh -F /tmp/fake]) }
+
+      it "uses the configured ssh-command" do
+        expect { ssh.run_command(target, command) }
+          .to raise_error(/Can't open user config file \/tmp\/fake/)
+      end
     end
 
     it "can upload a file to a host" do

--- a/spec/integration/transport/ssh_spec.rb
+++ b/spec/integration/transport/ssh_spec.rb
@@ -76,7 +76,7 @@ describe Bolt::Transport::SSH, ssh: true do
     include_examples 'with sudo'
   end
 
-  context 'with external ssh' do
+  context 'with native ssh' do
     let(:transport_config) { ssh_exec }
     let(:os_context)       { posix_context }
     let(:transport)        { :ssh }


### PR DESCRIPTION
This PR accomplishes 3 main tasks:
* It renames `external-ssh` to `native-ssh`, to make the purpose of the configuration option and documentation more intuitive and clear
* It adds a new `native-ssh` SSH configuration option which is used to enable shelling out to SSH rather than using the Ruby net-ssh library. Previously this option was toggled based on the presence of `ssh-command` configuration, which overloaded the option to both enable native ssh and provide the command that should be used to connect via SSH. This makes it so that if `native-ssh` is not set, `ssh-command` will be ignored
* Lastly it adds a new `warn_once` logging utility, which stores warn_once warnings in an instance variable on the `Bolt::Logger` class and verifies each warning type of warning is only printed once per Bolt run. Accessing the variable is protected by a mutex to avoid race conditions.

Closes #1938