### PR TITLE
(maint) Add stdlib to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ modules/python_task_helper
 modules/reboot
 modules/ruby_task_helper
 modules/service
+modules/stdlib
 
 modules/augeas_core/
 modules/cron_core/


### PR DESCRIPTION
Bolt includes the 'puppetlabs-stdlib' module in the Puppetfile, so if
you're developing Bolt and install the Puppetfile it will show up in the
git diff. This adds the module to the gitignore so that devs don't
accidentally commit the module to the repo.

!no-release-note