### PR TITLE
(GH-1967) Detect puppet agent install path on windows

### DIFF
--- a/lib/bolt/apply_result.rb
+++ b/lib/bolt/apply_result.rb
@@ -20,7 +20,7 @@ module Bolt
              error_hash['msg'] =~ /The term 'ruby.exe' is not recognized as the name of a cmdlet/)
         # Windows does not have Ruby present
         {
-          'msg' => "Puppet is not installed on the target in $env:ProgramFiles, please install it to enable 'apply'",
+          'msg' => "Puppet was not found on the target or in $env:ProgramFiles, please install it to enable 'apply'",
           'kind' => 'bolt/apply-error'
         }
       elsif exit_code == 1 && error_hash['msg'] =~ /cannot load such file -- puppet \(LoadError\)/

--- a/lib/bolt/shell/powershell/snippets.rb
+++ b/lib/bolt/shell/powershell/snippets.rb
@@ -85,12 +85,21 @@ module Bolt
 
           def shell_init
             <<~PS
-            $ENV:PATH += ";${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\bin\\;" +
-            "${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\puppet\\bin;" +
-            "${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\sys\\ruby\\bin\\"
-            $ENV:RUBYLIB = "${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\puppet\\lib;" +
-            "${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\facter\\lib;" +
-            "${ENV:ProgramFiles}\\Puppet Labs\\Puppet\\hiera\\lib;" +
+            $installRegKey = Get-ItemProperty -Path "HKLM:\\Software\\Puppet Labs\\Puppet" -ErrorAction 0
+            if(![string]::IsNullOrEmpty($installRegKey.RememberedInstallDir64)){
+              $boltBaseDir = $installRegKey.RememberedInstallDir64
+            }elseif(![string]::IsNullOrEmpty($installRegKey.RememberedInstallDir)){
+              $boltBaseDir = $installRegKey.RememberedInstallDir
+            }else{
+              $boltBaseDir = "${ENV:ProgramFiles}\\Puppet Labs\\Puppet"
+            }
+
+            $ENV:PATH += ";${boltBaseDir}\\bin\\;" +
+            "${boltBaseDir}\\puppet\\bin;" +
+            "${boltBaseDir}\\sys\\ruby\\bin\\"
+            $ENV:RUBYLIB = "${boltBaseDir}\\puppet\\lib;" +
+            "${boltBaseDir}\\facter\\lib;" +
+            "${boltBaseDir}\\hiera\\lib;" +
             $ENV:RUBYLIB
 
             Add-Type -AssemblyName System.ServiceModel.Web, System.Runtime.Serialization

--- a/spec/bolt/apply_result_spec.rb
+++ b/spec/bolt/apply_result_spec.rb
@@ -47,7 +47,7 @@ describe Bolt::ApplyResult do
       error = Bolt::ApplyResult.puppet_missing_error(orig_result)
       expect(error['kind']).to eq('bolt/apply-error')
       expect(error['msg'])
-        .to eq("Puppet is not installed on the target in $env:ProgramFiles, please install it to enable 'apply'")
+        .to eq("Puppet was not found on the target or in $env:ProgramFiles, please install it to enable 'apply'")
     end
 
     it 'errors if Puppet cannot be found on Windows' do

--- a/spec/integration/apply_error_spec.rb
+++ b/spec/integration/apply_error_spec.rb
@@ -57,7 +57,7 @@ describe "errors gracefully attempting to apply a manifest block" do
       error = result['details']['result_set'][0]['value']['_error']
       expect(error['kind']).to eq('bolt/apply-error')
       expect(error['msg'])
-        .to eq("Puppet is not installed on the target in $env:ProgramFiles, please install it to enable 'apply'")
+        .to eq("Puppet was not found on the target or in $env:ProgramFiles, please install it to enable 'apply'")
         .or eq("Found a Ruby without Puppet present, please install Puppet or " \
                "remove Ruby from $env:Path to enable 'apply'")
     end


### PR DESCRIPTION
Correctly detects the Puppet Agent install path on Windows during the initialization steps in a WinRM connection. It then uses the correct install path to amend the environment PATH variable.

The error text was modified to more clearly state we looked in known locations but could not find a valid install path.
