### PR TITLE
(GH-2072) Add 'interval' option to 'ctrl::do_until' function

### DIFF
--- a/bolt-modules/ctrl/lib/puppet/functions/ctrl/do_until.rb
+++ b/bolt-modules/ctrl/lib/puppet/functions/ctrl/do_until.rb
@@ -4,30 +4,36 @@
 Puppet::Functions.create_function(:'ctrl::do_until') do
   # @param options A hash of additional options.
   # @option options [Numeric] limit The number of times to repeat the block.
+  # @option options [Numeric] interval The number of seconds to wait before repeating the block.
   # @example Run a task until it succeeds
   #   ctrl::do_until() || {
-  #     run_task('test', $target, _catch_errors => true).ok()
+  #     run_task('test', $target, '_catch_errors' => true).ok()
   #   }
-  #
   # @example Run a task until it succeeds or fails 10 times
   #   ctrl::do_until('limit' => 10) || {
-  #     run_task('test', $target, _catch_errors => true).ok()
+  #     run_task('test', $target, '_catch_errors' => true).ok()
   #   }
-  #
+  # @example Run a task and wait 10 seconds before running it again
+  #   ctrl::do_until('interval' => 10) || {
+  #     run_task('test', $target, '_catch_errors' => true).ok()
+  #   }
   dispatch :do_until do
     optional_param 'Hash[String[1], Any]', :options
     block_param
   end
 
-  def do_until(options = { 'limit' => 0 })
+  def do_until(options = {})
     # Send Analytics Report
     Puppet.lookup(:bolt_executor) {}&.report_function_call(self.class.name)
 
-    limit = options['limit']
+    limit = options['limit'] || 0
+    interval = options['interval']
+
     i = 0
     until (x = yield)
       i += 1
       break if limit != 0 && i >= limit
+      Kernel.sleep(interval) if interval
     end
     x
   end

--- a/bolt-modules/ctrl/spec/functions/ctrl/do_until_spec.rb
+++ b/bolt-modules/ctrl/spec/functions/ctrl/do_until_spec.rb
@@ -31,4 +31,25 @@ describe 'ctrl::do_until' do
     end.and_return("truthy"))
     expect(seq.length).to eq(1)
   end
+
+  it 'sleeps with an interval' do
+    Kernel.expects(:sleep).with(1).times(2)
+
+    is_expected.to(run.with_params('interval' => 1).with_lambda do
+      seq.pop
+    end.and_return('truthy'))
+
+    expect(seq.length).to eq(1)
+  end
+
+  it 'does not sleep if first value is truthy' do
+    seq << 'truthy'
+    Kernel.expects(:sleep).never
+
+    is_expected.to(run.with_params('interval' => 1).with_lambda do
+      seq.pop
+    end.and_return('truthy'))
+
+    expect(seq.length).to eq(4)
+  end
 end


### PR DESCRIPTION
This adds an `interval` option to the `ctrl::do_until` plan function. It
accepts a numeric value specifying the number of seconds to sleep
before repeating the block again.

Closes #2072 

!feature

* **Set interval for repeating block in `ctrl::do_until` plan function**
  ([#2072](https://github.com/puppetlabs/bolt/issues/2072))

  The `ctrl::do_until` plan function now accepts an `interval` option.
  This option accepts a numeric value that specifies the number of
  seconds to wait before repeating the block.