### PR TITLE
(GH-2167) Add note that pry-remote and pry-nave do not work together

### DIFF
--- a/documentation/writing_tasks.md
+++ b/documentation/writing_tasks.md
@@ -1222,6 +1222,9 @@ From: /tmp/4f9dcfa3-ce0c-49e2-bcf5-8d761b202186/ruby/tasks/init.rb @ line 9 MyCl
     10:
 ```
 
+> **Note:** pry-remote does not work with pry-byebug or pry-nav in Ruby 2.x. Use 'help' in the pry
+> debugger for a list of available commands.
+
 📖 **Related information**
 - [`pry-remote` documentation](https://www.rubydoc.info/gems/pry-remote)
 - [`pry` documentation](http://pry.github.io/)


### PR DESCRIPTION
This adds a note to the 'Debugging Tasks' section of the docs under the
ruby section that the library we recommend, 'pry-remote', does not work
with common pry libraries 'pry-nav' and 'pry-byebug'. This issues is
[known](https://github.com/Mon-Ouie/pry-remote/issues/35#issuecomment-20290739)
and does not seem likely to be resolved.

I opted not to include this in our known issues page since this isn't an
issue with Bolt itself.

Closes #2167

!no-release-note