### PR TITLE
(maint) Group bolt server gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,13 +10,15 @@ ENV['BOLT_GEM'] = 'true'
 
 gemspec
 
-# Bolt server gems are managed here not in the gemspec
-gem "hocon", '>= 1.2.5'
-gem "json-schema", '>= 2.8.0'
-gem "puma", '>= 3.12.0'
-gem "rack", '>= 2.0.5'
-gem "rails-auth", '>= 2.1.4'
-gem "sinatra", '>= 2.0.4'
+group(:bolt_server) do
+  # Bolt server gems are managed here not in the gemspec
+  gem "hocon", '>= 1.2.5'
+  gem "json-schema", '>= 2.8.0'
+  gem "puma", '>= 3.12.0'
+  gem "rack", '>= 2.0.5'
+  gem "rails-auth", '>= 2.1.4'
+  gem "sinatra", '>= 2.0.4'
+end
 
 # Optional paint gem for rainbow outputter
 gem "paint", "~> 2.2"


### PR DESCRIPTION
This groups together the bolt server gems in the Gemfile to allow a user to omit these gems if they want. This decreases the amount installed and speeds up the time it takes to bundle install this project on windows.

!no-release-note
