### PR TITLE
(maint) Configure new default cops for Rubocop 0.87

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,9 +82,21 @@ Style/RedundantFetchBlock:
   Enabled: true
 
 Style/RedundantRegexpCharacterClass:
-  Enabled: false
+  Enabled: true
 
 Style/RedundantRegexpEscape:
+  Enabled: true
+
+Style/AccessorGrouping:
+  Enabled: true
+
+# Disabled due to a bug in Rubocop that raises an exception when accessors
+# are assigned using a splat operator
+# https://github.com/rubocop-hq/rubocop/issues/8257
+Style/BisectedAttrAccessor:
+  Enabled: false
+
+Style/RedundantAssignment:
   Enabled: true
 
 # Disable nearly all Metrics checks. These seem better off left to judgement.

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -48,9 +48,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-ssh-krb", "~> 0.5"
   spec.add_dependency "orchestrator_client", "~> 0.4"
   spec.add_dependency "puppet", [">= 6.16.0", "< 7"]
+  spec.add_dependency "puppetfile-resolver", "~> 0.1.0"
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "puppet-strings", "~> 2.3"
-  spec.add_dependency "puppetfile-resolver", "~> 0.1.0"
   spec.add_dependency "r10k", "~> 3.1"
   spec.add_dependency "ruby_smb", "~> 1.0"
   spec.add_dependency "terminal-table", "~> 1.8"

--- a/lib/bolt/shell/bash.rb
+++ b/lib/bolt/shell/bash.rb
@@ -170,7 +170,7 @@ module Bolt
       def check_sudo(out, inp, stdin)
         buffer = out.readpartial(CHUNK_SIZE)
         # Split on newlines, including the newline
-        lines = buffer.split(/(?<=[\n])/)
+        lines = buffer.split(/(?<=\n)/)
         # handle_sudo will return the line if it is not a sudo prompt or error
         lines.map! { |line| handle_sudo(inp, line, stdin) }
         lines.join("")

--- a/spec/lib/bolt_spec/bolt_server.rb
+++ b/spec/lib/bolt_spec/bolt_server.rb
@@ -64,8 +64,7 @@ module BoltSpec
     def puppet_server_get(path, params)
       uri = URI("#{config_data['file-server-uri']}#{path}")
       uri.query = URI.encode_www_form(params)
-      resp = make_client.request(Net::HTTP::Get.new(uri))
-      resp
+      make_client.request(Net::HTTP::Get.new(uri))
     end
 
     def get_task_data(task)

--- a/spec/lib/bolt_spec/puppetdb.rb
+++ b/spec/lib/bolt_spec/puppetdb.rb
@@ -27,8 +27,7 @@ module BoltSpec
 
       headers = { "Content-Type" => "application/json" }
 
-      response = client.http_client.post(url, body: body, header: headers)
-      response
+      client.http_client.post(url, body: body, header: headers)
     end
 
     def replace_facts(certname, facts, wait: nil)


### PR DESCRIPTION
This configures the following cops which are enabled by default in
Rubocop >= 0.87:

- `Style/AccessorGrouping`
- `Style/BisectedAttrAccessor`
- `Style/RedundantAssignment`

This also enables the `Style/RedundantRegexpCharacterClass` cop, which
was previously disabled due to a bug in Rubocop.