### PR TITLE
(maint) Bump puppetfile-resolver version to pick up gem

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-ssh-krb", "~> 0.5"
   spec.add_dependency "orchestrator_client", "~> 0.4"
   spec.add_dependency "puppet", "6.18.0"
-  spec.add_dependency "puppetfile-resolver", "~> 0.1.0"
+  spec.add_dependency "puppetfile-resolver", "~> 0.4"
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "puppet-strings", "~> 2.3"
   spec.add_dependency "r10k", "~> 3.1"


### PR DESCRIPTION
We updated puppet-runtime to use version 0.4.0 of the
puppetfile-resolver gem before updating dependency version here, causing
CI to fail. This updates the gem dependency version so that CI
environments work.