### PR TITLE
(GH-1917) Don't create Bolt Config object before loading config

### DIFF
--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -20,6 +20,8 @@ describe "Bolt::CLI" do
 
     allow_any_instance_of(Bolt::CLI).to receive(:outputter).and_return(outputter)
     allow_any_instance_of(Bolt::CLI).to receive(:warn)
+    # Don't print error messages to the console
+    allow($stdout).to receive(:puts)
 
     # Don't allow tests to override the captured log config
     allow(Bolt::Logger).to receive(:configure)
@@ -920,6 +922,7 @@ describe "Bolt::CLI" do
       end
 
       before :each do
+        allow(cli).to receive(:config).and_return(Bolt::Config.default)
         allow(Bolt::Executor).to receive(:new).and_return(executor)
         allow(executor).to receive(:log_plan) { |_plan_name, &block| block.call }
         allow(executor).to receive(:run_plan) do |scope, plan, params|
@@ -1956,6 +1959,7 @@ describe "Bolt::CLI" do
         outputter = Bolt::Outputter::JSON.new(false, false, false, output)
         allow(cli).to receive(:outputter).and_return(outputter)
         allow(executor).to receive(:report_bundled_content)
+        allow(cli).to receive(:config).and_return(Bolt::Config.default)
       end
 
       context "when running a task", :reset_puppet_settings do
@@ -2021,6 +2025,7 @@ describe "Bolt::CLI" do
 
       before :each do
         allow(cli).to receive(:outputter).and_return(Bolt::Outputter::JSON.new(false, false, false, output))
+        allow(cli).to receive(:config).and_return(Bolt::Config.default)
         allow(puppetfile).to receive(:exist?).and_return(true)
         allow_any_instance_of(Bolt::PAL).to receive(:generate_types)
         allow(R10K::Action::Puppetfile::Install).to receive(:new).and_return(action_stub)
@@ -2087,6 +2092,7 @@ describe "Bolt::CLI" do
 
       before :each do
         allow(cli).to receive(:outputter).and_return(Bolt::Outputter::JSON.new(false, false, false, output))
+        allow(cli).to receive(:config).and_return(Bolt::Config.default)
       end
 
       it 'fails if the code file does not exist' do

--- a/spec/integration/plugin/module_spec.rb
+++ b/spec/integration/plugin/module_spec.rb
@@ -41,6 +41,11 @@ describe 'using module based plugins' do
 
   let(:inventory) { {} }
 
+  before :each do
+    # Don't print error messages to the console
+    allow($stdout).to receive(:puts)
+  end
+
   around(:each) do |example|
     with_boltdir(inventory: inventory, config: config, plan: plan) do |project|
       @project = project
@@ -194,10 +199,8 @@ describe 'using module based plugins' do
         let(:plugin_config) { { 'task_conf_plug' => { 'random_key' => 'bar' } } }
 
         it 'forbids config entries that do not match task metadata schema' do
-          result = run_cli_json(['plan', 'run', 'test_plan', '--boltdir', project], rescue_exec: true)
-
-          expect(result).to include('kind' => "bolt/validation-error")
-          expect(result['msg']).to match(/Config for task_conf_plug plugin contains unexpected key random_key/)
+          expect { run_cli(%W[plan run test_plan --boltdir #{project}]) }
+            .to raise_error(Bolt::ValidationError, /task_conf_plug plugin contains unexpected key random_key/)
         end
       end
     end

--- a/spec/integration/yaml_plan_spec.rb
+++ b/spec/integration/yaml_plan_spec.rb
@@ -14,6 +14,8 @@ describe "running YAML plans", ssh: true do
   include BoltSpec::Logger
 
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
+  # Don't print error messages to the console
+  before(:each) { allow($stdout).to receive(:puts) }
 
   let(:modulepath) { fixture_path('modules') }
   let(:password) { conn_info('ssh')[:password] }
@@ -146,6 +148,8 @@ describe "running YAML plans", ssh: true do
     allow(Puppet::Util::Log).to receive(:newdestination).with(mock_logger)
     allow(mock_logger).to receive(:notice)
     allow(mock_logger).to receive(:info)
+    allow(mock_logger).to receive(:warn)
+      .with("No project name is specified in bolt-project.yaml. Project-level content will not be available.")
 
     expect(mock_logger).to receive(:warn).with(/Use the 'targets' parameter instead./)
 


### PR DESCRIPTION
Previously when we created a new instance of the `Bolt::CLI` object we
also loaded the default `Bolt::Config` object in order to create a
default outputter to print errors with. This caused any errors loading
config or the default project to be unhandled and backtrace. The error
was especially annoying because it used the default project path at
`~/.puppetlabs/bolt`, regardless of whether that was the actual project
that would be used during the Bolt run.

This commit moves the same behavior of the default outputter directly
into the CLI (namely printing any error messages to stdout, in red if
it's a tty) so that we no longer need to load the default project for
every invocation of Bolt. This makes it so any errors that occur when
loading config are printed, and their exit code returned, similar to
other errors raised in Bolt::CLI.

This also standardizes on calling the accessor method to get `config` in the CLI, so that it can easily be mocked for testing.

Closes #1917

!bug

* **Don't load default project for every Bolt invocation** ([1917](https://github.com/puppetlabs/bolt/issues/1917)

  We no longer load the default project at `~/.puppetlabs/bolt` for
  every Bolt invocation. When projects are loaded, the errors are now
  handled and don't backtrace.