### PR TITLE
(GH-2108) Warn when Bolt project shadows module of the same name

### DIFF
--- a/spec/fixtures/projects/named/modules/test_project/plans/init.pp
+++ b/spec/fixtures/projects/named/modules/test_project/plans/init.pp
@@ -1,0 +1,5 @@
+plan test_project(
+  TargetSpec $targets
+) {
+  fail_plan("This plan should be shadowed by the project")
+}


### PR DESCRIPTION
!feature

  * **Bolt will now warn if a project has the same name as a module**
     ([#2108](https://github.com/puppetlabs/bolt/issues/2108))

    Any module with the same name as the Bolt project will be ignored,
    and Bolt will now issue a warning to indicate that.