### PR TITLE
(maint) Bump service module to include enable feature

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -5,7 +5,7 @@ forge "http://forge.puppetlabs.com"
 moduledir File.join(File.dirname(__FILE__), 'modules')
 
 # Core modules used by 'apply'
-mod 'puppetlabs-service', '1.2.0'
+mod 'puppetlabs-service', '1.3.0'
 mod 'puppetlabs-puppet_agent', '3.2.0'
 mod 'puppetlabs-facts', '1.0.0'
 


### PR DESCRIPTION
This bumps the puppetlabs-service module to 1.3.0 to include the
'enable' and 'disable' actions.

!feature

* **Service task now supports 'enable' and 'disable' when available**

  The builtin Bolt service task now supports 'enable' and 'disable' for
  agentless targets if the actions are available on the target.