### PR TITLE
(maint) Print unsuccessful migration in red

### DIFF
--- a/lib/bolt/outputter.rb
+++ b/lib/bolt/outputter.rb
@@ -35,6 +35,10 @@ module Bolt
       raise NotImplementedError, "print_message() must be implemented by the outputter class"
     end
 
+    def print_error
+      raise NotImplementedError, "print_error() must be implemented by the outputter class"
+    end
+
     def stringify(message)
       formatted = format_message(message)
       if formatted.is_a?(Hash) || formatted.is_a?(Array)

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -401,6 +401,10 @@ module Bolt
         @stream.puts(message)
       end
 
+      def print_error(message)
+        @stream.puts(colorize(:red, message))
+      end
+
       def print_prompt(prompt)
         @stream.print(colorize(:cyan, indent(4, prompt)))
       end

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -135,6 +135,7 @@ module Bolt
       def print_message(message)
         $stderr.puts(message)
       end
+      alias print_error print_message
 
       def print_migrate_step(step)
         $stderr.puts(step)

--- a/lib/bolt/project_migrator.rb
+++ b/lib/bolt/project_migrator.rb
@@ -36,7 +36,7 @@ module Bolt
       if ok
         @outputter.print_message("Project successfully migrated")
       else
-        @outputter.print_message("Project could not be migrated completely")
+        @outputter.print_error("Project could not be migrated completely")
       end
 
       ok ? 0 : 1

--- a/spec/bolt/project_migrator_spec.rb
+++ b/spec/bolt/project_migrator_spec.rb
@@ -9,7 +9,13 @@ describe Bolt::ProjectMigrator do
   include BoltSpec::Project
 
   let(:config)    { Bolt::Config.from_project(project) }
-  let(:outputter) { double('outputter', print_message: nil, print_migrate_step: nil, print_prompt: nil) }
+  let(:outputter) {
+    double('outputter',
+           print_message: nil,
+           print_migrate_step: nil,
+           print_prompt: nil,
+           print_error: nil)
+  }
 
   let(:migrator)           { described_class.new(config, outputter) }
   let(:config_migrator)    { double('config_migrator', migrate: true) }


### PR DESCRIPTION
This modifies the 'Project could not be migrated completely' message
when project migration fails to be printed in red, letting the user know
at a glance that something went wrong. After migrating a project it's
easy to not read the output if it all looks successful at a glance.
Printing in red emphasizes that something in the migration needs the
users attention, and potentially manual migration.

!no-release-note