### PR TITLE
Extract Puppet interaction to a manager service

### DIFF
--- a/lib/bolt/catalog.rb
+++ b/lib/bolt/catalog.rb
@@ -9,7 +9,7 @@ require 'bolt/pal'
 require 'bolt/puppetdb'
 require 'bolt/util'
 
-Bolt::PAL.load_puppet
+Bolt::PAL::CompilerService.load_puppet
 
 require 'bolt/catalog/logging'
 

--- a/lib/bolt/pal/compiler_service.rb
+++ b/lib/bolt/pal/compiler_service.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+module Bolt
+  class PAL
+    class CompilerService
+      def initialize(project, modulepath)
+        require 'concurrent'
+
+        @project = project
+        @modulepath = modulepath
+        @queue = Queue.new
+      end
+
+      def start(&blk)
+        return if @thread
+        self.class.load_puppet
+        initialize_puppet
+        configure_logging
+
+        # XXX raise if already started
+        @thread = Thread.new do
+          in_bolt_compiler(@project, @modulepath) do |compiler|
+            initialize_compiler(compiler)
+            loop do
+              work = @queue.pop
+              func = work[:proc]
+              promise = work[:promise]
+              result = func.call(compiler)
+              promise.set(result)
+            end
+          end
+        end
+      end
+
+      def stop
+        return unless @thread
+        @thread.kill
+        @thread.join
+      end
+
+      def perform(&blk)
+        # If we're already executing in the scope of a compiler (ie. in the
+        # worker thread) then just yield the compiler. Otherwise, push a work
+        # item onto the queue. This allows the compiler service to be
+        # reentrant, avoiding deadlocks if code being run by the compiler needs
+        # to access the compiler again.
+        compiler = Puppet.lookup(:pal_compiler) { nil }
+
+        if compiler
+          yield compiler
+        else
+          promise = Concurrent::Promise.new
+          @queue.push(proc: blk, promise: promise)
+          promise.wait!
+          promise.value
+        end
+      end
+
+      def initialize_compiler(compiler)
+        detect_project_conflict(@project, Puppet.lookup(:environments).get('bolt'))
+        alias_types(compiler)
+        register_resource_types(Puppet.lookup(:loaders), @project)
+      end
+
+      def self.load_puppet
+        if Bolt::Util.windows?
+          # Windows 'fix' for openssl behaving strangely. Prevents very slow operation
+          # of random_bytes later when establishing winrm connections from a Windows host.
+          # See https://github.com/rails/rails/issues/25805 for background.
+          require 'openssl'
+          OpenSSL::Random.random_bytes(1)
+        end
+
+        begin
+          require 'puppet_pal'
+        rescue LoadError
+          raise Bolt::Error.new("Puppet must be installed to execute tasks", "bolt/puppet-missing")
+        end
+
+        require 'bolt/pal/logging'
+        require 'bolt/pal/issues'
+        require 'bolt/pal/yaml_plan/loader'
+        require 'bolt/pal/yaml_plan/transpiler'
+
+        # Now that puppet is loaded we can include puppet mixins in data types
+        Bolt::ResultSet.include_iterable
+      end
+
+      def initialize_puppet
+        Dir.mktmpdir('bolt') do |dir|
+          cli = []
+          Puppet::Settings::REQUIRED_APP_SETTINGS.each do |setting|
+            cli << "--#{setting}" << dir
+          end
+          Puppet.settings.send(:clear_everything_for_tests)
+          Puppet.initialize_settings(cli)
+          Puppet::GettextConfig.create_default_text_domain
+          Puppet[:trusted_external_command] = @trusted_external
+          Puppet.settings[:hiera_config] = @hiera_config
+          configure_logging
+        end
+      end
+
+      # Puppet logging is global so this is class method to avoid confusion
+      def configure_logging
+        Puppet::Util::Log.destinations.clear
+        Puppet::Util::Log.newdestination(Bolt::Logger.logger('Puppet'))
+        # Defer all log level decisions to the Logging library by telling Puppet
+        # to log everything
+        Puppet.settings[:log_level] = 'debug'
+      end
+
+      # Create a top-level alias for TargetSpec and PlanResult so that users don't have to
+      # namespace it with Boltlib, which is just an implementation detail. This
+      # allows them to feel like a built-in type in bolt, rather than
+      # something has been, no pun intended, "bolted on".
+      def alias_types(compiler)
+        compiler.evaluate_string('type TargetSpec = Boltlib::TargetSpec')
+        compiler.evaluate_string('type PlanResult = Boltlib::PlanResult')
+      end
+
+      # Register all resource types defined in $Project/.resource_types as well as
+      # the built in types registered with the runtime_3_init method.
+      def register_resource_types(loaders, project)
+        return unless project
+        static_loader = loaders.static_loader
+        static_loader.runtime_3_init
+        if File.directory?(project.resource_types)
+          Dir.children(project.resource_types).each do |resource_pp|
+            type_name_from_file = File.basename(resource_pp, '.pp').capitalize
+            typed_name = Puppet::Pops::Loader::TypedName.new(:type, type_name_from_file)
+            resource_type = Puppet::Pops::Types::TypeFactory.resource(type_name_from_file)
+            loaders.static_loader.set_entry(typed_name, resource_type)
+          end
+        end
+      end
+
+      def detect_project_conflict(project, environment)
+        return unless project && project.load_as_module?
+        # The environment modulepath has stripped out non-existent directories,
+        # so we don't need to check for them
+        modules = environment.modulepath.flat_map do |path|
+          Dir.children(path).select { |name| Puppet::Module.is_module_directory?(name, path) }
+        end
+        if modules.include?(project.name)
+          Bolt::Logger.warn_once("project shadows module",
+                                 "The project '#{project.name}' shadows an existing module of the same name")
+        end
+      end
+
+      # Runs a block in a PAL script compiler configured for Bolt.  Catches
+      # exceptions thrown by the block and re-raises them ensuring they are
+      # Bolt::Errors since the script compiler block will squash all exceptions.
+      def in_bolt_compiler(project, modulepath)
+        Puppet::Pal.in_tmp_environment('bolt', modulepath: modulepath, facts: {}) do |pal|
+          # Only load the project if it a) exists, b) has a name it can be loaded with
+          Puppet.override(bolt_project: project,
+                          yaml_plan_instantiator: Bolt::PAL::YamlPlan::Loader) do
+            pal.with_script_compiler(set_local_facts: false) do |compiler|
+              yield compiler
+            end
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -56,22 +56,8 @@ module Bolt
       private :empty_inventory
 
       def with_a_compiler
-        # If we're already inside a pal compiler block use that compiler
-        # This may blow up if you try to load a task in catalog pal. Should we
-        # guard against that?
-        compiler = nil
-        if defined?(Puppet)
-          begin
-            compiler = Puppet.lookup(:pal_compiler)
-          rescue Puppet::Context::UndefinedBindingError; end # rubocop:disable Lint/SuppressedException
-        end
-
-        if compiler
-          yield compiler
-        else
-          @pal.in_bolt_compiler do |temp_compiler|
-            yield temp_compiler
-          end
+        @pal.in_bolt_compiler do |temp_compiler|
+          yield temp_compiler
         end
       end
       private :with_a_compiler

--- a/lib/bolt_spec/run.rb
+++ b/lib/bolt_spec/run.rb
@@ -230,11 +230,8 @@ module BoltSpec
         executor = Bolt::Executor.new(config.concurrency, @analytics, noop)
         targets = inventory.get_targets(targets)
 
-        pal.in_plan_compiler(executor, inventory, puppetdb_client) do |compiler|
+        pal.with_bolt_executor(executor, inventory, puppetdb_client) do |compiler|
           compiler.call_function('apply_prep', targets)
-        end
-
-        pal.with_bolt_executor(executor, inventory, puppetdb_client) do
           Puppet.lookup(:apply_executor).apply_ast(ast, targets, catch_errors: true, noop: noop)
         end
       end


### PR DESCRIPTION
This pulls out the code from PAL that handles interacting with Puppet
and building a compiler into a new CompilerService class. That class
builds a compiler context in a dedicated thread and accepts operations
to perform via a work queue, posting results via a promise.

This allows us to only instantiate a single compiler to perform multiple
operations, rather than getting a new one each time we need to use
Puppet.

It also helps separate the code that knows how to interact with Puppet
on a basic level (CompilerService) from the code that knows how to do the particular
operations we care about in Bolt (Bolt::PAL itself).