### PR TITLE
(GH-1964) Add deprecation warning utility

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/datatypes/target.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/target.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# This was failing local test runs
-require 'bolt/target'
-
 Puppet::DataTypes.create_type('Target') do
   begin
     inventory = Puppet.lookup(:bolt_inventory)

--- a/bolt-modules/boltlib/lib/puppet/datatypes/target.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/target.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# This was failing local test runs
+require 'bolt/target'
+
 Puppet::DataTypes.create_type('Target') do
   begin
     inventory = Puppet.lookup(:bolt_inventory)

--- a/documentation/using_plugins.md
+++ b/documentation/using_plugins.md
@@ -323,7 +323,7 @@ the private key.
 ```yaml
 plugins:
   pkcs7:
-    private-key: ~/bolt_private_key.pem
+    private_key: ~/bolt_private_key.pem
 ```
 
 Plugin configuration can be derived from other plugins using `_plugin`

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -594,13 +594,13 @@ module Bolt
             bolt task show canary
     HELP
 
-    attr_reader :warnings
+    attr_reader :deprecations
 
     def initialize(options)
       super()
 
       @options = options
-      @warnings = []
+      @deprecations = []
 
       separator "\nINVENTORY OPTIONS"
       define('-t', '--targets TARGETS',
@@ -809,7 +809,8 @@ module Bolt
         @options[:debug] = true
         # We don't actually set '--log-level debug' here, but once the options are evaluated by
         # the config class the end result is the same.
-        @warnings << { msg: "Command line option '--debug' is deprecated, set '--log-level debug' instead." }
+        msg = "Command line option '--debug' is deprecated, set '--log-level debug' instead."
+        @deprecations << { type: 'Using --debug instead of --log-level debug', msg: msg }
       end
       define('--log-level LEVEL',
              "Set the log level for the console. Available options are",

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -131,6 +131,7 @@ module Bolt
                   end
 
         Bolt::Logger.configure(config.log, config.color)
+        Bolt::Logger.analytics = analytics
       rescue Bolt::Error => e
         if $stdout.isatty
           # Print the error message in red, mimicking outputter.fatal_error
@@ -149,8 +150,9 @@ module Bolt
       config_loaded
 
       # Display warnings created during parser and config initialization
-      parser.warnings.each { |warning| @logger.warn(warning[:msg]) }
       config.warnings.each { |warning| @logger.warn(warning[:msg]) }
+      parser.deprecations.each { |dep| Bolt::Logger.deprecation_warning(dep[:type], dep[:msg]) }
+      config.deprecations.each { |dep| Bolt::Logger.deprecation_warning(dep[:type], dep[:msg]) }
 
       # After validation, initialize inventory and targets. Errors here are better to catch early.
       # After this step

--- a/lib/bolt/logger.rb
+++ b/lib/bolt/logger.rb
@@ -67,6 +67,10 @@ module Bolt
       end
     end
 
+    def self.analytics=(analytics)
+      @analytics = analytics
+    end
+
     def self.console_layout(color)
       color_scheme = :bolt if color
       Logging.layouts.pattern(
@@ -113,6 +117,11 @@ module Bolt
           @warnings << type
         end
       }
+    end
+
+    def self.deprecation_warning(type, msg)
+      @analytics&.event('Warn', 'deprecation', label: type)
+      warn_once(type, msg)
     end
   end
 end

--- a/lib/bolt/pal/yaml_plan/evaluator.rb
+++ b/lib/bolt/pal/yaml_plan/evaluator.rb
@@ -142,7 +142,7 @@ module Bolt
           if plan.steps.any? { |step| step.body.key?('target') }
             msg = "The 'target' parameter for YAML plan steps is deprecated and will be removed "\
                   "in a future version of Bolt. Use the 'targets' parameter instead."
-            @logger.warn(msg)
+            Bolt::Logger.deprecation_warning("Using 'target' parameter for YAML plan steps, not 'targets'", msg)
           end
 
           plan_result = closure_scope.with_local_scope(args_hash) do |scope|

--- a/lib/bolt/plugin/module.rb
+++ b/lib/bolt/plugin/module.rb
@@ -184,12 +184,10 @@ module Bolt
       # Raises a deprecation warning if the pkcs7 plugin is using deprecated keys and
       # modifies the keys so they are the correct format
       def handle_deprecated_pkcs7_keys(params)
-        if (params.key?('private-key') || params.key?('public-key')) && !@deprecation_warning_issued
-          @deprecation_warning_issued = true
-
+        if params.key?('private-key') || params.key?('public-key')
           message = "pkcs7 keys 'private-key' and 'public-key' have been deprecated and will be "\
                     "removed in a future version of Bolt; use 'private_key' and 'public_key' instead."
-          Logging.logger[self].warn(message)
+          Bolt::Logger.deprecation_warning('PKCS7 keys using hyphens, not underscores', message)
         end
 
         params['private_key'] = params.delete('private-key') if params.key?('private-key')

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -508,9 +508,10 @@ describe "Bolt::CLI" do
       end
 
       it "warns when using debug" do
+        expect(Bolt::Logger).to receive(:deprecation_warning)
+          .with(anything, /Command line option '--debug' is deprecated/)
         cli = Bolt::CLI.new(%w[command run uptime --targets foo --debug])
         cli.parse
-        expect(@log_output.readlines).to include(/Command line option '--debug' is deprecated/)
       end
 
       it "log-level sets the log option" do

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -146,8 +146,9 @@ describe Bolt::Config do
         allow(File).to receive(:exist?).with(path + defaults_name).and_return(false)
         allow(File).to receive(:exist?).with(path + config_name).and_return(true)
 
-        warnings = Bolt::Config.load_defaults(project).flat_map { |config| config[:warnings] }
-        expect(warnings).to include(msg: /bolt.yaml is deprecated/)
+        deps = Bolt::Config.load_defaults(project).flat_map { |config| config[:deprecations] }
+        # All the deprecation messages + types
+        expect(deps.map(&:values).flatten).to include(/bolt.yaml is deprecated/)
       end
 
       it 'loads bolt-defaults.yaml if present' do
@@ -394,9 +395,9 @@ describe Bolt::Config do
 
     let(:config) {
       Bolt::Config.new(project, [
-                         { data: system_config, warnings: [] },
-                         { data: user_config, warnings: [] },
-                         { data: project_config, warnings: [] }
+                         { data: system_config, warnings: [], deprecations: [] },
+                         { data: user_config, warnings: [], deprecations: [] },
+                         { data: project_config, warnings: [], deprecations: [] }
                        ])
     }
 

--- a/spec/bolt/logger_spec.rb
+++ b/spec/bolt/logger_spec.rb
@@ -41,6 +41,16 @@ describe Bolt::Logger do
     end
   end
 
+  describe '::deprecation_warning' do
+    let(:analytics) { Bolt::Analytics::NoopClient.new }
+
+    it 'submits an analytics event' do
+      expect(analytics).to receive(:event).with('Warn', 'deprecation', { label: "We've got clearance Clarence" })
+      Bolt::Logger.analytics = analytics
+      Bolt::Logger.deprecation_warning("We've got clearance Clarence", 'Roger Roger')
+    end
+  end
+
   describe '::configure' do
     let(:appenders) {
       {

--- a/spec/bolt/pal/yaml_plan/evaluator_spec.rb
+++ b/spec/bolt/pal/yaml_plan/evaluator_spec.rb
@@ -21,6 +21,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
   before :each do
     # Make sure we don't accidentally call any run functions
     allow(scope).to receive(:call_function)
+    allow_any_instance_of(Bolt::Analytics::NoopClient).to receive(:event)
   end
 
   def call_plan(plan, params = {})

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -20,6 +20,8 @@ describe "passes parsed AST to the apply_catalog task" do
 
   before(:each) do
     allow(Bolt::ApplyResult).to receive(:from_task_result) { |r| r }
+    # Don't print warnings
+    allow($stdout).to receive(:puts)
     allow_any_instance_of(Bolt::Applicator).to receive(:catalog_apply_task) {
       path = File.join(__dir__, "../fixtures/apply/#{apply_task}")
       impl = { 'name' => apply_task, 'path' => path }

--- a/spec/integration/yaml_plan_spec.rb
+++ b/spec/integration/yaml_plan_spec.rb
@@ -151,7 +151,7 @@ describe "running YAML plans", ssh: true do
     allow(mock_logger).to receive(:warn)
       .with("No project name is specified in bolt-project.yaml. Project-level content will not be available.")
 
-    expect(mock_logger).to receive(:warn).with(/Use the 'targets' parameter instead./)
+    expect(Bolt::Logger).to receive(:deprecation_warning).with(anything, /Use the 'targets' parameter instead./)
 
     run_plan('yaml::target_param', targets: target)
   end


### PR DESCRIPTION
Previously, we had no way to track how many users were experiencing
warnings for deprecated features, or which deprecated features were
being used. This commit adds a new class method `deprecation_warning` to
the `Bolt::Logger` class, which sends an analytics event with which type
of warning was issued then calls `warn_once` for the deprecation. This
also changes existing deprecation warnings to use the new deprecation
method, and audits existing warnings to determine if they should use
`warn_once` or `deprecation_warning`.

Closes #1964

!no-release-note