### PR TITLE
(docs) Add available values for options to configuration references

### DIFF
--- a/documentation/templates/bolt_configuration_reference.md.erb
+++ b/documentation/templates/bolt_configuration_reference.md.erb
@@ -16,6 +16,9 @@ The `bolt.yaml` configuration file is supported in all [project directories](con
 <%= data[:description] %>
 
 - **Type:** <%= data[:type] %>
+<% if data.key?(:enum) -%>
+- **Available values:** `<%= data[:enum].join('`, `') %>`
+<% end -%>
 <% if data.key?(:_default) -%>
 - **Default:** <%= data[:_default] %>
 <% end -%>
@@ -27,6 +30,9 @@ The `bolt.yaml` configuration file is supported in all [project directories](con
 <%= data[:description] %>
 
 - **Type:** <%= data[:type] %>
+<% if data.key?(:enum) -%>
+- **Available values:** `<%= data[:enum].join('`, `') %>`
+<% end -%>
 <% if data.key?(:_default) -%>
 - **Default:** <%= data[:_default] %>
 <% end -%>

--- a/documentation/templates/bolt_defaults_reference.md.erb
+++ b/documentation/templates/bolt_defaults_reference.md.erb
@@ -11,6 +11,9 @@ which is supported in both the [system-wide and user-level configuration directo
 <%= data[:description] %>
 
 - **Type:** <%= data[:type] %>
+<% if data.key?(:enum) -%>
+- **Available values:** `<%= data[:enum].join('`, `') %>`
+<% end -%>
 <% if data.key?(:_default) -%>
 - **Default:** <%= data[:_default] %>
 <% end -%>
@@ -25,6 +28,9 @@ sub-options, see [Transport configuration reference](bolt_transports_reference.m
 <%= data[:description] %>
 
 - **Type:** <%= data[:type] %>
+<% if data.key?(:enum) -%>
+- **Available values:** `<%= data[:enum].join('`, `') %>`
+<% end -%>
 <% if data.key?(:_default) -%>
 - **Default:** <%= data[:_default] %>
 <% end %>

--- a/documentation/templates/bolt_project_reference.md.erb
+++ b/documentation/templates/bolt_project_reference.md.erb
@@ -14,6 +14,9 @@ which is supported in the [project directory](configuring_bolt.md).
 <%= data[:description] %>
 
 - **Type:** <%= data[:type] %>
+<% if data.key?(:enum) -%>
+- **Available values:** `<%= data[:enum].join('`, `') %>`
+<% end -%>
 <% if data.key?(:_default) -%>
 - **Default:** <%= data[:_default] %>
 <% end -%>
@@ -25,6 +28,9 @@ which is supported in the [project directory](configuring_bolt.md).
 <%= data[:description] %>
 
 - **Type:** <%= data[:type] %>
+<% if data.key?(:enum) -%>
+- **Available values:** `<%= data[:enum].join('`, `') %>`
+<% end -%>
 <% if data.key?(:_default) -%>
 - **Default:** <%= data[:_default] %>
 <% end -%>

--- a/documentation/templates/bolt_transports_reference.md.erb
+++ b/documentation/templates/bolt_transports_reference.md.erb
@@ -30,6 +30,9 @@ to targets. These options can be set in multiple locations:
 <% if data.key?(:type) -%>
 - **Type:** <%= data[:type] %>
 <% end -%>
+<% if data.key?(:enum) -%>
+- **Available values:** `<%= data[:enum].join('`, `') %>`
+<% end -%>
 <% if data.key?(:_default) -%>
 - **Default:** <%= data[:_default] %>
 <% end -%>
@@ -70,6 +73,9 @@ ssh:
 
 <% if data.key?(:type) -%>
 - **Type:** <%= data[:type] %>
+<% end -%>
+<% if data.key?(:enum) -%>
+- **Available values:** `<%= data[:enum].join('`, `') %>`
 <% end -%>
 <% if data.key?(:_default) -%>
 - **Default:** <%= data[:_default] %>


### PR DESCRIPTION
This adds 'Available values' to the configuration reference pages for
every option that has a restricted list of available values, which is
indicated by the presence of the `:enum` key in the configuration
options hash.

!no-release-note