### PR TITLE
(GH-2068) Write debug log by default

### DIFF
--- a/bolt-modules/boltlib/spec/spec_helper.rb
+++ b/bolt-modules/boltlib/spec/spec_helper.rb
@@ -8,3 +8,8 @@ require 'bolt/pal'
 Puppet[:tasks] = true
 Bolt::PAL.load_puppet
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do
+  require 'bolt/logger'
+  Bolt::Logger.initialize_logging
+end

--- a/bolt-modules/ctrl/spec/spec_helper.rb
+++ b/bolt-modules/ctrl/spec/spec_helper.rb
@@ -6,3 +6,8 @@ require 'puppet_pal'
 # so we get task loaders.
 Puppet[:tasks] = true
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do
+  require 'bolt/logger'
+  Bolt::Logger.initialize_logging
+end

--- a/bolt-modules/dir/spec/spec_helper.rb
+++ b/bolt-modules/dir/spec/spec_helper.rb
@@ -6,3 +6,8 @@ require 'puppet_pal'
 # so we get task loaders.
 Puppet[:tasks] = true
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do
+  require 'bolt/logger'
+  Bolt::Logger.initialize_logging
+end

--- a/bolt-modules/file/spec/spec_helper.rb
+++ b/bolt-modules/file/spec/spec_helper.rb
@@ -6,3 +6,8 @@ require 'puppet_pal'
 # so we get task loaders.
 Puppet[:tasks] = true
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do
+  require 'bolt/logger'
+  Bolt::Logger.initialize_logging
+end

--- a/bolt-modules/out/spec/spec_helper.rb
+++ b/bolt-modules/out/spec/spec_helper.rb
@@ -8,3 +8,8 @@ require 'bolt/pal'
 Puppet[:tasks] = true
 Bolt::PAL.load_puppet
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do
+  require 'bolt/logger'
+  Bolt::Logger.initialize_logging
+end

--- a/bolt-modules/prompt/spec/spec_helper.rb
+++ b/bolt-modules/prompt/spec/spec_helper.rb
@@ -8,3 +8,8 @@ require 'bolt/pal'
 Puppet[:tasks] = true
 Bolt::PAL.load_puppet
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do
+  require 'bolt/logger'
+  Bolt::Logger.initialize_logging
+end

--- a/bolt-modules/system/spec/spec_helper.rb
+++ b/bolt-modules/system/spec/spec_helper.rb
@@ -6,3 +6,8 @@ require 'puppet_pal'
 # so we get task loaders.
 Puppet[:tasks] = true
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do
+  require 'bolt/logger'
+  Bolt::Logger.initialize_logging
+end

--- a/exe/bolt
+++ b/exe/bolt
@@ -4,6 +4,7 @@
 require 'bolt'
 require 'bolt/cli'
 
+Thread.current[:name] ||= 'main'
 cli = Bolt::CLI.new(ARGV)
 begin
   opts = cli.parse

--- a/lib/bolt/analytics.rb
+++ b/lib/bolt/analytics.rb
@@ -161,9 +161,9 @@ module Bolt
         # Handle analytics submission in the background to avoid blocking the
         # app or polluting the log with errors
         Concurrent::Future.execute(executor: @executor) do
-          @logger.debug "Submitting analytics: #{JSON.pretty_generate(params)}"
+          @logger.trace "Submitting analytics: #{JSON.pretty_generate(params)}"
           @http.post(TRACKING_URL, params)
-          @logger.debug "Completed analytics submission"
+          @logger.trace "Completed analytics submission"
         end
       end
 
@@ -215,13 +215,13 @@ module Bolt
       end
 
       def screen_view(screen, **_kwargs)
-        @logger.debug "Skipping submission of '#{screen}' screenview because analytics is disabled"
+        @logger.trace "Skipping submission of '#{screen}' screenview because analytics is disabled"
       end
 
       def report_bundled_content(mode, name); end
 
       def event(category, action, **_kwargs)
-        @logger.debug "Skipping submission of '#{category} #{action}' event because analytics is disabled"
+        @logger.trace "Skipping submission of '#{category} #{action}' event because analytics is disabled"
       end
 
       def finish; end

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -300,7 +300,7 @@ module Bolt
 
         files.each do |file|
           tar_path = Pathname.new(file).relative_path_from(parent)
-          @logger.debug("Packing plugin #{file} to #{tar_path}")
+          @logger.trace("Packing plugin #{file} to #{tar_path}")
           stat = File.stat(file)
           content = File.binread(file)
           output.tar.add_file_simple(
@@ -314,7 +314,7 @@ module Bolt
       end
 
       duration = Time.now - start_time
-      @logger.debug("Packed plugins in #{duration * 1000} ms")
+      @logger.trace("Packed plugins in #{duration * 1000} ms")
 
       output.close
       Base64.encode64(sio.string)

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -27,7 +27,7 @@ module Bolt
       @hiera_config = hiera_config ? validate_hiera_config(hiera_config) : nil
       @apply_settings = apply_settings || {}
 
-      @pool = Concurrent::ThreadPoolExecutor.new(max_threads: max_compiles)
+      @pool = Concurrent::ThreadPoolExecutor.new(name: 'apply', max_threads: max_compiles)
       @logger = Logging.logger[self]
     end
 
@@ -217,6 +217,7 @@ module Bolt
       r = @executor.log_action(description, targets) do
         futures = targets.map do |target|
           Concurrent::Future.execute(executor: @pool) do
+            Thread.current[:name] ||= Thread.current.name
             @executor.with_node_logging("Compiling manifest block", [target]) do
               compile(target, scope)
             end

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -863,7 +863,7 @@ module Bolt
       end
       define('--log-level LEVEL',
              "Set the log level for the console. Available options are",
-             "debug, info, notice, warn, error, fatal, any.") do |level|
+             "trace, debug, info, warn, error, fatal, any.") do |level|
         @options[:log] = { 'console' => { 'level' => level } }
       end
       define('--plugin PLUGIN', 'Select the plugin to use') do |plug|

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -1056,7 +1056,7 @@ module Bolt
       msg = <<~MSG.chomp
         Loaded configuration from: '#{config.config_files.join("', '")}'
       MSG
-      @logger.debug(msg)
+      @logger.info(msg)
     end
 
     # Gem installs include the aggregate, canary, and puppetdb_fact modules, while

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -204,7 +204,7 @@ module Bolt
         'compile-concurrency' => Etc.nprocessors,
         'concurrency'         => default_concurrency,
         'format'              => 'human',
-        'log'                 => { 'console' => {} },
+        'log'                 => { 'console' => {}, 'bolt-debug.log' => { 'level' => 'debug', 'append' => false } },
         'plugin_hooks'        => {},
         'plugins'             => {},
         'puppetdb'            => {},

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -186,7 +186,7 @@ module Bolt
                 "level" => {
                   description: "The type of information to log.",
                   type: String,
-                  enum: %w[debug error info notice warn fatal any],
+                  enum: %w[trace debug error info warn fatal any],
                   _default: "warn"
                 }
               }
@@ -204,7 +204,7 @@ module Bolt
               "level" => {
                 description: "The type of information to log.",
                 type: String,
-                enum: %w[debug error info notice warn fatal any],
+                enum: %w[trace debug error info warn fatal any],
                 _default: "warn"
               }
             }

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -187,7 +187,7 @@ module Bolt
                   description: "The type of information to log.",
                   type: String,
                   enum: %w[debug error info notice warn fatal any],
-                  _default: "warn for console, notice for file"
+                  _default: "warn"
                 }
               }
             }
@@ -205,7 +205,7 @@ module Bolt
                 description: "The type of information to log.",
                 type: String,
                 enum: %w[debug error info notice warn fatal any],
-                _default: "warn for console, notice for file"
+                _default: "warn"
               }
             }
           },

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -56,11 +56,12 @@ module Bolt
       @reported_transports = Set.new
       @subscribers = {}
       @publisher = Concurrent::SingleThreadExecutor.new
+      @publisher.post { Thread.current[:name] = 'event-publisher' }
 
       @noop = noop
       @run_as = nil
       @pool = if concurrency > 0
-                Concurrent::ThreadPoolExecutor.new(max_threads: concurrency)
+                Concurrent::ThreadPoolExecutor.new(name: 'exec', max_threads: concurrency)
               else
                 Concurrent.global_immediate_executor
               end
@@ -125,6 +126,7 @@ module Bolt
           # Pass this argument through to avoid retaining a reference to a
           # local variable that will change on the next iteration of the loop.
           @pool.post(batch_promises) do |result_promises|
+            Thread.current[:name] ||= Thread.current.name
             results = yield transport, batch
             Array(results).each do |result|
               result_promises[result.target].set(result)

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -241,7 +241,7 @@ module Bolt
 
       @analytics&.event('Plan', 'yaml', plan_steps: steps, return_type: return_type)
     rescue StandardError => e
-      @logger.debug { "Failed to submit analytics event: #{e.message}" }
+      @logger.trace { "Failed to submit analytics event: #{e.message}" }
     end
 
     def with_node_logging(description, batch)

--- a/lib/bolt/inventory/group.rb
+++ b/lib/bolt/inventory/group.rb
@@ -119,7 +119,7 @@ module Bolt
         end
 
         if contains_target?(t_name)
-          @logger.warn("Ignoring duplicate target in #{@name}: #{target}")
+          @logger.debug("Ignoring duplicate target in #{@name}: #{target}")
           return
         end
 
@@ -200,14 +200,14 @@ module Bolt
           # If this is an alias for an existing target, then add it to this group
           elsif (canonical_name = aliases[string_target])
             if contains_target?(canonical_name)
-              @logger.warn("Ignoring duplicate target in #{@name}: #{canonical_name}")
+              @logger.debug("Ignoring duplicate target in #{@name}: #{canonical_name}")
             else
               @unresolved_targets[canonical_name] = { 'name' => canonical_name }
             end
           # If it's not the name or alias of an existing target, then make a
           # new target using the string as the URI
           elsif contains_target?(string_target)
-            @logger.warn("Ignoring duplicate target in #{@name}: #{string_target}")
+            @logger.debug("Ignoring duplicate target in #{@name}: #{string_target}")
           else
             @unresolved_targets[string_target] = { 'uri' => string_target }
           end

--- a/lib/bolt/logger.rb
+++ b/lib/bolt/logger.rb
@@ -80,7 +80,7 @@ module Bolt
 
     def self.default_layout
       Logging.layouts.pattern(
-        pattern: '%d %-6l %c: %m\n',
+        pattern: '%d %-6l [%T] [%c] %m\n',
         date_pattern: '%Y-%m-%dT%H:%M:%S.%6N'
       )
     end

--- a/lib/bolt/logger.rb
+++ b/lib/bolt/logger.rb
@@ -14,7 +14,7 @@ module Bolt
       # redefs, so skip it if it's already been initialized
       return if Logging.initialized?
 
-      Logging.init :debug, :info, :notice, :warn, :error, :fatal, :any
+      Logging.init :trace, :debug, :info, :notice, :warn, :error, :fatal, :any
       @mutex = Mutex.new
 
       Logging.color_scheme(

--- a/lib/bolt/logger.rb
+++ b/lib/bolt/logger.rb
@@ -20,7 +20,6 @@ module Bolt
       Logging.color_scheme(
         'bolt',
         lines: {
-          notice: :green,
           warn: :yellow,
           error: :red,
           fatal: %i[white on_red]
@@ -91,7 +90,7 @@ module Bolt
     end
 
     def self.default_file_level
-      :notice
+      :warn
     end
 
     # Explicitly check the log level names instead of the log level number, as levels

--- a/lib/bolt/outputter/logger.rb
+++ b/lib/bolt/outputter/logger.rb
@@ -40,13 +40,13 @@ module Bolt
 
       def log_plan_start(event)
         plan = event[:plan]
-        @logger.notice("Starting: plan #{plan}")
+        @logger.info("Starting: plan #{plan}")
       end
 
       def log_plan_finish(event)
         plan = event[:plan]
         duration = event[:duration]
-        @logger.notice("Finished: plan #{plan} in #{duration.round(2)} sec")
+        @logger.info("Finished: plan #{plan} in #{duration.round(2)} sec")
       end
     end
   end

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -67,7 +67,7 @@ module Bolt
 
       @logger = Logging.logger[self]
       if modulepath && !modulepath.empty?
-        @logger.info("Loading modules from #{@modulepath.join(File::PATH_SEPARATOR)}")
+        @logger.debug("Loading modules from #{@modulepath.join(File::PATH_SEPARATOR)}")
       end
 
       @loaded = false

--- a/lib/bolt/transport/local/connection.rb
+++ b/lib/bolt/transport/local/connection.rb
@@ -28,7 +28,7 @@ module Bolt
         end
 
         def upload_file(source, dest)
-          @logger.debug { "Uploading #{source}, to #{dest}" }
+          @logger.trace { "Uploading #{source} to #{dest}" }
           if source.is_a?(StringIO)
             Tempfile.create(File.basename(dest)) do |f|
               f.write(source.read)
@@ -46,7 +46,7 @@ module Bolt
         end
 
         def download_file(source, dest, _download)
-          @logger.debug { "Downloading #{source} to #{dest}" }
+          @logger.trace { "Downloading #{source} to #{dest}" }
           # Create the destination directory for the target, or the
           # copied file will have the target's name
           FileUtils.mkdir_p(dest)

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -38,7 +38,7 @@ module Bolt
           @connections.each_value do |conn|
             conn.finish_plan(result)
           rescue StandardError => e
-            @logger.debug("Failed to finish plan on #{conn.key}: #{e.message}")
+            @logger.trace("Failed to finish plan on #{conn.key}: #{e.message}")
           end
         end
       end
@@ -133,7 +133,7 @@ module Bolt
           next unless File.file?(file)
 
           tar_path = Pathname.new(file).relative_path_from(Pathname.new(directory))
-          @logger.debug("Packing #{file} to #{tar_path}")
+          @logger.trace("Packing #{file} to #{tar_path}")
           stat = File.stat(file)
           content = File.binread(file)
           output.tar.add_file_simple(
@@ -146,7 +146,7 @@ module Bolt
         end
 
         duration = Time.now - start_time
-        @logger.debug("Packed upload in #{duration * 1000} ms")
+        @logger.trace("Packed upload in #{duration * 1000} ms")
 
         output.close
         io.string

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -28,7 +28,7 @@ module Bolt
 
           @logger = Logging.logger[@target.safe_name]
           @transport_logger = transport_logger
-          @logger.debug("Initializing ssh connection to #{@target.safe_name}")
+          @logger.trace("Initializing ssh connection to #{@target.safe_name}")
 
           if target.options['private-key']&.instance_of?(String)
             begin
@@ -131,7 +131,7 @@ module Bolt
 
           @session = Net::SSH.start(target.host, @user, options)
           validate_ssh_version
-          @logger.debug { "Opened session" }
+          @logger.trace { "Opened session" }
         rescue Net::SSH::AuthenticationFailed => e
           raise Bolt::Node::ConnectError.new(
             e.message,
@@ -161,7 +161,7 @@ module Bolt
             rescue Timeout::Error
               @session.shutdown!
             end
-            @logger.debug { "Closed session" }
+            @logger.trace { "Closed session" }
           end
         end
 
@@ -237,7 +237,7 @@ module Bolt
 
         def upload_file(source, destination)
           # Do not log wrapper script content
-          @logger.debug { "Uploading #{source}, to #{destination}" } unless source.is_a?(StringIO)
+          @logger.trace { "Uploading #{source} to #{destination}" } unless source.is_a?(StringIO)
           @session.scp.upload!(source, destination, recursive: true)
         rescue StandardError => e
           raise Bolt::Node::FileError.new(e.message, 'WRITE_ERROR')
@@ -245,7 +245,7 @@ module Bolt
 
         def download_file(source, destination, _download)
           # Do not log wrapper script content
-          @logger.debug { "Downloading #{source} to #{destination}" }
+          @logger.trace { "Downloading #{source} to #{destination}" }
           @session.scp.download!(source, destination, recursive: true)
         rescue StandardError => e
           raise Bolt::Node::FileError.new(e.message, 'WRITE_ERROR')

--- a/lib/bolt/transport/ssh/exec_connection.rb
+++ b/lib/bolt/transport/ssh/exec_connection.rb
@@ -66,7 +66,7 @@ module Bolt
         end
 
         def upload_file(source, dest)
-          @logger.debug { "Uploading #{source}, to #{userhost}:#{dest}" } unless source.is_a?(StringIO)
+          @logger.trace { "Uploading #{source} to #{dest}" } unless source.is_a?(StringIO)
 
           cp_conf = @target.transport_config['copy-command'] || ["scp", "-r"]
           cp_cmd = Array(cp_conf)
@@ -87,7 +87,7 @@ module Bolt
                          end
 
           if stat.success?
-            @logger.debug "Successfully uploaded #{source} to #{dest}"
+            @logger.trace "Successfully uploaded #{source} to #{dest}"
           else
             message = "Could not copy file to #{dest}: #{err}"
             raise Bolt::Node::FileError.new(message, 'COPY_ERROR')
@@ -95,7 +95,7 @@ module Bolt
         end
 
         def download_file(source, dest, _download)
-          @logger.debug { "Downloading #{userhost}:#{source} to #{dest}" }
+          @logger.trace { "Downloading #{userhost}:#{source} to #{dest}" }
 
           FileUtils.mkdir_p(dest)
 
@@ -108,7 +108,7 @@ module Bolt
           _, err, stat = Open3.capture3(*cp_cmd)
 
           if stat.success?
-            @logger.debug "Successfully downloaded #{userhost}:#{source} to #{dest}"
+            @logger.trace "Successfully downloaded #{userhost}:#{source} to #{dest}"
           else
             message = "Could not copy file to #{dest}: #{err}"
             raise Bolt::Node::FileError.new(message, 'COPY_ERROR')

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -19,7 +19,7 @@ module Bolt
           # Build set of extensions from extensions config as well as interpreters
 
           @logger = Logging.logger[@target.safe_name]
-          logger.debug("Initializing winrm connection to #{@target.safe_name}")
+          logger.trace("Initializing winrm connection to #{@target.safe_name}")
           @transport_logger = transport_logger
         end
 
@@ -55,7 +55,7 @@ module Bolt
 
             @session = @connection.shell(:powershell)
             @session.run('$PSVersionTable.PSVersion')
-            @logger.debug { "Opened session" }
+            @logger.trace { "Opened session" }
           end
         rescue Timeout::Error
           # If we're using the default port with SSL, a timeout probably means the
@@ -97,11 +97,11 @@ module Bolt
         def disconnect
           @session&.close
           @client&.disconnect!
-          @logger.debug { "Closed session" }
+          @logger.trace { "Closed session" }
         end
 
         def execute(command)
-          @logger.debug { "Executing command: #{command}" }
+          @logger.trace { "Executing command: #{command}" }
 
           inp = StringIO.new
           # This transport doesn't accept stdin, so close the stream to ensure
@@ -134,12 +134,12 @@ module Bolt
             "with 'ulimit -n 1024'. See https://puppet.com/docs/bolt/latest/bolt_known_issues.html for details."
           raise Bolt::Error.new(msg, 'bolt/too-many-files')
         rescue StandardError
-          @logger.debug { "Command aborted" }
+          @logger.trace { "Command aborted" }
           raise
         end
 
         def upload_file(source, destination)
-          @logger.debug { "Uploading #{source}, to #{destination}" }
+          @logger.trace { "Uploading #{source} to #{destination}" }
           if target.options['file-protocol'] == 'smb'
             upload_file_smb(source, destination)
           else
@@ -185,7 +185,7 @@ module Bolt
         end
 
         def download_file(source, destination, download)
-          @logger.debug { "Downloading #{source} to #{destination}" }
+          @logger.trace { "Downloading #{source} to #{destination}" }
           if target.options['file-protocol'] == 'smb'
             download_file_smb(source, destination)
           else
@@ -257,7 +257,7 @@ module Bolt
           status = @client.login
           case status
           when WindowsError::NTStatus::STATUS_SUCCESS
-            @logger.debug { "Connected to #{@client.dns_host_name}" }
+            @logger.trace { "Connected to #{@client.dns_host_name}" }
           when WindowsError::NTStatus::STATUS_LOGON_FAILURE
             raise Bolt::Node::ConnectError.new(
               "SMB authentication failed for #{target.safe_name}",

--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -13,7 +13,7 @@ module Bolt
           msg = "Invalid content for #{file_name} file: #{path} should be a Hash or empty, not #{content.class}"
           raise Bolt::FileError.new(msg, path)
         end
-        logger.debug("Loaded #{file_name} from #{path}")
+        logger.trace("Loaded #{file_name} from #{path}")
         content
       rescue Errno::ENOENT
         raise Bolt::FileError.new("Could not read #{file_name} file: #{path}", path)

--- a/lib/bolt/util/puppet_log_level.rb
+++ b/lib/bolt/util/puppet_log_level.rb
@@ -4,9 +4,10 @@ module Bolt
   module Util
     module PuppetLogLevel
       MAPPING = {
-        debug: :debug,
-        info: :info,
-        notice: :notice,
+        # Demote Puppet's logs by one level, since Puppet is an implementation detail of Bolt
+        debug: :trace,
+        info: :debug,
+        notice: :info,
         warning: :warn,
         err: :error,
         # The following are used by Puppet functions of the same name, and are all treated as

--- a/lib/bolt_server/base_config.rb
+++ b/lib/bolt_server/base_config.rb
@@ -16,7 +16,7 @@ module BoltServer
 
     def defaults
       { 'host' => '127.0.0.1',
-        'loglevel' => 'notice',
+        'loglevel' => 'warn',
         'ssl-cipher-suites' => %w[ECDHE-ECDSA-AES256-GCM-SHA384
                                   ECDHE-RSA-AES256-GCM-SHA384
                                   ECDHE-ECDSA-CHACHA20-POLY1305

--- a/lib/bolt_spec/plans.rb
+++ b/lib/bolt_spec/plans.rb
@@ -206,7 +206,7 @@ module BoltSpec
       Puppet[:tasks] = true
 
       # Ensure logger is initialized with Puppet levels so 'notice' works when running plan specs.
-      Logging.init :debug, :info, :notice, :warn, :error, :fatal, :any
+      Logging.init :trace, :debug, :info, :notice, :warn, :error, :fatal, :any
     end
 
     # Provided as a class so expectations can be placed on it.

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -125,10 +125,10 @@
               "description": "The type of information to log.",
               "type": "string",
               "enum": [
+                "trace",
                 "debug",
                 "error",
                 "info",
-                "notice",
                 "warn",
                 "fatal",
                 "any"
@@ -149,10 +149,10 @@
             "description": "The type of information to log.",
             "type": "string",
             "enum": [
+              "trace",
               "debug",
               "error",
               "info",
-              "notice",
               "warn",
               "fatal",
               "any"

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -101,10 +101,10 @@
               "description": "The type of information to log.",
               "type": "string",
               "enum": [
+                "trace",
                 "debug",
                 "error",
                 "info",
-                "notice",
                 "warn",
                 "fatal",
                 "any"
@@ -125,10 +125,10 @@
             "description": "The type of information to log.",
             "type": "string",
             "enum": [
+              "trace",
               "debug",
               "error",
               "info",
-              "notice",
               "warn",
               "fatal",
               "any"

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -113,10 +113,10 @@
               "description": "The type of information to log.",
               "type": "string",
               "enum": [
+                "trace",
                 "debug",
                 "error",
                 "info",
-                "notice",
                 "warn",
                 "fatal",
                 "any"
@@ -137,10 +137,10 @@
             "description": "The type of information to log.",
             "type": "string",
             "enum": [
+              "trace",
               "debug",
               "error",
               "info",
-              "notice",
               "warn",
               "fatal",
               "any"

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -671,7 +671,7 @@ describe "Bolt::CLI" do
 
     describe "console log level" do
       it "is not sensitive to ordering of debug and verbose" do
-        expect(Bolt::Logger).to receive(:configure).with({ 'console' => { level: :debug } }, true)
+        expect(Bolt::Logger).to receive(:configure).with(include('console' => { level: :debug }), true)
 
         cli = Bolt::CLI.new(%w[command run uptime --targets foo --debug --verbose])
         cli.parse
@@ -690,9 +690,9 @@ describe "Bolt::CLI" do
       end
 
       it "log-level sets the log option" do
-        expect(Bolt::Logger).to receive(:configure).with({ 'console' => { level: 'notice' } }, true)
+        expect(Bolt::Logger).to receive(:configure).with(include('console' => { level: 'debug' }), true)
 
-        cli = Bolt::CLI.new(%w[command run uptime --targets foo --log-level notice])
+        cli = Bolt::CLI.new(%w[command run uptime --targets foo --log-level debug])
         cli.parse
       end
 
@@ -2407,10 +2407,8 @@ describe "Bolt::CLI" do
         cli = Bolt::CLI.new(%W[command run uptime --configfile #{conf.path} --targets foo --no-host-key-check])
         cli.parse
         normalized_path = File.expand_path(File.join(configdir, 'debug.log'))
-        expect(cli.config.log).to eq(
-          'console' => { level: 'warn' },
-          "file:#{normalized_path}" => { level: 'debug', append: false }
-        )
+        expect(cli.config.log).to include('console' => { level: 'warn' })
+        expect(cli.config.log).to include("file:#{normalized_path}" => { level: 'debug', append: false })
       end
     end
 

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -274,7 +274,7 @@ describe Bolt::Config do
       }
 
       expect { Bolt::Config.new(project, config) }.to raise_error(
-        /level of log file:.* must be one of debug, info, notice, warn, error, fatal, any; received foo/
+        /level of log file:.* must be one of .*; received foo/
       )
     end
 

--- a/spec/bolt/logger_spec.rb
+++ b/spec/bolt/logger_spec.rb
@@ -30,14 +30,12 @@ describe Bolt::Logger do
       Logging.reset
     end
 
-    it 'sets up the expected logging levels' do
+    it 'sets up the log levels' do
       expect(Logging::LEVELS).to be_empty
 
       Bolt::Logger.initialize_logging
 
-      expect(Logging::LEVELS).to eq(
-        %w[debug info notice warn error fatal any].each_with_object({}) { |l, h| h[l] = h.count }
-      )
+      expect(Logging::LEVELS).not_to be_empty
     end
   end
 

--- a/spec/bolt_server/config_spec.rb
+++ b/spec/bolt_server/config_spec.rb
@@ -110,7 +110,7 @@ describe BoltServer::Config do
     config = build_config(requiredconfig)
     expect(config['host']).to eq('127.0.0.1')
     expect(config['port']).to be(62658)
-    expect(config['loglevel']).to eq('notice')
+    expect(config['loglevel']).to eq('warn')
     expect(config['logfile']).to eq(nil)
     expect(config['whitelist']).to eq(nil)
     expect(config['ssl-cipher-suites']).to include('ECDHE-ECDSA-AES256-GCM-SHA384')

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -159,10 +159,10 @@ describe "passes parsed AST to the apply_catalog task" do
       result = run_cli_json(%w[plan run basic::error] + config_flags)
       expect(result[0]['status']).to eq('success')
       logs = @log_output.readlines
-      expect(logs).to include(/DEBUG.*Debugging/)
-      expect(logs).to include(/INFO.*Meh/)
+      expect(logs).to include(/TRACE.*Debugging/)
+      expect(logs).to include(/DEBUG.*Meh/)
       expect(logs).to include(/WARN.*Warned/)
-      expect(logs).to include(/NOTICE.*Helpful/)
+      expect(logs).to include(/INFO.*Helpful/)
       expect(logs).to include(/ERROR.*Fire/)
       expect(logs).to include(/ERROR.*Stop/)
       expect(logs).to include(/FATAL.*Drop/)
@@ -405,9 +405,9 @@ describe "passes parsed AST to the apply_catalog task" do
         @log_output.level = :debug
         run_cli(%w[plan run basic::error --log-level debug] + config_flags)
 
-        expect(lines).to include(/DEBUG.*Debugging/)
-        expect(lines).to include(/INFO.*Meh/)
-        expect(lines).to include(/NOTICE.*Helpful/)
+        expect(lines).not_to include(/TRACE.*Debugging/)
+        expect(lines).to include(/DEBUG.*Meh/)
+        expect(lines).to include(/INFO.*Helpful/)
         expect(lines).to include(/WARN.*Warned/)
         expect(lines).to include(/ERROR.*Fire/)
         expect(lines).to include(/ERROR.*Stop/)
@@ -419,23 +419,9 @@ describe "passes parsed AST to the apply_catalog task" do
         @log_output.level = :info
         run_cli(%w[plan run basic::error --log-level info] + config_flags)
 
-        expect(lines).not_to include(/DEBUG.*Debugging/)
-        expect(lines).to include(/INFO.*Meh/)
-        expect(lines).to include(/NOTICE.*Helpful/)
-        expect(lines).to include(/WARN.*Warned/)
-        expect(lines).to include(/ERROR.*Fire/)
-        expect(lines).to include(/ERROR.*Stop/)
-        expect(lines).to include(/FATAL.*Drop/)
-        expect(lines).to include(/FATAL.*Roll/)
-      end
-
-      it 'logs notice messages' do
-        @log_output.level = :notice
-        run_cli(%w[plan run basic::error --log-level notice] + config_flags)
-
-        expect(lines).not_to include(/DEBUG.*Debugging/)
-        expect(lines).not_to include(/INFO.*Meh/)
-        expect(lines).to include(/NOTICE.*Helpful/)
+        expect(lines).not_to include(/TRACE.*Debugging/)
+        expect(lines).not_to include(/DEBUG.*Meh/)
+        expect(lines).to include(/INFO.*Helpful/)
         expect(lines).to include(/WARN.*Warned/)
         expect(lines).to include(/ERROR.*Fire/)
         expect(lines).to include(/ERROR.*Stop/)
@@ -447,9 +433,9 @@ describe "passes parsed AST to the apply_catalog task" do
         @log_output.level = :warn
         run_cli(%w[plan run basic::error --log-level warn] + config_flags)
 
-        expect(lines).not_to include(/DEBUG.*Debugging/)
-        expect(lines).not_to include(/INFO.*Meh/)
-        expect(lines).not_to include(/NOTICE.*Helpful/)
+        expect(lines).not_to include(/TRACE.*Debugging/)
+        expect(lines).not_to include(/DEBUG.*Meh/)
+        expect(lines).not_to include(/INFO.*Helpful/)
         expect(lines).to include(/WARN.*Warned/)
         expect(lines).to include(/ERROR.*Fire/)
         expect(lines).to include(/ERROR.*Stop/)
@@ -461,9 +447,9 @@ describe "passes parsed AST to the apply_catalog task" do
         @log_output.level = :error
         run_cli(%w[plan run basic::error --log-level error] + config_flags)
 
-        expect(lines).not_to include(/DEBUG.*Debugging/)
-        expect(lines).not_to include(/INFO.*Meh/)
-        expect(lines).not_to include(/NOTICE.*Helpful/)
+        expect(lines).not_to include(/TRACE.*Debugging/)
+        expect(lines).not_to include(/DEBUG.*Meh/)
+        expect(lines).not_to include(/INFO.*Helpful/)
         expect(lines).not_to include(/WARN.*Warned/)
         expect(lines).to include(/ERROR.*Fire/)
         expect(lines).to include(/ERROR.*Stop/)
@@ -475,9 +461,9 @@ describe "passes parsed AST to the apply_catalog task" do
         @log_output.level = :fatal
         run_cli(%w[plan run basic::error --log-level fatal] + config_flags)
 
-        expect(lines).not_to include(/DEBUG.*Debugging/)
-        expect(lines).not_to include(/INFO.*Meh/)
-        expect(lines).not_to include(/NOTICE.*Helpful/)
+        expect(lines).not_to include(/TRACE.*Debugging/)
+        expect(lines).not_to include(/DEBUG.*Meh/)
+        expect(lines).not_to include(/INFO.*Helpful/)
         expect(lines).not_to include(/WARN.*Warned/)
         expect(lines).not_to include(/ERROR.*Fire/)
         expect(lines).not_to include(/ERROR.*Stop/)

--- a/spec/integration/catch_errors_spec.rb
+++ b/spec/integration/catch_errors_spec.rb
@@ -30,7 +30,7 @@ describe "catch_errors", ssh: true do
   it 'catches an error and continues' do
     run_cli(%w[plan run catch_errors] + config_flags)
     output = @log_output.readlines
-    expect(output).to include("NOTICE  Puppet : Step 1\n")
+    expect(output).to include(/Puppet : Step 1/)
   end
 
   it 'returns a ResultSet' do
@@ -61,7 +61,7 @@ describe "catch_errors", ssh: true do
 
       # Verify that the plan continued
       output = @log_output.readlines
-      expect(output).to include("NOTICE  Puppet : Step 2\n")
+      expect(output).to include(/Puppet : Step 2/)
     end
 
     it 'returns the error if it matches the second type in the array' do
@@ -91,7 +91,7 @@ describe "catch_errors", ssh: true do
                             config_flags)
       expect(result).to eq("Break the chain")
       output = @log_output.readlines
-      expect(output).to include("NOTICE  Puppet : firstcomment\n")
+      expect(output).to include(/Puppet : firstcomment/)
       expect(output).not_to include(/Out of bounds/)
     end
   end

--- a/spec/integration/logging_spec.rb
+++ b/spec/integration/logging_spec.rb
@@ -17,7 +17,7 @@ describe "when logging executor activity", ssh: true do
   let(:uri) { conn_uri('ssh', include_password: true) }
   let(:user) { conn_info('ssh')[:user] }
   let(:password) { conn_info('ssh')[:password] }
-  let(:log_level) { :notice }
+  let(:log_level) { :info }
   let(:lines) { @log_output.readlines }
 
   let(:config_flags) {
@@ -32,22 +32,10 @@ describe "when logging executor activity", ssh: true do
     @log_output.level = :all
   end
 
-  it 'does not log with a command' do
-    result = run_cli_json(%W[command run #{whoami}] + config_flags)
-    expect(lines).to be_empty
-    expect(result['items'][0]['value']['stdout'].strip).to eq(conn_info('ssh')[:user])
-  end
-
-  it 'does not log with a task' do
-    result = run_cli_json(%W[task run #{stdin_task} message=somemessage] + config_flags)
-    expect(lines).to be_empty
-    expect(result['items'][0]['value']['message'].strip).to eq('somemessage')
-  end
-
   it 'logs the start and end of a plan' do
     result = run_cli_json(%W[plan run #{echo_plan} description=somemessage] + config_flags)
-    expect(lines).to include(match(/NOTICE.*Starting: plan #{echo_plan}/))
-    expect(lines).to include(match(/NOTICE.*Finished: plan #{echo_plan}/))
+    expect(lines).to include(match(/INFO.*Starting: plan #{echo_plan}/))
+    expect(lines).to include(match(/INFO.*Finished: plan #{echo_plan}/))
     expect(result[0]['value']['_output'].strip).to match(/hi there/)
   end
 
@@ -68,46 +56,42 @@ describe "when logging executor activity", ssh: true do
     end
   end
 
-  context 'with verbose logging' do
-    let(:log_level) { :info }
+  it 'logs node-level details for a command' do
+    result = run_cli_json(%W[command run #{whoami}] + config_flags)
+    expect(lines).to include(match(/Starting: command '#{whoami}'/))
+    expect(lines).to include(match(/Running command '#{whoami}'/))
+    expect(lines).to include(match(/#{conn_info('ssh')[:user]}/))
+    expect(lines).to include(match(/Finished: command '#{whoami}'/))
+    expect(result['items'][0]['value']['stdout'].strip).to eq(conn_info('ssh')[:user])
+  end
 
-    it 'logs node-level details for a command' do
-      result = run_cli_json(%W[command run #{whoami}] + config_flags)
-      expect(lines).to include(match(/Starting: command '#{whoami}'/))
-      expect(lines).to include(match(/Running command '#{whoami}'/))
-      expect(lines).to include(match(/#{conn_info('ssh')[:user]}/))
-      expect(lines).to include(match(/Finished: command '#{whoami}'/))
-      expect(result['items'][0]['value']['stdout'].strip).to eq(conn_info('ssh')[:user])
-    end
+  it 'logs node-level details for a task' do
+    result = run_cli_json(%W[task run #{stdin_task} message=somemessage] + config_flags)
+    expect(lines).to include(match(/Starting: task #{stdin_task}/))
+    expect(lines).to include(match(/Running task #{stdin_task} with/))
+    expect(lines).to include(match(/somemessage/))
+    expect(lines).to include(match(/Finished: task #{stdin_task}/))
+    expect(result['items'][0]['value']['message'].strip).to eq('somemessage')
+  end
 
-    it 'logs node-level details for a task' do
-      result = run_cli_json(%W[task run #{stdin_task} message=somemessage] + config_flags)
-      expect(lines).to include(match(/Starting: task #{stdin_task}/))
-      expect(lines).to include(match(/Running task #{stdin_task} with/))
-      expect(lines).to include(match(/somemessage/))
-      expect(lines).to include(match(/Finished: task #{stdin_task}/))
-      expect(result['items'][0]['value']['message'].strip).to eq('somemessage')
-    end
+  it 'logs node-level details for a plan' do
+    result = run_cli_json(%W[plan run #{echo_plan}] + config_flags)
+    expect(lines).to include(match(/INFO.*Starting: plan #{echo_plan}/))
+    expect(lines).to include(match(/Starting: task sample::echo/))
+    expect(lines).to include(match(/Running task sample::echo with/))
+    expect(lines).to include(match(/hi there/))
+    expect(lines).to include(match(/Finished: task sample::echo/))
+    expect(lines).to include(match(/INFO.*Finished: plan #{echo_plan}/))
+    expect(result[0]['value']['_output'].strip).to match(/hi there/)
+  end
 
-    it 'logs node-level details for a plan' do
-      result = run_cli_json(%W[plan run #{echo_plan}] + config_flags)
-      expect(lines).to include(match(/NOTICE.*Starting: plan #{echo_plan}/))
-      expect(lines).to include(match(/Starting: task sample::echo/))
-      expect(lines).to include(match(/Running task sample::echo with/))
-      expect(lines).to include(match(/hi there/))
-      expect(lines).to include(match(/Finished: task sample::echo/))
-      expect(lines).to include(match(/NOTICE.*Finished: plan #{echo_plan}/))
-      expect(result[0]['value']['_output'].strip).to match(/hi there/)
-    end
-
-    it 'logs node-level details when without_default_logging is set in a plan' do
-      run_cli_json(%W[plan run #{without_default_plan}] + config_flags)
-      expect(lines).to include(match(/NOTICE.*Starting: plan #{without_default_plan}/))
-      expect(lines).to include(match(/Starting: task logging::echo/))
-      expect(lines).to include(match(/Running task logging::echo with/))
-      expect(lines).to include(match(/hi there/))
-      expect(lines).to include(match(/Finished: task logging::echo/))
-      expect(lines).to include(match(/NOTICE.*Finished: plan #{without_default_plan}/))
-    end
+  it 'logs node-level details when without_default_logging is set in a plan' do
+    run_cli_json(%W[plan run #{without_default_plan}] + config_flags)
+    expect(lines).to include(match(/INFO.*Starting: plan #{without_default_plan}/))
+    expect(lines).to include(match(/Starting: task logging::echo/))
+    expect(lines).to include(match(/Running task logging::echo with/))
+    expect(lines).to include(match(/hi there/))
+    expect(lines).to include(match(/Finished: task logging::echo/))
+    expect(lines).to include(match(/INFO.*Finished: plan #{without_default_plan}/))
   end
 end

--- a/spec/integration/result_set_spec.rb
+++ b/spec/integration/result_set_spec.rb
@@ -40,13 +40,13 @@ describe "when running a plan that manipulates an execution result", ssh: true d
         params = { target: uri }.to_json
         run_cli(['plan', 'run', 'results::test_methods', "--params", params] + config_flags)
         expect(@log_output.readlines)
-          .to include("NOTICE  Puppet : Filtered set: [#{safe_uri}]\n")
+          .to include(/Puppet : Filtered set: \[#{safe_uri}\]/)
       end
 
       it 'excludes target when filter is false' do
         params = { target: uri, fail: true }.to_json
         run_cli(['plan', 'run', 'results::test_methods', "--params", params] + config_flags)
-        expect(@log_output.readlines).to include("NOTICE  Puppet : Filtered set: []\n")
+        expect(@log_output.readlines).to include(/Puppet : Filtered set: \[\]/)
       end
     end
 
@@ -55,13 +55,13 @@ describe "when running a plan that manipulates an execution result", ssh: true d
         params = { target: uri }.to_json
         run_cli(['plan', 'run', 'results::test_methods', "--params", params] + config_flags)
         expect(@log_output.readlines)
-          .to include("NOTICE  Puppet : Single index: #{uri}\n")
+          .to include(/Puppet : Single index: #{uri}/)
       end
 
       it 'with a slice index' do
         params = { target: uri, fail: true }.to_json
         run_cli(['plan', 'run', 'results::test_methods', "--params", params] + config_flags)
-        expect(@log_output.readlines).to include("NOTICE  Puppet : Slice index: [#{uri}]\n")
+        expect(@log_output.readlines).to include(/Puppet : Slice index: \[#{uri}\]/)
       end
     end
 
@@ -69,7 +69,7 @@ describe "when running a plan that manipulates an execution result", ssh: true d
       params = { nodes: uri }.to_json
       result = run_cli(['plan', 'run', 'results::test_result', "--params", params] + config_flags)
       expect(@log_output.readlines)
-        .to include("NOTICE  Puppet : Result status: success\n")
+        .to include(/Puppet : Result status: success/)
       expect(JSON.parse(result).first).to include('value')
     end
   end

--- a/spec/lib/bolt_spec/logger.rb
+++ b/spec/lib/bolt_spec/logger.rb
@@ -9,6 +9,7 @@ module BoltSpec
       allow(Logging).to receive(:logger).and_return(mock_logger)
       allow(@mock_logger).to receive(:[]).and_return(mock_logger)
       # These are allowed since we don't test them and the ssh library uses them
+      allow(@mock_logger).to receive(:trace)
       allow(@mock_logger).to receive(:debug)
       allow(@mock_logger).to receive(:debug?)
       allow(@mock_logger).to receive(:info?)


### PR DESCRIPTION
Bolt now writes a `bolt-debug.log` file in the project directory that includes
debug-level information from the _most recent_ Bolt run. The log is overwritten
each time Bolt runs.

This also reorganizes the log levels a bit to suit writing a debug log without
including sensitive information. We now have a trace level beyond debug which
is used to log messages that are only really interesting when trying to debug
Bolt itself. Debug is now used for messages that help the user debug their
usage of Bolt or the execution of their plan. Info is used to report _what_
Bolt is doing.

To suit this debug log, we now downgrade Puppet log messages rather than
mapping them directly to the corresponding Bolt log level. Puppet info messages
go to Bolt debug level, Puppet debug messages go to Bolt trace level. As Puppet
is primarily an implementation detail of Bolt, this helps avoid noise in the
log. Specifically, Puppet is chatty at debug level and will overwhelm the debug
log without this change.

!feature

  * **Write a default log file**
    ([#2068](https://github.com/puppetlabs/bolt/issues/2068))

    Bolt will now log activity at debug level to `bolt-debug.log` in the
   project directory. This log will be truncated each time Bolt runs.