### PR TITLE
(maint) Surface Puppetfile Resolver validation errors

### DIFF
--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -423,6 +423,19 @@ module Bolt
         @stream.puts(step)
       end
 
+      def print_migrate_error(error)
+        # Running everything through 'wrap' messes with newlines. Separating
+        # into lines and wrapping each individually ensures separate errors are
+        # distinguishable.
+        first, *remaining = error.lines
+        first = colorize(:red, indent(2, "→ #{wrap(first, 76)}"))
+        wrapped = remaining.map { |l| wrap(l) }
+        to_print = wrapped.map { |line| colorize(:red, indent(4, line)) }
+        step = [first, *to_print, "\n"].join
+
+        @stream.puts(step)
+      end
+
       def duration_to_string(duration)
         hrs = (duration / 3600).floor
         mins = ((duration % 3600) / 60).floor

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -140,6 +140,7 @@ module Bolt
       def print_migrate_step(step)
         $stderr.puts(step)
       end
+      alias print_migrate_error print_migrate_step
     end
   end
 end

--- a/lib/bolt/project_migrator/modules.rb
+++ b/lib/bolt/project_migrator/modules.rb
@@ -49,7 +49,7 @@ module Bolt
           @outputter.print_migrate_step("Parsing Puppetfile at #{puppetfile_path}")
           puppetfile = Bolt::Puppetfile.parse(puppetfile_path, skip_unsupported_modules: true)
         rescue Bolt::Error => e
-          @outputter.print_migrate_step("#{e.message} Skipping module migration.")
+          @outputter.print_migrate_error("#{e.message}\nSkipping module migration.")
           return false
         end
 
@@ -65,7 +65,7 @@ module Bolt
           @outputter.print_migrate_step("Resolving module dependencies, this may take a moment")
           puppetfile.resolve
         rescue Bolt::Error => e
-          @outputter.print_migrate_step("#{e.message} Skipping module migration.")
+          @outputter.print_migrate_error("#{e.message}\nSkipping module migration.")
           return false
         end
 

--- a/lib/bolt/puppetfile.rb
+++ b/lib/bolt/puppetfile.rb
@@ -33,9 +33,12 @@ module Bolt
       end
 
       unless parsed.valid?
-        raise Bolt::ValidationError,
-              "Unable to parse Puppetfile #{path}. This may not be a Puppetfile "\
-              "managed by Bolt."
+        # valid? Just checks if validation_errors is empty, so if we get here we know it's not.
+        raise Bolt::ValidationError, <<~MSG
+        Unable to parse Puppetfile #{path}:
+        #{parsed.validation_errors.join("\n\n")}.
+        This may not be a Puppetfile managed by Bolt.
+        MSG
       end
 
       modules = parsed.modules.each_with_object([]) do |mod, acc|

--- a/spec/bolt/project_migrator/modules_spec.rb
+++ b/spec/bolt/project_migrator/modules_spec.rb
@@ -20,7 +20,12 @@ describe Bolt::ProjectMigrator::Modules do
     FileUtils.touch(@tmpdir + 'site' + 'baz' + 'good')
   end
 
-  let(:outputter)      { double('outputter', print_message: nil, print_migrate_step: nil) }
+  let(:outputter) {
+    double('outputter',
+           print_message: nil,
+           print_migrate_step: nil,
+           print_migrate_error: nil)
+  }
   let(:project_config) { {} }
   let(:project)        { Bolt::Project.new(project_config, @tmpdir) }
   let(:modulepath)     { project.modulepath }

--- a/spec/bolt/puppetfile_spec.rb
+++ b/spec/bolt/puppetfile_spec.rb
@@ -65,6 +65,14 @@ describe Bolt::Puppetfile do
       puppetfile = described_class.parse(path, skip_unsupported_modules: true)
       expect(puppetfile.modules.any?).to be(false)
     end
+
+    it 'surfaces errors from the Puppetfile resolver' do
+      File.write(path, "mod 'puppetlabs-yaml', install_path: '/foo/bar'")
+      expect { described_class.parse(path) }.to raise_error(
+        Bolt::ValidationError,
+        /Module puppetlabs-yaml with args.*doesn't have an implementation./
+      )
+    end
   end
 
   context '#write' do


### PR DESCRIPTION
We currently hardcode an error message when Puppetfile Resolver
successfully resolves a Puppetfile but with validation errors. This
updates the message to print the list of validation errors when
Puppetfile Resolver encounters them.

This additionally adds a format for migrate steps that fail, coloring
them red to indicate failure but maintaining the indent.

!no-release-note

![image](https://user-images.githubusercontent.com/5055819/94621268-d9438c80-0264-11eb-9dd3-bef780f49bcd.png)
