### PR TITLE
(Docs) Installing modules shuffle and edit

### DIFF
--- a/documentation/bolt_installing_modules.md
+++ b/documentation/bolt_installing_modules.md
@@ -4,7 +4,39 @@ To share the Bolt plans and tasks that you've created on the Forge, you can
 package them into Puppet modules. If you'd like to use a plan or task from a
 module that you found on the Forge, you can use Bolt to install the module.
 
-## Install a module
+## Create a new Bolt project and install a list of modules with dependencies
+
+If you want to get started with a new Bolt project and you need specific modules
+from the Puppet Forge, you can install the modules and their dependencies with
+the `bolt project init` command. 
+
+When you use `bolt project init` along with the `--modules` flag and a
+comma-separated list of Forge modules, Bolt installs the latest versions of each
+module and resolves and installs all dependencies required by those modules. For
+example, to create a project named `example_project` with the `apache` and
+`mysql` modules installed, use the following command:
+
+```shell
+bolt project init example_project --modules puppetlabs-apache,puppetlabs-mysql
+```
+
+The project's Puppetfile lists the `apache` and `mysql` modules and all of their
+dependencies:
+
+```puppet
+# example_project/Puppetfile
+mod 'puppetlabs-apache', '5.5.0'
+mod 'puppetlabs-mysql', '10.6.0'
+mod 'puppetlabs-stdlib', '6.3.0'
+mod 'puppetlabs-concat', '6.2.0'
+mod 'puppetlabs-translate', '2.2.0'
+mod 'puppetlabs-resource_api', '1.1.0'
+mod 'puppetlabs-puppetserver_gem', '1.1.1'
+```
+
+## Install a module to an existing project
+
+If you want to install a module to an existing project, use a Puppetfile. This method does not automatically resolve module dependencies. If the module you're installing requires other modules, make sure you add the required modules to your Puppetfile together with the module you're installing.
 
 > **Before you begin**
 >
@@ -37,35 +69,6 @@ To install a module:
       `modules/` subdirectory inside the Bolt project directory. To override
       this location, update the `modulepath` setting in your [project configuration file](bolt_project_reference.md).
 
-## Create a new Bolt project and install a list of modules with dependencies
-
-If you want to get started with a new Bolt project and you need specific modules
-from the Puppet Forge, you can install the modules and their dependencies with
-the `bolt project init` command. 
-
-When you use `bolt project init` along with the `--modules` flag and a
-comma-separated list of Forge modules, Bolt installs the latest versions of each
-module and resolves and installs all dependencies required by those modules. For
-example, to create a project named `example_project` with the `apache` and
-`mysql` modules installed, use the following command:
-
-```shell
-bolt project init example_project --modules puppetlabs-apache,puppetlabs-mysql
-```
-
-The project's Puppetfile lists the `apache` and `mysql` modules and all of their
-dependencies:
-
-```puppet
-# example_project/Puppetfile
-mod 'puppetlabs-apache', '5.5.0'
-mod 'puppetlabs-mysql', '10.6.0'
-mod 'puppetlabs-stdlib', '6.3.0'
-mod 'puppetlabs-concat', '6.2.0'
-mod 'puppetlabs-translate', '2.2.0'
-mod 'puppetlabs-resource_api', '1.1.0'
-mod 'puppetlabs-puppetserver_gem', '1.1.1'
-```
 
 ## Packaged modules
 

--- a/documentation/troubleshooting.md
+++ b/documentation/troubleshooting.md
@@ -1,4 +1,4 @@
-# Troubleshooting common issues
+# Troubleshooting
 
 ## Bolt can't find my task
 


### PR DESCRIPTION
In addition to shuffling some content around in the modules doc. I added a couple sentences to the "Install a module to an existing project" section intro about dependencies. 

I also snuck in a change to the troubleshooting page title. 