### PR TITLE
Target env_vars parameter

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/datatypes/target.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/target.rb
@@ -16,6 +16,7 @@ Puppet::DataTypes.create_type('Target') do
       target_alias => { type => Optional[Variant[String[1], Array[String[1]]]], kind => given_or_derived },
       config => { type => Optional[Hash[String[1], Data]], kind => given_or_derived },
       vars => { type => Optional[Hash[String[1], Data]], kind => given_or_derived },
+      env_vars => { type => Optional[Hash[String[1], String[1]]], kind => given_or_derived },
       facts => { type => Optional[Hash[String[1], Data]], kind => given_or_derived },
       features => { type => Optional[Array[String[1]]], kind => given_or_derived },
       plugin_hooks => { type => Optional[Hash[String[1], Data]], kind => given_or_derived },

--- a/lib/bolt/apply_target.rb
+++ b/lib/bolt/apply_target.rb
@@ -2,7 +2,7 @@
 
 module Bolt
   class ApplyTarget
-    ATTRIBUTES = %i[uri name target_alias config vars facts features
+    ATTRIBUTES = %i[uri name target_alias config vars env_vars facts features
                     plugin_hooks resources safe_name].freeze
     COMPUTED = %i[host password port protocol user].freeze
 
@@ -23,6 +23,7 @@ module Bolt
                                 config = nil,
                                 facts = nil,
                                 vars = nil,
+                                env_vars = nil,
                                 features = nil,
                                 plugin_hooks = nil,
                                 resources = nil)

--- a/lib/bolt/inventory/group.rb
+++ b/lib/bolt/inventory/group.rb
@@ -13,7 +13,7 @@ module Bolt
       NAME_REGEX = /\A[a-z0-9_][a-z0-9_-]*\Z/.freeze
 
       # NOTE: All keys should have a corresponding schema property in schemas/bolt-inventory.schema.json
-      DATA_KEYS = %w[config facts vars features plugin_hooks].freeze
+      DATA_KEYS = %w[config facts vars env_vars features plugin_hooks].freeze
       TARGET_KEYS = DATA_KEYS + %w[name alias uri]
       GROUP_KEYS = DATA_KEYS + %w[name groups targets]
       CONFIG_KEYS = Bolt::Config::INVENTORY_OPTIONS.keys
@@ -183,6 +183,7 @@ module Bolt
           # are assigned a new hash, rather than merging the existing value
           # with the value meant to replace it
           'vars' => data1['vars'].merge(data2['vars']),
+          'env_vars' => data1['env_vars'].merge(data2['env_vars']),
           'facts' => Bolt::Util.deep_merge(data1['facts'], data2['facts']),
           'features' => data1['features'] | data2['features'],
           'plugin_hooks' => data1['plugin_hooks'].merge(data2['plugin_hooks']),
@@ -318,6 +319,7 @@ module Bolt
         result = {
           'config' => @plugins.resolve_references(data.fetch('config', {})),
           'vars' => @plugins.resolve_references(data.fetch('vars', {})),
+          'env_vars' => @plugins.resolve_references(data.fetch('env_vars', {})),
           'facts' => @plugins.resolve_references(data.fetch('facts', {})),
           'features' => @plugins.resolve_references(data.fetch('features', [])),
           'plugin_hooks' => @plugins.resolve_references(data.fetch('plugin_hooks', {}))
@@ -331,6 +333,7 @@ module Bolt
         {
           'config' => Hash,
           'vars' => Hash,
+          'env_vars' => Hash,
           'facts' => Hash,
           'features' => Array,
           'plugin_hooks' => Hash

--- a/lib/bolt/inventory/inventory.rb
+++ b/lib/bolt/inventory/inventory.rb
@@ -278,6 +278,10 @@ module Bolt
         @targets[target.name].vars
       end
 
+      def env_vars(target)
+        @targets[target.name].env_vars
+      end
+
       def add_facts(target, new_facts = {})
         @targets[target.name].add_facts(new_facts)
         target

--- a/lib/bolt/inventory/target.rb
+++ b/lib/bolt/inventory/target.rb
@@ -36,6 +36,7 @@ module Bolt
 
         @config = target_data['config'] || {}
         @vars = target_data['vars'] || {}
+        @env_vars = target_data['env_vars'] || {}
         @facts = target_data['facts'] || {}
         @features = target_data['features'] || Set.new
         @plugin_hooks = target_data['plugin_hooks'] || {}
@@ -80,11 +81,23 @@ module Bolt
         group_cache['vars'].merge(@vars)
       end
 
+      def env_vars
+        group_cache['env_vars'].merge(@env_vars)
+      end
+
       # This method isn't actually an accessor and we want the name to
       # correspond to the Puppet function
       # rubocop:disable Naming/AccessorMethodName
       def set_var(var_hash)
         @vars.merge!(var_hash)
+      end
+      # rubocop:enable Naming/AccessorMethodName
+
+      # This method isn't actually an accessor and we want the name to
+      # correspond to the Puppet function
+      # rubocop:disable Naming/AccessorMethodName
+      def set_env_var(var_hash)
+        @env_vars.merge!(var_hash)
       end
       # rubocop:enable Naming/AccessorMethodName
 
@@ -230,6 +243,7 @@ module Bolt
           group_data ||= {
             'config' => {},
             'vars' => {},
+            'env_vars' => {},
             'facts' => {},
             'features' => Set.new,
             'plugin_hooks' => {},

--- a/lib/bolt/shell/powershell.rb
+++ b/lib/bolt/shell/powershell.rb
@@ -175,7 +175,7 @@ module Bolt
       end
 
       def run_command(command, options = {})
-        command = [*env_declarations(options[:env_vars]), command].join("\r\n") if options[:env_vars]
+        command = [*env_declarations(target.env_vars.merge(options[:env_vars] || {})), command].join("\r\n")
 
         output = execute(command)
         Bolt::Result.for_command(target,
@@ -197,7 +197,7 @@ module Bolt
                       args += escape_arguments(arguments)
                       execute_process(path, args)
                     end
-          command = [*env_declarations(options[:env_vars]), command].join("\r\n") if options[:env_vars]
+          command = [*env_declarations(target.env_vars.merge(options[:env_vars] || {})), command].join("\r\n")
 
           output = execute(command)
           Bolt::Result.for_command(target,

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -30,6 +30,7 @@ module Bolt
                                 config = nil,
                                 facts = nil,
                                 vars = nil,
+                                env_vars = nil,
                                 features = nil,
                                 plugin_hooks = nil,
                                 resources = nil)
@@ -54,6 +55,10 @@ module Bolt
 
     def vars
       @inventory.vars(self)
+    end
+
+    def env_vars
+      @inventory.env_vars(self)
     end
 
     def facts
@@ -108,6 +113,7 @@ module Bolt
           transport => options.to_h
         },
         'vars' => vars,
+        'env_vars' => env_vars,
         'features' => features,
         'facts' => facts,
         'plugin_hooks' => plugin_hooks,

--- a/lib/bolt/transport/docker.rb
+++ b/lib/bolt/transport/docker.rb
@@ -49,7 +49,7 @@ module Bolt
       def run_command(target, command, options = {})
         execute_options = {}
         execute_options[:tty] = target.options['tty']
-        execute_options[:environment] = options[:env_vars]
+        execute_options[:environment] = target.env_vars.merge(options[:env_vars] || {})
 
         if target.options['shell-command'] && !target.options['shell-command'].empty?
           # escape any double quotes in command
@@ -66,7 +66,7 @@ module Bolt
         # unpack any Sensitive data
         arguments = unwrap_sensitive_args(arguments)
         execute_options = {}
-        execute_options[:environment] = options[:env_vars]
+        execute_options[:environment] = target.env_vars.merge(options[:env_vars] || {})
 
         with_connection(target) do |conn|
           conn.with_remote_tmpdir do |dir|

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -82,7 +82,7 @@ module Bolt
       end
 
       def batch_command(targets, command, options = {}, &callback)
-        if options[:env_vars] && !options[:env_vars].empty?
+        if options[:env_vars] && !options[:env_vars].empty? || targets.any? { |target| !target.env_vars.empty? }
           raise NotImplementedError, "pcp transport does not support setting environment variables"
         end
 
@@ -102,7 +102,7 @@ module Bolt
       end
 
       def batch_script(targets, script, arguments, options = {}, &callback)
-        if options[:env_vars] && !options[:env_vars].empty?
+        if options[:env_vars] && !options[:env_vars].empty? || targets.any? { |target| !target.env_vars.empty? }
           raise NotImplementedError, "pcp transport does not support setting environment variables"
         end
 

--- a/schemas/bolt-inventory-base.json
+++ b/schemas/bolt-inventory-base.json
@@ -23,6 +23,9 @@
     "vars": {
       "$ref": "#/definitions/vars"
     },
+    "env_vars": {
+      "$ref": "#/definitions/env_vars"
+    },
     "version": {
       "$ref": "#/definitions/version"
     }
@@ -122,6 +125,9 @@
             },
             "vars": {
               "$ref": "#/definitions/vars"
+            },
+            "env_vars": {
+              "$ref": "#/definitions/env_vars"
             }
           },
           "required": ["name"]    
@@ -197,6 +203,9 @@
             },
             "vars": {
               "$ref": "#/definitions/vars"
+            },
+            "env_vars": {
+              "$ref": "#/definitions/env_vars"
             }
           },
           "anyOf": [
@@ -211,6 +220,17 @@
     },
     "vars": {
       "description": "The vars for a target.",
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "env_vars": {
+      "description": "The environment variables for a target.",
       "oneOf": [
         {
           "type": "object"

--- a/schemas/bolt-inventory.schema.json
+++ b/schemas/bolt-inventory.schema.json
@@ -23,6 +23,9 @@
     "vars": {
       "$ref": "#/definitions/vars"
     },
+    "env_vars": {
+      "$ref": "#/definitions/env_vars"
+    },
     "version": {
       "$ref": "#/definitions/version"
     }
@@ -145,6 +148,9 @@
             },
             "vars": {
               "$ref": "#/definitions/vars"
+            },
+            "env_vars": {
+              "$ref": "#/definitions/env_vars"
             }
           },
           "required": [
@@ -222,6 +228,9 @@
             },
             "vars": {
               "$ref": "#/definitions/vars"
+            },
+            "env_vars": {
+              "$ref": "#/definitions/env_vars"
             }
           },
           "anyOf": [
@@ -244,6 +253,17 @@
     },
     "vars": {
       "description": "The vars for a target.",
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "env_vars": {
+      "description": "The environment variables for a target.",
       "oneOf": [
         {
           "type": "object"

--- a/spec/bolt/inventory/group_spec.rb
+++ b/spec/bolt/inventory/group_spec.rb
@@ -50,6 +50,7 @@ describe Bolt::Inventory::Group do
     it 'should return empty data' do
       expect(group.target_collect('target1')).to eq('config' => {},
                                                     'vars' => {},
+                                                    'env_vars' => {},
                                                     'name' => nil,
                                                     'plugin_hooks' => {},
                                                     'uri' => 'target1',

--- a/spec/bolt/inventory/inventory_spec.rb
+++ b/spec/bolt/inventory/inventory_spec.rb
@@ -1337,6 +1337,7 @@ describe Bolt::Inventory::Inventory do
           }
         },
         'vars' => {},
+        'env_vars' => {},
         'facts' => { 'foo' => 'bar' },
         'features' => [],
         'groups' => %w[group1 group2 all],


### PR DESCRIPTION
This makes it possible to set environment variables only for duration of bolt-script.
A valid usage example would be configuring a SSH tunnel options with a `http_proxy` env variable:

```
ssh-command:
- ssh
- "-L"
- "3128:proxy:3128"

env_vars:
  http_proxy: "http://localhost:3128"
```

As the variable only makes sense while the script is running, it is better to define it in target instead of exporting it via remote files.

The changes are mostly a copy-paste of `vars`. I hope, I didn't miss anything. I could also copy tests if necessary.