### PR TITLE
(GH-2004) Add 'bolt plan new' CLI command

### DIFF
--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -327,3 +327,46 @@ To encrypt SSH connections using the unsupported algorithm
 > option to shell out to SSH. See [the net-ssh
 > README](https://github.com/net-ssh/net-ssh/#supported-algorithms) for a list of supported
 > algorithms.
+
+## `bolt plan new` command
+
+This feature was introduced in [Bolt
+2.22.0](https://github.com/puppetlabs/bolt/blob/main/CHANGELOG.md#bolt-2220-2020-08-10).
+
+Use the `bolt plan new` command to generate a new project-level YAML plan.
+The command accepts a single argument: the name of the plan. To use the `bolt
+plan new` command, you must have a named [Bolt project](projects.md).
+
+### Naming plans
+
+The plan name is used to identify and call the plan from the Bolt command line
+or from other plans. Plan names are composed of one or more name segments
+separated by a double colon `::`.
+
+Each plan name segment must begin with a lowercase letter, and may only include
+lowercase letters, digits, and underscores.
+
+Additionally, the first name segment of any plan created with `bolt plan new`
+must match the name of the project itself. For example, given a project named
+`myproject`, the following plan names are valid:
+
+- `myproject`
+- `myproject::myplan`
+- `myproject::my_plan`
+
+And the following plan names are invalid:
+
+- `myplan`
+- `myproject::MyPlan`
+- `myproject::1_myplan`
+- `myproject::my-plan`
+
+#### `init` plans
+
+Plan names that match the project name will create a special `init` plan.
+For example, if you have a project named `myproject` and run the command
+`bolt plan new myproject`, a plan will be created at
+`<project>/plans/init.yaml`.
+
+You can reference the `init` plan using the project's name. For example,
+you would run this plan using `bolt plan run myproject`.

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -66,6 +66,9 @@ module Bolt
         when 'convert'
           { flags: OPTIONS[:global] + OPTIONS[:global_config_setters],
             banner: PLAN_CONVERT_HELP }
+        when 'new'
+          { flags: OPTIONS[:global] + %w[configfile project],
+            banner: PLAN_NEW_HELP }
         when 'run'
           { flags: ACTION_OPTS + %w[params compile-concurrency tmpdir hiera-config],
             banner: PLAN_RUN_HELP }
@@ -159,10 +162,10 @@ module Bolt
       SUBCOMMANDS
           apply             Apply Puppet manifest code
           command           Run a command remotely
-          file              Upload a local file or directory
+          file              Copy files between the controller and targets
           group             Show the list of groups in the inventory
           inventory         Show the list of targets an action would run on
-          plan              Convert, show, and run Bolt plans
+          plan              Convert, create, show, and run Bolt plans
           project           Create and migrate Bolt projects
           puppetfile        Install and list modules and generate type references
           script            Upload a local script and run it remotely
@@ -319,10 +322,11 @@ module Bolt
           bolt plan <action> [parameters] [options]
 
       DESCRIPTION
-          Convert, show, and run Bolt plans.
+          Convert, create, show, and run Bolt plans.
 
       ACTIONS
           convert       Convert a YAML plan to a Bolt plan
+          new           Create a new plan in the current project
           run           Run a plan on the specified targets
           show          Show available plans and plan documentation
     HELP
@@ -343,6 +347,20 @@ module Bolt
 
       EXAMPLES
           bolt plan convert path/to/plan/myplan.yaml
+    HELP
+
+    PLAN_NEW_HELP = <<~HELP
+      NAME
+          new
+      
+      USAGE
+          bolt plan new <plan> [options]
+      
+      DESCRIPTION
+          Create a new plan in the current project.
+
+      EXAMPLES
+          bolt plan new myproject::myplan
     HELP
 
     PLAN_RUN_HELP = <<~HELP

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -31,7 +31,7 @@ module Bolt
     COMMANDS = { 'command' => %w[run],
                  'script' => %w[run],
                  'task' => %w[show run],
-                 'plan' => %w[show run convert],
+                 'plan' => %w[show run convert new],
                  'file' => %w[download upload],
                  'puppetfile' => %w[install show-modules generate-types],
                  'secret' => %w[encrypt decrypt createkeys],
@@ -283,6 +283,10 @@ module Bolt
         raise Bolt::CLIError, "Must specify a value to #{options[:action]}"
       end
 
+      if options[:subcommand] == 'plan' && options[:action] == 'new' && !options[:object]
+        raise Bolt::CLIError, "Must specify a plan name."
+      end
+
       if options.key?(:debug) && options.key?(:log)
         raise Bolt::CLIError, "Only one of '--debug' or '--log-level' may be specified"
       end
@@ -350,11 +354,8 @@ module Bolt
       # Initialize inventory and targets. Errors here are better to catch early.
       # options[:target_args] will contain a string/array version of the targetting options this is passed to plans
       # options[:targets] will contain a resolved set of Target objects
-      unless options[:subcommand] == 'puppetfile' ||
-             options[:subcommand] == 'secret' ||
-             options[:subcommand] == 'project' ||
-             options[:action] == 'show' ||
-             options[:action] == 'convert'
+      unless %w[project puppetfile secret].include?(options[:subcommand]) ||
+             %w[convert new show].include?(options[:action])
         update_targets(options)
       end
 
@@ -429,7 +430,12 @@ module Bolt
           code = migrate_project
         end
       when 'plan'
-        code = run_plan(options[:object], options[:task_options], options[:target_args], options)
+        case options[:action]
+        when 'new'
+          code = new_plan(options[:object])
+        when 'run'
+          code = run_plan(options[:object], options[:task_options], options[:target_args], options)
+        end
       when 'puppetfile'
         case options[:action]
         when 'generate-types'
@@ -547,6 +553,118 @@ module Bolt
     def list_groups
       groups = inventory.group_names
       outputter.print_groups(groups)
+    end
+
+    def new_plan(plan_name)
+      @logger.warn("Command 'bolt plan new' is experimental and subject to changes.")
+
+      if config.project.name.nil?
+        raise Bolt::Error.new(
+          "Project directory '#{config.project.path}' is not a named project. Unable to create "\
+          "a project-level plan. To name a project, set the 'name' key in the 'bolt-project.yaml' "\
+          "configuration file.",
+          "bolt/unnamed-project-error"
+        )
+      end
+
+      if plan_name !~ Bolt::Module::CONTENT_NAME_REGEX
+        message = <<~MESSAGE.chomp
+          Invalid plan name '#{plan_name}'. Plan names are composed of one or more name segments
+          separated by double colons '::'.
+          
+          Each name segment must begin with a lowercase letter, and may only include lowercase
+          letters, digits, and underscores.
+          
+          Examples of valid plan names:
+              - #{config.project.name}
+              - #{config.project.name}::my_plan
+        MESSAGE
+
+        raise Bolt::ValidationError, message
+      end
+
+      prefix, *name_segments, basename = plan_name.split('::')
+
+      # If the plan name is just the project name, then create an 'init' plan.
+      # Otherwise, use the last name segment for the plan's filename.
+      basename ||= 'init'
+
+      unless prefix == config.project.name
+        message = "First segment of plan name '#{plan_name}' must match project name '#{config.project.name}'. "\
+                  "Did you mean '#{config.project.name}::#{plan_name}'?"
+
+        raise Bolt::ValidationError, message
+      end
+
+      dir_path = config.project.plans_path.join(*name_segments)
+
+      %w[pp yaml].each do |ext|
+        next unless (path = config.project.plans_path + "#{basename}.#{ext}").exist?
+        raise Bolt::Error.new(
+          "A plan with the name '#{plan_name}' already exists at '#{path}', nothing to do.",
+          'bolt/existing-plan-error'
+        )
+      end
+
+      begin
+        FileUtils.mkdir_p(dir_path)
+      rescue Errno::EEXIST => e
+        raise Bolt::Error.new(
+          "#{e.message}; unable to create plan directory '#{dir_path}'",
+          'bolt/existing-file-error'
+        )
+      end
+
+      plan_path = dir_path + "#{basename}.yaml"
+
+      plan_template = <<~PLAN
+        # This is the structure of a simple plan. To learn more about writing
+        # YAML plans, see the documentation: http://pup.pt/bolt-yaml-plans
+
+        # The description sets the description of the plan that will appear
+        # in 'bolt plan show' output.
+        description: A plan created with bolt plan new
+
+        # The parameters key defines the parameters that can be passed to
+        # the plan.
+        parameters:
+          targets:
+            type: TargetSpec
+            description: A list of targets to run actions on
+            default: localhost
+
+        # The steps key defines the actions the plan will take in order.
+        steps:
+          - message: Hello from #{plan_name}
+          - name: command_step
+            command: whoami
+            targets: $targets
+
+        # The return key sets the return value of the plan.
+        return: $command_step
+      PLAN
+
+      begin
+        File.write(plan_path, plan_template)
+      rescue Errno::EACCES => e
+        raise Bolt::FileError.new(
+          "#{e.message}; unable to create plan",
+          plan_path
+        )
+      end
+
+      output = <<~OUTPUT
+        Created plan '#{plan_name}' at '#{plan_path}'
+
+        Show this plan with:
+            bolt plan show #{plan_name}
+        Run this plan with:
+            bolt plan run #{plan_name}
+      OUTPUT
+
+      outputter.print_message(output)
+
+      0
     end
 
     def run_plan(plan_name, plan_arguments, nodes, options)

--- a/lib/bolt/module.rb
+++ b/lib/bolt/module.rb
@@ -3,7 +3,8 @@
 # Is this Bolt::Pobs::Module?
 module Bolt
   class Module
-    MODULE_NAME_REGEX = /\A[a-z][a-z0-9_]*\z/.freeze
+    CONTENT_NAME_REGEX = /\A[a-z][a-z0-9_]*(::[a-z][a-z0-9_]*)*\z/.freeze
+    MODULE_NAME_REGEX  = /\A[a-z][a-z0-9_]*\z/.freeze
 
     def self.discover(modulepath)
       modulepath.each_with_object({}) do |path, mods|

--- a/pwsh_module/command.tests.ps1
+++ b/pwsh_module/command.tests.ps1
@@ -34,7 +34,7 @@ Describe "test bolt module" {
 
     it "has the correct number of exported functions" {
       # should count of pwsh functions plus legacy `bolt` function
-      @($commands).Count | Should -Be 21
+      @($commands).Count | Should -Be 22
     }
   }
 }
@@ -188,6 +188,10 @@ Describe "test all bolt command examples" {
       Write-Warning 'requires params to not be positionl...is that a problem'
       $result = Invoke-BoltPlan -name 'canary' -targets 'target1,target2' -params @{ 'command' = 'hostname' }
       $result | Should -Be "bolt plan run 'canary' --targets 'target1,target2' --params '{`"command`":`"hostname`"}'"
+    }
+    It "bolt plan new myproject::myplan" {
+      $result = New-BoltPlan -name 'myproject::myplan'
+      $result | Should -Be "bolt plan new 'myproject::myplan'"
     }
   }
 

--- a/rakelib/pwsh.rake
+++ b/rakelib/pwsh.rake
@@ -19,7 +19,8 @@ namespace :pwsh do
       'run'        => 'Invoke',
       'show'       => 'Get',
       'upload'     => 'Send', # deploy? publish?
-      'download'   => 'Receive'
+      'download'   => 'Receive',
+      'new'        => 'New'
     }
 
     @hardcoded_cmdlets = {
@@ -148,10 +149,11 @@ namespace :pwsh do
           # bolt plan show [plan] [options]
           # bolt plan run <plan> [parameters] [options]
           # bolt plan convert <path> [options]
+          # bolt plan new <plan> [options]
           @pwsh_command[:options] << {
             name:                       'Name',
             ruby_short:                 'n',
-            help_msg:                   "The plan to #{action}",
+            help_msg:                   "The plan to #{action == 'new' ? 'create' : action}",
             type:                       'string',
             switch:                     false,
             mandatory:                  false,

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -89,6 +89,167 @@ describe "Bolt::CLI" do
     end
   end
 
+  context 'plan new' do
+    let(:project_name) { 'project' }
+    let(:config)       { { 'name' => project_name } }
+    let(:project_path) { @project_dir }
+    let(:config_path)  { File.join(project_path, 'bolt-project.yaml') }
+    let(:command)      { %W[plan new #{plan_name}] }
+    let(:cli)          { Bolt::CLI.new(command) }
+    let(:plan_name)    { project_name }
+    let(:project)      { Bolt::Project.create_project(project_path) }
+
+    around(:each) do |example|
+      Dir.mktmpdir(nil, Dir.pwd) do |dir|
+        @project_dir = dir
+        example.run
+      end
+    end
+
+    before(:each) do
+      File.write(config_path, config.to_yaml)
+      allow(Bolt::Project).to receive(:create_project).and_return(project)
+    end
+
+    it 'errors without a plan name' do
+      cli = Bolt::CLI.new(%w[plan new])
+
+      expect { cli.parse }.to raise_error(
+        Bolt::CLIError,
+        /Must specify a plan name/
+      )
+    end
+
+    it 'calls #new_plan' do
+      allow(cli).to receive(:new_plan).and_return(0)
+      expect(cli).to receive(:new_plan).with(plan_name)
+      cli.execute(cli.parse)
+    end
+
+    describe '#new_plan' do
+      it 'errors without a named project' do
+        allow(project).to receive(:name).and_return(nil)
+        cli.parse
+
+        expect { cli.new_plan(plan_name) }.to raise_error(
+          Bolt::Error,
+          /Project directory '.*' is not a named project/
+        )
+      end
+
+      it 'errors when the plan name is invalid' do
+        cli.parse
+
+        %w[Foo foo-bar foo:: foo::Bar foo::1bar ::foo].each do |plan_name|
+          expect { cli.new_plan(plan_name) }.to raise_error(
+            Bolt::ValidationError,
+            /Invalid plan name '#{plan_name}'/
+          )
+        end
+      end
+
+      it 'errors if the first name segment is not the project name' do
+        plan_name = 'plan'
+        cli.parse
+
+        expect { cli.new_plan(plan_name) }.to raise_error(
+          Bolt::ValidationError,
+          /First segment of plan name '#{plan_name}' must match project name/
+        )
+      end
+
+      %w[pp yaml].each do |ext|
+        it "errors if there is an existing #{ext} plan with the same name" do
+          plan_path = File.join(project_path, 'plans', "init.#{ext}")
+          FileUtils.mkdir(File.dirname(plan_path))
+          FileUtils.touch(plan_path)
+
+          cli.parse
+
+          expect { cli.new_plan(plan_name) }.to raise_error(
+            Bolt::Error,
+            /A plan with the name '#{plan_name}' already exists/
+          )
+        end
+      end
+
+      it "creates a missing 'plans' directory" do
+        cli.parse
+        expect(Dir.exist?(project.plans_path)).to eq(false)
+        cli.new_plan(plan_name)
+        expect(Dir.exist?(project.plans_path)).to eq(true)
+      end
+
+      it 'creates a missing directory structure' do
+        plan_name = "#{project_name}::foo::bar"
+        cli.parse
+        expect(Dir.exist?(project.plans_path + 'foo')).to eq(false)
+        cli.new_plan(plan_name)
+        expect(Dir.exist?(project.plans_path + 'foo')).to eq(true)
+      end
+
+      it 'catches existing file errors when creating directories' do
+        plan_name = "#{project_name}::foo::bar"
+        FileUtils.mkdir(File.join(project_path, 'plans'))
+        FileUtils.touch(File.join(project_path, 'plans', 'foo'))
+
+        cli.parse
+
+        expect { cli.new_plan(plan_name) }.to raise_error(
+          Bolt::Error,
+          /unable to create plan directory/
+        )
+      end
+
+      it "creates an 'init' plan when the plan name matches the project name" do
+        cli.parse
+        cli.new_plan(plan_name)
+
+        plan_path = project.plans_path + 'init.yaml'
+
+        expect(File.exist?(plan_path)).to eq(true)
+      end
+
+      it 'creates a plan' do
+        plan_name = "#{project_name}::foo"
+
+        cli.parse
+        cli.new_plan(plan_name)
+
+        plan_path = project.plans_path + 'foo.yaml'
+
+        expect(File.size?(plan_path)).to be
+      end
+
+      it 'outputs the path to the plan and other helpful information' do
+        cli.parse
+
+        allow(cli.outputter).to receive(:print_message) do |output|
+          expect(output).to match(
+            /Created plan '#{plan_name}' at '#{project.plans_path + 'init.yaml'}'/
+          )
+          expect(output).to match(
+            /bolt plan show #{plan_name}/
+          )
+          expect(output).to match(
+            /bolt plan run #{plan_name}/
+          )
+        end
+
+        cli.new_plan(plan_name)
+      end
+
+      it "warns that 'plan new' is experimental" do
+        cli.parse
+        cli.new_plan(plan_name)
+
+        expect(@log_output.readlines).to include(
+          /Command 'bolt plan new' is experimental/
+        )
+      end
+    end
+  end
+
   context "without a config file" do
     let(:project) { Bolt::Project.new({}, '.') }
     before(:each) do


### PR DESCRIPTION
This adds a new `bolt plan new` command for generating a project-level
YAML plan. The command accepts a single argument, the name of the plan
that should be generated. If the given name is a valid plan name, and
the plan does not yet exist, Bolt will generate the necessary
directories under `<project>/plans` as well as the YAML plan file. Bolt
will then display the path to the plan, as well as commands to show and
run the plan.

The generated plan includes a single parameter and a couple simple plan
steps, comments describing each portion of the plan, and a link to the
'Writing YAML plans' documentation. The intent behind the generated plan
is to show users the structure of a YAML plan and provide helpful
information to get started with writing a plan.

This also fixes a bug where multi-line strings could be accepted as
project names, due to incorrect anchors in the regex (`^/$` instead of
`\A/\z`).

!feature

* **Create new project-level YAML plans with `bolt plan new`**
  ([#2004](#2004))

  Users can now quickly get started with writing a new project-level
  YAML plan using the `bolt plan new` command. The command accepts a
  single argument, the name of the plan to be generated, and creates the
  necessary directories and file in the project's `plans` directory.

  > **Note:** This feature is experimental and is subject to changes.

!bug

* **Reject multi-line project names**

  Previously, Bolt would accept a multi-line string as a project name,
  causing multiple errors. Bolt will now reject multi-line strings as
  project names.

Closes #2004 