### PR TITLE
(GH-1993) Remove -E from bash commands

### DIFF
--- a/lib/bolt/shell/bash.rb
+++ b/lib/bolt/shell/bash.rb
@@ -335,7 +335,6 @@ module Bolt
           sudo_str = if use_sudo
                        sudo_exec = target.options['sudo-executable'] || "sudo"
                        sudo_flags = [sudo_exec, "-S", "-H", "-u", run_as, "-p", sudo_prompt]
-                       sudo_flags += ["-E"] if options[:environment]
                        Shellwords.shelljoin(sudo_flags)
                      else
                        Shellwords.shelljoin(@target.options['run-as-command'] + [run_as])

--- a/spec/fixtures/modules/env_var/plans/command.pp
+++ b/spec/fixtures/modules/env_var/plans/command.pp
@@ -1,0 +1,7 @@
+plan env_var::command(
+  TargetSpec $targets,
+  String $user
+) {
+  $vars = { 'chips' => 'and guacamole' }
+  return run_command('echo $chips', $targets, '_env_vars' => $vars, '_run_as' => $user)
+}

--- a/spec/integration/run_as_spec.rb
+++ b/spec/integration/run_as_spec.rb
@@ -27,6 +27,20 @@ describe "when running a plan using run_as", ssh: true do
     expect(JSON.parse(output)).to eq(%W[#{user}\n root\n #{user}\n root\n #{user}\n root\n])
   end
 
+  context 'when passing environment variables' do
+    let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
+
+    it 'correctly passes environment variables to a task' do
+      output = run_cli_json(%W[task run sample message=tacos -t #{uri}] + config_flags)
+      expect(output['items'].first['value']['_output'].strip).to eq('tacos')
+    end
+
+    it 'correctly passes environment variables specified in a plan' do
+      output = run_cli_json(%W[plan run env_var::command -t #{uri} user=root] + config_flags).first
+      expect(output['value']['stdout'].strip).to eq('and guacamole')
+    end
+  end
+
   it 'runs sudo within a plan when specified' do
     output = run_plan('test::incept', target: uri)
     expect(JSON.parse(output)).to eq(%W[#{user}\n root\n #{user}\n root\n #{user}\n root\n])


### PR DESCRIPTION
Previously we passed `-E` to the sudo command built in the bash shell if
the operation required environment variables to be passed. Prior to #1899
this was needed because we set environment variables when invoking sudo
and required it to preserve them so they would be visible to the command
being invoked. We now pass the environment variables as arguments to
sudo, making the flag unnecessary and raising errors for users who don't
have permissions to preserve the environment.

Closes #1993

!feature

* **Environment preservation permission no longer required when using run-as** ([1993](https://github.com/puppetlabs/bolt/issues/1993))

  Bolt no longer passes the `-E` flag to sudo when building commands
  using 'run-as', which allows users who do not have permission to use the
  flag to use Bolt.