### PR TITLE
(docs) Standardize docs on modulepath, not module path

### DIFF
--- a/documentation/applying_manifest_blocks.md
+++ b/documentation/applying_manifest_blocks.md
@@ -99,7 +99,7 @@ in the following order:
 
 Like the code compiled with the `puppet apply` command, all of the variables are
 generated. As a result, you can reuse code between Bolt and Puppet. Bolt then
-copies custom module content from the module path to the targets and applies the
+copies custom module content from the modulepath to the targets and applies the
 catalog using Puppet.
 
 After the catalog compiles and is executed successfully on all targets, `bolt
@@ -188,7 +188,7 @@ in the following order:
 
 Like the code compiled with the `puppet apply` command, all the variables are
 generated. As a result, you can reuse code between Bolt and Puppet. Bolt then
-copies custom module content from the Bolt module path to the targets and
+copies custom module content from the Bolt modulepath to the targets and
 applies the catalog using Puppet.
 
 After the catalog compiles and is executed successfully on all targets, `apply`
@@ -362,7 +362,7 @@ Create a manifest that sets up a web server with nginx, and run it as a plan.
        ) {
 
          # Install the puppet-agent package if Puppet is not detected.
-         # Copy over custom facts from the Bolt module path.
+         # Copy over custom facts from the Bolt modulepath.
          # Run the `facter` command line tool to gather target information.
          $targets.apply_prep
 
@@ -449,7 +449,7 @@ Create a manifest that sets up a web server with IIS and run it as a plan.
        ) {
 
          # Install the puppet-agent package if Puppet is not detected. 
-         # Copy over custom facts from the Bolt module path.
+         # Copy over custom facts from the Bolt modulepath.
          # Run the `facter` command line tool to gather target information.
          $targets.apply_prep
 

--- a/documentation/bolt_installing_modules.md
+++ b/documentation/bolt_installing_modules.md
@@ -80,14 +80,14 @@ This list of packaged modules is available in a
 Bolt repository. The modules and supporting documentation are publicly available
 on the [Puppet Forge](https://forge.puppet.com/). 
 
-> 🔩 **Tip:** To see a list of all modules on your current module path, use
+> 🔩 **Tip:** To see a list of all modules on your current modulepath, use
 > `bolt puppetfile show-modules`.
 
-Modules installed on your module path take precedence over packaged modules with
+Modules installed on your modulepath take precedence over packaged modules with
 the same name. If you need to use a specific version of a packaged module, you
 can override the packaged version by installing the module into your `modules/`
-directory. If you’ve altered the module path in your Bolt configuration, and you
-want to override a packaged module, your altered module path must include the
+directory. If you’ve altered the modulepath in your Bolt configuration, and you
+want to override a packaged module, your altered modulepath must include the
 directory where you’ve installed the module.
 
 **Note:** If you installed Bolt as a Ruby Gem, make sure you have installed

--- a/documentation/bolt_running_tasks.md
+++ b/documentation/bolt_running_tasks.md
@@ -70,14 +70,14 @@ To pass JSON values in PowerShell without worrying about escaping, use
 bolt task run mymodule::mytask --targets app1.myorg.com --params $(@{load_balancers=@("lb1.myorg.com","lb2.myorg.com")} | ConvertTo-Json)
 ```
 
-## Specifying the module path
+## Specifying the modulepath
 
 In order for Bolt to find a task, the task must be in a module on the module
 path. The default modulepath is `[<PROJECT DIRECTORY>/modules, <PROJECT
 DIRECTORY>/site-modules]`.
 
 The current [Bolt project](./experimental_features.md#bolt-projects) is loaded
-as a standalone module at the front of the module path.  If you are developing a
+as a standalone module at the front of the modulepath.  If you are developing a
 new task, you can create a `<PROJECT DIRECTORY>/bolt-project.yaml` file, develop your
 task in `<PROJECT DIRECTORY>/tasks/`, and run Bolt from the root of your Bolt project
 directory to test the task. For more information, see [Bolt

--- a/documentation/inspecting_tasks.md
+++ b/documentation/inspecting_tasks.md
@@ -15,7 +15,7 @@ bolt task run package name=vim action=install --noop -n example.com
 
 ## Show a task list
 
-View a list of what tasks are installed in the current module path. Note that
+View a list of what tasks are installed in the current modulepath. Note that
 tasks marked with the `private` metadata key are not shown:
 
 ```

--- a/documentation/module_structure.md
+++ b/documentation/module_structure.md
@@ -2,9 +2,9 @@
 
 Puppet tasks, plans, functions, classes and types must exist inside a Puppet
 module in order for Bolt to load them. Bolt loads modules by searching for
-module directories on the module path.
+module directories on the modulepath.
 
-By default, the module path includes the `modules` and `site-modules`
+By default, the modulepath includes the `modules` and `site-modules`
 directories in the Bolt project directory. If `bolt-project.yaml` exists at the
 root of the project directory and contains a `name` key, the project itself is
 also loaded as a module and namespaced to the value of `name`. For more
@@ -12,7 +12,7 @@ information on `bolt-project.yaml`, see [Bolt projects](projects.md).
 
 ## Directory structure of a module
 
-A module is a sub-directory of one of the directories on the module path. In
+A module is a sub-directory of one of the directories on the modulepath. In
 order for Bolt to load tasks and plans, they must exist in the `tasks/` or
 `plans/` directory of a module with the correct name.
 
@@ -76,10 +76,10 @@ Follow these tips for managing standalone modules:
 
 -   Add `modules/*` to `.gitignore` of your project to prevent accidentally
     committing standalone modules.
--   When you run tasks and plans within a project directory the module path is
+-   When you run tasks and plans within a project directory the modulepath is
     searched in order for modules containing Bolt content. The Bolt project
-    directory itself is loaded as a module at the front of the module path, and
-    the default module path is `[<PROJECT DIRECTORY>/modules, <PROJECT
+    directory itself is loaded as a module at the front of the modulepath, and
+    the default modulepath is `[<PROJECT DIRECTORY>/modules, <PROJECT
     DIRECTORY>/site-modules]`. If you have a module in both the `modules` and
     `site-modules` directories, the version in `modules` will be used.
 -   As a best practice, write automated tests for the tasks and plans in your

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -441,7 +441,7 @@ module Bolt
     # Returns a mapping of all modules available to the Bolt compiler
     #
     # @return [Hash{String => Array<Hash{Symbol => String,nil}>}]
-    #   A hash that associates each directory on the module path with an array
+    #   A hash that associates each directory on the modulepath with an array
     #   containing a hash of information for each module in that directory.
     #   The information hash provides the name, version, and a string
     #   indicating whether the module belongs to an internal module group.

--- a/lib/bolt_spec/plans/mock_executor.rb
+++ b/lib/bolt_spec/plans/mock_executor.rb
@@ -40,7 +40,7 @@ module BoltSpec
 
       def module_file_id(file)
         modpath = @modulepath.select { |path| file =~ /^#{path}/ }
-        raise "Could not identify module path containing #{file}: #{modpath}" unless modpath.size == 1
+        raise "Could not identify modulepath containing #{file}: #{modpath}" unless modpath.size == 1
 
         path = Pathname.new(file)
         relative = path.relative_path_from(Pathname.new(modpath.first))

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -177,7 +177,7 @@ describe "Bolt::Outputter::Human" do
     TASK_OUTPUT
   end
 
-  it 'prints module path as builtin for builtin modules' do
+  it 'prints modulepath as builtin for builtin modules' do
     name = 'monkey_bread'
     files = [{ 'name' => 'monkey_bread.rb',
                'path' => "#{Bolt::PAL::MODULES_PATH}/monkey/bread" }]


### PR DESCRIPTION
This standardizes referring to the modulepath as 'modulepath', not
module path, in our documentation and code. This is just for clarify, and
avoid having to decide how to refer to the path of modules when writing
docs.

!no-release-note