### PR TITLE
(bug) Do not allow missing modules when resolving module dependencies

### DIFF
--- a/spec/bolt/puppetfile_spec.rb
+++ b/spec/bolt/puppetfile_spec.rb
@@ -82,7 +82,18 @@ describe Bolt::Puppetfile do
       it 'errors' do
         expect { puppetfile.resolve }.to raise_error(
           Bolt::Error,
-          /Unknown module name/
+          /could not find compatible versions for possibility named "boltymcboltface"/m
+        )
+      end
+    end
+
+    context 'with unknown module dependencies' do
+      let(:modules) { [{ 'name' => 'aursu-kubeinstall', 'version_requirement' => '0.2.1' }] }
+
+      it 'errors' do
+        expect { puppetfile.resolve }.to raise_error(
+          Bolt::Error,
+          /could not find compatible versions for possibility named "dockerinstall"/
         )
       end
     end


### PR DESCRIPTION
This fixes a bug in `Bolt::Puppetfile.resolve` that would allow the
resolver to return a dependency graph with missing module dependencies.
This would result in a graph that was difficult to parse and create a
helpful error for the user that informed them if any modules or their
dependencies could not be found. The resolver now does not permit any
missing module dependencies, which will cause the resolver to error as
soon as it encounters a missing module and notify the user that it could
not be found.

!bug

* **Show missing module dependencies when resolving modules**

  Bolt now correctly displays the names of missing module dependencies
  when resolving module dependencies errors. Previously, if a module
  dependency was missing, Bolt did not display the name of the missing
  module.