### PR TITLE
(docs) Clarify Hiera data loading docs

### DIFF
--- a/documentation/applying_manifest_blocks.md
+++ b/documentation/applying_manifest_blocks.md
@@ -240,12 +240,12 @@ plan do_thing() {
 ```
 
 Manifest block compilation can access Hiera data that you add to your Bolt
-configuration. The default location for Hiera config is `<project-directory>/hiera.yaml`.
+configuration. The default location for Hiera config is `<PROJECT DIRECTORY>/hiera.yaml`.
 You can change this with the `hiera-config` key in a Bolt config file or the
 `--hiera-config` CLI option.
 
 Following the Hiera 5 convention, the default data directory is relative to
-`hiera.yaml` at `<project-directory>/data`. For configuration file examples, see [Configuring
+`hiera.yaml` at `<PROJECT DIRECTORY>/data`. For configuration file examples, see [Configuring
 Hiera](https://puppet.com/docs/puppet/latest/hiera_config_yaml_5.html). Bolt 
 will not automatically load any Hiera data from this directory. If you want to load data from a
 data file you must set the relevant paths in your Hiera config.
@@ -263,7 +263,7 @@ under the `plan_hierarchy` key outside of apply blocks, and uses the the typical
 of apply blocks. This allows you to use your existing Hiera configs in Bolt plans without encountering 
 an error if interpolation exists and your plan tries to look up data outside of an apply block.
 
-For example, with this Hiera configuration at `<project>/hiera.yaml`:
+For example, with this Hiera configuration at `<PROJECT DIRECTORY>/hiera.yaml`:
 ```yaml
 version: 5
 

--- a/documentation/applying_manifest_blocks.md
+++ b/documentation/applying_manifest_blocks.md
@@ -240,13 +240,15 @@ plan do_thing() {
 ```
 
 Manifest block compilation can access Hiera data that you add to your Bolt
-configuration. The default location for Hiera config is `$BOLTDIR/hiera.yaml`.
+configuration. The default location for Hiera config is `<project-directory>/hiera.yaml`.
 You can change this with the `hiera-config` key in a Bolt config file or the
 `--hiera-config` CLI option.
 
-Following the Hiera 5 convention, the default data dir is relative to
-`hiera.yaml` at `$BOLTDIR/data`. For configfile examples, see [Configuring
-Hiera](https://puppet.com/docs/puppet/latest/hiera_config_yaml_5.html).
+Following the Hiera 5 convention, the default data directory is relative to
+`hiera.yaml` at `<project-directory>/data`. For configuration file examples, see [Configuring
+Hiera](https://puppet.com/docs/puppet/latest/hiera_config_yaml_5.html). Bolt 
+will not automatically load any Hiera data from this directory. If you want to load data from a
+data file you must set the relevant paths in your Hiera config.
 
 If a custom data provider is used, such as `hiera-eyaml`, which allows you to
 encrypt your data, the gem dependencies must be available to Bolt. See [Install

--- a/documentation/bolt_running_plans.md
+++ b/documentation/bolt_running_plans.md
@@ -32,11 +32,11 @@ language](./writing_plans.md#targetspec).
 
 In order for Bolt to find a plan, the plan must be in a module on the module
 path. By default, Bolt looks for downloaded module plans in
-`<PROJECT_NAME>/modules/plans/` and local plans in
-`<PROJECT_NAME>/site-modules/plans/`.
+`<PROJECT DIRECTORY>/modules/plans/` and local plans in
+`<PROJECT DIRECTORY>/site-modules/plans/`.
 
-Using a Bolt project, you can create a `<PROJECT_NAME>/bolt-project.yaml` file,
-develop your plan in `<PROJECT_NAME>/plans/`, and run Bolt from the root of your
+Using a Bolt project, you can create a `<PROJECT DIRECTORY>/bolt-project.yaml` file,
+develop your plan in `<PROJECT DIRECTORY>/plans/`, and run Bolt from the root of your
 Bolt project directory to test the plan. For more information, see [Bolt
 projects](projects.md)
 

--- a/documentation/bolt_running_tasks.md
+++ b/documentation/bolt_running_tasks.md
@@ -73,13 +73,13 @@ bolt task run mymodule::mytask --targets app1.myorg.com --params $(@{load_balanc
 ## Specifying the module path
 
 In order for Bolt to find a task, the task must be in a module on the module
-path. The default modulepath is `[<project directory>/modules, <project
-directory>/site-modules]`.
+path. The default modulepath is `[<PROJECT DIRECTORY>/modules, <PROJECT
+DIRECTORY>/site-modules]`.
 
 The current [Bolt project](./experimental_features.md#bolt-projects) is loaded
 as a standalone module at the front of the module path.  If you are developing a
-new task, you can create a `<PROJECT_NAME>/bolt-project.yaml` file, develop your
-task in `<PROJECT_NAME>/tasks/`, and run Bolt from the root of your Bolt project
+new task, you can create a `<PROJECT DIRECTORY>/bolt-project.yaml` file, develop your
+task in `<PROJECT DIRECTORY>/tasks/`, and run Bolt from the root of your Bolt project
 directory to test the task. For more information, see [Bolt
 projects](projects.md).
 

--- a/documentation/configuring_bolt.md
+++ b/documentation/configuring_bolt.md
@@ -53,7 +53,7 @@ a clear distinction between Bolt configuration and inventory configuration.
 
 ### `bolt-project.yaml`
 
-**Filepath:** `<project-directory>/bolt-project.yaml`
+**Filepath:** `<PROJECT DIRECTORY>/bolt-project.yaml`
 
 The project configuration file supports options that configure how Bolt behaves,
 such as how many threads it can use when running commands on targets. You can
@@ -71,7 +71,7 @@ options](bolt_project_reference.md).
 
 ### `inventory.yaml`
 
-**Filepath:** `<project-directory>/inventory.yaml`
+**Filepath:** `<PROJECT DIRECTORY>/inventory.yaml`
 
 The inventory file is a structured data file that contains groups of targets
 that you can run Bolt commands on, as well as configuration for the transports
@@ -97,7 +97,7 @@ fields](bolt_inventory_reference.md).
 future version of Bolt. Use `bolt-project.yaml` and `inventory.yaml` files
 instead.
 
-**Filepath:** `<project-directory>/bolt.yaml`
+**Filepath:** `<PROJECT DIRECTORY>/bolt.yaml`
 
 The Bolt configuration file can be used to set all available configuration
 options, including default inventory configuration options. Any directory

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -359,7 +359,7 @@ And the following plan names are invalid:
 Plan names that match the project name will create a special `init` plan.
 For example, if you have a project named `myproject` and run the command
 `bolt plan new myproject`, a plan will be created at
-`<project>/plans/init.yaml`.
+`<PROJECT DIRECTORY>/plans/init.yaml`.
 
 You can reference the `init` plan using the project's name. For example,
 you would run this plan using `bolt plan run myproject`.

--- a/documentation/module_structure.md
+++ b/documentation/module_structure.md
@@ -79,8 +79,8 @@ Follow these tips for managing standalone modules:
 -   When you run tasks and plans within a project directory the module path is
     searched in order for modules containing Bolt content. The Bolt project
     directory itself is loaded as a module at the front of the module path, and
-    the default module path is `[<project directory>/modules, <project
-    directory>/site-modules]`. If you have a module in both the `modules` and
+    the default module path is `[<PROJECT DIRECTORY>/modules, <PROJECT
+    DIRECTORY>/site-modules]`. If you have a module in both the `modules` and
     `site-modules` directories, the version in `modules` will be used.
 -   As a best practice, write automated tests for the tasks and plans in your
     module, if possible. For information about automated testing patterns, check

--- a/documentation/writing_yaml_plans.md
+++ b/documentation/writing_yaml_plans.md
@@ -186,7 +186,7 @@ to a destination directory on the local host.
 Files and directories are downloaded to the destination directory within a
 subdirectory matching the target's URL-encoded safe name. If the destination
 directory is a relative path, it will expand relative to the project's
-downloads directory, `<project>/downloads`.
+downloads directory, `<PROJECT DIRECTORY>/downloads`.
 
 File download steps use these fields:
 


### PR DESCRIPTION
This clarifies that while Bolt sets a default data dir and default Hiera
config file, it does not have any content in that Hiera config and will
not load any Hiera data unless the user configures it to.

!no-release-note