### PR TITLE
(GH-2012) Print objects using out::message

### DIFF
--- a/bolt-modules/out/lib/puppet/functions/out/message.rb
+++ b/bolt-modules/out/lib/puppet/functions/out/message.rb
@@ -12,7 +12,7 @@ Puppet::Functions.create_function(:'out::message') do
   # @example Print a message
   #   out::message('Something went wrong')
   dispatch :output_message do
-    param 'String', :message
+    param 'Any', :message
     return_type 'Undef'
   end
 

--- a/lib/bolt/outputter.rb
+++ b/lib/bolt/outputter.rb
@@ -21,6 +21,62 @@ module Bolt
       @trace = trace
       @stream = stream
     end
+
+    def indent(indent, string)
+      indent = ' ' * indent
+      string.gsub(/^/, indent.to_s)
+    end
+
+    def print_message_event(event)
+      print_message(stringify(event[:message]))
+    end
+
+    def print_message
+      raise NotImplementedError, "print_message() must be implemented by the outputter class"
+    end
+
+    def stringify(message)
+      formatted = format_message(message)
+      if formatted.is_a?(Hash) || formatted.is_a?(Array)
+        ::JSON.pretty_generate(formatted)
+      else
+        formatted
+      end
+    end
+
+    def format_message(message)
+      case message
+      when Array
+        message.map { |item| format_message(item) }
+      when Bolt::ApplyResult
+        format_apply_result(message)
+      when Bolt::Result, Bolt::ResultSet
+        # This is equivalent to to_s, but formattable
+        message.to_data
+      when Bolt::RunFailure
+        formatted_resultset = message.result_set.to_data
+        message.to_h.merge('result_set' => formatted_resultset)
+      when Hash
+        message.each_with_object({}) do |(k, v), h|
+          h[format_message(k)] = format_message(v)
+        end
+      when Integer, Float, NilClass
+        message
+      else
+        message.to_s
+      end
+    end
+
+    def format_apply_result(result)
+      logs = result.resource_logs&.map do |log|
+        # Omit low-level info/debug messages
+        next if %w[info debug].include?(log['level'])
+        indent(2, format_log(log))
+      end
+      hash = result.to_data
+      hash['logs'] = logs unless logs.empty?
+      hash
+    end
   end
 end
 

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -27,11 +27,6 @@ module Bolt
         end
       end
 
-      def indent(indent, string)
-        indent = ' ' * indent
-        string.gsub(/^/, indent.to_s)
-      end
-
       def remove_trail(string)
         string.sub(/\s\z/, '')
       end
@@ -370,10 +365,6 @@ module Bolt
         else
           @stream.puts(colorize(:red, "Failed to sync modules from #{puppetfile} to #{moduledir}"))
         end
-      end
-
-      def print_message_event(event)
-        print_message(event[:message])
       end
 
       def fatal_error(err)

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -121,10 +121,6 @@ module Bolt
         @stream.puts '}' if @object_open
       end
 
-      def print_message_event(event)
-        print_message(event[:message])
-      end
-
       def print_message(message)
         $stderr.puts(message)
       end

--- a/spec/bolt/outputter/outputter_spec.rb
+++ b/spec/bolt/outputter/outputter_spec.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/outputter'
+require 'bolt/cli'
+
+describe "Bolt::Outputter" do
+  let(:output) { StringIO.new }
+  let(:outputter) { Bolt::Outputter.new(false, false, false, output) }
+
+  let(:inventory) { Bolt::Inventory.empty }
+  let(:target) { inventory.get_target('target1') }
+  let(:target2) { inventory.get_target('target2') }
+
+  let(:result) { Bolt::Result.new(target, message: "ok", action: 'action') }
+  let(:err_result) { Bolt::Result.new(target2, error: { 'msg' => 'oops' }, action: 'action') }
+  let(:result_set) { Bolt::ResultSet.new([result, err_result]) }
+  let(:apply_result) { Bolt::ApplyResult.new(target, report: { 'status' => 'changed' }) }
+
+  let(:error) { Bolt::Error.new("Task 'watermelon' could not be found", 'bolt/apply-prep') }
+
+  let(:resource) { Bolt::ResourceInstance.new(resource_data) }
+  let(:resource_data) do
+    {
+      'target'        => target,
+      'type'          => 'File',
+      'title'         => '/etc/puppetlabs/',
+      'state'         => { 'ensure' => 'present' },
+      'desired_state' => { 'ensure' => 'absent' },
+      'events'        => [{ 'audited' => false }]
+    }
+  end
+
+  it "formats result sets" do
+    expect(outputter.stringify(result_set))
+      .to eq(<<~RESULT_SET.chomp)
+      [
+        {
+          "target": "target1",
+          "action": "action",
+          "object": null,
+          "status": "success",
+          "value": {
+            "_output": "ok"
+          }
+        },
+        {
+          "target": "target2",
+          "action": "action",
+          "object": null,
+          "status": "failure",
+          "value": {
+            "_error": {
+              "msg": "oops"
+            }
+          }
+        }
+      ]
+    RESULT_SET
+  end
+
+  it "formats a result" do
+    expect(outputter.stringify(result))
+      .to eq(<<~RESULT.chomp)
+      {
+        "target": "target1",
+        "action": "action",
+        "object": null,
+        "status": "success",
+        "value": {
+          "_output": "ok"
+        }
+      }
+    RESULT
+  end
+
+  it "formats an apply result" do
+    expect(outputter.stringify(apply_result))
+      .to eq(<<~APPLY_RESULT.chomp)
+    {
+      "target": "target1",
+      "action": "apply",
+      "object": null,
+      "status": "success",
+      "value": {
+        "report": {
+          "status": "changed"
+        }
+      }
+    }
+    APPLY_RESULT
+  end
+
+  it "formats resource instances" do
+    expect(outputter.stringify(resource))
+      .to eq("File[/etc/puppetlabs/]")
+  end
+
+  it "formats errors" do
+    expect(outputter.stringify(error))
+      .to eq("Task 'watermelon' could not be found")
+  end
+
+  it "formats targets" do
+    expect(outputter.stringify(target))
+      .to eq("target1")
+  end
+
+  it "formats arrays of complex objects" do
+    expect(outputter.stringify([target, result_set, ['subarray']]))
+      .to eq(<<~ARRAY.chomp)
+   [
+     "target1",
+     [
+       {
+         "target": "target1",
+         "action": "action",
+         "object": null,
+         "status": "success",
+         "value": {
+           "_output": "ok"
+         }
+       },
+       {
+         "target": "target2",
+         "action": "action",
+         "object": null,
+         "status": "failure",
+         "value": {
+           "_error": {
+             "msg": "oops"
+           }
+         }
+       }
+     ],
+     [
+       "subarray"
+     ]
+   ]
+   ARRAY
+  end
+
+  it "formats hashes of complex objects" do
+    expect(outputter.stringify({ target => /regex/, 'hello' => result }))
+      .to eq(<<~HASH.chomp)
+    {
+      "target1": "(?-mix:regex)",
+      "hello": {
+        "target": "target1",
+        "action": "action",
+        "object": null,
+        "status": "success",
+        "value": {
+          "_output": "ok"
+        }
+      }
+    }
+    HASH
+  end
+
+  it "formats unhandled objects as strings" do
+    expect(outputter.stringify(/regexp/))
+      .to eq('(?-mix:regexp)')
+  end
+end


### PR DESCRIPTION
This allows users to pass any data type to the `out::message()` plan
function and send it to the configured outputter for printing. This
adds a formatting function to the outputter that all messages pass
through, which formats known Bolt datatypes and classes nicely for
readable printing. Any unhandled types are stringified and passed to the
outputter. Printing is still left entirely to the outputter, but
formatting is shared among all outputter that inherit from the base
outputter class `Bolt::Outputter`. This ensures a consistent experience
across outputters.

Closes #2012

!feature

* **Print objects using out::message()** ([#2012](https://github.com/puppetlabs/bolt/issues/2012))

  Users can now print any valid data type using the plan function
  `out::message()`.