### PR TITLE
(maint) Add name segment regex constant in Bolt::Project

### DIFF
--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -7,6 +7,9 @@ require 'bolt/pal'
 module Bolt
   class Project
     BOLTDIR_NAME = 'Boltdir'
+
+    NAME_SEGMENT_REGEX = /\A[a-z][a-z0-9_]*\Z/.freeze
+
     PROJECT_SETTINGS = {
       "name"  => "The name of the project",
       "plans" => "An array of plan names to show, if they exist in the project."\
@@ -138,10 +141,9 @@ module Bolt
 
     def validate
       if name
-        name_regex = /^[a-z][a-z0-9_]*$/
-        if name !~ name_regex
+        if name !~ NAME_SEGMENT_REGEX
           raise Bolt::ValidationError, <<~ERROR_STRING
-          Invalid project name '#{name}' in bolt-project.yaml; project name must match #{name_regex.inspect}
+          Invalid project name '#{name}' in bolt-project.yaml; project name must match #{NAME_SEGMENT_REGEX.inspect}
           ERROR_STRING
         elsif Dir.children(Bolt::PAL::BOLTLIB_PATH).include?(name)
           raise Bolt::ValidationError, "The project '#{name}' will not be loaded. The project name conflicts "\


### PR DESCRIPTION
This moves the name segment regex `/^[a-z][a-z0-9_]*$/` to a constant in
the project class, `Bolt::Project::NAME_SEGMENT_REGEX`. It also updates
the regex to use `\A`/`\Z` in place of `^`/`$`, as the latter does not
properly match against multi-line strings.

!bug

* **Reject multi-line project names**

  Previously, Bolt would accept a multi-line string as a project name,
  causing multiple errors. Bolt will now reject multi-line strings as
  project names.