### PR TITLE
(GH-2082) Add 'module install' command to install module dependencies

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -64,6 +64,15 @@ module Bolt
       when 'guide'
         { flags: OPTIONS[:global] + %w[format],
           banner: GUIDE_HELP }
+      when 'module'
+        case action
+        when 'install'
+          { flags: OPTIONS[:global] + %w[configfile force project],
+            banner: MODULE_INSTALL_HELP }
+        else
+          { flags: OPTIONS[:global],
+            banner: MODULE_HELP }
+        end
       when 'plan'
         case action
         when 'convert'
@@ -339,6 +348,35 @@ module Bolt
 
       DESCRIPTION
           Show the list of targets an action would run on.
+    HELP
+
+    MODULE_HELP = <<~HELP
+      NAME
+          module
+      
+      USAGE
+          bolt module <action> [options]
+
+      DESCRIPTION
+          Install the project's modules
+
+      ACTIONS
+          install       Install the project's modules
+    HELP
+
+    MODULE_INSTALL_HELP = <<~HELP
+      NAME
+          install
+      
+      USAGE
+          bolt module install [options]
+
+      DESCRIPTION
+          Install the project's modules.
+
+          Module declarations are loaded from the project's configuration
+          file. Bolt will automatically resolve all module dependencies,
+          generate a Puppetfile, and install the modules.
     HELP
 
     PLAN_HELP = <<~HELP
@@ -864,9 +902,9 @@ module Bolt
       define('--modules MODULES',
              'A comma-separated list of modules to install from the Puppet Forge',
              'when initializing a project. Resolves and installs all dependencies.') do |modules|
-        @options[:modules] = modules.split(',')
+        @options[:modules] = modules.split(',').map { |mod| { 'name' => mod } }
       end
-      define('--force', 'Overwrite existing key pairs') do |_force|
+      define('--force', 'Force a destructive action') do |_force|
         @options[:force] = true
       end
 

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -227,6 +227,24 @@ module Bolt
           _example: ["~/.puppetlabs/bolt/modules", "~/.puppetlabs/bolt/site-modules"],
           _default: ["project/modules", "project/site-modules", "project/site"]
         },
+        "modules" => {
+          description: "A list of module dependencies for the project. Each dependency is a map of data specifying "\
+                       "the module to install. To install the project's module dependencies, run the `bolt module "\
+                       "install` command.",
+          type: Array,
+          items: {
+            type: Hash,
+            required: ["name"],
+            properties: {
+              "name" => {
+                description: "The name of the module.",
+                type: String
+              }
+            }
+          },
+          _plugin: false,
+          _example: [{ "name" => "puppetlabs-mysql" }, { "name" => "puppetlabs-apache" }]
+        },
         "name" => {
           description: "The name of the Bolt project. When this option is configured, the project is considered a "\
                        "[Bolt project](experimental_features.md#bolt-projects), allowing Bolt to load content from "\
@@ -476,6 +494,7 @@ module Bolt
         inventoryfile
         log
         modulepath
+        modules
         name
         plans
         plugin_hooks

--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -149,6 +149,10 @@ module Bolt
       @data['plans']
     end
 
+    def modules
+      @data['modules']
+    end
+
     def validate
       if name
         if name !~ Bolt::Module::MODULE_NAME_REGEX
@@ -168,6 +172,23 @@ module Bolt
       %w[tasks plans].each do |conf|
         unless @data.fetch(conf, []).is_a?(Array)
           raise Bolt::ValidationError, "'#{conf}' in bolt-project.yaml must be an array"
+        end
+      end
+
+      if @data['modules']
+        unless @data['modules'].is_a?(Array)
+          raise Bolt::ValidationError, "'modules' in bolt-project.yaml must be an array"
+        end
+
+        @data['modules'].each do |mod|
+          next if mod.is_a?(Hash)
+          raise Bolt::ValidationError, "Module declaration #{mod.inspect} must be a hash"
+        end
+
+        unknown_keys = data['modules'].flat_map(&:keys).uniq - ['name']
+        if unknown_keys.any?
+          @logs << { warn: "Module declarations in bolt-project.yaml only support a name key. Ignoring "\
+                           "unsupported keys: #{unknown_keys.join(', ')}." }
         end
       end
     end

--- a/lib/bolt/puppetfile.rb
+++ b/lib/bolt/puppetfile.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require 'bolt/error'
+require 'bolt/puppetfile/module'
+
+# This class manages the logical contents of a Puppetfile. It includes methods
+# for parsing a Puppetfile and its modules, resolving module dependencies,
+# and writing a Puppetfile.
+#
+module Bolt
+  class Puppetfile
+    attr_reader :modules
+
+    def initialize(modules = [])
+      @modules = Set.new
+      add_modules(modules)
+    end
+
+    # Loads a Puppetfile and parses its module specifications, returning a
+    # Bolt::Puppetfile object with the modules set.
+    #
+    def self.parse(path)
+      require 'puppetfile-resolver'
+      require 'puppetfile-resolver/puppetfile/parser/r10k_eval'
+
+      begin
+        parsed = ::PuppetfileResolver::Puppetfile::Parser::R10KEval.parse(File.read(path))
+      rescue StandardError => e
+        raise Bolt::Error.new(
+          "Unable to parse Puppetfile #{path}: #{e.message}",
+          'bolt/puppetfile-parsing'
+        )
+      end
+
+      unless parsed.valid?
+        raise Bolt::ValidationError,
+              "Unable to parse Puppetfile #{path}"
+      end
+
+      modules = parsed.modules.map do |mod|
+        Bolt::Puppetfile::Module.new(mod.owner, mod.name, mod.version)
+      end
+
+      new(modules)
+    end
+
+    # Writes a Puppetfile that includes specifications for each of the
+    # modules.
+    #
+    def write(path, force: false)
+      if File.exist?(path) && !force
+        raise Bolt::FileError.new(
+          "Cannot overwrite existing Puppetfile at #{path}. To forcibly overwrite, "\
+          "run with the '--force' option.",
+          path
+        )
+      end
+
+      File.open(path, 'w') do |file|
+        file.puts '# This Puppetfile is managed by Bolt. Do not edit.'
+        modules.each { |mod| file.puts mod.to_spec }
+        file.puts
+      end
+    rescue SystemCallError => e
+      raise Bolt::FileError.new(
+        "#{e.message}: unable to write Puppetfile.",
+        path
+      )
+    end
+
+    # Resolves module dependencies using the puppetfile-resolver library. The
+    # resolver will return a document model including all module dependencies
+    # and the latest version that can be installed for each. The document model
+    # is parsed and turned into a Set of Bolt::Puppetfile::Module objects.
+    #
+    def resolve
+      require 'puppetfile-resolver'
+
+      # Build the document model from the modules.
+      model = PuppetfileResolver::Puppetfile::Document.new('')
+
+      @modules.each do |mod|
+        model.add_module(
+          PuppetfileResolver::Puppetfile::ForgeModule.new(mod.title).tap do |tap|
+            tap.version = :latest
+          end
+        )
+      end
+
+      # Make sure the Puppetfile model is valid.
+      unless model.valid?
+        raise Bolt::ValidationError,
+              "Unable to resolve dependencies for modules: #{@modules.map(&:title).join(', ')}"
+      end
+
+      # Create the resolver using the Puppetfile model. nil disables Puppet
+      # version restrictions.
+      resolver = PuppetfileResolver::Resolver.new(model, nil)
+
+      # Configure and resolve the dependency graph, catching any errors
+      # raised by puppetfile-resolver and re-raising them as Bolt errors.
+      begin
+        result = resolver.resolve(
+          cache:                 nil,
+          ui:                    nil,
+          module_paths:          [],
+          allow_missing_modules: true
+        )
+      rescue StandardError => e
+        raise Bolt::Error.new(e.message, 'bolt/puppetfile-resolver-error')
+      end
+
+      # Validate that the modules exist.
+      missing_graph = result.specifications.select do |_name, spec|
+        spec.instance_of? PuppetfileResolver::Models::MissingModuleSpecification
+      end
+
+      if missing_graph.any?
+        titles = model.modules.each_with_object({}) do |mod, acc|
+          acc[mod.name] = mod.title
+        end
+
+        names = titles.values_at(*missing_graph.keys)
+        plural = names.count == 1 ? '' : 's'
+
+        raise Bolt::Error.new(
+          "Unknown module name#{plural} #{names.join(', ')}",
+          'bolt/unknown-modules'
+        )
+      end
+
+      # Filter the dependency graph to only include module specifications. This
+      # will only remove the Puppet version specification, which is not needed.
+      specs = result.specifications.select do |_name, spec|
+        spec.instance_of? PuppetfileResolver::Models::ModuleSpecification
+      end
+
+      @modules = specs.map do |_name, spec|
+        Bolt::Puppetfile::Module.new(spec.owner, spec.name, spec.version.to_s)
+      end.to_set
+    end
+
+    # Adds to the set of modules.
+    #
+    def add_modules(modules)
+      modules.each do |mod|
+        case mod
+        when Bolt::Puppetfile::Module
+          @modules << mod
+        when Hash
+          @modules << Bolt::Puppetfile::Module.from_hash(mod)
+        else
+          raise Bolt::ValidationError, "Module must be a Bolt::Puppetfile::Module or Hash."
+        end
+      end
+
+      @modules
+    end
+  end
+end

--- a/lib/bolt/puppetfile/installer.rb
+++ b/lib/bolt/puppetfile/installer.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'r10k/cli'
+require 'bolt/r10k_log_proxy'
+require 'bolt/error'
+
+# This class is used to install modules from a Puppetfile to a module directory.
+#
+module Bolt
+  class Puppetfile
+    class Installer
+      def initialize(config = {})
+        @config = config
+      end
+
+      def install(path, moduledir)
+        unless File.exist?(path)
+          raise Bolt::FileError.new(
+            "Could not find a Puppetfile at #{path}",
+            path
+          )
+        end
+
+        r10k_opts = {
+          root:       File.dirname(path),
+          puppetfile: path.to_s,
+          moduledir:  moduledir.to_s
+        }
+
+        settings = R10K::Settings.global_settings.evaluate(@config)
+        R10K::Initializers::GlobalInitializer.new(settings).call
+        install_action = R10K::Action::Puppetfile::Install.new(r10k_opts, nil)
+
+        # Override the r10k logger with a proxy to our own logger
+        R10K::Logging.instance_variable_set(:@outputter, Bolt::R10KLogProxy.new)
+
+        install_action.call
+      rescue R10K::Error => e
+        raise PuppetfileError, e
+      end
+    end
+  end
+end

--- a/lib/bolt/puppetfile/module.rb
+++ b/lib/bolt/puppetfile/module.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'bolt/error'
+
+# This class represents a module specification. It used by the Bolt::Puppetfile
+# class to have a consistent API for accessing a module's attributes.
+#
+module Bolt
+  class Puppetfile
+    class Module
+      attr_reader :owner, :name, :version
+
+      def initialize(owner, name, version = nil)
+        @owner   = owner
+        @name    = name
+        @version = version
+      end
+
+      # Creates a new module from a hash.
+      #
+      def self.from_hash(mod)
+        unless mod['name'].is_a?(String)
+          raise Bolt::ValidationError,
+                "Module name must be a String, not #{mod['name'].inspect}"
+        end
+
+        owner, name = mod['name'].tr('/', '-').split('-', 2)
+
+        unless owner && name
+          raise Bolt::ValidationError, "Module name #{mod['name']} must include both the owner and module name."
+        end
+
+        new(owner, name)
+      end
+
+      # Returns the module's title.
+      #
+      def title
+        "#{@owner}-#{@name}"
+      end
+
+      # Checks two modules for equality.
+      #
+      def eql?(other)
+        self.class == other.class && @owner == other.owner && @name == other.name
+      end
+      alias == eql?
+
+      # Hashes the module.
+      #
+      def hash
+        [@owner, @name].hash
+      end
+
+      # Returns the Puppetfile specification for the module.
+      #
+      def to_spec
+        if @version
+          "mod #{title.inspect}, #{@version.inspect}"
+        else
+          "mod #{title.inspect}"
+        end
+      end
+    end
+  end
+end

--- a/rakelib/pwsh.rake
+++ b/rakelib/pwsh.rake
@@ -47,7 +47,9 @@ namespace :pwsh do
     Bolt::CLI::COMMANDS.each do |subcommand, actions|
       # The 'bolt guide' command is handled by PowerShell's help system, so
       # don't create a cmdlet for it.
-      next if subcommand == 'guide'
+      # The 'bolt module' command is currently feature-flagged and should
+      # not be visible to users, so don't create a PowerShell cmdlet for now.
+      next if %w[guide module].include?(subcommand)
 
       actions << nil if actions.empty?
       actions.each do |action|

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -31,6 +31,9 @@
     "modulepath": {
       "$ref": "#/definitions/modulepath"
     },
+    "modules": {
+      "$ref": "#/definitions/modules"
+    },
     "name": {
       "$ref": "#/definitions/name"
     },
@@ -163,6 +166,22 @@
       ],
       "items": {
         "type": "string"
+      }
+    },
+    "modules": {
+      "description": "A list of module dependencies for the project. Each dependency is a map of data specifying the module to install. To install the project's module dependencies, run the `bolt module install` command.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "description": "The name of the module.",
+            "type": "string"
+          }
+        }
       }
     },
     "name": {

--- a/spec/bolt/project_spec.rb
+++ b/spec/bolt/project_spec.rb
@@ -83,6 +83,28 @@ describe Bolt::Project do
           .to raise_error(/Invalid project name 'puppetlabs-foo' in bolt-project.yaml/)
       end
     end
+
+    context 'with module delcarations' do
+      it 'errors if not an array' do
+        config = {
+          'modules' => {}
+        }
+
+        expect { Bolt::Project.new(config, pwd).validate }
+          .to raise_error(Bolt::ValidationError)
+      end
+
+      it 'errors if a module delcaration is not a hash' do
+        config = {
+          'modules' => [
+            'puppetlabs-yaml'
+          ]
+        }
+
+        expect { Bolt::Project.new(config, pwd).validate }
+          .to raise_error(Bolt::ValidationError)
+      end
+    end
   end
 
   describe "::find_boltdir" do

--- a/spec/bolt/puppetfile/installer_spec.rb
+++ b/spec/bolt/puppetfile/installer_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'bolt/puppetfile/installer'
+
+describe Bolt::Puppetfile::Installer do
+  let(:path)      { (@project + 'Puppetfile').expand_path }
+  let(:moduledir) { (@project + 'modules').expand_path }
+  let(:installer) { described_class.new }
+
+  around(:each) do |example|
+    Dir.mktmpdir(nil, Dir.pwd) do |project|
+      @project = Pathname.new(project)
+      example.run
+    end
+  end
+
+  context '#install' do
+    it 'errors if the Puppetfile does not exist' do
+      expect { installer.install(path, moduledir) }.to raise_error(
+        Bolt::Error,
+        /Could not find a Puppetfile/
+      )
+    end
+
+    it 'installs the modules to the modulepath' do
+      File.write(path, "mod 'puppetlabs-yaml', '0.2.0'")
+
+      result = installer.install(path, moduledir)
+
+      expect(result).to be
+      expect(Dir.exist?(moduledir)).to eq(true)
+      expect(Dir.children(moduledir)).to match_array(['yaml'])
+    end
+  end
+end

--- a/spec/bolt/puppetfile/module_spec.rb
+++ b/spec/bolt/puppetfile/module_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'bolt/puppetfile/module'
+
+describe Bolt::Puppetfile::Module do
+  context '#initialize' do
+    it 'creates a new module' do
+      expect(described_class.new('owner', 'name', '1.1.0')).to be
+    end
+
+    it 'does not require a version' do
+      expect(described_class.new('owner', 'name')).to be
+    end
+  end
+
+  context '#from_hash' do
+    it 'returns a module' do
+      expect(described_class.from_hash('name' => 'puppetlabs-apt')).to be_kind_of(described_class)
+    end
+
+    it 'errors if the name does not include the owner and module name' do
+      expect { described_class.from_hash('name' => 'apt') }.to raise_error(
+        Bolt::ValidationError,
+        /Module name apt must include both the owner and module name/
+      )
+    end
+  end
+
+  context '#title' do
+    it 'returns the module title' do
+      expect(described_class.new('owner', 'name').title).to eq('owner-name')
+    end
+  end
+
+  context '#eql?' do
+    it 'returns true for modules with the same owner and name' do
+      mod1 = described_class.new('owner', 'title')
+      mod2 = described_class.new('owner', 'title')
+
+      expect(mod1.eql?(mod2)).to eq(true)
+    end
+
+    it 'returns false for modules with differing titles' do
+      mod1 = described_class.new('owner', 'title')
+      mod2 = described_class.new('author', 'title')
+
+      expect(mod1.eql?(mod2)).to eq(false)
+    end
+  end
+
+  context '#hash' do
+    it 'errors without a name key' do
+      expect { described_class.from_hash('title' => 'puppetlabs-apt') }.to raise_error(
+        Bolt::ValidationError,
+        /Module name must be a String/
+      )
+    end
+
+    it 'errors if name is not a String' do
+      expect { described_class.from_hash('name' => 42) }.to raise_error(
+        Bolt::ValidationError,
+        /Module name must be a String/
+      )
+    end
+
+    it 'hashes from owner and name' do
+      mod1 = described_class.new('puppetlabs', 'apt')
+      mod2 = described_class.new('puppetlabs', 'apt')
+      mod3 = described_class.new('puppetlabs', 'yaml')
+      expect(Set.new([mod1, mod2, mod3]).size).to eq(2)
+    end
+
+    it 'does not hash from version' do
+      mod1 = described_class.new('puppetlabs', 'apt', '1.0.0')
+      mod2 = described_class.new('puppetlabs', 'apt', '2.0.0')
+      expect(Set.new([mod1, mod2]).size).to eq(1)
+    end
+  end
+
+  context '#to_spec' do
+    it 'returns a Puppetfile module spec' do
+      expect(described_class.new('owner', 'name', '1.0.0').to_spec).to eq(
+        'mod "owner-name", "1.0.0"'
+      )
+    end
+
+    it 'returns a Puppetfile module spec with :latest' do
+      expect(described_class.new('owner', 'name', :latest).to_spec).to eq(
+        'mod "owner-name", :latest'
+      )
+    end
+
+    it 'returns a Puppetfile module spec with no verison' do
+      expect(described_class.new('owner', 'name').to_spec).to eq(
+        'mod "owner-name"'
+      )
+    end
+  end
+end

--- a/spec/bolt/puppetfile_spec.rb
+++ b/spec/bolt/puppetfile_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'bolt/puppetfile'
+
+describe Bolt::Puppetfile do
+  let(:path)       { @project + 'Puppetfile' }
+  let(:modules)    { [{ 'name' => 'puppetlabs-yaml' }] }
+  let(:puppetfile) { described_class.new(modules) }
+
+  around(:each) do |example|
+    Dir.mktmpdir(nil, Dir.pwd) do |project|
+      @project = Pathname.new(project)
+      example.run
+    end
+  end
+
+  context '#initialize' do
+    it 'turns modules into Bolt::Puppetfile::Module objects' do
+      puppetfile = described_class.new(modules)
+
+      expect(puppetfile.modules).to be_kind_of(Set)
+      expect(puppetfile.modules.size).to eq(1)
+
+      puppetfile.modules.each do |mod|
+        expect(mod).to be_kind_of(Bolt::Puppetfile::Module)
+      end
+    end
+  end
+
+  context '#parse' do
+    it 'errors if unable to parse the Puppetfile' do
+      File.write(path, "mod 'puppetlabs-yaml' '0.2.0'")
+
+      expect { described_class.parse(path) }.to raise_error(
+        Bolt::Error,
+        /Unable to parse Puppetfile/
+      )
+    end
+
+    it 'returns a list of Bolt::Puppetfile::Module objects' do
+      File.write(path, "mod 'puppetlabs-yaml', '0.2.0'")
+
+      puppetfile = described_class.parse(path)
+
+      expect(puppetfile.modules).to be_kind_of(Set)
+      expect(puppetfile.modules.size).to eq(1)
+
+      puppetfile.modules.each do |mod|
+        expect(mod).to be_kind_of(Bolt::Puppetfile::Module)
+      end
+    end
+
+    it 'handles git modules' do
+      File.write(path, "mod 'puppetlabs-yaml', git: 'https://github.com/puppetlabs/puppetlabs-yaml', branch: 'master'")
+      expect { described_class.parse(path) }.not_to raise_error
+    end
+  end
+
+  context '#write' do
+    it 'errors if there is an existing Puppetfile' do
+      File.write(path, "mod 'puppetlabs-yaml', '0.2.0'")
+
+      expect { puppetfile.write(path) }.to raise_error(
+        Bolt::FileError,
+        /Cannot overwrite existing Puppetfile.*force/
+      )
+    end
+
+    it 'writes modules to the Puppetfile' do
+      puppetfile.write(path)
+      expect(path.exist?).to eq(true)
+      expect(File.read(path)).to match(/mod "puppetlabs-yaml"/)
+    end
+
+    it 'forcibly overwrites an existing Puppetfile' do
+      File.write(path, "mod 'puppetlabs-apt', '1.0.0'")
+
+      puppetfile.write(path, force: true)
+      expect(path.exist?).to eq(true)
+      expect(File.read(path)).to match(/mod "puppetlabs-yaml"/)
+    end
+  end
+
+  context '#resolve' do
+    context 'with unknown modules' do
+      let(:modules) { [{ 'name' => 'puppetlabs-boltymcboltface' }] }
+
+      it 'errors' do
+        expect { puppetfile.resolve }.to raise_error(
+          Bolt::Error,
+          /Unknown module name/
+        )
+      end
+    end
+
+    it 'resolves dependencies and returns a list of Bolt::Puppetfile::Module objects' do
+      modules = puppetfile.resolve
+
+      expect(modules).to be_kind_of(Set)
+      expect(modules.size).to be > 1
+
+      modules.each do |mod|
+        expect(mod).to be_kind_of(Bolt::Puppetfile::Module)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a new Bolt command `bolt module install` that installs a list of
modules declared in the project's configuration file, as well as all of
their dependencies. This command will resolve all dependencies for the
declared modules, generate a Puppetfile with specifications for each
module, and then install the modules to the project's `.modules`
directory.

As part of this work, the project configuration file,
`bolt-project.yaml`, now accepts a new `modules` key. This key accepts
an array of module declarations, where each declaration is a map that
must include the module's name under the `name` key. The `name` key is
the only supported key at this time.

The installed modules can be found in a new `.modules` directory within
the project. This directory is not currently added to the modulepath,
though users can configure their modulepath to include it if they want.

Depending on the modules declared in the project configuration file, and
whether the project has an existing Puppetfile, this command will behave
differently:

- **No module declarations**

  If the project configuration file `bolt-project.yaml` does not include
  a `modules` key, the command will do nothing.

- **No existing Puppetfile**

  If there are module declarations, but no existing Puppetfile, Bolt
  will resolve the module declarations, generate a new Puppetfile, and
  install the modules.

- **Existing Puppetfile with matching module declarations**

  If there are module declarations, and an existing Puppetfile has
  specifications for each of the module declarations, then Bolt will not
  resolve the module declarations and instead just reinstall the
  Puppetfile.

- **Existing Puppetfile with missing module declarations**

  If there are module declarations, and an existing Puppetfile does not
  have specifications for each of the module declarations, then Bolt
  will raise an error indicating that the Puppetfile may not be managed
  by Bolt.

  If a user wishes to override this behavior, they can run the command
  with the `--force` option, which will force Bolt to resolve the
  modules and overwrite the Puppetfile with a new Puppetfile:

  ```shell
  $ bolt module install --force
  ```

This work introduces a few new classes:

- `Bolt::Puppetfile`
   This manages the logical contents of a Puppetfile and includes
   methods for parsing a Puppetfile, resolving module dependencies,
   and writing a Puppetfile.

- `Bolt::Puppetfile::Installer`
   This installs modules from a Puppetfile.

- `Bolt::Puppetfile::Module`
   This represents a module specification. It includes a comparator
   and some convenience methods.

Lastly, this refactors the `Bolt::CLI#install_puppetfile` and
`Bolt::CLI#initialize_project` methods to use these new classes.

---

**Testing this feature**

This feature is feature flagged. To enable the `bolt module install`
command, set the environment variable `BOLT_MODULE_FEATURE`.

!no-release-note