### PR TITLE
(GH-2234) Add moduledir to generated Puppetfile

### DIFF
--- a/documentation/bolt.ditamap
+++ b/documentation/bolt.ditamap
@@ -79,7 +79,7 @@
                 <shortdesc>Use module structure if you use Forge modules with Bolt, or you want to develop your own modules to share tasks and plans.</shortdesc>
             </topicmeta>
         </topicref>
-    </topicref>    
+    </topicref>
     <topichead navtitle="Using Bolt with Puppet">
         <topicref href="applying_manifest_blocks.md" format="markdown"/>
         <topicref href="bolt_configure_orchestrator.md" format="markdown"/>

--- a/documentation/bolt.ditamap
+++ b/documentation/bolt.ditamap
@@ -79,7 +79,7 @@
                 <shortdesc>Use module structure if you use Forge modules with Bolt, or you want to develop your own modules to share tasks and plans.</shortdesc>
             </topicmeta>
         </topicref>
-    </topicref>
+    </topicref>    
     <topichead navtitle="Using Bolt with Puppet">
         <topicref href="applying_manifest_blocks.md" format="markdown"/>
         <topicref href="bolt_configure_orchestrator.md" format="markdown"/>

--- a/documentation/managing_modules.md
+++ b/documentation/managing_modules.md
@@ -48,7 +48,7 @@ the `modules` key in your `bolt-project.yaml`, resolves the modules and their
 dependencies, generates a Puppetfile listing all of the modules to install, and
 then installs the modules.
 
-If your project needs another module, you can use the `bolt module add` command to add the module to your
+If your project needs another module, you can use Bolt to add the module to your
 project configuration, generate a new Puppetfile that includes the new module
 and its dependencies, and install the modules.
 

--- a/documentation/managing_modules.md
+++ b/documentation/managing_modules.md
@@ -48,7 +48,7 @@ the `modules` key in your `bolt-project.yaml`, resolves the modules and their
 dependencies, generates a Puppetfile listing all of the modules to install, and
 then installs the modules.
 
-If your project needs another module, you can use Bolt to add the module to your
+If your project needs another module, you can use the `bolt module add` command to add the module to your
 project configuration, generate a new Puppetfile that includes the new module
 and its dependencies, and install the modules.
 
@@ -238,6 +238,19 @@ message if it cannot resolve a dependency due to a version requirement.
 > 🔩 **Tip**: For information on how to specify module versions, see the Puppet
 > documentation on [Specifying
 > versions](https://puppet.com/docs/puppet/latest/modules_metadata.html#specifying-versions).
+
+## Compatibility with Bolt versions
+
+The new module management style is incompatible with older Bolt versions, since it sets the
+moduledir in the Puppetfile to `.modules/` which is not on the modulepath in versions < 2.30.0. If
+you're using the new module management system in an environment in Puppet Enterprise, you need to
+specify `.modules` on the modulepath in your [environment.conf](https://puppet.com/docs/puppet/latest/config_file_environment.html#example), like so:
+
+```
+# /etc/puppetlabs/code/environments/test/environment.conf
+
+modulepath = site:dist:modules:$basemodulepath:.modules
+```
 
 ## Examples
 

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -391,7 +391,7 @@ module Bolt
         @logs << { warn: msg }
       end
 
-      if @project.modules && @data['modulepath']&.include?(@project.managed_moduledir)
+      if @project.modules && @data['modulepath']&.include?(@project.managed_moduledir.to_s)
         raise Bolt::ValidationError,
               "Found invalid path in modulepath: #{@project.managed_moduledir}. This path "\
               "is automatically appended to the modulepath and cannot be configured."
@@ -454,7 +454,7 @@ module Bolt
       path = @data['modulepath'] || @project.modulepath
 
       if @project.modules
-        path + [@project.managed_moduledir]
+        path + [@project.managed_moduledir.to_s]
       else
         path
       end

--- a/lib/bolt/module_installer.rb
+++ b/lib/bolt/module_installer.rb
@@ -55,7 +55,7 @@ module Bolt
 
       # Write the Puppetfile.
       @outputter.print_message "Writing Puppetfile at #{puppetfile_path}"
-      puppetfile.write(puppetfile_path)
+      puppetfile.write(puppetfile_path, moduledir)
 
       # Install the modules.
       install_puppetfile(puppetfile_path, moduledir)
@@ -114,7 +114,16 @@ module Bolt
           puppetfile.resolve
 
           @outputter.print_message "Writing Puppetfile at #{path}"
-          puppetfile.write(path)
+          # We get here either through 'bolt module install' which uses the
+          # managed modulepath (which isn't configurable) or through bolt
+          # project init --modules, which uses the default modulepath. This
+          # should be safe to assume that if `.modules/` is the moduledir the
+          # user is using the new workflow
+          if moduledir.basename == '.modules'
+            puppetfile.write(path, moduledir)
+          else
+            puppetfile.write(path)
+          end
         end
       end
 

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -97,7 +97,7 @@ module Bolt
       def print_puppetfile_result(success, puppetfile, moduledir)
         @stream.puts({ "success": success,
                        "puppetfile": puppetfile,
-                       "moduledir": moduledir }.to_json)
+                       "moduledir": moduledir.to_s }.to_json)
       end
 
       def print_targets(targets)

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -448,7 +448,7 @@ module Bolt
     def list_modules
       internal_module_groups = { BOLTLIB_PATH => 'Plan Language Modules',
                                  MODULES_PATH => 'Packaged Modules',
-                                 @project.managed_moduledir => 'Project Dependencies' }
+                                 @project.managed_moduledir.to_s => 'Project Dependencies' }
 
       in_bolt_compiler do
         # NOTE: Can replace map+to_h with transform_values when Ruby 2.4

--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -103,7 +103,7 @@ module Bolt
       @type              = type
       @downloads         = @path + 'downloads'
       @plans_path        = @path + 'plans'
-      @managed_moduledir = (@path + '.modules').to_s
+      @managed_moduledir = @path + '.modules'
       @backup_dir        = @path + '.bolt-bak'
 
       tc = Bolt::Config::INVENTORY_OPTIONS.keys & raw_data.keys

--- a/lib/bolt/project_migrator/modules.rb
+++ b/lib/bolt/project_migrator/modules.rb
@@ -94,7 +94,7 @@ module Bolt
 
           # Write Puppetfile
           @outputter.print_migrate_step("Updating Puppetfile at #{puppetfile_path}")
-          puppetfile.write(puppetfile_path)
+          puppetfile.write(puppetfile_path, managed_moduledir)
 
           # Install Puppetfile
           @outputter.print_migrate_step("Syncing modules from #{puppetfile_path} to #{managed_moduledir}")

--- a/lib/bolt/puppetfile.rb
+++ b/lib/bolt/puppetfile.rb
@@ -56,9 +56,10 @@ module Bolt
     # Writes a Puppetfile that includes specifications for each of the
     # modules.
     #
-    def write(path)
+    def write(path, moduledir = nil)
       File.open(path, 'w') do |file|
         file.puts '# This Puppetfile is managed by Bolt. Do not edit.'
+        file.puts "moduledir '#{moduledir.basename}'" if moduledir
         modules.each { |mod| file.puts mod.to_spec }
       end
     rescue SystemCallError => e

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -2882,6 +2882,7 @@ describe "Bolt::CLI" do
 
             expect(lines).to match_array([/mod "puppetlabs-yaml"/,
                                           /mod "puppetlabs-ruby_task_helper"/])
+            expect(lines).not_to include(/moduledir/)
 
             expect(Dir.exist?(modulepath)).to be
             expect(Dir.children(modulepath)).to match_array(%w[yaml ruby_task_helper])

--- a/spec/bolt/project_migrator/modules_spec.rb
+++ b/spec/bolt/project_migrator/modules_spec.rb
@@ -87,6 +87,13 @@ describe Bolt::ProjectMigrator::Modules do
       )
     end
 
+    it 'writes a new Puppetfile with the new moduledir' do
+      expect(migrate).to be(true)
+      expect(File.read(project.puppetfile).lines).to include(
+        /moduledir '.*\.modules'/
+      )
+    end
+
     it 'installs modules to the managed moduledir' do
       expect(migrate).to be(true)
       expect(Dir.exist?(project.managed_moduledir)).to be(true)


### PR DESCRIPTION
When generating the Puppetfile from the list of modules in
`bolt-project.yaml`, we now add the line `moduledir '.modules'` to
prevent R10K and old versions of Bolt from deleting the `modules/`
directory and installing modules from the Puppetfile to the wrong
location. This essentially ensures that using the new module management
workflow is safe with legacy tools, as the Puppetfile knows to install
modules to the new modules directory `.modules/` instead of installing
to `modules/` which should now be treated as a place for users' custom
modules. This line is only added when generating a new Puppetfile using
the new module management workflow - behavior is not modified if using
`bolt project init --modules`, which still uses the old workflow.

This additionally documents configuring the modulepath in PE
environments to pick up the new modulepath.

Closes #2234

!no-release-note

Note: I rebased this on #2204, so that needs to go in first in order to add the docs.
