### PR TITLE
(maint) Configure new Rubocop cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -170,3 +170,44 @@ Layout/HashAlignment:
 Layout/SpaceAroundMethodCallOperator:
   Enabled: true
 
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
+
+Lint/DuplicateRescueException:
+  Enabled: true
+
+Lint/EmptyConditionalBody:
+  Enabled: true
+
+Lint/FloatComparison:
+  Enabled: true
+
+Lint/MissingSuper:
+  Enabled: false
+
+Lint/OutOfRangeRegexpRef:
+  Enabled: true
+
+Lint/SelfAssignment:
+  Enabled: true
+
+Lint/TopLevelReturnWithArgument:
+  Enabled: true
+
+Lint/UnreachableLoop:
+  Enabled: true
+
+Style/ExplicitBlockArgument:
+  Enabled: false
+
+Style/GlobalStdStream:
+  Enabled: true
+
+Style/OptionalBooleanParameter:
+  Enabled: false
+
+Style/SingleArgumentDig:
+  Enabled: false
+
+Style/StringConcatenation:
+  Enabled: false

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -694,9 +694,9 @@ module Bolt
         @options[:password] = password
       end
       define('--password-prompt', 'Prompt for user to input password') do |_password|
-        STDERR.print "Please enter your password: "
-        @options[:password] = STDIN.noecho(&:gets).chomp
-        STDERR.puts
+        $stderr.print "Please enter your password: "
+        @options[:password] = $stdin.noecho(&:gets).chomp
+        $stderr.puts
       end
       define('--private-key KEY', 'Path to private ssh key to authenticate with') do |key|
         @options[:'private-key'] = File.expand_path(key)
@@ -720,9 +720,9 @@ module Bolt
         @options[:'sudo-password'] = password
       end
       define('--sudo-password-prompt', 'Prompt for user to input escalation password') do |_password|
-        STDERR.print "Please enter your privilege escalation password: "
-        @options[:'sudo-password'] = STDIN.noecho(&:gets).chomp
-        STDERR.puts
+        $stderr.print "Please enter your privilege escalation password: "
+        @options[:'sudo-password'] = $stdin.noecho(&:gets).chomp
+        $stderr.puts
       end
       define('--sudo-executable EXEC', "Specify an executable for running as another user.",
              "This option is experimental.") do |exec|
@@ -905,7 +905,7 @@ module Bolt
         file = value.sub(/^@/, '')
         read_arg_file(file)
       elsif value == '-'
-        STDIN.read
+        $stdin.read
       else
         value
       end

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -381,19 +381,19 @@ module Bolt
     end
 
     def prompt(prompt, options)
-      unless STDIN.tty?
+      unless $stdin.tty?
         raise Bolt::Error.new('STDIN is not a tty, unable to prompt', 'bolt/no-tty-error')
       end
 
-      STDERR.print("#{prompt}: ")
+      $stderr.print("#{prompt}: ")
 
       value = if options[:sensitive]
-                STDIN.noecho(&:gets).to_s.chomp
+                $stdin.noecho(&:gets).to_s.chomp
               else
-                STDIN.gets.to_s.chomp
+                $stdin.gets.to_s.chomp
               end
 
-      STDERR.puts if options[:sensitive]
+      $stderr.puts if options[:sensitive]
 
       value
     end

--- a/lib/bolt/plugin/prompt.rb
+++ b/lib/bolt/plugin/prompt.rb
@@ -18,9 +18,9 @@ module Bolt
       end
 
       def resolve_reference(opts)
-        STDERR.print("#{opts['message']}: ")
-        value = STDIN.noecho(&:gets).to_s.chomp
-        STDERR.puts
+        $stderr.print("#{opts['message']}: ")
+        value = $stdin.noecho(&:gets).to_s.chomp
+        $stderr.puts
 
         value
       end

--- a/lib/bolt_spec/plans/action_stubs.rb
+++ b/lib/bolt_spec/plans/action_stubs.rb
@@ -177,7 +177,7 @@ module BoltSpec
         if data['msg'] && data['kind'] && (data.keys - %w[msg kind details issue_code]).empty?
           @data[:default] = clazz.new(data['msg'], data['kind'], data['details'], data['issue_code'])
         else
-          STDERR.puts "In the future 'error_with()' may require msg and kind, and " \
+          $stderr.puts "In the future 'error_with()' may require msg and kind, and " \
                       "optionally accept only details and issue_code."
           @data[:default] = data
         end

--- a/libexec/apply_catalog.rb
+++ b/libexec/apply_catalog.rb
@@ -9,7 +9,7 @@ require 'puppet/module_tool/tar'
 require 'securerandom'
 require 'tempfile'
 
-args = JSON.parse(ARGV[0] ? File.read(ARGV[0]) : STDIN.read)
+args = JSON.parse(ARGV[0] ? File.read(ARGV[0]) : $stdin.read)
 
 # Create temporary directories for all core Puppet settings so we don't clobber
 # existing state or read from puppet.conf. Also create a temporary modulepath.
@@ -110,7 +110,7 @@ ensure
   begin
     FileUtils.remove_dir(puppet_root)
   rescue Errno::ENOTEMPTY => e
-    STDERR.puts("Could not cleanup temporary directory: #{e}")
+    $stderr.puts("Could not cleanup temporary directory: #{e}")
   end
 end
 

--- a/libexec/bolt_catalog
+++ b/libexec/bolt_catalog
@@ -40,7 +40,7 @@ when "compile"
   request = if ARGV[1]
               File.open(ARGV[1]) { |fh| JSON.parse(fh.read) }
             else
-              JSON.parse(STDIN.read)
+              JSON.parse($stdin.read)
             end
   begin
     catalog = Bolt::Catalog.new.compile_catalog(request)

--- a/libexec/custom_facts.rb
+++ b/libexec/custom_facts.rb
@@ -6,7 +6,7 @@ require 'puppet'
 require 'puppet/module_tool/tar'
 require 'tempfile'
 
-args = JSON.parse(STDIN.read)
+args = JSON.parse($stdin.read)
 
 Dir.mktmpdir do |puppet_root|
   # Create temporary directories for all core Puppet settings so we don't clobber

--- a/libexec/query_resources.rb
+++ b/libexec/query_resources.rb
@@ -6,7 +6,7 @@ require 'puppet'
 require 'puppet/module_tool/tar'
 require 'tempfile'
 
-args = JSON.parse(STDIN.read)
+args = JSON.parse($stdin.read)
 
 RESOURCE_INSTANCE = /^([^\[]+)\[([^\]]+)\]$/.freeze
 

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -448,7 +448,7 @@ describe "Bolt::CLI" do
          bar
         NODES
         cli = Bolt::CLI.new(%w[command run uptime --targets -])
-        allow(STDIN).to receive(:read).and_return(nodes)
+        allow($stdin).to receive(:read).and_return(nodes)
         options = cli.parse
         cli.update_targets(options)
         expect(options[:targets]).to eq(targets)
@@ -588,9 +588,9 @@ describe "Bolt::CLI" do
 
     describe "password-prompt" do
       it "prompts the user for password" do
-        allow(STDIN).to receive(:noecho).and_return('opensesame')
-        allow(STDERR).to receive(:print).with('Please enter your password: ')
-        allow(STDERR).to receive(:puts)
+        allow($stdin).to receive(:noecho).and_return('opensesame')
+        allow($stderr).to receive(:print).with('Please enter your password: ')
+        allow($stderr).to receive(:puts)
         cli = Bolt::CLI.new(%w[command run uptime --targets foo --password-prompt])
         expect(cli.parse).to include(password: 'opensesame')
       end
@@ -796,9 +796,9 @@ describe "Bolt::CLI" do
 
     describe "sudo password-prompt" do
       it "prompts the user for escalation password" do
-        allow(STDIN).to receive(:noecho).and_return('opensesame')
-        allow(STDERR).to receive(:print).with('Please enter your privilege escalation password: ')
-        allow(STDERR).to receive(:puts)
+        allow($stdin).to receive(:noecho).and_return('opensesame')
+        allow($stderr).to receive(:print).with('Please enter your privilege escalation password: ')
+        allow($stderr).to receive(:puts)
         cli = Bolt::CLI.new(%w[command run uptime --targets foo --sudo-password-prompt])
         expect(cli.parse).to include('sudo-password': 'opensesame')
       end
@@ -968,7 +968,7 @@ describe "Bolt::CLI" do
       it "reads json from stdin when --params is just '-'" do
         json_args = '{"kj":"2hv","iuhg":"iube","2whf":"lcv"}'
         cli = Bolt::CLI.new(%w[plan run my::plan --params - --modulepath .])
-        allow(STDIN).to receive(:read).and_return(json_args)
+        allow($stdin).to receive(:read).and_return(json_args)
         result = cli.parse
         expect(result[:task_options]).to eq('kj' => '2hv',
                                             'iuhg' => 'iube',

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -482,24 +482,24 @@ describe "Bolt::Executor" do
     let(:response) { 'response' }
 
     it 'prompts for data on STDERR when executed' do
-      allow(STDIN).to receive(:tty?).and_return(true)
-      allow(STDIN).to receive(:gets).and_return(response)
-      expect(STDERR).to receive(:print).with("#{prompt}: ")
+      allow($stdin).to receive(:tty?).and_return(true)
+      allow($stdin).to receive(:gets).and_return(response)
+      expect($stderr).to receive(:print).with("#{prompt}: ")
 
       executor.prompt(prompt, {})
     end
 
     it 'does not show input when sensitive' do
-      allow(STDIN).to receive(:tty?).and_return(true)
-      allow(STDERR).to receive(:puts)
-      allow(STDERR).to receive(:print).with("#{prompt}: ")
-      expect(STDIN).to receive(:noecho).and_return(prompt)
+      allow($stdin).to receive(:tty?).and_return(true)
+      allow($stderr).to receive(:puts)
+      allow($stderr).to receive(:print).with("#{prompt}: ")
+      expect($stdin).to receive(:noecho).and_return(prompt)
 
       executor.prompt(prompt, sensitive: true)
     end
 
     it 'errors if STDIN is not a tty' do
-      allow(STDIN).to receive(:tty?).and_return(false)
+      allow($stdin).to receive(:tty?).and_return(false)
       expect { executor.prompt(prompt, {}) }.to raise_error(Bolt::Error, /STDIN is not a tty, unable to prompt/)
     end
   end

--- a/spec/bolt/plugin/prompt_spec.rb
+++ b/spec/bolt/plugin/prompt_spec.rb
@@ -14,9 +14,9 @@ describe Bolt::Plugin::Prompt do
   end
 
   it 'prompts for data on STDERR when executed' do
-    allow(STDIN).to receive(:noecho).and_return(password)
-    allow(STDERR).to receive(:puts)
-    expect(STDERR).to receive(:print).with("#{prompt_data['message']}: ")
+    allow($stdin).to receive(:noecho).and_return(password)
+    allow($stderr).to receive(:puts)
+    expect($stderr).to receive(:print).with("#{prompt_data['message']}: ")
 
     val = subject.resolve_reference(prompt_data)
     expect(val).to eq(password)

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -651,10 +651,10 @@ describe 'running with an inventory file', reset_puppet_settings: true do
     let(:shell_cmd) { 'whoami' }
 
     it 'sets a password from a prompt and only executes a single concurrent delay' do
-      allow(STDIN).to receive(:noecho).and_return('bolt').once
-      allow(STDERR).to receive(:puts)
+      allow($stdin).to receive(:noecho).and_return('bolt').once
+      allow($stderr).to receive(:puts)
 
-      expect(STDERR).to receive(:print).with("password please: ").once
+      expect($stderr).to receive(:print).with("password please: ").once
 
       result = run_one_node(['command', 'run', shell_cmd, '--targets', 'target-1'] + config_flags)
       expect(result).to include('stdout' => "bolt\n")


### PR DESCRIPTION
This configures several new Rubocop cops released in Rubocop 0.89. Only
a handful of cops actually impact existing Bolt code, namely:
- Lint/MissingSuper
- Style/ExplicitBlockArgument
- Style/GlobalStdStream
- Style/OptionalBooleanParameter
- Style/SingleArgumentDig
- Style/StringConcatenation

I disabled cops that didn't seem useful, or would require more than 5
minutes of code rewriting to silence. The only cop I left enabled that
resulted in code changes was `Style/GlobalStdStream`, which prefers
`$stdout` to `STDOUT`. I left all other cops that didn't impact existing
code enabled.

!no-release-note