### PR TITLE
(GH-2182) Use new modulepath when 'modules' is configured

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -369,6 +369,9 @@ module Bolt
       DESCRIPTION
           Manage Bolt project modules
 
+          The module command is only supported when a project is configured
+          with the 'modules' key.
+
       ACTIONS
           add                   Add a module to the project
           generate-types        Generate type references to register in plans
@@ -386,10 +389,12 @@ module Bolt
       DESCRIPTION
           Add a module to the project.
 
-          Adds a module declaration to the project's configuration file.
-          Bolt will automatically resolve the new module's dependencies,
-          update any existing project modules if necessary, generate a
-          new Puppetfile, and install the modules.
+          Module declarations are loaded from the project's configuration
+          file. Bolt will automatically resolve all module dependencies,
+          generate a Puppetfile, and install the modules.
+
+          The module command is only supported when a project is configured
+          with the 'modules' key.
     HELP
 
     MODULE_GENERATETYPES_HELP = <<~HELP
@@ -401,6 +406,9 @@ module Bolt
 
       DESCRIPTION
           Generate type references to register in plans.
+
+          The module command is only supported when a project is configured
+          with the 'modules' key.
     HELP
 
     MODULE_INSTALL_HELP = <<~HELP
@@ -427,6 +435,9 @@ module Bolt
 
       DESCRIPTION
           List modules available to the Bolt project.
+
+          The module command is only supported when a project is configured
+          with the 'modules' key.
     HELP
 
     PLAN_HELP = <<~HELP

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -30,19 +30,20 @@ require 'bolt/module_installer'
 module Bolt
   class CLIExit < StandardError; end
   class CLI
-    COMMANDS = { 'command' => %w[run],
-                 'script' => %w[run],
-                 'task' => %w[show run],
-                 'plan' => %w[show run convert new],
-                 'file' => %w[download upload],
-                 'puppetfile' => %w[install show-modules generate-types],
-                 'secret' => %w[encrypt decrypt createkeys],
-                 'inventory' => %w[show],
-                 'group' => %w[show],
-                 'project' => %w[init migrate],
-                 'apply' => %w[],
-                 'guide' => %w[],
-                 'module' => %w[add generate-types install show] }.freeze
+    COMMANDS = {
+      'command'    => %w[run],
+      'script'     => %w[run],
+      'task'       => %w[show run],
+      'plan'       => %w[show run convert new],
+      'file'       => %w[download upload],
+      'puppetfile' => %w[install show-modules generate-types],
+      'secret'     => %w[encrypt decrypt createkeys],
+      'inventory'  => %w[show],
+      'group'      => %w[show],
+      'project'    => %w[init migrate],
+      'apply'      => %w[],
+      'guide'      => %w[]
+    }.freeze
 
     attr_reader :config, :options
 
@@ -59,6 +60,14 @@ module Bolt
     end
     private :inventory
 
+    def commands
+      if ENV['BOLT_MODULE_FEATURE']
+        COMMANDS.merge('module' => %w[add generate-types install show])
+      else
+        COMMANDS
+      end
+    end
+
     def help?(remaining)
       # Set the subcommand
       options[:subcommand] = remaining.shift
@@ -70,7 +79,7 @@ module Bolt
 
       # This section handles parsing non-flag options which are
       # subcommand specific rather then part of the config
-      actions = COMMANDS[options[:subcommand]]
+      actions = commands[options[:subcommand]]
       if actions && !actions.empty?
         options[:action] = remaining.shift
       end
@@ -100,6 +109,10 @@ module Bolt
       # This part aims to handle both `bolt <mode> --help` and `bolt help <mode>`.
       remaining = handle_parser_errors { parser.permute(@argv) } unless @argv.empty?
       if @argv.empty? || help?(remaining)
+        # If the subcommand is not enabled, display the default
+        # help text
+        options[:subcommand] = nil unless commands.include?(options[:subcommand])
+
         # Update the parser for the subcommand (or lack thereof)
         parser.update
         puts parser.help
@@ -190,8 +203,9 @@ module Bolt
 
       warn_inventory_overrides_cli(options)
 
-      # Disable the puppetfile subcommand when 'modules' is configured.
-      assert_puppetfile_command(config.project.modules)
+      # Assert whether the puppetfile/module commands are available depending
+      # on whether 'modules' is configured.
+      assert_puppetfile_or_module_command(config.project.modules)
 
       options
     rescue Bolt::Error => e
@@ -220,17 +234,13 @@ module Bolt
     end
 
     def validate(options)
-      # Disables the 'module' subcommand unless the module feature flag is set.
-      commands = COMMANDS.dup
-      commands.delete('module') unless ENV['BOLT_MODULE_FEATURE']
-
       unless commands.include?(options[:subcommand])
         raise Bolt::CLIError,
               "Expected subcommand '#{options[:subcommand]}' to be one of " \
               "#{commands.keys.join(', ')}"
       end
 
-      actions = COMMANDS[options[:subcommand]]
+      actions = commands[options[:subcommand]]
       if actions.any?
         if options[:action].nil?
           raise Bolt::CLIError,
@@ -932,13 +942,18 @@ module Bolt
     # Raises an error if the 'puppetfile install' command is deprecated due to
     # modules being configured.
     #
-    def assert_puppetfile_command(modules)
-      if modules
+    def assert_puppetfile_or_module_command(modules)
+      if modules && options[:subcommand] == 'puppetfile'
         raise Bolt::CLIError,
               "Unable to use command 'bolt puppetfile #{options[:action]}' when "\
               "'modules' is configured in bolt-project.yaml. Use the 'module' command "\
               "instead. For a list of available actions for the 'module' command, run "\
               "'bolt module --help'."
+      elsif modules.nil? && options[:subcommand] == 'module'
+        raise Bolt::CLIError,
+              "Unable to use command 'bolt module #{options[:action]}'. To use "\
+              "this command, update your project configuration to manage module "\
+              "dependencies."
       end
     end
 

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -453,7 +453,7 @@ module Bolt
     def modulepath
       path = @data['modulepath'] || @project.modulepath
 
-      if @project.modules
+      if @project.modules && ENV['BOLT_MODULE_FEATURE']
         path + [@project.managed_moduledir]
       else
         path

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -391,6 +391,12 @@ module Bolt
         @logs << { warn: msg }
       end
 
+      if @project.modules && @data['modulepath']&.include?(@project.managed_moduledir)
+        raise Bolt::ValidationError,
+              "Found invalid path in modulepath: #{@project.managed_moduledir}. This path "\
+              "is automatically appended to the modulepath and cannot be configured."
+      end
+
       keys = OPTIONS.keys - %w[plugins plugin_hooks puppetdb]
       keys.each do |key|
         next unless Bolt::Util.references?(@data[key])
@@ -445,7 +451,13 @@ module Bolt
     end
 
     def modulepath
-      @data['modulepath'] || @project.modulepath
+      path = @data['modulepath'] || @project.modulepath
+
+      if @project.modules
+        path + [@project.managed_moduledir]
+      else
+        path
+      end
     end
 
     def modulepath=(value)

--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -114,7 +114,7 @@ module Bolt
 
       # If the 'modules' key is present in the project configuration file,
       # use the new, shorter modulepath.
-      @modulepath = if @data.key?('modules')
+      @modulepath = if @data.key?('modules') && ENV['BOLT_MODULE_FEATURE']
                       [(@path + 'modules').to_s]
                     else
                       [(@path + 'modules').to_s, (@path + 'site-modules').to_s, (@path + 'site').to_s]

--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -16,9 +16,9 @@ module Bolt
                  "These tasks are included in `bolt task show` output"
     }.freeze
 
-    attr_reader :path, :data, :config_file, :inventory_file, :modulepath, :hiera_config,
+    attr_reader :path, :data, :config_file, :inventory_file, :hiera_config,
                 :puppetfile, :rerunfile, :type, :resource_types, :logs, :project_file,
-                :deprecations, :downloads, :plans_path, :managed_moduledir
+                :deprecations, :downloads, :plans_path, :modulepath, :managed_moduledir
 
     def self.default_project(logs = [])
       create_project(File.expand_path(File.join('~', '.puppetlabs', 'bolt')), 'user', logs)
@@ -95,7 +95,6 @@ module Bolt
       end
 
       @inventory_file    = @path + 'inventory.yaml'
-      @modulepath        = [(@path + 'modules').to_s, (@path + 'site-modules').to_s, (@path + 'site').to_s]
       @hiera_config      = @path + 'hiera.yaml'
       @puppetfile        = @path + 'Puppetfile'
       @rerunfile         = @path + '.rerun.json'
@@ -112,6 +111,14 @@ module Bolt
       end
 
       @data = raw_data.reject { |k, _| Bolt::Config::INVENTORY_OPTIONS.include?(k) }
+
+      # If the 'modules' key is present in the project configuration file,
+      # use the new, shorter modulepath.
+      @modulepath = if @data.key?('modules')
+                      [(@path + 'modules').to_s]
+                    else
+                      [(@path + 'modules').to_s, (@path + 'site-modules').to_s, (@path + 'site').to_s]
+                    end
 
       # Once bolt.yaml deprecation is removed, this attribute should be removed
       # and replaced with .project_file in lib/bolt/config.rb

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -456,6 +456,14 @@ describe Bolt::Config do
     let(:overrides)         { { 'modulepath' => managed_moduledir } }
 
     context 'with modules configured' do
+      around(:each) do |example|
+        original = ENV['BOLT_MODULE_FEATURE']
+        ENV['BOLT_MODULE_FEATURE'] = 'true'
+        example.run
+      ensure
+        ENV['BOLT_MODULE_FEATURE'] = original
+      end
+
       it 'appends the managed moduledir to the modulepath' do
         expect(config.modulepath[-1]).to eq(managed_moduledir)
       end

--- a/spec/bolt/project_spec.rb
+++ b/spec/bolt/project_spec.rb
@@ -2,8 +2,11 @@
 
 require 'spec_helper'
 require 'bolt/project'
+require 'bolt_spec/project'
 
 describe Bolt::Project do
+  include BoltSpec::Project
+
   it "loads from system-wide config path if homedir expansion fails" do
     allow(File).to receive(:expand_path).and_call_original
     allow(File)
@@ -16,26 +19,21 @@ describe Bolt::Project do
   end
 
   describe "configuration" do
-    let(:pwd) { @tmpdir }
-    let(:config) { { 'tasks' => ['facts'] } }
+    let(:project_config) { { 'tasks' => ['facts'] } }
 
     around(:each) do |example|
-      Dir.mktmpdir("foo") do |tmpdir|
-        @tmpdir = Pathname.new(File.join(tmpdir, "validprojectname"))
-        FileUtils.mkdir_p(@tmpdir)
-        FileUtils.touch(@tmpdir + 'bolt-project.yaml')
+      with_project do
         example.run
       end
     end
 
     it "loads config with defaults" do
-      project = Bolt::Project.new(config, pwd)
-      expect(project.tasks).to eq(config['tasks'])
+      expect(project.tasks).to eq(project_config['tasks'])
       expect(project.plans).to eq(nil)
     end
 
     context 'with bolt config values' do
-      let(:config) {
+      let(:project_config) {
         {
           'concurrency' => 20,
           'transport' => 'ssh',
@@ -46,41 +44,36 @@ describe Bolt::Project do
       }
 
       it 'loads config' do
-        project = Bolt::Project.new(config, pwd)
         expect(project.data['concurrency']).to eq(20)
       end
 
       it "ignores transport config" do
-        project = Bolt::Project.new(config, pwd)
         expect(project.data.key?('ssh')).to be false
         expect(project.data.key?('transport')).to be false
       end
     end
 
     describe "with invalid tasks config" do
-      let(:config) { { 'tasks' => 'foo' } }
+      let(:project_config) { { 'tasks' => 'foo' } }
 
       it "raises an error" do
-        expect { Bolt::Project.new(config, pwd).validate }
-          .to raise_error(/'tasks' in bolt-project.yaml must be an array/)
+        expect { project.validate }.to raise_error(/'tasks' in bolt-project.yaml must be an array/)
       end
     end
 
     describe "with invalid name config" do
-      let(:config) { { 'name' => '_invalid' } }
+      let(:project_config) { { 'name' => '_invalid' } }
 
       it "raises an error" do
-        expect { Bolt::Project.new(config, pwd).validate }
-          .to raise_error(/Invalid project name '_invalid' in bolt-project.yaml/)
+        expect { project.validate }.to raise_error(/Invalid project name '_invalid' in bolt-project.yaml/)
       end
     end
 
     describe "with namespaced project names" do
-      let(:config) { { 'name' => 'puppetlabs-foo' } }
+      let(:project_config) { { 'name' => 'puppetlabs-foo' } }
 
       it "raises an error" do
-        expect { Bolt::Project.new(config, pwd).validate }
-          .to raise_error(/Invalid project name 'puppetlabs-foo' in bolt-project.yaml/)
+        expect { project.validate }.to raise_error(/Invalid project name 'puppetlabs-foo' in bolt-project.yaml/)
       end
     end
 
@@ -90,7 +83,7 @@ describe Bolt::Project do
           'modules' => {}
         }
 
-        expect { Bolt::Project.new(config, pwd).validate }
+        expect { Bolt::Project.new(config, project_path).validate }
           .to raise_error(Bolt::ValidationError)
       end
 
@@ -101,108 +94,90 @@ describe Bolt::Project do
           ]
         }
 
-        expect { Bolt::Project.new(config, pwd).validate }
+        expect { Bolt::Project.new(config, project_path).validate }
           .to raise_error(Bolt::ValidationError)
       end
     end
   end
 
   describe "::find_boltdir" do
-    let(:boltdir_path) { @tmpdir + 'foo' + 'Boltdir' }
-    let(:project) { Bolt::Project.new({}, boltdir_path) }
-
     around(:each) do |example|
-      Dir.mktmpdir do |tmpdir|
-        @tmpdir = Pathname.new(tmpdir)
-        FileUtils.mkdir_p(boltdir_path)
+      with_boltdir do
         example.run
       end
     end
 
     describe "when the project directory is named Boltdir" do
       it 'finds project from inside project' do
-        pwd = boltdir_path
-        expect(Bolt::Project.find_boltdir(pwd)).to eq(project)
+        expect(Bolt::Project.find_boltdir(project_path)).to eq(project)
       end
 
       it 'finds project from the parent directory' do
-        pwd = boltdir_path.parent
-        expect(Bolt::Project.find_boltdir(pwd)).to eq(project)
+        expect(Bolt::Project.find_boltdir(project_path.parent)).to eq(project)
       end
 
       it 'does not find project from the grandparent directory' do
-        pwd = boltdir_path.parent.parent
-        expect(Bolt::Project.find_boltdir(pwd)).not_to eq(project)
+        expect(Bolt::Project.find_boltdir(project_path.parent.parent)).not_to eq(project)
       end
 
       it 'finds the project from a sibling directory' do
-        pwd = boltdir_path.parent + 'bar'
-        FileUtils.mkdir_p(pwd)
+        sibling = project_path.parent + 'bar'
+        FileUtils.mkdir_p(sibling)
 
-        expect(Bolt::Project.find_boltdir(pwd)).to eq(project)
+        expect(Bolt::Project.find_boltdir(sibling)).to eq(project)
       end
 
       it 'finds the project from a child directory' do
-        pwd = boltdir_path + 'baz'
-        FileUtils.mkdir_p(pwd)
+        child = project_path + 'baz'
+        FileUtils.mkdir_p(child)
 
-        expect(Bolt::Project.find_boltdir(pwd)).to eq(project)
+        expect(Bolt::Project.find_boltdir(child)).to eq(project)
       end
     end
 
     describe "when using a control repo-style project" do
       it 'uses the current directory if it has a bolt.yaml' do
-        pwd = @tmpdir
-        FileUtils.touch(pwd + 'bolt.yaml')
-        expect(Bolt::Project.find_boltdir(pwd)).to eq(Bolt::Project.new({}, pwd))
+        FileUtils.touch(tmpdir + 'bolt.yaml')
+        expect(Bolt::Project.find_boltdir(tmpdir)).to eq(Bolt::Project.new({}, tmpdir))
       end
 
       it 'ignores non-project children with bolt.yaml' do
-        pwd = @tmpdir
-        FileUtils.mkdir_p(pwd + 'bar')
-        FileUtils.touch(pwd + 'bar' + 'bolt.yaml')
+        FileUtils.mkdir_p(tmpdir + 'bar')
+        FileUtils.touch(tmpdir + 'bar' + 'bolt.yaml')
 
-        expect(Bolt::Project.find_boltdir(pwd)).to eq(Bolt::Project.default_project)
+        expect(Bolt::Project.find_boltdir(tmpdir)).to eq(Bolt::Project.default_project)
       end
 
       it 'prefers a directory called Boltdir over the local directory' do
-        pwd = boltdir_path.parent
-        FileUtils.touch(pwd + 'bolt.yaml')
-
-        expect(Bolt::Project.find_boltdir(pwd)).to eq(project)
+        FileUtils.touch(project_path.parent + 'bolt.yaml')
+        expect(Bolt::Project.find_boltdir(project_path.parent)).to eq(project)
       end
 
       it 'prefers a directory called Boltdir over the parent directory' do
-        pwd = boltdir_path.parent + 'bar'
-        FileUtils.mkdir_p(pwd)
-        FileUtils.touch(boltdir_path.parent + 'bolt.yaml')
-
-        expect(Bolt::Project.find_boltdir(pwd)).to eq(project)
+        sibling = project_path.parent + 'bar'
+        FileUtils.mkdir_p(sibling)
+        FileUtils.touch(project_path.parent + 'bolt.yaml')
+        expect(Bolt::Project.find_boltdir(sibling)).to eq(project)
       end
     end
 
     describe 'when setting a type' do
       it 'sets type to embedded when a project is used' do
-        pwd = boltdir_path.parent
-        expect(Bolt::Project.find_boltdir(pwd).type).to eq('embedded')
+        expect(Bolt::Project.find_boltdir(project_path.parent).type).to eq('embedded')
       end
 
       it 'sets type to local when a bolt.yaml is used' do
-        pwd = @tmpdir
-        FileUtils.touch(pwd + 'bolt.yaml')
-
-        expect(Bolt::Project.find_boltdir(pwd).type).to eq('local')
+        FileUtils.touch(tmpdir + 'bolt.yaml')
+        expect(Bolt::Project.find_boltdir(tmpdir).type).to eq('local')
       end
 
       it 'sets type to user when the default is used' do
-        pwd = @tmpdir
-        expect(Bolt::Project.find_boltdir(pwd).type).to eq('user')
+        expect(Bolt::Project.find_boltdir(tmpdir).type).to eq('user')
       end
     end
 
     it 'returns the default when no project is found' do
-      pwd = @tmpdir
-      expect(Bolt::Project.find_boltdir(pwd)).to eq(Bolt::Project.default_project)
+      expect(Bolt::Project.find_boltdir(tmpdir)).to eq(Bolt::Project.default_project)
     end
   end
 
@@ -237,6 +212,31 @@ describe Bolt::Project do
       expect(Bolt::Project).to receive(:new).with(anything, 'myproject', 'user',
                                                   [{ warn: /Could not create default project / }])
       Bolt::Project.create_project('myproject', 'user')
+    end
+  end
+
+  describe '#modulepath' do
+    let(:project_config) { { 'modules' => [] } }
+
+    around(:each) do |example|
+      with_project do
+        example.run
+      end
+    end
+
+    it 'returns the new default modulepath if modules is set' do
+      expect(project.modulepath).to match_array([
+                                                  (project_path + 'modules').to_s
+                                                ])
+    end
+
+    it 'returns the old default modulepath if modules is not set' do
+      delete_config
+      expect(project.modulepath).to match_array([
+                                                  (project_path + 'modules').to_s,
+                                                  (project_path + 'site-modules').to_s,
+                                                  (project_path + 'site').to_s
+                                                ])
     end
   end
 end

--- a/spec/bolt/project_spec.rb
+++ b/spec/bolt/project_spec.rb
@@ -225,9 +225,12 @@ describe Bolt::Project do
     end
 
     it 'returns the new default modulepath if modules is set' do
-      expect(project.modulepath).to match_array([
-                                                  (project_path + 'modules').to_s
-                                                ])
+      original = ENV['BOLT_MODULE_FEATURE']
+      ENV['BOLT_MODULE_FEATURE'] = 'true'
+
+      expect(project.modulepath).to match_array([(project_path + 'modules').to_s])
+    ensure
+      ENV['BOLT_MODULE_FEATURE'] = original
     end
 
     it 'returns the old default modulepath if modules is not set' do

--- a/spec/integration/plan_spec.rb
+++ b/spec/integration/plan_spec.rb
@@ -5,12 +5,14 @@ require 'bolt_spec/config'
 require 'bolt_spec/conn'
 require 'bolt_spec/files'
 require 'bolt_spec/integration'
+require 'bolt_spec/project'
 require 'bolt_spec/puppet_agent'
 
 describe 'plans' do
   include BoltSpec::Integration
   include BoltSpec::Config
   include BoltSpec::Conn
+  include BoltSpec::Project
   include BoltSpec::PuppetAgent
 
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
@@ -23,6 +25,7 @@ describe 'plans' do
      '--no-host-key-check']
   }
   let(:target) { conn_uri('ssh', include_password: true) }
+  let(:project_config) { { 'modules' => [] } }
 
   context "When a plan succeeds" do
     it 'prints the result', ssh: true do
@@ -87,10 +90,14 @@ describe 'plans' do
       end
 
       it 'runs registers types defined in $project/.resource_types', ssh: true do
-        # generate types based and save in project (based on value of --configfile)
-        run_cli(%w[module generate-types] + config_flags)
-        result = run_cli(['plan', 'run', 'resource_types', '--targets', target] + config_flags)
-        expect(JSON.parse(result)).to eq('built-in' => 'success', 'core' => 'success', 'custom' => 'success')
+        with_project do
+          config_flags = %W[--format json -m #{modulepath} --project #{project.path} --no-host-key-check]
+
+          # generate types based and save in project (based on value of --configfile)
+          run_cli(%w[module generate-types] + config_flags)
+          result = run_cli(['plan', 'run', 'resource_types', '--targets', target] + config_flags)
+          expect(JSON.parse(result)).to eq('built-in' => 'success', 'core' => 'success', 'custom' => 'success')
+        end
       end
     end
   end

--- a/spec/lib/bolt_spec/project.rb
+++ b/spec/lib/bolt_spec/project.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module BoltSpec
+  module Project
+    def with_project(name = 'project')
+      Dir.mktmpdir(nil, Dir.pwd) do |tmpdir|
+        @tmpdir       = Pathname.new(tmpdir).expand_path
+        @project_path = (@tmpdir + name).expand_path
+        @config_path  = (@project_path + 'bolt-project.yaml').expand_path
+
+        FileUtils.mkdir_p(@project_path)
+        File.write(@config_path, project_config.to_yaml)
+        yield
+      end
+    end
+
+    def with_boltdir
+      with_project do
+        @project_path += 'Boltdir'
+        FileUtils.mkdir_p(@project_path)
+        yield
+      end
+    end
+
+    def tmpdir
+      @tmpdir
+    end
+
+    def project_path
+      @project_path
+    end
+
+    def config_path
+      @config_path
+    end
+
+    def project_config
+      {}
+    end
+
+    def project
+      Bolt::Project.create_project(project_path)
+    end
+
+    def delete_config
+      FileUtils.rm(@config_path)
+    end
+  end
+end


### PR DESCRIPTION
This updates `Bolt::Project` and `Bolt::Config` to use a new modulepath
when `modules` is configured in `bolt-project.yaml`. This work is part
of the new module management workflow.

When `modules` is configured, the default modulepath is `['modules']`
and the full modulepath will have `.modules` appended to it, whether
Bolt uses the default modulepath or the user-configured modulepath. If
the user-configured modulepath includes `.modules`, Bolt will error and
display a helpful message that the modulepath cannot be configured with
`.modules` as it is automatically appended.

If `modules` is not configured, Bolt's behavior remains the same and the
default modulepath is `['modules', 'site-modules', 'site']`.

This also adds new `BoltSpec::Project` library functions that will
create a temporary project. This is useful for spec tests and prevents
Bolt from unintentionally loading configuration on the system running
the tests.

This change is shipping dark until the full module management workflow
is complete.

---

This also deprecates the `bolt puppetfile install` command when
`modules` is configured, and disables the `bolt module *` commands
when `modules` is not configured.

---

Closes #2182 