### PR TITLE
(maint) Remove PowerShell Classes from module

### DIFF
--- a/pwsh_module/pwsh_bolt.psm1.erb
+++ b/pwsh_module/pwsh_bolt.psm1.erb
@@ -133,38 +133,6 @@ function Get-BoltCommandline {
   Write-Output $params
 }
 
-function Get-BoltTaskData{
-  param($data)
-  $final = $data.tasks | % {
-    [BoltTask]::new(@{name = $_[0]; description = $_[1] })
-  }
-  Write-Output $final
-}
-
-function Get-BoltPlanData{
-  param($data)
-  $final = $data.plans | % {
-    [BoltPlan]::new($_)
-  }
-  Write-Output $final
-}
-
-class BoltTask {
-  [string]$Name
-  [string]$Description
-  BoltTask([pscustomobject]$o){
-    $this.Name = $o.name
-    $this.Description = $o.description
-  }
-}
-
-class BoltPlan {
-  [string]$Name
-  BoltPlan([pscustomobject]$o){
-    $this.Name = $o.name
-  }
-}
-
 $boltFunctions = @(
 'bolt',
 '<%= @commands.sort_by { |cmd| cmd[:cmdlet] }.map{|cmd| cmd[:cmdlet] }.join("',\n'") %>'


### PR DESCRIPTION
Removes a work in progress implementation of formatted objects from the generated PowerShell module. This would cause the module to fail to import on a PowerShell 2 host.
