### PR TITLE
(maint) Update plan convert help text

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -366,11 +366,11 @@ module Bolt
           bolt plan convert <path> [options]
 
       DESCRIPTION
-          Convert a YAML plan to a Bolt plan.
+          Convert a YAML plan to a Puppet language plan and print the converted plan to stdout.
 
           Converting a YAML plan may result in a plan that is syntactically
           correct but has different behavior. Always verify a converted plan's
-          functionality.
+          functionality. Note that the converted plan is not written to a file.
 
       EXAMPLES
           bolt plan convert path/to/plan/myplan.yaml


### PR DESCRIPTION
This updates the `bolt plan convert` help text to state that the
converted plan is printed to the console, not written to a file. It also
clarifies that YAML plans are converted to Puppet language plans, as
"Bolt plan" is ambiguous.

!no-release-note