### PR TITLE
(maint) Group label for project dependencies in bolt module show

### DIFF
--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -447,7 +447,8 @@ module Bolt
     #   indicating whether the module belongs to an internal module group.
     def list_modules
       internal_module_groups = { BOLTLIB_PATH => 'Plan Language Modules',
-                                 MODULES_PATH => 'Packaged Modules' }
+                                 MODULES_PATH => 'Packaged Modules',
+                                 @project.managed_moduledir => 'Project Dependencies' }
 
       in_bolt_compiler do
         # NOTE: Can replace map+to_h with transform_values when Ruby 2.4


### PR DESCRIPTION
Previously, `bolt module show` would prefix the list of installed
project dependencies with the full path to the `.modules` directory.
Since that directory is meant to be fully managed and internal, we now
replace the explicit path with a label indicating that these are the
project dependency modules.

!no-release-note