### PR TITLE
(maint) Properly detect gem install again

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -1046,7 +1046,7 @@ module Bolt
     # Gem installs include the aggregate, canary, and puppetdb_fact modules, while
     # package installs include modules listed in the Bolt repo Puppetfile
     def incomplete_install?
-      (Dir.children(Bolt::PAL::MODULES_PATH) - %w[aggregate canary puppetdb_fact]).empty?
+      (Dir.children(Bolt::PAL::MODULES_PATH) - %w[aggregate canary puppetdb_fact secure_env_vars]).empty?
     end
 
     # Mimicks the output from Outputter::Human#fatal_error. This should be used to print


### PR DESCRIPTION
This detection was broken since we added the secure_env_vars module as a
built-in, but didn't add it to the list of "expected" built-ins. That
caused Bolt to always believe there was "non-gem install" content
present and so it would never warn that the user had an incomplete
install.

!bug

  * **Fix warning when running from a gem install**

    Bolt again properly detects when it's being run from a gem install
    and emits a warning.