### PR TITLE
(PE-30034) Remove harmful bolt-server terminology

### DIFF
--- a/config/transport_service_config.rb
+++ b/config/transport_service_config.rb
@@ -42,8 +42,9 @@ bind bind_addr
 threads 0, config['concurrency']
 
 impl = BoltServer::TransportApp.new(config)
-unless config['whitelist'].nil?
-  impl = BoltServer::ACL.new(impl, config['whitelist'])
+
+if config['allowlist']
+  impl = BoltServer::ACL.new(impl, config['allowlist'])
 end
 
 app impl

--- a/lib/bolt_server/acl.rb
+++ b/lib/bolt_server/acl.rb
@@ -16,9 +16,9 @@ module BoltServer
       end
     end
 
-    def initialize(app, whitelist)
+    def initialize(app, allowlist)
       acls = []
-      whitelist.each do |entry|
+      allowlist.each do |entry|
         acls << {
           'resources' => [
             {

--- a/lib/bolt_server/base_config.rb
+++ b/lib/bolt_server/base_config.rb
@@ -7,7 +7,7 @@ module BoltServer
   class BaseConfig
     def config_keys
       %w[host port ssl-cert ssl-key ssl-ca-cert
-         ssl-cipher-suites loglevel logfile whitelist projects-dir]
+         ssl-cipher-suites loglevel logfile allowlist projects-dir]
     end
 
     def env_keys
@@ -98,8 +98,8 @@ module BoltServer
         raise Bolt::ValidationError, "Configured 'ssl-cipher-suites' must be an array of cipher suite names"
       end
 
-      unless @data['whitelist'].nil? || @data['whitelist'].is_a?(Array)
-        raise Bolt::ValidationError, "Configured 'whitelist' must be an array of names"
+      unless @data['allowlist'].nil? || @data['allowlist'].is_a?(Array)
+        raise Bolt::ValidationError, "Configured 'allowlist' must be an array of names"
       end
     end
 

--- a/spec/bolt_server/acl_spec.rb
+++ b/spec/bolt_server/acl_spec.rb
@@ -15,10 +15,10 @@ describe BoltServer::ACL do
   include Rack::Test::Methods
 
   let(:yes_app) { ->(_) { [200, { 'Content-Type' => 'text/plain' }, ['OK']] } }
-  let(:app) { described_class.new(yes_app, whitelist) }
+  let(:app) { described_class.new(yes_app, allowlist) }
 
-  context 'with empty whitelist' do
-    let(:whitelist) { [] }
+  context 'with empty allowlist' do
+    let(:allowlist) { [] }
 
     it 'rejects all requests' do
       get '/'
@@ -28,11 +28,11 @@ describe BoltServer::ACL do
     end
   end
 
-  context 'with whitelist' do
-    let(:whitelist) { %w[cert1 cert2] }
+  context 'with allowlist' do
+    let(:allowlist) { %w[cert1 cert2] }
 
-    it 'accepts requests from whitelisted certs' do
-      whitelist.each do |name|
+    it 'accepts requests from allowlisted certs' do
+      allowlist.each do |name|
         get '/', {}, 'HTTPS' => 'on', 'puma.peercert' => x509_certificate(name)
 
         expect(last_response).to be_ok

--- a/spec/bolt_server/config_spec.rb
+++ b/spec/bolt_server/config_spec.rb
@@ -38,8 +38,8 @@ describe BoltServer::Config do
       expect(config['logfile']).to eq('/var/log/global')
     end
 
-    it 'reads whitelist' do
-      expect(config['whitelist']).to eq(['a'])
+    it 'reads allowlist' do
+      expect(config['allowlist']).to eq(['a'])
     end
 
     it 'reads ssl-cipher-suites' do
@@ -112,7 +112,7 @@ describe BoltServer::Config do
     expect(config['port']).to be(62658)
     expect(config['loglevel']).to eq('warn')
     expect(config['logfile']).to eq(nil)
-    expect(config['whitelist']).to eq(nil)
+    expect(config['allowlist']).to eq(nil)
     expect(config['ssl-cipher-suites']).to include('ECDHE-ECDSA-AES256-GCM-SHA384')
     expect(config['concurrency']).to eq(100)
   end
@@ -136,10 +136,10 @@ describe BoltServer::Config do
     }.to raise_error(Bolt::ValidationError, /You must configure/)
   end
 
-  it "errors when whitelist is not an array" do
+  it "errors when allowlist is not an array" do
     expect {
-      BoltServer::Config.new(base_config.merge('whitelist' => 'notanarray')).validate
-    }.to raise_error(Bolt::ValidationError, /Configured 'whitelist' must be an array of names/)
+      BoltServer::Config.new(base_config.merge('allowlist' => 'notanarray')).validate
+    }.to raise_error(Bolt::ValidationError, /Configured 'allowlist' must be an array of names/)
   end
 
   it "errors when ssl-cipher-suites is not an array" do

--- a/spec/fixtures/api_server_configs/global-bolt-server.conf
+++ b/spec/fixtures/api_server_configs/global-bolt-server.conf
@@ -10,6 +10,6 @@ bolt-server: {
     file-server-uri: "https://localhost:8140"
     loglevel: debug
     logfile: /var/log/global
-    whitelist: [a]
+    allowlist: [a]
     concurrency: 12
 }

--- a/spec/fixtures/api_server_configs/global-plan-executor.conf
+++ b/spec/fixtures/api_server_configs/global-plan-executor.conf
@@ -10,7 +10,7 @@ plan-executor: {
     file-server-uri: "https://localhost:8140"
     loglevel: debug
     logfile: /var/log/global
-    whitelist: [a]
+    allowlist: [a]
     workers: 3
     orchestrator-url: "abcde.puppet.com"
 }

--- a/spec/fixtures/api_server_configs/local-bolt-server.conf
+++ b/spec/fixtures/api_server_configs/local-bolt-server.conf
@@ -8,6 +8,6 @@ bolt-server: {
 
     loglevel: info
     logfile: /var/log/local
-    whitelist: [b]
+    allowlist: [b]
     concurrency: 1
 }

--- a/spec/fixtures/api_server_configs/local-plan-executor.conf
+++ b/spec/fixtures/api_server_configs/local-plan-executor.conf
@@ -9,5 +9,5 @@ plan-executor: {
     modulepath: "spec/fixtures/modules"
     loglevel: info
     logfile: /var/log/local
-    whitelist: [b]
+    allowlist: [b]
 }


### PR DESCRIPTION
We are replacing bolt-server.conf's `whitelist` key with an `allowlist`
key, in our effort to remove harmful terminology from bolt-server, and
this commit updates bolt-server to read from that new value instead.