### PR TITLE
(maint) Remove module command and config from docs

### DIFF
--- a/rakelib/docs.rake
+++ b/rakelib/docs.rake
@@ -30,6 +30,8 @@ begin
       @commands = {}
 
       Bolt::CLI::COMMANDS.each do |subcommand, actions|
+        next if subcommand == 'module'
+
         actions << nil if actions.empty?
 
         actions.each do |action|

--- a/rakelib/schemas.rake
+++ b/rakelib/schemas.rake
@@ -177,7 +177,7 @@ namespace :schemas do
     require 'bolt/config'
 
     filepath    = File.expand_path('../schemas/bolt-project.schema.json', __dir__)
-    options     = Bolt::Config::BOLT_PROJECT_OPTIONS
+    options     = Bolt::Config::BOLT_PROJECT_OPTIONS - ['modules']
     definitions = Bolt::Config::Options::OPTIONS.slice(*options)
 
     properties = options.each_with_object({}) do |option, acc|

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -31,9 +31,6 @@
     "modulepath": {
       "$ref": "#/definitions/modulepath"
     },
-    "modules": {
-      "$ref": "#/definitions/modules"
-    },
     "name": {
       "$ref": "#/definitions/name"
     },
@@ -166,26 +163,6 @@
       ],
       "items": {
         "type": "string"
-      }
-    },
-    "modules": {
-      "description": "A list of module dependencies for the project. Each dependency is a map of data specifying the module to install. To install the project's module dependencies, run the `bolt module install` command.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "description": "The name of the module.",
-            "type": "string"
-          },
-          "version_requirement": {
-            "description": "The version requirement for the module. Accepts a specific version (1.2.3), version shorthand (1.2.x), or a version range (>= 1.2.0).",
-            "type": "string"
-          }
-        }
       }
     },
     "name": {


### PR DESCRIPTION
This updates the docs rake task to not include the `bolt module` command
on the command references page, and updates the schemas rake task to not
include the `modules` option in the `bolt-project.yaml` schema.

!no-release-note