### PR TITLE
(bug) Pass YAML plan message argument in array

### DIFF
--- a/lib/bolt/pal/yaml_plan/evaluator.rb
+++ b/lib/bolt/pal/yaml_plan/evaluator.rb
@@ -109,7 +109,7 @@ module Bolt
         end
 
         def message_step(scope, step)
-          scope.call_function('out::message', step['message'])
+          scope.call_function('out::message', [step['message']])
         end
 
         def generate_manifest(resources)

--- a/spec/bolt/pal/yaml_plan/evaluator_spec.rb
+++ b/spec/bolt/pal/yaml_plan/evaluator_spec.rb
@@ -190,7 +190,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
     end
 
     it 'calls out::message' do
-      expect(scope).to receive(:call_function).with('out::message', 'hello world')
+      expect(scope).to receive(:call_function).with('out::message', ['hello world'])
       subject.message_step(scope, step)
     end
   end


### PR DESCRIPTION
This fixes a bug in the YAML plan message step, which was passing
arguments to the `out::message` plan function incorrectly. Previously,
the message was passed directly to the plan function. If the message was
an object such as an array or hash, the object would be splatted and
passed to the `out::message` plan function as multiple arguments. Now,
the message is passed as a single element array to the plan function,
allowing the function to be called correctly.

!bug

* **Correctly pass objects to YAML plan message step**

  Bolt was incorrectly passing objects used in the YAML plan `message`
  step, resulting in an error. Any objects used in YAML plan `message`
  steps are now correctly passed and printed to the console.