### PR TITLE
(bug-fix) Find embedded projects specified on the CLI

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -115,7 +115,12 @@ module Bolt
                   Bolt::Config.from_file(options[:configfile], options)
                 else
                   project = if options[:boltdir]
-                              Bolt::Project.create_project(options[:boltdir])
+                              dir = Pathname.new(options[:boltdir])
+                              if (dir + Bolt::Project::BOLTDIR_NAME).directory?
+                                Bolt::Project.create_project(dir + Bolt::Project::BOLTDIR_NAME)
+                              else
+                                Bolt::Project.create_project(dir)
+                              end
                             else
                               Bolt::Project.find_boltdir(Dir.pwd)
                             end

--- a/spec/fixtures/projects/embedded/plans/init.pp
+++ b/spec/fixtures/projects/embedded/plans/init.pp
@@ -1,7 +1,0 @@
-plan embedded(
-  TargetSpec $targets
-) {
-  $target_object = get_target($targets)
-  return run_command("echo polo", $target_object)
-}
-

--- a/spec/integration/project_spec.rb
+++ b/spec/integration/project_spec.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'bolt_spec/config'
 require 'bolt_spec/conn'
 require 'bolt_spec/integration'
 
 describe "When loading content", ssh: true do
+  include BoltSpec::Config
   include BoltSpec::Conn
   include BoltSpec::Integration
 
   let(:local) { Bolt::Project.create_project(File.join(__dir__, '../fixtures/projects/local'), 'local') }
+  let(:embedded) { fixture_path('projects/embedded') }
   let(:target) { conn_uri('ssh') }
   let(:config_flags) { %W[--no-host-key-check --password #{conn_info('ssh')[:password]}] }
 
@@ -20,6 +23,11 @@ describe "When loading content", ssh: true do
   it "loads plans from project when specified with --project" do
     result = run_cli_json(%W[plan run local -t #{target} --project #{local.path}] + config_flags)
     expect(result[0]['value']['stdout'].strip).to eq('polo')
+  end
+
+  it "loads embedded plans from a project specified with --project" do
+    result = run_cli_json(%W[plan show --project #{embedded}])
+    expect(result['plans']).to include(['embedded'])
   end
 
   it "project level content can reference other modules" do


### PR DESCRIPTION
This modifies how projects specified with `--project` or `--boltdir` are
found. Previously the provided path would be used as the path to the
project, where bolt configuration was expected to be found. However with
embedded projects - those that store files in `Boltdir` - users would
specify the parent directory of `Boltdir` expect the project to be
loaded as if they were executing Bolt from that parent directory. This
modifies how we handle project directories first looks for a `Boltdir`
in the specified directory, and if none is present use the specified
directory as the project root.

!bug

* **Load projects with an embedded Boltdir when specified on the CLI**

  We now look for a `Boltdir` in the directory specified by `--project`
  or `--boltdir` and use that if present. If not, we use the specified
  path as the project root.