### PR TITLE
(maint) Don't expose Pathname object to Puppet

### DIFF
--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -109,7 +109,7 @@ module Bolt
     # This API is used to prepend the project as a module to Puppet's internal
     # module_references list. CHANGE AT YOUR OWN RISK
     def to_h
-      { path: @path, name: name }
+      { path: @path.to_s, name: name }
     end
 
     def eql?(other)


### PR DESCRIPTION
Previously, when passing the Bolt project to Puppet to turn into a
module, we were exposing the "path" variable as a Pathname instance.
Puppet expects the path will always be a string and fails in at least
one case if it receives another value. Since we just use Pathname for
our own internal tracking, we now turn it into a string in the `to_h`
method for Puppet's consumption.

!bug

  * **Don't fail for tasks referring to project-level files**

    Tasks with a `files` key that refers to files that exist at the
    project level will now load properly rather than throwing an error.