### PR TITLE
(maint) Pin Puppet to 6.17.0

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-ssh", ">= 4.0"
   spec.add_dependency "net-ssh-krb", "~> 0.5"
   spec.add_dependency "orchestrator_client", "~> 0.4"
-  spec.add_dependency "puppet", [">= 6.16.0", "< 7"]
+  spec.add_dependency "puppet", [">= 6.16.0", "< 6.18.0"]
   spec.add_dependency "puppetfile-resolver", "~> 0.1.0"
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "puppet-strings", "~> 2.3"


### PR DESCRIPTION
This temporarily pins Puppet to 6.17.0 until we can merge in
puppetlabs/bolt#2051 and puppetlabs/bolt#2074, as the Puppet 6.18.0
release includes changes that rely on these being merged. Without
pinning Puppet to 6.17.0, Bolt will fail when run from source.

!no-release-note