### PR TITLE
(maint) Fix logging levels

### DIFF
--- a/rakelib/pwsh.rake
+++ b/rakelib/pwsh.rake
@@ -301,7 +301,7 @@ namespace :pwsh do
           when 'transport'
             pwsh_param[:validate_set] = Bolt::Config::Options::TRANSPORT_CONFIG.keys
           when 'loglevel'
-            pwsh_param[:validate_set] = %w[debug info notice warn error fatal any]
+            pwsh_param[:validate_set] = %w[trace debug info notice warn error fatal any]
           when 'filter'
             pwsh_param[:validate_pattern] = '^[a-z0-9_:]+$'
           when 'targets'


### PR DESCRIPTION
When the logging changes were implemented in 7b063c640cc7f6f57450247d82db18138cba71d7, we missed added the `trace` level to the validate_set in pwsh.