### PR TITLE
(GH-1841) Prefer bolt-*.yaml and inventory.yaml to bolt.yaml in documentation

### DIFF
--- a/developer-docs/bolt_spec-run.md
+++ b/developer-docs/bolt_spec-run.md
@@ -4,8 +4,8 @@ The `BoltSpec::Run` module is intended to provide a method of executing bolt in 
 
 ## Configuration
 
-### Config (bolt.yaml)
-Bolt configuration data normally found in `bolt.yaml` can be passed with the `:config` key in the options hash for each method. This has the highest priority. 
+### Config
+Bolt configuration data can be passed with the `:config` key in the options hash for each method. This has the highest priority. 
 
 In order to avoid passing the same config option every time you want to use it each method will use `bolt_config` if it is available in scope and no config has been passed in the `options` hash. 
 

--- a/developer-docs/kerberos.md
+++ b/developer-docs/kerberos.md
@@ -66,7 +66,7 @@ Important client tools include:
 
 Manual verification of Bolt can be performed from a Linux node that is domain joined to Active Directory using the following steps:
 
-- Set the default winrm authentication to specify the domain in `~/puppetlabs/bolt/bolt.yaml` like:
+- Set the default winrm authentication to specify the domain in `~/puppetlabs/bolt/inventory.yaml` like:
 
 ```yaml
 winrm:

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -73,7 +73,9 @@ To generate this documentation, run:
 $ bundle exec rake docs:function_reference
 ```
 
-### `bolt.yaml` options
+### ⛔ `bolt.yaml` options
+
+`bolt.yaml` is deprecated and will be removed in a future version of Bolt.
 
 **Documentation page**
 - https://puppet.com/docs/bolt/latest/bolt_configuration_reference.html

--- a/documentation/bolt_examples.md
+++ b/documentation/bolt_examples.md
@@ -67,7 +67,9 @@ file](inventory_file_v2.md). The inventory file is a YAML file that contains a
 list of targets and target specific data.
 
 1.  Inside the `bolt-guide` directory, use a text editor to create an
-    `inventory.yaml` file.
+    `inventory.yaml` file and a `bolt-project.yaml` file. The `inventory.yaml` file is where
+    connection information is stored, while `bolt-project.yaml` tells Bolt that the directory is a project
+    and that it should load the inventory file from the directory.
 2.  Inside the new `inventory.yaml` file, add the following content, listing the
     fully qualified domain names of the targets you want to run the script on,
     and replacing the credentials in the `winrm` section with those appropriate
@@ -94,9 +96,9 @@ list of targets and target specific data.
     You now have an inventory file where you can store information about your
     targets.
 
-    You can also configure a variety of options for Bolt in `bolt.yaml`,
-    including global and transport options. For more information, see [Bolt
-    configuration options](bolt_configuration_reference.md).
+    You can also configure a variety of options for Bolt in `bolt-project.yaml`. For more
+    information about configuration see [Configuring Bolt](configuring_bolt.md). For more
+    information about Bolt projects see [Bolt project directories](bolt_project_directories.md)
 
 
 ### 3. Convert your script to a Bolt task
@@ -207,13 +209,13 @@ configuration, code, and data loaded by Bolt.
 mkdir bolt_choco_example
 ```
 
-1. Add a `bolt.yaml` file to the `puppet_choco_tap` directory:
+1. Add a `bolt-project.yaml` file to the `puppet_choco_tap` directory:
 
 ```
-New-Item -Type File -Path .\puppet_choco_tap\bolt.yaml
+New-Item -Type File -Path .\puppet_choco_tap\bolt-project.yaml
 ```
 
-Adding a `bolt.yaml` file (even if it's empty),  makes the containing directory
+Adding a `bolt-project.yaml` file (even if it's empty),  makes the containing directory
 a Bolt project directory when you run Bolt from it. This is where Bolt loads
 code and configuration from.
 

--- a/documentation/bolt_installing.md
+++ b/documentation/bolt_installing.md
@@ -409,7 +409,7 @@ Bolt collects data about how you use it. You can opt out of providing this data.
 -   The number of targets targeted with a Bolt command
 -   The output format selected (human-readable, JSON)
 -   Whether the Bolt project directory was determined from the location of a
-    `bolt.yaml` file or with the `--project` flag
+    `bolt-project.yaml` file or with the `--project` flag
 -   The number of times Bolt tasks and plans are run (not including user-defined
     tasks or plans.)
 -   The number of statements in a manifest block, and how many resources that
@@ -420,7 +420,7 @@ Bolt collects data about how you use it. You can opt out of providing this data.
 
 This data is associated with a random, non-identifiable user UUID.
 
-To see the data Bolt collects, add `--debug` to a command.
+To see the data Bolt collects, add `--log-level debug` to a command.
 
 ### Why does Bolt collect data?
 

--- a/documentation/bolt_options.md
+++ b/documentation/bolt_options.md
@@ -177,8 +177,7 @@ target.
 
 If the host target runs Linux, the target runs Windows, and your network uses
 Kerberos for authentication, you can specify a Kerberos realm in your
-`bolt.yaml` file. This file is introduced in the [Configuring
-Bolt](configuring_bolt.md) section below. The best source of information and
+[inventory file](inventory_file_v2.md). The best source of information and
 examples for this advanced topic is the [Kerberos
 section](https://github.com/puppetlabs/bolt/blob/main/developer-docs/kerberos.md)
 of the Bolt developer documentation.

--- a/documentation/bolt_types_reference.md
+++ b/documentation/bolt_types_reference.md
@@ -117,7 +117,7 @@ The following functions are available to `Target` objects:
 
 | Function | Type returned | Description | Note |
 |---|---|---|---|
-| `config` | `Hash[String, Data]` | The inventory configuration for the target. | This function returns the configuration set directly on the target in `inventory.yaml` or set in a plan using `Target.new` or `set_config()`. It does not return default configuration values or configuration set in `bolt.yaml`.  |
+| `config` | `Hash[String, Data]` | The inventory configuration for the target. | This function returns the configuration set directly on the target in `inventory.yaml` or set in a plan using `Target.new` or `set_config()`. It does not return default configuration values or configuration set in Bolt configuration files.  |
 | `facts` | `Hash[String, Data]` | The target's facts. | This function does not look up facts for a target and only returns the facts specified in an `inventory.yaml` file or set on a target during a plan run. |
 | `features` | `Array[String]` | The target's features. ||
 | `host` | `String` | The target's hostname. ||
@@ -130,7 +130,7 @@ The following functions are available to `Target` objects:
 | `safe_name` | `String` | The target's safe name. Equivalent to `name` if a name was given, or the target's `uri` with any password omitted. ||
 | `target_alias` | `Variant[String, Array[String]]` | The target's aliases. ||
 | `transport` | `String` | The transport used to connect to the target. ||
-| `transport_config` | `Hash[String, Data]` | The merged configuration for the target's `transport`. | This function returns the merged configuration for a target's transport. This includes defaults, configuration set in a `bolt.yaml`, configuration set `inventory.yaml`, and configuration set in a plan using `set_config()`.|
+| `transport_config` | `Hash[String, Data]` | The merged configuration for the target's `transport`. | This function returns the merged configuration for a target's transport. This includes defaults, configuration set in `inventory.yaml`, configuration set in `bolt-defaults.yaml`, and configuration set in a plan using `set_config()`.|
 | `uri` | `String` | The target's URI. ||
 | `user` | `String` | The user to connect to the target. ||
 | `vars` | `Hash[String, Data]` | The target's variables. ||

--- a/documentation/getting_started_with_bolt.md
+++ b/documentation/getting_started_with_bolt.md
@@ -33,24 +33,22 @@ After you've completed this guide, you'll know how to:
 
 ## Create a Bolt project and set up targets
 
-A Bolt project is a directory containing a `bolt.yaml` file. The `bolt.yaml`
+A Bolt project is a directory containing a `bolt-project.yaml` file. The `bolt-project.yaml`
 file contains project-wide configuration settings. Your `my_project` directory
-must contain a `bolt.yaml` file so that Bolt recognizes it as a Bolt project.
+must contain a `bolt-project.yaml` file so that Bolt recognizes it as a Bolt project.
 
 ### Create a Bolt project directory
 
-Use the `bolt project init` command to create a project directory named
-`my_project`:
 
+Create a directory named my_project:
 ```bash
-bolt project init ./my_project
+mkdir my_project
 ```
 
-Listing the contents of `my_project` shows a `bolt.yaml` file:
-
+In your my_project directory, create a file named bolt-project.yaml with the following contents:
 ```bash
-$ ls my_project
-bolt.yaml
+# my_project/bolt-project.yaml
+name: my_project
 ```
 
 To use Bolt plans or tasks, your Bolt project must use a specific directory
@@ -69,7 +67,7 @@ mkdir -p site-modules/apache/files
 After creating the directories, the file structure of `my_project` looks like this:
 ```bash
 .
-├── bolt.yaml
+├── bolt-project.yaml
 └── site-modules
     └── apache
         ├── files
@@ -133,7 +131,7 @@ structure looks like this:
 ```bash
 .
 ├── Dockerfile
-├── bolt.yaml
+├── bolt-project.yaml
 ├── docker-compose.yaml
 └── site-modules
     └── apache
@@ -234,7 +232,7 @@ At this point, your file structure looks like this:
 ```bash
 .
 ├── Dockerfile
-├── bolt.yaml
+├── bolt-project.yaml
 ├── docker-compose.yaml
 ├── inventory.yaml
 └── site-modules
@@ -294,7 +292,7 @@ After creating `install.yaml`, your file structure looks like this:
 ```bash
 .
 ├── Dockerfile
-├── bolt.yaml
+├── bolt-project.yaml
 ├── docker-compose.yaml
 ├── inventory.yaml
 └── site-modules
@@ -377,7 +375,7 @@ At this point, your file structure looks like this:
 ```bash
 .
 ├── Dockerfile
-├── bolt.yaml
+├── bolt-project.yaml
 ├── docker-compose.yaml
 ├── inventory.yaml
 └── site-modules
@@ -467,7 +465,7 @@ Your final file structure looks like this:
 ```bash
 .
 ├── Dockerfile
-├── bolt.yaml
+├── bolt-project.yaml
 ├── docker-compose.yaml
 ├── inventory.yaml
 └── site-modules
@@ -576,5 +574,5 @@ homepage.
   tasks](./tasks.md).
 - To find Puppet modules that use tasks, take a look at the [Puppet
   Forge](https://forge.puppet.com/).
-- For information on the settings you can use in `bolt.yaml`, see [Bolt
-  configuration options](./bolt_configuration_reference.md).
+- For information on Bolt configuration see [Configuring Bolt](configuring_bolt.md).
+- For information on Bolt projects see [Bolt project directories](bolt_project_directories.md)

--- a/documentation/inventory_file_v2.md
+++ b/documentation/inventory_file_v2.md
@@ -376,7 +376,7 @@ config:
       field: password
 ```
 
-The `bolt.yaml` configuration file:
+The `bolt-project.yaml` configuration file:
 
 ```yaml
 plugins:

--- a/documentation/running_bolt_commands.md
+++ b/documentation/running_bolt_commands.md
@@ -355,8 +355,7 @@ target.
 
 If the host target runs Linux, the target runs Windows, and your network uses
 Kerberos for authentication, you can specify a Kerberos realm in your
-`bolt.yaml` file. This file is introduced in the [Configuring
-Bolt](configuring_bolt.md) section below. The best source of information and
+[inventory file](inventory_file_v2.md). The best source of information and
 examples for this advanced topic is the [Kerberos
 section](https://github.com/puppetlabs/bolt/blob/main/developer-docs/kerberos.md)
 of the Bolt developer documentation.

--- a/documentation/running_bolt_from_docker_image.md
+++ b/documentation/running_bolt_from_docker_image.md
@@ -18,7 +18,7 @@ docker pull puppet/puppet-bolt
 When running Bolt from the container, the `localhost` target is the container
 environment (not the Docker host environment). The following example shows
 running a command against the localhost target in the container.
-```console
+```
 $ docker run puppet/puppet-bolt command run 'cat /etc/os-release' -t localhost
 Started on localhost...
 Finished on localhost:
@@ -66,7 +66,7 @@ targets:
 Here is an example of running the built-in `facts` task against the target
 listed in inventory. 
 
-```console
+```
 $ docker run --env "BOLT_INVENTORY=$(cat Boltdir/inventory.yaml)" puppet/puppet-bolt task run facts -t docker-example
 Started on pnz2rzpxfzp95hh.delivery.puppetlabs.net...
 Finished on pnz2rzpxfzp95hh.delivery.puppetlabs.net:
@@ -89,11 +89,11 @@ Ran on 1 target in 0.55 seconds
 
 This section describes making a Bolt project directory (Boltdir) available to
 the container. Here is the directory structure and relevant file content:
-```console
+```
 $ tree
 .
 └── Boltdir
-    ├── bolt.yaml
+    ├── bolt-project.yaml
     ├── inventory.yaml
     ├── keys
     │   └── id_rsa-acceptance
@@ -105,7 +105,7 @@ $ tree
 5 directories, 4 files
 ```
 
-**`bolt.yaml`**
+📄 `bolt-project.yaml`
 
 Bolt configuration file
 ```yaml
@@ -114,7 +114,8 @@ log:
   console:
     level: notice
 ```
-**`inventory.yaml`**
+
+📄 `inventory.yaml`
 
 Store information about targets. Note the absolute path to the private key is
 the path in the container, not on the host.
@@ -132,11 +133,11 @@ targets:
         host-key-check: false
 ```
 
-**`init.sh`**
+📄 `init.sh`
 
 Here is a sample shell task that echoes a `message` parameter:
 
-```shell script
+```bash
 #!/bin/bash
 echo "Message: ${PT_message}"
 ```
@@ -144,7 +145,7 @@ echo "Message: ${PT_message}"
 To execute the task with Docker and provide all the information from the Bolt
 project directory, mount the Boltdir on the host:
 
-```shell script
+```
 $ docker run --mount type=bind,source=/home/cas/working_dir/docker_bolt/Boltdir,destination=/Boltdir puppet/puppet-bolt task run docker_task message=hi -t docker-example
 Started on pnz2rzpxfzp95hh.delivery.puppetlabs.net...
 Finished on pnz2rzpxfzp95hh.delivery.puppetlabs.net:
@@ -161,11 +162,11 @@ invocation is all native to Bolt.
 
 ## Building on top of the puppet-bolt image
 
-```console
+```
 cas@cas-ThinkPad-T460p:~/working_dir/docker_bolt$ tree
 .
 └── Boltdir
-    ├── bolt.yaml
+    ├── bolt-project.yaml
     ├── Dockerfile
     ├── inventory.yaml
     ├── keys
@@ -182,9 +183,9 @@ You can also extend the puppet-bolt image and copy in data that will always be
 available for that image. To illustrate this, you can add a Dockerfile with the
 following content (with the directory structure defined above):
 
-**`Dockerfile`**
+📄 `Dockerfile`
 
-```Dockerfile
+```
 FROM puppet/puppet-bolt
 
 COPY . /Boltdir
@@ -193,7 +194,7 @@ COPY . /Boltdir
 This command builds a container image with our custom module content and tags it
 `my-extended-puppet-bolt`:
 
-```shell script
+```
 $ docker build . -t my-extended-puppet-bolt
 Sending build context to Docker daemon  10.75kB
 Step 1/2 : FROM puppet-bolt
@@ -207,7 +208,7 @@ Successfully tagged my-extended-puppet-bolt:latest
 You can now run that container with the custom module content and connection
 information available inside the container:
 
-```shell script
+```
 $ docker run my-extended-puppet-bolt task run docker_task message=hi -t docker-example
 Started on pnz2rzpxfzp95hh.delivery.puppetlabs.net...
 Finished on pnz2rzpxfzp95hh.delivery.puppetlabs.net:

--- a/documentation/running_bolt_in_docker.md
+++ b/documentation/running_bolt_in_docker.md
@@ -99,7 +99,7 @@ typical Boltdir:
 $ tree
 .
 └── Boltdir
-     ├── bolt.yaml
+     ├── bolt-project.yaml
      ├── inventory.yaml
      ├── keys
      │    └── id_rsa-acceptance
@@ -113,9 +113,9 @@ $ tree
 
 Here is sample content from relevant files in the Boltdir above.
 
-**`bolt.yaml`**
+**`bolt-project.yaml`**
 
-This is a basic Bolt configuration file.
+This is a basic [project configuration](configuring_bolt.md) file.
 
 ```yaml
 log:
@@ -179,7 +179,7 @@ Boltdir:
 $ tree
     .
     └── Boltdir
-          ├── bolt.yaml
+          ├── bolt-project.yaml
           ├── Dockerfile
           ├── inventory.yaml
           ├── keys

--- a/documentation/troubleshooting.md
+++ b/documentation/troubleshooting.md
@@ -15,7 +15,7 @@ example, if your task is named `mytask.rb`, you must name your metadata file
 
 ## My task fails mysteriously
 
-Try running Bolt with `--debug` to see the exact output from your task.
+Try running Bolt with `--log-level debug` to see the exact output from your task.
 
 Make sure your task executable starts with a shebang (`#!`) line indicating the
 interpreter to use and verify that the executable is present on the target
@@ -42,8 +42,14 @@ If you can connect to the host over SSH outside Bolt, you can store the SSH host
 key fingerprint with `ssh-keyscan hostname.example.com >> ~/.ssh/known_hosts`.
 
 You can disable this check entirely with `--no-host-key-check` on the CLI or the
-`host-key-check: false` option under the `ssh` section of `bolt.yaml`. Note that
-doing so will reduce the security of your SSH connection.
+`host-key-check: false` option under the `config: ssh` section of [inventory.yaml](inventory_file_v2.md).
+Note that doing so will reduce the security of your SSH connection.
+
+```yaml
+config:
+  ssh:
+    host-key-check: false
+```
 
 ### Timeout or connection refused
 
@@ -81,8 +87,8 @@ If you need to send a message that is not a string value or is in an apply
 block, you can use the `warning` Puppet log function. 
 
 If you only wish to see the output in the console when executing your plan with
-the `--debug` flag, use the `notice` Puppet log function. The `notice` function
-sets the console log level to `debug` for that run.
+the `--log-level debug` flag, use the `notice` Puppet log function. The `notice` function sets the
+console log level to `debug` for that run.
 
 For more information, see the docs for configuring [Bolt's log
 level](https://puppet.com/docs/bolt/latest/bolt_configuration_options.html#log-file-configuration-options).

--- a/documentation/writing_plans.md
+++ b/documentation/writing_plans.md
@@ -739,12 +739,11 @@ to the log file.
 
 ### Puppet log functions
 
-To generate log messages from a plan, use the Puppet log function that
-corresponds to the level you want to track: `error`, `warn`, `notice`, `info`,
-or `debug`. Configure the log level for both log files and console logging in
-`bolt.yaml`. The default log level for the console is `warn` and for log files
-is `notice`. Use the `--debug` flag to set the console log level to `debug` for
-a single run.
+To generate log messages from a plan, use the Puppet log function that corresponds to the level you
+want to track: `error`, `warn`, `notice`, `info`, or `debug`. Configure the log level for both log
+files and console logging in `bolt-project.yaml`.  The default log level for the console is `warn`.
+For log files, the default is `notice`.  Use the `--log-level debug` flag to set the console log
+level to `debug` for a single run.
 
 ### Default action logging
 

--- a/documentation/writing_plugins.md
+++ b/documentation/writing_plugins.md
@@ -12,8 +12,8 @@ Puppet library.
 
 ## Configuration
 
-Plugins can use configuration from the `bolt.yaml` file. To allow a plugin to be
-configured, add a `parameters` section to the [task
+Plugins can use configuration from the `bolt-project.yaml` or `bolt-defaults.yaml` files. To allow a
+plugin to be configured, add a `parameters` section to the [task
 metadata](writing_tasks.md#task-metadata).
 
 ```json


### PR DESCRIPTION
This modifies the documentation to prefer bolt-project.yaml,
bolt-defaults.yaml, and inventory.yaml over bolt.yaml. This mostly
includes instructing users to create a `bolt-project.yaml` instead of a
`bolt.yaml` file to create a Bolt project (both of which work at this
time), and specifying which file certain configuration options should
belong it. It doesn't update the documented default files or remove
bolt.yaml documentation, as bolt.yaml is still technically default and
has not been removed.

Closes #1841

!no-release-note