### PR TITLE
(PE-29834) Do not rely on initializing Bolt::Logger for class methods

### DIFF
--- a/lib/bolt/logger.rb
+++ b/lib/bolt/logger.rb
@@ -15,7 +15,6 @@ module Bolt
       return if Logging.initialized?
 
       Logging.init :debug, :info, :notice, :warn, :error, :fatal, :any
-      @mutex = Mutex.new
 
       Logging.color_scheme(
         'bolt',
@@ -105,6 +104,7 @@ module Bolt
     end
 
     def self.warn_once(type, msg)
+      @mutex ||= Mutex.new
       @mutex.synchronize {
         @warnings ||= []
         @logger ||= Logging.logger[self]


### PR DESCRIPTION
Previously the mutex used for warn_once relied on calling the initialize_logging method which contains logging configuration specific to bolt. This commit move the mutex to the warn_once class method so that it can be used without having to have called the bolt-specific initialize_logging method.