### PR TITLE
(GH-1997) Add tests for JSON schemas

### DIFF
--- a/.github/workflows/schemas.yaml
+++ b/.github/workflows/schemas.yaml
@@ -1,0 +1,56 @@
+name: Schemas
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'rakelib/schemas.rake'
+      - 'schemas/*.json'
+      - 'lib/bolt/config/options.rb'
+      - 'lib/bolt/config/transport/options.rb'
+  pull_request:
+    type: [opened, reopened, edited]
+    paths:
+      - 'rakelib/schemas.rake'
+      - 'schemas/*.json'
+      - 'lib/bolt/config/options.rb'
+      - 'lib/bolt/config/transport/options.rb'
+
+jobs:
+
+  generate:
+    name: Generate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.5.x'
+      - name: Install bundler
+        run: |
+          gem install bundler
+          bundle config path vendor/bundle
+      - name: Cache gems
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
+      - name: Install gems
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: bundle install --jobs 4 --retry 3
+      - name: Generate schemas
+        run: bundle exec rake schemas:all
+      - name: Compare changes
+        run: |
+          if git diff --quiet; then
+            echo 'Did not detect changes to JSON schemas'
+            exit 0
+          else
+            echo 'Detected changes to JSON schemas. Run schema generation task and commit changes:
+            bundle exec rake schemas:all'
+            exit 1
+          fi
+

--- a/spec/bolt/config/options_spec.rb
+++ b/spec/bolt/config/options_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/options'
+require 'bolt/config/options'
+
+context 'Bolt::Config::Options::OPTIONS' do
+  include BoltSpec::Options
+
+  it 'has a type and description for each option' do
+    expect(Bolt::Config::Options::OPTIONS.class).to eq(Hash)
+    assert_type_description(Bolt::Config::Options::OPTIONS)
+  end
+end
+
+context 'Bolt::Config::Options::INVENTORY_OPTIONS' do
+  include BoltSpec::Options
+
+  it 'has a type and description for each option' do
+    expect(Bolt::Config::Options::INVENTORY_OPTIONS.class).to eq(Hash)
+    assert_type_description(Bolt::Config::Options::INVENTORY_OPTIONS)
+  end
+end

--- a/spec/bolt/config/transport/options_spec.rb
+++ b/spec/bolt/config/transport/options_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/options'
+require 'bolt/config/transport/options'
+
+context 'Bolt::Config::Transport::Options::TRANSPORT_OPTIONS' do
+  include BoltSpec::Options
+
+  it 'has a type and description for each option' do
+    expect(Bolt::Config::Transport::Options::TRANSPORT_OPTIONS.class).to eq(Hash)
+    assert_type_description(Bolt::Config::Transport::Options::TRANSPORT_OPTIONS)
+  end
+end

--- a/spec/lib/bolt_spec/options.rb
+++ b/spec/lib/bolt_spec/options.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module BoltSpec
+  module Options
+    # This function is used to ensure that every config option
+    # has a :type and :description key, as they are required for
+    # generating the JSON schemas and validating config.
+    def assert_type_description(definitions)
+      definitions.each do |option, definition|
+        expect(definition.key?(:description)).to be, "missing :description key for option '#{option}'"
+        expect(definition.key?(:type)).to be, "missing :type key for option '#{option}'"
+
+        if definition.key?(:properties)
+          expect(definition[:properties].class).to eq(Hash), ":properties key for option '#{option}' must be a Hash"
+          assert_type_description(definition[:properties])
+        end
+
+        %i[additionalProperties items].each do |key|
+          next unless definition.key?(key)
+          expect(definition[key].class).to eq(Hash), ":#{key} key for option '#{option}' must be a Hash"
+          expect(definition[key].key?(:type)).to be, "missing :type key for :#{key} in option '#{option}'"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds tests to ensure that the config options hashes include
`:type` and `:description` keys, which are required to correctly
generate Bolt's JSON schemas.

It also includes a workflow for generating the JSON schemas and
checking if there were any changes from the schemas that were committed.
If there are changes, the workflow fails and notifies the user that they
should run the `schemas:all` Rake task and commit the changes.

Closes #1997 

!no-release-note