### PR TITLE
add doc on how to use target name in hiera paths

### DIFF
--- a/documentation/applying_manifest_blocks.md
+++ b/documentation/applying_manifest_blocks.md
@@ -241,6 +241,13 @@ Following the Hiera 5 convention, the default data dir is relative to
 `hiera.yaml` at `$BOLTDIR/data`. For configfile examples, see [Configuring
 Hiera](https://puppet.com/docs/puppet/latest/hiera_config_yaml_5.html).
 
+The target name is made available to hiera via the `certname` key of the `$trusted` top level Puppet variable, ie `$trusted['certname']`. This can be interpolated in hierarchy paths within `$BOLTDIR/hiera.yaml` using `%{trusted.certname}`.
+
+```yaml
+    paths:
+      - "targets/%{trusted.certname}.yaml"
+```
+
 If a custom data provider is used, such as `hiera-eyaml`, which allows you to
 encrypt your data, the gem dependencies must be available to Bolt. See [Install
 gems with Bolt packages](bolt_installing.md#).


### PR DESCRIPTION
This PR adds some additional points to the docs on using hiera with `bolt apply`, specifically how to use the target name as part of a hiera path. 

