### PR TITLE
(bug) Validate 'inventory-config' option in bolt-defaults.yaml

### DIFF
--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -139,9 +139,22 @@ module Bolt
         )
       end
 
-      # Move data under transport-config to top-level so it can be easily merged with
-      # config from other sources.
+      # Move data under inventory-config to top-level so it can be easily merged with
+      # config from other sources. Error early if inventory-config is not a hash or
+      # has a plugin reference.
       if data.key?('inventory-config')
+        unless data['inventory-config'].is_a?(Hash)
+          raise Bolt::ValidationError,
+                "Option 'inventory-config' must be of type Hash, received #{data['inventory-config']} "\
+                "#{data['inventory-config']} (file: #{filepath})"
+        end
+
+        if data['inventory-config'].key?('_plugin')
+          raise Bolt::ValidationError,
+                "Found unsupported key '_plugin' for option 'inventory-config'; supported keys are "\
+                "'#{INVENTORY_OPTIONS.keys.join("', '")}' (file: #{filepath})"
+        end
+
         data = data.merge(data.delete('inventory-config'))
       end
 

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -229,6 +229,33 @@ describe Bolt::Config do
       data = Bolt::Config.load_bolt_defaults_yaml(path)[:data]
       expect(data).to eq(Bolt::Config::INVENTORY_OPTIONS)
     end
+
+    it 'errors when inventory-config is not a Hash' do
+      allow(File).to receive(:exist?)
+      allow(Bolt::Util).to receive(:read_yaml_hash).and_return(
+        'inventory-config' => 'foo'
+      )
+
+      expect { Bolt::Config.load_bolt_defaults_yaml(path) }.to raise_error(
+        Bolt::ValidationError,
+        /must be of type Hash/
+      )
+    end
+
+    it 'errors when inventory-config is a plugin reference' do
+      allow(File).to receive(:exist?)
+      allow(Bolt::Util).to receive(:read_yaml_hash).and_return(
+        'inventory-config' => {
+          '_plugin'  => 'yaml',
+          'filepath' => '~/.puppetlabs/bolt/config.yaml'
+        }
+      )
+
+      expect { Bolt::Config.load_bolt_defaults_yaml(path) }.to raise_error(
+        Bolt::ValidationError,
+        /Found unsupported key '_plugin'/
+      )
+    end
   end
 
   describe "validate" do


### PR DESCRIPTION
This adds some validation checks for the `inventory-config` option in
the `bolt-defaults.yaml` file. Previously, setting this option to a
value other than a hash would result in an unhelpful error, as Bolt was
assuming that the value would always be a hash. Additionally, if the
value was a plugin reference, the plugin reference would be merged with
the top-level config, potentially resulting in config values being
overwritten and resulting in the entire config hash being considered a
plugin reference.

Now, Bolt will first check that the `inventory-config` option is a hash
and is not a plugin reference before continuing with loading config.

!bug

* **Validate `inventory-config` option in `bolt-defaults.yaml`**

  Bolt now checks that the `inventory-config` option in a
  `bolt-defaults.yaml` file is a hash and is not a plugin reference
  before merging configuration files. Previously, setting this value to
  a hash or plugin reference would raise an unhelpful error.