### PR TITLE
(GH-2134) Add 'bolt module add' command

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -99,6 +99,7 @@ Lint/StructNewOverride:
 Lint/SuppressedException:
   Exclude:
     - lib/bolt/shell/bash.rb
+    - lib/bolt/module_installer.rb
 
 Lint/TopLevelReturnWithArgument:
   Enabled: true

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -66,15 +66,18 @@ module Bolt
           banner: GUIDE_HELP }
       when 'module'
         case action
+        when 'add'
+          { flags: OPTIONS[:global] + %w[configfile force project],
+            banner: MODULE_ADD_HELP }
+        when 'generate-types'
+          { flags: OPTIONS[:global] + OPTIONS[:global_config_setters],
+            banner: MODULE_GENERATETYPES_HELP }
         when 'install'
           { flags: OPTIONS[:global] + %w[configfile force project],
             banner: MODULE_INSTALL_HELP }
         when 'show'
           { flags: OPTIONS[:global] + OPTIONS[:global_config_setters],
             banner: MODULE_SHOW_HELP }
-        when 'generate-types'
-          { flags: OPTIONS[:global] + OPTIONS[:global_config_setters],
-            banner: MODULE_GENERATETYPES_HELP }
         else
           { flags: OPTIONS[:global],
             banner: MODULE_HELP }
@@ -364,12 +367,40 @@ module Bolt
           bolt module <action> [options]
 
       DESCRIPTION
-          Install and list modules and generate type references
+          Manage Bolt project modules
 
       ACTIONS
+          add                   Add a module to the project
           generate-types        Generate type references to register in plans
           install               Install the project's modules
           show                  List modules available to the Bolt project
+    HELP
+
+    MODULE_ADD_HELP = <<~HELP
+      NAME
+          add
+      
+      USAGE
+          bolt module add <module> [options]
+
+      DESCRIPTION
+          Add a module to the project.
+
+          Adds a module declaration to the project's configuration file.
+          Bolt will automatically resolve the new module's dependencies,
+          update any existing project modules if necessary, generate a
+          new Puppetfile, and install the modules.
+    HELP
+
+    MODULE_GENERATETYPES_HELP = <<~HELP
+      NAME
+          generate-types
+
+      USAGE
+          bolt module generate-types [options]
+
+      DESCRIPTION
+          Generate type references to register in plans.
     HELP
 
     MODULE_INSTALL_HELP = <<~HELP
@@ -385,17 +416,6 @@ module Bolt
           Module declarations are loaded from the project's configuration
           file. Bolt will automatically resolve all module dependencies,
           generate a Puppetfile, and install the modules.
-    HELP
-
-    MODULE_GENERATETYPES_HELP = <<~HELP
-      NAME
-          generate-types
-
-      USAGE
-          bolt module generate-types [options]
-
-      DESCRIPTION
-          Generate type references to register in plans.
     HELP
 
     MODULE_SHOW_HELP = <<~HELP

--- a/lib/bolt/module_installer.rb
+++ b/lib/bolt/module_installer.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'bolt/error'
+require 'bolt/logger'
+
+module Bolt
+  class ModuleInstaller
+    def initialize(outputter, pal)
+      @outputter = outputter
+      @pal       = pal
+      @logger    = Bolt::Logger.logger(self)
+    end
+
+    # Adds a single module to the project.
+    #
+    def add(name, modules, puppetfile_path, moduledir, config_path)
+      require 'bolt/puppetfile'
+
+      # If the project configuration file already includes this module,
+      # exit early.
+      puppetfile  = Bolt::Puppetfile.new(modules)
+      new_module  = Bolt::Puppetfile::Module.from_hash('name' => name)
+
+      if puppetfile.modules.include?(new_module)
+        @outputter.print_message "Project configuration file #{config_path} already "\
+                                 "includes module #{new_module}. Nothing to do."
+        return true
+      end
+
+      # If the Puppetfile exists, make sure it's managed by Bolt.
+      if puppetfile_path.exist?
+        assert_managed_puppetfile(puppetfile, puppetfile_path)
+      end
+
+      # Create a Puppetfile object that includes the new module and its
+      # dependencies. We error early here so we don't add the new module to the
+      # project config or modify the Puppetfile.
+      puppetfile = add_new_module_to_puppetfile(new_module, modules, puppetfile_path)
+
+      # Add the module to the project configuration.
+      @outputter.print_message "Updating project configuration file at #{config_path}"
+
+      data = Bolt::Util.read_yaml_hash(config_path, 'project')
+      data['modules'] ||= []
+      data['modules'] <<  { 'name' => new_module.title }
+
+      begin
+        File.write(config_path, data.to_yaml)
+      rescue SystemCallError => e
+        raise Bolt::FileError.new(
+          "Unable to update project configuration file: #{e.message}",
+          config
+        )
+      end
+
+      # Write the Puppetfile.
+      @outputter.print_message "Writing Puppetfile at #{puppetfile_path}"
+      puppetfile.write(puppetfile_path)
+
+      # Install the modules.
+      install_puppetfile(puppetfile_path, moduledir)
+    end
+
+    # Creates a new Puppetfile that includes the new module and its dependencies.
+    #
+    private def add_new_module_to_puppetfile(new_module, modules, path)
+      @outputter.print_message "Resolving module dependencies, this may take a moment"
+
+      # If there is an existing Puppetfile, add the new module and attempt
+      # to resolve. This will not update the versions of any installed modules.
+      if path.exist?
+        puppetfile = Bolt::Puppetfile.parse(path)
+        puppetfile.add_modules(new_module)
+
+        begin
+          puppetfile.resolve
+          return puppetfile
+        rescue Bolt::Error
+          @logger.debug "Unable to find a version of #{new_module} compatible "\
+                        "with installed modules. Attempting to re-resolve modules "\
+                        "from project configuration; some versions of installed "\
+                        "modules may change."
+        end
+      end
+
+      # If there is not an existing Puppetfile, or resolving with pinned
+      # modules fails, resolve all of the module declarations with the new
+      # module.
+      puppetfile = Bolt::Puppetfile.new(modules)
+      puppetfile.add_modules(new_module)
+      puppetfile.resolve
+      puppetfile
+    end
+
+    # Installs a project's module dependencies.
+    #
+    def install(modules, path, moduledir, force: false)
+      require 'bolt/puppetfile'
+
+      puppetfile = Bolt::Puppetfile.new(modules)
+
+      # If the Puppetfile exists, check if it includes specs for each declared
+      # module, erroring if there are any missing. Otherwise, resolve the
+      # module dependencies and write a new Puppetfile. Users can forcibly
+      # overwrite an existing Puppetfile with the '--force' option.
+      if path.exist? && !force
+        assert_managed_puppetfile(puppetfile, path)
+      else
+        @outputter.print_message "Resolving module dependencies, this may take a moment"
+        puppetfile.resolve
+
+        @outputter.print_message "Writing Puppetfile at #{path}"
+        puppetfile.write(path)
+      end
+
+      # Install the modules.
+      install_puppetfile(path, moduledir)
+    end
+
+    # Installs the Puppetfile and generates types.
+    #
+    def install_puppetfile(path, moduledir, config = {})
+      require 'bolt/puppetfile/installer'
+
+      @outputter.print_message "Syncing modules from #{path} to #{moduledir}"
+      ok = Bolt::Puppetfile::Installer.new(config).install(path, moduledir)
+
+      # Automatically generate types after installing modules
+      @pal.generate_types
+
+      @outputter.print_puppetfile_result(ok, path, moduledir)
+
+      ok
+    end
+
+    # Asserts that an existing Puppetfile is managed by Bolt.
+    #
+    private def assert_managed_puppetfile(puppetfile, path)
+      existing_puppetfile = Bolt::Puppetfile.parse(path)
+
+      unless existing_puppetfile.modules.superset? puppetfile.modules
+        missing_modules = puppetfile.modules - existing_puppetfile.modules
+
+        raise Bolt::Error.new(
+          "Puppetfile #{path} is missing module specifications: "\
+          "#{missing_modules.to_a.join(', ')}. This may not be a Puppetfile "\
+          "managed by Bolt. To forcibly overwrite the Puppetfile and "\
+          "install modules, run 'bolt module install --force'.",
+          'bolt/missing-module-specs'
+        )
+      end
+    end
+  end
+end

--- a/lib/bolt/puppetfile.rb
+++ b/lib/bolt/puppetfile.rb
@@ -34,7 +34,8 @@ module Bolt
 
       unless parsed.valid?
         raise Bolt::ValidationError,
-              "Unable to parse Puppetfile #{path}"
+              "Unable to parse Puppetfile #{path}. This may not be a Puppetfile "\
+              "managed by Bolt."
       end
 
       modules = parsed.modules.map do |mod|
@@ -47,19 +48,10 @@ module Bolt
     # Writes a Puppetfile that includes specifications for each of the
     # modules.
     #
-    def write(path, force: false)
-      if File.exist?(path) && !force
-        raise Bolt::FileError.new(
-          "Cannot overwrite existing Puppetfile at #{path}. To forcibly overwrite, "\
-          "run with the '--force' option.",
-          path
-        )
-      end
-
+    def write(path)
       File.open(path, 'w') do |file|
         file.puts '# This Puppetfile is managed by Bolt. Do not edit.'
         modules.each { |mod| file.puts mod.to_spec }
-        file.puts
       end
     rescue SystemCallError => e
       raise Bolt::FileError.new(
@@ -143,7 +135,7 @@ module Bolt
     # Adds to the set of modules.
     #
     def add_modules(modules)
-      modules.each do |mod|
+      Array(modules).each do |mod|
         case mod
         when Bolt::Puppetfile::Module
           @modules << mod

--- a/lib/bolt/puppetfile/module.rb
+++ b/lib/bolt/puppetfile/module.rb
@@ -38,6 +38,7 @@ module Bolt
       def title
         "#{@owner}-#{@name}"
       end
+      alias to_s title
 
       # Checks two modules for equality.
       #

--- a/spec/bolt/module_installer_spec.rb
+++ b/spec/bolt/module_installer_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/module_installer'
+require 'bolt/puppetfile/installer'
+
+describe Bolt::ModuleInstaller do
+  let(:puppetfile)           { @project + 'Puppetfile' }
+  let(:moduledir)            { @project + '.modules' }
+  let(:config)               { @project + 'bolt-project.yaml' }
+  let(:new_module)           { 'puppetlabs-pkcs7' }
+  let(:modules_config)       { [{ 'name' => 'puppetlabs-yaml' }] }
+  let(:outputter)            { double('outputter', print_message: nil, print_puppetfile_result: nil) }
+  let(:pal)                  { double('pal', generate_types: nil) }
+  let(:installer)            { described_class.new(outputter, pal) }
+  let(:puppetfile_installer) { double('puppetfile_installer', install: true) }
+
+  around(:each) do |example|
+    Dir.mktmpdir(nil, Dir.pwd) do |project|
+      @project = Pathname.new(project)
+      example.run
+    end
+  end
+
+  before(:each) do
+    conf = { 'modules' => [] }
+    File.write(config, conf.to_yaml)
+    allow(Bolt::Puppetfile::Installer).to receive(:new).and_return(puppetfile_installer)
+  end
+
+  context '#add' do
+    it 'returns early if the module is already declared' do
+      result = installer.add('puppetlabs-yaml', modules_config, puppetfile, moduledir, config)
+      expect(result).to eq(true)
+      expect(puppetfile.exist?).to eq(false)
+    end
+
+    it 'errors if Puppetfile is not managed by Bolt' do
+      File.write(puppetfile, '')
+      expect { installer.add(new_module, modules_config, puppetfile, moduledir, config) }.to raise_error(
+        Bolt::Error,
+        /managed by Bolt/
+      )
+    end
+
+    it 'updates files and installs modules' do
+      expect(puppetfile_installer).to receive(:install)
+      installer.add(new_module, modules_config, puppetfile, moduledir, config)
+
+      expect(puppetfile.exist?).to be(true)
+      expect(File.read(puppetfile)).to match(/mod "puppetlabs-pkcs7"/)
+
+      conf = YAML.safe_load(File.read(config))
+      expect(conf['modules']).to match_array([
+                                               { 'name' => 'puppetlabs-pkcs7' }
+                                             ])
+    end
+
+    it 'does not update version of installed modules' do
+      spec = 'mod "puppetlabs-yaml", "0.1.0"'
+      File.write(puppetfile, spec)
+      result = installer.add(new_module, modules_config, puppetfile, moduledir, config)
+
+      expect(result).to eq(true)
+      expect(File.read(puppetfile)).to match(/#{spec}/)
+    end
+
+    it 'updates version of installed modules if unable to resolve with pinned versions' do
+      spec = 'mod "puppetlabs-ruby_task_helper", "0.3.0"'
+      File.write(puppetfile, spec)
+      result = installer.add(new_module, [], puppetfile, moduledir, config)
+
+      expect(result).to eq(true)
+      expect(File.read(puppetfile)).not_to match(/#{spec}/)
+    end
+  end
+
+  context '#install' do
+    it 'errors if Puppetfile is not managed by Bolt' do
+      File.write(puppetfile, '')
+      expect { installer.install(modules_config, puppetfile, moduledir) }.to raise_error(
+        Bolt::Error,
+        /managed by Bolt/
+      )
+    end
+
+    it 'installs modules forcibly' do
+      File.write(puppetfile, '')
+      expect(puppetfile_installer).to receive(:install)
+      installer.install(modules_config, puppetfile, moduledir, force: true)
+    end
+
+    it 'writes a Puppetfile' do
+      installer.install(modules_config, puppetfile, moduledir)
+      expect(puppetfile.exist?).to be(true)
+    end
+
+    it 'installs a Puppetfile' do
+      expect(puppetfile_installer).to receive(:install)
+      installer.install(modules_config, puppetfile, moduledir)
+    end
+  end
+end

--- a/spec/bolt/puppetfile_spec.rb
+++ b/spec/bolt/puppetfile_spec.rb
@@ -59,25 +59,8 @@ describe Bolt::Puppetfile do
   end
 
   context '#write' do
-    it 'errors if there is an existing Puppetfile' do
-      File.write(path, "mod 'puppetlabs-yaml', '0.2.0'")
-
-      expect { puppetfile.write(path) }.to raise_error(
-        Bolt::FileError,
-        /Cannot overwrite existing Puppetfile.*force/
-      )
-    end
-
     it 'writes modules to the Puppetfile' do
       puppetfile.write(path)
-      expect(path.exist?).to eq(true)
-      expect(File.read(path)).to match(/mod "puppetlabs-yaml"/)
-    end
-
-    it 'forcibly overwrites an existing Puppetfile' do
-      File.write(path, "mod 'puppetlabs-apt', '1.0.0'")
-
-      puppetfile.write(path, force: true)
       expect(path.exist?).to eq(true)
       expect(File.read(path)).to match(/mod "puppetlabs-yaml"/)
     end


### PR DESCRIPTION
This adds a new `bolt module add` command that adds a new module to the
project. The command accepts a single module name, resolves its
dependencies, updates the project configuration file and `Puppetfile`,
and installs the project's modules.

If the project configuration file already includes a declaration for the
new module, Bolt will display a helpful message and exit successfully
without doing anything.

When resolving modules, Bolt will first attempt to resolve the new
module with each of the installed modules pinned to a specific version.
This is intended to prevent any installed modules from being updated
unintentionally. If resolving with this approach fails, Bolt falls back
to re-resolving all of the module declarations with the new module,
which may result in insalled modules being updated to different
versions.

Lastly, this includes a new `ModuleInstaller` class which moves most of
the logic for installing modules from the `CLI` class.

This feature is shipping dark and does not have an associated release
note.

!no-release-note