### PR TITLE
(GH-2168) Add version requirements for module declarations

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -892,13 +892,17 @@ module Bolt
         unless existing.modules.superset? puppetfile.modules
           missing_modules = puppetfile.modules - existing.modules
 
-          raise Bolt::Error.new(
-            "Puppetfile #{puppetfile_path} is missing specifications for modules: "\
-            "#{missing_modules.map(&:title).join(', ')}. This may not be a Puppetfile "\
-            "managed by Bolt. To forcibly overwrite the Puppetfile, run with the "\
-            "'--force' option.",
-            'bolt/missing-module-specs'
-          )
+          message = <<~MESSAGE.chomp
+            Puppetfile #{puppetfile_path} is missing specifications for the following
+            module declarations:
+            
+            #{missing_modules.map(&:to_hash).to_yaml.lines.drop(1).join.chomp}
+
+            This may not be a Puppetfile managed by Bolt. To forcibly overwrite the
+            Puppetfile, run 'bolt module install --force'.
+          MESSAGE
+
+          raise Bolt::Error.new(message, 'bolt/missing-module-specs')
         end
       else
         outputter.print_message "Resolving module dependencies, this may take a moment"

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -239,11 +239,21 @@ module Bolt
               "name" => {
                 description: "The name of the module.",
                 type: String
+              },
+              "version_requirement" => {
+                description: "The version requirement for the module. Accepts a specific version (1.2.3), version "\
+                             "shorthand (1.2.x), or a version range (>= 1.2.0).",
+                type: String
               }
             }
           },
           _plugin: false,
-          _example: [{ "name" => "puppetlabs-mysql" }, { "name" => "puppetlabs-apache" }]
+          _example: [
+            { "name" => "puppetlabs-mysql" },
+            { "name" => "puppetlabs-apache", "version_requirement" => "5.5.0" },
+            { "name" => "puppetlabs-puppetdb", "version_requirement" => "7.x" },
+            { "name" => "puppetlabs-firewall", "version_requirement" => ">= 1.0.0 < 3.0.0" }
+          ]
         },
         "name" => {
           description: "The name of the Bolt project. When this option is configured, the project is considered a "\

--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -199,10 +199,9 @@ module Bolt
           raise Bolt::ValidationError, "Module declaration #{mod.inspect} must be a hash"
         end
 
-        unknown_keys = data['modules'].flat_map(&:keys).uniq - ['name']
+        unknown_keys = data['modules'].flat_map(&:keys).uniq - %w[name version_requirement]
         if unknown_keys.any?
-          @logs << { warn: "Module declarations in bolt-project.yaml only support a name key. Ignoring "\
-                           "unsupported keys: #{unknown_keys.join(', ')}." }
+          @logs << { warn: "Ignoring unknown keys in module declarations: #{unknown_keys.join(', ')}." }
         end
       end
     end

--- a/lib/bolt/puppetfile.rb
+++ b/lib/bolt/puppetfile.rb
@@ -82,7 +82,7 @@ module Bolt
       @modules.each do |mod|
         model.add_module(
           PuppetfileResolver::Puppetfile::ForgeModule.new(mod.title).tap do |tap|
-            tap.version = :latest
+            tap.version = mod.version || :latest
           end
         )
       end

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -180,6 +180,10 @@
           "name": {
             "description": "The name of the module.",
             "type": "string"
+          },
+          "version_requirement": {
+            "description": "The version requirement for the module. Accepts a specific version (1.2.3), version shorthand (1.2.x), or a version range (>= 1.2.0).",
+            "type": "string"
           }
         }
       }

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -228,7 +228,7 @@ describe "Bolt::CLI" do
 
         expect { cli.execute(cli.parse) }.to raise_error(
           Bolt::Error,
-          /Puppetfile .* is missing specifications for modules/
+          /puppetlabs-apt/
         )
       end
 

--- a/spec/bolt/puppetfile/module_spec.rb
+++ b/spec/bolt/puppetfile/module_spec.rb
@@ -48,6 +48,20 @@ describe Bolt::Puppetfile::Module do
 
       expect(mod1.eql?(mod2)).to eq(false)
     end
+
+    it 'returns true if versions intersect' do
+      mod1 = described_class.new('owner', 'title', '1.0.0')
+      mod2 = described_class.new('owner', 'title', '>= 1.0.0')
+
+      expect(mod1.eql?(mod2)).to eq(true)
+    end
+
+    it 'returns false if versions do not intersect' do
+      mod1 = described_class.new('owner', 'title', '1.0.0')
+      mod2 = described_class.new('owner', 'title', '>= 2.0.0')
+
+      expect(mod1.eql?(mod2)).to eq(false)
+    end
   end
 
   context '#hash' do
@@ -72,10 +86,11 @@ describe Bolt::Puppetfile::Module do
       expect(Set.new([mod1, mod2, mod3]).size).to eq(2)
     end
 
-    it 'does not hash from version' do
+    it 'hashes from version intersection' do
       mod1 = described_class.new('puppetlabs', 'apt', '1.0.0')
-      mod2 = described_class.new('puppetlabs', 'apt', '2.0.0')
-      expect(Set.new([mod1, mod2]).size).to eq(1)
+      mod2 = described_class.new('puppetlabs', 'apt', '1.x')
+      mod3 = described_class.new('puppetlabs', 'apt', '>= 2.0.0')
+      expect(Set.new([mod1, mod2, mod3]).size).to eq(2)
     end
   end
 

--- a/spec/bolt/puppetfile_spec.rb
+++ b/spec/bolt/puppetfile_spec.rb
@@ -105,5 +105,32 @@ describe Bolt::Puppetfile do
         expect(mod).to be_kind_of(Bolt::Puppetfile::Module)
       end
     end
+
+    context 'with a specific version' do
+      let(:modules) { [{ 'name' => 'puppetlabs-facts', 'version_requirement' => '0.5.0' }] }
+
+      it 'resolves' do
+        modules = puppetfile.resolve.to_a
+        expect(modules.first.version).to eq('0.5.0')
+      end
+    end
+
+    context 'with version shorthand' do
+      let(:modules) { [{ 'name' => 'puppetlabs-facts', 'version_requirement' => '0.x' }] }
+
+      it 'resolves' do
+        modules = puppetfile.resolve.to_a
+        expect(modules.first.version).to eq('0.6.0')
+      end
+    end
+
+    context 'with a version range' do
+      let(:modules) { [{ 'name' => 'puppetlabs-facts', 'version_requirement' => '>= 0.2.0 < 0.4.0' }] }
+
+      it 'resolves' do
+        modules = puppetfile.resolve.to_a
+        expect(modules.first.version).to eq('0.3.1')
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds support for specifying version requirements for a module
declaration under the `modules` key of a project config file. To specify
a version, the module declaration should have a `version_requirement`
key. Version requirements should be valid according to semantic-puppet,
and includes support for specific versions (`1.0.0`), version shorthand
(`1.x`), and version ranges (`>= 1.0.0 < 3.0.0`).

Depends on https://github.com/puppetlabs/puppet-runtime/pull/371
Closes #2168 

!no-release-note