### PR TITLE
(maint) Prettify module show output

### DIFF
--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -195,7 +195,7 @@ module Bolt
         @stream.puts total_msg
       end
 
-      def print_table(results)
+      def print_table(results, padding_left = 0, padding_right = 3)
         # lazy-load expensive gem code
         require 'terminal-table'
 
@@ -205,8 +205,8 @@ module Bolt
             border_x: '',
             border_y: '',
             border_i: '',
-            padding_left: 0,
-            padding_right: 3,
+            padding_left: padding_left,
+            padding_right: padding_right,
             border_top: false,
             border_bottom: false
           }
@@ -306,9 +306,9 @@ module Bolt
       def print_module_list(module_list)
         module_list.each do |path, modules|
           if (mod = modules.find { |m| m[:internal_module_group] })
-            @stream.puts(mod[:internal_module_group])
+            @stream.puts(colorize(:cyan, mod[:internal_module_group]))
           else
-            @stream.puts(path)
+            @stream.puts(colorize(:cyan, path))
           end
 
           if modules.empty?
@@ -324,7 +324,7 @@ module Bolt
               [m[:name], version]
             end
 
-            print_table(module_info)
+            print_table(module_info, 2, 1)
           end
 
           @stream.write("\n")

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -92,6 +92,21 @@ describe "Bolt::Outputter::Human" do
     TABLE
   end
 
+  it 'formats a modules with padding' do
+    modules = { "/modulepath" =>
+                [{ name: "boltlib", version: nil, internal_module_group: "Plan Language Modules" },
+                 { name: "ctrl", version: nil, internal_module_group: "Plan Language Modules" },
+                 { name: "dir", version: nil, internal_module_group: "Plan Language Modules" }] }
+    outputter.print_module_list(modules)
+    expect(output.string).to eq(<<~TABLE)
+    Plan Language Modules
+      boltlib   (built-in)
+      ctrl      (built-in)
+      dir       (built-in)
+
+    TABLE
+  end
+
   it "formats a task" do
     name = 'cinnamon_roll'
     files = [{ 'name' => 'cinnamon.rb',


### PR DESCRIPTION
This updates the `puppetfile show-modules` and `module show` output to
be a bit more readable by indenting the module tables to offset them
from the group headings, and colorizing the group headings to clarify
that they are headings.