### PR TITLE
(bug) Fix broken headers in privilege escalation template

### DIFF
--- a/documentation/templates/privilege_escalation.md.erb
+++ b/documentation/templates/privilege_escalation.md.erb
@@ -7,7 +7,7 @@ doesn't allow incoming connections as the root user.  Bolt has several
 configuration options for setting which user to execute as, how to escalate to
 that user, and how to run commands as that user.
 
-### Limitations
+## Limitations
 
 Bolt will only use the `run-as` user if:
 
@@ -35,7 +35,7 @@ You can configure escalation privilege in your `inventory.yaml` or
 [Configuring Bolt](configuring_bolt.html).
 
 <% @run_as.each do |option, data| -%>
-### `<%= option %>`
+#### `<%= option %>`
 
 <%= data[:desc] %>
 


### PR DESCRIPTION
The docs job does not ship the privilege escalation docs due to a jump
from a h1 to h3 without an intermediary h2. This updates the template to
use the correct heading sizes.

!no-release-note