### PR TITLE
(maint) Relax Puppet version pinning

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-ssh", ">= 4.0"
   spec.add_dependency "net-ssh-krb", "~> 0.5"
   spec.add_dependency "orchestrator_client", "~> 0.4"
-  spec.add_dependency "puppet", "6.18.0"
+  spec.add_dependency "puppet", [">= 6.18.0", "< 7"]
   spec.add_dependency "puppetfile-resolver", "~> 0.1.0"
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "puppet-strings", "~> 2.3"


### PR DESCRIPTION
The version was pinned in #2119 to workaround a regression in Puppet
6.18.0, but now we can get rid of it.