### PR TITLE
(GH-2117) Initialize logger in BoltSpec::Run

### DIFF
--- a/lib/bolt_spec/run.rb
+++ b/lib/bolt_spec/run.rb
@@ -8,6 +8,7 @@ require 'bolt/pal'
 require 'bolt/plugin'
 require 'bolt/puppetdb'
 require 'bolt/util'
+require 'bolt/logger'
 
 # This is intended to provide a relatively stable method of executing bolt in process from tests.
 module BoltSpec
@@ -153,6 +154,8 @@ module BoltSpec
       end
 
       def initialize(config_data, inventory_data, project_path)
+        Bolt::Logger.initialize_logging
+
         @config_data = config_data || {}
         @inventory_data = inventory_data || {}
         @project_path = project_path


### PR DESCRIPTION
This updates `BoltSpec::Run` to initialize Bolt's logger as part of
initializing the `BoltRunner`. Previously, the logger was not
initialized, which would cause BoltSpec to fail whenever Bolt attempted
to log a message to the `trace` level, which is not a level recognized
by default in the `Logging` class. This fix ensures that `BoltSpec::Run`
will always initialize the logger in the same manner as Bolt itself.

!bug

* **Initialize logger in `BoltSpec::Run`**
  ([#2117](https://github.com/puppetlabs/bolt/issues/2117))

  Bolt now initializes the logger when using `BoltSpec::Run` methods.
  Previously, the logger was not initialized with Bolt's custom log
  levels, causing `BoltSpec::Run` to raise an error when it encountered
  a message being logged to one of these custom levels.