### PR TITLE
(GH-2217) Explicitly pass kwargs to methods that accept them

### DIFF
--- a/lib/bolt/catalog.rb
+++ b/lib/bolt/catalog.rb
@@ -97,7 +97,7 @@ module Bolt
       }
 
       with_puppet_settings(puppet_settings) do
-        Puppet::Pal.in_tmp_environment('bolt_catalog', env_conf) do |pal|
+        Puppet::Pal.in_tmp_environment('bolt_catalog', **env_conf) do |pal|
           Puppet.override(puppet_overrides) do
             Puppet.lookup(:pal_current_node).trusted_data = target['trusted']
             pal.with_catalog_compiler do |compiler|

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -412,7 +412,7 @@ module Bolt
                                   inventory_version: inventory.version)
       end
 
-      analytics.screen_view(screen, screen_view_fields)
+      analytics.screen_view(screen, **screen_view_fields)
 
       case options[:action]
       when 'show'

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -227,7 +227,7 @@ module Bolt
         data[:resource_mean] = sum / resource_counts.length
       end
 
-      @analytics&.event('Apply', 'ast', data)
+      @analytics&.event('Apply', 'ast', **data)
     end
 
     def report_yaml_plan(plan)

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -55,9 +55,9 @@ module Bolt
           when :node_result
             print_result(event[:result]) if @verbose
           when :step_start
-            print_step_start(event) if plan_logging?
+            print_step_start(**event) if plan_logging?
           when :step_finish
-            print_step_finish(event) if plan_logging?
+            print_step_finish(**event) if plan_logging?
           when :plan_start
             print_plan_start(event)
           when :plan_finish

--- a/lib/bolt/outputter/logger.rb
+++ b/lib/bolt/outputter/logger.rb
@@ -13,9 +13,9 @@ module Bolt
       def handle_event(event)
         case event[:type]
         when :step_start
-          log_step_start(event)
+          log_step_start(**event)
         when :step_finish
-          log_step_finish(event)
+          log_step_finish(**event)
         when :plan_start
           log_plan_start(event)
         when :plan_finish

--- a/lib/bolt/plugin/module.rb
+++ b/lib/bolt/plugin/module.rb
@@ -16,7 +16,7 @@ module Bolt
         mod = modules[name]
         if mod&.plugin?
           opts[:mod] = mod
-          plugin = Bolt::Plugin::Module.new(opts)
+          plugin = Bolt::Plugin::Module.new(**opts)
           plugin.setup
           plugin
         else

--- a/lib/bolt/shell/bash.rb
+++ b/lib/bolt/shell/bash.rb
@@ -143,7 +143,7 @@ module Bolt
 
             execute_options[:stdin] = stdin
             execute_options[:sudoable] = true if run_as
-            output = execute(remote_task_path, execute_options)
+            output = execute(remote_task_path, **execute_options)
           end
           Bolt::Result.for_task(target, output.stdout.string,
                                 output.stderr.string,


### PR DESCRIPTION
In some places, we were passing keyword arguments as a hash as the last
argument to the method. This syntax is deprecated in Ruby 2.7 in favor
of explicitly passing them as keyword arguments using the ** operator.
Unfortunately, it's hard to programmatically find places where this
issue occurs since it depends on the definitin of the method, so this
commit is just a first stab.

!no-release-note