### PR TITLE
(GH-1994) Configure timeouts in PuppetDB client

### DIFF
--- a/documentation/bolt_connect_puppetdb.md
+++ b/documentation/bolt_connect_puppetdb.md
@@ -50,6 +50,9 @@ config](configuring_bolt.md) with the following values:
     the protocol `https` and the port, which is usually `8081`. For example,
     `https://my-master.example.com:8081`.
 -   `cacert`: The path to the ca certificate for PuppetDB.
+-   `connect_timeout`: How long to wait in seconds when establishing
+    connections with PuppetDB.
+-   `read_timeout`: How long to wait in seconds for a response from PuppetDB.
 
 If you are using certificate authentication also set:
 

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -275,10 +275,24 @@ module Bolt
               type: String,
               _example: "/etc/puppetlabs/puppet/ssl/certs/my-host.example.com.pem"
             },
+            "connect_timeout" => {
+              description: "How long to wait in seconds when establishing connections with PuppetDB.",
+              type: Integer,
+              minimum: 1,
+              _default: 60,
+              _example: 120
+            },
             "key" => {
               description: "The private key for the certificate.",
               type: String,
               _example: "/etc/puppetlabs/puppet/ssl/private_keys/my-host.example.com.pem"
+            },
+            "read_timeout" => {
+              description: "How long to wait in seconds for a response from PuppetDB.",
+              type: Integer,
+              minimum: 1,
+              _default: 60,
+              _example: 120
             },
             "server_urls" => {
               description: "An array containing the PuppetDB host to connect to. Include the protocol `https` "\

--- a/lib/bolt/puppetdb/client.rb
+++ b/lib/bolt/puppetdb/client.rb
@@ -96,6 +96,8 @@ module Bolt
         @http = HTTPClient.new
         @http.ssl_config.set_client_cert_file(@config.cert, @config.key) if @config.cert
         @http.ssl_config.add_trust_ca(@config.cacert)
+        @http.connect_timeout = @config.connect_timeout if @config.connect_timeout
+        @http.receive_timeout = @config.read_timeout if @config.read_timeout
 
         @http
       end

--- a/lib/bolt/puppetdb/config.rb
+++ b/lib/bolt/puppetdb/config.rb
@@ -132,6 +132,22 @@ module Bolt
         end
       end
 
+      def connect_timeout
+        validate_timeout('connect_timeout')
+        @settings['connect_timeout']
+      end
+
+      def read_timeout
+        validate_timeout('read_timeout')
+        @settings['read_timeout']
+      end
+
+      def validate_timeout(timeout)
+        unless @settings[timeout].nil? || (@settings[timeout].is_a?(Integer) && @settings[timeout] > 0)
+          raise Bolt::PuppetDBError, "#{timeout} must be a positive integer, received #{@settings[timeout]}"
+        end
+      end
+
       def to_hash
         @settings.dup
       end

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -207,9 +207,19 @@
               "description": "The path to the client certificate file to use for authentication.",
               "type": "string"
             },
+            "connect_timeout": {
+              "description": "How long to wait in seconds when establishing connections with PuppetDB.",
+              "type": "integer",
+              "minimum": 1
+            },
             "key": {
               "description": "The private key for the certificate.",
               "type": "string"
+            },
+            "read_timeout": {
+              "description": "How long to wait in seconds for a response from PuppetDB.",
+              "type": "integer",
+              "minimum": 1
             },
             "server_urls": {
               "description": "An array containing the PuppetDB host to connect to. Include the protocol `https` and the port, which is usually `8081`. For example, `https://my-master.example.com:8081`.",

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -173,9 +173,19 @@
               "description": "The path to the client certificate file to use for authentication.",
               "type": "string"
             },
+            "connect_timeout": {
+              "description": "How long to wait in seconds when establishing connections with PuppetDB.",
+              "type": "integer",
+              "minimum": 1
+            },
             "key": {
               "description": "The private key for the certificate.",
               "type": "string"
+            },
+            "read_timeout": {
+              "description": "How long to wait in seconds for a response from PuppetDB.",
+              "type": "integer",
+              "minimum": 1
             },
             "server_urls": {
               "description": "An array containing the PuppetDB host to connect to. Include the protocol `https` and the port, which is usually `8081`. For example, `https://my-master.example.com:8081`.",

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -203,9 +203,19 @@
               "description": "The path to the client certificate file to use for authentication.",
               "type": "string"
             },
+            "connect_timeout": {
+              "description": "How long to wait in seconds when establishing connections with PuppetDB.",
+              "type": "integer",
+              "minimum": 1
+            },
             "key": {
               "description": "The private key for the certificate.",
               "type": "string"
+            },
+            "read_timeout": {
+              "description": "How long to wait in seconds for a response from PuppetDB.",
+              "type": "integer",
+              "minimum": 1
             },
             "server_urls": {
               "description": "An array containing the PuppetDB host to connect to. Include the protocol `https` and the port, which is usually `8081`. For example, `https://my-master.example.com:8081`.",


### PR DESCRIPTION
This adds support for a `connect_timeout` and `read_timeout` option
in `puppetdb` config. The `connect_timeout` value is used to set the
connection timeout for the HTTP client that connects to PuppetDB, while
`read_timeout` is used to set the receive timeout for the HTTP client.
The value for each of these options must be a positive integer. If the
options are not set, both are set to the default values defined by the
`httpclient` Ruby library (currently 60 seconds).

!feature

* **Configure connection and read timeout length in PuppetDB client**
  ([#1994](#1994))

  Users can now configure the connection and read timeout length for the
  PuppetDB client with the `connect_timeout` and `read_timeout`
  options under the `puppetdb` config option.