### PR TITLE
(GH-1982) Handle WinRM connection loss

### DIFF
--- a/spec/fixtures/modules/error/plans/winrm_disconnect.pp
+++ b/spec/fixtures/modules/error/plans/winrm_disconnect.pp
@@ -1,0 +1,7 @@
+plan error::winrm_disconnect(
+  TargetSpec $targets
+) {
+  $result = run_command('restart-service winrm', $targets, _catch_errors => true)
+  return run_command('get-service |? name -like winrm', $targets)
+}
+

--- a/spec/integration/winrm_spec.rb
+++ b/spec/integration/winrm_spec.rb
@@ -79,6 +79,11 @@ describe "when runnning over the winrm transport", winrm: true do
       result = run_one_node(%w[task run sample::ps_noop message=somemessage] + config_flags)
       expect(result['_output'].strip).to eq("somemessage with noop")
     end
+
+    it 'handles disconnects gracefully', :reset_puppet_settings do
+      result = run_cli_json(%w[plan run error::winrm_disconnect] + config_flags)
+      expect(result.first['status']).to eq("success")
+    end
   end
 
   context 'when using a configfile' do


### PR DESCRIPTION
Previously, losing connection to WinRM (for instance, due to the
service being stopped or restarted) would cause a stacktrace and a
deadlock. This happened because we manage the output from the command in
a thread which wasn't handling exceptions. The stack trace came from the
exception bubbling up, with the default behavior of Thread being to
print all exceptions that escape the thread. The deadlock came from our
failure to close the out/err streams that the shell was waiting on.

We now ensure the out/err streams are always closed and we disabled the
"report_on_exception" behavior to avoid an unnecessary stack trace, as
our own code will handle the exception at the next level up.