### PR TITLE
(bug) Do not re-rescue errors raised before config is loaded

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -75,72 +75,100 @@ module Bolt
     end
     private :help?
 
+    # Wrapper method that is called by the Bolt executable. Parses the command and
+    # then loads the project and config. Once config is loaded, it completes the
+    # setup process by configuring Bolt and issuing warnings.
+    #
+    # This separation is needed since the Bolt::Outputter class that normally handles
+    # printing errors relies on config being loaded. All setup that happens before
+    # config is loaded will have errors printed directly to stdout, while all errors
+    # raised after config is loaded are handled by the outputter.
     def parse
-      begin
-        parser = BoltOptionParser.new(options)
-        # This part aims to handle both `bolt <mode> --help` and `bolt help <mode>`.
-        remaining = handle_parser_errors { parser.permute(@argv) } unless @argv.empty?
-        if @argv.empty? || help?(remaining)
-          # Update the parser for the subcommand (or lack thereof)
-          parser.update
-          puts parser.help
-          raise Bolt::CLIExit
-        end
+      parse_command
+      load_config
+      finalize_setup
+    end
 
-        options[:object] = remaining.shift
-
-        # Only parse task_options for task or plan
-        if %w[task plan].include?(options[:subcommand])
-          task_options, remaining = remaining.partition { |s| s =~ /.+=/ }
-          if options[:task_options]
-            unless task_options.empty?
-              raise Bolt::CLIError,
-                    "Parameters must be specified through either the --params " \
-                    "option or param=value pairs, not both"
-            end
-            options[:params_parsed] = true
-          elsif task_options.any?
-            options[:params_parsed] = false
-            options[:task_options] = Hash[task_options.map { |a| a.split('=', 2) }]
-          else
-            options[:params_parsed] = true
-            options[:task_options] = {}
-          end
-        end
-        options[:leftovers] = remaining
-
-        validate(options)
-
-        @config = if ENV['BOLT_PROJECT']
-                    project = Bolt::Project.create_project(ENV['BOLT_PROJECT'], 'environment')
-                    Bolt::Config.from_project(project, options)
-                  elsif options[:configfile]
-                    Bolt::Config.from_file(options[:configfile], options)
-                  else
-                    project = if options[:boltdir]
-                                dir = Pathname.new(options[:boltdir])
-                                if (dir + Bolt::Project::BOLTDIR_NAME).directory?
-                                  Bolt::Project.create_project(dir + Bolt::Project::BOLTDIR_NAME)
-                                else
-                                  Bolt::Project.create_project(dir)
-                                end
-                              else
-                                Bolt::Project.find_boltdir(Dir.pwd)
-                              end
-                    Bolt::Config.from_project(project, options)
-                  end
-
-        Bolt::Logger.configure(config.log, config.color)
-        Bolt::Logger.analytics = analytics
-      rescue Bolt::Error => e
-        if $stdout.isatty
-          # Print the error message in red, mimicking outputter.fatal_error
-          $stdout.puts("\033[31m#{e.message}\033[0m")
-        else
-          $stdout.puts(e.message)
-        end
-        raise e
+    # Parses the command and validates options. All errors that are raised here
+    # are not handled by the outputter, as it relies on config being loaded.
+    def parse_command
+      parser = BoltOptionParser.new(options)
+      # This part aims to handle both `bolt <mode> --help` and `bolt help <mode>`.
+      remaining = handle_parser_errors { parser.permute(@argv) } unless @argv.empty?
+      if @argv.empty? || help?(remaining)
+        # Update the parser for the subcommand (or lack thereof)
+        parser.update
+        puts parser.help
+        raise Bolt::CLIExit
       end
+
+      options[:object] = remaining.shift
+
+      # Only parse task_options for task or plan
+      if %w[task plan].include?(options[:subcommand])
+        task_options, remaining = remaining.partition { |s| s =~ /.+=/ }
+        if options[:task_options]
+          unless task_options.empty?
+            raise Bolt::CLIError,
+                  "Parameters must be specified through either the --params " \
+                  "option or param=value pairs, not both"
+          end
+          options[:params_parsed] = true
+        elsif task_options.any?
+          options[:params_parsed] = false
+          options[:task_options] = Hash[task_options.map { |a| a.split('=', 2) }]
+        else
+          options[:params_parsed] = true
+          options[:task_options] = {}
+        end
+      end
+      options[:leftovers] = remaining
+
+      # Default to verbose for everything except plans
+      unless options.key?(:verbose)
+        options[:verbose] = options[:subcommand] != 'plan'
+      end
+
+      validate(options)
+
+      # Deprecation warnings can't be issued until after config is loaded, so
+      # store them for later.
+      @parser_deprecations = parser.deprecations
+    rescue Bolt::Error => e
+      fatal_error(e)
+      raise e
+    end
+
+    # Loads the project and configuration. All errors that are raised here are not
+    # handled by the outputter, as it relies on config being loaded.
+    def load_config
+      @config = if ENV['BOLT_PROJECT']
+                  project = Bolt::Project.create_project(ENV['BOLT_PROJECT'], 'environment')
+                  Bolt::Config.from_project(project, options)
+                elsif options[:configfile]
+                  Bolt::Config.from_file(options[:configfile], options)
+                else
+                  project = if options[:boltdir]
+                              dir = Pathname.new(options[:boltdir])
+                              if (dir + Bolt::Project::BOLTDIR_NAME).directory?
+                                Bolt::Project.create_project(dir + Bolt::Project::BOLTDIR_NAME)
+                              else
+                                Bolt::Project.create_project(dir)
+                              end
+                            else
+                              Bolt::Project.find_boltdir(Dir.pwd)
+                            end
+                  Bolt::Config.from_project(project, options)
+                end
+    rescue Bolt::Error => e
+      fatal_error(e)
+      raise e
+    end
+
+    # Completes the setup process by configuring Bolt and issuing warnings
+    def finalize_setup
+      Bolt::Logger.configure(config.log, config.color)
+      Bolt::Logger.analytics = analytics
 
       # Logger must be configured before checking path case and project file, otherwise warnings will not display
       config.check_path_case('modulepath', config.modulepath)
@@ -151,28 +179,11 @@ module Bolt
 
       # Display warnings created during parser and config initialization
       config.warnings.each { |warning| @logger.warn(warning[:msg]) }
-      parser.deprecations.each { |dep| Bolt::Logger.deprecation_warning(dep[:type], dep[:msg]) }
+      @parser_deprecations.each { |dep| Bolt::Logger.deprecation_warning(dep[:type], dep[:msg]) }
       config.deprecations.each { |dep| Bolt::Logger.deprecation_warning(dep[:type], dep[:msg]) }
 
-      # After validation, initialize inventory and targets. Errors here are better to catch early.
-      # After this step
-      # options[:target_args] will contain a string/array version of the targetting options this is passed to plans
-      # options[:targets] will contain a resolved set of Target objects
-      unless options[:subcommand] == 'puppetfile' ||
-             options[:subcommand] == 'secret' ||
-             options[:subcommand] == 'project' ||
-             options[:action] == 'show' ||
-             options[:action] == 'convert'
-
-        update_targets(options)
-      end
-
-      unless options.key?(:verbose)
-        # Default to verbose for everything except plans
-        options[:verbose] = options[:subcommand] != 'plan'
-      end
-
       warn_inventory_overrides_cli(options)
+
       options
     rescue Bolt::Error => e
       outputter.fatal_error(e)
@@ -327,6 +338,17 @@ module Bolt
           "Exiting after receiving SIG#{Signal.signame(signo)} signal.#{message ? ' ' + message : ''}"
         )
         exit!
+      end
+
+      # Initialize inventory and targets. Errors here are better to catch early.
+      # options[:target_args] will contain a string/array version of the targetting options this is passed to plans
+      # options[:targets] will contain a resolved set of Target objects
+      unless options[:subcommand] == 'puppetfile' ||
+             options[:subcommand] == 'secret' ||
+             options[:subcommand] == 'project' ||
+             options[:action] == 'show' ||
+             options[:action] == 'convert'
+        update_targets(options)
       end
 
       if options[:action] == 'convert'
@@ -878,6 +900,16 @@ module Bolt
     # package installs include modules listed in the Bolt repo Puppetfile
     def incomplete_install?
       (Dir.children(Bolt::PAL::MODULES_PATH) - %w[aggregate canary puppetdb_fact]).empty?
+    end
+
+    # Mimicks the output from Outputter::Human#fatal_error. This should be used to print
+    # errors prior to config being loaded, as the outputter relies on config being loaded.
+    def fatal_error(error)
+      if $stdout.isatty
+        $stdout.puts("\033[31m#{error.message}\033[0m")
+      else
+        $stdout.puts(error.message)
+      end
     end
   end
 end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -261,18 +261,24 @@ describe "Bolt::CLI" do
 
       it "accepts a single node" do
         cli = Bolt::CLI.new(%w[command run uptime --targets foo])
-        expect(cli.parse).to include(targets: [target])
+        options = cli.parse
+        cli.update_targets(options)
+        expect(options).to include(targets: [target])
       end
 
       it "accepts multiple nodes" do
         cli = Bolt::CLI.new(%w[command run uptime --targets foo,bar])
-        expect(cli.parse).to include(targets: targets)
+        options = cli.parse
+        cli.update_targets(options)
+        expect(options).to include(targets: targets)
       end
 
       it "accepts multiple nodes across multiple declarations" do
         cli = Bolt::CLI.new(%w[command run uptime --targets foo,bar --targets bar,more,bars])
+        options = cli.parse
+        cli.update_targets(options)
         extra_targets = [Bolt::Target.new('more'), Bolt::Target.new('bars')]
-        expect(cli.parse).to include(targets: targets + extra_targets)
+        expect(options).to include(targets: targets + extra_targets)
       end
 
       it "reads from stdin when --targets is '-'" do
@@ -282,8 +288,9 @@ describe "Bolt::CLI" do
         NODES
         cli = Bolt::CLI.new(%w[command run uptime --targets -])
         allow(STDIN).to receive(:read).and_return(nodes)
-        result = cli.parse
-        expect(result[:targets]).to eq(targets)
+        options = cli.parse
+        cli.update_targets(options)
+        expect(options[:targets]).to eq(targets)
       end
 
       it "reads from a file when --targets starts with @" do
@@ -293,8 +300,9 @@ describe "Bolt::CLI" do
         NODES
         with_tempfile_containing('nodes-args', nodes) do |file|
           cli = Bolt::CLI.new(%W[command run uptime --targets @#{file.path}])
-          result = cli.parse
-          expect(result[:targets]).to eq(targets)
+          options = cli.parse
+          cli.update_targets(options)
+          expect(options[:targets]).to eq(targets)
         end
       end
 
@@ -302,9 +310,10 @@ describe "Bolt::CLI" do
         nodes = "  foo\nbar  \nbaz\nqux  "
         with_tempfile_containing('nodes-args', nodes) do |file|
           cli = Bolt::CLI.new(%W[command run uptime --targets @#{file.path}])
-          result = cli.parse
+          options = cli.parse
+          cli.update_targets(options)
           extra_targets = [Bolt::Target.new('baz'), Bolt::Target.new('qux')]
-          expect(result[:targets]).to eq(targets + extra_targets)
+          expect(options[:targets]).to eq(targets + extra_targets)
         end
       end
 
@@ -312,8 +321,9 @@ describe "Bolt::CLI" do
         expect(File).to receive(:read).with(File.join(Dir.home, 'nodes.txt')).and_return("foo\nbar\n")
         cli = Bolt::CLI.new(%w[command run uptime --targets @~/nodes.txt])
         allow(cli).to receive(:puppetdb_client)
-        result = cli.parse
-        expect(result[:targets]).to eq(targets)
+        options = cli.parse
+        cli.update_targets(options)
+        expect(options[:targets]).to eq(targets)
       end
 
       it "generates an error message if no nodes given" do
@@ -325,8 +335,9 @@ describe "Bolt::CLI" do
 
       it "generates an error message if nodes is omitted" do
         cli = Bolt::CLI.new(%w[command run uptime])
+        options = cli.parse
         expect {
-          cli.parse
+          cli.update_targets(options)
         }.to raise_error(Bolt::CLIError, /Command requires a targeting option/)
       end
     end
@@ -341,8 +352,9 @@ describe "Bolt::CLI" do
         NODES
         with_tempfile_containing('nodes-args', nodes) do |file|
           cli = Bolt::CLI.new(%W[command run uptime --targets @#{file.path}])
-          result = cli.parse
-          expect(result[:targets]).to eq(targets)
+          options = cli.parse
+          cli.update_targets(options)
+          expect(options[:targets]).to eq(targets)
         end
       end
 
@@ -369,8 +381,9 @@ describe "Bolt::CLI" do
 
         targets = [Bolt::Target.new('foo'), Bolt::Target.new('bar')]
 
-        result = cli.parse
-        expect(result[:targets]).to eq(targets)
+        options = cli.parse
+        cli.update_targets(options)
+        expect(options[:targets]).to eq(targets)
       end
 
       it "fails if it can't retrieve targets from PuppetDB" do
@@ -378,15 +391,16 @@ describe "Bolt::CLI" do
         puppetdb = double('puppetdb')
         allow(puppetdb).to receive(:query_certnames).and_raise(Bolt::PuppetDBError, "failed to puppetdb the nodes")
         allow(cli).to receive(:puppetdb_client).and_return(puppetdb)
+        options = cli.parse
 
-        expect { cli.parse }
+        expect { cli.update_targets(options) }
           .to raise_error(Bolt::PuppetDBError, /failed to puppetdb the nodes/)
       end
 
       it "fails if both --targets and --query are specified" do
         cli = Bolt::CLI.new(%w[command run id --query nodes{} --targets foo,bar])
-
-        expect { cli.parse }.to raise_error(Bolt::CLIError, /Only one/)
+        options = cli.parse
+        expect { cli.update_targets(options) }.to raise_error(Bolt::CLIError, /Only one/)
       end
     end
 
@@ -834,7 +848,7 @@ describe "Bolt::CLI" do
       it "fails when --targets AND --query provided" do
         expect {
           cli = Bolt::CLI.new(%w[plan run foo --query nodes{} --targets bar])
-          cli.parse
+          cli.update_targets(cli.parse)
         }.to raise_error(Bolt::CLIError, /Only one targeting option/)
       end
 
@@ -1678,7 +1692,7 @@ describe "Bolt::CLI" do
         let(:plan_params) { { 'nodes' => targets.map(&:host).join(',') } }
         let(:options) {
           {
-            target_args: [],
+            targets: [],
             subcommand: 'plan',
             action: 'run',
             object: plan_name,
@@ -1696,7 +1710,7 @@ describe "Bolt::CLI" do
         context 'with TargetSpec $nodes plan param' do
           it "uses the nodes passed using the --targets option(s) as the 'nodes' plan parameter" do
             plan_params.clear
-            options[:target_args] = targets.map(&:host)
+            options[:targets] = targets.map(&:host)
 
             expect(executor)
               .to receive(:run_task)
@@ -1724,7 +1738,7 @@ describe "Bolt::CLI" do
           let(:plan_name) { 'sample::single_task_targets' }
           it "uses the nodes passed using the --targets option(s) as the 'targets' plan parameter" do
             plan_params.clear
-            options[:target_args] = targets.map(&:host)
+            options[:targets] = targets.map(&:host)
 
             expect(executor)
               .to receive(:run_task)
@@ -1749,14 +1763,14 @@ describe "Bolt::CLI" do
         end
 
         it "errors when the --targets option(s) and the 'targets' plan parameter are both specified" do
-          options[:target_args] = targets.map(&:host)
+          options[:targets] = targets.map(&:host)
           options[:task_options] = { 'targets' => targets.map(&:host).join(',') }
           regex = /A plan's 'targets' parameter may be specified using the --targets option/
           expect { cli.execute(options) }.to raise_error(regex)
         end
 
         it "errors when the --targets option(s) and the 'targets' plan parameter are both specified" do
-          options[:target_args] = targets.map(&:host)
+          options[:targets] = targets.map(&:host)
           options[:task_options] = { 'targets' => targets.map(&:host).join(',') }
           regex = /A plan's 'targets' parameter may be specified using the --targets option/
           expect { cli.execute(options) }.to raise_error(regex)
@@ -1766,7 +1780,7 @@ describe "Bolt::CLI" do
           let(:plan_name) { 'sample::targets_nodes' }
           it "warns when --targets does not populate both $targets and $nodes" do
             plan_params.clear
-            options[:target_args] = targets.map(&:host)
+            options[:targets] = targets.map(&:host)
 
             expect(executor).to receive(:start_plan)
             expect(executor).to receive(:log_plan)
@@ -2085,7 +2099,8 @@ describe "Bolt::CLI" do
     describe "applying Puppet code" do
       let(:options) {
         {
-          subcommand: 'apply'
+          subcommand: 'apply',
+          targets: 'foo'
         }
       }
       let(:output) { StringIO.new }
@@ -2334,7 +2349,7 @@ describe "Bolt::CLI" do
         %W[command run uptime --inventoryfile #{File.join(inventorydir, 'invalid.yml')} --targets foo]
       )
       expect {
-        cli.parse
+        cli.update_targets(cli.parse)
       }.to raise_error(Bolt::Error, /Could not parse/)
     end
 


### PR DESCRIPTION
This fixes a bug introduced in #1917 that caused errors raised before
config is loaded to be re-raised and rescued by `Bolt::CLI#parse` and
sent to the outputter. This resulted in a `NoMethodError` being raised,
as the outputter relies on the config being loaded when it is
instantiated.

This seperates the logic that was in the `#parse` method into three
separate methods. The `#parse_command` method handles parsing and
validating the command, the `#load_config` method loads the project and
config, and the `#finalize_setup` method finishes configuring Bolt and
issuing any warnings from the previous steps.

Splitting the logic into separate methods allows us to handle errors
raised before and after config is loaded differently.

!bug

* **Do not re-rescue errors raised before config is loaded**

  Errors raised before Bolt's configuration was loaded were raising a
  second, ambiguous `NoMethodError`. Bolt now correctly handles errors
  raised before configuration is loaded and will no longer trigger
  additional errors.