### PR TITLE
(maint) Do not set facts for script compiler scope

### DIFF
--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -151,7 +151,7 @@ module Bolt
         # Only load the project if it a) exists, b) has a name it can be loaded with
         Puppet.override(bolt_project: @project,
                         yaml_plan_instantiator: Bolt::PAL::YamlPlan::Loader) do
-          pal.with_script_compiler do |compiler|
+          pal.with_script_compiler(set_local_facts: false) do |compiler|
             alias_types(compiler)
             register_resource_types(Puppet.lookup(:loaders)) if @resource_types
             begin


### PR DESCRIPTION
This updates `Bolt::PAL#in_bolt_compiler` to set the `set_local_facts`
option for the script compiler to `false`. Setting this will disable
setting facts, trusted facts, and server facts in the script compiler's
scope.

Changes made to Puppet in puppetlabs/puppet#8063 updated the script
compiler to never set facts in the script compiler's scope. However,
this resulted in breaking changes to PAL's public API. The work in
puppetlabs/puppet#8268 reverses these changes and adds the
`set_local_facts` option to allow users to disable setting facts if they
wish. By default, `set_local_facts` is set to `true`.

!no-release-note