### PR TITLE
(bug) Show YAML plan parameters without defaults as required

### DIFF
--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -409,7 +409,7 @@ module Bolt
                      end
           params[name] = { 'type' => type_str }
           params[name]['sensitive'] = param.type_expr.instance_of?(Puppet::Pops::Types::PSensitiveType)
-          params[name]['default_value'] = param.value
+          params[name]['default_value'] = param.value unless param.value.nil?
           params[name]['description'] = param.description if param.description
         end
         {

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1520,7 +1520,6 @@ describe "Bolt::CLI" do
             "parameters" => {
               "nodes" => {
                 "type" => "TargetSpec",
-                "default_value" => nil,
                 "sensitive" => false
               },
               "param_optional" => {


### PR DESCRIPTION
This fixes a minor bug in `Bolt::PAL.get_plan_info` that incorrectly
built the parameter hash for YAML plans, resulting in an inaccurate
usage line in `bolt plan show <plan>` output.

Previously, if a YAML plan parameter did not have a default value,
the parameter hash would receive a value of `nil` for the parameter's
default value. When this hash is received by the outputter to display
the plan info, it would check whether the parameter had a default value
key specified to determine whether it should display the parameter as
optional or required in the usage line. Since parameters for YAML plans
would always have this key, the outputter would show all parameters as
optional. Now, the default value key is only added if there is a default
value for the parameter.

!bug

* **Show YAML plan parameters without default values as required**

  Bolt was displaying YAML plan parameters without default values as
  optional in `bolt plan show` output. Now, Bolt will show a parameter
  without a default value as required.