### PR TITLE
(GH-1980) Add --env-var cli flag

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -28,6 +28,7 @@ mod 'puppetlabs-python_task_helper', '0.4.3'
 mod 'puppetlabs-reboot', '3.0.0'
 mod 'puppetlabs-ruby_task_helper', '0.5.1'
 mod 'puppetlabs-ruby_plugin_helper', '0.1.0'
+mod 'puppetlabs-stdlib', '6.3.0'
 
 # Plugin modules
 mod 'puppetlabs-aws_inventory', '0.5.0'
@@ -42,3 +43,4 @@ mod 'puppetlabs-yaml', '0.2.0'
 mod 'canary', local: true
 mod 'aggregate', local: true
 mod 'puppetdb_fact', local: true
+mod 'secure_env_vars', local: true

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -25,7 +25,7 @@ module Bolt
       when 'command'
         case action
         when 'run'
-          { flags: ACTION_OPTS,
+          { flags: ACTION_OPTS + %w[env-var],
             banner: COMMAND_RUN_HELP }
         else
           { flags: OPTIONS[:global],
@@ -106,7 +106,7 @@ module Bolt
       when 'script'
         case action
         when 'run'
-          { flags: ACTION_OPTS + %w[tmpdir],
+          { flags: ACTION_OPTS + %w[tmpdir env-var],
             banner: SCRIPT_RUN_HELP }
         else
           { flags: OPTIONS[:global],
@@ -759,6 +759,15 @@ module Bolt
       end
       define('--[no-]save-rerun', 'Whether to update the rerun file after this command.') do |save|
         @options[:'save-rerun'] = save
+      end
+
+      separator "\nREMOTE ENVIRONMENT OPTIONS"
+      define('--env-var ENVIRONMENT_VARIABLES', 'Environment variables to set on the target') do |envvar|
+        unless envvar.include?('=')
+          raise Bolt::CLIError, "Environment variables must be specified using 'myenvvar=key' format"
+        end
+        @options[:env_vars] ||= {}
+        @options[:env_vars].store(*envvar.split('=', 2))
       end
 
       separator "\nTRANSPORT OPTIONS"

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -258,6 +258,13 @@ module Bolt
               "Option '--noop' may only be specified when running a task or applying manifest code"
       end
 
+      if options[:env_vars]
+        unless %w[command script].include?(options[:subcommand]) && options[:action] == 'run'
+          raise Bolt::CLIError,
+                "Option '--env-var' may only be specified when running a command or script"
+        end
+      end
+
       if options[:subcommand] == 'apply' && (options[:object] && options[:code])
         raise Bolt::CLIError, "--execute is unsupported when specifying a manifest file"
       end
@@ -450,6 +457,7 @@ module Bolt
         elapsed_time = Benchmark.realtime do
           executor_opts = {}
           executor_opts[:description] = options[:description] if options.key?(:description)
+          executor_opts[:env_vars] = options[:env_vars] if options.key?(:env_vars)
           executor.subscribe(outputter)
           executor.subscribe(log_outputter)
           results =

--- a/modules/secure_env_vars/plans/init.pp
+++ b/modules/secure_env_vars/plans/init.pp
@@ -1,0 +1,20 @@
+plan secure_env_vars(
+  TargetSpec $targets,
+  Optional[String] $command = undef,
+  Optional[String] $script = undef
+) {
+  $env_vars = parsejson(system::env('BOLT_ENV_VARS'))
+  unless type($command) == Undef or type($script) == Undef {
+      fail_plan('Cannot specify both script and command for secure_env_vars')
+  }
+
+  return if $command {
+           run_command($command, $targets, '_env_vars' => $env_vars)
+         }
+         elsif $script {
+           run_script($script, $targets, '_env_vars' => $env_vars)
+         }
+         else {
+           fail_plan('Must specify either script or command for secure_env_vars')
+         }
+}

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -700,6 +700,11 @@ describe "Bolt::CLI" do
           cli.parse
         }.to raise_error(Bolt::CLIError, /Must specify a command to run/)
       end
+
+      it "sets specified environment variables" do
+        cli = Bolt::CLI.new(%w[command run --targets foo whoami --env-var POP=TARTS])
+        expect(cli.parse[:env_vars]).to eq({ 'POP' => 'TARTS' })
+      end
     end
 
     it "distinguishes subcommands" do
@@ -714,6 +719,12 @@ describe "Bolt::CLI" do
           result = cli.parse
           expect(result[:object]).to eq('./src')
           expect(result[:leftovers].first).to eq('/path/dest')
+        end
+
+        it "fails with --env-var" do
+          cli = Bolt::CLI.new(%w[file upload -t foo --env-var POP=ROCKS])
+          expect { cli.parse }
+            .to raise_error(Bolt::CLIError, /Option '--env-var' may only be specified when running a command or script/)
         end
       end
 

--- a/spec/integration/parsing_spec.rb
+++ b/spec/integration/parsing_spec.rb
@@ -107,4 +107,10 @@ describe "CLI parses input" do
     result = run_one_node(['script', 'run', script_path, '--targets', target] + params + config_flags)
     expect(result['stdout']).to match(/dont=split/)
   end
+
+  it 'parses environment variables', ssh: true do
+    script = File.join(__dir__, '../fixtures/modules/env_var/tasks/get_var.sh')
+    output = run_cli_json(%W[script run #{script} -t #{target} --env-var test_var=123] + config_flags)
+    expect(output['items'][0]['value']['stdout'].strip).to eq('123')
+  end
 end


### PR DESCRIPTION
This adds the `--env-var` cli flag, which accepts a string that contains
an equals sign and parses it into a key-value pair to set as an
environment variable on the target. This flag is only available when
running commands or scripts, and can be specified multiple times with
different environment variables. If the same key is specified multiple
times the last instance will take precedence. This doesn't interact with
`_env_var` specified in plans since the flag can only be used when
running commands and scripts.

Closes #1980

!feature

* **Specify remote environment variables using --env-var** ([1980](https://github.com/puppetlabs/bolt/issue/1980))

  Users can now set environment variables on targets when running
  commands and scripts using the CLI flag `--env-var`.