### PR TITLE
(GH-2025) Do not modify order of plan variables in catalog compilation

### DIFF
--- a/spec/bolt/catalog_spec.rb
+++ b/spec/bolt/catalog_spec.rb
@@ -45,7 +45,9 @@ describe Bolt::Catalog do
       'target' => {
         'name' => uri,
         'facts' => {},
-        'variables' => {},
+        'variables' => {
+          'roles' => %w[foo bar]
+        },
         'trusted' => {
           'authenticated' => 'local',
           'certname' => uri,
@@ -82,7 +84,9 @@ describe Bolt::Catalog do
           }
         },
         "facts" => {},
-        "vars" => {},
+        "vars" => {
+          "roles" => %w[foo bar]
+        },
         "features" => [],
         "plugin_hooks" => {},
         "resources" => {}
@@ -138,6 +142,31 @@ describe Bolt::Catalog do
         'plan_vars'  => plan_vars
       )
       expect { catalog.compile_catalog(request) }.not_to raise_error
+    end
+
+    # This test checks that the order of plan_vars is not modified
+    # when merging with target_vars during catalog compilation.
+    # Plan vars may have local references to other plan vars. Because
+    # variables are deserialized in the order they appear in a hash,
+    # changing the order of plan variables may result in Puppet being
+    # unable to deserialize them, since a local reference may appear
+    # before the variable it references.
+    it 'does not change the order of plan_vars' do
+      plan_vars.merge!(
+        'roles' => {
+          '__ptype'  => 'LocalRef',
+          '__pvalue' => "$['t1'][0]['vars']['roles']"
+        }
+      )
+
+      request.merge!('plan_vars' => plan_vars)
+
+      allow(Puppet::Pal).to receive(:in_tmp_environment) do |_type, env_conf|
+        expect(env_conf[:variables].to_a).to eq(plan_vars.to_a)
+        expect(env_conf[:variables]['roles']).to eq(plan_vars['roles'])
+      end
+
+      catalog.compile_catalog(request)
     end
   end
 end


### PR DESCRIPTION
This fixes a bug in catalog compilation that was caused by modifying the
order of plan variables in the catalog request. This bug was caused by
the following conditions being met:

- A plan variable has the same name as a target variable
- The plan variable references the same complex data as a variable that
was listed earlier in the plan (for example, it references a target's
config)

When Puppet serializes data with local references, it replaces any
repeated, complex data with a local reference. Then, when this data is
deserialized, Puppet will examine the variables in order and resolve any
local references it comes across. If a local reference appears before
the data it references, Puppet will be unable to resolve the reference
and will raise an error.

In short, Puppet expects that any data that has
been serialized will only create local references for data that appeared
earlier, and that during deserialization any local references will only
reference data that has already been resolved/deserialized.

When Bolt prepares to compile a catalog request, it first shadows any
variable conflicts between target facts, plan variables, and target
variables. After shadowing conflicts, Bolt then merges plan variables
into the target variables. Because of the way Ruby merges two hashes,
any variables that exist in the target hash will be replaced by
similarly-named plan variables, and then any additional variables will
be appended to the end of the hash. This results in any plan variables
with local references being placed 'higher up' in order than any plan
variable it references.

Now, instead of simply merging target and plan variables, Bolt will
first remove any conflicting target variables from the variables hash,
then merge in the plan variables. This results in the order of the plan
variables being maintained.

!bug

* **Do not modify order of plan variables in catalog compilation**
  ([#2025](https://github.com/puppetlabs/bolt/issues/2025))

  Bolt will no longer error during catalog compilation when a plan
  variable shares the same name as a target variable. Previously, Bolt
  would modify the order plan variables were listed in a catalog if they
  shared the name of a target variable, causing catalog compilation to
  fail when deserializing variables.