### PR TITLE
Add support for configuring log in bolt-defaults.yaml

### DIFF
--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -175,7 +175,7 @@ module Bolt
         "log" => {
           description: "A map of configuration for the logfile output. Under `log`, you can configure log options "\
                        "for `console` and add configuration for individual log files, such as "\
-                       "~/.puppetlabs/bolt/debug.log`. Individual log files must be valid filepaths. If the log "\
+                       "`~/.puppetlabs/bolt/debug.log`. Individual log files must be valid filepaths. If the log "\
                        "file does not exist, then Bolt will create it before logging information.",
           type: Hash,
           properties: {
@@ -440,6 +440,7 @@ module Bolt
         concurrency
         format
         inventory-config
+        log
         plugin_hooks
         plugins
         puppetdb


### PR DESCRIPTION
This adds support for configuring log files in a `bolt-defaults.yaml`
file. Previously, log files could only be configured in a `bolt.yaml`
or `bolt-project.yaml` file.

!feature

* **Support configuring log files in `bolt-defaults.yaml`**

  The system-wide and user-level default configuration file,
  `bolt-defaults.yaml`, now supports configuring log files using the
  `log` option.