### PR TITLE
(maint) Comment Invoke-BoltTask params test

### DIFF
--- a/pwsh_module/command.tests.ps1
+++ b/pwsh_module/command.tests.ps1
@@ -263,8 +263,9 @@ Describe "test all bolt command examples" {
       $results = Invoke-BoltTask -name 'package' -targets 'target1,target2' -params '{"name":"bash","action":"status"}'
       $results | Should -Be "bolt task run 'package' --targets 'target1,target2' --params '{`"name`":`"bash`",`"action`":`"status`"}'"
 
-      $results = Invoke-BoltTask -name 'package' -targets 'target1,target2' -params @{ 'name' = 'bash'; 'action' = 'status' }
-      $results | Should -Be "bolt task run 'package' --targets 'target1,target2' --params '{`"name`":`"bash`",`"action`":`"status`"}'"
+      # Addressing in https://github.com/puppetlabs/bolt/issues/2148
+      # $results = Invoke-BoltTask -name 'package' -targets 'target1,target2' -params @{ 'name' = 'bash'; 'action' = 'status' }
+      # $results | Should -Be "bolt task run 'package' --targets 'target1,target2' --params '{`"name`":`"bash`",`"action`":`"status`"}'"
     }
     It "bolt task show" {
       $results = Get-BoltTask


### PR DESCRIPTION
This commit comments out the hashtable test for the Invoke-BoltTask params parameter as the exact order of the returned JSON can vary. This is commented out so that project work can continue, while https://github.com/puppetlabs/bolt/issues/2148 is tasked on fixing the test.
