### PR TITLE
(maint) Update cops for Rubocop 0.93

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -75,6 +75,9 @@ Lint/EmptyFile:
 Lint/FloatComparison:
   Enabled: true
 
+Lint/HashCompareByIdentity:
+  Enabled: false
+
 Lint/IdentityComparison:
   Enabled: true
 
@@ -88,6 +91,9 @@ Lint/OutOfRangeRegexpRef:
   Enabled: true
 
 Lint/RaiseException:
+  Enabled: true
+
+Lint/RedundantSafeNavigation:
   Enabled: true
 
 Lint/SelfAssignment:
@@ -165,6 +171,9 @@ Style/BlockDelimiters:
   Enabled: false
 
 Style/CaseLikeIf:
+  Enabled: true
+
+Style/ClassEqualityComparison:
   Enabled: true
 
 Style/CombinableLoops:

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -16,7 +16,7 @@ module Bolt
     # Bolt::Errors
     class PALError < Bolt::Error
       def self.from_preformatted_error(err)
-        if err.cause&.is_a? Bolt::Error
+        if err.cause.is_a? Bolt::Error
           err.cause
         else
           from_error(err)

--- a/lib/bolt/shell/bash.rb
+++ b/lib/bolt/shell/bash.rb
@@ -202,13 +202,14 @@ module Bolt
       end
 
       def handle_sudo_errors(err)
-        if err =~ /^#{conn.user} is not in the sudoers file\./
+        case err
+        when /^#{conn.user} is not in the sudoers file\./
           @logger.trace { err }
           raise Bolt::Node::EscalateError.new(
             "User #{conn.user} does not have sudo permission on #{target}",
             'SUDO_DENIED'
           )
-        elsif err =~ /^Sorry, try again\./
+        when /^Sorry, try again\./
           @logger.trace { err }
           raise Bolt::Node::EscalateError.new(
             "Sudo password for user #{conn.user} not recognized on #{target}",

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -30,7 +30,7 @@ module Bolt
           @transport_logger = transport_logger
           @logger.trace("Initializing ssh connection to #{@target.safe_name}")
 
-          if target.options['private-key']&.instance_of?(String)
+          if target.options['private-key'].instance_of?(String)
             begin
               Bolt::Util.validate_file('ssh key', target.options['private-key'])
             rescue Bolt::FileError => e


### PR DESCRIPTION
This adds configuration for new cops introduced in Rubocop 0.93.

!no-release-note