### PR TITLE
(GH-1900) Generate JSON schemas with plugin references

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -49,9 +49,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "orchestrator_client", "~> 0.4"
   spec.add_dependency "paint", "~> 2.2"
   spec.add_dependency "puppet", [">= 6.16.0", "< 7"]
+  spec.add_dependency "puppetfile-resolver", "~> 0.1.0"
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "puppet-strings", "~> 2.3"
-  spec.add_dependency "puppetfile-resolver", "~> 0.1.0"
   spec.add_dependency "r10k", "~> 3.1"
   spec.add_dependency "ruby_smb", "~> 1.0"
   spec.add_dependency "terminal-table", "~> 1.8"

--- a/documentation/templates/bolt_configuration_reference.md.erb
+++ b/documentation/templates/bolt_configuration_reference.md.erb
@@ -13,22 +13,22 @@ The `bolt.yaml` configuration file is supported in all [project directories](con
 <% @opts.each do |option, data| -%>
 ### `<%= option %>`
 
-<%= data[:desc] %>
+<%= data[:description] %>
 
 - **Type:** <%= data[:type] %>
-<% if data.key?(:def) -%>
-- **Default:** <%= data[:def] %>
+<% if data.key?(:_default) -%>
+- **Default:** <%= data[:_default] %>
 <% end -%>
 
-<% if @subopts.key?(option) -%>
-<% @subopts[option].each do |option, data| -%>
+<% if data.key?(:properties) -%>
+<% data[:properties].each do |option, data| -%>
 #### `<%= option %>`
 
-<%= data[:desc] %>
+<%= data[:description] %>
 
 - **Type:** <%= data[:type] %>
-<% if data.key?(:def) -%>
-- **Default:** <%= data[:def] %>
+<% if data.key?(:_default) -%>
+- **Default:** <%= data[:_default] %>
 <% end -%>
 <% end %>
 <% end -%>

--- a/documentation/templates/bolt_defaults_reference.md.erb
+++ b/documentation/templates/bolt_defaults_reference.md.erb
@@ -8,29 +8,27 @@ which is supported in both the [system-wide and user-level configuration directo
 <% @opts.each do |option, data| -%>
 ### `<%= option %>`
 
-<%= data[:desc] %>
+<%= data[:description] %>
 
 - **Type:** <%= data[:type] %>
-<% if data.key?(:def) -%>
-- **Default:** <%= data[:def] %>
+<% if data.key?(:_default) -%>
+- **Default:** <%= data[:_default] %>
 <% end -%>
 
-<% if @subopts.key?(option) -%>
 <% if option == 'inventory-config' %>
 For a detailed description of each option, their default values, and any available
 sub-options, see [Transport configuration reference](bolt_transports_reference.md).
-<% else %>
-<% @subopts[option].each do |option, data| -%>
+<% elsif data.key?(:properties) -%>
+<% data[:properties].each do |option, data| -%>
 #### `<%= option %>`
 
-<%= data[:desc] %>
+<%= data[:description] %>
 
 - **Type:** <%= data[:type] %>
-<% if data.key?(:def) -%>
-- **Default:** <%= data[:def] %>
+<% if data.key?(:_default) -%>
+- **Default:** <%= data[:_default] %>
 <% end %>
 <% end -%>
-<% end %>
 <% end -%>
 
 ```yaml

--- a/documentation/templates/bolt_project_reference.md.erb
+++ b/documentation/templates/bolt_project_reference.md.erb
@@ -11,22 +11,22 @@ which is supported in the [project directory](configuring_bolt.md).
 <% @opts.each do |option, data| -%>
 ### `<%= option %>`
 
-<%= data[:desc] %>
+<%= data[:description] %>
 
 - **Type:** <%= data[:type] %>
-<% if data.key?(:def) -%>
-- **Default:** <%= data[:def] %>
+<% if data.key?(:_default) -%>
+- **Default:** <%= data[:_default] %>
 <% end -%>
 
-<% if @subopts.key?(option) -%>
-<% @subopts[option].each do |option, data| -%>
+<% if data.key?(:properties) -%>
+<% data[:properties].each do |option, data| -%>
 #### `<%= option %>`
 
-<%= data[:desc] %>
+<%= data[:description] %>
 
 - **Type:** <%= data[:type] %>
-<% if data.key?(:def) -%>
-- **Default:** <%= data[:def] %>
+<% if data.key?(:_default) -%>
+- **Default:** <%= data[:_default] %>
 <% end -%>
 <% end %>
 <% end -%>

--- a/documentation/templates/bolt_transports_reference.md.erb
+++ b/documentation/templates/bolt_transports_reference.md.erb
@@ -10,33 +10,33 @@ to targets. These options can be set in multiple locations:
 <% @opts.each do |option, data| -%>
 ## `<%= option %>`
 
-<%= data[:desc] %>
+<%= data[:description] %>
 
 <% if option == 'local' -%>
 - ***nix:** `<%= @local_sets[:nix].join('`, `') %>`
 - **Windows:** `<%= @local_sets[:win].join('`, `') %>`
 <% end -%>
 
-<% unless data[:def].nil? -%>
-- **Default:** <%= data[:def] %>
+<% if data.key?(:_default) -%>
+- **Default:** <%= data[:_default] %>
 <% end -%>
 
-<% if @subopts.key?(option) -%>
-<% @subopts[option].each do |transport_option, data| -%>
+<% if data.key?(:properties) -%>
+<% data[:properties].each do |transport_option, data| -%>
 ### `<%= transport_option %>`
 
-<%= data[:desc] %>
+<%= data[:description] %>
 
 <% if data.key?(:type) -%>
-- **Type:** <%= data[:type] == TrueClass ? 'Boolean' : data[:type] %>
+- **Type:** <%= data[:type] %>
 <% end -%>
-<% if data.key?(:def) -%>
-- **Default:** <%= data[:def] %>
+<% if data.key?(:_default) -%>
+- **Default:** <%= data[:_default] %>
 <% end -%>
 
-<% if data.key?(:exmp) -%>
+<% if data.key?(:_example) -%>
 ```yaml
-<%= { transport_option => data[:exmp] }.to_yaml(indentation: 2).split("\n").drop(1).join("\n") %>
+<%= { transport_option => data[:_example] }.to_yaml(indentation: 2).split("\n").drop(1).join("\n") %>
 ```
 <% end %>
 <% end %>
@@ -63,24 +63,29 @@ ssh:
 > breaking changes. To read more about the external SSH transport, see
 > [External SSH transport](experimental-features.md#external-ssh-transport).
 
-<% @subopts['external-ssh'].each do |transport_option, data| -%>
+<% @external.each do |transport_option, data| -%>
 ### `<%= transport_option %>`
 
-<%= data[:desc] %>
+<%= data[:description] %>
 
 <% if data.key?(:type) -%>
-- **Type:** <%= data[:type] == TrueClass ? 'Boolean' : data[:type] %>
+- **Type:** <%= data[:type] %>
 <% end -%>
-<% if data.key?(:def) -%>
-- **Default:** <%= data[:def] %>
+<% if data.key?(:_default) -%>
+- **Default:** <%= data[:_default] %>
 <% end -%>
 
-<% if data.key?(:exmp) -%>
+<% if data.key?(:_example) -%>
 ```yaml
-<%= { transport_option => data[:exmp] }.to_yaml(indentation: 2).split("\n").drop(1).join("\n") %>
+<%= { transport_option => data[:_example] }.to_yaml(indentation: 2).split("\n").drop(1).join("\n") %>
 ```
 <% end %>
 <% end %>
+<% end %>
+<% if data.key?(:_example) -%>
+```yaml
+<%= { option => data[:_example] }.to_yaml(indentation: 2).split("\n").drop(1).join("\n") %>
+```
 <% end %>
 <% end %>
 

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -6,13 +6,6 @@ require 'pathname'
 require 'bolt/project'
 require 'bolt/logger'
 require 'bolt/util'
-# Transport config objects
-require 'bolt/config/transport/ssh'
-require 'bolt/config/transport/winrm'
-require 'bolt/config/transport/orch'
-require 'bolt/config/transport/local'
-require 'bolt/config/transport/docker'
-require 'bolt/config/transport/remote'
 require 'bolt/config/options'
 
 module Bolt
@@ -30,17 +23,6 @@ module Bolt
 
     BOLT_CONFIG_NAME = 'bolt.yaml'
     BOLT_DEFAULTS_NAME = 'bolt-defaults.yaml'
-
-    # Transport config classes. Used to load default transport config which
-    # gets passed along to the inventory.
-    TRANSPORT_CONFIG = {
-      'ssh'    => Bolt::Config::Transport::SSH,
-      'winrm'  => Bolt::Config::Transport::WinRM,
-      'pcp'    => Bolt::Config::Transport::Orch,
-      'local'  => Bolt::Config::Transport::Local,
-      'docker' => Bolt::Config::Transport::Docker,
-      'remote' => Bolt::Config::Transport::Remote
-    }.freeze
 
     # The default concurrency value that is used when the ulimit is not low (i.e. < 700)
     DEFAULT_DEFAULT_CONCURRENCY = 100
@@ -316,8 +298,8 @@ module Bolt
       end
 
       # Filter hashes to only include valid options
-      @data['apply_settings'] = @data['apply_settings'].slice(*SUBOPTIONS['apply_settings'].keys)
-      @data['puppetfile'] = @data['puppetfile'].slice(*SUBOPTIONS['puppetfile'].keys)
+      @data['apply_settings'] = @data['apply_settings'].slice(*OPTIONS['apply_settings'][:properties].keys)
+      @data['puppetfile'] = @data['puppetfile'].slice(*OPTIONS['puppetfile'][:properties].keys)
     end
 
     private def normalize_log(target)
@@ -331,7 +313,7 @@ module Bolt
         next unless val.is_a?(Hash)
 
         name = normalize_log(key)
-        acc[name] = val.slice(*SUBOPTIONS['log'].keys)
+        acc[name] = val.slice('append', 'level')
                        .transform_keys(&:to_sym)
 
         if (v = acc[name][:level])

--- a/lib/bolt/config/transport/options.rb
+++ b/lib/bolt/config/transport/options.rb
@@ -6,290 +6,439 @@ module Bolt
       module Options
         LOGIN_SHELLS = %w[sh bash zsh dash ksh powershell].freeze
 
-        # The following constant defines the various configuration options available to Bolt's.
-        # transports. Each key is a configuration option and values are the data describing the
-        # option. Data includes the following keys:
-        #   :def     The **documented** default value. This is the value that is displayed
-        #            in the reference docs and is not used by Bolt to actually set a default
-        #            value.
-        #   :desc    The text description of the option that is displayed in documentation.
-        #   :exmp    An example value for the option. This is used to generate an example
-        #            configuration file in the reference docs.
-        #   :type    The option's expected type. If an option accepts multiple types, this is
-        #            an array of the accepted types. Any options that accept a Boolean value
-        #            should use the [TrueClass, FalseClass] type.
+        # The following constants define the various configuration options available to Bolt's
+        # transports. Each constant is a hash where keys are the configuration option and values
+        # are the option's definition. These options are used in multiple locations:
         #
-        # NOTE: All transport configuration options should have a corresponding schema definition
-        #       in schemas/bolt-transport-definitions.json
+        #   - Automatic type validation when loading and setting configuration
+        #   - Generating reference documentation for configuration files
+        #   - Generating JSON schemas for configuration files
+        #
+        # Data includes keys defined by JSON Schema Draft 07 as well as some metadata used
+        # by Bolt to generate documentation. The following keys are used:
+        #
+        #   :description    String      A detailed description of the option and what it does. This
+        #                               field is used in both documentation and the JSON schemas,
+        #                               and should provide as much detail as possible, including
+        #                               links to relevant documentation.
+        #
+        #   :type           Class       The expected type of a value. These should be Ruby classes,
+        #                               as this field is used to perform automatic type validation.
+        #                               If an option can accept more than one type, this should be
+        #                               an array of types. Boolean values should set :type to
+        #                               [TrueClass, FalseClass], as Ruby does not have a single
+        #                               Boolean class.
+        #
+        #   :items          Hash        A definition hash for items in an array. Similar to values
+        #                               for top-level options, items can have a :description, :type,
+        #                               or any other key in this list.
+        #
+        #   :uniqueItems    Boolean     Whether or not an array should contain only unique items.
+        #
+        #   :properties     Hash        A hash where keys are sub-options and values are definitions
+        #                               for the sub-option. Similar to values for top-level options,
+        #                               properties can have a :description, :type, or any other key
+        #                               in this list.
+        #
+        #   :additionalProperties       A variation of the :properties key, where the hash is a
+        #                   Hash        definition for any properties not specified in :properties.
+        #                               This can be used to permit arbitrary sub-options, such as
+        #                               logs for the 'log' option.
+        #
+        #   :propertyNames  Hash        A hash that defines the properties that an option's property
+        #                               names must adhere to.
+        #
+        #   :required       Array       An array of properties that are required for options that
+        #                               accept Hash values.
+        #
+        #   :minimum        Integer     The minimum integer value for an option.
+        #
+        #   :enum           Array       An array of values that the option recognizes.
+        #
+        #   :pattern        String      A JSON regex pattern that the option's vaue should match.
+        #
+        #   :format         String      Requires that a string value matches a format defined by the
+        #                               JSON Schema draft.
+        #
+        #   :_plugin        Boolean     Whether the option accepts a plugin reference. This is used
+        #                               when generating the JSON schemas to determine whether or not
+        #                               to include a reference to the _plugin definition. If :_plugin
+        #                               is set to true, the script that generates JSON schemas will
+        #                               automatically recurse through the :items and :properties keys
+        #                               and add plugin references if applicable.
+        #
+        #   :_example       Any         An example value for the option. This is used to generate
+        #                               reference documentation for configuration files.
+        #
+        #   :_default       Any         The documented default value for the option. This is only
+        #                               used to generate reference documentation for configuration
+        #                               files and is not used by Bolt to actually set default values.
         TRANSPORT_OPTIONS = {
           "basic-auth-only" => {
             type: [TrueClass, FalseClass],
-            desc: "Whether to force basic authentication. This option is only available when using SSL.",
-            def:  false,
-            exmp: true
+            description: "Whether to force basic authentication. This option is only available when using SSL.",
+            _plugin: true,
+            _default: false,
+            _example: true
           },
           "cacert" => {
             type: String,
-            desc: "The path to the CA certificate.",
-            exmp: "~/.puppetlabs/puppet/cert.pem"
+            description: "The path to the CA certificate.",
+            _plugin: true,
+            _example: "~/.puppetlabs/puppet/cert.pem"
           },
           "cleanup" => {
             type: [TrueClass, FalseClass],
-            desc: "Whether to clean up temporary files created on targets. When running commands on a target, "\
-                  "Bolt may create temporary files. After completing the command, these files are automatically "\
-                  "deleted. This value can be set to 'false' if you wish to leave these temporary files on the "\
-                  "target.",
-            def:  true,
-            exmp: false
+            description: "Whether to clean up temporary files created on targets. When running commands on a target, "\
+                         "Bolt may create temporary files. After completing the command, these files are "\
+                         "automatically deleted. This value can be set to 'false' if you wish to leave these "\
+                         "temporary files on the target.",
+            _plugin: true,
+            _default: true,
+            _example: false
           },
           "connect-timeout" => {
             type: Integer,
-            desc: "How long to wait in seconds when establishing connections. Set this value higher if you "\
-                  "frequently encounter connection timeout errors when running Bolt.",
-            def:  10,
-            exmp: 15
+            description: "How long to wait in seconds when establishing connections. Set this value higher if you "\
+                         "frequently encounter connection timeout errors when running Bolt.",
+            minimum: 1,
+            _plugin: true,
+            _default: 10,
+            _example: 15
           },
           "copy-command" => {
             type: [Array, String],
-            desc: "The command to use when copying files using ssh-command. Bolt runs `<copy-command> <src> <dest>`. "\
-                  "This option is used when you need support for features or algorithms that are not supported "\
-                  "by the net-ssh Ruby library. **This option is experimental.** You can read more about this "\
-                  "option in [External SSH transport](experimental_features.md#external-ssh-transport).",
-            def:  "scp -r",
-            exmp: "scp -r -F ~/ssh-config/myconf"
+            description: "The command to use when copying files using ssh-command. Bolt runs `<copy-command> <src> "\
+                         "<dest>`. This option is used when you need support for features or algorithms that are not "\
+                         "supported by the net-ssh Ruby library. **This option is experimental.** You can read more "\
+                         "about this option in [External SSH "\
+                         "transport](experimental_features.md#external-ssh-transport).",
+            items: {
+              type: String
+            },
+            _plugin: true,
+            _default: "scp -r",
+            _example: "scp -r -F ~/ssh-config/myconf"
           },
           "disconnect-timeout" => {
             type: Integer,
-            desc: "How long to wait in seconds before force-closing a connection.",
-            def:  5,
-            exmp: 10
+            description: "How long to wait in seconds before force-closing a connection.",
+            minimum: 1,
+            _plugin: true,
+            _default: 5,
+            _example: 10
           },
           "encryption-algorithms" => {
             type: Array,
-            desc: "A list of encryption algorithms to use when establishing a connection "\
-                  "to a target. Supported algorithms are defined by the Ruby net-ssh library and can be "\
-                  "viewed [here](https://github.com/net-ssh/net-ssh#supported-algorithms). All supported, "\
-                  "non-deprecated algorithms are available by default when this option is not used. To "\
-                  "reference all default algorithms using this option, add 'defaults' to the list of "\
-                  "supported algorithms.",
-            exmp: %w[defaults idea-cbc]
+            description: "A list of encryption algorithms to use when establishing a connection "\
+                         "to a target. Supported algorithms are defined by the Ruby net-ssh library and can be "\
+                         "viewed [here](https://github.com/net-ssh/net-ssh#supported-algorithms). All supported, "\
+                         "non-deprecated algorithms are available by default when this option is not used. To "\
+                         "reference all default algorithms using this option, add 'defaults' to the list of "\
+                         "supported algorithms.",
+            uniqueItems: true,
+            items: {
+              type: String
+            },
+            _plugin: true,
+            _example: %w[defaults idea-cbc]
           },
           "extensions" => {
             type: Array,
-            desc: "A list of file extensions that are accepted for scripts or tasks on "\
-                  "Windows. Scripts with these file extensions rely on the target's file "\
-                  "type association to run. For example, if Python is installed on the "\
-                  "system, a `.py` script runs with `python.exe`. The extensions `.ps1`, "\
-                  "`.rb`, and `.pp` are always allowed and run via hard-coded "\
-                  "executables.",
-            exmp: [".sh"]
+            description: "A list of file extensions that are accepted for scripts or tasks on "\
+                         "Windows. Scripts with these file extensions rely on the target's file "\
+                         "type association to run. For example, if Python is installed on the "\
+                         "system, a `.py` script runs with `python.exe`. The extensions `.ps1`, "\
+                         "`.rb`, and `.pp` are always allowed and run via hard-coded "\
+                         "executables.",
+            uniqueItems: true,
+            items: {
+              type: String
+            },
+            _plugin: true,
+            _example: [".sh"]
           },
           "file-protocol" => {
             type: String,
-            desc: "Which file transfer protocol to use. Either `winrm` or `smb`. Using `smb` is "\
-                  "recommended for large file transfers.",
-            def:  "winrm",
-            exmp: "smb"
+            description: "Which file transfer protocol to use. Either `winrm` or `smb`. Using `smb` is "\
+                         "recommended for large file transfers.",
+            enum: %w[smb winrm],
+            _plugin: true,
+            _default: "winrm",
+            _example: "smb"
           },
           "host" => {
             type: String,
-            desc: "The target's hostname.",
-            exmp: "docker_host_production"
+            description: "The target's hostname.",
+            _plugin: true,
+            _example: "docker_host_production"
           },
           "host-key-algorithms" => {
             type: Array,
-            desc: "A list of host key algorithms to use when establishing a connection "\
-                  "to a target. Supported algorithms are defined by the Ruby net-ssh library and can be "\
-                  "viewed [here](https://github.com/net-ssh/net-ssh#supported-algorithms). All supported, "\
-                  "non-deprecated algorithms are available by default when this option is not used. To "\
-                  "reference all default algorithms using this option, add 'defaults' to the list of "\
-                  "supported algorithms.",
-            exmp: %w[defaults ssh-dss]
+            description: "A list of host key algorithms to use when establishing a connection "\
+                         "to a target. Supported algorithms are defined by the Ruby net-ssh library and can be "\
+                         "viewed [here](https://github.com/net-ssh/net-ssh#supported-algorithms). All supported, "\
+                         "non-deprecated algorithms are available by default when this option is not used. To "\
+                         "reference all default algorithms using this option, add 'defaults' to the list of "\
+                         "supported algorithms.",
+            uniqueItems: true,
+            items: {
+              type: String
+            },
+            _plugin: true,
+            _example: %w[defaults ssh-dss]
           },
           "host-key-check" => {
             type: [TrueClass, FalseClass],
-            desc: "Whether to perform host key validation when connecting.",
-            exmp: false
+            description: "Whether to perform host key validation when connecting.",
+            _plugin: true,
+            _example: false
           },
           "interpreters" => {
             type: Hash,
-            desc: "A map of an extension name to the absolute path of an executable,  enabling you to override "\
-                  "the shebang defined in a task executable. The extension can optionally be specified with the "\
-                  "`.` character (`.py` and `py` both map to a task executable `task.py`) and the extension is "\
-                  "case sensitive. When a target's name is `localhost`, Ruby tasks run with the Bolt Ruby "\
-                  "interpreter by default.",
-            exmp: { "rb" => "/usr/bin/ruby" }
+            description: "A map of an extension name to the absolute path of an executable,  enabling you to "\
+                         "override the shebang defined in a task executable. The extension can optionally be "\
+                         "specified with the `.` character (`.py` and `py` both map to a task executable "\
+                         "`task.py`) and the extension is case sensitive. When a target's name is `localhost`, "\
+                         "Ruby tasks run with the Bolt Ruby interpreter by default.",
+            additionalProperties: {
+              type: String
+            },
+            propertyNames: {
+              pattern: "^.?[a-zA-Z0-9]+$"
+            },
+            _plugin: true,
+            _example: { "rb" => "/usr/bin/ruby" }
           },
           "job-poll-interval" => {
             type: Integer,
-            desc: "The interval, in seconds, to poll orchestrator for job status.",
-            exmp: 2
+            description: "The interval, in seconds, to poll orchestrator for job status.",
+            minimum: 1,
+            _plugin: true,
+            _example: 2
           },
           "job-poll-timeout" => {
             type: Integer,
-            desc: "The time, in seconds, to wait for orchestrator job status.",
-            exmp: 2000
+            description: "The time, in seconds, to wait for orchestrator job status.",
+            minimum: 1,
+            _plugin: true,
+            _example: 2000
           },
           "kex-algorithms" => {
             type: Array,
-            desc: "A list of key exchange algorithms to use when establishing a connection "\
-                  "to a target. Supported algorithms are defined by the Ruby net-ssh library and can be "\
-                  "viewed [here](https://github.com/net-ssh/net-ssh#supported-algorithms). All supported, "\
-                  "non-deprecated algorithms are available by default when this option is not used. To "\
-                  "reference all default algorithms using this option, add 'defaults' to the list of "\
-                  "supported algorithms.",
-            exmp: %w[defaults diffie-hellman-group1-sha1]
+            description: "A list of key exchange algorithms to use when establishing a connection "\
+                         "to a target. Supported algorithms are defined by the Ruby net-ssh library and can be "\
+                         "viewed [here](https://github.com/net-ssh/net-ssh#supported-algorithms). All supported, "\
+                         "non-deprecated algorithms are available by default when this option is not used. To "\
+                         "reference all default algorithms using this option, add 'defaults' to the list of "\
+                         "supported algorithms.",
+            uniqueItems: true,
+            items: {
+              type: String
+            },
+            _plugin: true,
+            _example: %w[defaults diffie-hellman-group1-sha1]
           },
           "load-config" => {
             type: [TrueClass, FalseClass],
-            desc: "Whether to load system SSH configuration from '~/.ssh/config' and '/etc/ssh_config'.",
-            def:  true,
-            exmp: false
+            description: "Whether to load system SSH configuration from '~/.ssh/config' and '/etc/ssh_config'.",
+            _plugin: true,
+            _default: true,
+            _example: false
           },
           "login-shell" => {
             type: String,
-            desc: "Which login shell Bolt should expect on the target. Supported shells are " \
-                  "#{LOGIN_SHELLS.join(', ')}. **This option is experimental.**",
-            def:  "bash",
-            exmp: "powershell"
+            description: "Which login shell Bolt should expect on the target. Supported shells are " \
+                         "#{LOGIN_SHELLS.join(', ')}. **This option is experimental.**",
+            enum: LOGIN_SHELLS,
+            _plugin: true,
+            _default: "bash",
+            _example: "powershell"
           },
           "mac-algorithms" => {
             type: Array,
-            desc: "List of message authentication code algorithms to use when establishing a connection "\
-                  "to a target. Supported algorithms are defined by the Ruby net-ssh library and can be "\
-                  "viewed [here](https://github.com/net-ssh/net-ssh#supported-algorithms). All supported, "\
-                  "non-deprecated algorithms are available by default when this option is not used. To "\
-                  "reference all default algorithms using this option, add 'defaults' to the list of "\
-                  "supported algorithms.",
-            exmp: %w[defaults hmac-md5]
+            description: "List of message authentication code algorithms to use when establishing a connection "\
+                         "to a target. Supported algorithms are defined by the Ruby net-ssh library and can be "\
+                         "viewed [here](https://github.com/net-ssh/net-ssh#supported-algorithms). All supported, "\
+                         "non-deprecated algorithms are available by default when this option is not used. To "\
+                         "reference all default algorithms using this option, add 'defaults' to the list of "\
+                         "supported algorithms.",
+            uniqueItems: true,
+            items: {
+              type: String
+            },
+            _plugin: true,
+            _example: %w[defaults hmac-md5]
           },
           "password" => {
             type: String,
-            desc: "The password to use to login.",
-            exmp: "hunter2!"
+            description: "The password to use to login.",
+            _plugin: true,
+            _example: "hunter2!"
           },
           "port" => {
             type: Integer,
-            desc: "The port to use when connecting to the target.",
-            exmp: 22
+            description: "The port to use when connecting to the target.",
+            minimum: 0,
+            _plugin: true,
+            _example: 22
           },
           "private-key" => {
             type: [Hash, String],
-            desc: "Either the path to the private key file to use for authentication, or "\
-                  "a hash with the key `key-data` and the contents of the private key.",
-            exmp: "~/.ssh/id_rsa"
+            description: "Either the path to the private key file to use for authentication, or "\
+                         "a hash with the key `key-data` and the contents of the private key.",
+            required: ["key-data"],
+            properties: {
+              "key-data" => {
+                description: "The contents of the private key.",
+                type: String
+              }
+            },
+            _plugin: true,
+            _example: "~/.ssh/id_rsa"
           },
           "proxyjump" => {
             type: String,
-            desc: "A jump host to proxy connections through, and an optional user to connect with.",
-            exmp: "jump.example.com"
+            description: "A jump host to proxy connections through, and an optional user to connect with.",
+            format: "uri",
+            _plugin: true,
+            _example: "jump.example.com"
           },
           "realm" => {
             type: String,
-            desc: "The Kerberos realm (Active Directory domain) to authenticate against.",
-            exmp: "BOLT.PRODUCTION"
+            description: "The Kerberos realm (Active Directory domain) to authenticate against.",
+            _plugin: true,
+            _example: "BOLT.PRODUCTION"
           },
           "run-as" => {
             type: String,
-            desc: "The user to run commands as after login. The run-as user must be different than the login user.",
-            exmp: "root"
+            description: "The user to run commands as after login. The run-as user must be different than the "\
+                         "login user.",
+            _plugin: true,
+            _example: "root"
           },
           "run-as-command" => {
             type: Array,
-            desc: "The command to elevate permissions. Bolt appends the user and command strings to the configured "\
-                  "`run-as-command` before running it on the target. This command must not require an interactive "\
-                  "password prompt, and the `sudo-password` option is ignored when `run-as-command` is specified. "\
-                  "The `run-as-command` must be specified as an array.",
-            exmp: ["sudo", "-nkSEu"]
+            description: "The command to elevate permissions. Bolt appends the user and command strings to the "\
+                         "configured `run-as-command` before running it on the target. This command must not require "\
+                         " aninteractive password prompt, and the `sudo-password` option is ignored when "\
+                         "`run-as-command` is specified. The `run-as-command` must be specified as an array.",
+            items: {
+              type: String
+            },
+            _plugin: true,
+            _example: ["sudo", "-nkSEu"]
           },
           "run-on" => {
             type: String,
-            desc: "The proxy target that the task executes on.",
-            def:  "localhost",
-            exmp: "proxy_target"
+            description: "The proxy target that the task executes on.",
+            format: "uri",
+            _plugin: true,
+            _default: "localhost",
+            _example: "proxy_target"
           },
           "script-dir" => {
             type: String,
-            desc: "The subdirectory of the tmpdir to use in place of a randomized "\
-                  "subdirectory for uploading and executing temporary files on the "\
-                  "target. It's expected that this directory already exists as a subdir "\
-                  "of tmpdir, which is either configured or defaults to `/tmp`.",
-            exmp: "bolt_scripts"
+            description: "The subdirectory of the tmpdir to use in place of a randomized "\
+                         "subdirectory for uploading and executing temporary files on the "\
+                         "target. It's expected that this directory already exists as a subdir "\
+                         "of tmpdir, which is either configured or defaults to `/tmp`.",
+            _plugin: true,
+            _example: "bolt_scripts"
           },
           "service-url" => {
             type: String,
-            desc: "The URL of the host used for API requests.",
-            exmp: "https://api.example.com"
+            description: "The URL of the host used for API requests.",
+            format: "uri",
+            _plugin: true,
+            _example: "https://api.example.com"
           },
           "shell-command" => {
             type: String,
-            desc: "A shell command to wrap any Docker exec commands in, such as `bash -lc`.",
-            exmp: "bash -lc"
+            description: "A shell command to wrap any Docker exec commands in, such as `bash -lc`.",
+            _plugin: true,
+            _example: "bash -lc"
           },
           "smb-port" => {
             type: Integer,
-            desc: "The port to use when connecting to the target when file-protocol is set to 'smb'.",
-            exmp: 445
+            description: "The port to use when connecting to the target when file-protocol is set to 'smb'.",
+            minimum: 0,
+            _plugin: true,
+            _example: 445
           },
           "ssh-command" => {
             type: [Array, String],
-            desc: "The command and flags to use when SSHing. This enables the external SSH transport, which "\
-                  "shells out to the specified command. This option is used when you need support for "\
-                  "features or algorithms that are not supported by the net-ssh Ruby library. **This option is "\
-                  "experimental.** You can read more about this  option in [External SSH "\
-                  "transport](experimental_features.md#external-ssh-transport).",
-            exmp: "ssh"
+            description: "The command and flags to use when SSHing. This enables the external SSH transport, which "\
+                         "shells out to the specified command. This option is used when you need support for "\
+                         "features or algorithms that are not supported by the net-ssh Ruby library. **This option "\
+                         "is experimental.** You can read more about this  option in [External SSH "\
+                         "transport](experimental_features.md#external-ssh-transport).",
+            items: {
+              type: String
+            },
+            _plugin: true,
+            _example: "ssh"
           },
           "ssl" => {
             type: [TrueClass, FalseClass],
-            desc: "Whether to use secure https connections for WinRM.",
-            def:  true,
-            exmp: false
+            description: "Whether to use secure https connections for WinRM.",
+            _plugin: true,
+            _default: true,
+            _example: false
           },
           "ssl-verify" => {
             type: [TrueClass, FalseClass],
-            desc: "Whether to verify that the target's certificate matches the cacert.",
-            def:  true,
-            exmp: false
+            description: "Whether to verify that the target's certificate matches the cacert.",
+            _plugin: true,
+            _default: true,
+            _example: false
           },
           "sudo-executable" => {
             type: String,
-            desc: "The executable to use when escalating to the configured `run-as` user. This is useful when you "\
-                  "want to escalate using the configured `sudo-password`, since `run-as-command` does not use "\
-                  "`sudo-password` or support prompting. The command executed on the target is `<sudo-executable> "\
-                  "-S -u <user> -p custom_bolt_prompt <command>`. **This option is experimental.**",
-            exmp: "dzdo"
+            description: "The executable to use when escalating to the configured `run-as` user. This is useful "\
+                         "when you want to escalate using the configured `sudo-password`, since `run-as-command` "\
+                         "does not use `sudo-password` or support prompting. The command executed on the target "\
+                         "is `<sudo-executable> -S -u <user> -p custom_bolt_prompt <command>`. **This option is "\
+                         "experimental.**",
+            _plugin: true,
+            _example: "dzdo"
           },
           "sudo-password" => {
             type: String,
-            desc: "The password to use when changing users via `run-as`.",
-            exmp: "p@$$w0rd!"
+            description: "The password to use when changing users via `run-as`.",
+            _plugin: true,
+            _example: "p@$$w0rd!"
           },
           "task-environment" => {
             type: String,
-            desc: "The environment the orchestrator loads task code from.",
-            def:  "production",
-            exmp: "development"
+            description: "The environment the orchestrator loads task code from.",
+            _plugin: true,
+            _default: "production",
+            _example: "development"
           },
           "tmpdir" => {
             type: String,
-            desc: "The directory to upload and execute temporary files on the target.",
-            exmp: "/tmp/bolt"
+            description: "The directory to upload and execute temporary files on the target.",
+            _plugin: true,
+            _example: "/tmp/bolt"
           },
           "token-file" => {
             type: String,
-            desc: "The path to the token file.",
-            exmp: "~/.puppetlabs/puppet/token.pem"
+            description: "The path to the token file.",
+            _plugin: true,
+            _example: "~/.puppetlabs/puppet/token.pem"
           },
           "tty" => {
             type: [TrueClass, FalseClass],
-            desc: "Whether to enable tty on exec commands.",
-            exmp: true
+            description: "Whether to enable tty on exec commands.",
+            _plugin: true,
+            _example: true
           },
           "user" => {
             type: String,
-            desc: "The user name to login as.",
-            exmp: "bolt"
+            description: "The user name to login as.",
+            _plugin: true,
+            _example: "bolt"
           }
         }.freeze
 

--- a/schemas/Rakefile
+++ b/schemas/Rakefile
@@ -1,0 +1,267 @@
+# frozen_string_literal: true
+
+require "bolt/config"
+
+require "fileutils"
+require "json"
+require "erb"
+
+def to_json_types(ruby_types)
+  # Pull out the type and turn it into an array. This allows us to
+  # handle single types and multi-types the same way.
+  types = Array(ruby_types)
+
+  # Now we can replace the Ruby classes with stringified JSON types.
+  # Since Ruby does not have a Boolean class, we replace both TrueClass
+  # and FalseClass with 'boolean' then make sure the types array has
+  # unique values.
+  types = types.map do |type|
+    case type.to_s
+    when 'Hash'
+      'object'
+    when 'TrueClass', 'FalseClass'
+      'boolean'
+    when 'String', 'Integer', 'Array'
+      type.to_s.downcase
+    else
+      raise "Cannot convert Ruby type to JSON type: #{type}"
+    end
+  end.uniq
+
+  # If there is only a single valid type, un-Array-ify it.
+  types.length > 1 ? types : types.first
+end
+
+def add_plugin_reference(definition)
+  definition, data = definition.partition do |k, _|
+    k == :description
+  end.map(&:to_h)
+
+  definition[:oneOf] = [
+    data,
+    { "$ref" => "#/definitions/_plugin" }
+  ]
+
+  definition
+end
+
+# Recurses through a definition and JSON-ifies the data types.
+def to_schema(data)
+  return data unless data.is_a?(Hash)
+
+  # Pull out all metadata since we don't want this in the schema.
+  metadata, data = data.partition do |key, _|
+    key.to_s.start_with?('_')
+  end.map(&:to_h)
+
+  # Recurse through :items, :additionalProperties, and :properties,
+  # since each of these can have their own definitions.
+  %i[items additionalProperties].each do |key|
+    next unless data.key?(key)
+    data[key] = to_schema(data[key])
+  end
+
+  if data.key?(:properties)
+    data[:properties] = data[:properties].transform_values do |definition|
+      to_schema(definition)
+    end
+  end
+
+  # Turn Ruby types into JSON types.
+  data[:type] = to_json_types(data[:type]) if data.key?(:type)
+
+  # Add a plugin definition if supported by the option.
+  metadata[:_plugin] ? add_plugin_reference(data) : data
+end
+
+desc 'Generate JSON schemas for all Bolt configuration files'
+task schemas: 'schemas:all'
+
+namespace :schemas do
+  task all: %i[project defaults config inventory]
+
+  desc 'Generate bolt-project.yaml JSON schema'
+  task :project do
+    filepath    = File.expand_path('bolt-project.schema.json', __dir__)
+    options     = Bolt::Config::BOLT_PROJECT_OPTIONS
+    definitions = Bolt::Config::Options::OPTIONS.slice(*options)
+
+    properties = options.each_with_object({}) do |option, acc|
+      acc[option] = { "$ref" => "#/definitions/#{option}" }
+    end
+
+    definitions = definitions.transform_values do |data|
+      to_schema(data)
+    end
+
+    definitions = definitions.merge(Bolt::Config::Options::PLUGIN)
+
+    schema = {
+      "$schema"     => "http://json-schema.org/draft-07/schema#",
+      "title"       => "Bolt Project",
+      "description" => "Bolt Project bolt-project.yaml Schema",
+      "type"        => "object",
+      "properties"  => properties,
+      "definitions" => definitions
+    }
+
+    json = JSON.pretty_generate(schema)
+
+    File.write(filepath, json)
+
+    $stdout.puts "Generated bolt-defaults.yaml schema at:\n\t#{filepath}"
+  end
+
+  desc 'Generate bolt-defaults.yaml JSON schema'
+  task :defaults do
+    filepath          = File.expand_path('bolt-defaults.schema.json', __dir__)
+    options           = Bolt::Config::Options::BOLT_DEFAULTS_OPTIONS
+    inventory_options = Bolt::Config::Options::INVENTORY_OPTIONS
+    transport_options = Bolt::Config::Transport::Options::TRANSPORT_OPTIONS
+    transports        = Bolt::Config::TRANSPORT_CONFIG
+    definitions       = Bolt::Config::Options::OPTIONS.slice(*options)
+
+    properties = options.each_with_object({}) do |option, acc|
+      acc[option] = { "$ref" => "#/definitions/#{option}" }
+    end
+
+    # Add inventory option definition references to the 'inventory-config' option
+    definitions['inventory-config'][:properties] = inventory_options.each_with_object({}) do |(option, _), acc|
+      acc[option] = { "$ref" => "#/definitions/#{option}" }
+    end
+
+    # Add transport definitions to the definitions hash
+    definitions = definitions.merge(inventory_options)
+
+    # Add transport option definition references to each transport definition
+    transports.each do |option, transport|
+      definitions[option][:properties] = transport.options.each_with_object({}) do |opt, acc|
+        acc[opt] = { "$ref" => "#/transport_definitions/#{opt}" }
+      end
+    end
+
+    definitions = definitions.transform_values do |data|
+      to_schema(data)
+    end
+
+    transport_definitions = transport_options.transform_values do |data|
+      to_schema(data)
+    end
+
+    definitions = definitions.merge(Bolt::Config::Options::PLUGIN)
+
+    schema = {
+      "$schema"               => "http://json-schema.org/draft-07/schema#",
+      "title"                 => "Bolt Defaults",
+      "description"           => "Bolt Defaults bolt-defaults.yaml Schema",
+      "type"                  => "object",
+      "properties"            => properties,
+      "definitions"           => definitions,
+      "transport_definitions" => transport_definitions
+    }
+
+    json = JSON.pretty_generate(schema)
+
+    File.write(filepath, json)
+
+    $stdout.puts "Generated bolt-defaults.yaml schema at:\n\t#{filepath}"
+  end
+
+  desc 'Generate bolt.yaml JSON schema'
+  task :config do
+    filepath          = File.expand_path('bolt-config.schema.json', __dir__)
+    options           = Bolt::Config::Options::BOLT_OPTIONS.dup
+    inventory_options = Bolt::Config::Options::INVENTORY_OPTIONS
+    transport_options = Bolt::Config::Transport::Options::TRANSPORT_OPTIONS
+    transports        = Bolt::Config::TRANSPORT_CONFIG
+    definitions       = Bolt::Config::Options::OPTIONS.slice(*options)
+
+    properties = options.concat(inventory_options.keys).each_with_object({}) do |option, acc|
+      acc[option] = { "$ref" => "#/definitions/#{option}" }
+    end
+
+    # Add transport definitions to the definitions hash
+    definitions = definitions.merge(inventory_options)
+
+    # Add transport option definition references to each transport definition
+    transports.each do |option, transport|
+      definitions[option][:properties] = transport.options.each_with_object({}) do |opt, acc|
+        acc[opt] = { "$ref" => "#/transport_definitions/#{opt}" }
+      end
+    end
+
+    definitions = definitions.transform_values do |data|
+      to_schema(data)
+    end
+
+    transport_definitions = transport_options.transform_values do |data|
+      to_schema(data)
+    end
+
+    definitions = definitions.merge(Bolt::Config::Options::PLUGIN)
+
+    schema = {
+      "$schema"               => "http://json-schema.org/draft-07/schema#",
+      "title"                 => "Bolt Configuration",
+      "description"           => "Bolt Configuration bolt.yaml Schema",
+      "type"                  => "object",
+      "properties"            => properties,
+      "definitions"           => definitions,
+      "transport_definitions" => transport_definitions
+    }
+
+    json = JSON.pretty_generate(schema)
+
+    File.write(filepath, json)
+
+    $stdout.puts "Generated bolt.yaml schema at:\n\t#{filepath}"
+  end
+
+  # The inventory schema is generated from a template as opposed to an OPTIONS hash
+  # as it has a more complicated structure than the other schemas. However, the
+  # transport configuration options are generated from OPTIONS hashes and are added
+  # to the base schema.
+  desc 'Generate inventory.yaml JSON schema'
+  task :inventory do
+    filepath          = File.expand_path('bolt-inventory.schema.json', __dir__)
+    base              = JSON.parse(File.read(File.expand_path('bolt-base-inventory.json', __dir__)))
+    inventory_options = Bolt::Config::INVENTORY_OPTIONS
+    transport_options = Bolt::Config::Transport::Options::TRANSPORT_OPTIONS
+    transports        = Bolt::Config::TRANSPORT_CONFIG
+
+    # Add transport definition references to the 'config' option.
+    config_properties = inventory_options.keys.each_with_object({}) do |option, acc|
+      acc[option] = { "$ref" => "#/definitions/#{option}" }
+    end
+
+    # The base schema already includes the 'oneOf' key. These properties should
+    # be added to the first element of that array.
+    base['definitions']['config']['oneOf'][0]['properties'] = config_properties
+
+    # Add transport option definitions references to the transport definitions
+    transports.each do |option, transport|
+      inventory_options[option][:properties] = transport.options.each_with_object({}) do |opt, acc|
+        acc[opt] = { "$ref" => "#/transport_definitions/#{opt}" }
+      end
+    end
+
+    # Add transport definitions
+    inventory_options.each do |option, definition|
+      base['definitions'][option] = to_schema(definition)
+    end
+
+    # Add transport option definitions
+    base['transport_definitions'] = transport_options.transform_values do |data|
+      to_schema(data)
+    end
+
+    # Add _plugin definition
+    base['definitions'] = base['definitions'].merge(Bolt::Config::PLUGIN)
+
+    json = JSON.pretty_generate(base)
+
+    File.write(filepath, json)
+
+    $stdout.puts "Generated inventory.yaml schema at:\n\t#{filepath}"
+  end
+end

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -1,15 +1,83 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Bolt Config",
-  "description": "Bolt Config bolt.yaml Schema",
+  "title": "Bolt Configuration",
+  "description": "Bolt Configuration bolt.yaml Schema",
   "type": "object",
   "properties": {
     "apply_settings": {
-      "description": "A map of Puppet settings to use when applying Puppet code.",
+      "$ref": "#/definitions/apply_settings"
+    },
+    "color": {
+      "$ref": "#/definitions/color"
+    },
+    "compile-concurrency": {
+      "$ref": "#/definitions/compile-concurrency"
+    },
+    "concurrency": {
+      "$ref": "#/definitions/concurrency"
+    },
+    "format": {
+      "$ref": "#/definitions/format"
+    },
+    "hiera-config": {
+      "$ref": "#/definitions/hiera-config"
+    },
+    "inventoryfile": {
+      "$ref": "#/definitions/inventoryfile"
+    },
+    "log": {
+      "$ref": "#/definitions/log"
+    },
+    "modulepath": {
+      "$ref": "#/definitions/modulepath"
+    },
+    "plugin_hooks": {
+      "$ref": "#/definitions/plugin_hooks"
+    },
+    "plugins": {
+      "$ref": "#/definitions/plugins"
+    },
+    "puppetdb": {
+      "$ref": "#/definitions/puppetdb"
+    },
+    "puppetfile": {
+      "$ref": "#/definitions/puppetfile"
+    },
+    "save-rerun": {
+      "$ref": "#/definitions/save-rerun"
+    },
+    "trusted-external-command": {
+      "$ref": "#/definitions/trusted-external-command"
+    },
+    "transport": {
+      "$ref": "#/definitions/transport"
+    },
+    "docker": {
+      "$ref": "#/definitions/docker"
+    },
+    "local": {
+      "$ref": "#/definitions/local"
+    },
+    "pcp": {
+      "$ref": "#/definitions/pcp"
+    },
+    "remote": {
+      "$ref": "#/definitions/remote"
+    },
+    "ssh": {
+      "$ref": "#/definitions/ssh"
+    },
+    "winrm": {
+      "$ref": "#/definitions/winrm"
+    }
+  },
+  "definitions": {
+    "apply_settings": {
+      "description": "A map of Puppet settings to use when applying Puppet code using the `apply` plan function or the `bolt apply` command.",
       "type": "object",
       "properties": {
         "show_diff": {
-          "description": "Whether to log and report a contextual diff when files are being replaced.",
+          "description": "Whether to log and report a contextual diff.",
           "type": "boolean"
         }
       }
@@ -21,28 +89,32 @@
     "compile-concurrency": {
       "description": "The maximum number of simultaneous manifest block compiles.",
       "type": "integer",
-      "min": 1
+      "minimum": 1
     },
     "concurrency": {
       "description": "The number of threads to use when executing on remote targets.",
       "type": "integer",
-      "min": 1
+      "minimum": 1
     },
     "format": {
       "description": "The format to use when printing results.",
       "type": "string",
-      "enum": ["human", "json"]
+      "enum": [
+        "human",
+        "json",
+        "rainbow"
+      ]
     },
     "hiera-config": {
-      "description": "The path to your Hiera config.",
+      "description": "The path to the Hiera configuration file.",
       "type": "string"
     },
     "inventoryfile": {
-      "description": "The path to your inventory file.",
+      "description": "The path to a structured data inventory file used to refer to groups of targets on the command line and from plans. Read more about using inventory files in [Inventory files](inventory_file_v2.md).",
       "type": "string"
     },
     "log": {
-      "description": "The configuration of the logfile output. Configuration can be set for console and the path to a log file, such as ~/.puppetlabs/bolt/debug.log.",
+      "description": "A map of configuration for the logfile output. Configuration can be set for `console` and individual log files, such as `~/.puppetlabs/bolt/debug.log`. Each key in the map is the logfile output to configure, with the corresponding value configuring the logfile output.",
       "type": "object",
       "properties": {
         "console": {
@@ -50,100 +122,125 @@
           "type": "object",
           "properties": {
             "level": {
-              "description": "The type of information in the log.",
+              "description": "The type of information to log.",
               "type": "string",
-              "enum": ["debug", "error", "info", "notice", "warn"]
+              "enum": [
+                "debug",
+                "error",
+                "info",
+                "notice",
+                "warn",
+                "fatal",
+                "any"
+              ]
             }
           }
         }
       },
       "additionalProperties": {
-        "description": "Configuration for logs output to a file.",
+        "description": "Configuration for the logfile output.",
         "type": "object",
         "properties": {
           "append": {
-            "description": "Add output to an existing log file.",
+            "description": "Whether to append output to an existing log file.",
             "type": "boolean"
           },
           "level": {
-            "description": "The type of information in the log.",
+            "description": "The type of information to log.",
             "type": "string",
-            "enum": ["debug", "error", "info", "notice", "warn"]
+            "enum": [
+              "debug",
+              "error",
+              "info",
+              "notice",
+              "warn",
+              "fatal",
+              "any"
+            ]
           }
         }
       }
     },
     "modulepath": {
-      "description": "The module path for loading tasks and plan code. This is either an array of directories or a string containing a list of directories separated by the OS-specific PATH separator.",
-      "type": ["array", "string"],
+      "description": "An array of directories that Bolt loads content such as plans and tasks from. Read more about modules in [Module structure](module_structure.md).",
+      "type": [
+        "array",
+        "string"
+      ],
       "items": {
-        "description": "Module path.",
         "type": "string"
-      },
-      "uniqueItems": true
+      }
     },
     "plugin_hooks": {
-      "description": "Which plugins a specific hook should use.",
-      "type": "object",
-      "properties": {
-        "puppet_library": {
-          "description": "Specify which plugin should be used to ensure the Puppet library is installed on a target.",
+      "description": "A map of [plugin hooks](writing_plugins.md#hooks) and which plugins a hook should use. The only configurable plugin hook is `puppet_library`, which can use two possible plugins: [`puppet_agent`](https://github.com/puppetlabs/puppetlabs-puppet_agent#puppet_agentinstall) and [`task`](using_plugins.md#task).",
+      "oneOf": [
+        {
           "type": "object"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
         }
-      }
+      ]
     },
     "plugins": {
-      "description": "A map of plugins and their configuration data.",
-      "type": "object",
-      "patternProperties": {
-        "^[a-z][a-z0-9_]*$": { 
+      "description": "A map of plugins and their configuration data, where each key is the name of a plugin and its value is a map of configuration data. Configurable options are specified by the plugin. Read more about configuring plugins in [Using plugins](using_plugins.md#configuring-plugins).",
+      "oneOf": [
+        {
           "type": "object"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
         }
-      }
+      ]
     },
     "puppetdb": {
-      "description": "A map containing options for configuring the Bolt PuppetDB client.",
-      "type": "object",
-      "properties": {
-        "cacert": {
-          "description": "The path to the ca certificate for PuppetDB.",
-          "type": "string"
-        },
-        "cert": {
-          "description": "The path to the client certificate file to use for authentication.",
-          "type": "string"
-        },
-        "key": {
-          "description": "The path to the private key for the certificate.",
-          "type": "string"
-        },
-        "server_urls": {
-          "description": "An array containing the PuppetDB host to connect to. Include the protocol https and the port, which is usually 8081. For example, https://my-master.example.com:8081.",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "description": "A PuppetDB host.",
-            "type": "string",
-            "format": "uri"
+      "description": "A map containing options for [configuring the Bolt PuppetDB client](bolt_connect_puppetdb.md).",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cacert": {
+              "description": "The path to the ca certificate for PuppetDB.",
+              "type": "string"
+            },
+            "cert": {
+              "description": "The path to the client certificate file to use for authentication.",
+              "type": "string"
+            },
+            "key": {
+              "description": "The private key for the certificate.",
+              "type": "string"
+            },
+            "server_urls": {
+              "description": "An array containing the PuppetDB host to connect to. Include the protocol `https` and the port, which is usually `8081`. For example, `https://my-master.example.com:8081`.",
+              "type": "array"
+            },
+            "token": {
+              "description": "The path to the PE RBAC Token.",
+              "type": "string"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
         }
-      }
+      ]
     },
     "puppetfile": {
-      "description": "A map containing options for the 'bolt puppetfile install' command.",
+      "description": "A map containing options for the `bolt puppetfile install` command.",
       "type": "object",
       "properties": {
         "forge": {
-          "description": "A subsection that can have its own proxy setting to set an HTTP proxy for Forge operations only, and a baseurl setting to specify a different Forge host.",
+          "description": "A subsection that can have its own `proxy` setting to set an HTTP proxy for Forge operations only, and a `baseurl` setting to specify a different Forge host.",
           "type": "object",
           "properties": {
             "baseurl": {
-              "description": "The URI for the Forge host.",
+              "description": "The URL to the Forge host.",
               "type": "string",
               "format": "uri"
             },
             "proxy": {
-              "description": "The HTTP proxy to use for Forge operations.",
+              "description": "The HTTP proxy to use for Git and Forge operations.",
               "type": "string",
               "format": "uri"
             }
@@ -157,35 +254,831 @@
       }
     },
     "save-rerun": {
-      "description": "Whether to update .rerun.json in the Bolt project directory. If your target names include passwords, set this value to false to avoid writing passwords to disk.",
+      "description": "Whether to update `.rerun.json` in the Bolt project directory. If your target names include passwords, set this value to `false` to avoid writing passwords to disk.",
       "type": "boolean"
     },
-    "transport": {
-      "description": "The default transport to use when the transport for a target is not specified in the URL or inventory.",
-      "type": "string",
-      "enum": ["docker", "local", "pcp", "remote", "ssh", "winrm"]
-    },
     "trusted-external-command": {
-      "description": "The path to an executable on the Bolt controller that can produce external trusted facts.",
+      "description": "The path to an executable on the Bolt controller that can produce external trusted facts. **External trusted facts are experimental in both Puppet and Bolt and this API may change or be removed.**",
       "type": "string"
     },
+    "transport": {
+      "description": "The default transport to use when the transport for a target is not specified in the URI.",
+      "type": "string",
+      "enum": [
+        "ssh",
+        "winrm",
+        "pcp",
+        "local",
+        "docker",
+        "remote"
+      ]
+    },
     "docker": {
-      "$ref": "bolt-transport-definitions.json#/docker"
+      "description": "A map of configuration options for the docker transport.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cleanup": {
+              "$ref": "#/transport_definitions/cleanup"
+            },
+            "host": {
+              "$ref": "#/transport_definitions/host"
+            },
+            "interpreters": {
+              "$ref": "#/transport_definitions/interpreters"
+            },
+            "service-url": {
+              "$ref": "#/transport_definitions/service-url"
+            },
+            "shell-command": {
+              "$ref": "#/transport_definitions/shell-command"
+            },
+            "tmpdir": {
+              "$ref": "#/transport_definitions/tmpdir"
+            },
+            "tty": {
+              "$ref": "#/transport_definitions/tty"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
     },
     "local": {
-      "$ref": "bolt-transport-definitions.json#/local"
+      "description": "A map of configuration options for the local transport. The set of available options is platform dependent.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cleanup": {
+              "$ref": "#/transport_definitions/cleanup"
+            },
+            "interpreters": {
+              "$ref": "#/transport_definitions/interpreters"
+            },
+            "run-as": {
+              "$ref": "#/transport_definitions/run-as"
+            },
+            "run-as-command": {
+              "$ref": "#/transport_definitions/run-as-command"
+            },
+            "sudo-executable": {
+              "$ref": "#/transport_definitions/sudo-executable"
+            },
+            "sudo-password": {
+              "$ref": "#/transport_definitions/sudo-password"
+            },
+            "tmpdir": {
+              "$ref": "#/transport_definitions/tmpdir"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
     },
     "pcp": {
-      "$ref": "bolt-transport-definitions.json#/pcp"
+      "description": "A map of configuration options for the pcp transport.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cacert": {
+              "$ref": "#/transport_definitions/cacert"
+            },
+            "host": {
+              "$ref": "#/transport_definitions/host"
+            },
+            "job-poll-interval": {
+              "$ref": "#/transport_definitions/job-poll-interval"
+            },
+            "job-poll-timeout": {
+              "$ref": "#/transport_definitions/job-poll-timeout"
+            },
+            "service-url": {
+              "$ref": "#/transport_definitions/service-url"
+            },
+            "task-environment": {
+              "$ref": "#/transport_definitions/task-environment"
+            },
+            "token-file": {
+              "$ref": "#/transport_definitions/token-file"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
     },
     "remote": {
-      "$ref": "bolt-transport-definitions.json#/remote"
+      "description": "A map of configuration options for the remote transport.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "run-on": {
+              "$ref": "#/transport_definitions/run-on"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
     },
     "ssh": {
-      "$ref": "bolt-transport-definitions.json#/ssh"
+      "description": "A map of configuration options for the ssh transport.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cleanup": {
+              "$ref": "#/transport_definitions/cleanup"
+            },
+            "connect-timeout": {
+              "$ref": "#/transport_definitions/connect-timeout"
+            },
+            "disconnect-timeout": {
+              "$ref": "#/transport_definitions/disconnect-timeout"
+            },
+            "encryption-algorithms": {
+              "$ref": "#/transport_definitions/encryption-algorithms"
+            },
+            "extensions": {
+              "$ref": "#/transport_definitions/extensions"
+            },
+            "host": {
+              "$ref": "#/transport_definitions/host"
+            },
+            "host-key-algorithms": {
+              "$ref": "#/transport_definitions/host-key-algorithms"
+            },
+            "host-key-check": {
+              "$ref": "#/transport_definitions/host-key-check"
+            },
+            "interpreters": {
+              "$ref": "#/transport_definitions/interpreters"
+            },
+            "kex-algorithms": {
+              "$ref": "#/transport_definitions/kex-algorithms"
+            },
+            "load-config": {
+              "$ref": "#/transport_definitions/load-config"
+            },
+            "login-shell": {
+              "$ref": "#/transport_definitions/login-shell"
+            },
+            "mac-algorithms": {
+              "$ref": "#/transport_definitions/mac-algorithms"
+            },
+            "password": {
+              "$ref": "#/transport_definitions/password"
+            },
+            "port": {
+              "$ref": "#/transport_definitions/port"
+            },
+            "private-key": {
+              "$ref": "#/transport_definitions/private-key"
+            },
+            "proxyjump": {
+              "$ref": "#/transport_definitions/proxyjump"
+            },
+            "run-as": {
+              "$ref": "#/transport_definitions/run-as"
+            },
+            "run-as-command": {
+              "$ref": "#/transport_definitions/run-as-command"
+            },
+            "script-dir": {
+              "$ref": "#/transport_definitions/script-dir"
+            },
+            "sudo-executable": {
+              "$ref": "#/transport_definitions/sudo-executable"
+            },
+            "sudo-password": {
+              "$ref": "#/transport_definitions/sudo-password"
+            },
+            "tmpdir": {
+              "$ref": "#/transport_definitions/tmpdir"
+            },
+            "tty": {
+              "$ref": "#/transport_definitions/tty"
+            },
+            "user": {
+              "$ref": "#/transport_definitions/user"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
     },
     "winrm": {
-      "$ref": "bolt-transport-definitions.json#/winrm"
+      "description": "A map of configuration options for the winrm transport.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "basic-auth-only": {
+              "$ref": "#/transport_definitions/basic-auth-only"
+            },
+            "cacert": {
+              "$ref": "#/transport_definitions/cacert"
+            },
+            "cleanup": {
+              "$ref": "#/transport_definitions/cleanup"
+            },
+            "connect-timeout": {
+              "$ref": "#/transport_definitions/connect-timeout"
+            },
+            "extensions": {
+              "$ref": "#/transport_definitions/extensions"
+            },
+            "file-protocol": {
+              "$ref": "#/transport_definitions/file-protocol"
+            },
+            "host": {
+              "$ref": "#/transport_definitions/host"
+            },
+            "interpreters": {
+              "$ref": "#/transport_definitions/interpreters"
+            },
+            "password": {
+              "$ref": "#/transport_definitions/password"
+            },
+            "port": {
+              "$ref": "#/transport_definitions/port"
+            },
+            "realm": {
+              "$ref": "#/transport_definitions/realm"
+            },
+            "smb-port": {
+              "$ref": "#/transport_definitions/smb-port"
+            },
+            "ssl": {
+              "$ref": "#/transport_definitions/ssl"
+            },
+            "ssl-verify": {
+              "$ref": "#/transport_definitions/ssl-verify"
+            },
+            "tmpdir": {
+              "$ref": "#/transport_definitions/tmpdir"
+            },
+            "user": {
+              "$ref": "#/transport_definitions/user"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "_plugin": {
+      "description": "A plugin reference.",
+      "type": "object",
+      "required": [
+        "_plugin"
+      ],
+      "properties": {
+        "_plugin": {
+          "description": "The name of the plugin.",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "transport_definitions": {
+    "basic-auth-only": {
+      "description": "Whether to force basic authentication. This option is only available when using SSL.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "cacert": {
+      "description": "The path to the CA certificate.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "cleanup": {
+      "description": "Whether to clean up temporary files created on targets. When running commands on a target, Bolt may create temporary files. After completing the command, these files are automatically deleted. This value can be set to 'false' if you wish to leave these temporary files on the target.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "connect-timeout": {
+      "description": "How long to wait in seconds when establishing connections. Set this value higher if you frequently encounter connection timeout errors when running Bolt.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "copy-command": {
+      "description": "The command to use when copying files using ssh-command. Bolt runs `<copy-command> <src> <dest>`. This option is used when you need support for features or algorithms that are not supported by the net-ssh Ruby library. **This option is experimental.** You can read more about this option in [External SSH transport](experimental_features.md#external-ssh-transport).",
+      "oneOf": [
+        {
+          "type": [
+            "array",
+            "string"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "disconnect-timeout": {
+      "description": "How long to wait in seconds before force-closing a connection.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "encryption-algorithms": {
+      "description": "A list of encryption algorithms to use when establishing a connection to a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed [here](https://github.com/net-ssh/net-ssh#supported-algorithms). All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms using this option, add 'defaults' to the list of supported algorithms.",
+      "oneOf": [
+        {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "extensions": {
+      "description": "A list of file extensions that are accepted for scripts or tasks on Windows. Scripts with these file extensions rely on the target's file type association to run. For example, if Python is installed on the system, a `.py` script runs with `python.exe`. The extensions `.ps1`, `.rb`, and `.pp` are always allowed and run via hard-coded executables.",
+      "oneOf": [
+        {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "file-protocol": {
+      "description": "Which file transfer protocol to use. Either `winrm` or `smb`. Using `smb` is recommended for large file transfers.",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "smb",
+            "winrm"
+          ]
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "host": {
+      "description": "The target's hostname.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "host-key-algorithms": {
+      "description": "A list of host key algorithms to use when establishing a connection to a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed [here](https://github.com/net-ssh/net-ssh#supported-algorithms). All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms using this option, add 'defaults' to the list of supported algorithms.",
+      "oneOf": [
+        {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "host-key-check": {
+      "description": "Whether to perform host key validation when connecting.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "interpreters": {
+      "description": "A map of an extension name to the absolute path of an executable,  enabling you to override the shebang defined in a task executable. The extension can optionally be specified with the `.` character (`.py` and `py` both map to a task executable `task.py`) and the extension is case sensitive. When a target's name is `localhost`, Ruby tasks run with the Bolt Ruby interpreter by default.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "propertyNames": {
+            "pattern": "^.?[a-zA-Z0-9]+$"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "job-poll-interval": {
+      "description": "The interval, in seconds, to poll orchestrator for job status.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "job-poll-timeout": {
+      "description": "The time, in seconds, to wait for orchestrator job status.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "kex-algorithms": {
+      "description": "A list of key exchange algorithms to use when establishing a connection to a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed [here](https://github.com/net-ssh/net-ssh#supported-algorithms). All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms using this option, add 'defaults' to the list of supported algorithms.",
+      "oneOf": [
+        {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "load-config": {
+      "description": "Whether to load system SSH configuration from '~/.ssh/config' and '/etc/ssh_config'.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "login-shell": {
+      "description": "Which login shell Bolt should expect on the target. Supported shells are sh, bash, zsh, dash, ksh, powershell. **This option is experimental.**",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "sh",
+            "bash",
+            "zsh",
+            "dash",
+            "ksh",
+            "powershell"
+          ]
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "mac-algorithms": {
+      "description": "List of message authentication code algorithms to use when establishing a connection to a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed [here](https://github.com/net-ssh/net-ssh#supported-algorithms). All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms using this option, add 'defaults' to the list of supported algorithms.",
+      "oneOf": [
+        {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "password": {
+      "description": "The password to use to login.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "port": {
+      "description": "The port to use when connecting to the target.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 0
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "private-key": {
+      "description": "Either the path to the private key file to use for authentication, or a hash with the key `key-data` and the contents of the private key.",
+      "oneOf": [
+        {
+          "type": [
+            "object",
+            "string"
+          ],
+          "required": [
+            "key-data"
+          ],
+          "properties": {
+            "key-data": {
+              "description": "The contents of the private key.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "proxyjump": {
+      "description": "A jump host to proxy connections through, and an optional user to connect with.",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "uri"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "realm": {
+      "description": "The Kerberos realm (Active Directory domain) to authenticate against.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "run-as": {
+      "description": "The user to run commands as after login. The run-as user must be different than the login user.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "run-as-command": {
+      "description": "The command to elevate permissions. Bolt appends the user and command strings to the configured `run-as-command` before running it on the target. This command must not require  aninteractive password prompt, and the `sudo-password` option is ignored when `run-as-command` is specified. The `run-as-command` must be specified as an array.",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "run-on": {
+      "description": "The proxy target that the task executes on.",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "uri"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "script-dir": {
+      "description": "The subdirectory of the tmpdir to use in place of a randomized subdirectory for uploading and executing temporary files on the target. It's expected that this directory already exists as a subdir of tmpdir, which is either configured or defaults to `/tmp`.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "service-url": {
+      "description": "The URL of the host used for API requests.",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "uri"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "shell-command": {
+      "description": "A shell command to wrap any Docker exec commands in, such as `bash -lc`.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "smb-port": {
+      "description": "The port to use when connecting to the target when file-protocol is set to 'smb'.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 0
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "ssh-command": {
+      "description": "The command and flags to use when SSHing. This enables the external SSH transport, which shells out to the specified command. This option is used when you need support for features or algorithms that are not supported by the net-ssh Ruby library. **This option is experimental.** You can read more about this  option in [External SSH transport](experimental_features.md#external-ssh-transport).",
+      "oneOf": [
+        {
+          "type": [
+            "array",
+            "string"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "ssl": {
+      "description": "Whether to use secure https connections for WinRM.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "ssl-verify": {
+      "description": "Whether to verify that the target's certificate matches the cacert.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "sudo-executable": {
+      "description": "The executable to use when escalating to the configured `run-as` user. This is useful when you want to escalate using the configured `sudo-password`, since `run-as-command` does not use `sudo-password` or support prompting. The command executed on the target is `<sudo-executable> -S -u <user> -p custom_bolt_prompt <command>`. **This option is experimental.**",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "sudo-password": {
+      "description": "The password to use when changing users via `run-as`.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "task-environment": {
+      "description": "The environment the orchestrator loads task code from.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "tmpdir": {
+      "description": "The directory to upload and execute temporary files on the target.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "token-file": {
+      "description": "The path to the token file.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "tty": {
+      "description": "Whether to enable tty on exec commands.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "user": {
+      "description": "The user name to login as.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
     }
   }
 }

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -5,115 +5,157 @@
   "type": "object",
   "properties": {
     "color": {
+      "$ref": "#/definitions/color"
+    },
+    "compile-concurrency": {
+      "$ref": "#/definitions/compile-concurrency"
+    },
+    "concurrency": {
+      "$ref": "#/definitions/concurrency"
+    },
+    "format": {
+      "$ref": "#/definitions/format"
+    },
+    "inventory-config": {
+      "$ref": "#/definitions/inventory-config"
+    },
+    "plugin_hooks": {
+      "$ref": "#/definitions/plugin_hooks"
+    },
+    "plugins": {
+      "$ref": "#/definitions/plugins"
+    },
+    "puppetdb": {
+      "$ref": "#/definitions/puppetdb"
+    },
+    "puppetfile": {
+      "$ref": "#/definitions/puppetfile"
+    },
+    "save-rerun": {
+      "$ref": "#/definitions/save-rerun"
+    }
+  },
+  "definitions": {
+    "color": {
       "description": "Whether to use colored output when printing messages to the console.",
       "type": "boolean"
     },
     "compile-concurrency": {
       "description": "The maximum number of simultaneous manifest block compiles.",
       "type": "integer",
-      "min": 1
+      "minimum": 1
     },
     "concurrency": {
       "description": "The number of threads to use when executing on remote targets.",
       "type": "integer",
-      "min": 1
+      "minimum": 1
     },
     "format": {
       "description": "The format to use when printing results.",
       "type": "string",
-      "enum": ["human", "json"]
+      "enum": [
+        "human",
+        "json",
+        "rainbow"
+      ]
     },
     "inventory-config": {
-      "description": "A map containing default configuration for each of Bolt's transports as well as the default transport to apply to targets that do not specify one in their URI or inventory configuration.",
+      "description": "A map of default configuration options for the inventory. This includes options for setting the default transport to use when connecting to targets, as well as options for configuring the default behavior of each transport.",
       "type": "object",
-      "parameters": {
+      "properties": {
+        "transport": {
+          "$ref": "#/definitions/transport"
+        },
         "docker": {
-          "$ref": "bolt-transport-definitions.json#/docker"
+          "$ref": "#/definitions/docker"
         },
         "local": {
-          "$ref": "bolt-transport-definitions.json#/local"
+          "$ref": "#/definitions/local"
         },
         "pcp": {
-          "$ref": "bolt-transport-definitions.json#/pcp"
+          "$ref": "#/definitions/pcp"
         },
         "remote": {
-          "$ref": "bolt-transport-definitions.json#/remote"
+          "$ref": "#/definitions/remote"
         },
         "ssh": {
-          "$ref": "bolt-transport-definitions.json#/ssh"
-        },
-        "transport": {
-          "description": "The default transport to use when the transport for a target is not specified in the URI or inventory.",
-          "type": "string",
-          "enum": ["docker", "local", "pcp", "remote", "ssh", "winrm"]
+          "$ref": "#/definitions/ssh"
         },
         "winrm": {
-          "$ref": "bolt-transport-definitions.json#/winrm"
+          "$ref": "#/definitions/winrm"
         }
       }
     },
     "plugin_hooks": {
-      "description": "Which plugins a specific hook should use.",
-      "type": "object",
-      "properties": {
-        "puppet_library": {
-          "description": "Specify which plugin should be used to ensure the Puppet library is installed on a target.",
+      "description": "A map of [plugin hooks](writing_plugins.md#hooks) and which plugins a hook should use. The only configurable plugin hook is `puppet_library`, which can use two possible plugins: [`puppet_agent`](https://github.com/puppetlabs/puppetlabs-puppet_agent#puppet_agentinstall) and [`task`](using_plugins.md#task).",
+      "oneOf": [
+        {
           "type": "object"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
         }
-      }
+      ]
     },
     "plugins": {
-      "description": "A map of plugins and their configuration data.",
-      "type": "object",
-      "patternProperties": {
-        "^[a-z][a-z0-9_]*$": { 
+      "description": "A map of plugins and their configuration data, where each key is the name of a plugin and its value is a map of configuration data. Configurable options are specified by the plugin. Read more about configuring plugins in [Using plugins](using_plugins.md#configuring-plugins).",
+      "oneOf": [
+        {
           "type": "object"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
         }
-      }
+      ]
     },
     "puppetdb": {
-      "description": "A map containing options for configuring the Bolt PuppetDB client.",
-      "type": "object",
-      "properties": {
-        "cacert": {
-          "description": "The path to the ca certificate for PuppetDB.",
-          "type": "string"
-        },
-        "cert": {
-          "description": "The path to the client certificate file to use for authentication.",
-          "type": "string"
-        },
-        "key": {
-          "description": "The path to the private key for the certificate.",
-          "type": "string"
-        },
-        "server_urls": {
-          "description": "An array containing the PuppetDB host to connect to. Include the protocol https and the port, which is usually 8081. For example, https://my-master.example.com:8081.",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "description": "A PuppetDB host.",
-            "type": "string",
-            "format": "uri"
+      "description": "A map containing options for [configuring the Bolt PuppetDB client](bolt_connect_puppetdb.md).",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cacert": {
+              "description": "The path to the ca certificate for PuppetDB.",
+              "type": "string"
+            },
+            "cert": {
+              "description": "The path to the client certificate file to use for authentication.",
+              "type": "string"
+            },
+            "key": {
+              "description": "The private key for the certificate.",
+              "type": "string"
+            },
+            "server_urls": {
+              "description": "An array containing the PuppetDB host to connect to. Include the protocol `https` and the port, which is usually `8081`. For example, `https://my-master.example.com:8081`.",
+              "type": "array"
+            },
+            "token": {
+              "description": "The path to the PE RBAC Token.",
+              "type": "string"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
         }
-      }
+      ]
     },
     "puppetfile": {
-      "description": "A map containing options for the 'bolt puppetfile install' command.",
+      "description": "A map containing options for the `bolt puppetfile install` command.",
       "type": "object",
       "properties": {
         "forge": {
-          "description": "A subsection that can have its own proxy setting to set an HTTP proxy for Forge operations only, and a baseurl setting to specify a different Forge host.",
+          "description": "A subsection that can have its own `proxy` setting to set an HTTP proxy for Forge operations only, and a `baseurl` setting to specify a different Forge host.",
           "type": "object",
           "properties": {
             "baseurl": {
-              "description": "The URI for the Forge host.",
+              "description": "The URL to the Forge host.",
               "type": "string",
               "format": "uri"
             },
             "proxy": {
-              "description": "The HTTP proxy to use for Forge operations.",
+              "description": "The HTTP proxy to use for Git and Forge operations.",
               "type": "string",
               "format": "uri"
             }
@@ -127,8 +169,827 @@
       }
     },
     "save-rerun": {
-      "description": "Whether to update .rerun.json in the Bolt project directory. If your target names include passwords, set this value to false to avoid writing passwords to disk.",
+      "description": "Whether to update `.rerun.json` in the Bolt project directory. If your target names include passwords, set this value to `false` to avoid writing passwords to disk.",
       "type": "boolean"
+    },
+    "transport": {
+      "description": "The default transport to use when the transport for a target is not specified in the URI.",
+      "type": "string",
+      "enum": [
+        "ssh",
+        "winrm",
+        "pcp",
+        "local",
+        "docker",
+        "remote"
+      ]
+    },
+    "docker": {
+      "description": "A map of configuration options for the docker transport.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cleanup": {
+              "$ref": "#/transport_definitions/cleanup"
+            },
+            "host": {
+              "$ref": "#/transport_definitions/host"
+            },
+            "interpreters": {
+              "$ref": "#/transport_definitions/interpreters"
+            },
+            "service-url": {
+              "$ref": "#/transport_definitions/service-url"
+            },
+            "shell-command": {
+              "$ref": "#/transport_definitions/shell-command"
+            },
+            "tmpdir": {
+              "$ref": "#/transport_definitions/tmpdir"
+            },
+            "tty": {
+              "$ref": "#/transport_definitions/tty"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "local": {
+      "description": "A map of configuration options for the local transport. The set of available options is platform dependent.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cleanup": {
+              "$ref": "#/transport_definitions/cleanup"
+            },
+            "interpreters": {
+              "$ref": "#/transport_definitions/interpreters"
+            },
+            "run-as": {
+              "$ref": "#/transport_definitions/run-as"
+            },
+            "run-as-command": {
+              "$ref": "#/transport_definitions/run-as-command"
+            },
+            "sudo-executable": {
+              "$ref": "#/transport_definitions/sudo-executable"
+            },
+            "sudo-password": {
+              "$ref": "#/transport_definitions/sudo-password"
+            },
+            "tmpdir": {
+              "$ref": "#/transport_definitions/tmpdir"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "pcp": {
+      "description": "A map of configuration options for the pcp transport.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cacert": {
+              "$ref": "#/transport_definitions/cacert"
+            },
+            "host": {
+              "$ref": "#/transport_definitions/host"
+            },
+            "job-poll-interval": {
+              "$ref": "#/transport_definitions/job-poll-interval"
+            },
+            "job-poll-timeout": {
+              "$ref": "#/transport_definitions/job-poll-timeout"
+            },
+            "service-url": {
+              "$ref": "#/transport_definitions/service-url"
+            },
+            "task-environment": {
+              "$ref": "#/transport_definitions/task-environment"
+            },
+            "token-file": {
+              "$ref": "#/transport_definitions/token-file"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "remote": {
+      "description": "A map of configuration options for the remote transport.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "run-on": {
+              "$ref": "#/transport_definitions/run-on"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "ssh": {
+      "description": "A map of configuration options for the ssh transport.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cleanup": {
+              "$ref": "#/transport_definitions/cleanup"
+            },
+            "connect-timeout": {
+              "$ref": "#/transport_definitions/connect-timeout"
+            },
+            "disconnect-timeout": {
+              "$ref": "#/transport_definitions/disconnect-timeout"
+            },
+            "encryption-algorithms": {
+              "$ref": "#/transport_definitions/encryption-algorithms"
+            },
+            "extensions": {
+              "$ref": "#/transport_definitions/extensions"
+            },
+            "host": {
+              "$ref": "#/transport_definitions/host"
+            },
+            "host-key-algorithms": {
+              "$ref": "#/transport_definitions/host-key-algorithms"
+            },
+            "host-key-check": {
+              "$ref": "#/transport_definitions/host-key-check"
+            },
+            "interpreters": {
+              "$ref": "#/transport_definitions/interpreters"
+            },
+            "kex-algorithms": {
+              "$ref": "#/transport_definitions/kex-algorithms"
+            },
+            "load-config": {
+              "$ref": "#/transport_definitions/load-config"
+            },
+            "login-shell": {
+              "$ref": "#/transport_definitions/login-shell"
+            },
+            "mac-algorithms": {
+              "$ref": "#/transport_definitions/mac-algorithms"
+            },
+            "password": {
+              "$ref": "#/transport_definitions/password"
+            },
+            "port": {
+              "$ref": "#/transport_definitions/port"
+            },
+            "private-key": {
+              "$ref": "#/transport_definitions/private-key"
+            },
+            "proxyjump": {
+              "$ref": "#/transport_definitions/proxyjump"
+            },
+            "run-as": {
+              "$ref": "#/transport_definitions/run-as"
+            },
+            "run-as-command": {
+              "$ref": "#/transport_definitions/run-as-command"
+            },
+            "script-dir": {
+              "$ref": "#/transport_definitions/script-dir"
+            },
+            "sudo-executable": {
+              "$ref": "#/transport_definitions/sudo-executable"
+            },
+            "sudo-password": {
+              "$ref": "#/transport_definitions/sudo-password"
+            },
+            "tmpdir": {
+              "$ref": "#/transport_definitions/tmpdir"
+            },
+            "tty": {
+              "$ref": "#/transport_definitions/tty"
+            },
+            "user": {
+              "$ref": "#/transport_definitions/user"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "winrm": {
+      "description": "A map of configuration options for the winrm transport.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "basic-auth-only": {
+              "$ref": "#/transport_definitions/basic-auth-only"
+            },
+            "cacert": {
+              "$ref": "#/transport_definitions/cacert"
+            },
+            "cleanup": {
+              "$ref": "#/transport_definitions/cleanup"
+            },
+            "connect-timeout": {
+              "$ref": "#/transport_definitions/connect-timeout"
+            },
+            "extensions": {
+              "$ref": "#/transport_definitions/extensions"
+            },
+            "file-protocol": {
+              "$ref": "#/transport_definitions/file-protocol"
+            },
+            "host": {
+              "$ref": "#/transport_definitions/host"
+            },
+            "interpreters": {
+              "$ref": "#/transport_definitions/interpreters"
+            },
+            "password": {
+              "$ref": "#/transport_definitions/password"
+            },
+            "port": {
+              "$ref": "#/transport_definitions/port"
+            },
+            "realm": {
+              "$ref": "#/transport_definitions/realm"
+            },
+            "smb-port": {
+              "$ref": "#/transport_definitions/smb-port"
+            },
+            "ssl": {
+              "$ref": "#/transport_definitions/ssl"
+            },
+            "ssl-verify": {
+              "$ref": "#/transport_definitions/ssl-verify"
+            },
+            "tmpdir": {
+              "$ref": "#/transport_definitions/tmpdir"
+            },
+            "user": {
+              "$ref": "#/transport_definitions/user"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "_plugin": {
+      "description": "A plugin reference.",
+      "type": "object",
+      "required": [
+        "_plugin"
+      ],
+      "properties": {
+        "_plugin": {
+          "description": "The name of the plugin.",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "transport_definitions": {
+    "basic-auth-only": {
+      "description": "Whether to force basic authentication. This option is only available when using SSL.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "cacert": {
+      "description": "The path to the CA certificate.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "cleanup": {
+      "description": "Whether to clean up temporary files created on targets. When running commands on a target, Bolt may create temporary files. After completing the command, these files are automatically deleted. This value can be set to 'false' if you wish to leave these temporary files on the target.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "connect-timeout": {
+      "description": "How long to wait in seconds when establishing connections. Set this value higher if you frequently encounter connection timeout errors when running Bolt.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "copy-command": {
+      "description": "The command to use when copying files using ssh-command. Bolt runs `<copy-command> <src> <dest>`. This option is used when you need support for features or algorithms that are not supported by the net-ssh Ruby library. **This option is experimental.** You can read more about this option in [External SSH transport](experimental_features.md#external-ssh-transport).",
+      "oneOf": [
+        {
+          "type": [
+            "array",
+            "string"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "disconnect-timeout": {
+      "description": "How long to wait in seconds before force-closing a connection.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "encryption-algorithms": {
+      "description": "A list of encryption algorithms to use when establishing a connection to a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed [here](https://github.com/net-ssh/net-ssh#supported-algorithms). All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms using this option, add 'defaults' to the list of supported algorithms.",
+      "oneOf": [
+        {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "extensions": {
+      "description": "A list of file extensions that are accepted for scripts or tasks on Windows. Scripts with these file extensions rely on the target's file type association to run. For example, if Python is installed on the system, a `.py` script runs with `python.exe`. The extensions `.ps1`, `.rb`, and `.pp` are always allowed and run via hard-coded executables.",
+      "oneOf": [
+        {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "file-protocol": {
+      "description": "Which file transfer protocol to use. Either `winrm` or `smb`. Using `smb` is recommended for large file transfers.",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "smb",
+            "winrm"
+          ]
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "host": {
+      "description": "The target's hostname.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "host-key-algorithms": {
+      "description": "A list of host key algorithms to use when establishing a connection to a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed [here](https://github.com/net-ssh/net-ssh#supported-algorithms). All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms using this option, add 'defaults' to the list of supported algorithms.",
+      "oneOf": [
+        {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "host-key-check": {
+      "description": "Whether to perform host key validation when connecting.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "interpreters": {
+      "description": "A map of an extension name to the absolute path of an executable,  enabling you to override the shebang defined in a task executable. The extension can optionally be specified with the `.` character (`.py` and `py` both map to a task executable `task.py`) and the extension is case sensitive. When a target's name is `localhost`, Ruby tasks run with the Bolt Ruby interpreter by default.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "propertyNames": {
+            "pattern": "^.?[a-zA-Z0-9]+$"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "job-poll-interval": {
+      "description": "The interval, in seconds, to poll orchestrator for job status.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "job-poll-timeout": {
+      "description": "The time, in seconds, to wait for orchestrator job status.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "kex-algorithms": {
+      "description": "A list of key exchange algorithms to use when establishing a connection to a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed [here](https://github.com/net-ssh/net-ssh#supported-algorithms). All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms using this option, add 'defaults' to the list of supported algorithms.",
+      "oneOf": [
+        {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "load-config": {
+      "description": "Whether to load system SSH configuration from '~/.ssh/config' and '/etc/ssh_config'.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "login-shell": {
+      "description": "Which login shell Bolt should expect on the target. Supported shells are sh, bash, zsh, dash, ksh, powershell. **This option is experimental.**",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "sh",
+            "bash",
+            "zsh",
+            "dash",
+            "ksh",
+            "powershell"
+          ]
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "mac-algorithms": {
+      "description": "List of message authentication code algorithms to use when establishing a connection to a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed [here](https://github.com/net-ssh/net-ssh#supported-algorithms). All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms using this option, add 'defaults' to the list of supported algorithms.",
+      "oneOf": [
+        {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "password": {
+      "description": "The password to use to login.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "port": {
+      "description": "The port to use when connecting to the target.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 0
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "private-key": {
+      "description": "Either the path to the private key file to use for authentication, or a hash with the key `key-data` and the contents of the private key.",
+      "oneOf": [
+        {
+          "type": [
+            "object",
+            "string"
+          ],
+          "required": [
+            "key-data"
+          ],
+          "properties": {
+            "key-data": {
+              "description": "The contents of the private key.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "proxyjump": {
+      "description": "A jump host to proxy connections through, and an optional user to connect with.",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "uri"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "realm": {
+      "description": "The Kerberos realm (Active Directory domain) to authenticate against.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "run-as": {
+      "description": "The user to run commands as after login. The run-as user must be different than the login user.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "run-as-command": {
+      "description": "The command to elevate permissions. Bolt appends the user and command strings to the configured `run-as-command` before running it on the target. This command must not require  aninteractive password prompt, and the `sudo-password` option is ignored when `run-as-command` is specified. The `run-as-command` must be specified as an array.",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "run-on": {
+      "description": "The proxy target that the task executes on.",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "uri"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "script-dir": {
+      "description": "The subdirectory of the tmpdir to use in place of a randomized subdirectory for uploading and executing temporary files on the target. It's expected that this directory already exists as a subdir of tmpdir, which is either configured or defaults to `/tmp`.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "service-url": {
+      "description": "The URL of the host used for API requests.",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "uri"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "shell-command": {
+      "description": "A shell command to wrap any Docker exec commands in, such as `bash -lc`.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "smb-port": {
+      "description": "The port to use when connecting to the target when file-protocol is set to 'smb'.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 0
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "ssh-command": {
+      "description": "The command and flags to use when SSHing. This enables the external SSH transport, which shells out to the specified command. This option is used when you need support for features or algorithms that are not supported by the net-ssh Ruby library. **This option is experimental.** You can read more about this  option in [External SSH transport](experimental_features.md#external-ssh-transport).",
+      "oneOf": [
+        {
+          "type": [
+            "array",
+            "string"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "ssl": {
+      "description": "Whether to use secure https connections for WinRM.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "ssl-verify": {
+      "description": "Whether to verify that the target's certificate matches the cacert.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "sudo-executable": {
+      "description": "The executable to use when escalating to the configured `run-as` user. This is useful when you want to escalate using the configured `sudo-password`, since `run-as-command` does not use `sudo-password` or support prompting. The command executed on the target is `<sudo-executable> -S -u <user> -p custom_bolt_prompt <command>`. **This option is experimental.**",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "sudo-password": {
+      "description": "The password to use when changing users via `run-as`.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "task-environment": {
+      "description": "The environment the orchestrator loads task code from.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "tmpdir": {
+      "description": "The directory to upload and execute temporary files on the target.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "token-file": {
+      "description": "The path to the token file.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "tty": {
+      "description": "Whether to enable tty on exec commands.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "user": {
+      "description": "The user name to login as.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
     }
   }
 }

--- a/schemas/bolt-inventory-base.json
+++ b/schemas/bolt-inventory-base.json
@@ -1,0 +1,228 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Bolt Inventory",
+  "description": "Bolt Inventory inventory.yaml Schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "config": {
+      "$ref": "#/definitions/config"
+    },
+    "facts": {
+      "$ref": "#/definitions/facts"
+    },
+    "features": {
+      "$ref": "#/definitions/features"
+    },
+    "groups": {
+      "$ref": "#/definitions/groups"
+    },
+    "targets": {
+      "$ref": "#/definitions/targets"
+    },
+    "vars": {
+      "$ref": "#/definitions/vars"
+    },
+    "version": {
+      "$ref": "#/definitions/version"
+    }
+  },
+  "definitions": {
+    "config": {
+      "description": "The configuration for a target.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false    
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "facts": {
+      "description": "The facts for a target.",
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "features": {
+      "description": "The features for a target.",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "groups": {
+      "description": "A list of target groups.",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/group"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "group": {
+      "description": "A group of targets.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "config": {
+              "$ref": "#/definitions/config"
+            },
+            "facts": {
+              "$ref": "#/definitions/facts"
+            },
+            "features": {
+              "$ref": "#/definitions/features"
+            },
+            "groups": {
+              "$ref": "#/definitions/groups"
+            },
+            "name": {
+              "description": "The group's name.",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "pattern": "^[a-z0-9_][a-z0-9_-]*$"    
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
+            "targets": {
+              "$ref": "#/definitions/targets"
+            },
+            "vars": {
+              "$ref": "#/definitions/vars"
+            }
+          },
+          "required": ["name"]    
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "targets": {
+      "description": "A list of targets. Targets can be defined by either a string representation of its URI, or a map of its attributes and configuration.",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/target"
+          }    
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "target": {
+      "description": "A target definition.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "alias": {
+              "description": "A unique alias to refer to the target.",
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "string",
+                        "pattern": "^[a-z0-9_][a-z0-9_-]*$"  
+                      },
+                      {
+                        "$ref": "#/definitions/_plugin"
+                      }
+                    ]  
+                  }
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
+            "config": {
+              "$ref": "#/definitions/config"
+            },
+            "facts": {
+              "$ref": "#/definitions/facts"
+            },
+            "features": {
+              "$ref": "#/definitions/features"
+            },
+            "name": {
+              "description": "A human-readable name for a target.",
+              "type": "string"
+            },
+            "uri": {
+              "description": "The URI of the target.",
+              "type": "string",
+              "format": "uri"
+            },
+            "vars": {
+              "$ref": "#/definitions/vars"
+            }
+          },
+          "anyOf": [
+            { "required": ["uri"] },
+            { "required": ["name"] }
+          ]    
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "vars": {
+      "description": "The vars for a target.",
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "version": {
+      "description": "The version of the inventory file.",
+      "type": "integer"
+    }
+  }
+}

--- a/schemas/bolt-inventory.schema.json
+++ b/schemas/bolt-inventory.schema.json
@@ -24,140 +24,1057 @@
       "$ref": "#/definitions/vars"
     },
     "version": {
-      "description": "The version of the inventory file.",
-      "type": "integer"
+      "$ref": "#/definitions/version"
     }
   },
   "definitions": {
     "config": {
       "description": "The configuration for a target.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "transport": {
-          "description": "The transport used to connect to a target.",
-          "type": "string",
-          "enum": ["docker", "local", "pcp", "remote", "ssh", "winrm"]
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "transport": {
+              "$ref": "#/definitions/transport"
+            },
+            "docker": {
+              "$ref": "#/definitions/docker"
+            },
+            "local": {
+              "$ref": "#/definitions/local"
+            },
+            "pcp": {
+              "$ref": "#/definitions/pcp"
+            },
+            "remote": {
+              "$ref": "#/definitions/remote"
+            },
+            "ssh": {
+              "$ref": "#/definitions/ssh"
+            },
+            "winrm": {
+              "$ref": "#/definitions/winrm"
+            }
+          }
         },
-        "docker": {
-          "$ref": "bolt-transport-definitions.json#/docker"
-        },
-        "local": {
-          "$ref": "bolt-transport-definitions.json#/local"
-        },
-        "pcp": {
-          "$ref": "bolt-transport-definitions.json#/pcp"
-        },
-        "remote": {
-          "$ref": "bolt-transport-definitions.json#/remote"
-        },
-        "ssh": {
-          "$ref": "bolt-transport-definitions.json#/ssh"
-        },
-        "winrm": {
-          "$ref": "bolt-transport-definitions.json#/winrm"
+        {
+          "$ref": "#/definitions/_plugin"
         }
-      }
+      ]
     },
     "facts": {
       "description": "The facts for a target.",
-      "type": "object"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
     },
     "features": {
       "description": "The features for a target.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
     },
     "groups": {
       "description": "A list of target groups.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/group"
-      }
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/group"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
     },
     "group": {
       "description": "A group of targets.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "config": {
-          "$ref": "#/definitions/config"
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "config": {
+              "$ref": "#/definitions/config"
+            },
+            "facts": {
+              "$ref": "#/definitions/facts"
+            },
+            "features": {
+              "$ref": "#/definitions/features"
+            },
+            "groups": {
+              "$ref": "#/definitions/groups"
+            },
+            "name": {
+              "description": "The group's name.",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "pattern": "^[a-z0-9_][a-z0-9_-]*$"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
+            "targets": {
+              "$ref": "#/definitions/targets"
+            },
+            "vars": {
+              "$ref": "#/definitions/vars"
+            }
+          },
+          "required": [
+            "name"
+          ]
         },
-        "facts": {
-          "$ref": "#/definitions/facts"
-        },
-        "features": {
-          "$ref": "#/definitions/features"
-        },
-        "groups": {
-          "$ref": "#/definitions/groups"
-        },
-        "name": {
-          "description": "The group's name.",
-          "type": "string",
-          "pattern": "^[a-z0-9_][a-z0-9_-]*$"
-        },
-        "targets": {
-          "$ref": "#/definitions/targets"
-        },
-        "vars": {
-          "$ref": "#/definitions/vars"
+        {
+          "$ref": "#/definitions/_plugin"
         }
-      },
-      "required": ["name"]
+      ]
     },
     "targets": {
       "description": "A list of targets. Targets can be defined by either a string representation of its URI, or a map of its attributes and configuration.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/target"
-      }
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/target"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
     },
     "target": {
       "description": "A target definition.",
-      "type": ["object", "string"],
-      "additionalProperties": false,
-      "properties": {
-        "alias": {
-          "description": "A unique alias to refer to the target.",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "pattern": "^[a-z0-9_][a-z0-9_-]*$"
-          }
-        },
-        "config": {
-          "$ref": "#/definitions/config"
-        },
-        "facts": {
-          "$ref": "#/definitions/facts"
-        },
-        "features": {
-          "$ref": "#/definitions/features"
-        },
-        "name": {
-          "description": "A human-readable name for a target.",
+      "oneOf": [
+        {
           "type": "string"
         },
-        "uri": {
-          "description": "The URI of the target.",
-          "type": "string",
-          "format": "uri"
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "alias": {
+              "description": "A unique alias to refer to the target.",
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "string",
+                        "pattern": "^[a-z0-9_][a-z0-9_-]*$"
+                      },
+                      {
+                        "$ref": "#/definitions/_plugin"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
+            "config": {
+              "$ref": "#/definitions/config"
+            },
+            "facts": {
+              "$ref": "#/definitions/facts"
+            },
+            "features": {
+              "$ref": "#/definitions/features"
+            },
+            "name": {
+              "description": "A human-readable name for a target.",
+              "type": "string"
+            },
+            "uri": {
+              "description": "The URI of the target.",
+              "type": "string",
+              "format": "uri"
+            },
+            "vars": {
+              "$ref": "#/definitions/vars"
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "uri"
+              ]
+            },
+            {
+              "required": [
+                "name"
+              ]
+            }
+          ]
         },
-        "vars": {
-          "$ref": "#/definitions/vars"
+        {
+          "$ref": "#/definitions/_plugin"
         }
-      },
-      "anyOf": [
-        { "required": ["uri"] },
-        { "required": ["name"] }
       ]
     },
     "vars": {
       "description": "The vars for a target.",
-      "type": "object"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "version": {
+      "description": "The version of the inventory file.",
+      "type": "integer"
+    },
+    "transport": {
+      "description": "The default transport to use when the transport for a target is not specified in the URI.",
+      "type": "string",
+      "enum": [
+        "ssh",
+        "winrm",
+        "pcp",
+        "local",
+        "docker",
+        "remote"
+      ]
+    },
+    "docker": {
+      "description": "A map of configuration options for the docker transport.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cleanup": {
+              "$ref": "#/transport_definitions/cleanup"
+            },
+            "host": {
+              "$ref": "#/transport_definitions/host"
+            },
+            "interpreters": {
+              "$ref": "#/transport_definitions/interpreters"
+            },
+            "service-url": {
+              "$ref": "#/transport_definitions/service-url"
+            },
+            "shell-command": {
+              "$ref": "#/transport_definitions/shell-command"
+            },
+            "tmpdir": {
+              "$ref": "#/transport_definitions/tmpdir"
+            },
+            "tty": {
+              "$ref": "#/transport_definitions/tty"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "local": {
+      "description": "A map of configuration options for the local transport. The set of available options is platform dependent.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cleanup": {
+              "$ref": "#/transport_definitions/cleanup"
+            },
+            "interpreters": {
+              "$ref": "#/transport_definitions/interpreters"
+            },
+            "run-as": {
+              "$ref": "#/transport_definitions/run-as"
+            },
+            "run-as-command": {
+              "$ref": "#/transport_definitions/run-as-command"
+            },
+            "sudo-executable": {
+              "$ref": "#/transport_definitions/sudo-executable"
+            },
+            "sudo-password": {
+              "$ref": "#/transport_definitions/sudo-password"
+            },
+            "tmpdir": {
+              "$ref": "#/transport_definitions/tmpdir"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "pcp": {
+      "description": "A map of configuration options for the pcp transport.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cacert": {
+              "$ref": "#/transport_definitions/cacert"
+            },
+            "host": {
+              "$ref": "#/transport_definitions/host"
+            },
+            "job-poll-interval": {
+              "$ref": "#/transport_definitions/job-poll-interval"
+            },
+            "job-poll-timeout": {
+              "$ref": "#/transport_definitions/job-poll-timeout"
+            },
+            "service-url": {
+              "$ref": "#/transport_definitions/service-url"
+            },
+            "task-environment": {
+              "$ref": "#/transport_definitions/task-environment"
+            },
+            "token-file": {
+              "$ref": "#/transport_definitions/token-file"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "remote": {
+      "description": "A map of configuration options for the remote transport.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "run-on": {
+              "$ref": "#/transport_definitions/run-on"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "ssh": {
+      "description": "A map of configuration options for the ssh transport.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cleanup": {
+              "$ref": "#/transport_definitions/cleanup"
+            },
+            "connect-timeout": {
+              "$ref": "#/transport_definitions/connect-timeout"
+            },
+            "disconnect-timeout": {
+              "$ref": "#/transport_definitions/disconnect-timeout"
+            },
+            "encryption-algorithms": {
+              "$ref": "#/transport_definitions/encryption-algorithms"
+            },
+            "extensions": {
+              "$ref": "#/transport_definitions/extensions"
+            },
+            "host": {
+              "$ref": "#/transport_definitions/host"
+            },
+            "host-key-algorithms": {
+              "$ref": "#/transport_definitions/host-key-algorithms"
+            },
+            "host-key-check": {
+              "$ref": "#/transport_definitions/host-key-check"
+            },
+            "interpreters": {
+              "$ref": "#/transport_definitions/interpreters"
+            },
+            "kex-algorithms": {
+              "$ref": "#/transport_definitions/kex-algorithms"
+            },
+            "load-config": {
+              "$ref": "#/transport_definitions/load-config"
+            },
+            "login-shell": {
+              "$ref": "#/transport_definitions/login-shell"
+            },
+            "mac-algorithms": {
+              "$ref": "#/transport_definitions/mac-algorithms"
+            },
+            "password": {
+              "$ref": "#/transport_definitions/password"
+            },
+            "port": {
+              "$ref": "#/transport_definitions/port"
+            },
+            "private-key": {
+              "$ref": "#/transport_definitions/private-key"
+            },
+            "proxyjump": {
+              "$ref": "#/transport_definitions/proxyjump"
+            },
+            "run-as": {
+              "$ref": "#/transport_definitions/run-as"
+            },
+            "run-as-command": {
+              "$ref": "#/transport_definitions/run-as-command"
+            },
+            "script-dir": {
+              "$ref": "#/transport_definitions/script-dir"
+            },
+            "sudo-executable": {
+              "$ref": "#/transport_definitions/sudo-executable"
+            },
+            "sudo-password": {
+              "$ref": "#/transport_definitions/sudo-password"
+            },
+            "tmpdir": {
+              "$ref": "#/transport_definitions/tmpdir"
+            },
+            "tty": {
+              "$ref": "#/transport_definitions/tty"
+            },
+            "user": {
+              "$ref": "#/transport_definitions/user"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "winrm": {
+      "description": "A map of configuration options for the winrm transport.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "basic-auth-only": {
+              "$ref": "#/transport_definitions/basic-auth-only"
+            },
+            "cacert": {
+              "$ref": "#/transport_definitions/cacert"
+            },
+            "cleanup": {
+              "$ref": "#/transport_definitions/cleanup"
+            },
+            "connect-timeout": {
+              "$ref": "#/transport_definitions/connect-timeout"
+            },
+            "extensions": {
+              "$ref": "#/transport_definitions/extensions"
+            },
+            "file-protocol": {
+              "$ref": "#/transport_definitions/file-protocol"
+            },
+            "host": {
+              "$ref": "#/transport_definitions/host"
+            },
+            "interpreters": {
+              "$ref": "#/transport_definitions/interpreters"
+            },
+            "password": {
+              "$ref": "#/transport_definitions/password"
+            },
+            "port": {
+              "$ref": "#/transport_definitions/port"
+            },
+            "realm": {
+              "$ref": "#/transport_definitions/realm"
+            },
+            "smb-port": {
+              "$ref": "#/transport_definitions/smb-port"
+            },
+            "ssl": {
+              "$ref": "#/transport_definitions/ssl"
+            },
+            "ssl-verify": {
+              "$ref": "#/transport_definitions/ssl-verify"
+            },
+            "tmpdir": {
+              "$ref": "#/transport_definitions/tmpdir"
+            },
+            "user": {
+              "$ref": "#/transport_definitions/user"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "_plugin": {
+      "description": "A plugin reference.",
+      "type": "object",
+      "required": [
+        "_plugin"
+      ],
+      "properties": {
+        "_plugin": {
+          "description": "The name of the plugin.",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "transport_definitions": {
+    "basic-auth-only": {
+      "description": "Whether to force basic authentication. This option is only available when using SSL.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "cacert": {
+      "description": "The path to the CA certificate.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "cleanup": {
+      "description": "Whether to clean up temporary files created on targets. When running commands on a target, Bolt may create temporary files. After completing the command, these files are automatically deleted. This value can be set to 'false' if you wish to leave these temporary files on the target.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "connect-timeout": {
+      "description": "How long to wait in seconds when establishing connections. Set this value higher if you frequently encounter connection timeout errors when running Bolt.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "copy-command": {
+      "description": "The command to use when copying files using ssh-command. Bolt runs `<copy-command> <src> <dest>`. This option is used when you need support for features or algorithms that are not supported by the net-ssh Ruby library. **This option is experimental.** You can read more about this option in [External SSH transport](experimental_features.md#external-ssh-transport).",
+      "oneOf": [
+        {
+          "type": [
+            "array",
+            "string"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "disconnect-timeout": {
+      "description": "How long to wait in seconds before force-closing a connection.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "encryption-algorithms": {
+      "description": "A list of encryption algorithms to use when establishing a connection to a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed [here](https://github.com/net-ssh/net-ssh#supported-algorithms). All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms using this option, add 'defaults' to the list of supported algorithms.",
+      "oneOf": [
+        {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "extensions": {
+      "description": "A list of file extensions that are accepted for scripts or tasks on Windows. Scripts with these file extensions rely on the target's file type association to run. For example, if Python is installed on the system, a `.py` script runs with `python.exe`. The extensions `.ps1`, `.rb`, and `.pp` are always allowed and run via hard-coded executables.",
+      "oneOf": [
+        {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "file-protocol": {
+      "description": "Which file transfer protocol to use. Either `winrm` or `smb`. Using `smb` is recommended for large file transfers.",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "smb",
+            "winrm"
+          ]
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "host": {
+      "description": "The target's hostname.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "host-key-algorithms": {
+      "description": "A list of host key algorithms to use when establishing a connection to a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed [here](https://github.com/net-ssh/net-ssh#supported-algorithms). All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms using this option, add 'defaults' to the list of supported algorithms.",
+      "oneOf": [
+        {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "host-key-check": {
+      "description": "Whether to perform host key validation when connecting.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "interpreters": {
+      "description": "A map of an extension name to the absolute path of an executable,  enabling you to override the shebang defined in a task executable. The extension can optionally be specified with the `.` character (`.py` and `py` both map to a task executable `task.py`) and the extension is case sensitive. When a target's name is `localhost`, Ruby tasks run with the Bolt Ruby interpreter by default.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "propertyNames": {
+            "pattern": "^.?[a-zA-Z0-9]+$"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "job-poll-interval": {
+      "description": "The interval, in seconds, to poll orchestrator for job status.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "job-poll-timeout": {
+      "description": "The time, in seconds, to wait for orchestrator job status.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "kex-algorithms": {
+      "description": "A list of key exchange algorithms to use when establishing a connection to a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed [here](https://github.com/net-ssh/net-ssh#supported-algorithms). All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms using this option, add 'defaults' to the list of supported algorithms.",
+      "oneOf": [
+        {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "load-config": {
+      "description": "Whether to load system SSH configuration from '~/.ssh/config' and '/etc/ssh_config'.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "login-shell": {
+      "description": "Which login shell Bolt should expect on the target. Supported shells are sh, bash, zsh, dash, ksh, powershell. **This option is experimental.**",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "sh",
+            "bash",
+            "zsh",
+            "dash",
+            "ksh",
+            "powershell"
+          ]
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "mac-algorithms": {
+      "description": "List of message authentication code algorithms to use when establishing a connection to a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed [here](https://github.com/net-ssh/net-ssh#supported-algorithms). All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms using this option, add 'defaults' to the list of supported algorithms.",
+      "oneOf": [
+        {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "password": {
+      "description": "The password to use to login.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "port": {
+      "description": "The port to use when connecting to the target.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 0
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "private-key": {
+      "description": "Either the path to the private key file to use for authentication, or a hash with the key `key-data` and the contents of the private key.",
+      "oneOf": [
+        {
+          "type": [
+            "object",
+            "string"
+          ],
+          "required": [
+            "key-data"
+          ],
+          "properties": {
+            "key-data": {
+              "description": "The contents of the private key.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "proxyjump": {
+      "description": "A jump host to proxy connections through, and an optional user to connect with.",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "uri"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "realm": {
+      "description": "The Kerberos realm (Active Directory domain) to authenticate against.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "run-as": {
+      "description": "The user to run commands as after login. The run-as user must be different than the login user.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "run-as-command": {
+      "description": "The command to elevate permissions. Bolt appends the user and command strings to the configured `run-as-command` before running it on the target. This command must not require  aninteractive password prompt, and the `sudo-password` option is ignored when `run-as-command` is specified. The `run-as-command` must be specified as an array.",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "run-on": {
+      "description": "The proxy target that the task executes on.",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "uri"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "script-dir": {
+      "description": "The subdirectory of the tmpdir to use in place of a randomized subdirectory for uploading and executing temporary files on the target. It's expected that this directory already exists as a subdir of tmpdir, which is either configured or defaults to `/tmp`.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "service-url": {
+      "description": "The URL of the host used for API requests.",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "uri"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "shell-command": {
+      "description": "A shell command to wrap any Docker exec commands in, such as `bash -lc`.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "smb-port": {
+      "description": "The port to use when connecting to the target when file-protocol is set to 'smb'.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 0
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "ssh-command": {
+      "description": "The command and flags to use when SSHing. This enables the external SSH transport, which shells out to the specified command. This option is used when you need support for features or algorithms that are not supported by the net-ssh Ruby library. **This option is experimental.** You can read more about this  option in [External SSH transport](experimental_features.md#external-ssh-transport).",
+      "oneOf": [
+        {
+          "type": [
+            "array",
+            "string"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "ssl": {
+      "description": "Whether to use secure https connections for WinRM.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "ssl-verify": {
+      "description": "Whether to verify that the target's certificate matches the cacert.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "sudo-executable": {
+      "description": "The executable to use when escalating to the configured `run-as` user. This is useful when you want to escalate using the configured `sudo-password`, since `run-as-command` does not use `sudo-password` or support prompting. The command executed on the target is `<sudo-executable> -S -u <user> -p custom_bolt_prompt <command>`. **This option is experimental.**",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "sudo-password": {
+      "description": "The password to use when changing users via `run-as`.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "task-environment": {
+      "description": "The environment the orchestrator loads task code from.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "tmpdir": {
+      "description": "The directory to upload and execute temporary files on the target.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "token-file": {
+      "description": "The path to the token file.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "tty": {
+      "description": "Whether to enable tty on exec commands.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "user": {
+      "description": "The user name to login as.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
     }
   }
 }

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -5,11 +5,67 @@
   "type": "object",
   "properties": {
     "apply_settings": {
-      "description": "A map of Puppet settings to use when applying Puppet code.",
+      "$ref": "#/definitions/apply_settings"
+    },
+    "color": {
+      "$ref": "#/definitions/color"
+    },
+    "compile-concurrency": {
+      "$ref": "#/definitions/compile-concurrency"
+    },
+    "concurrency": {
+      "$ref": "#/definitions/concurrency"
+    },
+    "format": {
+      "$ref": "#/definitions/format"
+    },
+    "hiera-config": {
+      "$ref": "#/definitions/hiera-config"
+    },
+    "inventoryfile": {
+      "$ref": "#/definitions/inventoryfile"
+    },
+    "log": {
+      "$ref": "#/definitions/log"
+    },
+    "modulepath": {
+      "$ref": "#/definitions/modulepath"
+    },
+    "name": {
+      "$ref": "#/definitions/name"
+    },
+    "plans": {
+      "$ref": "#/definitions/plans"
+    },
+    "plugin_hooks": {
+      "$ref": "#/definitions/plugin_hooks"
+    },
+    "plugins": {
+      "$ref": "#/definitions/plugins"
+    },
+    "puppetdb": {
+      "$ref": "#/definitions/puppetdb"
+    },
+    "puppetfile": {
+      "$ref": "#/definitions/puppetfile"
+    },
+    "save-rerun": {
+      "$ref": "#/definitions/save-rerun"
+    },
+    "tasks": {
+      "$ref": "#/definitions/tasks"
+    },
+    "trusted-external-command": {
+      "$ref": "#/definitions/trusted-external-command"
+    }
+  },
+  "definitions": {
+    "apply_settings": {
+      "description": "A map of Puppet settings to use when applying Puppet code using the `apply` plan function or the `bolt apply` command.",
       "type": "object",
       "properties": {
         "show_diff": {
-          "description": "Whether to log and report a contextual diff when files are being replaced.",
+          "description": "Whether to log and report a contextual diff.",
           "type": "boolean"
         }
       }
@@ -21,28 +77,32 @@
     "compile-concurrency": {
       "description": "The maximum number of simultaneous manifest block compiles.",
       "type": "integer",
-      "min": 1
+      "minimum": 1
     },
     "concurrency": {
       "description": "The number of threads to use when executing on remote targets.",
       "type": "integer",
-      "min": 1
+      "minimum": 1
     },
     "format": {
       "description": "The format to use when printing results.",
       "type": "string",
-      "enum": ["human", "json"]
+      "enum": [
+        "human",
+        "json",
+        "rainbow"
+      ]
     },
     "hiera-config": {
-      "description": "The path to your Hiera config.",
+      "description": "The path to the Hiera configuration file.",
       "type": "string"
     },
     "inventoryfile": {
-      "description": "The path to your inventory file.",
+      "description": "The path to a structured data inventory file used to refer to groups of targets on the command line and from plans. Read more about using inventory files in [Inventory files](inventory_file_v2.md).",
       "type": "string"
     },
     "log": {
-      "description": "The configuration of the logfile output. Configuration can be set for console and the path to a log file, such as ~/.puppetlabs/bolt/debug.log.",
+      "description": "A map of configuration for the logfile output. Configuration can be set for `console` and individual log files, such as `~/.puppetlabs/bolt/debug.log`. Each key in the map is the logfile output to configure, with the corresponding value configuring the logfile output.",
       "type": "object",
       "properties": {
         "console": {
@@ -50,115 +110,133 @@
           "type": "object",
           "properties": {
             "level": {
-              "description": "The type of information in the log.",
+              "description": "The type of information to log.",
               "type": "string",
-              "enum": ["debug", "error", "info", "notice", "warn"]
+              "enum": [
+                "debug",
+                "error",
+                "info",
+                "notice",
+                "warn",
+                "fatal",
+                "any"
+              ]
             }
           }
         }
       },
       "additionalProperties": {
-        "description": "Configuration for logs output to a file.",
+        "description": "Configuration for the logfile output.",
         "type": "object",
         "properties": {
           "append": {
-            "description": "Add output to an existing log file.",
+            "description": "Whether to append output to an existing log file.",
             "type": "boolean"
           },
           "level": {
-            "description": "The type of information in the log.",
+            "description": "The type of information to log.",
             "type": "string",
-            "enum": ["debug", "error", "info", "notice", "warn"]
+            "enum": [
+              "debug",
+              "error",
+              "info",
+              "notice",
+              "warn",
+              "fatal",
+              "any"
+            ]
           }
         }
       }
     },
     "modulepath": {
-      "description": "The module path for loading tasks and plan code. This is either an array of directories or a string containing a list of directories separated by the OS-specific PATH separator.",
-      "type": ["array", "string"],
+      "description": "An array of directories that Bolt loads content such as plans and tasks from. Read more about modules in [Module structure](module_structure.md).",
+      "type": [
+        "array",
+        "string"
+      ],
       "items": {
-        "description": "Module path.",
         "type": "string"
-      },
-      "uniqueItems": true
+      }
     },
     "name": {
-      "description": "The Bolt project name.",
-      "type": "string",
-      "pattern": "^([a-zA-Z0-9]+[-])?[a-z][a-z0-9_]*$"
+      "description": "The name of the Bolt project. When this option is configured, the project is considered a [Bolt project](experimental_features.md#bolt-projects), allowing Bolt to load content from the project directory as though it were a module.",
+      "type": "string"
     },
     "plans": {
-      "description": "A list of plan names to show in 'bolt plan show' output, if they exist. This option is used to limit the visibility of plans for users of the project. For example, project authors might want to limit the visibility of plans that are bundled with Bolt or plans that should only be run as part of another plan. When this option is not configured, all plans are visible. This option does not prevent users from running plans that are not part of this list.",
-      "type": "array",
-      "items": {
-        "description": "Whitelisted plan.",
-        "type": "string",
-        "pattern": "^[a-z][a-z0-9_]*(::[a-z][a-z0-9_]*)*$"
-      },
-      "uniqueItems": true
+      "description": "A list of plan names to show in `bolt plan show` output, if they exist. This option is used to limit the visibility of plans for users of the project. For example, project authors might want to limit the visibility of plans that are bundled with Bolt or plans that should only be run as part of another plan. When this option is not configured, all plans are visible. This option does not prevent users from running plans that are not part of this list.",
+      "type": "array"
     },
     "plugin_hooks": {
-      "description": "Which plugins a specific hook should use.",
-      "type": "object",
-      "properties": {
-        "puppet_library": {
-          "description": "Specify which plugin should be used to ensure the Puppet library is installed on a target.",
+      "description": "A map of [plugin hooks](writing_plugins.md#hooks) and which plugins a hook should use. The only configurable plugin hook is `puppet_library`, which can use two possible plugins: [`puppet_agent`](https://github.com/puppetlabs/puppetlabs-puppet_agent#puppet_agentinstall) and [`task`](using_plugins.md#task).",
+      "oneOf": [
+        {
           "type": "object"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
         }
-      }
+      ]
     },
     "plugins": {
-      "description": "A map of plugins and their configuration data.",
-      "type": "object",
-      "patternProperties": {
-        "^[a-z][a-z0-9_]*$": { 
+      "description": "A map of plugins and their configuration data, where each key is the name of a plugin and its value is a map of configuration data. Configurable options are specified by the plugin. Read more about configuring plugins in [Using plugins](using_plugins.md#configuring-plugins).",
+      "oneOf": [
+        {
           "type": "object"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
         }
-      }
+      ]
     },
     "puppetdb": {
-      "description": "A map containing options for configuring the Bolt PuppetDB client.",
-      "type": "object",
-      "properties": {
-        "cacert": {
-          "description": "The path to the ca certificate for PuppetDB.",
-          "type": "string"
-        },
-        "cert": {
-          "description": "The path to the client certificate file to use for authentication.",
-          "type": "string"
-        },
-        "key": {
-          "description": "The path to the private key for the certificate.",
-          "type": "string"
-        },
-        "server_urls": {
-          "description": "An array containing the PuppetDB host to connect to. Include the protocol https and the port, which is usually 8081. For example, https://my-master.example.com:8081.",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "description": "A PuppetDB host.",
-            "type": "string",
-            "format": "uri"
+      "description": "A map containing options for [configuring the Bolt PuppetDB client](bolt_connect_puppetdb.md).",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cacert": {
+              "description": "The path to the ca certificate for PuppetDB.",
+              "type": "string"
+            },
+            "cert": {
+              "description": "The path to the client certificate file to use for authentication.",
+              "type": "string"
+            },
+            "key": {
+              "description": "The private key for the certificate.",
+              "type": "string"
+            },
+            "server_urls": {
+              "description": "An array containing the PuppetDB host to connect to. Include the protocol `https` and the port, which is usually `8081`. For example, `https://my-master.example.com:8081`.",
+              "type": "array"
+            },
+            "token": {
+              "description": "The path to the PE RBAC Token.",
+              "type": "string"
+            }
           }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
         }
-      }
+      ]
     },
     "puppetfile": {
-      "description": "A map containing options for the 'bolt puppetfile install' command.",
+      "description": "A map containing options for the `bolt puppetfile install` command.",
       "type": "object",
       "properties": {
         "forge": {
-          "description": "A subsection that can have its own proxy setting to set an HTTP proxy for Forge operations only, and a baseurl setting to specify a different Forge host.",
+          "description": "A subsection that can have its own `proxy` setting to set an HTTP proxy for Forge operations only, and a `baseurl` setting to specify a different Forge host.",
           "type": "object",
           "properties": {
             "baseurl": {
-              "description": "The URI for the Forge host.",
+              "description": "The URL to the Forge host.",
               "type": "string",
               "format": "uri"
             },
             "proxy": {
-              "description": "The HTTP proxy to use for Forge operations.",
+              "description": "The HTTP proxy to use for Git and Forge operations.",
               "type": "string",
               "format": "uri"
             }
@@ -172,22 +250,32 @@
       }
     },
     "save-rerun": {
-      "description": "Whether to update .rerun.json in the Bolt project directory. If your target names include passwords, set this value to false to avoid writing passwords to disk.",
+      "description": "Whether to update `.rerun.json` in the Bolt project directory. If your target names include passwords, set this value to `false` to avoid writing passwords to disk.",
       "type": "boolean"
     },
     "tasks": {
-      "description": "A list of task names to show in 'bolt task show' output, if they exist. This option is used to limit the visibility of tasks for users of the project. For example, project authors might want to limit the visibility of tasks that are bundled with Bolt or tasks that should only be run as part of another task. When this option is not configured, all tasks are visible. This option does not prevent users from running tasks that are not part of this list.",
+      "description": "A list of task names to show in `bolt task show` output, if they exist. This option is used to limit the visibility of tasks for users of the project. For example, project authors might want to limit the visibility of tasks that are bundled with Bolt or plans that should only be run as part of a larger workflow. When this option is not configured, all tasks are visible. This option does not prevent users from running tasks that are not part of this list.",
       "type": "array",
       "items": {
-        "description": "Whitelisted task.",
-        "type": "string",
-        "pattern": "^[a-z][a-z0-9_]*(::[a-z][a-z0-9_]*)*$"
-      },
-      "uniqueItems": true
+        "type": "string"
+      }
     },
     "trusted-external-command": {
-      "description": "The path to an executable on the Bolt controller that can produce external trusted facts.",
+      "description": "The path to an executable on the Bolt controller that can produce external trusted facts. **External trusted facts are experimental in both Puppet and Bolt and this API may change or be removed.**",
       "type": "string"
+    },
+    "_plugin": {
+      "description": "A plugin reference.",
+      "type": "object",
+      "required": [
+        "_plugin"
+      ],
+      "properties": {
+        "_plugin": {
+          "description": "The name of the plugin.",
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/schemas/bolt-transport-definitions.json
+++ b/schemas/bolt-transport-definitions.json
@@ -102,102 +102,278 @@
   },
 
   "definitions": {
-    "basic-auth-only": {
-      "description": "Force basic authentication. This option is only available when using SSL.",
-      "type": "boolean"
-    },
-    "cacert": {
-      "description": "The path to the CA certificate.",
-      "type": "string"
-    },
-    "connect-timeout": {
-      "description": "How long to wait in seconds when establishing connections.",
-      "type": "integer",
-      "min": 1
-    },
-    "copy-command": {
-      "description": "Array of command and flags to use when copying files using ssh-command. Bolt runs `<copy-command> <src> <dest>`.",
-      "type": ["array", "string"]
-    },
-    "disconnect-timeout": {
-      "description": "How long to wait in seconds before force-closing a connection.",
-      "type": "integer",
-      "min": 1
-    },
-    "encryption-algorithms": {
-      "description": "List of encryption algorithms to use when establishing a connection with a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed at https://github.com/net-ssh/net-ssh#supported-algorithms . All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms when using this option, add 'defaults' to the list of supported algorithms.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "cleanup": {
-      "description": "Whether to clean up temporary files created on targets.",
-      "type": "boolean"
-    },
-    "extensions": {
-      "description": "A list of file extensions that are accepted for scripts or tasks.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "uniqueItems": true
-    },
-    "file-protocol": {
-      "description": "Which file transfer protocol to use. 'smb' is recommended for large file transfers.",
-      "type": "string",
-      "enum": ["smb", "winrm"]
-    },
-    "host": {
-      "description": "The host's name.",
-      "type": "string"
-    },
-    "host-key-algorithms": {
-      "description": "List of host key algorithms to use when establishing a connection with a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed at https://github.com/net-ssh/net-ssh#supported-algorithms . All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms when using this option, add 'defaults' to the list of supported algorithms.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "host-key-check": {
-      "description": "Whether to perform host key validation when connecting.",
-      "type": "boolean"
-    },
-    "interpreters": {
-      "description": "A map of extension names to the absolute path of an executable, enabling you to override the shebang defined in a task executable.",
+    "_plugin": {
+      "description": "A plugin reference.",
       "type": "object",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^.?[a-zA-Z0-9]+$": {
-          "type": "string"
+      "required": ["_plugin"],
+      "properties": {
+        "_plugin": {
+          "description": "The name of the plugin to use.",
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$"
         }
       }
     },
+    "basic-auth-only": {
+      "description": "Force basic authentication. This option is only available when using SSL.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "cacert": {
+      "description": "The path to the CA certificate.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "connect-timeout": {
+      "description": "How long to wait in seconds when establishing connections.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "copy-command": {
+      "description": "Array of command and flags to use when copying files using ssh-command. Bolt runs `<copy-command> <src> <dest>`.",
+      "oneOf": [
+        {
+          "type": "array"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "disconnect-timeout": {
+      "description": "How long to wait in seconds before force-closing a connection.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "encryption-algorithms": {
+      "description": "List of encryption algorithms to use when establishing a connection with a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed at https://github.com/net-ssh/net-ssh#supported-algorithms . All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms when using this option, add 'defaults' to the list of supported algorithms.",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "cleanup": {
+      "description": "Whether to clean up temporary files created on targets.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "extensions": {
+      "description": "A list of file extensions that are accepted for scripts or tasks.",
+      "oneOf": [
+        {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "file-protocol": {
+      "description": "Which file transfer protocol to use. 'smb' is recommended for large file transfers.",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["smb", "winrm"]
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "host": {
+      "description": "The host's name.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "host-key-algorithms": {
+      "description": "List of host key algorithms to use when establishing a connection with a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed at https://github.com/net-ssh/net-ssh#supported-algorithms . All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms when using this option, add 'defaults' to the list of supported algorithms.",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "host-key-check": {
+      "description": "Whether to perform host key validation when connecting.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "interpreters": {
+      "description": "A map of extension names to the absolute path of an executable, enabling you to override the shebang defined in a task executable.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^.?[a-zA-Z0-9]+$": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            }
+          }    
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
     "job-poll-interval": {
       "description": "The interval to poll orchestrator for job status.",
-      "type": "integer",
-      "min": 1
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
     },
     "job-poll-timeout": {
       "description": "The time to wait for orchestrator job status.",
-      "type": "integer",
-      "min": 1
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
     },
     "kex-algorithms": {
       "description": "List of key exchange algorithms to use when establishing a connection with a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed at https://github.com/net-ssh/net-ssh#supported-algorithms . All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms when using this option, add 'defaults' to the list of supported algorithms.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
     },
     "load-config": {
       "description": "Whether to load system SSH configuration.",
-      "type": "boolean"
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
     },
     "login-shell": {
       "description": "Which login shell Bolt should expect on the target.",
-      "type": "string",
-      "enum": ["sh", "bash", "zsh", "dash", "ksh", "powershell"]
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["sh", "bash", "zsh", "dash", "ksh", "powershell"]
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
     },
     "mac-algorithms": {
       "description": "List of message authentication code algorithms to use when establishing a connection with a target. Supported algorithms are defined by the Ruby net-ssh library and can be viewed at https://github.com/net-ssh/net-ssh#supported-algorithms . All supported, non-deprecated algorithms are available by default when this option is not used. To reference all default algorithms when using this option, add 'defaults' to the list of supported algorithms.",


### PR DESCRIPTION
This contains changes that enable generating the JSON schemas using a
rake task using data contained in the `Bolt::Config::Options` and
`Bolt::Config::Transport::TRANSPORT_OPTIONS` constants.

A new Rakefile `schemas/Rakefile` contains rake tasks that generate
each of the JSON schemas. These tasks can be run using the following
command:

```shell
$ rake -f schemas/Rakefile schemas
```

This also updates the `Bolt::Config::OPTIONS` and
`Bolt::Config::Transport::TRANSPORT_OPTIONS` constants to include
additional data for each option that is included in the JSON schemas.
The additional keys are direct equivalents to keys recognized by the
JSON Schema standard, Draft 07. The constants also include several
metadata keys such as `:_example` and `:_default`, which are used to
generate docuemntation for the configuration files.

This change also updates the JSON schemas to support plugin references.
The `:_plugin` metadata key can be set on an option to indicate that the
JSON schema should include a plugin reference as a valid value for the
option.

!bug

* **Support plugin references in JSON schemas**
  ([#1900](#1900))

  The JSON schemas no longer mark plugin references as invalid values
  when the option can accept a plugin reference. Previously, the schemas
  would mark any plugin reference as an invalid value.