### PR TITLE
(GH-2118) Fix Invoke-BoltTask -params

### DIFF
--- a/pwsh_module/command.tests.ps1
+++ b/pwsh_module/command.tests.ps1
@@ -4,7 +4,7 @@ BeforeAll {
   Mock -ModuleName 'PuppetBolt' -Verifiable -CommandName Invoke-BoltCommandLine -MockWith {
     return "bolt " + $params -join " "
   }
-  
+
   Mock Get-ItemProperty {
     return [PSCustomObject]@{
       RememberedInstallDir = 'C:/Program Files/Puppet Labs/Bolt'
@@ -257,13 +257,14 @@ Describe "test all bolt command examples" {
 
   Context "bolt task" {
     It "bolt task run package --targets target1,target2 action=status name=bash" {
-      $results = Invoke-BoltTask -name 'package' -targets 'target1,target2' -params 'action=status name=bash'
-      Write-Warning "Come back to this"
-      $results | Should -Be "bolt task run 'package' --targets 'target1,target2' --params 'action=status name=bash'"
+      $results = Invoke-BoltTask -name 'package' -targets 'target1,target2' action=status name=bash
+      $results | Should -Be "bolt task run 'package' --targets 'target1,target2' action=status name=bash"
 
-      # $results = Invoke-BoltTask -name 'package' -targets 'target1,target2' -params @{ 'action' = 'status'; 'name' = 'bash' }
-      # Write-Warning "Come back to this"
-      # $results | Should -Be "bolt task run 'package' --targets 'target1,target2' --params 'action=status name=bash'"
+      $results = Invoke-BoltTask -name 'package' -targets 'target1,target2' -params '{"name":"bash","action":"status"}'
+      $results | Should -Be "bolt task run 'package' --targets 'target1,target2' --params '{`"name`":`"bash`",`"action`":`"status`"}'"
+
+      $results = Invoke-BoltTask -name 'package' -targets 'target1,target2' -params @{ 'name' = 'bash'; 'action' = 'status' }
+      $results | Should -Be "bolt task run 'package' --targets 'target1,target2' --params '{`"name`":`"bash`",`"action`":`"status`"}'"
     }
     It "bolt task show" {
       $results = Get-BoltTask

--- a/pwsh_module/pwsh_bolt.psm1.erb
+++ b/pwsh_module/pwsh_bolt.psm1.erb
@@ -39,6 +39,9 @@ pwsh_command[:options].each do |option|
   if option[:position]
     parameter_statement << "Position=#{option[:position]}"
   end
+  if option[:value_from_remaining_arguments]
+    parameter_statement << "ValueFromRemainingArguments=$#{option[:value_from_remaining_arguments]}"
+  end
   if option[:parameter_set]
     parameter_statement << "ParameterSetName='#{option[:parameter_set]}'"
   end
@@ -78,11 +81,11 @@ end
   }
 <% end -%>
 
-  $params = @('<%= pwsh_command[:ruby_command] -%>'<% if pwsh_command[:ruby_action] -%>, '<%= pwsh_command[:ruby_action] -%>'<% end -%>)
+  $executionParams = @('<%= pwsh_command[:ruby_command] -%>'<% if pwsh_command[:ruby_action] -%>, '<%= pwsh_command[:ruby_action] -%>'<% end -%>)
 
-  $params = $params + (Get-BoltCommandline -parameterHash $PSBoundParameters -mapping $mapping)
+  $executionParams = $executionParams + (Get-BoltCommandline -parameterHash $PSBoundParameters -mapping $mapping)
 
-  $result = Invoke-BoltCommandline $params
+  $result = Invoke-BoltCommandline $executionParams
 
   Write-Output $result
 

--- a/rakelib/pwsh.rake
+++ b/rakelib/pwsh.rake
@@ -322,7 +322,7 @@ namespace :pwsh do
     source = File.expand_path(File.join(__dir__, '..', 'guides'))
     dest   = File.expand_path(File.join(__dir__, '..', 'pwsh_module', 'en-US'))
 
-    FileUtils.mkdir(dest)
+    FileUtils.mkdir(dest) unless File.exist?(dest)
 
     Dir.children(source).each do |file|
       next if file !~ /\.txt\z/

--- a/rakelib/pwsh.rake
+++ b/rakelib/pwsh.rake
@@ -292,8 +292,10 @@ namespace :pwsh do
             pwsh_param[:mandatory] = true
             pwsh_param[:position] = 0
           when 'params'
+            pwsh_param[:mandatory] = false
             pwsh_param[:position] = 1
             pwsh_param[:type] = nil
+            pwsh_param[:value_from_remaining_arguments] = true
           when 'modules'
             pwsh_param[:type] = nil
           when 'format'


### PR DESCRIPTION
The `-params` parameter was originally typed an `[object]` to allow both string `action=status name=spooler` and hashtable values `@{ action = 'status'; name = 'spooler' }`. This succeeded with hashtables but failed with strings because PowerShell parses `action=status name=spooler` into two groups of parameter-value pairs: `action=status` and `name=spooler`. PowerShell then (rightly) fails to bind the second set of params to any of the existing parameter sets and produces an error. The fix for this is to make `-params` have the `ValueFromRemainingArguments` attribute which will pull in all of the task params and store it in `-params`.

This fix however falls into a subtle trap in the switch statement in `Get-BoltCommandLine`. In PowerShell switch statements unwrap arrays and since we 'fixed' `-params` to now be an array, it takes `action=status name=spooler` and makes `--params action=status --params name=spooler`, which bolt (rightly) fails to process. To fix this an if/else statement is used. While this is more verbose than the switch statement, it ensures correct parsing of arrays, and presumably allows for more parameter types to be handled correctly in the future.

As a result of this investigation, I found/rediscovered the `$params` variable used in `Invoke-BoltCommandLine`. Since Invoke-BoltTask uses a parameter called `-params`, and parameters are variables, there are two 'uses' of the variable `$params`. This could cause a subtle bug where the value of `$params` is reassigned before it could be used, but we avoid this because we use `$PSBoundParameters` instead of individual parameters when building the commandline in `Get-BoltCommandLine`. To be safe, I renamed `$params` to be `$executionParams` to avoid any name clashes.


Acceptance Criteria:

To test:

Clone the repo, then build the cmdlets and import them:
```
PS > bundle exec rake pwsh:generate_module
PS > ipmo ./pwsh_module/puppetbolt.psd1 -for
```

The following should all work:

```
Invoke-BoltTask -t 'localhost' -name 'service' name=spooler action=status
Invoke-BoltTask -t 'localhost' 'service' name=spooler action=status
Invoke-BoltTask -t 'localhost' -name 'service' -params '{"name":"spooler","action":"status"}'
Invoke-BoltTask -t 'localhost' 'service' -params '{"name":"spooler","action":"status"}'
Invoke-BoltTask -t 'localhost' -name 'service' -params @{ name = "spooler"; action = "status" }
```