### PR TITLE
Add moduledir directive to Puppetfile with 'module install'

### DIFF
--- a/lib/bolt/module_installer.rb
+++ b/lib/bolt/module_installer.rb
@@ -119,7 +119,7 @@ module Bolt
           # project init --modules, which uses the default modulepath. This
           # should be safe to assume that if `.modules/` is the moduledir the
           # user is using the new workflow
-          if moduledir.basename == '.modules'
+          if moduledir.basename.to_s == '.modules'
             puppetfile.write(path, moduledir)
           else
             puppetfile.write(path)

--- a/lib/bolt/puppetfile.rb
+++ b/lib/bolt/puppetfile.rb
@@ -61,8 +61,15 @@ module Bolt
     #
     def write(path, moduledir = nil)
       File.open(path, 'w') do |file|
-        file.puts '# This Puppetfile is managed by Bolt. Do not edit.'
-        file.puts "moduledir '#{moduledir.basename}'" if moduledir
+        if moduledir
+          file.puts "# This Puppetfile is managed by Bolt. Do not edit."
+          file.puts "# For more information, see https://pup.pt/bolt-modules"
+          file.puts
+          file.puts "# The following directive installs modules to the managed moduledir."
+          file.puts "moduledir '#{moduledir.basename}'"
+          file.puts
+        end
+
         modules.each { |mod| file.puts mod.to_spec }
       end
     rescue SystemCallError => e

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -2877,12 +2877,11 @@ describe "Bolt::CLI" do
 
             expect(File.file?(puppetfile)).to be
 
-            lines = File.read(puppetfile).split("\n")
-            lines.shift
+            content = File.read(puppetfile)
 
-            expect(lines).to match_array([/mod "puppetlabs-yaml"/,
-                                          /mod "puppetlabs-ruby_task_helper"/])
-            expect(lines).not_to include(/moduledir/)
+            expect(content).to match(/mod "puppetlabs-yaml"/)
+            expect(content).to match(/mod "puppetlabs-ruby_task_helper"/)
+            expect(content).not_to match(/moduledir/)
 
             expect(Dir.exist?(modulepath)).to be
             expect(Dir.children(modulepath)).to match_array(%w[yaml ruby_task_helper])

--- a/spec/bolt/puppetfile_spec.rb
+++ b/spec/bolt/puppetfile_spec.rb
@@ -6,6 +6,7 @@ require 'bolt/puppetfile'
 
 describe Bolt::Puppetfile do
   let(:path)       { @project + 'Puppetfile' }
+  let(:moduledir)  { @project + '.modules' }
   let(:modules)    { [{ 'name' => 'puppetlabs-yaml' }] }
   let(:puppetfile) { described_class.new(modules) }
 
@@ -80,6 +81,12 @@ describe Bolt::Puppetfile do
       puppetfile.write(path)
       expect(path.exist?).to eq(true)
       expect(File.read(path)).to match(/mod "puppetlabs-yaml"/)
+    end
+
+    it 'writes the moduledir to the Puppetfile' do
+      puppetfile.write(path, moduledir)
+      expect(path.exist?).to eq(true)
+      expect(File.read(path)).to match(/moduledir '.modules'/)
     end
   end
 


### PR DESCRIPTION
This fixes a bug in the `Bolt::ModuleInstaller` class that does not
correctly pass the managed moduledir to `Bolt::Puppetfile#write`. This
resulted in Bolt generating Puppetfiles with the `bolt module install`
command that did not include the `moduledir` directive.

!bug

* **Add moduledir directive to generated Puppetfile**

  Puppetfiles generated using the `bolt module install` command did not
  include the `moduledir` directive.