### PR TITLE
(GH-2131) Add bolt module subcommands

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -69,6 +69,12 @@ module Bolt
         when 'install'
           { flags: OPTIONS[:global] + %w[configfile force project],
             banner: MODULE_INSTALL_HELP }
+        when 'show'
+          { flags: OPTIONS[:global] + OPTIONS[:global_config_setters],
+            banner: MODULE_SHOW_HELP }
+        when 'generate-types'
+          { flags: OPTIONS[:global] + OPTIONS[:global_config_setters],
+            banner: MODULE_GENERATETYPES_HELP }
         else
           { flags: OPTIONS[:global],
             banner: MODULE_HELP }
@@ -358,10 +364,12 @@ module Bolt
           bolt module <action> [options]
 
       DESCRIPTION
-          Install the project's modules
+          Install and list modules and generate type references
 
       ACTIONS
-          install       Install the project's modules
+          generate-types        Generate type references to register in plans
+          install               Install the project's modules
+          show                  List modules available to the Bolt project
     HELP
 
     MODULE_INSTALL_HELP = <<~HELP
@@ -377,6 +385,28 @@ module Bolt
           Module declarations are loaded from the project's configuration
           file. Bolt will automatically resolve all module dependencies,
           generate a Puppetfile, and install the modules.
+    HELP
+
+    MODULE_GENERATETYPES_HELP = <<~HELP
+      NAME
+          generate-types
+
+      USAGE
+          bolt module generate-types [options]
+
+      DESCRIPTION
+          Generate type references to register in plans.
+    HELP
+
+    MODULE_SHOW_HELP = <<~HELP
+      NAME
+          show
+
+      USAGE
+          bolt module show [options]
+
+      DESCRIPTION
+          List modules available to the Bolt project.
     HELP
 
     PLAN_HELP = <<~HELP

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -41,7 +41,7 @@ module Bolt
                  'project' => %w[init migrate],
                  'apply' => %w[],
                  'guide' => %w[],
-                 'module' => %w[install] }.freeze
+                 'module' => %w[install show generate-types] }.freeze
 
     attr_reader :config, :options
 
@@ -409,6 +409,8 @@ module Bolt
           end
         when 'group'
           list_groups
+        when 'module'
+          list_modules
         end
         return 0
       when 'show-modules'
@@ -452,6 +454,8 @@ module Bolt
         case options[:action]
         when 'install'
           code = install_project_modules
+        when 'generate-types'
+          code = generate_types
         end
       when 'puppetfile'
         case options[:action]

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -2459,6 +2459,15 @@ describe "Bolt::CLI" do
 
         expect(output.string).to be_empty
       end
+
+      it 'lists modules in the puppetfile' do
+        allow(cli).to receive(:outputter).and_return(Bolt::Outputter::Human.new(false, false, false, output))
+        modules = cli.list_modules
+        expect(modules.keys.first).to match(/bolt-modules/)
+        expect(modules.values.first.map { |h| h[:name] }).to eq(%w[boltlib ctrl dir file out prompt system])
+        expect(modules.values[1].map { |h| h[:name] })
+          .to include("aggregate", "canary", "puppetdb_fact", "puppetlabs/yaml")
+      end
     end
 
     describe "applying Puppet code" do

--- a/spec/integration/plan_spec.rb
+++ b/spec/integration/plan_spec.rb
@@ -79,8 +79,9 @@ describe 'plans' do
       end
 
       it 'runs registers types defined in $project/.resource_types', ssh: true do
+        ENV['BOLT_MODULE_FEATURE'] = 'true'
         # generate types based and save in project (based on value of --configfile)
-        run_cli(%w[puppetfile generate-types] + config_flags)
+        run_cli(%w[module generate-types] + config_flags)
         result = run_cli(['plan', 'run', 'resource_types', '--targets', target] + config_flags)
         expect(JSON.parse(result)).to eq('built-in' => 'success', 'core' => 'success', 'custom' => 'success')
       end


### PR DESCRIPTION
This adds the `bolt module generate-types` and `bolt module show`
subcommands, which are analagous to `bolt puppetfile generate-types` and
`bolt puppetfile show-modules` respectively. These commands have the
exact same behavior as the puppetfile subcommands. The environment
variable `BOLT_MODULE_FEATURE` must be set to use the `bolt module`
subcommand. The puppetfile commands aren't deprecated yet - we'll do
that closer to 3.0. This also doesn't include a release note, as we're
launching the module feature dark until the entire workflow is complete.

Closes #2131

!no-release-note