### PR TITLE
(GH-2038) Add YAML plan message step

### DIFF
--- a/documentation/writing_yaml_plans.md
+++ b/documentation/writing_yaml_plans.md
@@ -71,11 +71,28 @@ failed.
 
 Steps use these fields:
 
--   `name`: A unique name that can be used to refer to the result of the step
-    later
+-   `name`: (Optional) A unique name that can be used to refer to the result of
+    the step later.
 -   `description`: (Optional) An explanation of what the step is doing.
 
 Other available keys depend on the type of step.
+
+#### Message step
+
+Use a `message` step to print a message. This will print a message to `stdout`
+when using the `human` output format, and print to `stderr` when using the
+`json` output format.
+
+Message steps use a single field:
+
+-   `message`: The message to print
+
+For example:
+
+```yaml
+steps:
+  - message: hello world
+```
 
 #### Command step
 

--- a/lib/bolt/pal/yaml_plan/evaluator.rb
+++ b/lib/bolt/pal/yaml_plan/evaluator.rb
@@ -108,6 +108,10 @@ module Bolt
           apply_manifest(scope, targets, manifest)
         end
 
+        def message_step(scope, step)
+          scope.call_function('out::message', step['message'])
+        end
+
         def generate_manifest(resources)
           # inspect returns the Ruby representation of the resource hashes,
           # which happens to be the same as the Puppet representation

--- a/lib/bolt/pal/yaml_plan/step.rb
+++ b/lib/bolt/pal/yaml_plan/step.rb
@@ -12,7 +12,19 @@ module Bolt
           Set['name', 'description', 'target', 'targets']
         end
 
-        STEP_KEYS = %w[command script task plan source destination eval resources upload download].freeze
+        STEP_KEYS = %w[
+          command
+          destination
+          download
+          eval
+          message
+          plan
+          resources
+          script
+          source
+          task
+          upload
+        ].freeze
 
         def self.create(step_body, step_number)
           type_keys = (STEP_KEYS & step_body.keys)
@@ -165,3 +177,4 @@ require 'bolt/pal/yaml_plan/step/script'
 require 'bolt/pal/yaml_plan/step/task'
 require 'bolt/pal/yaml_plan/step/upload'
 require 'bolt/pal/yaml_plan/step/download'
+require 'bolt/pal/yaml_plan/step/message'

--- a/lib/bolt/pal/yaml_plan/step/message.rb
+++ b/lib/bolt/pal/yaml_plan/step/message.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Bolt
+  class PAL
+    class YamlPlan
+      class Step
+        class Message < Step
+          def self.allowed_keys
+            super + Set['message']
+          end
+
+          def self.required_keys
+            Set['message']
+          end
+
+          def initialize(step_body)
+            super
+            @message = step_body['message']
+          end
+
+          def transpile
+            code = String.new("  ")
+            code << function_call('out::message', [@message])
+            code << "\n"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/bolt/pal/yaml_plan/evaluator_spec.rb
+++ b/spec/bolt/pal/yaml_plan/evaluator_spec.rb
@@ -182,6 +182,19 @@ describe Bolt::PAL::YamlPlan::Evaluator do
     end
   end
 
+  describe "#message_step" do
+    let(:step) do
+      {
+        'message' => 'hello world'
+      }
+    end
+
+    it 'calls out::message' do
+      expect(scope).to receive(:call_function).with('out::message', 'hello world')
+      subject.message_step(scope, step)
+    end
+  end
+
   describe "#task_step" do
     let(:step) do
       { 'task' => 'package',

--- a/spec/bolt/pal/yaml_plan/step_spec.rb
+++ b/spec/bolt/pal/yaml_plan/step_spec.rb
@@ -12,6 +12,19 @@ describe Bolt::PAL::YamlPlan::Step do
       Bolt::PAL::YamlPlan::BareString.new(str)
     end
 
+    context 'with message step' do
+      let(:step_body) do
+        {
+          "message" => make_string("hello world")
+        }
+      end
+      let(:output) { "  out::message('hello world')\n" }
+
+      it 'stringifies a message step' do
+        expect(step.transpile).to eq(output)
+      end
+    end
+
     context 'with command step' do
       let(:step_body) do
         { "command" => make_string("echo peanut butter"),

--- a/spec/bolt/pal/yaml_plan_spec.rb
+++ b/spec/bolt/pal/yaml_plan_spec.rb
@@ -155,7 +155,7 @@ describe Bolt::PAL::YamlPlan do
         expect { plan }.to raise_error do |error|
           expect(error.kind).to eq('bolt/invalid-plan')
           expect(error.message).to match(/Parse error in step "foo-bar"/)
-          expect(error.message).to match(/Multiple action keys detected: \["task", "eval"\]/)
+          expect(error.message).to match(/Multiple action keys detected: \["eval", "task"\]/)
         end
       end
 


### PR DESCRIPTION
This adds a YAML plan message step that prints a message. Messages are
printed to `stdout` when using the `human` output format and `stderr`
when using the `json` output format.

!feature

* **YAML plan message step**
  ([#2038](https://github.com/puppetlabs/bolt/issues/2038))

  YAML plans now support a message step that prints a message.