### PR TITLE
(GH-2086) Treat the _sensitive key as sensitive

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/datatypes/result.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/result.rb
@@ -9,11 +9,12 @@ Puppet::DataTypes.create_type('Result') do
     functions => {
       error => Callable[[], Optional[Error]],
       message => Callable[[], Optional[String]],
+      sensitive => Callable[[], Optional[Sensitive[Data]]],
       action => Callable[[], String],
       status => Callable[[], String],
       to_data => Callable[[], Hash],
       ok => Callable[[], Boolean],
-      '[]' => Callable[[String[1]], Data]
+      '[]' => Callable[[String[1]], Variant[Data, Sensitive[Data]]]
     }
   PUPPET
 

--- a/documentation/bolt_types_reference.md
+++ b/documentation/bolt_types_reference.md
@@ -72,6 +72,7 @@ The following functions are available to `Result` objects.
 | `action` | `String` | The type of result. For example, `task` or `command`. |
 | `error` | `Error` | An object constructed from the `_error` field of the result's value. |
 | `message` | `String` | The `_output` field of the result's value. |
+| `sensitive` | `Sensitive` | The `_sensitive` field of the result's value, wrapped in a `Sensitive` object. Call `unwrap()` to extract the value. |
 | `ok` | `Boolean` | Whether the result was successful. |
 | `status` | `String` | Either `success` if the result was successful or `failure`. |
 | `target` | `Target` | The target the result is from. |

--- a/documentation/writing_tasks.md
+++ b/documentation/writing_tasks.md
@@ -421,6 +421,26 @@ end
 puts result.to_json
 ```
 
+### Returning sensitive data
+
+To return secrets from a task, use the `_sensitive` key in the output. Bolt
+will treat the result as sensitive and won't allow it to be printed to the
+console or log.
+
+```ruby
+#!/opt/puppetlabs/puppet/bin/ruby
+
+require 'json'
+
+user_name = 'someone'
+# Generate a 10 letter password
+user_password = [*'a'..'z'].sample(10).join
+
+result = { user: user_name, _sensitive: { password: user_password } }
+
+puts result.to_json
+```
+
 ## Supporting no-op in tasks
 
 Tasks support no-operation functionality, also known as no-op mode. This

--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -65,6 +65,10 @@ module Bolt
                             'msg' => msg,
                             'details' => { 'exit_code' => exit_code } }
       end
+
+      if value.key?('_sensitive')
+        value['_sensitive'] = Puppet::Pops::Types::PSensitiveType::Sensitive.new(value['_sensitive'])
+      end
       new(target, value: value, action: 'task', object: task)
     end
 
@@ -204,6 +208,10 @@ module Bolt
         Puppet::DataTypes::Error.from_asserted_hash(error_hash)
 
       end
+    end
+
+    def sensitive
+      value['_sensitive']
     end
   end
 end

--- a/spec/bolt/result_spec.rb
+++ b/spec/bolt/result_spec.rb
@@ -89,11 +89,24 @@ describe Bolt::Result do
       expect(result.value).to eq(obj)
     end
 
-    it 'doesnt include _ keys in generic_value' do
+    it 'marks _sensitive values as sensitive' do
+      obj = { "user" => "someone", "_sensitive" => { "password" => "sosecretive" } }
+      result = Bolt::Result.for_task(target, obj.to_json, '', 0, 'atask')
+      expect(result.sensitive).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
+      expect(result.sensitive.unwrap).to eq('password' => 'sosecretive')
+    end
+
+    it 'excludes _output and _error from generic_value' do
       obj = { "key" => "val" }
       special = { "_error" => {}, "_output" => "output" }
       result = Bolt::Result.for_task(target, obj.merge(special).to_json, '', 0, 'atask')
       expect(result.generic_value).to eq(obj)
+    end
+
+    it 'includes _sensitive in generic_value' do
+      obj = { "user" => "someone", "_sensitive" => { "password" => "sosecretive" } }
+      result = Bolt::Result.for_task(target, obj.to_json, '', 0, 'atask')
+      expect(result.generic_value.keys).to include('user', '_sensitive')
     end
 
     it "doesn't parse arrays" do

--- a/spec/fixtures/apply/puppet_types/plans/sensitive_result.pp
+++ b/spec/fixtures/apply/puppet_types/plans/sensitive_result.pp
@@ -1,0 +1,13 @@
+plan puppet_types::sensitive_result (
+  TargetSpec $targets
+) {
+  $target = get_target($targets)
+  $target.apply_prep
+
+  $result = run_task('sensitive', $target).first
+
+  return apply($target) {
+    notify { "Result sensitive value: ${$result.sensitive.unwrap['password']}": }
+  }
+}
+

--- a/spec/fixtures/apply/sensitive/tasks/init.sh
+++ b/spec/fixtures/apply/sensitive/tasks/init.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo '{"user": "someone", "_sensitive": { "password": "secretpassword" }}'

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -363,6 +363,12 @@ describe "passes parsed AST to the apply_catalog task" do
         expect(notify[0]['title']).to eq("ApplyResult resource: The command failed with exit code 127")
       end
 
+      it 'preserves the sensitive data of Results' do
+        result = run_cli_json(%w[plan run puppet_types::sensitive_result] + config_flags)
+        notify = get_notifies(result)
+        expect(notify[0]['title']).to eq("Result sensitive value: secretpassword")
+      end
+
       context 'when calling invalid functions in apply' do
         it 'errors when get_targets is called' do
           result = run_cli_json(%w[plan run puppet_types::get_targets] + config_flags)


### PR DESCRIPTION
When constructing a Bolt::Result from the output of a task, we now look
for a _sensitive key and wrap it in Puppet's Sensitive type if found.
This prevents the data from being printed on the CLI.

!feature

  * **Allow task output to be treated as sensitive**
     ([#2086](https://github.com/puppetlabs/bolt/issues/2086))

    Tasks can now return a _sensitive key in their output which can
    contain an arbitrary value which will be treated as sensitive by
    Bolt. This means that it won't be printed to the console or log at
    any log level, and plans will need to use unwrap() to get the value.