### PR TITLE
(bug) Fix changelog script path in rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,5 +14,5 @@ end
 
 desc "Update Bolt's changelog for release"
 task :changelog, [:version] do |_t, args|
-  sh "../scripts/generate_changelog.rb #{args[:version]}"
+  sh "scripts/generate_changelog.rb #{args[:version]}"
 end


### PR DESCRIPTION
This updates the path to the changelog script in the changelog rake task
to be relative to the current directory instead of the parent directory.

!no-release-note