### PR TITLE
(maint) Only require release notes tag for bolt source code

### DIFF
--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -3,7 +3,17 @@ name: Release Notes
 on:
   pull_request:
     type: [opened, reopened, edited]
-    paths-ignore: ['*.md', '**.md', '**.erb']
+    paths-ignore: 
+      - '*.md'
+      - '**.md'
+      - '**.erb'
+      - 'lib/bolt_server/**'
+      - 'spec/**'
+      - 'acceptance/**'
+      - 'bolt_spec_spec/**'
+      - 'config/**'
+      - '.github/**'
+      - 'rakelib/**'
 
 jobs:
 


### PR DESCRIPTION
This commit updates the commit message tag check to only run when the commit touches a file that contains a change to bolt source code. This excludes files in tests, bolt-server source, and other files that where changes will not need to be added to the changelog.