### PR TITLE
(maint) Properly mark non-optional YAML plan parameters in usage info

### DIFF
--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -260,7 +260,7 @@ module Bolt
           pretty_params << "- #{name}: #{p['type']}\n"
           pretty_params << "    Default: #{p['default_value']}\n" unless p['default_value'].nil?
           pretty_params << "    #{p['description']}\n" if p['description']
-          usage << (p.include?('default_value') ? " [#{name}=<value>]" : " #{name}=<value>")
+          usage << (p['default_value'].nil? ? " #{name}=<value>" : " [#{name}=<value>]")
         end
 
         plan_info << "\n#{plan['name']}"


### PR DESCRIPTION
Previously, YAML plans without a default value were always marked as
optional (surrounded with brackets) in the usage info displayed in
`bolt plan show <plan>`. That happened because we always populate a
default_value field for those parameters, even if it happens to be nil.
Since nil is not a valid value in Puppet, we now explicitly check for it
instead of just using the presence of the key.