### PR TITLE
(packaging) Make the paint gem required by the rainbow outputter optional

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
+          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
+          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3
@@ -67,7 +67,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
+          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3

--- a/.github/workflows/modules.yaml
+++ b/.github/workflows/modules.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
+          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3
@@ -60,7 +60,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
+          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
+          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3
@@ -82,7 +82,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('**/Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
+          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,9 @@ gem "rack", '>= 2.0.5'
 gem "rails-auth", '>= 2.1.4'
 gem "sinatra", '>= 2.0.4'
 
+# Optional paint gem for rainbow outputter
+gem "paint", "~> 2.2"
+
 group(:test) do
   gem "beaker-hostgenerator"
   gem "mocha", '~> 1.4.0'

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -47,7 +47,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-ssh", ">= 4.0"
   spec.add_dependency "net-ssh-krb", "~> 0.5"
   spec.add_dependency "orchestrator_client", "~> 0.4"
-  spec.add_dependency "paint", "~> 2.2"
   spec.add_dependency "puppet", [">= 6.16.0", "< 7"]
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "puppet-strings", "~> 2.3"

--- a/lib/bolt/outputter.rb
+++ b/lib/bolt/outputter.rb
@@ -26,5 +26,5 @@ end
 
 require 'bolt/outputter/human'
 require 'bolt/outputter/json'
-require 'bolt/outputter/rainbow'
 require 'bolt/outputter/logger'
+require 'bolt/outputter/rainbow'

--- a/lib/bolt/outputter/rainbow.rb
+++ b/lib/bolt/outputter/rainbow.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 require 'bolt/pal'
-require 'paint'
 
 module Bolt
   class Outputter
     class Rainbow < Bolt::Outputter::Human
       def initialize(color, verbose, trace, stream = $stdout)
+        begin
+          require 'paint'
+        rescue LoadError
+          raise "The 'paint' gem is required to use the rainbow outputter."
+        end
         super
         @line_color = 0
         @color = 0


### PR DESCRIPTION


Given we dont want to ship the paint gem with PE this commit makes the gem optional. The gem will only attempt to be loaded when the rainbow outputter is requested. The paint gem will ship with bolt packages and is included in the Gemfile, but is ommited from the gemspec.