### PR TITLE
(GH-2148) Fix JSON ordering in pester test

### DIFF
--- a/pwsh_module/command.tests.ps1
+++ b/pwsh_module/command.tests.ps1
@@ -263,9 +263,12 @@ Describe "test all bolt command examples" {
       $results = Invoke-BoltTask -name 'package' -targets 'target1,target2' -params '{"name":"bash","action":"status"}'
       $results | Should -Be "bolt task run 'package' --targets 'target1,target2' --params '{`"name`":`"bash`",`"action`":`"status`"}'"
 
-      # Addressing in https://github.com/puppetlabs/bolt/issues/2148
-      # $results = Invoke-BoltTask -name 'package' -targets 'target1,target2' -params @{ 'name' = 'bash'; 'action' = 'status' }
-      # $results | Should -Be "bolt task run 'package' --targets 'target1,target2' --params '{`"name`":`"bash`",`"action`":`"status`"}'"
+      $results = Invoke-BoltTask -name 'package' -targets 'target1,target2' -params @{ 'name' = 'bash'; 'action' = 'status' }
+      # We don't care about the order of JSON keys, and they might become out
+      # of order due to ConvertToJson
+      $results | Should -BeIn @("bolt task run 'package' --targets 'target1,target2' --params '{`"name`":`"bash`",`"action`":`"status`"}'",
+          "bolt task run 'package' --targets 'target1,target2' --params '{`"action`":`"status`",`"name`":`"bash`"}'")
+
     }
     It "bolt task show" {
       $results = Get-BoltTask


### PR DESCRIPTION
The ConvertTo-JSON cmdlet respects JSON ordering in Powershell 5.1 and
7.1, but not version 7.0. This caused the test that verifies passing a
JSON object to Invoke-BoltTask to fail, as the ordering of JSON
parameters was wrong and the test simply verifies the resulting Bolt
command as a string. This updates the test to accept the JSON object
elements in any order. Because users and their tasks don't care about
the order, it doesn't make sense to fix this in the code itself - just
to update the test to also not care about the order.

Closes #2148

!no-release-note