### PR TITLE
(GH-2116) Handle file writing errors

### DIFF
--- a/lib/bolt/analytics.rb
+++ b/lib/bolt/analytics.rb
@@ -93,6 +93,10 @@ module Bolt
     def self.write_config(filename, config)
       FileUtils.mkdir_p(File.dirname(filename))
       File.write(filename, config.to_yaml)
+    rescue StandardError => e
+      Bolt::Logger.warn_once('unwriteable_file', "Could not write analytics configuration to #{filename}.")
+      # This will get caught by build_client and create a NoopClient
+      raise e
     end
 
     class Client

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -64,7 +64,7 @@ module Bolt
              end
 
       data = load_defaults(project).push(
-        filepath: project.config_file,
+        filepath: configfile,
         data: conf,
         logs: logs,
         deprecations: []
@@ -344,6 +344,14 @@ module Bolt
     end
 
     private def update_logs(logs)
+      begin
+        if logs['bolt-debug.log'] && logs['bolt-debug.log'] != 'disable'
+          FileUtils.touch(File.expand_path('bolt-debug.log', @project.path))
+        end
+      rescue StandardError
+        logs.delete('bolt-debug.log')
+      end
+
       logs.each_with_object({}) do |(key, val), acc|
         # Remove any disabled logs
         next if val == 'disable'

--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -50,6 +50,20 @@ module Bolt
     def self.create_project(path, type = 'option', logs = [])
       fullpath = Pathname.new(path).expand_path
 
+      if type == 'user'
+        begin
+          # This is already expanded if the type is user
+          FileUtils.mkdir_p(path)
+        rescue StandardError
+          logs << { warn: "Could not create default project at #{path}. Continuing without a writeable project. "\
+                    "Log and rerun files will not be written." }
+        end
+      end
+
+      if type == 'option' && !File.directory?(path)
+        raise Bolt::Error.new("Could not find project at #{path}", "bolt/project-error")
+      end
+
       if !Bolt::Util.windows? && type != 'environment' && fullpath.world_writable?
         raise Bolt::Error.new(
           "Project directory '#{fullpath}' is world-writable which poses a security risk. Set "\

--- a/lib/bolt/rerun.rb
+++ b/lib/bolt/rerun.rb
@@ -53,7 +53,7 @@ module Bolt
         end
       end
     rescue StandardError => e
-      @logger.warn("Failed to save result to #{@path}: #{e.message}")
+      Bolt::Logger.warn_once('unwriteable_file', "Failed to save result to #{@path}: #{e.message}")
     end
   end
 end

--- a/spec/bolt/analytics_spec.rb
+++ b/spec/bolt/analytics_spec.rb
@@ -85,7 +85,17 @@ describe Bolt::Analytics do
       subject.build_client
     end
 
-    it 'warns when user-level config and defaul project config both exist' do
+    it 'errors if new config cannot be written' do
+      allow(subject).to receive(:write_config).and_call_original
+      allow(File).to receive(:write)
+        .and_raise(Errno::EACCES, "Permission denied")
+
+      subject.build_client
+
+      expect(@log_output.readlines).to include(/Could not write analytics/)
+    end
+
+    it 'warns when user-level config and default project config both exist' do
       allow(File).to receive(:exist?).with(path).and_return(true)
       allow(File).to receive(:exist?).with(old_path).and_return(true)
 

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -342,6 +342,7 @@ describe "Bolt::Executor" do
       Dir.mktmpdir(nil, Dir.pwd) do |destination|
         allow(ssh).to receive(:download)
         expect(FileUtils).to receive(:mkdir_p).with(destination)
+        expect(FileUtils).to receive(:mkdir_p).with(File.expand_path(File.join('~', '.puppetlabs', 'bolt')))
 
         executor.download_file(targets, source, destination)
       end

--- a/spec/integration/logging_spec.rb
+++ b/spec/integration/logging_spec.rb
@@ -2,11 +2,13 @@
 
 require 'spec_helper'
 require 'bolt_spec/conn'
+require 'bolt_spec/files'
 require 'bolt_spec/integration'
 require 'logging'
 
 describe "when logging executor activity", ssh: true do
   include BoltSpec::Conn
+  include BoltSpec::Files
   include BoltSpec::Integration
 
   let(:whoami) { "whoami" }
@@ -37,6 +39,12 @@ describe "when logging executor activity", ssh: true do
     expect(lines).to include(match(/INFO.*Starting: plan #{echo_plan}/))
     expect(lines).to include(match(/INFO.*Finished: plan #{echo_plan}/))
     expect(result[0]['value']['_output'].strip).to match(/hi there/)
+  end
+
+  it 'does not error if the default log file cannot be written' do
+    expect(FileUtils).to receive(:touch).with(/bolt-debug\.log/).and_raise(Errno::EACCES)
+    expect { run_cli(%W[command run #{whoami}] + config_flags) }
+      .not_to raise_error
   end
 
   context 'with misconfigured ssh-command' do


### PR DESCRIPTION
This cleans up how we handle failures when Bolt fails to write a file to
the current project. We now attempt to create the project directory if
it is the default directory and does not exist. If that creation fails,
we warn and continue without a Bolt project - this effectively means
that Bolt has default configuration, and that logfiles and rerun files
will not be written. If any individual file can't be written to the
project, we warn once and continue. If multiple files can't be written,
we warn for the first file that isn't writeable and not for subsequent
files.

When users explicitly configure a logfile that is unwriteable we now
error.

When users explicitly configure a project that is unwriteable, we now
error.

Closes #2116

!bug

* **Handle project file writing errors more gracefully** ([#2116](https://github.com/puppetlabs/bolt/issues/2116))

  Bolt will now warn and continue executing when it fails to write files
  to the active project. Additionally, any user-specified file data that
  fails to be written to will error.