### PR TITLE
(maint) docs - Clarify puppet log functions

### DIFF
--- a/documentation/applying_manifest_blocks.md
+++ b/documentation/applying_manifest_blocks.md
@@ -292,6 +292,20 @@ plan plan_lookup(
 }
 ```
 
+## Puppet log functions in Bolt
+
+You can use Puppet log functions in Bolt plans, but Bolt log levels do not map
+directly to Puppet log levels. For example, a `notice` function in a plan logs
+at the `info` level in Bolt. Log levels map as follows:
+
+| Puppet log level | Bolt log level |
+| --- | --- |
+| `debug` | `trace` |
+| `info` | `debug` |
+| `notice` | `info` |
+| `warning` | `warn` |
+| `err` | `error` |
+
 📖 **Related information**  
 
 - [Configuring Bolt](configuring_bolt.md)

--- a/documentation/writing_plans.md
+++ b/documentation/writing_plans.md
@@ -811,33 +811,9 @@ plan pdb_discover {
 
 ## Plan logging
 
-Plan run information can be captured in log files or printed to a terminal
-session using the following methods.
-
-### Outputting message to the terminal
-
 Print message strings to `STDOUT` using the plan function `out::message`. This
 function always prints messages regardless of the log level and doesn't log them
 to the log file.
-
-### Puppet log functions
-
-To generate log messages from a plan, you can use Puppet's built-in log functions and configure
-your Bolt log level accordingly. Be aware that Bolt logs messages at slightly different levels than
-Puppet. Puppet log levels map to Bolt log levels in the following way:
-
-| Puppet log level | Bolt log level |
-| --- | --- |
-| `debug` | `trace` |
-| `info` | `debug` |
-| `notice` | `info` |
-| `warning` | `warn` |
-| `err` | `error` |
-
-Configure the log level for both log files and console logging in `bolt-project.yaml`. The default
-log level for both the console and log files is `warn`. Use the `--log-level debug` flag to set
-the console log level to `debug` for a single run.  For more information on configuring log
-levels, see [Logs](logs.md).
 
 ### Default action logging
 
@@ -879,6 +855,22 @@ not
 ```
 without_default_logging { run_command('echo hi', $targets) }
 ```
+
+For information on configuring log levels, see [Logs](logs.md).
+
+### Puppet log functions in Bolt
+
+You can use Puppet log functions in Bolt plans, but Bolt log levels do not map
+directly to Puppet log levels. For example, a `notice` function in a plan logs
+at the `info` level in Bolt. Log levels map as follows:
+
+| Puppet log level | Bolt log level |
+| --- | --- |
+| `debug` | `trace` |
+| `info` | `debug` |
+| `notice` | `info` |
+| `warning` | `warn` |
+| `err` | `error` |
 
 ## Documenting plans
 


### PR DESCRIPTION
Had a chat with Cas and Barr about this. Because puppet log functions in Bolt do not map 1:1, it seems better to recommend out::message instead. To try and make that a bit clearer, I've simplified the hierarchy a bit and moved the bit about Puppet log functions down a bit. I also added this info to the apply doc, seeing as though people who are used to applying Puppet code might be confused about why their log functions aren't working as expected.   