### PR TITLE
(maint) Ensure logging is always initialized before logging

### DIFF
--- a/bolt-modules/boltlib/spec/spec_helper.rb
+++ b/bolt-modules/boltlib/spec/spec_helper.rb
@@ -8,8 +8,3 @@ require 'bolt/pal'
 Puppet[:tasks] = true
 Bolt::PAL.load_puppet
 require 'puppetlabs_spec_helper/module_spec_helper'
-
-RSpec.configure do
-  require 'bolt/logger'
-  Bolt::Logger.initialize_logging
-end

--- a/bolt-modules/ctrl/spec/spec_helper.rb
+++ b/bolt-modules/ctrl/spec/spec_helper.rb
@@ -6,8 +6,3 @@ require 'puppet_pal'
 # so we get task loaders.
 Puppet[:tasks] = true
 require 'puppetlabs_spec_helper/module_spec_helper'
-
-RSpec.configure do
-  require 'bolt/logger'
-  Bolt::Logger.initialize_logging
-end

--- a/bolt-modules/dir/spec/spec_helper.rb
+++ b/bolt-modules/dir/spec/spec_helper.rb
@@ -6,8 +6,3 @@ require 'puppet_pal'
 # so we get task loaders.
 Puppet[:tasks] = true
 require 'puppetlabs_spec_helper/module_spec_helper'
-
-RSpec.configure do
-  require 'bolt/logger'
-  Bolt::Logger.initialize_logging
-end

--- a/bolt-modules/file/spec/spec_helper.rb
+++ b/bolt-modules/file/spec/spec_helper.rb
@@ -6,8 +6,3 @@ require 'puppet_pal'
 # so we get task loaders.
 Puppet[:tasks] = true
 require 'puppetlabs_spec_helper/module_spec_helper'
-
-RSpec.configure do
-  require 'bolt/logger'
-  Bolt::Logger.initialize_logging
-end

--- a/bolt-modules/out/spec/spec_helper.rb
+++ b/bolt-modules/out/spec/spec_helper.rb
@@ -8,8 +8,3 @@ require 'bolt/pal'
 Puppet[:tasks] = true
 Bolt::PAL.load_puppet
 require 'puppetlabs_spec_helper/module_spec_helper'
-
-RSpec.configure do
-  require 'bolt/logger'
-  Bolt::Logger.initialize_logging
-end

--- a/bolt-modules/prompt/spec/spec_helper.rb
+++ b/bolt-modules/prompt/spec/spec_helper.rb
@@ -8,8 +8,3 @@ require 'bolt/pal'
 Puppet[:tasks] = true
 Bolt::PAL.load_puppet
 require 'puppetlabs_spec_helper/module_spec_helper'
-
-RSpec.configure do
-  require 'bolt/logger'
-  Bolt::Logger.initialize_logging
-end

--- a/bolt-modules/system/spec/spec_helper.rb
+++ b/bolt-modules/system/spec/spec_helper.rb
@@ -6,8 +6,3 @@ require 'puppet_pal'
 # so we get task loaders.
 Puppet[:tasks] = true
 require 'puppetlabs_spec_helper/module_spec_helper'
-
-RSpec.configure do
-  require 'bolt/logger'
-  Bolt::Logger.initialize_logging
-end

--- a/config/transport_service_config.rb
+++ b/config/transport_service_config.rb
@@ -20,7 +20,7 @@ config.load_file_config(config_path)
 config.load_env_config
 config.validate
 
-Logging.logger[:root].add_appenders Logging.appenders.stderr(
+Bolt::Logger.logger(:root).add_appenders Logging.appenders.stderr(
   'console',
   layout: Bolt::Logger.default_layout,
   level: config['loglevel']

--- a/lib/bolt/analytics.rb
+++ b/lib/bolt/analytics.rb
@@ -27,7 +27,7 @@ module Bolt
     }.freeze
 
     def self.build_client
-      logger = Logging.logger[self]
+      logger = Bolt::Logger.logger(self)
       begin
         config_file = config_path(logger)
         config = load_config(config_file, logger)
@@ -106,7 +106,7 @@ module Bolt
         require 'httpclient'
         require 'locale'
 
-        @logger = Logging.logger[self]
+        @logger = Bolt::Logger.logger(self)
         @http = HTTPClient.new
         @user_id = user_id
         @executor = Concurrent.global_io_executor
@@ -210,7 +210,7 @@ module Bolt
       attr_accessor :bundled_content
 
       def initialize
-        @logger = Logging.logger[self]
+        @logger = Bolt::Logger.logger(self)
         @bundled_content = []
       end
 

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -28,7 +28,7 @@ module Bolt
       @apply_settings = apply_settings || {}
 
       @pool = Concurrent::ThreadPoolExecutor.new(name: 'apply', max_threads: max_compiles)
-      @logger = Logging.logger[self]
+      @logger = Bolt::Logger.logger(self)
     end
 
     private def libexec

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -46,7 +46,7 @@ module Bolt
 
     def initialize(argv)
       Bolt::Logger.initialize_logging
-      @logger = Logging.logger[self]
+      @logger = Bolt::Logger.logger(self)
       @argv = argv
       @options = {}
     end

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -191,7 +191,7 @@ module Bolt
                          deprecations: [] }]
       end
 
-      @logger       = Logging.logger[self]
+      @logger       = Bolt::Logger.logger(self)
       @project      = project
       @warnings     = @project.warnings.dup
       @deprecations = @project.deprecations.dup

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -40,7 +40,7 @@ module Bolt
       require 'concurrent'
 
       @analytics = analytics
-      @logger = Logging.logger[self]
+      @logger = Bolt::Logger.logger(self)
 
       @transports = Bolt::TRANSPORTS.each_with_object({}) do |(key, val), coll|
         coll[key.to_s] = if key == :remote

--- a/lib/bolt/inventory/group.rb
+++ b/lib/bolt/inventory/group.rb
@@ -19,7 +19,7 @@ module Bolt
       CONFIG_KEYS = Bolt::Config::INVENTORY_OPTIONS.keys
 
       def initialize(input, plugins)
-        @logger = Logging.logger[self]
+        @logger = Bolt::Logger.logger(self)
         @plugins = plugins
 
         input = @plugins.resolve_top_level_references(input) if @plugins.reference?(input)

--- a/lib/bolt/inventory/inventory.rb
+++ b/lib/bolt/inventory/inventory.rb
@@ -16,7 +16,7 @@ module Bolt
 
       # TODO: Pass transport config instead of config object
       def initialize(data, transport, transports, plugins)
-        @logger       = Logging.logger[self]
+        @logger       = Bolt::Logger.logger(self)
         @data         = data || {}
         @transport    = transport
         @config       = transports

--- a/lib/bolt/inventory/target.rb
+++ b/lib/bolt/inventory/target.rb
@@ -13,7 +13,7 @@ module Bolt
           raise Bolt::Inventory::ValidationError.new("Target must have either a name or uri", nil)
         end
 
-        @logger = Logging.logger[inventory]
+        @logger = Bolt::Logger.logger(inventory)
 
         # If the target isn't mentioned by any groups, it won't have a uri or
         # name and we will use the target_name as both

--- a/lib/bolt/logger.rb
+++ b/lib/bolt/logger.rb
@@ -28,7 +28,7 @@ module Bolt
     end
 
     def self.configure(destinations, color)
-      root_logger = Logging.logger[:root]
+      root_logger = Bolt::Logger.logger(:root)
 
       root_logger.add_appenders Logging.appenders.stderr(
         'console',
@@ -64,6 +64,13 @@ module Bolt
 
         appender.level = params[:level] if params[:level]
       end
+    end
+
+    # A helper to ensure the Logging library is always initialized with our
+    # custom log levels before retrieving a Logger instance.
+    def self.logger(name)
+      initialize_logging
+      Logging.logger[name]
     end
 
     def self.analytics=(analytics)
@@ -110,7 +117,7 @@ module Bolt
     def self.warn_once(type, msg)
       @mutex.synchronize {
         @warnings ||= []
-        @logger ||= Logging.logger[self]
+        @logger ||= Bolt::Logger.logger(self)
         unless @warnings.include?(type)
           @logger.warn(msg)
           @warnings << type

--- a/lib/bolt/outputter/logger.rb
+++ b/lib/bolt/outputter/logger.rb
@@ -7,7 +7,7 @@ module Bolt
     class Logger < Bolt::Outputter
       def initialize(verbose, trace)
         super(false, verbose, trace)
-        @logger = Logging.logger[self]
+        @logger = Bolt::Logger.logger(self)
       end
 
       def handle_event(event)

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -65,7 +65,7 @@ module Bolt
       @resource_types = resource_types
       @project = project
 
-      @logger = Logging.logger[self]
+      @logger = Bolt::Logger.logger(self)
       if modulepath && !modulepath.empty?
         @logger.debug("Loading modules from #{@modulepath.join(File::PATH_SEPARATOR)}")
       end
@@ -76,7 +76,7 @@ module Bolt
     # Puppet logging is global so this is class method to avoid confusion
     def self.configure_logging
       Puppet::Util::Log.destinations.clear
-      Puppet::Util::Log.newdestination(Logging.logger['Puppet'])
+      Puppet::Util::Log.newdestination(Bolt::Logger.logger('Puppet'))
       # Defer all log level decisions to the Logging library by telling Puppet
       # to log everything
       Puppet.settings[:log_level] = 'debug'

--- a/lib/bolt/pal/yaml_plan/evaluator.rb
+++ b/lib/bolt/pal/yaml_plan/evaluator.rb
@@ -7,7 +7,7 @@ module Bolt
     class YamlPlan
       class Evaluator
         def initialize(analytics = Bolt::Analytics::NoopClient.new)
-          @logger = Logging.logger[self]
+          @logger = Bolt::Logger.logger(self)
           @analytics = analytics
           @evaluator = Puppet::Pops::Parser::EvaluatingParser.new
         end

--- a/lib/bolt/plugin/puppetdb.rb
+++ b/lib/bolt/plugin/puppetdb.rb
@@ -19,7 +19,7 @@ module Bolt
       def initialize(config:, context:)
         pdb_config = Bolt::PuppetDB::Config.load_config(config, context.boltdir)
         @puppetdb_client = Bolt::PuppetDB::Client.new(pdb_config)
-        @logger = Logging.logger[self]
+        @logger = Bolt::Logger.logger(self)
       end
 
       def name

--- a/lib/bolt/puppetdb/client.rb
+++ b/lib/bolt/puppetdb/client.rb
@@ -13,7 +13,7 @@ module Bolt
         @config = config
         @bad_urls = []
         @current_url = nil
-        @logger = Logging.logger[self]
+        @logger = Bolt::Logger.logger(self)
       end
 
       def query_certnames(query)

--- a/lib/bolt/puppetdb/config.rb
+++ b/lib/bolt/puppetdb/config.rb
@@ -35,7 +35,7 @@ module Bolt
         begin
           config = JSON.parse(File.read(filepath)) if filepath
         rescue StandardError => e
-          Logging.logger[self].error("Could not load puppetdb.conf from #{filepath}: #{e.message}")
+          Bolt::Logger.logger(self).error("Could not load puppetdb.conf from #{filepath}: #{e.message}")
         end
 
         config = config.fetch('puppetdb', {})

--- a/lib/bolt/r10k_log_proxy.rb
+++ b/lib/bolt/r10k_log_proxy.rb
@@ -7,7 +7,7 @@ module Bolt
     def initialize
       super('bolt')
 
-      @logger = Logging.logger[self]
+      @logger = Bolt::Logger.logger(self)
     end
 
     def canonical_log(event)

--- a/lib/bolt/rerun.rb
+++ b/lib/bolt/rerun.rb
@@ -8,7 +8,7 @@ module Bolt
     def initialize(path, save_failures)
       @path = path
       @save_failures = save_failures
-      @logger = Logging.logger[self]
+      @logger = Bolt::Logger.logger(self)
     end
 
     def data

--- a/lib/bolt/shell.rb
+++ b/lib/bolt/shell.rb
@@ -7,7 +7,7 @@ module Bolt
     def initialize(target, conn)
       @target = target
       @conn = conn
-      @logger = Logging.logger[@target.safe_name]
+      @logger = Bolt::Logger.logger(@target.safe_name)
     end
 
     def run_command(*_args)

--- a/lib/bolt/task.rb
+++ b/lib/bolt/task.rb
@@ -26,7 +26,7 @@ module Bolt
       @metadata = metadata
       @files = files
       @remote = remote
-      @logger = Logging.logger[self]
+      @logger = Bolt::Logger.logger(self)
 
       validate_metadata
     end

--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -40,7 +40,7 @@ module Bolt
       attr_reader :logger
 
       def initialize
-        @logger = Logging.logger[self]
+        @logger = Bolt::Logger.logger(self)
       end
 
       def with_events(target, callback, action)

--- a/lib/bolt/transport/docker/connection.rb
+++ b/lib/bolt/transport/docker/connection.rb
@@ -10,7 +10,7 @@ module Bolt
         def initialize(target)
           raise Bolt::ValidationError, "Target #{target.safe_name} does not have a host" unless target.host
           @target = target
-          @logger = Logging.logger[target.safe_name]
+          @logger = Bolt::Logger.logger(target.safe_name)
           @docker_host = @target.options['service-url']
           @logger.trace("Initializing docker connection to #{@target.safe_name}")
         end

--- a/lib/bolt/transport/local/connection.rb
+++ b/lib/bolt/transport/local/connection.rb
@@ -16,7 +16,7 @@ module Bolt
           @target = target
           # The familiar problem: Etc.getlogin is broken on osx
           @user = ENV['USER'] || Etc.getlogin
-          @logger = Logging.logger[self]
+          @logger = Bolt::Logger.logger(self)
         end
 
         def shell

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -17,7 +17,7 @@ module Bolt
         rescue LoadError
           logger.debug("Authentication method 'gssapi-with-mic' (Kerberos) is not available.")
         end
-        @transport_logger = Logging.logger[Net::SSH]
+        @transport_logger = Bolt::Logger.logger(Net::SSH)
         @transport_logger.level = :warn
       end
 

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -26,7 +26,7 @@ module Bolt
           @user = @target.user || ssh_config[:user] || Etc.getlogin
           @strict_host_key_checking = ssh_config[:strict_host_key_checking]
 
-          @logger = Logging.logger[@target.safe_name]
+          @logger = Bolt::Logger.logger(@target.safe_name)
           @transport_logger = transport_logger
           @logger.trace("Initializing ssh connection to #{@target.safe_name}")
 

--- a/lib/bolt/transport/ssh/exec_connection.rb
+++ b/lib/bolt/transport/ssh/exec_connection.rb
@@ -14,7 +14,7 @@ module Bolt
           @target = target
           ssh_config = Net::SSH::Config.for(target.host)
           @user = @target.user || ssh_config[:user] || Etc.getlogin
-          @logger = Logging.logger[self]
+          @logger = Bolt::Logger.logger(self)
         end
 
         # This is used to verify we can connect to targets with `connected?`

--- a/lib/bolt/transport/winrm.rb
+++ b/lib/bolt/transport/winrm.rb
@@ -11,7 +11,7 @@ module Bolt
         require 'winrm'
         require 'winrm-fs'
 
-        @transport_logger = Logging.logger[::WinRM]
+        @transport_logger = Bolt::Logger.logger(::WinRM)
         @transport_logger.level = :warn
       end
 

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -18,7 +18,7 @@ module Bolt
           @user = @target.user
           # Build set of extensions from extensions config as well as interpreters
 
-          @logger = Logging.logger[@target.safe_name]
+          @logger = Bolt::Logger.logger(@target.safe_name)
           logger.trace("Initializing winrm connection to #{@target.safe_name}")
           @transport_logger = transport_logger
         end

--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -6,7 +6,7 @@ module Bolt
       def read_yaml_hash(path, file_name)
         require 'yaml'
 
-        logger = Logging.logger[self]
+        logger = Bolt::Logger.logger(self)
         path = File.expand_path(path)
         content = File.open(path, "r:UTF-8") { |f| YAML.safe_load(f.read) } || {}
         unless content.is_a?(Hash)

--- a/lib/bolt_server/file_cache.rb
+++ b/lib/bolt_server/file_cache.rb
@@ -33,7 +33,7 @@ module BoltServer
       @executor = executor
       @cache_dir = config['cache-dir']
       @config = config
-      @logger = Logging.logger[self]
+      @logger = Bolt::Logger.logger(self)
       @cache_dir_mutex = cache_dir_mutex
 
       if do_purge

--- a/spec/bolt/transport/ssh/connection_spec.rb
+++ b/spec/bolt/transport/ssh/connection_spec.rb
@@ -12,7 +12,7 @@ describe Bolt::Transport::SSH::Connection do
   let(:uri) { 'ssh://foo.example.com' }
   let(:inventory) { Bolt::Inventory.empty }
   let(:target) { inventory.get_target(uri) }
-  let(:transport_logger) { Logging.logger[Net::SSH] }
+  let(:transport_logger) { Bolt::Logger.logger(Net::SSH) }
   let(:subject) { described_class.new(target, transport_logger) }
 
   context "when setting user" do


### PR DESCRIPTION
When using Bolt as a library, it was possible to create Bolt objects that
had loggers which weren't safe to be used as the levels corresponding to
the methods they call hadn't been defined. In particular, this would cause
a NoMethodError any time Bolt tried to log something at trace level.

We now have a `Bolt::Logger.logger` method which wraps the
`Logging.logger` method and ensures that we have first called
`initialize_logging` to create the appropriate log levels. This means 
consumers of Bolt no longer need to worry about doing that themselves.

!no-release-note