### PR TITLE
(bug) Catch existing file errors when downloading files

### DIFF
--- a/documentation/running_bolt_commands.md
+++ b/documentation/running_bolt_commands.md
@@ -152,7 +152,8 @@ was downloaded from. The target directory names are URL-encoded to ensure
 that they are valid directory names.
 
 For example, the following command downloads the SSH daemon configuration 
-file from two targets, `linux` and `ssh://example.com`:
+file from two targets, `linux` and `ssh://example.com`, and saves it to the
+destination directory `sshd_config`:
 
 ```shell
 $ bolt file download /etc/ssh/sshd_config sshd_config --targets linux,ssh://example.com
@@ -166,12 +167,11 @@ $ tree
 .
 ├── bolt-project.yaml
 ├── inventory.yaml
-└── downloads/
-    └── sshd_config/
-        ├── linux/
-        │   └── sshd_config
-        └── ssh%3A%2F%2Fexample.com/
-            └── sshd_config
+└── sshd_config/
+    ├── linux/
+    │   └── sshd_config
+    └── ssh%3A%2F%2Fexample.com/
+        └── sshd_config
 ```
 
 > 🔩 **Tip:** To avoid URL encoding the target's safe name, give the target a

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -322,7 +322,13 @@ module Bolt
 
     def download_file(targets, source, destination, options = {})
       description = options.fetch(:description, "file download from #{source} to #{destination}")
-      FileUtils.mkdir_p(destination)
+
+      begin
+        FileUtils.mkdir_p(destination)
+      rescue Errno::EEXIST => e
+        message = "#{e.message}; unable to create destination directory #{destination}"
+        raise Bolt::Error.new(message, 'bolt/file-exist-error')
+      end
 
       log_action(description, targets) do
         options[:run_as] = run_as if run_as && !options.key?(:run_as)


### PR DESCRIPTION
This catches existing file errors that are raised when creating the
destination directory for file downloads in the
`Bolt::Executor#download_file` method. Previously, if any portion of the
destination directory was an existing file, Bolt would error and emit a
backtrace. This catches those errors and adds additional information
that the destination directory could not be created.

Any similar errors raised when files are being downloaded by the
individual transports are already caught and handled by the transport.

!bug

* **Handle existing file errors when downloading files**

  Bolt now handles existing file errors raised when creating the
  destination directory for file downloads. Previously, if a file
  already existed somewhere on the destination directory path, Bolt
  would raise an error with a full backtrace.