### PR TITLE
(PE-29929) Add /tasks endpoint to bolt-server

### DIFF
--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -375,6 +375,22 @@ module BoltServer
       end
     end
 
+    # Fetches the list of tasks for an environment
+    #
+    # @param environment [String] the environment to fetch the list of tasks from
+    get '/tasks' do
+      in_pe_pal_env(params['environment']) do |pal|
+        tasks = pal.list_tasks
+        tasks_response = tasks.map { |task_name, _description| { 'name' => task_name } }.to_json
+
+        # We structure this array of tasks to be an array of hashes so that it matches the structure
+        # returned by the puppetserver API that serves data like this. Structuring the output this way
+        # makes switching between puppetserver and bolt-server easier, which makes changes to switch
+        # to bolt-server smaller/simpler.
+        [200, tasks_response]
+      end
+    end
+
     error 404 do
       err = Bolt::Error.new("Could not find route #{request.path}",
                             'boltserver/not-found')


### PR DESCRIPTION
This commit adds a new endpoint to list all tasks to bolt-server,
similar to the /plans endpoint that already exists. Tasks are
returned as an array where each element in the array is of the
form `{"name":"<TASK_NAME>"}`