### PR TITLE
(maint) Address rubocop warning about Style/RedundantFetchBlock

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,6 +78,9 @@ Style/SafeNavigation:
 Style/SlicingWithRange:
   Enabled: false
 
+Style/RedundantFetchBlock:
+  Enabled: true
+
 Style/RedundantRegexpCharacterClass:
   Enabled: false
 


### PR DESCRIPTION
A new cop was added to rubocop 0.86.0 titled 'Style/RedundantFetchBlock'
which "identifies places where fetch(key) { value } can be replaced by
fetch(key, value)"
((link)[https://docs.rubocop.org/rubocop/0.86/cops_style.html#styleredundantfetchblock]).
Rubocop warns if this cop isn't configured, so this commit enables the
cop to both silence the warning and standardize `fetch` usage.

!no-release-note