### PR TITLE
(docs) Remove bolt projects from experimental features page

### DIFF
--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -8,13 +8,6 @@ API may change, requiring the user to update their code or configuration. The
 Bolt team attempts to make these changes painless by providing useful warnings
 around breaking behavior where possible. 
 
-## Bolt projects
-
-This feature was introduced in [Bolt
-2.8.0](https://github.com/puppetlabs/bolt/blob/main/CHANGELOG.md#bolt-280-2020-05-05)
-
-For more information, see [Bolt projects](projects.md)
-
 ## `ResourceInstance` data type
 
 This feature was introduced in [Bolt


### PR DESCRIPTION
This removes Bolt projects from the experimental features doc, which was
missed when projects were moved out of experimental.

!no-release-note