### PR TITLE
(PUP-10653) Remove dependency on win32/dir

### DIFF
--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -97,11 +97,8 @@ module Bolt
     end
 
     def self.system_path
-      # Lazy-load expensive gem code
-      require 'win32/dir' if Bolt::Util.windows?
-
       if Bolt::Util.windows?
-        Pathname.new(File.join(Dir::COMMON_APPDATA, 'PuppetLabs', 'bolt', 'etc'))
+        Pathname.new(File.join(ENV['ALLUSERSPROFILE'], 'PuppetLabs', 'bolt', 'etc'))
       else
         Pathname.new(File.join('/etc', 'puppetlabs', 'bolt'))
       end

--- a/lib/bolt/puppetdb/config.rb
+++ b/lib/bolt/puppetdb/config.rb
@@ -18,8 +18,7 @@ module Bolt
       end
 
       def self.default_windows_config
-        require 'win32/dir'
-        File.expand_path(File.join(Dir::COMMON_APPDATA, 'PuppetLabs/client-tools/puppetdb.conf'))
+        File.expand_path(File.join(ENV['ALLUSERSPROFILE'], 'PuppetLabs/client-tools/puppetdb.conf'))
       end
 
       def self.load_config(options, project_path = nil)


### PR DESCRIPTION
For Puppet 7 we are dropping the `win32/dir` dependency as we only used
constants from it, which we replaced with environment variables (see:
https://github.com/puppetlabs/puppet/pull/8314).

This would become breaking in bolt when it switches to Puppet 7 and the
win32 gems are no longer pulled.

For AIO bolt, the Puppet change won't break anything since bolt uses its
own runtime which still packages the win32 gems, but it would still be
an improvement in speed if the dependency is dropped.

The `win32/dir` gem also monkey patches some `Dir` methods, most notably
`glob` and `pwd` to use backslashes which end up causing more trouble as
Ruby uses `/` as the default separator for Windows.

Switch to using the `ALLUSERSPROFILE` environment variable instead of
the `Dir::COMMON_APPDATA` constant, and remove a `Dir.pwd` workaround.