### PR TITLE
(maint) Have modules key accept strings

### DIFF
--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -233,7 +233,7 @@ module Bolt
                        "install` command.",
           type: Array,
           items: {
-            type: Hash,
+            type: [Hash, String],
             required: ["name"],
             properties: {
               "name" => {
@@ -250,6 +250,7 @@ module Bolt
           _plugin: false,
           _example: [
             { "name" => "puppetlabs-mysql" },
+            "puppetlabs-facts",
             { "name" => "puppetlabs-apache", "version_requirement" => "5.5.0" },
             { "name" => "puppetlabs-puppetdb", "version_requirement" => "7.x" },
             { "name" => "puppetlabs-firewall", "version_requirement" => ">= 1.0.0 < 3.0.0" }

--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -174,7 +174,13 @@ module Bolt
     end
 
     def modules
-      @data['modules']
+      @modules ||= @data['modules']&.map do |mod|
+        if mod.is_a?(String)
+          { 'name' => mod }
+        else
+          mod
+        end
+      end
     end
 
     def validate
@@ -205,11 +211,11 @@ module Bolt
         end
 
         @data['modules'].each do |mod|
-          next if mod.is_a?(Hash) && mod.key?('name')
+          next if (mod.is_a?(Hash) && mod.key?('name')) || mod.is_a?(String)
           raise Bolt::ValidationError, "Module declaration #{mod.inspect} must be a hash with a name key"
         end
 
-        unknown_keys = data['modules'].flat_map(&:keys).uniq - %w[name version_requirement]
+        unknown_keys = modules.flat_map(&:keys).uniq - %w[name version_requirement]
         if unknown_keys.any?
           @logs << { warn: "Ignoring unknown keys in module declarations: #{unknown_keys.join(', ')}." }
         end

--- a/spec/bolt/project_spec.rb
+++ b/spec/bolt/project_spec.rb
@@ -53,6 +53,19 @@ describe Bolt::Project do
       end
     end
 
+    describe "with modules specified as strings and hashes" do
+      let(:project_config) {
+        { 'modules' => [
+          'puppetlabs-yaml',
+          { 'name' => 'puppetlabs-apache' }
+        ] }
+      }
+
+      it 'accepts string and hash input, and normalizes' do
+        expect(project.modules).to eq([{ "name" => "puppetlabs-yaml" }, { "name" => "puppetlabs-apache" }])
+      end
+    end
+
     describe "with invalid tasks config" do
       let(:project_config) { { 'tasks' => 'foo' } }
 
@@ -87,10 +100,10 @@ describe Bolt::Project do
           .to raise_error(Bolt::ValidationError)
       end
 
-      it 'errors if a module delcaration is not a hash' do
+      it 'errors if a module delcaration is not a hash or string' do
         config = {
           'modules' => [
-            'puppetlabs-yaml'
+            23
           ]
         }
 


### PR DESCRIPTION
This adds support for the 'modules' key accepting strings in addition to
hashes as part of the modules array. If a module in the array is a
barestring it will be converted to the hash `{ name: <string> }`,
similar to how targets accept a string and treat it as the URI. This
provides a nice shorthand for users listing modules manually. The `bolt
module add` command will still add the hash version.

!no-release-note