### PR TITLE
(GH-2166) Ensure logging is initialized in inventory

### DIFF
--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -46,7 +46,7 @@ module Bolt
     end
 
     def self.from_config(config, plugins)
-      logger = Logging.logger[self]
+      logger = Bolt::Logger.logger(self)
 
       if ENV.include?(ENVIRONMENT_VAR)
         begin


### PR DESCRIPTION
Commit 546b5554 replaced all calls to `Logging.logger` with a wrapper
method `Bolt::Logger.logger` that initializes logging before returning a
logger object, to ensure that the log methods we need are created.
However, commit 23bb8b33 was in flight at the same time and added a
*new* call to `Logging.logger`. These two changes logically conflicted
but not in a way that could be identified by Git. We therefore wound up
with an undesired call directly to `Logging.logger`, which can cause
failures related to the logging not being initialized when using Bolt as
a library.

This commit changes the `Logging.logger` call to the proper
`Bolt::Logger.logger`.

!no-release-note