### PR TITLE
(bug) Return empty hash when analytics file is empty

### DIFF
--- a/lib/bolt/analytics.rb
+++ b/lib/bolt/analytics.rb
@@ -72,7 +72,7 @@ module Bolt
 
     def self.load_config(filename, logger)
       if File.exist?(filename)
-        YAML.load_file(filename)
+        Bolt::Util.read_optional_yaml_hash(filename, 'analytics')
       else
         unless ENV['BOLT_DISABLE_ANALYTICS']
           logger.warn <<~ANALYTICS

--- a/spec/bolt/analytics_spec.rb
+++ b/spec/bolt/analytics_spec.rb
@@ -6,13 +6,13 @@ require 'bolt/analytics'
 describe Bolt::Analytics do
   let(:default_config) { {} }
 
-  before :each do
+  before :each do |test|
     # We use a hard override to disable analytics for tests, but that obviously
     # interferes with these tests...
     ENV.delete('BOLT_DISABLE_ANALYTICS')
 
     # Ensure these tests will never read or write a local config
-    allow(subject).to receive(:load_config).and_return(default_config)
+    allow(subject).to receive(:load_config).and_return(default_config) unless test.metadata[:load_config]
     allow(subject).to receive(:write_config)
   end
 
@@ -94,6 +94,15 @@ describe Bolt::Analytics do
       subject.build_client
 
       expect(@log_output.readlines).to include(/Detected analytics configuration files/)
+    end
+
+    it 'returns an empty hash if config file is empty', :load_config do
+      logger = double('logger')
+      allow(logger).to receive(:warn)
+
+      Tempfile.create('analytics.yaml', Dir.pwd) do |file|
+        expect(subject.load_config(file, logger)).to eq({})
+      end
     end
   end
 end


### PR DESCRIPTION
When Bolt loads the anayltics config file, it uses the `YAML.load`
method. If the file is empty, or otherwise cannot be parsed as YAML,
this method returns `false`. This causes an error when Bolt checks the
loaded config for the `disabled` key, as the returned value is not a
hash.

This updates the `Bolt::Analytics.load_config` method to return an empty
hash when the analytics config file cannot be parsed as YAML.

!bug

* **Do not error when analytics configuration file is empty**

  Empty analytics configuration files would cause Bolt to raise a
  `NoMethodError`. Now, if an analytics configuration file is empty,
  Bolt will instead rewrite the file.