### PR TITLE
(GH-2226) Do not set module version to latest when migrating

### DIFF
--- a/lib/bolt/puppetfile/module.rb
+++ b/lib/bolt/puppetfile/module.rb
@@ -13,7 +13,7 @@ module Bolt
       def initialize(owner, name, version = nil)
         @owner   = owner
         @name    = name
-        @version = version
+        @version = version unless version == :latest
       end
 
       # Creates a new module from a hash.

--- a/spec/bolt/project_migrator/modules_spec.rb
+++ b/spec/bolt/project_migrator/modules_spec.rb
@@ -131,6 +131,30 @@ describe Bolt::ProjectMigrator::Modules do
       expect(data['modulepath']).to be(nil)
     end
 
+    context 'with a non-versioned module' do
+      let(:puppetfile_content) { "mod 'puppetlabs-yaml'" }
+
+      it 'does not set a version requirement' do
+        expect(migrate).to be(true)
+        data = Bolt::Util.read_yaml_hash(project.project_file, 'project')
+        expect(data['modules']).to match_array([
+                                                 { 'name' => 'puppetlabs-yaml' }
+                                               ])
+      end
+    end
+
+    context 'with a :latest version module' do
+      let(:puppetfile_content) { "mod 'puppetlabs-yaml', :latest" }
+
+      it 'does not set a version requirement' do
+        expect(migrate).to be(true)
+        data = Bolt::Util.read_yaml_hash(project.project_file, 'project')
+        expect(data['modules']).to match_array([
+                                                 { 'name' => 'puppetlabs-yaml' }
+                                               ])
+      end
+    end
+
     context 'without any managed modules' do
       before(:each) do
         allow(Bolt::Util).to receive(:prompt_yes_no).and_return(false)

--- a/spec/bolt/puppetfile/module_spec.rb
+++ b/spec/bolt/puppetfile/module_spec.rb
@@ -13,6 +13,11 @@ describe Bolt::Puppetfile::Module do
     it 'does not require a version' do
       expect(described_class.new('owner', 'name')).to be
     end
+
+    it 'does not set version if version is :latest' do
+      mod = described_class.new('owner', 'name', :latest)
+      expect(mod.version).to be(nil)
+    end
   end
 
   context '#from_hash' do
@@ -98,12 +103,6 @@ describe Bolt::Puppetfile::Module do
     it 'returns a Puppetfile module spec' do
       expect(described_class.new('owner', 'name', '1.0.0').to_spec).to eq(
         'mod "owner-name", "1.0.0"'
-      )
-    end
-
-    it 'returns a Puppetfile module spec with :latest' do
-      expect(described_class.new('owner', 'name', :latest).to_spec).to eq(
-        'mod "owner-name", :latest'
       )
     end
 


### PR DESCRIPTION
This prevents a module's version requirement in `bolt-project.yaml` from
being set to the string `:latest` when migrating a project. Previously,
if a Puppetfile had a module specification with either a version
`:latest` or no version at all, the module's version requirement would
be set to `:latest`, which is not valid. Now, in these instances the
module will not have a version requirement in the `bolt-project.yaml`.

!no-release-note