### PR TITLE
(GH-2022) Pickup puppet agent 4.1.1

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,7 +6,7 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '1.3.0'
-mod 'puppetlabs-puppet_agent', '3.2.0'
+mod 'puppetlabs-puppet_agent', '4.1.1'
 mod 'puppetlabs-facts', '1.0.0'
 
 # Core types and providers for Puppet 6

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -486,6 +486,9 @@ describe "apply", expensive: true do
 
     context "when running against puppet 6" do
       before(:all) do
+        # Stop the puppet service to avoid errors when upgrading
+        run_task('service', conn_uri('winrm'),
+                 { 'action' => 'stop', 'name' => 'puppet' }, config: config)
         result = run_task('puppet_agent::install', conn_uri('winrm'),
                           { 'collection' => 'puppet6', 'version' => 'latest' }, config: config)
         expect(result.count).to eq(1)


### PR DESCRIPTION
Puppet agent 4.1.1 includes several updates we'd like to pick up,
including:
- Stopping agent runs if Puppet is upgraded mid-run
- Adding a puppet_agent::run plan to run the agent on remote targets

This allows users to run the agent without Bolt erroring due to a
non-zero exit code.

Closes #2022

!feature

* **Add puppet_agent::run plan to run the agent** ([#2022](https://github.com/puppetlabs/bolt/issues/2022)

  The puppet_agent::run plan will run the agent if it's available and
  returns a resultset including agents that failed and the results from
  runs that succeeded.