### PR TITLE
(PE-29495) Serve task metadata from bolt-projects managed with code manager

### DIFF
--- a/developer-docs/bolt-api-servers.md
+++ b/developer-docs/bolt-api-servers.md
@@ -25,6 +25,7 @@ Most options are shared by the bolt server and plan executor applications
 
 **Bolt Server Only Options**
 - `concurrency`: Integer, *optional* - The maximum number of server threads (default `100`).
+- `projects-dir`: String, *optional* - Path to bolt-projects dir managed by code manager when serving bolt-project content for team console.
 
 **Plan Executor Only Options**
 - `modulepath`: String, *required* - The path to modules to read plans from
@@ -548,6 +549,134 @@ The files array is required, and contains details about the files the task needs
 
 
 
+
+### GET /project_tasks
+- `project_ref`: String, *required* - Reference to the bolt project (in the form [PROJECT NAME]\_[SHA])
+
+#### Response
+
+```
+[
+  {
+    "name": "facts"
+  },
+  {
+    "name": "package"
+  }
+]
+```
+
+### GET /project_tasks/:module_name/:task_name
+- `project_ref`: String, *required* - Reference to the bolt project (in the form [PROJECT NAME]\_[SHA])
+
+#### Response
+
+```
+{
+  "metadata": {
+    "description": "Manage and inspect the state of services",
+    "input_method": "stdin",
+    "parameters": {
+      "action": {
+        "description": "The operation (start, stop, restart, enable, disable, status) to perform on the service.",
+        "type": "Enum[start, stop, restart, enable, disable, status]"
+      },
+      "name": {
+        "description": "The name of the service to operate on.",
+        "type": "String[1]"
+      },
+      "force": {
+        "description": "Force a Windows service to restart even if it has dependent services. This parameter is passed for Windows services only.",
+        "type": "Optional[Boolean]"
+      },
+      "provider": {
+        "description": "The provider to use to manage or inspect the service, defaults to the system service manager. Only used when the 'puppet-agent' feature is available on the target so we can leverage Puppet.",
+        "type": "Optional[String[1]]"
+      }
+    },
+    "implementations": [
+      {
+        "name": "init.rb",
+        "requirements": [
+          "puppet-agent"
+        ]
+      },
+      {
+        "name": "windows.ps1",
+        "requirements": [
+          "powershell"
+        ],
+        "input_method": "powershell"
+      },
+      {
+        "name": "linux.sh",
+        "requirements": [
+          "shell"
+        ],
+        "input_method": "environment",
+        "files": [
+          "service/files/common.sh"
+        ]
+      }
+    ],
+    "extensions": {
+      "discovery": {
+        "friendlyName": "Manage service",
+        "type": [
+          "host"
+        ]
+      }
+    }
+  },
+  "name": "service",
+  "files": [
+    {
+      "filename": "init.rb",
+      "sha256": "da9441915636b2a231bca3da898788920490b8a061eb28b086f079da72dd3141",
+      "size_bytes": 1285,
+      "uri": {
+        "path": "/puppet/v3/file_content/tasks/service/init.rb",
+        "params": {
+          "project": "my_project_somesha"
+        }
+      }
+    },
+    {
+      "filename": "windows.ps1",
+      "sha256": "a706b8c127b1aa72d7c75d6fbb0833d25abc97db89197f9b3faadf1caf688964",
+      "size_bytes": 2636,
+      "uri": {
+        "path": "/puppet/v3/file_content/tasks/service/windows.ps1",
+        "params": {
+          "project": "my_project_somesha"
+        }
+      }
+    },
+    {
+      "filename": "linux.sh",
+      "sha256": "71d6bae0c580529d7c1a84e865bc08606aa5f8d6f627ef5083a2bc6918338cab",
+      "size_bytes": 4220,
+      "uri": {
+        "path": "/puppet/v3/file_content/tasks/service/linux.sh",
+        "params": {
+          "project": "my_project_somesha"
+        }
+      }
+    },
+    {
+      "filename": "service/files/common.sh",
+      "sha256": "dbe3a6bdf0382a311b2cc885128b1069b3749c7bb3fef1143348179f0a659c30",
+      "size_bytes": 1120,
+      "uri": {
+        "path": "/puppet/v3/file_content/modules/service/common.sh",
+        "params": {
+          "project": "my_project_somesha"
+        }
+      }
+    }
+  ]
+}
+```
 
 ## Plan Executor API Endpoints
 Each API endpoint accepts a request as described below. The request body must be a JSON object.

--- a/lib/bolt_server/base_config.rb
+++ b/lib/bolt_server/base_config.rb
@@ -7,7 +7,7 @@ module BoltServer
   class BaseConfig
     def config_keys
       %w[host port ssl-cert ssl-key ssl-ca-cert
-         ssl-cipher-suites loglevel logfile whitelist]
+         ssl-cipher-suites loglevel logfile whitelist projects-dir]
     end
 
     def env_keys

--- a/lib/bolt_server/config.rb
+++ b/lib/bolt_server/config.rb
@@ -7,7 +7,7 @@ require 'bolt/error'
 module BoltServer
   class Config < BoltServer::BaseConfig
     def config_keys
-      super + %w[concurrency cache-dir file-server-conn-timeout file-server-uri]
+      super + %w[concurrency cache-dir file-server-conn-timeout file-server-uri projects-dir]
     end
 
     def env_keys

--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -5,6 +5,7 @@ require 'addressable/uri'
 require 'bolt'
 require 'bolt/error'
 require 'bolt/inventory'
+require 'bolt/project'
 require 'bolt/target'
 require 'bolt_server/file_cache'
 require 'bolt/task/puppet_server'
@@ -191,20 +192,39 @@ module BoltServer
     end
 
     def in_pe_pal_env(environment)
-      if environment.nil?
-        [400, '`environment` is a required argument']
-      else
-        @pal_mutex.synchronize do
-          pal = BoltServer::PE::PAL.new({}, environment)
-          yield pal
-        rescue Puppet::Environments::EnvironmentNotFound
-          [400, {
-            "class" => 'bolt/unknown-environment',
-            "message" => "Environment #{environment} not found"
-          }.to_json]
-        rescue Bolt::Error => e
-          [400, e.to_json]
-        end
+      return [400, '`environment` is a required argument'] if environment.nil?
+      @pal_mutex.synchronize do
+        pal = BoltServer::PE::PAL.new({}, environment)
+        yield pal
+      rescue Puppet::Environments::EnvironmentNotFound
+        [400, {
+          "class" => 'bolt/unknown-environment',
+          "message" => "Environment #{environment} not found"
+        }.to_json]
+      rescue Bolt::Error => e
+        [400, e.to_json]
+      end
+    end
+
+    def in_bolt_project(bolt_project)
+      return [400, '`project_ref` is a required argument'] if bolt_project.nil?
+      project_dir = File.join(@config['projects-dir'], bolt_project)
+      return [400, "`project_ref`: #{project_dir} does not exist"] unless Dir.exist?(project_dir)
+      @pal_mutex.synchronize do
+        project = Bolt::Project.create_project(project_dir)
+        bolt_config = Bolt::Config.from_project(project, {})
+        pal = Bolt::PAL.new(bolt_config.modulepath, nil, nil, nil, nil, nil, bolt_config.project)
+        module_path = [BoltServer::PE::PAL::PE_BOLTLIB_PATH, Bolt::PAL::BOLTLIB_PATH, *bolt_config.modulepath]
+        # CODEREVIEW: I *think* this is the only thing we need to make different between bolt's PAL. Is it acceptable
+        # to hack this? Modulepath is currently a readable attribute, could we make it writeable?
+        pal.instance_variable_set(:@modulepath, module_path)
+        context = {
+          pal: pal,
+          config: bolt_config
+        }
+        yield context
+      rescue Bolt::Error => e
+        [400, e.to_json]
       end
     end
 
@@ -221,14 +241,12 @@ module BoltServer
       plan_info
     end
 
-    def build_puppetserver_uri(file_identifier, module_name, environment)
+    def build_puppetserver_uri(file_identifier, module_name, parameters)
       segments = file_identifier.split('/', 3)
       if segments.size == 1
         {
           'path' => "/puppet/v3/file_content/tasks/#{module_name}/#{file_identifier}",
-          'params' => {
-            'environment' => environment
-          }
+          'params' => parameters
         }
       else
         module_segment, mount_segment, name_segment = *segments
@@ -241,14 +259,12 @@ module BoltServer
                     when 'lib'
                       "/puppet/v3/file_content/plugins/#{name_segment}"
                     end,
-          'params' => {
-            'environment' => environment
-          }
+          'params' => parameters
         }
       end
     end
 
-    def pe_task_info(pal, module_name, task_name, environment)
+    def pe_task_info(pal, module_name, task_name, parameters)
       # Handle case where task name is simply module name with special `init` task
       task_name = if task_name == 'init' || task_name.nil?
                     module_name
@@ -261,7 +277,7 @@ module BoltServer
           'filename' => file_hash['name'],
           'sha256' => Digest::SHA256.hexdigest(File.read(file_hash['path'])),
           'size_bytes' => File.size(file_hash['path']),
-          'uri' => build_puppetserver_uri(file_hash['name'], module_name, environment)
+          'uri' => build_puppetserver_uri(file_hash['name'], module_name, parameters)
         }
       end
       {
@@ -269,6 +285,12 @@ module BoltServer
         'name' => task.name,
         'files' => files
       }
+    end
+
+    def task_list(pal, task_show_list = nil)
+      tasks = pal.list_tasks
+      tasks.select! { |task| task_show_list.include?(task.first) } unless task_show_list.nil?
+      tasks.map { |task_name, _description| { 'name' => task_name } }
     end
 
     get '/' do
@@ -406,7 +428,23 @@ module BoltServer
     # @param environment [String] the environment to fetch the task from
     get '/tasks/:module_name/:task_name' do
       in_pe_pal_env(params['environment']) do |pal|
-        task_info = pe_task_info(pal, params[:module_name], params[:task_name], params['environment'])
+        ps_parameters = {
+          'environment' => params['environment']
+        }
+        task_info = pe_task_info(pal, params[:module_name], params[:task_name], ps_parameters)
+        [200, task_info.to_json]
+      end
+    end
+
+    # Fetches the metadata for a single task
+    #
+    # @param bolt_project_ref [String] the reference to the bolt-project directory to load task metadata from
+    get '/project_tasks/:module_name/:task_name' do
+      in_bolt_project(params['project_ref']) do |context|
+        ps_parameters = {
+          'project' => params['project_ref']
+        }
+        task_info = pe_task_info(context[:pal], params[:module_name], params[:task_name], ps_parameters)
         [200, task_info.to_json]
       end
     end
@@ -440,8 +478,22 @@ module BoltServer
     # @param environment [String] the environment to fetch the list of tasks from
     get '/tasks' do
       in_pe_pal_env(params['environment']) do |pal|
-        tasks = pal.list_tasks
-        tasks_response = tasks.map { |task_name, _description| { 'name' => task_name } }.to_json
+        tasks_response = task_list(pal).to_json
+
+        # We structure this array of tasks to be an array of hashes so that it matches the structure
+        # returned by the puppetserver API that serves data like this. Structuring the output this way
+        # makes switching between puppetserver and bolt-server easier, which makes changes to switch
+        # to bolt-server smaller/simpler.
+        [200, tasks_response]
+      end
+    end
+
+    # Fetches the list of tasks for a bolt-project
+    #
+    # @param environment [String] the environment to fetch the list of tasks from
+    get '/project_tasks' do
+      in_bolt_project(params['project_ref']) do |context|
+        tasks_response = task_list(context[:pal], context[:config].project.tasks).to_json
 
         # We structure this array of tasks to be an array of hashes so that it matches the structure
         # returned by the puppetserver API that serves data like this. Structuring the output this way

--- a/spec/bolt_server/transport_app_spec.rb
+++ b/spec/bolt_server/transport_app_spec.rb
@@ -184,7 +184,7 @@ describe "BoltServer::TransportApp" do
       let(:fake_pal) { instance_double('BoltServer::PE::PAL') }
       let(:path) { "/tasks?environment=production" }
 
-      it 'returns just the list of plan names when metadata=false' do
+      it 'returns just the list of task names' do
         expect(BoltServer::PE::PAL).to receive(:new).and_return(fake_pal)
         expect(fake_pal).to receive(:list_tasks).and_return([%w[abc abc_description], %w[def def_description]])
         get(path)
@@ -196,6 +196,50 @@ describe "BoltServer::TransportApp" do
         stub_const("Puppet::Environments::EnvironmentNotFound", StandardError)
         expect(BoltServer::PE::PAL).to receive(:new).and_raise(Puppet::Environments::EnvironmentNotFound)
         get(path)
+        expect(last_response.status).to eq(400)
+      end
+    end
+
+    describe '/project_tasks' do
+      let(:fake_pal) { instance_double('Bolt::PAL') }
+      let(:fake_project) { instance_double('Bolt::Project') }
+      let(:fake_config) { instance_double('Bolt::Config') }
+      let(:path) { "/project_tasks?project_ref=some_project_somesha" }
+
+      it 'returns just the list of task names' do
+        allow(Dir).to receive(:exist?).with('/tmp/foo/some_project_somesha').and_return(true)
+        allow(Bolt::Project).to receive(:create_project).and_return(fake_project)
+        allow(Bolt::Config).to receive(:from_project).and_return(fake_config)
+
+        allow(fake_config).to receive(:modulepath)
+        allow(fake_config).to receive(:project).and_return(fake_project)
+        allow(fake_project).to receive(:tasks)
+        expect(Bolt::PAL).to receive(:new).and_return(fake_pal)
+        expect(fake_pal).to receive(:list_tasks).and_return([%w[abc abc_description], %w[def def_description]])
+        get(path)
+        metadata = JSON.parse(last_response.body)
+        expect(metadata).to eq([{ 'name' => 'abc' }, { 'name' => 'def' }])
+      end
+
+      it 'returns just the list of task names filtered on project allowlist' do
+        allow(Dir).to receive(:exist?).with('/tmp/foo/some_project_somesha').and_return(true)
+        allow(Bolt::Project).to receive(:create_project).and_return(fake_project)
+        allow(Bolt::Config).to receive(:from_project).and_return(fake_config)
+
+        allow(fake_config).to receive(:modulepath)
+        allow(fake_config).to receive(:project).and_return(fake_project)
+        allow(fake_project).to receive(:tasks).and_return('abc')
+        expect(Bolt::PAL).to receive(:new).and_return(fake_pal)
+        expect(fake_pal).to receive(:list_tasks).and_return([%w[abc abc_description], %w[def def_description]])
+        get(path)
+        metadata = JSON.parse(last_response.body)
+        expect(metadata).to eq([{ 'name' => 'abc' }])
+      end
+
+      it 'returns 400 if an environment not found error is thrown' do
+        get(path)
+        error = last_response.body
+        expect(error).to eq('`project_ref`: /tmp/foo/some_project_somesha does not exist')
         expect(last_response.status).to eq(400)
       end
     end
@@ -272,6 +316,105 @@ describe "BoltServer::TransportApp" do
         let(:path) { '/tasks/foo/bar?environment=production' }
         it 'returns 400 if an unknown plan error is thrown' do
           expect(BoltServer::PE::PAL).to receive(:new).and_return(fake_pal)
+          expect(fake_pal).to receive(:get_task).with('foo::bar').and_raise(Bolt::Error.unknown_task('foo::bar'))
+          get(path)
+          expect(last_response.status).to eq(400)
+        end
+      end
+    end
+
+    describe '/project_tasks/:module_name/:task_name' do
+      let(:fake_pal) { instance_double('Bolt::PAL') }
+      let(:fake_project) { instance_double('Bolt::Project') }
+      let(:fake_config) { instance_double('Bolt::Config') }
+
+      context 'with module_name::task_name' do
+        let(:path) { '/project_tasks/foo/bar?project_ref=some_project_somesha' }
+        let(:mock_task) {
+          Bolt::Task.new(task_name, {}, [{ 'name' => 'bar.rb', 'path' => File.expand_path(__FILE__) }])
+        }
+        let(:task_name) { 'foo::bar' }
+        let(:expected_response) {
+          {
+            "metadata" => {},
+            "name" => "foo::bar",
+            "files" => [
+              {
+                "filename" => "bar.rb",
+                "sha256" => Digest::SHA256.hexdigest(File.read(__FILE__)),
+                "size_bytes" => File.size(__FILE__),
+                "uri" => {
+                  "path" => "/puppet/v3/file_content/tasks/foo/bar.rb",
+                  "params" => { "project" => "some_project_somesha" }
+                }
+              }
+            ]
+          }
+        }
+        it '/tasks/:module_name/:task_name handles module::task_name' do
+          allow(Dir).to receive(:exist?).with('/tmp/foo/some_project_somesha').and_return(true)
+          allow(Bolt::Project).to receive(:create_project).and_return(fake_project)
+          allow(Bolt::Config).to receive(:from_project).and_return(fake_config)
+
+          allow(fake_config).to receive(:modulepath)
+          allow(fake_config).to receive(:project)
+          expect(Bolt::PAL).to receive(:new).and_return(fake_pal)
+          expect(fake_pal).to receive(:get_task).with(task_name).and_return(mock_task)
+          get(path)
+          resp = JSON.parse(last_response.body)
+          expect(resp).to eq(expected_response)
+        end
+      end
+
+      context 'with module_name' do
+        let(:path) { '/project_tasks/foo/init?project_ref=some_project_somesha' }
+        let(:mock_task) {
+          Bolt::Task.new(task_name, {}, [{ 'name' => 'init.rb', 'path' => File.expand_path(__FILE__) }])
+        }
+        let(:task_name) { 'foo' }
+        let(:expected_response) {
+          {
+            "metadata" => {},
+            "name" => "foo",
+            "files" => [
+              {
+                "filename" => "init.rb",
+                "sha256" => Digest::SHA256.hexdigest(File.read(__FILE__)),
+                "size_bytes" => File.size(__FILE__),
+                "uri" => {
+                  "path" => "/puppet/v3/file_content/tasks/foo/init.rb",
+                  "params" => { "project" => "some_project_somesha" }
+                }
+              }
+            ]
+          }
+        }
+
+        it '/tasks/:module_name/:task_name handles task name = module name (init.rb) task' do
+          allow(Dir).to receive(:exist?).with('/tmp/foo/some_project_somesha').and_return(true)
+          allow(Bolt::Project).to receive(:create_project).and_return(fake_project)
+          allow(Bolt::Config).to receive(:from_project).and_return(fake_config)
+
+          allow(fake_config).to receive(:modulepath)
+          allow(fake_config).to receive(:project)
+          expect(Bolt::PAL).to receive(:new).and_return(fake_pal)
+          expect(fake_pal).to receive(:get_task).with(task_name).and_return(mock_task)
+          get(path)
+          resp = JSON.parse(last_response.body)
+          expect(resp).to eq(expected_response)
+        end
+      end
+
+      context 'with non-existant task' do
+        let(:path) { '/project_tasks/foo/bar?project_ref=some_project_somesha' }
+        it 'returns 400 if an unknown plan error is thrown' do
+          allow(Dir).to receive(:exist?).with('/tmp/foo/some_project_somesha').and_return(true)
+          allow(Bolt::Project).to receive(:create_project).and_return(fake_project)
+          allow(Bolt::Config).to receive(:from_project).and_return(fake_config)
+
+          allow(fake_config).to receive(:modulepath)
+          allow(fake_config).to receive(:project)
+          expect(Bolt::PAL).to receive(:new).and_return(fake_pal)
           expect(fake_pal).to receive(:get_task).with('foo::bar').and_raise(Bolt::Error.unknown_task('foo::bar'))
           get(path)
           expect(last_response.status).to eq(400)

--- a/spec/lib/bolt_spec/bolt_server.rb
+++ b/spec/lib/bolt_spec/bolt_server.rb
@@ -13,7 +13,8 @@ module BoltSpec
         'ssl-key' => File.join(ssl_dir, "key.pem"),
         'ssl-ca-cert' => File.join(ssl_dir, "ca.pem"),
         'cache-dir' => File.join(spec_dir, "tmp", "cache"),
-        'file-server-uri' => 'https://localhost:8140'
+        'file-server-uri' => 'https://localhost:8140',
+        'projects-dir' => '/tmp/foo'
       }
     end
 


### PR DESCRIPTION
Add new endpoints to bolt-server capable of listing tasks and task metadata from bolt projects. 