### PR TITLE
(GH-2197) Error gracefully when yaml plans fail to parse

### DIFF
--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -29,15 +29,12 @@ module Bolt
         message = err.cause ? err.cause.message : err.message
 
         # Provide the location of an error if it came from a plan
-        details = if defined?(err.file) && err.file
-                    { file:   err.file,
-                      line:   err.line,
-                      column: err.pos }.compact
-                  else
-                    {}
-                  end
+        details = {}
+        details[:file]   = err.file if defined?(err.file)
+        details[:line]   = err.line if defined?(err.line)
+        details[:column] = err.pos if defined?(err.pos)
 
-        e = new(message, details)
+        e = new(message, details.compact)
 
         e.set_backtrace(err.backtrace)
         e

--- a/spec/fixtures/modules/yaml/plans/invalid.yaml
+++ b/spec/fixtures/modules/yaml/plans/invalid.yaml
@@ -1,0 +1,12 @@
+parameters:
+  targets:
+    type: TargetSpec
+    description: A list of targets to run actions on
+    default: localhost
+
+# The steps key defines the actions the plan will take in order.
+steps:
+ - resources:
+    - class: prometheus
+    targets: $targets
+    description: 'Install prometheus'

--- a/spec/integration/yaml_plan_spec.rb
+++ b/spec/integration/yaml_plan_spec.rb
@@ -150,6 +150,13 @@ describe "running YAML plans", ssh: true do
     expect(result['msg']).to match(/Parse error in step "x_fail":/)
   end
 
+  it 'fails gracefully when the yaml plan contains errors' do
+    result = run_plan('yaml::invalid', targets: target)
+
+    expect(result['kind']).to eq("bolt/pal-error")
+    expect(result['msg']).to match(/did not find expected '-' indicator.*at line 10 column 5/)
+  end
+
   it 'passes information between steps' do
     result = run_plan('yaml::param_passing')
 


### PR DESCRIPTION
Previously when raising an error from a plan run in Bolt we would only
check if the error had a `file` method and use that to determine whether
the error was from Puppet or not. If the error was from Puppet we could
assume other methods on the error, like line and pos. However,
when yaml plans were syntactically invalid and failed to parse this
would raise a Psych::SyntaxError, which has a `file` method but not a
`pos` method. This would cause a stacktrace when we assumed the error
was a Puppet error and tried to call `pos` on it.

This change modifies the details hash to only add each key if the
corresponding method exists on the error. We can't be sure this will
catch all relevant details from an error (for example if the `pos`
exists on an error but is accessed by a method `position`), but it will
at least not stacktrace when a non-Puppet error with any of those
methods is raised.

Closes #2197

!bug

* **Invalid YAML plans now fail gracefully** ([2197](https://github.com/puppetlabs/bolt/issue/2197))

  Previously, if a YAML plan had a syntax error Bolt would stacktrace
  due to an assumption about what methods the resulting error had. It now
  fails gracefully with the line of the error.