### PR TITLE
(GH-2207) Log when default inventory file cannot be loaded

### DIFF
--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -56,16 +56,17 @@ module Bolt
         rescue Psych::Exception
           raise Bolt::ParseError, "Could not parse inventory from $#{ENVIRONMENT_VAR}"
         end
+      elsif config.inventoryfile
+        data = Bolt::Util.read_yaml_hash(config.inventoryfile, 'inventory')
+        logger.debug("Loaded inventory from #{config.inventoryfile}")
       else
-        data = if config.inventoryfile
-                 Bolt::Util.read_yaml_hash(config.inventoryfile, 'inventory')
-               else
-                 i = Bolt::Util.read_optional_yaml_hash(config.default_inventoryfile, 'inventory')
-                 logger.debug("Loaded inventory from #{config.default_inventoryfile}") if i
-                 i
-               end
-        # This avoids rubocop complaining about identical conditionals
-        logger.debug("Loaded inventory from #{config.inventoryfile}") if config.inventoryfile
+        data = Bolt::Util.read_optional_yaml_hash(config.default_inventoryfile, 'inventory')
+
+        if config.default_inventoryfile.exist?
+          logger.debug("Loaded inventory from #{config.default_inventoryfile}")
+        else
+          logger.debug("Tried to load inventory from #{config.default_inventoryfile}, but the file does not exist")
+        end
       end
 
       # Resolve plugin references from transport config


### PR DESCRIPTION
This change updates how Bolt logs which inventory file it loaded.
Previously, if Bolt loaded the default inventory file, it would log that
it loaded the file, even if the file does not exist. Now, if the default
inventory file does not exist, Bolt will instead notify the user that it
tried to load the file, but that it does not exist.

!bug

* **Log when default inventory file cannot be loaded**
  ([#2207](https://github.com/puppetlabs/bolt/issues/2207))

  Bolt now logs that it tried but failed to load the default inventory
  file when the default inventory file does not exist. Previously, Bolt
  would log that it loaded the default inventory file, even when it was
  unable to do so.