### PR TITLE
(GH-1995) Log where projects are loaded from

### DIFF
--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -19,7 +19,7 @@ module Bolt
   class Config
     include Bolt::Config::Options
 
-    attr_reader :config_files, :warnings, :data, :transports, :project, :modified_concurrency, :deprecations
+    attr_reader :config_files, :logs, :data, :transports, :project, :modified_concurrency, :deprecations
 
     BOLT_CONFIG_NAME = 'bolt.yaml'
     BOLT_DEFAULTS_NAME = 'bolt-defaults.yaml'
@@ -32,16 +32,19 @@ module Bolt
     end
 
     def self.from_project(project, overrides = {})
+      logs = []
       conf = if project.project_file == project.config_file
                project.data
              else
-               Bolt::Util.read_optional_yaml_hash(project.config_file, 'config')
+               c = Bolt::Util.read_optional_yaml_hash(project.config_file, 'config')
+               logs << { debug: "Loaded configuration from #{project.config_file}" } if File.exist?(project.config_file)
+               c
              end
 
       data = load_defaults(project).push(
         filepath: project.config_file,
         data: conf,
-        warnings: [],
+        logs: logs,
         deprecations: []
       )
 
@@ -50,17 +53,20 @@ module Bolt
 
     def self.from_file(configfile, overrides = {})
       project = Bolt::Project.create_project(Pathname.new(configfile).expand_path.dirname)
+      logs = []
 
       conf = if project.project_file == project.config_file
                project.data
              else
-               Bolt::Util.read_yaml_hash(configfile, 'config')
+               c = Bolt::Util.read_yaml_hash(configfile, 'config')
+               logs << { debug: "Loaded configuration from #{configfile}" }
+               c
              end
 
       data = load_defaults(project).push(
         filepath: project.config_file,
         data: conf,
-        warnings: [],
+        logs: logs,
         deprecations: []
       )
 
@@ -90,13 +96,13 @@ module Bolt
     def self.load_bolt_defaults_yaml(dir)
       filepath = dir + BOLT_DEFAULTS_NAME
       data     = Bolt::Util.read_yaml_hash(filepath, 'config')
-      warnings = []
+      logs     = [{ debug: "Loaded configuration from #{filepath}" }]
 
       # Warn if 'bolt.yaml' detected in same directory.
       if File.exist?(bolt_yaml = dir + BOLT_CONFIG_NAME)
-        warnings.push(
-          msg: "Detected multiple configuration files: ['#{bolt_yaml}', '#{filepath}']. '#{bolt_yaml}' "\
-               "will be ignored."
+        logs.push(
+          warn: "Detected multiple configuration files: ['#{bolt_yaml}', '#{filepath}']. '#{bolt_yaml}' "\
+          "will be ignored."
         )
       end
 
@@ -105,9 +111,9 @@ module Bolt
 
       if project_config.any?
         data.reject! { |key, _| project_config.include?(key) }
-        warnings.push(
-          msg: "Unsupported project configuration detected in '#{filepath}': #{project_config.keys}. "\
-                "Project configuration should be set in 'bolt-project.yaml'."
+        logs.push(
+          warn: "Unsupported project configuration detected in '#{filepath}': #{project_config.keys}. "\
+          "Project configuration should be set in 'bolt-project.yaml'."
         )
       end
 
@@ -116,10 +122,10 @@ module Bolt
 
       if transport_config.any?
         data.reject! { |key, _| transport_config.include?(key) }
-        warnings.push(
-          msg: "Unsupported inventory configuration detected in '#{filepath}': #{transport_config.keys}. "\
-               "Transport configuration should be set under the 'inventory-config' option or "\
-               "in 'inventory.yaml'."
+        logs.push(
+          warn: "Unsupported inventory configuration detected in '#{filepath}': #{transport_config.keys}. "\
+          "Transport configuration should be set under the 'inventory-config' option or "\
+          "in 'inventory.yaml'."
         )
       end
 
@@ -142,7 +148,7 @@ module Bolt
         data = data.merge(data.delete('inventory-config'))
       end
 
-      { filepath: filepath, data: data, warnings: warnings, deprecations: [] }
+      { filepath: filepath, data: data, logs: logs, deprecations: [] }
     end
 
     # Loads a 'bolt.yaml' file, the legacy configuration file. There's no special munging needed
@@ -150,11 +156,12 @@ module Bolt
     def self.load_bolt_yaml(dir)
       filepath = dir + BOLT_CONFIG_NAME
       data     = Bolt::Util.read_yaml_hash(filepath, 'config')
+      logs     = [{ debug: "Loaded configuration from #{filepath}" }]
       deprecations = [{ type: 'Using bolt.yaml for system configuration',
                         msg: "Configuration file #{filepath} is deprecated and will be removed in a future version "\
                         "of Bolt. Use '#{dir + BOLT_DEFAULTS_NAME}' instead." }]
 
-      { filepath: filepath, data: data, warnings: [], deprecations: deprecations }
+      { filepath: filepath, data: data, logs: logs, deprecations: deprecations }
     end
 
     def self.load_defaults(project)
@@ -187,13 +194,13 @@ module Bolt
       unless config_data.is_a?(Array)
         config_data = [{ filepath: project.config_file,
                          data: config_data,
-                         warnings: [],
+                         logs: [],
                          deprecations: [] }]
       end
 
       @logger       = Logging.logger[self]
       @project      = project
-      @warnings     = @project.warnings.dup
+      @logs         = @project.logs.dup
       @deprecations = @project.deprecations.dup
       @transports   = {}
       @config_files = []
@@ -221,7 +228,7 @@ module Bolt
       end
 
       loaded_data = config_data.each_with_object([]) do |data, acc|
-        @warnings.concat(data[:warnings]) if data[:warnings].any?
+        @logs.concat(data[:logs]) if data[:logs].any?
         @deprecations.concat(data[:deprecations]) if data[:deprecations].any?
 
         if data[:data].any?
@@ -365,7 +372,7 @@ module Bolt
     def validate
       if @data['future']
         msg = "Configuration option 'future' no longer exposes future behavior."
-        @warnings << { option: 'future', msg: msg }
+        @logs << { warn: msg }
       end
 
       keys = OPTIONS.keys - %w[plugins plugin_hooks puppetdb]

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -199,16 +199,16 @@ describe Bolt::Config do
       allow(Bolt::Util).to receive(:read_yaml_hash).and_return({})
       allow(File).to receive(:exist?).with(path + config_name).and_return(true)
 
-      warnings = Bolt::Config.load_bolt_defaults_yaml(path)[:warnings]
-      expect(warnings).to include(msg: /Detected multiple configuration files/)
+      logs = Bolt::Config.load_bolt_defaults_yaml(path)[:logs]
+      expect(logs).to include(warn: /Detected multiple configuration files/)
     end
 
     it 'warns when inventory config keys are present' do
       allow(File).to receive(:exist?)
       allow(Bolt::Util).to receive(:read_yaml_hash).and_return(Bolt::Config::INVENTORY_OPTIONS.dup)
 
-      warnings = Bolt::Config.load_bolt_defaults_yaml(path)[:warnings]
-      expect(warnings).to include(msg: /Unsupported inventory configuration/)
+      logs = Bolt::Config.load_bolt_defaults_yaml(path)[:logs]
+      expect(logs).to include(warn: /Unsupported inventory configuration/)
     end
 
     it 'warns when project config keys are present' do
@@ -217,8 +217,8 @@ describe Bolt::Config do
       allow(File).to receive(:exist?)
       allow(Bolt::Util).to receive(:read_yaml_hash).and_return(project_config)
 
-      warnings = Bolt::Config.load_bolt_defaults_yaml(path)[:warnings]
-      expect(warnings).to include(msg: /Unsupported project configuration/)
+      logs = Bolt::Config.load_bolt_defaults_yaml(path)[:logs]
+      expect(logs).to include(warn: /Unsupported project configuration/)
     end
 
     it 'puts keys under inventory-config at the top level' do
@@ -308,10 +308,7 @@ describe Bolt::Config do
     let(:config) { Bolt::Config.new(project, future_config) }
 
     it 'logs a warning' do
-      expect(config.warnings).to include(
-        msg: /Configuration option 'future'/,
-        option: 'future'
-      )
+      expect(config.logs).to include(warn: /Configuration option 'future'/)
     end
   end
 
@@ -395,9 +392,9 @@ describe Bolt::Config do
 
     let(:config) {
       Bolt::Config.new(project, [
-                         { data: system_config, warnings: [], deprecations: [] },
-                         { data: user_config, warnings: [], deprecations: [] },
-                         { data: project_config, warnings: [], deprecations: [] }
+                         { data: system_config, logs: [], deprecations: [] },
+                         { data: user_config, logs: [], deprecations: [] },
+                         { data: project_config, logs: [], deprecations: [] }
                        ])
     }
 

--- a/spec/integration/yaml_plan_spec.rb
+++ b/spec/integration/yaml_plan_spec.rb
@@ -165,6 +165,8 @@ describe "running YAML plans", ssh: true do
     allow(mock_logger).to receive(:info)
     allow(mock_logger).to receive(:warn)
       .with("No project name is specified in bolt-project.yaml. Project-level content will not be available.")
+    allow(mock_logger).to receive(:warn)
+      .with("bolt-project.yaml contains valid config keys, bolt.yaml will be ignored")
 
     expect(Bolt::Logger).to receive(:deprecation_warning).with(anything, /Use the 'targets' parameter instead./)
 


### PR DESCRIPTION
This will now log the path that a project is loaded from at `info`
level. This also moves the message listing loaded config files to
`debug`. Lastly this adds a message when Bolt is searching for a project
and doesn't find one at the path stating that the path won't be loaded
as a project.

This also does some restructuring of how logs are gathered from project
and config loading and passed back to the CLI to be logged. Because the
project and config are loaded before the logger is configured (because
log configuration is in the config), we need to store up those logs and
pass them back to the CLI so they can be logged once everything is set
up. Previously we just had a `warnings` instance variable on the config
class that inherited from the project class, got read and logged. The
same flow is true, but now instead of an array of messages to log at
`warn` level there's a new instance variable `logs` which stores an
ordered array of hashes, where each hash is a log level and it's
message. This lets us print the logs in order at the correct log level
in the CLI.

Closes #1995

!no-release-note