### PR TITLE
(bugfix) Don't remove Bolt modulepaths from the modulepath when listing

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -526,7 +526,7 @@ module Bolt
       tasks = pal.list_tasks
       tasks.select! { |task| task.first.include?(options[:filter]) } if options[:filter]
       tasks.select! { |task| config.project.tasks.include?(task.first) } unless config.project.tasks.nil?
-      outputter.print_tasks(tasks, pal.list_modulepath)
+      outputter.print_tasks(tasks, pal.user_modulepath)
     end
 
     def show_plan(plan_name)
@@ -537,7 +537,7 @@ module Bolt
       plans = pal.list_plans
       plans.select! { |plan| plan.first.include?(options[:filter]) } if options[:filter]
       plans.select! { |plan| config.project.plans.include?(plan.first) } unless config.project.plans.nil?
-      outputter.print_plans(plans, pal.list_modulepath)
+      outputter.print_plans(plans, pal.user_modulepath)
     end
 
     def list_targets

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -48,7 +48,7 @@ module Bolt
       end
     end
 
-    attr_reader :modulepath
+    attr_reader :modulepath, :user_modulepath
 
     def initialize(modulepath, hiera_config, resource_types, max_compiles = Etc.nprocessors,
                    trusted_external = nil, apply_settings = {}, project = nil)
@@ -56,7 +56,7 @@ module Bolt
       # is safe and in practice only happens in tests
       self.class.load_puppet
 
-      @original_modulepath = modulepath
+      @user_modulepath = modulepath
       @modulepath = [BOLTLIB_PATH, *modulepath, MODULES_PATH]
       @hiera_config = hiera_config
       @trusted_external = trusted_external
@@ -208,7 +208,7 @@ module Bolt
           # Skip syncing built-in plugins, since we vendor some Puppet 6
           # versions of "core" types, which are already present on the agent,
           # but may cause issues on Puppet 5 agents.
-          @original_modulepath,
+          @user_modulepath,
           @project,
           pdb_client,
           @hiera_config,
@@ -276,10 +276,6 @@ module Bolt
           end
         end
       end
-    end
-
-    def list_modulepath
-      @modulepath - [BOLTLIB_PATH, MODULES_PATH]
     end
 
     def parse_params(type, object_name, params)

--- a/lib/bolt_server/pe/pal.rb
+++ b/lib/bolt_server/pe/pal.rb
@@ -58,7 +58,7 @@ module BoltServer
           # Bolt::PAL::MODULES_PATH which would be more complex if we tried to use @modulepath since
           # we need to append our modulepaths and exclude modules shiped in bolt gem code
           modulepath_dirs = environment.modulepath
-          @original_modulepath = modulepath_dirs
+          @user_modulepath = modulepath_dirs
           @modulepath = [PE_BOLTLIB_PATH, Bolt::PAL::BOLTLIB_PATH, *modulepath_dirs]
         end
       end


### PR DESCRIPTION
When we print the modulepath for users when listing tasks or plans, we
previously would calculate the modulpath by subtracting the
Bolt-packaged modulepaths `boltlib` and `modules` from the full
modulepath. This erroneously removes `modules` from the modulepath if it
is listed in the user's path though, which is confusing. This modifies
the modulepath to be calculated from the original modulepath the user
supplied, so that any supplied modulepaths aren't incorrectly removed.

!bugfix

* **Include modules/ in displayed modulepath if it's in the user-configured modulepath**
    
  Bolt now includes `<bolt-installation-directory>/modules` in the displayed
  modulepath if the user has the path as a component of their configured
  modulepath. If installed as a package on *nix,
  bolt-installation-directory would be `/opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/bolt-x.y.z/`.