### PR TITLE
(GH-2051) Always set `bolt_project` Puppet setting

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/download_file.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/download_file.rb
@@ -96,7 +96,7 @@ Puppet::Functions.create_function(:download_file, Puppet::Functions::InternalFun
 
     # Paths expand relative to the default downloads directory for the project
     # e.g. ~/.puppetlabs/bolt/downloads/
-    destination = Puppet.lookup(:bolt_project_data).downloads + destination
+    destination = Puppet.lookup(:bolt_project).downloads + destination
 
     # If the destination directory already exists, delete any existing contents
     if Dir.exist?(destination)

--- a/bolt-modules/boltlib/spec/functions/download_file_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/download_file_spec.rb
@@ -16,7 +16,7 @@ describe 'download_file' do
 
   around(:each) do |example|
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor, bolt_inventory: inventory, bolt_project_data: project) do
+    Puppet.override(bolt_executor: executor, bolt_inventory: inventory, bolt_project: project) do
       inventory.stubs(:version).returns(2)
       inventory.stubs(:target_implementation_class).returns(Bolt::Target)
       example.run

--- a/bolt-modules/dir/lib/puppet/functions/dir/children.rb
+++ b/bolt-modules/dir/lib/puppet/functions/dir/children.rb
@@ -25,7 +25,7 @@ Puppet::Functions.create_function(:'dir::children', Puppet::Functions::InternalF
     full_mod_path = File.join(mod_path, subpath || '') if mod_path
 
     # Expand relative to the project directory if path is relative
-    project = Puppet.lookup(:bolt_project_data)
+    project = Puppet.lookup(:bolt_project)
     pathname = Pathname.new(dirname)
     full_dir = pathname.absolute? ? dirname : File.expand_path(File.join(project.path, dirname))
 

--- a/bolt-modules/dir/spec/functions/dir/children_spec.rb
+++ b/bolt-modules/dir/spec/functions/dir/children_spec.rb
@@ -9,9 +9,9 @@ describe 'dir::children' do
 
   around(:each) do |example|
     Puppet[:tasks] = true
-    project = Struct.new(:name, :path).new('default', File.expand_path(path))
+    project = Struct.new(:name, :path, :load_as_module?).new('default', File.expand_path(path), true)
 
-    Puppet.override(bolt_project_data: project) do
+    Puppet.override(bolt_project: project) do
       example.run
     end
   end

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-ssh", ">= 4.0"
   spec.add_dependency "net-ssh-krb", "~> 0.5"
   spec.add_dependency "orchestrator_client", "~> 0.4"
-  spec.add_dependency "puppet", [">= 6.16.0", "< 6.18.0"]
+  spec.add_dependency "puppet", "6.18.0"
   spec.add_dependency "puppetfile-resolver", "~> 0.1.0"
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "puppet-strings", "~> 2.3"

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -183,11 +183,10 @@ module Bolt
                                                                        type_by_reference: true,
                                                                        local_reference: true)
 
-      bolt_project = @project if @project&.name
       scope = {
         code_ast: ast,
         modulepath: @modulepath,
-        project: bolt_project.to_h,
+        project: @project.to_h,
         pdb_config: @pdb_client.config.to_hash,
         hiera_config: @hiera_config,
         plan_vars: plan_vars,

--- a/lib/bolt/catalog.rb
+++ b/lib/bolt/catalog.rb
@@ -57,8 +57,10 @@ module Bolt
 
     def compile_catalog(request)
       pdb_client = Bolt::PuppetDB::Client.new(Bolt::PuppetDB::Config.new(request['pdb_config']))
-      project = request['project'] || {}
-      bolt_project = Struct.new(:name, :path).new(project['name'], project['path']) unless project.empty?
+      project = request['project']
+      bolt_project = Struct.new(:name, :path, :load_as_module?).new(project['name'],
+                                                                    project['path'],
+                                                                    project['load_as_module?'])
       inv = Bolt::ApplyInventory.new(request['config'])
       puppet_overrides = {
         bolt_pdb_client: pdb_client,

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -149,13 +149,7 @@ module Bolt
       setup
       r = Puppet::Pal.in_tmp_environment('bolt', modulepath: @modulepath, facts: {}) do |pal|
         # Only load the project if it a) exists, b) has a name it can be loaded with
-        bolt_project = @project if @project&.name
-        # Puppet currently won't receive the project unless it is a named project. Since
-        # the download_file plan function needs access to the project path, add it to the
-        # context.
-        bolt_project_data = @project
-        Puppet.override(bolt_project: bolt_project,
-                        bolt_project_data: bolt_project_data,
+        Puppet.override(bolt_project: @project,
                         yaml_plan_instantiator: Bolt::PAL::YamlPlan::Loader) do
           pal.with_script_compiler do |compiler|
             alias_types(compiler)

--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -119,7 +119,9 @@ module Bolt
     # This API is used to prepend the project as a module to Puppet's internal
     # module_references list. CHANGE AT YOUR OWN RISK
     def to_h
-      { path: @path.to_s, name: name }
+      { path: @path.to_s,
+        name: name,
+        load_as_module?: load_as_module? }
     end
 
     def eql?(other)
@@ -129,6 +131,10 @@ module Bolt
 
     def project_file?
       @project_file.file?
+    end
+
+    def load_as_module?
+      !name.nil?
     end
 
     def name

--- a/spec/bolt/catalog_spec.rb
+++ b/spec/bolt/catalog_spec.rb
@@ -35,11 +35,13 @@ describe Bolt::Catalog do
   }
 
   let(:plan) { File.join(__FILE__, '../../fixtures/apply/basic/plans/trusted.pp') }
+  let(:project) { Struct.new(:name, :path, :load_as_module?).new('project', '', false) }
 
   let(:request) do
     { 'code_ast' => {},
       'modulepath' => [],
       'pdb_config' => pdb_config.to_hash,
+      'project' => project,
       'hiera_config' => nil,
       'plan_vars' => {},
       'target' => {

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1325,6 +1325,7 @@ describe "Bolt::CLI" do
             resource_types: '',
             tasks: ['facts'],
             project_file?: true,
+            load_as_module?: true,
             name: nil,
             to_h: {}
           }

--- a/spec/bolt/pal_spec.rb
+++ b/spec/bolt/pal_spec.rb
@@ -144,19 +144,11 @@ describe Bolt::PAL do
   end
 
   describe :in_bolt_compiler do
-    it "sets the bolt_project in the context if it has a name" do
+    it "sets the bolt_project in the context" do
       project = Bolt::Project.new({ 'name' => 'mytestproject' }, Dir.getwd)
       pal = Bolt::PAL.new(nil, nil, nil, 1, nil, {}, project)
       pal.in_bolt_compiler do
         expect(Puppet.lookup(:bolt_project).name).to eq('mytestproject')
-      end
-    end
-
-    it "doesn't set bolt_project in the context if it doesn't have a name" do
-      project = Bolt::Project.new({}, Dir.getwd)
-      pal = Bolt::PAL.new(nil, nil, nil, 1, nil, {}, project)
-      pal.in_bolt_compiler do
-        expect(Puppet.lookup(:bolt_project)).to be_nil
       end
     end
   end


### PR DESCRIPTION
This adds a method `load_as_module?` to the `Bolt::Project` class to use
in Puppet to determine whether to load the project as a module.
Previously, `bolt_project` would only be set if the project was named,
which isn't necessary for a valid project, and Puppet would only load
the project as a module if the setting was set. Puppet can now use
`load_as_module?` to determine whether to load the project as a module,
which lets us always set the `bolt_project` Puppet setting. This lets us
use that setting to access the project from within Bolt plan functions
for things like getting the project path to set the destination to
download files to.

This PR also removes the now-unnecessary `bolt_project_data` Puppet
setting, which was an interim means of accessing the project path from
plan functions.

Closes #2051

!no-release-note