### PR TITLE
(GH-2127) Parallelize plan steps across targets

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/parallelize.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/parallelize.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'bolt/yarn'
+
+# Map a code bock onto an array, where each array element executes in parallel.
+# This function is experimental.
+#
+# > **Note:** Not available in apply block.
+Puppet::Functions.create_function(:parallelize, Puppet::Functions::InternalFunction) do
+  # Map a block onto an array, where each array element executes in parallel.
+  # This function is experimental.
+  # @param data The array to apply the block to.
+  # @return [Array] An array of PlanResult objects. Each input from the input
+  #   array returns a corresponding PlanResult object.
+  # @example Execute two tasks on multiple targets. Once the task finishes on one
+  #   target, that target can move to the next step without waiting for the task
+  #   to finish on the second target.
+  # $targets = get_targets(["host1", "host2"])
+  # $result = parallelize ($targets) |$t| {
+  #   run_task('a', $t)
+  #   run_task('b', $t)
+  # }
+  dispatch :parallelize do
+    scope_param
+    param 'Array[Any]', :data
+    block_param 'Callable[Any]', :block
+    return_type 'Array[Boltlib::PlanResult]'
+  end
+
+  def parallelize(scope, data, &block)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'parallelize')
+    end
+
+    executor = Puppet.lookup(:bolt_executor)
+    executor.report_function_call(self.class.name)
+
+    skein = data.each_with_index.map do |object, index|
+      fiber = Fiber.new do
+        # Create the new scope
+        newscope = Puppet::Parser::Scope.new(scope.compiler)
+        local = Puppet::Parser::Scope::LocalScope.new
+
+        # Compress the current scopes into a single vars hash to add to the new scope
+        current_scope = scope.effective_symtable(true)
+        until current_scope.nil?
+          current_scope.instance_variable_get(:@symbols)&.each_pair { |k, v| local[k] = v }
+          current_scope = current_scope.parent
+        end
+        newscope.push_ephemerals([local])
+
+        begin
+          result = catch(:return) do
+            args = { block.parameters[0][1].to_s => object }
+            block.closure.call_by_name_with_scope(newscope, args, true)
+          end
+
+          # If we got a return from the block, get it's value
+          # Otherwise the result is the last line from the block
+          result = result.value if result.is_a?(Puppet::Pops::Evaluator::Return)
+
+          # Validate the result is a PlanResult
+          unless Puppet::Pops::Types::TypeParser.singleton.parse('Boltlib::PlanResult').instance?(result)
+            raise Bolt::InvalidParallelResult.new(result.to_s, *Puppet::Pops::PuppetStack.top_of_stack)
+          end
+
+          result
+        rescue Puppet::PreformattedError => e
+          if e.cause.is_a?(Bolt::Error)
+            e.cause
+          else
+            raise e
+          end
+        end
+      end
+
+      Bolt::Yarn.new(fiber, index)
+    end
+
+    result = executor.round_robin(skein)
+
+    failed_indices = result.each_index.select do |i|
+      result[i].is_a?(Bolt::Error)
+    end
+
+    # TODO: Inner catch errors block?
+    if failed_indices.any?
+      raise Bolt::ParallelFailure.new(result, failed_indices)
+    end
+
+    result
+  end
+end

--- a/bolt-modules/boltlib/lib/puppet/functions/parallelize.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/parallelize.rb
@@ -2,7 +2,7 @@
 
 require 'bolt/yarn'
 
-# Map a code bock onto an array, where each array element executes in parallel.
+# Map a code block onto an array, where each array element executes in parallel.
 # This function is experimental.
 #
 # > **Note:** Not available in apply block.

--- a/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
@@ -84,15 +84,34 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
     # Ensure that given targets are all Target instances)
     targets = inventory.get_targets(targets)
 
-    r = if targets.empty?
-          Bolt::ResultSet.new([])
-        else
-          executor.run_script(targets, found, arguments, options, Puppet::Pops::PuppetStack.top_of_stack)
-        end
+    if targets.empty?
+      Bolt::ResultSet.new([])
+    else
+      r = if executor.in_parallel
+            require 'concurrent'
+            require 'fiber'
+            future = Concurrent::Future.execute do
+              executor.run_script(targets,
+                                  found,
+                                  arguments,
+                                  options,
+                                  Puppet::Pops::PuppetStack.top_of_stack)
+            end
 
-    if !r.ok && !options[:catch_errors]
-      raise Bolt::RunFailure.new(r, 'run_script', script)
+            Fiber.yield('unfinished') while future.incomplete?
+            future.value || future.reason
+          else
+            executor.run_script(targets,
+                                found,
+                                arguments,
+                                options,
+                                Puppet::Pops::PuppetStack.top_of_stack)
+          end
+
+      if !r.ok && !options[:catch_errors]
+        raise Bolt::RunFailure.new(r, 'run_script', script)
+      end
+      r
     end
-    r
   end
 end

--- a/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
@@ -140,12 +140,8 @@ Puppet::Functions.create_function(:run_task) do
                    executor.run_task(targets, task, params, options, Puppet::Pops::PuppetStack.top_of_stack)
                  end
 
-                 while future.incomplete?
-                   Fiber.yield
-                   # Induce a context switch to give the task a chance to complete
-                   sleep(0)
-                 end
-                 future.value
+                 Fiber.yield('unfinished') while future.incomplete?
+                 future.value || future.reason
                else
                  executor.run_task(targets, task, params, options, Puppet::Pops::PuppetStack.top_of_stack)
                end

--- a/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
@@ -137,13 +137,21 @@ Puppet::Functions.create_function(:run_task) do
                  require 'concurrent'
                  require 'fiber'
                  future = Concurrent::Future.execute do
-                   executor.run_task(targets, task, params, options, Puppet::Pops::PuppetStack.top_of_stack)
+                   executor.run_task(targets,
+                                     task,
+                                     params,
+                                     options,
+                                     Puppet::Pops::PuppetStack.top_of_stack)
                  end
 
                  Fiber.yield('unfinished') while future.incomplete?
                  future.value || future.reason
                else
-                 executor.run_task(targets, task, params, options, Puppet::Pops::PuppetStack.top_of_stack)
+                 executor.run_task(targets,
+                                   task,
+                                   params,
+                                   options,
+                                   Puppet::Pops::PuppetStack.top_of_stack)
                end
 
       if !result.ok && !options[:catch_errors]

--- a/bolt-modules/boltlib/spec/functions/download_file_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/download_file_spec.rb
@@ -323,6 +323,29 @@ describe 'download_file' do
     end
   end
 
+  context 'running in parallel' do
+    let(:future) { mock('future') }
+    let(:hostname) { 'test.example.com' }
+    let(:target) { Bolt::Target.new(hostname) }
+    let(:result) { Bolt::Result.new(target, value: { 'stdout' => hostname }) }
+    let(:result_set) { Bolt::ResultSet.new([result]) }
+    let(:source)      { '/path/to/source' }
+    let(:destination) { 'downloads' }
+
+    it 'executes in a thread if the executor is in parallel mode' do
+      inventory.expects(:get_targets).with(hostname).returns([target])
+
+      Concurrent::Future.expects(:execute).returns(future)
+      future.expects(:incomplete?).returns(false)
+      future.expects(:value).returns(result_set)
+      executor.expects(:in_parallel).returns(true)
+
+      is_expected.to run
+        .with_params(source, destination, hostname)
+        .and_return(result_set)
+    end
+  end
+
   context 'without tasks enabled' do
     let(:tasks_enabled) { false }
 

--- a/bolt-modules/boltlib/spec/functions/parallelize_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/parallelize_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'puppet_pal'
+require 'bolt/executor'
+require 'bolt/inventory'
+require 'bolt/plan_result'
+# require 'bolt/plugin'
+# require 'puppet/pops/types/p_sensitive_type'
+
+describe 'parallelize' do
+  include PuppetlabsSpec::Fixtures
+  let(:array) { %w[a b c d] }
+  let(:executor) { Bolt::Executor.new }
+  let(:result_array) { %w[ea eb ec ed] }
+  let(:tasks_enabled) { true }
+
+  around(:each) do |example|
+    Puppet[:tasks] = tasks_enabled
+    Puppet.override(bolt_executor: executor) do
+      example.run
+    end
+  end
+
+  it 'reports the function call to analytics' do
+    executor.expects(:report_function_call).with('parallelize')
+
+    array.each_with_index do |elem, index|
+      yarn = mock('yarn', alive?: false, value: 'e' + elem, index: index)
+      executor.expects(:create_yarn)
+              .with(anything, anything, elem, index)
+              .returns(yarn)
+    end
+
+    is_expected.to(run
+      .with_params(array)
+      .with_lambda { |elem| 'e' + elem })
+  end
+
+  it 'returns an array in order' do
+    array.each_with_index do |elem, index|
+      yarn = mock('yarn', alive?: false, value: 'e' + elem, index: index)
+      executor.expects(:create_yarn)
+              .with(anything, anything, elem, index)
+              .returns(yarn)
+    end
+
+    is_expected.to(run
+      .with_params(array)
+      .with_lambda { |elem| 'e' + elem }
+      .and_return(result_array))
+  end
+
+  context "with errors in the block" do
+    it "returns a ParallelFailure" do
+      error = Bolt::Error.new("error", 'bolt/test-failure')
+
+      array.each_with_index do |elem, index|
+        yarn = mock('yarn', alive?: false, value: error, index: index)
+        executor.expects(:create_yarn)
+                .with(anything, anything, elem, index)
+                .returns(yarn)
+      end
+
+      is_expected.to(run
+        .with_params(array)
+        .with_lambda { |elem| 'e' + elem }
+        .and_raise_error(Bolt::ParallelFailure, /parallel block failed on 4 targets/))
+    end
+  end
+end

--- a/bolt-modules/boltlib/spec/functions/run_script_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_script_spec.rb
@@ -216,6 +216,27 @@ describe 'run_script' do
     end
   end
 
+  context 'running in parallel' do
+    let(:future) { mock('future') }
+    let(:hostname) { 'test.example.com' }
+    let(:target) { Bolt::Target.new(hostname) }
+    let(:result) { Bolt::Result.new(target, value: { 'stdout' => hostname }) }
+    let(:result_set) { Bolt::ResultSet.new([result]) }
+
+    it 'executes in a thread if the executor is in parallel mode' do
+      inventory.expects(:get_targets).with(hostname).returns([target])
+
+      Concurrent::Future.expects(:execute).returns(future)
+      future.expects(:incomplete?).returns(false)
+      future.expects(:value).returns(result_set)
+      executor.expects(:in_parallel).returns(true)
+
+      is_expected.to run
+        .with_params('test/uploads/hostname.sh', hostname)
+        .and_return(result_set)
+    end
+  end
+
   context 'without tasks enabled' do
     let(:tasks_enabled) { false }
 

--- a/lib/bolt/error.rb
+++ b/lib/bolt/error.rb
@@ -90,6 +90,20 @@ module Bolt
     end
   end
 
+  class ParallelFailure < Bolt::Error
+    def initialize(results, failed_indices)
+      details = {
+        'action' => 'parallelize',
+        'failed_indices' => failed_indices,
+        'results' => results
+      }
+      message = "Plan aborted: parallel block failed on #{failed_indices.length} target"
+      message += "s" unless failed_indices.length == 1
+      super(message, 'bolt/parallel-failure', details)
+      @error_code = 2
+    end
+  end
+
   class PlanFailure < Error
     def initialize(*args)
       super(*args)
@@ -127,6 +141,16 @@ module Bolt
       super("Plan #{plan_name} returned an invalid result: #{result_str}",
             'bolt/invalid-plan-result',
             { 'plan_name' => plan_name,
+              'result_string' => result_str })
+    end
+  end
+
+  class InvalidParallelResult < Error
+    def initialize(result_str, file, line)
+      super("Parallel block returned an invalid result: #{result_str}",
+            'bolt/invalid-plan-result',
+            { 'file' => file,
+              'line' => line,
               'result_string' => result_str })
     end
   end

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -414,12 +414,6 @@ module Bolt
     def handle_event(event)
       case event[:type]
       when :node_result
-        # Give the result a chance to return back to the function
-        # If we resume the fiber before the result makes it there, this will
-        # spin forever
-        #
-        # TODO: Is there a way to avoid this?
-        sleep(1)
         @thread_completed = true
       end
     end
@@ -443,7 +437,7 @@ module Bolt
         end
 
         next unless r == 'unfinished'
-        sleep(1) until @thread_completed || skein.empty?
+        sleep(0.1) until @thread_completed || skein.empty?
       end
 
       @in_parallel = false

--- a/lib/bolt/yarn.rb
+++ b/lib/bolt/yarn.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Bolt
+  class Yarn
+    attr_reader :fiber, :value, :index
+
+    def initialize(fiber, index)
+      @fiber = fiber
+      @index = index
+      @value = nil
+    end
+
+    def alive?
+      fiber.alive?
+    end
+
+    def resume
+      @value = fiber.resume
+    end
+  end
+end

--- a/lib/bolt/yarn.rb
+++ b/lib/bolt/yarn.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'fiber'
+
 module Bolt
   class Yarn
     attr_reader :fiber, :value, :index

--- a/lib/bolt_spec/plans/mock_executor.rb
+++ b/lib/bolt_spec/plans/mock_executor.rb
@@ -17,12 +17,13 @@ module BoltSpec
 
     # Nothing on the executor is 'public'
     class MockExecutor
-      attr_reader :noop, :error_message
+      attr_reader :noop, :error_message, :in_parallel
       attr_accessor :run_as, :transport_features, :execute_any_plan
 
       def initialize(modulepath)
         @noop = false
         @run_as = nil
+        @in_parallel = false
         @error_message = nil
         @allow_apply = false
         @modulepath = [modulepath].flatten.map { |path| File.absolute_path(path) }

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1211,7 +1211,7 @@ describe "Bolt::CLI" do
     end
 
     describe "execute" do
-      let(:executor) { double('executor', noop: false, subscribe: nil, shutdown: nil) }
+      let(:executor) { double('executor', noop: false, subscribe: nil, shutdown: nil, in_parallel: false) }
       let(:cli) { Bolt::CLI.new({}) }
       let(:targets) { [target] }
       let(:output) { StringIO.new }
@@ -2252,7 +2252,7 @@ describe "Bolt::CLI" do
     end
 
     describe "execute with noop" do
-      let(:executor) { double('executor', noop: true, subscribe: nil, shutdown: nil) }
+      let(:executor) { double('executor', noop: true, subscribe: nil, shutdown: nil, in_parallel: false) }
       let(:cli) { Bolt::CLI.new({}) }
       let(:targets) { [target] }
       let(:output) { StringIO.new }

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -853,7 +853,7 @@ describe "Bolt::Executor" do
 
   context "when round robining" do
     it "subscribes to node_result messages" do
-      expect(self).to receive(:subscribe).with(self, [:node_result])
+      expect(executor).to receive(:subscribe).with(executor, [:node_result])
       executor.round_robin([])
     end
 
@@ -874,5 +874,4 @@ describe "Bolt::Executor" do
       expect(executor.round_robin([])).to eq([])
     end
   end
-
 end

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -850,4 +850,29 @@ describe "Bolt::Executor" do
       end
     end
   end
+
+  context "when round robining" do
+    it "subscribes to node_result messages" do
+      expect(self).to receive(:subscribe).with(self, [:node_result])
+      executor.round_robin([])
+    end
+
+    it "returns results in the same order they were originally" do
+      skein = %w[a b c d].each_with_index.map do |val, index|
+        fiber = Fiber.new do
+          sleep(rand(0.01..0.1))
+          val + 'e'
+        end
+
+        Bolt::Yarn.new(fiber, index)
+      end
+
+      expect(executor.round_robin(skein)).to eq(%w[ae be ce de])
+    end
+
+    it "returns an empty array if there are no elements to round robin" do
+      expect(executor.round_robin([])).to eq([])
+    end
+  end
+
 end

--- a/spec/fixtures/inventory/docker.yml
+++ b/spec/fixtures/inventory/docker.yml
@@ -1,0 +1,24 @@
+---
+version: 2
+groups:
+- name: ssh
+  targets:
+  - name: ubuntu_node
+    alias: agentless
+    config:
+      ssh:
+        port: 20022
+  - name: puppet_5_node
+    config:
+      ssh:
+        port: 20023
+  - name: puppet_6_node
+    config:
+      ssh:
+        port: 20024
+  config:
+    ssh:
+      host: localhost
+      host-key-check: false
+      user: root
+      password: root

--- a/spec/fixtures/modules/parallel/plans/catch_error_inner.pp
+++ b/spec/fixtures/modules/parallel/plans/catch_error_inner.pp
@@ -1,0 +1,11 @@
+plan parallel::catch_error_inner(
+  TargetSpec $targets
+) {
+  $ts = get_targets($targets)
+  parallelize($ts) |$t| {
+    catch_errors() || {
+      run_task('error::fail', $t)
+    }
+  }
+  return "We made it"
+}

--- a/spec/fixtures/modules/parallel/plans/catch_error_outer.pp
+++ b/spec/fixtures/modules/parallel/plans/catch_error_outer.pp
@@ -1,0 +1,11 @@
+plan parallel::catch_error_outer(
+  TargetSpec $targets
+) {
+  $ts = get_targets($targets)
+  catch_errors() || {
+    parallelize($ts) |$t| {
+      run_task('error::fail', $t)
+    }
+  }
+  return "We made it"
+}

--- a/spec/fixtures/modules/parallel/plans/error.pp
+++ b/spec/fixtures/modules/parallel/plans/error.pp
@@ -1,0 +1,14 @@
+plan parallel::error(
+  TargetSpec $targets
+) {
+  $ts = get_targets($targets)
+  parallelize($ts) |$t| {
+    if $t.port == 20024 {
+      run_task('error::fail', $t)
+    } else {
+      run_task('parallel', $t, 'time' => 0, 'val' => 'a')
+    }
+  }
+
+  return "We shouldn't get here"
+}

--- a/spec/fixtures/modules/parallel/plans/hard_fail.pp
+++ b/spec/fixtures/modules/parallel/plans/hard_fail.pp
@@ -1,0 +1,9 @@
+plan parallel::hard_fail(
+  TargetSpec $targets
+) {
+  $ts = get_targets($targets)
+  return parallelize($ts) |$t| {
+    foo
+    run_task('parallel', $t, 'time' => 2, 'val' => $t.name)
+  }
+}

--- a/spec/fixtures/modules/parallel/plans/init.pp
+++ b/spec/fixtures/modules/parallel/plans/init.pp
@@ -1,0 +1,8 @@
+plan parallel(
+  TargetSpec $targets
+) {
+  $ts = get_targets($targets)
+  return parallelize($ts) |$t| {
+    run_task('parallel', $t, 'time' => 2, 'val' => 'print')
+  }
+}

--- a/spec/fixtures/modules/parallel/plans/non_parallel.pp
+++ b/spec/fixtures/modules/parallel/plans/non_parallel.pp
@@ -1,0 +1,11 @@
+plan parallel::non_parallel(
+  TargetSpec $targets
+) {
+  $ts = get_targets($targets)
+  parallelize($ts) |$t| {
+    $a = 2*2
+    $b = 3+5
+  }
+
+  return "Success"
+}

--- a/spec/fixtures/modules/parallel/plans/return.pp
+++ b/spec/fixtures/modules/parallel/plans/return.pp
@@ -1,0 +1,9 @@
+plan parallel::return(
+  TargetSpec $targets
+) {
+  $ts = get_targets($targets)
+  return parallelize($ts) |$t| {
+    return 'a'
+    run_task('parallel', $t, 'time' => 2, 'val' => $t.name)
+  }
+}

--- a/spec/fixtures/modules/parallel/tasks/init.json
+++ b/spec/fixtures/modules/parallel/tasks/init.json
@@ -1,0 +1,16 @@
+{
+  "description": "Sleep for a time and print a string",
+  "input_method": "environment",
+  "parameters": {
+    "val": {
+      "type": "String"
+    },
+    "time": {
+      "type": "Integer"
+    }
+  },
+  "implementations": [
+    {"name": "init.sh", "requirements": ["shell"]},
+    {"name": "init.ps1", "requirements": ["powershell"]}
+  ]
+}

--- a/spec/fixtures/modules/parallel/tasks/init.ps1
+++ b/spec/fixtures/modules/parallel/tasks/init.ps1
@@ -1,0 +1,2 @@
+Start-Sleep -S ${env:PT_time}
+Write-Output "${env:PT_val}"

--- a/spec/fixtures/modules/parallel/tasks/init.sh
+++ b/spec/fixtures/modules/parallel/tasks/init.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+sleep $PT_time
+echo $PT_val

--- a/spec/integration/parallel_spec.rb
+++ b/spec/integration/parallel_spec.rb
@@ -19,7 +19,7 @@ describe 'plans' do
   let(:modulepath) { fixture_path('modules') }
 
   shared_examples "parallelize plan function" do
-    let(:return_value) { 
+    let(:return_value) {
       { "action" => "task",
         "object" => "parallel",
         "status" => "success",
@@ -89,23 +89,23 @@ describe 'plans' do
                              "object" => "parallel",
                              "status" => "success",
                              "value" => { "_output" => "a\n" } }],
-      { "kind" => "bolt/run-failure",
-        "msg" => "Plan aborted: run_task 'error::fail' failed on 1 target",
-        "details" =>
-      { "action" => "run_task",
-        "object" => "error::fail",
-        "result_set" =>
-      [{ "target" => 'puppet_6_node',
-         "action" => "task",
-         "object" => "error::fail",
-         "status" => "failure",
-         "value" =>
-      { "_output" => "failing\n",
-        "_error" =>
-      { "kind" => "puppetlabs.tasks/task-error",
-        "issue_code" => "TASK_ERROR",
-        "msg" => "The task failed with exit code 1",
-        "details" => { "exit_code" => 1 } } } }] } }]
+                          { "kind" => "bolt/run-failure",
+                            "msg" => "Plan aborted: run_task 'error::fail' failed on 1 target",
+                            "details" =>
+                          { "action" => "run_task",
+                            "object" => "error::fail",
+                            "result_set" =>
+                          [{ "target" => 'puppet_6_node',
+                             "action" => "task",
+                             "object" => "error::fail",
+                             "status" => "failure",
+                             "value" =>
+                          { "_output" => "failing\n",
+                            "_error" =>
+                          { "kind" => "puppetlabs.tasks/task-error",
+                            "issue_code" => "TASK_ERROR",
+                            "msg" => "The task failed with exit code 1",
+                            "details" => { "exit_code" => 1 } } } }] } }]
 
       result = run_cli_json(%w[plan run parallel::error] + config_flags)
       expect(result).to include(expected_err)

--- a/spec/integration/parallel_spec.rb
+++ b/spec/integration/parallel_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/config'
+require 'bolt_spec/conn'
+require 'bolt_spec/files'
+require 'bolt_spec/integration'
+require 'bolt_spec/project'
+require 'bolt_spec/puppet_agent'
+
+describe 'plans' do
+  include BoltSpec::Integration
+  include BoltSpec::Config
+  include BoltSpec::Conn
+  include BoltSpec::Project
+
+  after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
+
+  let(:modulepath) { fixture_path('modules') }
+
+  shared_examples "parallelize plan function" do
+    let(:return_value) { 
+      { "action" => "task",
+        "object" => "parallel",
+        "status" => "success",
+        "value" => { "_output" => /print/ } }
+    }
+
+    it "returns an array of Results" do
+      results = run_cli_json(%w[plan run parallel] + config_flags)
+      results.each do |result|
+        expect(result).to be_a(Array)
+        expect(result.length).to eq(1)
+        expect(result.first).to include(return_value)
+      end
+    end
+
+    it "returns from a return statement" do
+      before_time = Time.now
+      results = run_cli_json(%w[plan run parallel::return] + config_flags)
+      wall_time = Time.now - before_time
+      # Assert we don't execute the sleep
+      expect(wall_time).to be < 2
+      results.each do |result|
+        expect(result).to eq('a')
+      end
+    end
+
+    it "does not raise an error when catch_errors wraps the block" do
+      result = run_cli_json(%w[plan run parallel::catch_error_outer] + config_flags)
+      expect(result).to eq("We made it")
+    end
+
+    it "does not raise an error when catch_errors is inside the block" do
+      result = run_cli_json(%w[plan run parallel::catch_error_inner] + config_flags)
+      expect(result).to eq("We made it")
+    end
+
+    it "fails immediately when a Puppet error is raised" do
+      expect { run_cli_json(%w[plan run parallel::hard_fail] + config_flags) }
+        .to raise_error(Bolt::PAL::PALError, /This Name has no effect./)
+    end
+
+    it "runs normally when no steps are parallelizable" do
+      result = run_cli_json(%w[plan run parallel::non_parallel] + config_flags)
+      expect(result).to eq("Success")
+    end
+  end
+
+  context "over ssh", ssh: true do
+    let(:inv_path) { fixture_path('inventory', 'docker.yml') }
+    let(:config_flags) {
+      ['-t all',
+       '--modulepath', modulepath,
+       '--inventoryfile', inv_path,
+       '--verbose',
+       '--no-host-key-check']
+    }
+
+    include_examples 'parallelize plan function'
+
+    it "finishes executing the block then raises an error when there's an error" do
+      expected_err = { "kind" => "bolt/parallel-failure",
+                       "msg" => "Plan aborted: parallel block failed on 1 target" }
+      expected_details = { "action" => "parallelize",
+                           "failed_indices" => [2] }
+      expected_results = [[{ "target" => 'ubuntu_node',
+                             "action" => "task",
+                             "object" => "parallel",
+                             "status" => "success",
+                             "value" => { "_output" => "a\n" } }],
+      { "kind" => "bolt/run-failure",
+        "msg" => "Plan aborted: run_task 'error::fail' failed on 1 target",
+        "details" =>
+      { "action" => "run_task",
+        "object" => "error::fail",
+        "result_set" =>
+      [{ "target" => 'puppet_6_node',
+         "action" => "task",
+         "object" => "error::fail",
+         "status" => "failure",
+         "value" =>
+      { "_output" => "failing\n",
+        "_error" =>
+      { "kind" => "puppetlabs.tasks/task-error",
+        "issue_code" => "TASK_ERROR",
+        "msg" => "The task failed with exit code 1",
+        "details" => { "exit_code" => 1 } } } }] } }]
+
+      result = run_cli_json(%w[plan run parallel::error] + config_flags)
+      expect(result).to include(expected_err)
+      expect(result['details']).to include(expected_details)
+      expect(expected_results - result['details']['results']).to eq([])
+    end
+  end
+
+  context "over winrm", winrm: true do
+    let(:targets) { conn_uri('winrm') }
+    let(:config_flags) {
+      ['-t', targets,
+       '--modulepath', modulepath,
+       '--verbose',
+       '--password', conn_info('winrm')[:password],
+       '--no-ssl',
+       '--no-ssl-verify']
+    }
+
+    include_examples 'parallelize plan function'
+  end
+end


### PR DESCRIPTION
This implements a new (to-be-named) `parallelize` function which
accepts an array and a block and maps the given block to the array in
parallel. That is to say, the block is executed in sequence for each
element in the array, with the array elements executing in parallel.
This is in contrast to typical plan steps which execute each step in
parallel across targets and wait for all targets to finish before
continuing to the next step.

The block will wait for the sequence to finish on all elements of the
array before returning an array of Results - one per element in the
array. The results can be either the value of a `return` statement, the
result of the last line in the block (can be nil), or an error that was
raised during the block for that element. The results are in the same
order the original array was in, regardless of which elements finish the
block 'first'. Unless `catch_errors()` wraps the block (either inside or
outside), if any element errored during the block the plan will fail and
all results (successful and error) will be included in the failure
details. If `catch_errors()` wraps the block then the array will contain
Error objects for errored results, as usual.

Parallel execution is managed by the executor. When a parallel block
begins, we make a copy of the existing variable scope for each element
in the array so that any variables defined in the scope won't get
overridden by parallel execution. Then we create a Ruby Fiber for each
element of the array executing the block, and send the array of Fibers
to the executor. The executor goes into "parallel mode", where it will
resume each fiber in turn until the block has completed for all elements
of the array. Certain plan function can then be "Fiber aware" by
starting a new thread and yielding their Fiber once the thread has
started, waiting for the thread to finish before returning the result
back to the executor. This allows certain functions to not block on
other array elements continuing to execute the block, while other
functions (or just certain parts of functions, like loading tasks) will
block.

!feature

* **Experimental: Add `parallelize()` plan function**

  This adds a new function `parallelize()` that accepts an array and a
  block and executes the block on each element of the array in parallel.
  This allows plan authors to continue executing a block on other targets
  if a particular plan function may take a long time on one target. This
  features is experimental.