### PR TITLE
(GH-1936) Docs - connecting Bolt to PE

### DIFF
--- a/documentation/bolt_configure_orchestrator.md
+++ b/documentation/bolt_configure_orchestrator.md
@@ -1,9 +1,13 @@
-# Using Bolt with Puppet Enterprise
+# Connecting Bolt to Puppet Enterprise
 
-If you're a Puppet Enterprise (PE) customer, you can configure Bolt to use the
-PE orchestrator and perform actions on managed targets. Pairing PE with Bolt
-enables role-based access control, logging, and visual reports in the
-PE console.
+If you're a Puppet Enterprise (PE) customer, you can connect Bolt to Puppet Enterprise (PE) using the
+Puppet Communications Protocol (PCP) transport. However, in most cases this is not
+necessary, because tasks and plans are already supported from the console or the
+command line using
+[PE orchestrator](https://puppet.com/docs/pe/latest/running_jobs_with_puppet_orchestrator_overview.html). Wherever possible, we recommend using PE tasks and plans instead of connecting
+Bolt to PE over PCP. 
 
-For details about using Bolt with PE, see the [PE orchestrator
-documentation](https://puppet.com/docs/pe/latest/bolt_configure_orchestrator.html).
+For more information on tasks and plans in PE, see [Tasks and
+plans](https://puppet.com/docs/pe/latest/running_tasks_and_plans_pe.html).
+
+For information on connecting Bolt to PE, see [Connecting Bolt to PE](https://puppet.com/docs/pe/latest/bolt_configure_orchestrator.html).


### PR DESCRIPTION
Most of the docs changes are happening on the PE side,
but this updates the doc to recommend Puppet tasks and
plans where possible.

!no-release-note