### PR TITLE
(maint) Add Litmus smoke tests

### DIFF
--- a/.github/workflows/litmus_smoke.yaml
+++ b/.github/workflows/litmus_smoke.yaml
@@ -1,0 +1,69 @@
+name: Litmus Smoke Test
+
+on:
+  push:
+    branches: [main]
+    paths-ignore: ['**.md', '**.erb', 'schemas/*']
+  pull_request:
+    type: [opened, reopened, edited]
+    paths-ignore: ['**.md', '**.erb', 'schemas/*']
+
+jobs:
+  tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.5.x'
+      - name: Checkout package module
+        uses: actions/checkout@v2
+        with:
+          # Default fetch-depth is 1
+          repository: puppetlabs/puppetlabs-package
+      - name: Modify Gemfile
+        uses: DamianReeves/write-file-action@v1.0
+        with:
+          path: Gemfile
+          # This action appends by default
+          contents: "gem 'bolt', require: false, git: 'https://github.com/${{ github.repository }}', branch: '${{ github.ref }}'"
+      - name: Install bundler
+        run: |
+          gem install bundler
+          bundle config path vendor/bundle
+          bundle config with development
+      - name: Cache gems
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
+      - name: Install gems
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: bundle install --jobs 4 --retry 3
+      - name: Run smoke test on Ubuntu
+        if: runner.os == 'Linux'
+        env:
+          PLATFORMS: deb_puppet6
+        run: |
+          bundle exec rake spec_prep
+          bundle exec rake litmus:provision_list[default]
+          bundle exec rake litmus:install_agent
+          bundle exec rake litmus:install_module
+          bundle exec rake litmus:install_modules_from_directory[./spec/fixtures/modules]
+          bundle exec rake litmus:add_feature[test_123]
+          bundle exec rake litmus:acceptance:parallel
+          bundle exec rake litmus:tear_down
+      - name: Run smoke test on Windows
+        if: runner.os == 'Windows'
+        env:
+          RUBY_VERSION: 25-x64
+          ACCEPTANCE: yes
+          TARGET_HOST: localhost
+        run: |
+          bundle exec rake spec_prep
+          bundle exec rake litmus:acceptance:localhost


### PR DESCRIPTION
This adds a new Github workflow that verifies that Litmus executes using
the latest version of Bolt. Since Litmus relies on Bolt to work, this
verifies that any changes in Bolt won't break Litmus before we merge.
This sets up a matrix of Ubuntu and Windows platforms and runs the tests
on each, where the test on Ubuntu uses a remote target and the Windows
test verifies Litmus against localhost. Both tests simply run the Litmus
acceptance tests using the Bolt version that triggered the action to run 
(so the PR branch).

!no-release-note