### PR TITLE
(GH-2003) 'bolt project init' now creates bolt-project.yaml

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -420,19 +420,18 @@ module Bolt
           init
 
       USAGE
-          bolt project init [directory] [options]
+          bolt project init [name] [options]
 
       DESCRIPTION
-          Create a new Bolt project.
+          Create a new Bolt project in the current working directory.
 
-          Specify a directory to create a Bolt project in. Defaults to the
-          curent working directory.
+          Specify a name for the Bolt project. Defaults to the basename of the current working directory.
 
       EXAMPLES
-          Create a new Bolt project in the current working directory.
+          Create a new Bolt project using the directory as the project name.
             bolt project init
-          Create a new Bolt project at a specified path.
-            bolt project init ~/path/to/project
+          Create a new Bolt project with a specified name.
+            bolt project init myproject
           Create a new Bolt project with existing modules.
             bolt project init --modules puppetlabs-apt,puppetlabs-ntp
     HELP

--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -141,8 +141,10 @@ module Bolt
     def validate
       if name
         if name !~ Bolt::Module::MODULE_NAME_REGEX
-          raise Bolt::ValidationError, "Invalid project name #{name.inspect.tr('"', "'")} in bolt-project.yaml; "\
-                                       "project name must match #{Bolt::Module::MODULE_NAME_REGEX.inspect}"
+          raise Bolt::ValidationError, <<~ERROR_STRING
+          Invalid project name '#{name}' in bolt-project.yaml; project name must begin with a lowercase letter
+          and can include lowercase letters, numbers, and underscores.
+          ERROR_STRING
         elsif Dir.children(Bolt::PAL::BOLTLIB_PATH).include?(name)
           raise Bolt::ValidationError, "The project '#{name}' will not be loaded. The project name conflicts "\
             "with a built-in Bolt module of the same name."

--- a/pwsh_module/command.tests.ps1
+++ b/pwsh_module/command.tests.ps1
@@ -200,18 +200,6 @@ Describe "test all bolt command examples" {
       $result = Get-BoltPlan
       $result | Should -Be "bolt plan show"
     }
-    It "bolt project init" {
-      $result = New-BoltProject
-      $result | Should -Be "bolt project init"
-    }
-    It "bolt project init ~/path/to/project" {
-      $result = New-BoltProject -Directory '~/path/to/project'
-      $result | Should -Be "bolt project init '~/path/to/project'"
-    }
-    It "bolt project init --modules puppetlabs-apt,puppetlabs-ntp" {
-      $result = New-BoltProject -modules 'puppetlabs-apt,puppetlabs-ntp'
-      $result | Should -Be "bolt project init --modules 'puppetlabs-apt,puppetlabs-ntp'"
-    }
   }
 
   Context "bolt project" {
@@ -219,9 +207,17 @@ Describe "test all bolt command examples" {
       $result = Update-BoltProject
       $result | Should -Be "bolt project migrate"
     }
-    It "bolt project migrate 'foo'" {
-      $result = Update-BoltProject -directory 'foo'
-      $result | Should -Be "bolt project migrate 'foo'"
+    It "bolt project init" {
+      $result = New-BoltProject
+      $result | Should -Be "bolt project init"
+    }
+    It "bolt project init myproject" {
+      $result = New-BoltProject -name 'myproject'
+      $result | Should -Be "bolt project init 'myproject'"
+    }
+    It "bolt project init --modules puppetlabs-apt,puppetlabs-ntp" {
+      $result = New-BoltProject -modules 'puppetlabs-apt,puppetlabs-ntp'
+      $result | Should -Be "bolt project init --modules 'puppetlabs-apt,puppetlabs-ntp'"
     }
   }
 

--- a/rakelib/pwsh.rake
+++ b/rakelib/pwsh.rake
@@ -200,11 +200,11 @@ namespace :pwsh do
             validate_not_null_or_empty: true
           }
         when 'project'
-          # bolt project init [directory] [options]
+          # bolt project init [name] [options]
           @pwsh_command[:options] << {
-            name:                       'Directory',
-            ruby_short:                 'd',
-            help_msg:                   'The directory to turn into a Bolt project',
+            name:                       'Name',
+            ruby_short:                 'n',
+            help_msg:                   'The name of the Bolt project to create',
             mandatory:                  false,
             type:                       'string',
             switch:                     false,


### PR DESCRIPTION
This PR modernizes the behavior for the `bolt project init` command in a
few ways:

- Previously, `bolt project init` with no arguments would create an
  empty `bolt.yaml`file in the current working directory. It now creates
  a file `bolt-project.yaml` in the current working directory, with the
  content:
  ```
  ---
  name: <cwd_basename>
  ```
  where `cwd_basename` is the name of the directory.
- Previously the command took an optional argument `[directory]` with a
  path to where to create the project. The command no longer accepts the
  directory as an argument. It instead has an optional argument `[name]`
  which specifies the name of the project.
  ```
  $ bolt project init myproject
  $ cat bolt-project.yaml
  ---
  name: myproject
  ```
- If `bolt-project.yaml` or `bolt.yaml` exist, we warn and do not modify the file even if it
  has no content
- All module installation behavior is the same.

Closes #2003

!feature

* **'bolt project init' now creates bolt-project.yaml** ([#2003](https://github.com/puppetlabs/bolt/issues/2003))

  `bolt project init` now creates a `bolt-project.yaml` file instead of
  `bolt.yaml`. It additionally accepts a project name, and no longer
  accepts a directory to the project to create.