### PR TITLE
(GH-1895) Add action to trigger updating ps module in bolt-vanagon

### DIFF
--- a/.github/workflows/trigger-powershell-module-update.yaml
+++ b/.github/workflows/trigger-powershell-module-update.yaml
@@ -1,0 +1,18 @@
+name: Trigger Powershell cmdlets module update
+
+on:
+  push:
+    branches: [master]
+    paths: ['pwsh/*']
+
+jobs:
+  trigger-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: lucywyman/bolt-vanagon
+          event-type: update-cmdlets
+          client-payload: '{"sha": "${{ github.sha }}"}'


### PR DESCRIPTION
In order to ship the powershell cmdlets module in the Bolt MSI package
we need generate the module from it's constituent files and commit it to
bolt-vanagon. This will happen by creating a repository-dispatch event
whenever changes to the powershell files are committed to master. The
repository-dispatch event sends a payload to the specified repository
which can be used to trigger another Github Action. This
repository-dispatch will trigger an action that generates the powershell
module and commits it to master of bolt-vanagon. This should ensure that
the module in bolt-vanagon stays up to date with the module components
in bolt.

!no-release-note