### PR TITLE
(GH-2068) Only write a debug log if the project exists

### DIFF
--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -204,7 +204,7 @@ module Bolt
         'compile-concurrency' => Etc.nprocessors,
         'concurrency'         => default_concurrency,
         'format'              => 'human',
-        'log'                 => { 'console' => {}, 'bolt-debug.log' => { 'level' => 'debug', 'append' => false } },
+        'log'                 => { 'console' => {} },
         'plugin_hooks'        => {},
         'plugins'             => {},
         'puppetdb'            => {},
@@ -212,6 +212,13 @@ module Bolt
         'save-rerun'          => true,
         'transport'           => 'ssh'
       }
+
+      if project.path.directory?
+        default_data['log']['bolt-debug.log'] = {
+          'level' => 'debug',
+          'append' => false
+        }
+      end
 
       loaded_data = config_data.each_with_object([]) do |data, acc|
         @warnings.concat(data[:warnings]) if data[:warnings].any?


### PR DESCRIPTION
Previously, we always defined a default `bolt-debug.log` and tried to
write to it. That would fail if the user had no project and also had
not created the default project directory.

We now check whether the project directory exists and only try to write
a debug log if it does. This is largely an interim solution and we
should eventually handle and prevent the cases where we might run
without an extant project directory.

!bug

  * **Don't fail if bolt-debug.log can't be created**
     ([#2115](https://github.com/puppetlabs/bolt/issues/2115))

    This fixes a bug introduced in Bolt 2.24.0 where Bolt would fail
    when trying to create the `bolt-debug.log` file if the Bolt project
    didn't exist.