### PR TITLE
(maint) Report screen_view for `bolt plan convert` command

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -358,11 +358,6 @@ module Bolt
         update_targets(options)
       end
 
-      if options[:action] == 'convert'
-        convert_plan(options[:object])
-        return 0
-      end
-
       screen = "#{options[:subcommand]}_#{options[:action]}"
       # submit a different screen for `bolt task show` and `bolt task show foo`
       if options[:action] == 'show' && options[:object]
@@ -413,6 +408,9 @@ module Bolt
         return 0
       when 'show-modules'
         list_modules
+        return 0
+      when 'convert'
+        convert_plan(options[:object])
         return 0
       end
 


### PR DESCRIPTION
Previously, the code for this command was executing and exiting *before*
the point where we would send a data point about its invocation to
google analytics. That meant it appeared that nobody had ever used this
command. We now fold it into an existing case expression after the
analytics report has been sent.

!no-release-note