### PR TITLE
(PE-30092) Dont write a bolt-debug.log when listing project content

### DIFF
--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -212,7 +212,7 @@ module BoltServer
       return [400, "`project_ref`: #{project_dir} does not exist"] unless Dir.exist?(project_dir)
       @pal_mutex.synchronize do
         project = Bolt::Project.create_project(project_dir)
-        bolt_config = Bolt::Config.from_project(project, {})
+        bolt_config = Bolt::Config.from_project(project, { log: { 'bolt-debug.log' => 'disable' } })
         pal = Bolt::PAL.new(bolt_config.modulepath, nil, nil, nil, nil, nil, bolt_config.project)
         module_path = [
           BoltServer::PE::PAL::PE_BOLTLIB_PATH,


### PR DESCRIPTION
This commit updates bolt-server metadata endpoints for serving project content to not create a bolt-debug.log file at the root of the project directory.