### PR TITLE
(maint) Unpend plan_hiera tests

### DIFF
--- a/spec/fixtures/hiera/data/hierarchy.yaml
+++ b/spec/fixtures/hiera/data/hierarchy.yaml
@@ -1,0 +1,1 @@
+pop: tarts

--- a/spec/fixtures/hiera/data/plan_hierarchy.yaml
+++ b/spec/fixtures/hiera/data/plan_hierarchy.yaml
@@ -1,0 +1,1 @@
+pop: goes the weasel

--- a/spec/fixtures/hiera/modules/test/plans/plan_lookup.pp
+++ b/spec/fixtures/hiera/modules/test/plans/plan_lookup.pp
@@ -1,0 +1,11 @@
+plan test::plan_lookup(
+  TargetSpec $targets
+) {
+  $outside_apply = lookup('pop')
+  $in_apply = apply($targets) {
+    notify { lookup('pop'): }
+  }
+  $a = { 'outside_apply' => $outside_apply,
+         'in_apply' => $in_apply.first.report['resource_statuses'] }
+  return $a
+}

--- a/spec/integration/lookup_spec.rb
+++ b/spec/integration/lookup_spec.rb
@@ -141,7 +141,6 @@ describe "lookup() in plans" do
     let(:uri)          { 'localhost' }
 
     it 'uses plan_hierarchy outside apply block, and hierarchy in apply block' do
-      pending('Until Puppet 6.18 is released')
       result = run_cli_json(cli_command + %W[-t #{uri}])
       expect(result['outside_apply']).to eq('goes the weasel')
       expect(result['in_apply'].keys).to include('Notify[tarts]')
@@ -154,7 +153,6 @@ describe "lookup() in plans" do
     let(:uri)          { 'localhost' }
 
     it 'raises a validation error' do
-      pending('Until Puppet 6.18 is released')
       result = run_cli_json(cli_command + %W[-t #{uri}])
       expect(result).to include(
         'kind' => 'bolt/pal-error',


### PR DESCRIPTION
These tests were marked pending until Puppet 6.18 was released with the
needed Puppet-side changes to enable plan_hiera. This re-enables them
and adds the necessary fixtures.

!no-release-note