### PR TITLE
(maint) Fix 'project show' help text

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -421,9 +421,9 @@ module Bolt
           the plan, including a list of available parameters.
 
       EXAMPLES
-          Display a list of available tasks
+          Display a list of available plans
             bolt plan show
-          Display documentation for the canary task
+          Display documentation for the aggregate::count plan
             bolt plan show aggregate::count
     HELP
 


### PR DESCRIPTION
This fixes some typos in the `project show` help text, which
erroneously said how to show a list of tasks and how to run
a task.

!no-release-note