### PR TITLE
(GH-1901) Change 'master' references to 'main'

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,7 +2,7 @@ name: Docs
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths-ignore: ['**.md', 'schemas/*']
   pull_request:
     type: [opened, reopened, edited]

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,7 +2,7 @@ name: Linting
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
     type: [opened, reopened, edited]

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -2,7 +2,7 @@ name: Linux
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
     type: [opened, reopened, edited]

--- a/.github/workflows/modules.yaml
+++ b/.github/workflows/modules.yaml
@@ -2,7 +2,7 @@ name: Modules
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
     type: [opened, reopened, edited]

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -2,7 +2,7 @@ name: Windows
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
     type: [opened, reopened, edited]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ License Agreement before we can accept your pull request: https://cla.puppet.com
 1. Fork the Bolt project (button in the top-right, next to 'star' and 'watch')
 1. Clone your fork of Bolt
 1. Add the puppetlabs repo as an upstream - `git remote add upstream git@github.com:puppetlabs/bolt`
-1. Make a new branch off of master - `git checkout -b mybranchname`
+1. Make a new branch off of main - `git checkout -b mybranchname`
 1. Commit your changes and add a useful commit message, including what specifically you changed and why - `git commit`
     * If your changes are user-facing, add a release note to the end of a commit message. Release notes should begin
       with a label indicating what kind of change you are making. Valid labels include `!feature`, `!bug`, `!deprecation`,
@@ -51,16 +51,16 @@ License Agreement before we can accept your pull request: https://cla.puppet.com
         Descriptive summary of changes.
       ```
 1. Push your changes to your branch on your fork - `git push origin mybranchname`
-1. Open a PR against master at https://github.com/puppetlabs/bolt
+1. Open a PR against main at https://github.com/puppetlabs/bolt
 
 **If it's not your first PR**
 1. Update from upstream:
    ```
-   git fetch upstream && git checkout upstream/master && git checkout -b mybranchname
+   git fetch upstream && git checkout upstream/main && git checkout -b mybranchname
    ```
 1. Commit your changes and add a useful commit message, including what specifically you changed and why - `git commit`
 1. Push your changes to your branch on your fork - `git push origin mybranchname`
-1. Open a PR against master at https://github.com/puppetlabs/bolt
+1. Open a PR against main at https://github.com/puppetlabs/bolt
 
 ## Installing Bolt
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Modules Status](https://github.com/puppetlabs/bolt/workflows/Modules/badge.svg?branch=master)](https://github.com/puppetlabs/bolt/actions)
-[![Linux Status](https://github.com/puppetlabs/bolt/workflows/Linux/badge.svg?branch=master)](https://github.com/puppetlabs/bolt/actions)
-[![Windows Status](https://github.com/puppetlabs/bolt/workflows/Windows/badge.svg?branch=master)](https://github.com/puppetlabs/bolt/actions)
+[![Modules Status](https://github.com/puppetlabs/bolt/workflows/Modules/badge.svg?branch=main)](https://github.com/puppetlabs/bolt/actions)
+[![Linux Status](https://github.com/puppetlabs/bolt/workflows/Linux/badge.svg?branch=main)](https://github.com/puppetlabs/bolt/actions)
+[![Windows Status](https://github.com/puppetlabs/bolt/workflows/Windows/badge.svg?branch=main)](https://github.com/puppetlabs/bolt/actions)
 [![Version](https://img.shields.io/github/v/tag/puppetlabs/bolt?label=version)](./CHANGELOG.md)
 [![Platforms](https://img.shields.io/badge/platforms-linux%20%7C%20windows%20%7C%20macos-lightgrey)](./documentation/bolt_installing.md)
 [![License](https://img.shields.io/github/license/puppetlabs/bolt)](./LICENSE)
@@ -29,7 +29,7 @@ More information and documentation is available on the [Bolt website](https://pu
 
 Bolt can be installed on Linux, Windows, and macOS. For complete installation details, see the [installation docs](./documentation/bolt_installing.md).
 
-For alternate installation methods and running from source code, see our [contributing guidelines](https://github.com/puppetlabs/bolt/blob/master/CONTRIBUTING.md).
+For alternate installation methods and running from source code, see our [contributing guidelines](https://github.com/puppetlabs/bolt/blob/main/CONTRIBUTING.md).
 
 ## Getting help
 

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -28,7 +28,7 @@ This acceptance suite allows you to test bolt using the following methods:
 * gem: Install bolt via gem from a gemsource defined as an environment
  variable (defaults to https://gems.rubygems.org).
 * git: Install bolt via the git repo from a branch or SHA defined as
- environment variables (defaults to #master/HEAD).
+ environment variables (defaults to #main/HEAD).
 * package: Install bolt via the puppet repos 
 
 The tests assume the following [Beaker
@@ -122,7 +122,7 @@ install, this value will be used by the test pre-suites in conjunction
 with `GIT_SERVER` to determine where the git repo should be obtained
 from.
 
-**GIT_BRANCH** (Default `master`): When testing via git install, this
+**GIT_BRANCH** (Default `main`): When testing via git install, this
 value will be used by the test pre-suites to determine what branch
 should be checked out for testing.
 
@@ -192,7 +192,7 @@ bundle exec rake test:gem
 
 #### Git
 
-Example to test latest git commit to master on https://github.com/puppetlabs/bolt
+Example to test latest git commit to main on https://github.com/puppetlabs/bolt
 ```
 SSH_PASSWORD='S3@ret3' \
 WINRM_PASSWORD='S3@ret3' \

--- a/acceptance/lib/acceptance/bolt_setup_helper.rb
+++ b/acceptance/lib/acceptance/bolt_setup_helper.rb
@@ -35,7 +35,7 @@ module Acceptance
     end
 
     def git_branch
-      ENV['GIT_BRANCH'] || 'master'
+      ENV['GIT_BRANCH'] || 'main'
     end
 
     def git_sha

--- a/developer-docs/adding-gem-dependencies.md
+++ b/developer-docs/adding-gem-dependencies.md
@@ -31,7 +31,7 @@ When new gem dependencies are added to Bolt, it's important to add them to both 
 
 1. Open a PR in the [Bolt repo](https://github.com/puppetlabs/bolt) with the following changes:
 
-    * Add each gem to [`bolt.gemspec`](https://github.com/puppetlabs/bolt/blob/master/bolt.gemspec).
+    * Add each gem to [`bolt.gemspec`](https://github.com/puppetlabs/bolt/blob/main/bolt.gemspec).
 
         ```ruby
         spec.add_dependency "<GEM_NAME>", "<GEM_VERSION>"

--- a/developer-docs/releasing-bolt.md
+++ b/developer-docs/releasing-bolt.md
@@ -9,7 +9,7 @@ aim to release new versions of Bolt on Mondays.
    $ rake 'changelog[VERSION]'
    ```
    
-   Open a PR against `puppetlabs/bolt` and merge the changes into `master`.
+   Open a PR against `puppetlabs/bolt` and merge the changes into `main`.
 
    > **Note:** To use the rake task you must be a member of the `puppetlabs` organization and set the environment
      variable `GITHUB_TOKEN` with a [personal access token](https://github.com/settings/tokens) that has

--- a/documentation/applying_manifest_blocks.md
+++ b/documentation/applying_manifest_blocks.md
@@ -13,14 +13,14 @@ block limitations](#manifest-block-limitations).
 > 🔩 **Tip:** If you installed Bolt as a Ruby Gem, make sure you have installed
   the core modules required to use the `puppet apply` command. These modules are
   listed in the [Bolt GitHub
-  repository](https://github.com/puppetlabs/bolt/blob/master/Puppetfile) and you
+  repository](https://github.com/puppetlabs/bolt/blob/main/Puppetfile) and you
   can install them using a Puppetfile.
 
 📖 **Related information**  
 
 - [Configure Bolt to download and install modules](bolt_installing_modules.md#)
 - [Puppetfile
-  example](https://github.com/puppetlabs/bolt/blob/master/Puppetfile)
+  example](https://github.com/puppetlabs/bolt/blob/main/Puppetfile)
 - [Puppet Forge](https://forge.puppet.com/)
 
 ## Applying manifest blocks from the command line

--- a/documentation/bolt.ditamap
+++ b/documentation/bolt.ditamap
@@ -2,7 +2,7 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map id="boltmap" title="Bolt">
     <topicref href="bolt.md" format="markdown" linking="targetonly">
-        <topicref navtitle="Changelog" href="https://github.com/puppetlabs/bolt/blob/master/CHANGELOG.md" format="html" scope="external" />
+        <topicref navtitle="Changelog" href="https://github.com/puppetlabs/bolt/blob/main/CHANGELOG.md" format="html" scope="external" />
         <topicref href="bolt_versioning.md" format="markdown"/>
         <topicref href="migrating_inventory_files.md" format="markdown"/>   
         <topicref href="bolt_known_issues.md" format="markdown"/>

--- a/documentation/bolt_installing_modules.md
+++ b/documentation/bolt_installing_modules.md
@@ -44,7 +44,7 @@ Bolt is packaged with a collection of useful modules to support common
 workflows.
 
 This list of packaged modules is available in a
-[Puppetfile](https://github.com/puppetlabs/bolt/blob/master/Puppetfile) in the
+[Puppetfile](https://github.com/puppetlabs/bolt/blob/main/Puppetfile) in the
 Bolt repository. The modules and supporting documentation are publicly available
 on the [Puppet Forge](https://forge.puppet.com/).
 
@@ -92,12 +92,12 @@ these core modules.
 
 ### Bolt-specific modules that are not available on the Forge
 
--   [aggregate](https://github.com/puppetlabs/bolt/tree/master/modules/aggregate):
+-   [aggregate](https://github.com/puppetlabs/bolt/tree/main/modules/aggregate):
     Aggregate task, script or command results.
--   [canary](https://github.com/puppetlabs/bolt/tree/master/modules/canary): Run
+-   [canary](https://github.com/puppetlabs/bolt/tree/main/modules/canary): Run
     action against a small number of targets and only if it succeeds will it run
     on the rest.
--   [puppetdb_fact](https://github.com/puppetlabs/bolt/tree/master/modules/puppetdb_fact):
+-   [puppetdb_fact](https://github.com/puppetlabs/bolt/tree/main/modules/puppetdb_fact):
     Collect facts for the specified targets from the configured PuppetDB
     connection and stores the collected facts on the targets.
 
@@ -124,4 +124,4 @@ these core modules.
 - Search the [Puppet Forge](https://forge.puppet.com/) for plan and task
   content.
 - For an example of a Puppetfile, see the [Bolt
-  Puppetfile](https://github.com/puppetlabs/bolt/blob/master/Puppetfile)
+  Puppetfile](https://github.com/puppetlabs/bolt/blob/main/Puppetfile)

--- a/documentation/bolt_options.md
+++ b/documentation/bolt_options.md
@@ -180,7 +180,7 @@ Kerberos for authentication, you can specify a Kerberos realm in your
 `bolt.yaml` file. This file is introduced in the [Configuring
 Bolt](configuring_bolt.md) section below. The best source of information and
 examples for this advanced topic is the [Kerberos
-section](https://github.com/puppetlabs/bolt/blob/master/developer-docs/kerberos.md)
+section](https://github.com/puppetlabs/bolt/blob/main/developer-docs/kerberos.md)
 of the Bolt developer documentation.
 
 ## Rerunning commands based on the last result

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -11,7 +11,7 @@ around breaking behavior where possible.
 ## Bolt projects
 
 This feature was introduced in [Bolt
-2.8.0](https://github.com/puppetlabs/bolt/blob/master/CHANGELOG.md#bolt-280-2020-05-05)
+2.8.0](https://github.com/puppetlabs/bolt/blob/main/CHANGELOG.md#bolt-280-2020-05-05)
 
 Bolt project directories have been around for a while in Bolt, but this release
 signals a shift in the direction we're taking with them. We see Bolt projects as
@@ -133,7 +133,7 @@ Use `bolt plan show <plan-name>` to view details and parameters for a specific p
 ## `ResourceInstance` data type
 
 This feature was introduced in [Bolt
-2.10.0](https://github.com/puppetlabs/bolt/blob/master/CHANGELOG.md#bolt-2100-2020-05-18).
+2.10.0](https://github.com/puppetlabs/bolt/blob/main/CHANGELOG.md#bolt-2100-2020-05-18).
 
 Bolt has had a limited ability to interact with Puppet's Resource Abstraction
 Layer. You could use the `apply` function to generate catalogs and return
@@ -360,7 +360,7 @@ $apply_results.each |$result| {
 ## Native SSH transport
 
 This feature was introduced in [Bolt
-2.10.0](https://github.com/puppetlabs/bolt/blob/master/CHANGELOG.md#bolt-2100-2020-05-18).
+2.10.0](https://github.com/puppetlabs/bolt/blob/main/CHANGELOG.md#bolt-2100-2020-05-18).
 
 Bolt's SSH transport uses the ruby library `net-ssh`, which is a pure ruby
 implementation of the SSH2 client protocol. While robust, the library lacks

--- a/documentation/migrating_inventory_files.md
+++ b/documentation/migrating_inventory_files.md
@@ -7,7 +7,7 @@ post](https://puppet.com/blog/introducing-bolt-2-0/).
 
 **Before you upgrade:**
 - Take a look at the
-  [Changelog](https://github.com/puppetlabs/bolt/blob/master/CHANGELOG.md).
+  [Changelog](https://github.com/puppetlabs/bolt/blob/main/CHANGELOG.md).
 - Make sure you've [migrated your inventory files to version
   2](#migrating-inventory-files-from-version-1-to-version-2). 
 

--- a/documentation/running_bolt_commands.md
+++ b/documentation/running_bolt_commands.md
@@ -309,7 +309,7 @@ Kerberos for authentication, you can specify a Kerberos realm in your
 `bolt.yaml` file. This file is introduced in the [Configuring
 Bolt](configuring_bolt.md) section below. The best source of information and
 examples for this advanced topic is the [Kerberos
-section](https://github.com/puppetlabs/bolt/blob/master/developer-docs/kerberos.md)
+section](https://github.com/puppetlabs/bolt/blob/main/developer-docs/kerberos.md)
 of the Bolt developer documentation.
 
 ### Rerunning commands based on the last result

--- a/resources/plugins.md
+++ b/resources/plugins.md
@@ -1,6 +1,6 @@
 # Bolt third-party plugins
 
-Below is a list of documented third-party plugins for Bolt.  If you have created a plugin you can add it to the list and [open a pull request](https://github.com/puppetlabs/bolt/blob/master/CONTRIBUTING.md#pull-requests) with the changes.
+Below is a list of documented third-party plugins for Bolt.  If you have created a plugin you can add it to the list and [open a pull request](https://github.com/puppetlabs/bolt/blob/main/CONTRIBUTING.md#pull-requests) with the changes.
 
 ## Plugins
 | Plugin | Description | Module Link | Author |

--- a/scripts/generate_changelog.rb
+++ b/scripts/generate_changelog.rb
@@ -52,7 +52,7 @@ class ChangelogGenerator
   end
 
   def commits
-    @commits ||= client.compare('puppetlabs/bolt', latest, 'master').commits
+    @commits ||= client.compare('puppetlabs/bolt', latest, 'main').commits
   end
 
   def org_members
@@ -123,14 +123,14 @@ class ChangelogGenerator
   end
 
   def generate
-    puts "Loading and parsing commits for #{latest}..master"
+    puts "Loading and parsing commits for #{latest}..main"
 
     commits.each do |commit|
       parse_commit(commit)
     end
 
     if entries.each_value.all? { |type| type[:entries].empty? }
-      warn "No release notes for #{latest}..master"
+      warn "No release notes for #{latest}..main"
       exit 0
     end
 


### PR DESCRIPTION
This updates documentation, scripts and github workflows to point to the
'main' branch instead of 'master'.