### PR TITLE
(maint) Configure new default cops for Rubocop 0.88

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,13 +90,25 @@ Style/RedundantRegexpEscape:
 Style/AccessorGrouping:
   Enabled: true
 
-# Disabled due to a bug in Rubocop that raises an exception when accessors
-# are assigned using a splat operator
-# https://github.com/rubocop-hq/rubocop/issues/8257
 Style/BisectedAttrAccessor:
-  Enabled: false
+  Enabled: true
 
 Style/RedundantAssignment:
+  Enabled: true
+
+Style/ArrayCoercion:
+  Enabled: true
+
+Style/CaseLikeIf:
+  Enabled: true
+
+Style/HashAsLastArrayItem:
+  Enabled: false
+
+Style/HashLikeCase:
+  Enabled: true
+
+Style/RedundantFileExtensionInRequire:
   Enabled: true
 
 # Disable nearly all Metrics checks. These seem better off left to judgement.
@@ -143,6 +155,9 @@ Lint/DeprecatedOpenSSLConstant:
 
 Lint/MixedRegexpCaptureTypes:
   Enabled: false
+
+Lint/DuplicateElsifCondition:
+  Enabled: true
 
 # Enforce LF line endings, even when on Windows
 Layout/EndOfLine:

--- a/lib/bolt/catalog.rb
+++ b/lib/bolt/catalog.rb
@@ -138,9 +138,10 @@ module Bolt
         # That means the apply body either a) consists of just a
         # NodeDefinition, b) consists of a BlockExpression which may
         # contain NodeDefinitions, or c) doesn't contain NodeDefinitions.
-        definitions = if ast.is_a?(Puppet::Pops::Model::BlockExpression)
+        definitions = case ast
+                      when Puppet::Pops::Model::BlockExpression
                         ast.statements.select { |st| st.is_a?(Puppet::Pops::Model::NodeDefinition) }
-                      elsif ast.is_a?(Puppet::Pops::Model::NodeDefinition)
+                      when Puppet::Pops::Model::NodeDefinition
                         [ast]
                       else
                         []

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -357,30 +357,32 @@ module Bolt
 
       analytics.screen_view(screen, screen_view_fields)
 
-      if options[:action] == 'show'
-        if options[:subcommand] == 'task'
+      case options[:action]
+      when 'show'
+        case options[:subcommand]
+        when 'task'
           if options[:object]
             show_task(options[:object])
           else
             list_tasks
           end
-        elsif options[:subcommand] == 'plan'
+        when 'plan'
           if options[:object]
             show_plan(options[:object])
           else
             list_plans
           end
-        elsif options[:subcommand] == 'inventory'
+        when 'inventory'
           if options[:detail]
             show_targets
           else
             list_targets
           end
-        elsif options[:subcommand] == 'group'
+        when 'group'
           list_groups
         end
         return 0
-      elsif options[:action] == 'show-modules'
+      when 'show-modules'
         list_modules
         return 0
       end
@@ -393,17 +395,19 @@ module Bolt
 
       case options[:subcommand]
       when 'project'
-        if options[:action] == 'init'
+        case options[:action]
+        when 'init'
           code = initialize_project
-        elsif options[:action] == 'migrate'
+        when 'migrate'
           code = migrate_project
         end
       when 'plan'
         code = run_plan(options[:object], options[:task_options], options[:target_args], options)
       when 'puppetfile'
-        if options[:action] == 'generate-types'
+        case options[:action]
+        when 'generate-types'
           code = generate_types
-        elsif options[:action] == 'install'
+        when 'install'
           code = install_puppetfile(config.puppetfile_config, config.puppetfile, config.modulepath)
         end
       when 'secret'

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -499,7 +499,7 @@ module Bolt
     end
 
     def matching_paths(paths)
-      [*paths].map { |p| Dir.glob([p, casefold(p)]) }.flatten.uniq.reject { |p| [*paths].include?(p) }
+      Array(paths).map { |p| Dir.glob([p, casefold(p)]) }.flatten.uniq.reject { |p| Array(paths).include?(p) }
     end
 
     private def casefold(path)

--- a/lib/bolt/inventory/group.rb
+++ b/lib/bolt/inventory/group.rb
@@ -50,10 +50,11 @@ module Bolt
           # or it could be a name/alias of a target defined in another group.
           # We can't tell the difference until all groups have been resolved,
           # so we store the string on its own here and process it later.
-          if target.is_a?(String)
+          case target
+          when String
             @string_targets << target
           # Handle plugins at this level so that lookups cannot trigger recursive lookups
-          elsif target.is_a?(Hash)
+          when Hash
             add_target_definition(target)
           else
             raise ValidationError.new("Target entry must be a String or Hash, not #{target.class}", @name)

--- a/lib/bolt/inventory/inventory.rb
+++ b/lib/bolt/inventory/inventory.rb
@@ -109,11 +109,12 @@ module Bolt
       private :resolve_name
 
       def expand_targets(targets)
-        if targets.is_a? Bolt::Target
+        case targets
+        when Bolt::Target
           targets
-        elsif targets.is_a? Array
+        when Array
           targets.map { |tish| expand_targets(tish) }
-        elsif targets.is_a? String
+        when String
           # Expand a comma-separated list
           targets.split(/[[:space:],]+/).reject(&:empty?).map do |name|
             ts = resolve_name(name)

--- a/lib/bolt/outputter/rainbow.rb
+++ b/lib/bolt/outputter/rainbow.rb
@@ -39,9 +39,10 @@ module Bolt
             a = string.chars.map do |c|
               case @state
               when :normal
-                if c == "\e"
+                case c
+                when "\e"
                   @state = :ansi
-                elsif c == "\n"
+                when "\n"
                   @line_color += 1
                   @color = @line_color
                   c

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -284,9 +284,10 @@ module Bolt
 
     def parse_params(type, object_name, params)
       in_bolt_compiler do |compiler|
-        if type == 'task'
+        case type
+        when 'task'
           param_spec = compiler.task_signature(object_name)&.task_hash&.dig('parameters')
-        elsif type == 'plan'
+        when 'plan'
           plan = compiler.plan_signature(object_name)
           param_spec = plan.params_type.elements&.each_with_object({}) { |t, h| h[t.name] = t.value_type } if plan
         end

--- a/lib/bolt/plugin/puppetdb.rb
+++ b/lib/bolt/plugin/puppetdb.rb
@@ -85,7 +85,8 @@ module Bolt
 
       def resolve_facts(config, certname, target_data)
         Bolt::Util.walk_vals(config) do |value|
-          if value.is_a?(String)
+          case value
+          when String
             if value == 'certname'
               certname
             else
@@ -94,7 +95,7 @@ module Bolt
               # If there's no fact data this will be nil
               data&.fetch('value', nil)
             end
-          elsif value.is_a?(Array) || value.is_a?(Hash)
+          when Array, Hash
             value
           else
             raise FactLookupError.new(value, "fact lookups must be a string")

--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -107,12 +107,13 @@ module Bolt
       # Accepts a Data object and returns a copy with all hash keys
       # modified by block. use &:to_s to stringify keys or &:to_sym to symbolize them
       def walk_keys(data, &block)
-        if data.is_a? Hash
+        case data
+        when Hash
           data.each_with_object({}) do |(k, v), acc|
             v = walk_keys(v, &block)
             acc[yield(k)] = v
           end
-        elsif data.is_a? Array
+        when Array
           data.map { |v| walk_keys(v, &block) }
         else
           data
@@ -124,9 +125,10 @@ module Bolt
       # their descendants are.
       def walk_vals(data, skip_top = false, &block)
         data = yield(data) unless skip_top
-        if data.is_a? Hash
+        case data
+        when Hash
           data.transform_values { |v| walk_vals(v, &block) }
-        elsif data.is_a? Array
+        when Array
           data.map { |v| walk_vals(v, &block) }
         else
           data
@@ -137,9 +139,10 @@ module Bolt
       # modified by the given block. Descendants are modified before their
       # parents.
       def postwalk_vals(data, skip_top = false, &block)
-        new_data = if data.is_a? Hash
+        new_data = case data
+                   when Hash
                      data.transform_values { |v| postwalk_vals(v, &block) }
-                   elsif data.is_a? Array
+                   when Array
                      data.map { |v| postwalk_vals(v, &block) }
                    else
                      data
@@ -193,11 +196,12 @@ module Bolt
           cloned[obj.object_id] = cl
           cloned[cl.object_id] = cl
 
-          if cl.is_a? Hash
+          case cl
+          when Hash
             obj.each { |k, v| cl[k] = deep_clone(v, cloned) }
-          elsif cl.is_a? Array
+          when Array
             cl.collect! { |v| deep_clone(v, cloned) }
-          elsif cl.is_a? Struct
+          when Struct
             obj.each_pair { |k, v| cl[k] = deep_clone(v, cloned) }
           end
 
@@ -257,9 +261,10 @@ module Bolt
 
       # Recursively searches a data structure for plugin references
       def references?(input)
-        if input.is_a?(Hash)
+        case input
+        when Hash
           input.key?('_plugin') || input.values.any? { |v| references?(v) }
-        elsif input.is_a?(Array)
+        when Array
           input.any? { |v| references?(v) }
         else
           false

--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -151,13 +151,14 @@ module BoltServer
         sha256 = file['sha256']
         kind = file['kind']
         path = File.join(cache_dir, relative_path)
-        if kind == 'file'
+        case kind
+        when 'file'
           # The parent should already be created by `directory` entries,
           # but this is to be on the safe side.
           parent = File.dirname(path)
           FileUtils.mkdir_p(parent)
           @file_cache.serial_execute { @file_cache.download_file(path, sha256, uri) }
-        elsif kind == 'directory'
+        when 'directory'
           # Create directory in cache so we can move files in.
           FileUtils.mkdir_p(path)
         else

--- a/lib/bolt_spec/plans/action_stubs.rb
+++ b/lib/bolt_spec/plans/action_stubs.rb
@@ -118,7 +118,7 @@ module BoltSpec
       # Restricts the stub to only match invocations with
       # the correct targets
       def with_targets(targets)
-        targets = [targets] unless targets.is_a? Array
+        targets = Array(targets)
         @invocation[:targets] = targets.map do |target|
           if target.is_a? String
             target

--- a/libexec/bolt_catalog
+++ b/libexec/bolt_catalog
@@ -32,10 +32,11 @@ require 'json'
 # }
 
 command = ARGV[0]
-if command == "parse"
+case command
+when "parse"
   code = File.open(ARGV[1], &:read)
   puts JSON.pretty_generate(Bolt::Catalog.new.generate_ast(code, ARGV[1]))
-elsif command == "compile"
+when "compile"
   request = if ARGV[1]
               File.open(ARGV[1]) { |fh| JSON.parse(fh.read) }
             else


### PR DESCRIPTION
This adds configuration for several new default cops introduced in
Rubocop 0.88. It also enables the `Style/BisectedAttrAccessor` cop,
which was previously disabled due to a bug.

!no-release-note