### PR TITLE
(maint) Support Rainbow format on windows

### DIFF
--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -378,7 +378,7 @@ module Bolt
         raise Bolt::ValidationError, "Compilation is CPU-intensive, set concurrency less than #{compile_limit}"
       end
 
-      if (format == 'rainbow' && Bolt::Util.windows?) || !(%w[human json rainbow].include? format)
+      unless %w[human json rainbow].include? format
         raise Bolt::ValidationError, "Unsupported format: '#{format}'"
       end
 

--- a/lib/bolt/outputter/rainbow.rb
+++ b/lib/bolt/outputter/rainbow.rb
@@ -8,6 +8,12 @@ module Bolt
       def initialize(color, verbose, trace, stream = $stdout)
         begin
           require 'paint'
+          if Bolt::Util.windows?
+            # the Paint gem thinks that windows does not support ansi colors
+            # but windows 10 or later does
+            # we can display colors if we force mode to TRUE_COLOR
+            Paint.mode = 0xFFFFFF
+          end
         rescue LoadError
           raise "The 'paint' gem is required to use the rainbow outputter."
         end


### PR DESCRIPTION
The Paint gem detects the OS and what terminal it is running in and makes some decisions about what color scheme is supported. On windows it assumes no color is supported unless the `ANSICON` or `ConEmuANSI` enviroment variables are set. Until that gem is updated to detect Windows 10 and treat it as valid, we can force the Paint gem to work by setting the mode manually.

We could instruct the user to set `ANSICON` to true or `ConEmuANSI` to ON and get rainbow formatting (not ideal but ) or set either of those variables ourselves in the code (I don't think that is acceptable).

Instead if we set `Paint.mode` to `TRUE_COLOR` (`0xFFFFFF`) if we are on Windows, the user does not have to do anything. This works in PowerShell 5.1, 6, 7, WSL, and even in cmd.exe on Windows 10. We need to detect OS however, because if we try on an older OS the user will see raw ANSI escape codes

Reference https://github.com/janlelis/paint/blob/4492d100d885d5c2d46305417738b75e69db7f03/lib/paint.rb#L177-L194