### PR TITLE
(GH-1650) Handle exit codes greater than 1 in winrm transport

### DIFF
--- a/lib/bolt/shell/powershell.rb
+++ b/lib/bolt/shell/powershell.rb
@@ -278,6 +278,8 @@ module Bolt
             script_invocation = ['powershell.exe', *PS_ARGS, '-File', *args].join(' ')
             execute(script_invocation)
           end
+        else
+          command = Bolt::Shell::Powershell::Snippets.exit_with_code(command)
         end
         inp, out, err, t = conn.execute(command)
 


### PR DESCRIPTION
When using `powershell.exe -Command`, PowerShell sets the exit code of `powershell.exe` based on the `success status` of the **last statement**  executed in the command string.

- If the **last statement** is a PowerShell command (think cmdlet/function/etc) success is determined from `$?` which is `0` if `$true` or `1` if `$false`.
- If the **last statement** executed is an external program (not PowerShell code), `1` is returned if the exit code is anything but `0`. This means an exit code of `42` is still a `1` at the end of the execution.
- This does not happen with PowerShell scripts executed with `-File` command and that use a `exit <NUMBER>` to return a success status.

When executing `bolt command run 'foo'`, we are effectively doing a `powershell.exe -Command 'foo'`. This means the exit codes are mapped to `0` and `1` as in the first bullet point. We can pass the 'true' exit code by appending the `exit $LASTEXITCODE` statement to the end of every command. This was applied in f0fe7cdb2258d100940069377050a81aa2d919da, but only for the `local` transport. This fix applies it to the `winrm` transport as well.

This has the side effect of correctly passing the exit code for binary executions, like in the spec test executing `cmd.exe /c exit 42`. The spec test relied on the original (undesired) behavior and marked it passing even though it was the undesired behavior, making the user handle returning the correct exit code using `$LASTEXITCODE`. Since we are now deciding to try to pass the correct `$LASTEXITCODE` in both local and winrm transports, this test is corrected to expect the correct exit code.

Closes #1650