### PR TITLE
(GH-2112) Ensure task error objects have correct format

### DIFF
--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -66,9 +66,24 @@ module Bolt
                             'details' => { 'exit_code' => exit_code } }
       end
 
+      if value.key?('_error')
+        unless value['_error'].is_a?(Hash) && value['_error'].key?('msg')
+          value['_error'] = {
+            'msg'     => "Invalid error returned from task #{task}: #{value['_error'].inspect}. Error "\
+                         "must be an object with a msg key.",
+            'kind'    => 'bolt/invalid-task-error',
+            'details' => { 'original_error' => value['_error'] }
+          }
+        end
+
+        value['_error']['kind']    ||= 'bolt/error'
+        value['_error']['details'] ||= {}
+      end
+
       if value.key?('_sensitive')
         value['_sensitive'] = Puppet::Pops::Types::PSensitiveType::Sensitive.new(value['_sensitive'])
       end
+
       new(target, value: value, action: 'task', object: task)
     end
 


### PR DESCRIPTION
This updates `Bolt::Result.for_task` to ensure that an error object
returned from a task has the correct format. Previously, any error
object returned from a task was accepted as-is, even if it did not have
the expected `msg`, `kind`, and `detail` keys. Now, a `msg` key is
required, and Bolt will raise a helpful error if the error object is
missing this key. If either the `kind` or `details` keys are missing
from the error object, Bolt will automatically add reasonable default
values of `bolt/error` and `{}` to the error object.

!bug

* **Ensure task error objects have correct format**
  ([#2112](https://github.com/puppetlabs/bolt/issues/2112))

  Bolt now ensures that error objects returned from a task have the
  correct format and include a `msg` key. Bolt will also automatically
  add `kind` and `details` keys if they are absent from the object, with
  default values of `bolt/error` and `{}`.