### PR TITLE
(GH-2135) Add Powershell 'module' subcommands and un-feature-flag

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -187,6 +187,7 @@ module Bolt
           group             Show the list of groups in the inventory
           guide             View guides for Bolt concepts and features
           inventory         Show the list of targets an action would run on
+          module            Manage Bolt project modules
           plan              Convert, create, show, and run Bolt plans
           project           Create and migrate Bolt projects
           puppetfile        Install and list modules and generate type references

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -41,6 +41,7 @@ module Bolt
       'inventory'  => %w[show],
       'group'      => %w[show],
       'project'    => %w[init migrate],
+      'module'     => %w[add generate-types install show],
       'apply'      => %w[],
       'guide'      => %w[]
     }.freeze
@@ -60,14 +61,6 @@ module Bolt
     end
     private :inventory
 
-    def commands
-      if ENV['BOLT_MODULE_FEATURE']
-        COMMANDS.merge('module' => %w[add generate-types install show])
-      else
-        COMMANDS
-      end
-    end
-
     def help?(remaining)
       # Set the subcommand
       options[:subcommand] = remaining.shift
@@ -79,7 +72,7 @@ module Bolt
 
       # This section handles parsing non-flag options which are
       # subcommand specific rather then part of the config
-      actions = commands[options[:subcommand]]
+      actions = COMMANDS[options[:subcommand]]
       if actions && !actions.empty?
         options[:action] = remaining.shift
       end
@@ -111,7 +104,7 @@ module Bolt
       if @argv.empty? || help?(remaining)
         # If the subcommand is not enabled, display the default
         # help text
-        options[:subcommand] = nil unless commands.include?(options[:subcommand])
+        options[:subcommand] = nil unless COMMANDS.include?(options[:subcommand])
 
         # Update the parser for the subcommand (or lack thereof)
         parser.update
@@ -234,13 +227,13 @@ module Bolt
     end
 
     def validate(options)
-      unless commands.include?(options[:subcommand])
+      unless COMMANDS.include?(options[:subcommand])
         raise Bolt::CLIError,
               "Expected subcommand '#{options[:subcommand]}' to be one of " \
-              "#{commands.keys.join(', ')}"
+              "#{COMMANDS.keys.join(', ')}"
       end
 
-      actions = commands[options[:subcommand]]
+      actions = COMMANDS[options[:subcommand]]
       if actions.any?
         if options[:action].nil?
           raise Bolt::CLIError,

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -453,7 +453,7 @@ module Bolt
     def modulepath
       path = @data['modulepath'] || @project.modulepath
 
-      if @project.modules && ENV['BOLT_MODULE_FEATURE']
+      if @project.modules
         path + [@project.managed_moduledir]
       else
         path

--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -116,7 +116,7 @@ module Bolt
 
       # If the 'modules' key is present in the project configuration file,
       # use the new, shorter modulepath.
-      @modulepath = if @data.key?('modules') && ENV['BOLT_MODULE_FEATURE']
+      @modulepath = if @data.key?('modules')
                       [(@path + 'modules').to_s]
                     else
                       [(@path + 'modules').to_s, (@path + 'site-modules').to_s, (@path + 'site').to_s]

--- a/lib/bolt/project_migrator.rb
+++ b/lib/bolt/project_migrator.rb
@@ -31,11 +31,7 @@ module Bolt
 
       @outputter.print_message('')
 
-      ok = migrate_inventory && migrate_config
-
-      if ok && ENV['BOLT_MODULE_FEATURE']
-        ok = migrate_modules
-      end
+      ok = migrate_inventory && migrate_config && migrate_modules
 
       if ok
         @outputter.print_message("Project successfully migrated")

--- a/lib/bolt/project_migrator/modules.rb
+++ b/lib/bolt/project_migrator/modules.rb
@@ -6,7 +6,7 @@ module Bolt
   class ProjectMigrator
     class Modules < Base
       def migrate(project, configured_modulepath)
-        return true unless ENV['BOLT_MODULE_FEATURE'] && project.modules.nil?
+        return true unless project.modules.nil?
 
         @outputter.print_message "Migrating project modules\n\n"
 

--- a/pwsh_module/command.tests.ps1
+++ b/pwsh_module/command.tests.ps1
@@ -34,7 +34,7 @@ Describe "test bolt module" {
 
     it "has the correct number of exported functions" {
       # should count of pwsh functions plus legacy `bolt` function
-      @($commands).Count | Should -Be 22
+      @($commands).Count | Should -Be 26
     }
   }
 }
@@ -235,6 +235,26 @@ Describe "test all bolt command examples" {
       $result | Should -Be 'bolt puppetfile show-modules'
     }
   }
+
+  Context "bolt module" {
+    It "bolt module add" {
+      $result = Add-BoltModule -M puppetlabs-yaml
+      $result | Should -Be "bolt module add 'puppetlabs-yaml'"
+    }
+    It "bolt module generate-types" {
+      $result = Register-BoltModuleTypes
+      $result | Should -Be 'bolt module generate-types'
+    }
+    It "bolt module install" {
+      $result = Install-BoltModule
+      $result | Should -Be 'bolt module install'
+    }
+    It "bolt module show" {
+      $result = Get-BoltModule
+      $result | Should -Be 'bolt module show'
+    }
+  }
+
 
   Context "bolt script" {
     It "bolt script run myscript.sh 'echo hello' --targets target1,target2" {

--- a/rakelib/docs.rake
+++ b/rakelib/docs.rake
@@ -30,8 +30,6 @@ begin
       @commands = {}
 
       Bolt::CLI::COMMANDS.each do |subcommand, actions|
-        next if subcommand == 'module'
-
         actions << nil if actions.empty?
 
         actions.each do |action|

--- a/rakelib/schemas.rake
+++ b/rakelib/schemas.rake
@@ -177,7 +177,7 @@ namespace :schemas do
     require 'bolt/config'
 
     filepath    = File.expand_path('../schemas/bolt-project.schema.json', __dir__)
-    options     = Bolt::Config::BOLT_PROJECT_OPTIONS - ['modules']
+    options     = Bolt::Config::BOLT_PROJECT_OPTIONS
     definitions = Bolt::Config::Options::OPTIONS.slice(*options)
 
     properties = options.each_with_object({}) do |option, acc|

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -172,7 +172,10 @@
       "description": "A list of module dependencies for the project. Each dependency is a map of data specifying the module to install. To install the project's module dependencies, run the `bolt module install` command.",
       "type": "array",
       "items": {
-        "type": "object",
+        "type": [
+          "object",
+          "string"
+        ],
         "required": [
           "name"
         ],

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -31,6 +31,9 @@
     "modulepath": {
       "$ref": "#/definitions/modulepath"
     },
+    "modules": {
+      "$ref": "#/definitions/modules"
+    },
     "name": {
       "$ref": "#/definitions/name"
     },
@@ -163,6 +166,26 @@
       ],
       "items": {
         "type": "string"
+      }
+    },
+    "modules": {
+      "description": "A list of module dependencies for the project. Each dependency is a map of data specifying the module to install. To install the project's module dependencies, run the `bolt module install` command.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "description": "The name of the module.",
+            "type": "string"
+          },
+          "version_requirement": {
+            "description": "The version requirement for the module. Accepts a specific version (1.2.3), version shorthand (1.2.x), or a version range (>= 1.2.0).",
+            "type": "string"
+          }
+        }
       }
     },
     "name": {

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -173,26 +173,13 @@ describe "Bolt::CLI" do
     let(:installer) { double('installer', add: true, install: true) }
 
     around(:each) do |example|
-      original = ENV['BOLT_MODULE_FEATURE']
-      ENV['BOLT_MODULE_FEATURE'] = 'true'
-
       with_project do
         example.run
       end
-    ensure
-      ENV['BOLT_MODULE_FEATURE'] = original
     end
 
     before(:each) do
       allow(Bolt::ModuleInstaller).to receive(:new).and_return(installer)
-    end
-
-    it 'errors without BOLT_MODULE_FEATURE being set' do
-      ENV.delete('BOLT_MODULE_FEATURE')
-      expect { cli.parse }.to raise_error(
-        Bolt::CLIError,
-        /Expected subcommand/
-      )
     end
 
     it 'errors without modules configured' do

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -456,14 +456,6 @@ describe Bolt::Config do
     let(:overrides)         { { 'modulepath' => managed_moduledir } }
 
     context 'with modules configured' do
-      around(:each) do |example|
-        original = ENV['BOLT_MODULE_FEATURE']
-        ENV['BOLT_MODULE_FEATURE'] = 'true'
-        example.run
-      ensure
-        ENV['BOLT_MODULE_FEATURE'] = original
-      end
-
       it 'appends the managed moduledir to the modulepath' do
         expect(config.modulepath[-1]).to eq(managed_moduledir)
       end

--- a/spec/bolt/project_migrator/modules_spec.rb
+++ b/spec/bolt/project_migrator/modules_spec.rb
@@ -27,15 +27,10 @@ describe Bolt::ProjectMigrator::Modules do
   let(:migrator)       { described_class.new(outputter) }
 
   around(:each) do |example|
-    original = ENV['BOLT_MODULE_FEATURE']
-    ENV['BOLT_MODULE_FEATURE'] = 'true'
-
     Dir.mktmpdir(nil, Dir.pwd) do |tmpdir|
       @tmpdir = Pathname.new(tmpdir)
       example.run
     end
-  ensure
-    ENV['BOLT_MODULE_FEATURE'] = original
   end
 
   before(:each) do

--- a/spec/bolt/project_migrator_spec.rb
+++ b/spec/bolt/project_migrator_spec.rb
@@ -17,14 +17,9 @@ describe Bolt::ProjectMigrator do
   let(:modules_migrator)   { double('modules_migrator', migrate: true) }
 
   around :each do |example|
-    original = ENV['BOLT_MODULE_FEATURE']
-    ENV['BOLT_MODULE_FEATURE'] = 'true'
-
     with_project do
       example.run
     end
-  ensure
-    ENV['BOLT_MODULE_FEATURE'] = original
   end
 
   before(:each) do

--- a/spec/bolt/project_spec.rb
+++ b/spec/bolt/project_spec.rb
@@ -238,12 +238,7 @@ describe Bolt::Project do
     end
 
     it 'returns the new default modulepath if modules is set' do
-      original = ENV['BOLT_MODULE_FEATURE']
-      ENV['BOLT_MODULE_FEATURE'] = 'true'
-
       expect(project.modulepath).to match_array([(project_path + 'modules').to_s])
-    ensure
-      ENV['BOLT_MODULE_FEATURE'] = original
     end
 
     it 'returns the old default modulepath if modules is not set' do

--- a/spec/integration/plan_spec.rb
+++ b/spec/integration/plan_spec.rb
@@ -72,12 +72,9 @@ describe 'plans' do
 
     context 'with puppet-agent installed for get_resources' do
       around(:each) do |example|
-        original = ENV['BOLT_MODULE_FEATURE']
-        ENV['BOLT_MODULE_FEATURE'] = 'true'
         install(conn_uri('ssh', include_password: true))
         example.run
       ensure
-        ENV['BOLT_MODULE_FEATURE'] = original
         FileUtils.rm_rf(fixture_path('configs', '.resource_types'))
         uninstall(conn_uri('ssh', include_password: true))
       end


### PR DESCRIPTION
### Add 'module' subcommands to pwsh cmdlets module
This adds the `bolt module` subcommands to the Powershell cmdlets module
as `Add-BoltModule`, `Register-BoltModuleTypes`, `Install-BoltModule`,
and `Get-BoltModule`. This call directly into the respective `bolt
module` subcommands and should exhibit the same behavior.

This additionally fixes up the parameters to some Bolt commands in the
powershell module, ensuring that parameters are only included if they
are valid and marking them as optional or required appropriately.
    
Closes #2135
    
!no-release-note

---
### Remove BOLT_MODULE feature flag
This removes the feature flag for the `bolt module` command, now that
the workflow is ready to be marked experimental and shipped. The module
workflow is now only enabled by the presence of the `modules` key in a
`bolt-project.yaml` file.
    
!feature
    
* **New Bolt module subcommand**
    
   The new 'bolt module' subcommand and 'modules' key in project config
   can be used to manage a project's module dependencies, including
   resolving dependencies and version ranges. Use 'bolt project migrate' to
   migrate to the new workflow. See http://pup.pt/bolt-modules for
   documentation. This feature is experimental.