### PR TITLE
(GH-2120) Disable log files when set to "disable"

### DIFF
--- a/documentation/bolt_installing.md
+++ b/documentation/bolt_installing.md
@@ -420,7 +420,7 @@ Bolt collects data about how you use it. You can opt out of providing this data.
 
 This data is associated with a random, non-identifiable user UUID.
 
-To see the data Bolt collects, add `--log-level debug` to a command.
+To see the data Bolt collects, add `--log-level trace` to a command.
 
 ### Why does Bolt collect data?
 

--- a/documentation/projects.md
+++ b/documentation/projects.md
@@ -117,6 +117,7 @@ The following are common files and directories found in a Bolt project.
 |[`manifests`](applying_manifest_blocks.md)|A directory for storing your Puppet code files, known as _manifests_.|
 |`hiera.yaml`|Contains the Hiera config to use for target-specific data when using `apply`.|
 |`data/`|The standard path to store static Hiera data files.|
+|`bolt-debug.log`|Contains debug log output for the most recent Bolt command.|
 |[`bolt.yaml`](bolt_configuration_reference.md)|Contains configuration options for Bolt. ⛔ **`bolt.yaml` is deprecated; use `bolt-project.yaml` instead.** |
 
 > **Remember:** A directory must have a `bolt-project.yaml` file before Bolt

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -338,9 +338,17 @@ module Bolt
 
     private def update_logs(logs)
       logs.each_with_object({}) do |(key, val), acc|
-        next unless val.is_a?(Hash)
+        # Remove any disabled logs
+        next if val == 'disable'
 
         name = normalize_log(key)
+
+        # But otherwise it has to be a Hash
+        unless val.is_a?(Hash)
+          raise Bolt::ValidationError,
+                "config of log #{name} must be a Hash, received #{val.class} #{val.inspect}"
+        end
+
         acc[name] = val.slice('append', 'level')
                        .transform_keys(&:to_sym)
 

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -176,7 +176,8 @@ module Bolt
           description: "A map of configuration for the logfile output. Under `log`, you can configure log options "\
                        "for `console` and add configuration for individual log files, such as "\
                        "`~/.puppetlabs/bolt/debug.log`. Individual log files must be valid filepaths. If the log "\
-                       "file does not exist, then Bolt will create it before logging information.",
+                       "file does not exist, then Bolt will create it before logging information. Set the value to "\
+                       "`disable` to remove a log file defined at an earlier level of the config hierarchy.",
           type: Hash,
           properties: {
             "console" => {
@@ -194,7 +195,8 @@ module Bolt
           },
           additionalProperties: {
             description: "Configuration for the logfile output.",
-            type: Hash,
+            type: [String, Hash],
+            enum: ['disable'],
             properties: {
               "append" => {
                 description: "Whether to append output to an existing log file.",

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -177,7 +177,8 @@ module Bolt
                        "for `console` and add configuration for individual log files, such as "\
                        "`~/.puppetlabs/bolt/debug.log`. Individual log files must be valid filepaths. If the log "\
                        "file does not exist, then Bolt will create it before logging information. Set the value to "\
-                       "`disable` to remove a log file defined at an earlier level of the config hierarchy.",
+                       "`disable` to remove a log file defined at an earlier level of the config hierarchy. By "\
+                       "default, Bolt logs to a bolt-debug.log file in the Bolt project directory.",
           type: Hash,
           properties: {
             "console" => {

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -114,7 +114,7 @@
       "type": "string"
     },
     "log": {
-      "description": "A map of configuration for the logfile output. Under `log`, you can configure log options for `console` and add configuration for individual log files, such as `~/.puppetlabs/bolt/debug.log`. Individual log files must be valid filepaths. If the log file does not exist, then Bolt will create it before logging information. Set the value to `disable` to remove a log file defined at an earlier level of the config hierarchy.",
+      "description": "A map of configuration for the logfile output. Under `log`, you can configure log options for `console` and add configuration for individual log files, such as `~/.puppetlabs/bolt/debug.log`. Individual log files must be valid filepaths. If the log file does not exist, then Bolt will create it before logging information. Set the value to `disable` to remove a log file defined at an earlier level of the config hierarchy. By default, Bolt logs to a bolt-debug.log file in the Bolt project directory.",
       "type": "object",
       "properties": {
         "console": {

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -114,7 +114,7 @@
       "type": "string"
     },
     "log": {
-      "description": "A map of configuration for the logfile output. Under `log`, you can configure log options for `console` and add configuration for individual log files, such as `~/.puppetlabs/bolt/debug.log`. Individual log files must be valid filepaths. If the log file does not exist, then Bolt will create it before logging information.",
+      "description": "A map of configuration for the logfile output. Under `log`, you can configure log options for `console` and add configuration for individual log files, such as `~/.puppetlabs/bolt/debug.log`. Individual log files must be valid filepaths. If the log file does not exist, then Bolt will create it before logging information. Set the value to `disable` to remove a log file defined at an earlier level of the config hierarchy.",
       "type": "object",
       "properties": {
         "console": {
@@ -139,7 +139,13 @@
       },
       "additionalProperties": {
         "description": "Configuration for the logfile output.",
-        "type": "object",
+        "type": [
+          "string",
+          "object"
+        ],
+        "enum": [
+          "disable"
+        ],
         "properties": {
           "append": {
             "description": "Whether to append output to an existing log file.",

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -90,7 +90,7 @@
       }
     },
     "log": {
-      "description": "A map of configuration for the logfile output. Under `log`, you can configure log options for `console` and add configuration for individual log files, such as `~/.puppetlabs/bolt/debug.log`. Individual log files must be valid filepaths. If the log file does not exist, then Bolt will create it before logging information.",
+      "description": "A map of configuration for the logfile output. Under `log`, you can configure log options for `console` and add configuration for individual log files, such as `~/.puppetlabs/bolt/debug.log`. Individual log files must be valid filepaths. If the log file does not exist, then Bolt will create it before logging information. Set the value to `disable` to remove a log file defined at an earlier level of the config hierarchy.",
       "type": "object",
       "properties": {
         "console": {
@@ -115,7 +115,13 @@
       },
       "additionalProperties": {
         "description": "Configuration for the logfile output.",
-        "type": "object",
+        "type": [
+          "string",
+          "object"
+        ],
+        "enum": [
+          "disable"
+        ],
         "properties": {
           "append": {
             "description": "Whether to append output to an existing log file.",

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -90,7 +90,7 @@
       }
     },
     "log": {
-      "description": "A map of configuration for the logfile output. Under `log`, you can configure log options for `console` and add configuration for individual log files, such as `~/.puppetlabs/bolt/debug.log`. Individual log files must be valid filepaths. If the log file does not exist, then Bolt will create it before logging information. Set the value to `disable` to remove a log file defined at an earlier level of the config hierarchy.",
+      "description": "A map of configuration for the logfile output. Under `log`, you can configure log options for `console` and add configuration for individual log files, such as `~/.puppetlabs/bolt/debug.log`. Individual log files must be valid filepaths. If the log file does not exist, then Bolt will create it before logging information. Set the value to `disable` to remove a log file defined at an earlier level of the config hierarchy. By default, Bolt logs to a bolt-debug.log file in the Bolt project directory.",
       "type": "object",
       "properties": {
         "console": {

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -102,7 +102,7 @@
       "type": "string"
     },
     "log": {
-      "description": "A map of configuration for the logfile output. Under `log`, you can configure log options for `console` and add configuration for individual log files, such as `~/.puppetlabs/bolt/debug.log`. Individual log files must be valid filepaths. If the log file does not exist, then Bolt will create it before logging information. Set the value to `disable` to remove a log file defined at an earlier level of the config hierarchy.",
+      "description": "A map of configuration for the logfile output. Under `log`, you can configure log options for `console` and add configuration for individual log files, such as `~/.puppetlabs/bolt/debug.log`. Individual log files must be valid filepaths. If the log file does not exist, then Bolt will create it before logging information. Set the value to `disable` to remove a log file defined at an earlier level of the config hierarchy. By default, Bolt logs to a bolt-debug.log file in the Bolt project directory.",
       "type": "object",
       "properties": {
         "console": {

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -102,7 +102,7 @@
       "type": "string"
     },
     "log": {
-      "description": "A map of configuration for the logfile output. Under `log`, you can configure log options for `console` and add configuration for individual log files, such as `~/.puppetlabs/bolt/debug.log`. Individual log files must be valid filepaths. If the log file does not exist, then Bolt will create it before logging information.",
+      "description": "A map of configuration for the logfile output. Under `log`, you can configure log options for `console` and add configuration for individual log files, such as `~/.puppetlabs/bolt/debug.log`. Individual log files must be valid filepaths. If the log file does not exist, then Bolt will create it before logging information. Set the value to `disable` to remove a log file defined at an earlier level of the config hierarchy.",
       "type": "object",
       "properties": {
         "console": {
@@ -127,7 +127,13 @@
       },
       "additionalProperties": {
         "description": "Configuration for the logfile output.",
-        "type": "object",
+        "type": [
+          "string",
+          "object"
+        ],
+        "enum": [
+          "disable"
+        ],
         "properties": {
           "append": {
             "description": "Whether to append output to an existing log file.",

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -402,7 +402,6 @@ describe Bolt::Config do
     }
 
     it 'performs a depth 2 shallow merge on plugins' do
-      allow(Bolt::Util).to receive(:validate_file).and_return(true)
       expect(config.plugins).to eq(
         'vault' => {
           'server_url' => 'http://example.com',
@@ -420,7 +419,6 @@ describe Bolt::Config do
     end
 
     it 'performs a deep merge on transport config' do
-      allow(Bolt::Util).to receive(:validate_file).and_return(true)
       expect(config.transports['ssh'].to_h).to include(
         'user' => 'bolt',
         'password' => 'bolt',
@@ -429,13 +427,11 @@ describe Bolt::Config do
     end
 
     it 'overwrites non-hash values' do
-      allow(Bolt::Util).to receive(:validate_file).and_return(true)
       expect(config.transport).to eq('remote')
       expect(config.concurrency).to eq(5)
     end
 
     it 'performs a shallow merge on hash values' do
-      allow(Bolt::Util).to receive(:validate_file).and_return(true)
       expect(config.plugin_hooks).to eq(
         'puppet_library' => {
           'plugin' => 'puppet_agent',
@@ -445,6 +441,11 @@ describe Bolt::Config do
           'plugin' => 'fake_plugin'
         }
       )
+    end
+
+    it 'removes log files that are disabled' do
+      project_config['log'] = { '~/.puppetlabs/debug.log' => 'disable' }
+      expect(config.log).not_to include('~/.puppetlabs/debug.log')
     end
   end
 end


### PR DESCRIPTION
We now allow users to set a log config to the string "disable" to indicate
that the file should be disabled if it was defined at a previous level of
the config hierarchy. This also allows users to disable the default
bolt-debug.log file.

This behavior actually worked already, but only incidentally as we happened
to skip over any logs whose config wasn't a Hash. We now explicitly check
for the string "disable" and otherwise fail if the value isn't a Hash.

!feature

  * **Disable log files by setting them to `disable`**
    ([#2120](https://github.com/puppetlabs/bolt/issues/2120))

    Log files can now be disabled if they were set at a previous level
   of the hierarchy. This also allows the default `bolt-debug.log` file
   to be disabled.