### PR TITLE
(bug) Show unknown modules and dependencies when failing to resolve

### DIFF
--- a/spec/bolt/puppetfile_spec.rb
+++ b/spec/bolt/puppetfile_spec.rb
@@ -82,7 +82,18 @@ describe Bolt::Puppetfile do
       it 'errors' do
         expect { puppetfile.resolve }.to raise_error(
           Bolt::Error,
-          /Unknown module name/
+          /Unknown modules.*puppetlabs-boltymcboltface/m
+        )
+      end
+    end
+
+    context 'with unknown module dependencies' do
+      let(:modules) { [{ 'name' => 'aursu-kubeinstall', 'version_requirement' => '0.2.1' }] }
+
+      it 'errors' do
+        expect { puppetfile.resolve }.to raise_error(
+          Bolt::Error,
+          %r{Unknown module dependencies.*aursu/dockerinstall}m
         )
       end
     end


### PR DESCRIPTION
This updates `Bolt::Puppetfile.resolve` to show a list of unknown
modules and unknown module dependencies when unable to resolve modules.
Previously, if resolving modules failed due to an unknown module, only
the unknown modules specified by the user would be shown. Now, Bolt will
use the dependency graph returned by `puppetfile-resolver` to build a
list of unknown modules specified by the user and unknown modules that
are listed as dependencies of another module.

!bug

* **Show unknown module dependencies when failing to resolve modules**

  Bolt now shows the names of unknown module dependencies if it is
  unable to resolve modules due to an unknown module. Previously, Bolt
  would only show the names of unknown modules that were specified by
  the user.