### PR TITLE
(GH-2186) Add resolve and force options for module subcommand

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -67,13 +67,13 @@ module Bolt
       when 'module'
         case action
         when 'add'
-          { flags: OPTIONS[:global] + %w[configfile force project],
+          { flags: OPTIONS[:global] + %w[configfile project],
             banner: MODULE_ADD_HELP }
         when 'generate-types'
           { flags: OPTIONS[:global] + OPTIONS[:global_config_setters],
             banner: MODULE_GENERATETYPES_HELP }
         when 'install'
-          { flags: OPTIONS[:global] + %w[configfile force project],
+          { flags: OPTIONS[:global] + %w[configfile force project resolve],
             banner: MODULE_INSTALL_HELP }
         when 'show'
           { flags: OPTIONS[:global] + OPTIONS[:global_config_setters],
@@ -935,6 +935,13 @@ module Bolt
       end
       define('--tmpdir DIR', 'The directory to upload and execute temporary files on the target') do |tmpdir|
         @options[:tmpdir] = tmpdir
+      end
+
+      separator "\nMODULE OPTIONS"
+      define('--[no-]resolve',
+             'Use --no-resolve to install modules listed in the Puppetfile without resolving modules configured',
+             'in Bolt project configuration') do |resolve|
+        @options[:resolve] = resolve
       end
 
       separator "\nDISPLAY OPTIONS"

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -478,7 +478,7 @@ module Bolt
         when 'add'
           code = add_project_module(options[:object], config.project)
         when 'install'
-          code = install_project_modules(config.project, options[:force])
+          code = install_project_modules(config.project, options[:force], options[:resolve])
         when 'generate-types'
           code = generate_types
         end
@@ -888,7 +888,7 @@ module Bolt
 
     # Installs modules declared in the project configuration file.
     #
-    def install_project_modules(project, force)
+    def install_project_modules(project, force, resolve)
       assert_project_file(project)
 
       unless project.modules
@@ -899,7 +899,11 @@ module Bolt
 
       installer = Bolt::ModuleInstaller.new(outputter, pal)
 
-      ok = installer.install(project.modules, project.puppetfile, project.managed_moduledir, force: force)
+      ok = installer.install(project.modules,
+                             project.puppetfile,
+                             project.managed_moduledir,
+                             force: force,
+                             resolve: resolve)
       ok ? 0 : 1
     end
 
@@ -911,7 +915,11 @@ module Bolt
       modules   = project.modules || []
       installer = Bolt::ModuleInstaller.new(outputter, pal)
 
-      ok = installer.add(name, modules, project.puppetfile, project.managed_moduledir, project.project_file)
+      ok = installer.add(name,
+                         modules,
+                         project.puppetfile,
+                         project.managed_moduledir,
+                         project.project_file)
       ok ? 0 : 1
     end
 

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -235,6 +235,16 @@ describe "Bolt::CLI" do
         expect(installer).to receive(:add)
         cli.execute(cli.parse)
       end
+
+      it 'passes force' do
+        cli = Bolt::CLI.new(%W[module add puppetlabs-yaml --project #{project} --force])
+
+        allow(installer).to receive(:install) do |*args|
+          expect(args).to include({ force: true })
+        end
+
+        cli.execute(cli.parse)
+      end
     end
 
     context 'install' do
@@ -251,6 +261,26 @@ describe "Bolt::CLI" do
 
       it 'runs' do
         expect(installer).to receive(:install)
+        cli.execute(cli.parse)
+      end
+
+      it 'installs project modules forcibly' do
+        cli = Bolt::CLI.new(%W[module install --project #{project} --force])
+
+        allow(installer).to receive(:install) do |*args|
+          expect(args).to include({ force: true, resolve: nil })
+        end
+
+        cli.execute(cli.parse)
+      end
+
+      it 'install modules from Puppetfile with resolving' do
+        cli = Bolt::CLI.new(%W[module install --project #{project} --no-resolve])
+
+        allow(installer).to receive(:install) do |*args|
+          expect(args).to include({ force: nil, resolve: false })
+        end
+
         cli.execute(cli.parse)
       end
     end


### PR DESCRIPTION
This adds a new `--[no-]resolve` flag, which defaults to true, that will
allow users to install the Puppetfile without resolving the modules
enumerated in `modules` key in Bolt config. No release notes as
this will ship dark until the full workflow is implemented.

Closes #2186

!no-release-note