### PR TITLE
(GH-1835) Add tests for plan_hierarchy lookups

### DIFF
--- a/spec/fixtures/hiera/plan_hiera.yaml
+++ b/spec/fixtures/hiera/plan_hiera.yaml
@@ -1,0 +1,9 @@
+version: 5
+
+hierarchy:
+  - name: Common
+    path: hierarchy.yaml
+
+plan_hierarchy:
+  - name: Common
+    path: plan_hierarchy.yaml

--- a/spec/fixtures/hiera/plan_hiera_interpolations.yaml
+++ b/spec/fixtures/hiera/plan_hiera_interpolations.yaml
@@ -1,0 +1,12 @@
+---
+version: 5 
+
+defaults:
+  data_hash: yaml_data
+
+plan_hierarchy:
+  - name: "Interpolations"
+    path: "os/%{facts.os.name}.yaml"
+
+  - name: "Common"
+    path: "common.yaml"


### PR DESCRIPTION
Previously, Bolt would use the same Hiera hierarchy for lookups both
inside apply blocks and outside apply blocks, and simply removed facts
and vars from the PAL ScriptCompiler to prevent users from using
interpolations in their hierarchies for lookups outside apply blocks.
This meant that hierarchies that used interpolations would error even if
the user wasn't looking up data that included an interpolation. To
mitigate this, we added a separate hierarchy under the key
`plan_hierarchy` in puppetlabs/puppet#8232. This PR adds integration
level tests to verify that the plan hierarchy is loaded and used
correctly, and marks them as pending since this feature won't be
available in Bolt until Puppet 6.18 ships.

!no-release-note