### PR TITLE
Extract config parsing out of PAL

### DIFF
--- a/bolt-modules/boltlib/spec/functions/resolve_references_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/resolve_references_spec.rb
@@ -7,7 +7,7 @@ describe 'resolve_references' do
   include PuppetlabsSpec::Fixtures
   let(:project)       { Bolt::Project.create_project('./spec/fixtures') }
   let(:config)        { Bolt::Config.new(project, {}) }
-  let(:pal)           { Bolt::PAL.new(config.modulepath, config.hiera_config, config.project.resource_types) }
+  let(:pal)           { Bolt::PAL.new(config) }
   let(:plugins)       { Bolt::Plugin.setup(config, pal) }
   let(:executor)      { Bolt::Executor.new }
   let(:inventory)     { Bolt::Inventory.create_version({}, config.transport, config.transports, plugins) }

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -962,13 +962,7 @@ module Bolt
     end
 
     def pal
-      @pal ||= Bolt::PAL.new(config.modulepath,
-                             config.hiera_config,
-                             config.project.resource_types,
-                             config.compile_concurrency,
-                             config.trusted_external,
-                             config.apply_settings,
-                             config.project)
+      @pal ||= Bolt::PAL.new(config)
     end
 
     # Collects the list of Bolt guides and maps them to their topics.
@@ -1061,7 +1055,7 @@ module Bolt
                   'Task' => [],
                   'Plugin' => Bolt::Plugin::BUILTIN_PLUGINS }
       if %w[plan task].include?(options[:subcommand]) && options[:action] == 'run'
-        default_content = Bolt::PAL.new([], nil, nil)
+        default_content = Bolt::PAL.new(Bolt::Config.new(Bolt::Project.default_project, {}, { :modulepath => [] }))
         content['Plan'] = default_content.list_plans.each_with_object([]) do |iter, col|
           col << iter&.first
         end
@@ -1076,7 +1070,7 @@ module Bolt
     # Gem installs include the aggregate, canary, and puppetdb_fact modules, while
     # package installs include modules listed in the Bolt repo Puppetfile
     def incomplete_install?
-      (Dir.children(Bolt::PAL::MODULES_PATH) - %w[aggregate canary puppetdb_fact secure_env_vars]).empty?
+      (Dir.children(Bolt::Config::MODULES_PATH) - %w[aggregate canary puppetdb_fact secure_env_vars]).empty?
     end
 
     # Mimicks the output from Outputter::Human#fatal_error. This should be used to print

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -23,6 +23,8 @@ module Bolt
 
     BOLT_CONFIG_NAME = 'bolt.yaml'
     BOLT_DEFAULTS_NAME = 'bolt-defaults.yaml'
+    BOLTLIB_PATH = File.expand_path('../../bolt-modules', __dir__)
+    MODULES_PATH = File.expand_path('../../modules', __dir__)
 
     # The default concurrency value that is used when the ulimit is not low (i.e. < 700)
     DEFAULT_DEFAULT_CONCURRENCY = 100
@@ -462,6 +464,14 @@ module Bolt
 
     def modulepath=(value)
       @data['modulepath'] = value
+    end
+
+    # The modified_modulepath is used by bolt internally as the real
+    # modulepath used during plan execution. The modifications add
+    # BOLTLIB_PATH and MODULES_PATH to ensure that plan functions,
+    # bolt types, and built in content are available.
+    def modified_modulepath
+      [BOLTLIB_PATH, *modulepath, MODULES_PATH]
     end
 
     def concurrency

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -248,7 +248,7 @@ module Bolt
         task_info << "MODULE:\n"
 
         path = task.files.first['path'].chomp("/tasks/#{task.files.first['name']}")
-        task_info << if path.start_with?(Bolt::PAL::MODULES_PATH)
+        task_info << if path.start_with?(Bolt::Config::MODULES_PATH)
                        "built-in module"
                      else
                        path
@@ -278,7 +278,7 @@ module Bolt
         plan_info << "MODULE:\n"
 
         path = plan['module']
-        plan_info << if path.start_with?(Bolt::PAL::MODULES_PATH)
+        plan_info << if path.start_with?(Bolt::Config::MODULES_PATH)
                        "built-in module"
                      else
                        path

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -48,7 +48,7 @@ module Bolt
 
       def print_task_info(task)
         path = task.files.first['path'].chomp("/tasks/#{task.files.first['name']}")
-        module_dir = if path.start_with?(Bolt::PAL::MODULES_PATH)
+        module_dir = if path.start_with?(Bolt::Config::MODULES_PATH)
                        "built-in module"
                      else
                        path
@@ -62,7 +62,7 @@ module Bolt
 
       def print_plan_info(plan)
         path = plan.delete('module')
-        plan['module_dir'] = if path.start_with?(Bolt::PAL::MODULES_PATH)
+        plan['module_dir'] = if path.start_with?(Bolt::Config::MODULES_PATH)
                                "built-in module"
                              else
                                path

--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -190,7 +190,7 @@ module Bolt
           Invalid project name '#{name}' in bolt-project.yaml; project name must begin with a lowercase letter
           and can include lowercase letters, numbers, and underscores.
           ERROR_STRING
-        elsif Dir.children(Bolt::PAL::BOLTLIB_PATH).include?(name)
+        elsif Dir.children(Bolt::Config::BOLTLIB_PATH).include?(name)
           raise Bolt::ValidationError, "The project '#{name}' will not be loaded. The project name conflicts "\
             "with a built-in Bolt module of the same name."
         end

--- a/lib/bolt_server/pe/pal.rb
+++ b/lib/bolt_server/pe/pal.rb
@@ -54,12 +54,12 @@ module BoltServer
           environment = Puppet.lookup(:environments).get!(environment_name)
           # A new modulepath is created from scratch (rather than using super's @modulepath)
           # so that we can have full control over all the entries in modulepath. In the future
-          # it's likely we will need to preceed _both_ Bolt::PAL::BOLTLIB_PATH _and_
-          # Bolt::PAL::MODULES_PATH which would be more complex if we tried to use @modulepath since
+          # it's likely we will need to preceed _both_ Bolt::Config::BOLTLIB_PATH _and_
+          # Bolt::Config::MODULES_PATH which would be more complex if we tried to use @modulepath since
           # we need to append our modulepaths and exclude modules shiped in bolt gem code
           modulepath_dirs = environment.modulepath
           @user_modulepath = modulepath_dirs
-          @modulepath = [PE_BOLTLIB_PATH, Bolt::PAL::BOLTLIB_PATH, *modulepath_dirs]
+          @modulepath = [PE_BOLTLIB_PATH, Bolt::Config::BOLTLIB_PATH, *modulepath_dirs]
         end
       end
     end

--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -213,12 +213,12 @@ module BoltServer
       @pal_mutex.synchronize do
         project = Bolt::Project.create_project(project_dir)
         bolt_config = Bolt::Config.from_project(project, { log: { 'bolt-debug.log' => 'disable' } })
-        pal = Bolt::PAL.new(bolt_config.modulepath, nil, nil, nil, nil, nil, bolt_config.project)
+        pal = Bolt::PAL.new(bolt_config)
         module_path = [
           BoltServer::PE::PAL::PE_BOLTLIB_PATH,
-          Bolt::PAL::BOLTLIB_PATH,
+          Bolt::Config::BOLTLIB_PATH,
           *bolt_config.modulepath,
-          Bolt::PAL::MODULES_PATH
+          Bolt::Config::MODULES_PATH
         ]
         # CODEREVIEW: I *think* this is the only thing we need to make different between bolt's PAL. Is it acceptable
         # to hack this? Modulepath is currently a readable attribute, could we make it writeable?

--- a/lib/bolt_spec/bolt_context.rb
+++ b/lib/bolt_spec/bolt_context.rb
@@ -105,7 +105,7 @@ module BoltSpec
 
       # Set the things
       Puppet[:tasks] = true
-      RSpec.configuration.module_path = [modulepath, Bolt::PAL::BOLTLIB_PATH].join(File::PATH_SEPARATOR)
+      RSpec.configuration.module_path = [modulepath, Bolt::Config::BOLTLIB_PATH].join(File::PATH_SEPARATOR)
       opts = {
         bolt_executor: executor,
         bolt_inventory: inventory,
@@ -153,7 +153,7 @@ module BoltSpec
     end
 
     def pal
-      @pal ||= Bolt::PAL.new(config.modulepath, config.hiera_config, config.project.resource_types)
+      @pal ||= Bolt::PAL.new(config)
     end
 
     BoltSpec::Plans::MOCKED_ACTIONS.each do |action|

--- a/lib/bolt_spec/plans.rb
+++ b/lib/bolt_spec/plans.rb
@@ -223,15 +223,7 @@ module BoltSpec
     end
 
     def run_plan(name, params)
-      pal = Bolt::PAL.new(
-        config.modulepath,
-        config.hiera_config,
-        config.project.resource_types,
-        config.compile_concurrency,
-        config.trusted_external,
-        config.apply_settings,
-        config.project
-      )
+      pal = Bolt::PAL.new(config)
 
       result = executor.with_plan_allowed_exec(name, params) do
         pal.run_plan(name, params, executor, inventory, puppetdb_client)

--- a/lib/bolt_spec/run.rb
+++ b/lib/bolt_spec/run.rb
@@ -179,10 +179,7 @@ module BoltSpec
       end
 
       def pal
-        @pal ||= Bolt::PAL.new(config.modulepath,
-                               config.hiera_config,
-                               config.project.resource_types,
-                               config.compile_concurrency)
+        @pal ||= Bolt::PAL.new(config)
       end
 
       def resolve_targets(target_spec)

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -20,7 +20,7 @@ describe Bolt::Applicator do
                                'token' => 'token')
   end
   let(:pdb_client) { Bolt::PuppetDB::Client.new(config) }
-  let(:modulepath) { [Bolt::PAL::BOLTLIB_PATH, Bolt::PAL::MODULES_PATH] }
+  let(:modulepath) { [Bolt::Config::BOLTLIB_PATH, Bolt::Config::MODULES_PATH] }
   let(:applicator) { Bolt::Applicator.new(inventory, executor, modulepath, plugindirs, nil, pdb_client, nil, 2, {}) }
   let(:ast) { { 'resources' => [] } }
 

--- a/spec/bolt/catalog_spec.rb
+++ b/spec/bolt/catalog_spec.rb
@@ -13,7 +13,7 @@ describe Bolt::Catalog do
   let(:target) { inventory.get_target(uri) }
   let(:inventory) { Bolt::Inventory.empty }
   let(:executor) { Bolt::Executor.new }
-  let(:boltlib) { Bolt::PAL::BOLTLIB_PATH }
+  let(:boltlib) { Bolt::Config::BOLTLIB_PATH }
   let(:pdb_config) do
     Bolt::PuppetDB::Config.new('server_urls' => 'https://localhost:8081',
                                'cacert' => '/path/to/cacert',

--- a/spec/bolt/inventory/group_spec.rb
+++ b/spec/bolt/inventory/group_spec.rb
@@ -795,7 +795,7 @@ describe Bolt::Inventory::Group do
     let(:lookup_data) { {} }
 
     let(:modulepath) { [''] }
-    let(:pal) { Bolt::PAL.new(modulepath, nil, nil) }
+    let(:pal) { Bolt::PAL.new(Bolt::Config.new(Bolt::Project.default_project, {}, { :modulepath => modulepath })) }
 
     let(:plugins) do
       plugins = Bolt::Plugin.setup(config, pal)

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -180,7 +180,7 @@ describe "Bolt::Outputter::Human" do
   it 'prints modulepath as builtin for builtin modules' do
     name = 'monkey_bread'
     files = [{ 'name' => 'monkey_bread.rb',
-               'path' => "#{Bolt::PAL::MODULES_PATH}/monkey/bread" }]
+               'path' => "#{Bolt::Config::MODULES_PATH}/monkey/bread" }]
     metadata = {}
     outputter.print_task_info(Bolt::Task.new(name, metadata, files))
     expect(output.string).to eq(<<~TASK_OUTPUT)
@@ -199,7 +199,7 @@ describe "Bolt::Outputter::Human" do
     task = {
       'name' => 'monkey_bread',
       'files' => [{ 'name' => 'monkey_bread.rb',
-                    'path' => "#{Bolt::PAL::MODULES_PATH}/monkey/bread" }],
+                    'path' => "#{Bolt::Config::MODULES_PATH}/monkey/bread" }],
       'metadata' => {}
     }
     outputter.print_tasks([task], %w[path1 path2])

--- a/spec/bolt/outputter/json_spec.rb
+++ b/spec/bolt/outputter/json_spec.rb
@@ -70,7 +70,7 @@ describe "Bolt::Outputter::JSON" do
   it "prints builtin for builtin modules" do
     name = 'monkey bread'
     files = [{ 'name' => 'monkey_bread.rb',
-               'path' => "#{Bolt::PAL::MODULES_PATH}/monkey/bread" }]
+               'path' => "#{Bolt::Config::MODULES_PATH}/monkey/bread" }]
     metadata = {}
 
     result = {

--- a/spec/bolt/pal/yaml_plan/evaluator_spec.rb
+++ b/spec/bolt/pal/yaml_plan/evaluator_spec.rb
@@ -6,7 +6,7 @@ require 'bolt/pal/yaml_plan/evaluator'
 
 describe Bolt::PAL::YamlPlan::Evaluator do
   let(:plan_name) { Puppet::Pops::Loader::TypedName.new(:plan, 'test') }
-  let(:pal) { Bolt::PAL.new([], nil, nil) }
+  let(:pal) { Bolt::PAL.new(Bolt::Config.default) }
   # It doesn't really matter which loader or scope we use, but we need them, so take the
   # static loader and global scope
   let(:loader) { Puppet.lookup(:loaders).static_loader }

--- a/spec/bolt/pal/yaml_plan/loader_spec.rb
+++ b/spec/bolt/pal/yaml_plan/loader_spec.rb
@@ -6,7 +6,7 @@ require 'bolt/pal/yaml_plan/loader'
 
 describe Bolt::PAL::YamlPlan::Loader do
   let(:plan_name) { Puppet::Pops::Loader::TypedName.new(:plan, 'test') }
-  let(:pal) { Bolt::PAL.new([], nil, nil) }
+  let(:pal) { Bolt::PAL.new(Bolt::Config.default) }
   # It doesn't really matter which loader or scope we use, but we need them, so take the
   # static loader and global scope
   let(:loader) { Puppet.lookup(:loaders).static_loader }

--- a/spec/bolt/pal/yaml_plan_spec.rb
+++ b/spec/bolt/pal/yaml_plan_spec.rb
@@ -6,7 +6,7 @@ require 'bolt/pal/yaml_plan'
 
 describe Bolt::PAL::YamlPlan do
   let(:plan_name) { Puppet::Pops::Loader::TypedName.new(:plan, 'test') }
-  let(:pal) { Bolt::PAL.new([], nil, nil) }
+  let(:pal) { Bolt::PAL.new(Bolt::Config.default) }
   # It doesn't really matter which loader or scope we use, but we need them, so take the
   # static loader and global scope
   let(:loader) { Puppet.lookup(:loaders).static_loader }

--- a/spec/bolt/pal_spec.rb
+++ b/spec/bolt/pal_spec.rb
@@ -13,7 +13,7 @@ describe Bolt::PAL do
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
   describe :parse_manifest do
-    let(:pal) { Bolt::PAL.new(nil, nil, nil) }
+    let(:pal) { Bolt::PAL.new(Bolt::Config.default) }
 
     it "should parse a manifest string" do
       ast = pal.parse_manifest('notify { "hello world": }', 'test.pp')
@@ -146,7 +146,7 @@ describe Bolt::PAL do
   describe :in_bolt_compiler do
     it "sets the bolt_project in the context" do
       project = Bolt::Project.new({ 'name' => 'mytestproject' }, Dir.getwd)
-      pal = Bolt::PAL.new(nil, nil, nil, 1, nil, {}, project)
+      pal = Bolt::PAL.new(Bolt::Config.from_project(project, {}))
       pal.in_bolt_compiler do
         expect(Puppet.lookup(:bolt_project).name).to eq('mytestproject')
       end

--- a/spec/bolt/plugin/module_spec.rb
+++ b/spec/bolt/plugin/module_spec.rb
@@ -14,7 +14,7 @@ describe Bolt::Plugin::Module do
   let(:plugin_config) { {} }
   let(:config_data) { { 'modulepath' => modulepath, 'plugins' => plugin_config } }
 
-  let(:pal) { Bolt::PAL.new(modulepath, {}, nil) }
+  let(:pal) { Bolt::PAL.new(Bolt::Config.new(Bolt::Project.default_project, {}, { :modulepath => modulepath })) }
   let(:plugins) { Bolt::Plugin.setup(config(config_data), pal) }
 
   let(:module_name) { 'empty_plug' }

--- a/spec/bolt/plugin_spec.rb
+++ b/spec/bolt/plugin_spec.rb
@@ -14,7 +14,7 @@ describe Bolt::Plugin do
   let(:modulepath) { [fixtures_path('plugin_modules')] }
   let(:plugin_config) { {} }
   let(:config_data) { { 'modulepath' => modulepath, 'plugins' => plugin_config } }
-  let(:pal) { Bolt::PAL.new(modulepath, nil, nil) }
+  let(:pal) { Bolt::PAL.new(Bolt::Config.new(Bolt::Project.default_project, {}, { :modulepath => modulepath })) }
 
   let(:plugins) { Bolt::Plugin.setup(config(config_data), pal) }
 

--- a/spec/lib/bolt_spec/pal.rb
+++ b/spec/lib/bolt_spec/pal.rb
@@ -39,7 +39,7 @@ module BoltSpec
     def pal_with_module_content(mods)
       Dir.mktmpdir do |tmpdir|
         mk_files(tmpdir, mods)
-        pal = Bolt::PAL.new(tmpdir, nil, nil)
+        pal = Bolt::PAL.new(Bolt::Config.new(Bolt::Project.default_project, {}, { :modulepath => tmpdir }))
         yield pal
       end
     end

--- a/spec/pal/apply_result_spec.rb
+++ b/spec/pal/apply_result_spec.rb
@@ -17,7 +17,7 @@ describe 'ApplyResult DataType' do
   before(:all) { Bolt::PAL.load_puppet }
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
-  let(:pal)     { Bolt::PAL.new(modulepath, nil, nil) }
+  let(:pal) { Bolt::PAL.new(Bolt::Config.new(Bolt::Project.default_project, {}, { :modulepath => modulepath })) }
   let(:plugins) { Bolt::Plugin.setup(config, nil) }
 
   let(:result_code) do

--- a/spec/pal/facts_spec.rb
+++ b/spec/pal/facts_spec.rb
@@ -24,7 +24,7 @@ describe 'Facts functions' do
       'facts' => { 'hot' => 'chocolate' }
     }
   }
-  let(:pal)     { Bolt::PAL.new(modulepath, nil, nil) }
+  let(:pal) { Bolt::PAL.new(Bolt::Config.new(Bolt::Project.default_project, {}, { :modulepath => modulepath })) }
   let(:plugins) { Bolt::Plugin.setup(config, nil) }
   let(:inv)     { Bolt::Inventory::Inventory.new(data, config.transport, config.transports, plugins) }
 

--- a/spec/pal/features_spec.rb
+++ b/spec/pal/features_spec.rb
@@ -18,7 +18,7 @@ describe 'set_features function' do
 
   let(:executor) { Bolt::Executor.new(1) }
 
-  let(:pal) { Bolt::PAL.new(modulepath, nil, nil) }
+  let(:pal) { Bolt::PAL.new(Bolt::Config.new(Bolt::Project.default_project, {}, { :modulepath => modulepath })) }
   let(:inventory) { Bolt::Inventory.empty }
   let(:target) { inventory.get_targets('example')[0] }
 

--- a/spec/pal/result_set_spec.rb
+++ b/spec/pal/result_set_spec.rb
@@ -17,7 +17,7 @@ describe 'ResultSet DataType' do
   before(:all) { Bolt::PAL.load_puppet }
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
-  let(:pal)     { Bolt::PAL.new(modulepath, nil, nil) }
+  let(:pal) { Bolt::PAL.new(Bolt::Config.new(Bolt::Project.default_project, {}, { :modulepath => modulepath })) }
   let(:plugins) { Bolt::Plugin.setup(config, nil) }
 
   let(:result_code) do

--- a/spec/pal/result_spec.rb
+++ b/spec/pal/result_spec.rb
@@ -17,7 +17,7 @@ describe 'Result DataType' do
   before(:all) { Bolt::PAL.load_puppet }
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
-  let(:pal)     { Bolt::PAL.new(modulepath, nil, nil) }
+  let(:pal) { Bolt::PAL.new(Bolt::Config.new(Bolt::Project.default_project, {}, { :modulepath => modulepath })) }
   let(:plugins) { Bolt::Plugin.setup(config, nil) }
 
   let(:result_code) do

--- a/spec/pal/target_spec.rb
+++ b/spec/pal/target_spec.rb
@@ -17,7 +17,7 @@ describe 'Target DataType' do
   before(:all) { Bolt::PAL.load_puppet }
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
-  let(:pal)     { Bolt::PAL.new(modulepath, nil, nil) }
+  let(:pal) { Bolt::PAL.new(Bolt::Config.new(Bolt::Project.default_project, {}, { :modulepath => modulepath })) }
   let(:plugins) { Bolt::Plugin.setup(config, nil) }
 
   let(:target_code) { "$target = Target('pcp://user1:pass1@example.com:33')\n" }

--- a/spec/pal/vars_spec.rb
+++ b/spec/pal/vars_spec.rb
@@ -24,7 +24,7 @@ describe 'Vars function' do
   }
 
   let(:inventory) { Bolt::Inventory::Inventory.new(data, config.transport, config.transports, plugins) }
-  let(:pal)       { Bolt::PAL.new(modulepath, nil, nil) }
+  let(:pal) { Bolt::PAL.new(Bolt::Config.new(Bolt::Project.default_project, {}, { :modulepath => modulepath })) }
   let(:plugins)   { Bolt::Plugin.setup(config, nil) }
 
   let(:executor)  { Bolt::Executor.new }


### PR DESCRIPTION
This commit updates the Bolt::PAL class to take the whole Bolt::Config object
as a single parameter rather than taking options from config as seperate
parameters.

As part of the change, the functionality of munging the modulepath to include
BOLTLIB and built-in content has moved to a read-only function in the Config
class.

All of the inputs to PAL came from config already, and this distinction -that
PAL just takes config as one object- helps define how tools that use bolt as a
library (like PE) should use and extend bolt for their needs. Specifically
this change helps other tools use Bolt without needing to redefine PAL, but
instead those tools can redefine or update the config class for their needs
and have the config sent to PAL.