### PR TITLE
(GH-2032) Document using Puppet Forge modules in YAML plans

### DIFF
--- a/documentation/applying_manifest_blocks.md
+++ b/documentation/applying_manifest_blocks.md
@@ -43,7 +43,8 @@ task](https://forge.puppet.com/puppetlabs/puppet_agent) to install the agent.
 
 ### Applying manifest files
 
-To apply Puppet code from an existing manifest file, use the `bolt apply` command and specify the absolute path to the manifest file:
+To apply Puppet code from an existing manifest file, use the `bolt apply`
+command and specify the absolute path to the manifest file:
 
 ```shell
 $ bolt apply ~/bolt/site-modules/profiles/manifests/server.pp -t target1,target2
@@ -125,10 +126,19 @@ Successful on 2 targets: target1,target2
 Ran on 2 targets in 8.42 sec
 ```
 
-## Applying manifest blocks from a plan
+## Applying Puppet code from Puppet Forge modules in a YAML plan
 
-In addition to the `bolt apply` command, you can apply manifest blocks to remote
-systems during plan execution using the `apply` function.
+In addition to the `bolt apply` command, you can apply Puppet code from a
+module downloaded from the Puppet Forge in a YAML plan. To apply Puppet
+code in a YAML plan, use the YAML plan `resources` step.
+
+To learn more about applying Puppet code in YAML plans, see [Writing YAML
+plans](writing_yaml_plans.md#applying-puppet-code-from-puppet-forge-modules).
+
+## Applying manifest blocks from a Puppet plan
+
+You can apply manifest blocks to remote systems during execution of a Puppet
+plan using the `apply` function.
 
 Manifest blocks require facts to compile. If your plan includes a manifest
 block, use the `apply_prep` function in your plan _before_ your manifest block.

--- a/documentation/writing_yaml_plans.md
+++ b/documentation/writing_yaml_plans.md
@@ -557,6 +557,54 @@ When your plans need more sophisticated control flow or error handling beyond
 running a list of steps in order, it's time to convert them to [Puppet language
 plans](writing_plans.md#).
 
+## Applying Puppet code from Puppet Forge modules
+
+Modules downloaded from the Puppet Forge often include Puppet code that you can
+use to simplify your workflow. The Puppet code in these modules can be applied
+to targets from a YAML plan using the [resources step](#resources-step).
+
+For example, if you wanted to install and configure Apache and MySQL on a group
+of targets, you could download the
+[apache](https://forge.puppet.com/puppetlabs/apache) and
+[mysql](https://forge.puppet.com/puppetlabs/mysql) modules and apply the
+`apache` and `mysql::server` classes to the targets with a resources step. You
+can invoke a class as part of a resources step by using the syntax `class:
+classname`.
+
+The following YAML plan accepts a list of targets and then installs and
+configures Apache and MySQL using classes from the `apache` and `mysql`
+modules:
+
+```yaml
+description: Install and configure Apache and MySQL
+
+parameters:
+  targets:
+    type: TargetSpec
+    description: The targets to configure
+
+steps:
+  - description: Install and configure Apache and MySQL
+    name: configure
+    targets: $targets
+    resources:
+      - class: apache
+      - class: mysql::server
+
+return: $configure
+```
+
+Puppet code included in modules often accepts parameters. To set parameters,
+add a map of parameter names and values under the `parameters` key for a
+specific resource.
+
+```yaml
+- class: apache
+  parameters:
+    user: apache
+    manage_user: false
+```
+
 ## Converting YAML plans to Puppet language plans
 
 You can convert a YAML plan to a Puppet language plan with the `bolt plan


### PR DESCRIPTION
This adds a section to the 'Writing YAML plans' docs that describes how
to use Puppet code from a module in a YAML plan. It also adds a link to
this section in the 'Applying Puppet manifests' doc.

Closes #2032 

!no-release-note