### PR TITLE
(docs) Fix typo in writing_plans page

### DIFF
--- a/documentation/writing_plans.md
+++ b/documentation/writing_plans.md
@@ -444,7 +444,7 @@ check fails:
 ```
 $r = run_task('sometask', ..., '_catch_errors' => true)
 unless $r.ok {
-  fail("Running sometask failed on the targets ${r.error_targets.names}")
+  fail("Running sometask failed on the targets ${r.error_set.names}")
 }
 ```
 


### PR DESCRIPTION
An example uses a non existing method on a ResultSet. This commit updates the example to use an existing method.