### PR TITLE
(docs) Clarify `_run_as` precedence and behavior

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_plan.rb
@@ -11,6 +11,9 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
   # @param args A hash of arguments to the plan. Can also include additional options.
   # @option args [Boolean] _catch_errors Whether to catch raised errors.
   # @option args [String] _run_as User to run as using privilege escalation.
+  #   This option sets the [run-as user](privilege_escalation.md) for all
+  #   targets whenever Bolt connects to a target. This is set for all functions
+  #   in the called plan, including `run_plan()`.
   # @return [PlanResult] The result of running the plan. Undef if plan does not explicitly return results.
   # @example Run a plan
   #   run_plan('canary', 'command' => 'false', 'targets' => $targets, '_catch_errors' => true)
@@ -31,6 +34,9 @@ Puppet::Functions.create_function(:run_plan, Puppet::Functions::InternalFunction
   # @param args A hash of arguments to the plan. Can also include additional options.
   # @option args [Boolean] _catch_errors Whether to catch raised errors.
   # @option args [String] _run_as User to run as using privilege escalation.
+  #   This option sets the [run-as user](privilege_escalation.md) for all
+  #   targets whenever Bolt connects to a target. This is set for all functions
+  #   in the called plan, including `run_plan()`.
   # @return [PlanResult] The result of running the plan. Undef if plan does not explicitly return results.
   # @example Run a plan
   #   run_plan('canary', $targets, 'command' => 'false')

--- a/documentation/configuring_bolt.md
+++ b/documentation/configuring_bolt.md
@@ -216,13 +216,14 @@ options](bolt_configuration_reference.md).
 Bolt uses the following precedence when interpolating configuration settings,
 from highest precedence to lowest:
 
-  - Target URI (i.e. ssh://user:password@hostname:port)
-  - [Inventory file](inventory_file_v2.md) options
-  - [Command line flags](bolt_command_reference.md)
-  - Project-level configuration file
-  - User-level configuration file
-  - System-wide configuration file
-  - SSH configuration file options (e.g. `~/.ssh/config`)
+  - Configuration specifications from the target's URI. For example, `ssh://user:password@hostname:port`.
+  - [Plan function](plan_functions.md) options that modify configuration, such as `_run_as`.
+  - [Inventory file](inventory_file_v2.md) configuration options.
+  - [Command line flags](bolt_command_reference.md) that modify configuration.
+  - Options from the project-level configuration file, `bolt-project.yaml`. 
+  - Options from the user-level configuration file, `~/.puppetlabs/etc/bolt/bolt-defaults.yaml`.
+  - Options from the system-wide configuration file, `/etc/puppetlabs/bolt/bolt-defaults.yaml`.
+  - SSH configuration file options. For example, `~/.ssh/config`.
 
 ## Merge strategy
 


### PR DESCRIPTION
It's unclear from the existing documentation whether `_run_as` will
override existing configuration for a target, and how the plan function
option will be used in sub-plans (plans called from another plan where
`run_plan` has `_run_as` set). This clarifies that `_run_as` will take
precedence over existing target configuration, and that it will be
applied to all connections created from an function call, including
sub-plans and even sub-sub-plans where the initial plan has `_run_as`
specified.

Note: I'm a bit dubious of the formatting of the multiline strings in the docs here. Suggestions welcome!

!no-release-note