### PR TITLE
(GH-2205) Improve 'bolt inventory show' output

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -587,8 +587,24 @@ module Bolt
     end
 
     def list_targets
+      inventoryfile = config.inventoryfile || config.default_inventoryfile
+
+      # Retrieve the known group and target names. This needs to be done before
+      # updating targets, as that will add adhoc targets to the inventory.
+      known_names = inventory.target_names
+
       update_targets(options)
-      outputter.print_targets(options[:targets])
+
+      inventory_targets, adhoc_targets = options[:targets].partition do |target|
+        known_names.include?(target.name)
+      end
+
+      target_list = {
+        inventory: inventory_targets,
+        adhoc:     adhoc_targets
+      }
+
+      outputter.print_targets(target_list, inventoryfile)
     end
 
     def show_targets

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -331,10 +331,28 @@ module Bolt
         end
       end
 
-      def print_targets(targets)
-        count = "#{targets.count} target#{'s' unless targets.count == 1}"
-        @stream.puts targets.map(&:name).join("\n")
-        @stream.puts colorize(:green, count)
+      def print_targets(target_list, inventoryfile)
+        adhoc = colorize(:yellow, "(Not found in inventory file)")
+
+        targets  = []
+        targets += target_list[:inventory].map { |target| [target.name, nil] }
+        targets += target_list[:adhoc].map { |target| [target.name, adhoc] }
+
+        if targets.any?
+          print_table(targets, 0, 2)
+          @stream.puts
+        end
+
+        @stream.puts "INVENTORY FILE:"
+        if inventoryfile.exist?
+          @stream.puts inventoryfile
+        else
+          @stream.puts wrap("Tried to load inventory from #{inventoryfile}, but the file does not exist")
+        end
+
+        @stream.puts "\nTARGET COUNT:"
+        @stream.puts "#{targets.count} total, #{target_list[:inventory].count} from inventory, "\
+                     "#{target_list[:adhoc].count} adhoc"
       end
 
       def print_target_info(targets)

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -100,10 +100,19 @@ module Bolt
                        "moduledir": moduledir.to_s }.to_json)
       end
 
-      def print_targets(targets)
+      def print_targets(target_list, inventoryfile)
         @stream.puts ::JSON.pretty_generate(
-          "targets": targets.map(&:name),
-          "count": targets.count
+          "inventory": {
+            "targets": target_list[:inventory].map(&:name),
+            "count": target_list[:inventory].count,
+            "file": inventoryfile.to_s
+          },
+          "adhoc": {
+            "targets": target_list[:adhoc].map(&:name),
+            "count": target_list[:adhoc].count
+          },
+          "targets": target_list.values.flatten.map(&:name),
+          "count": target_list.values.flatten.count
         )
       end
 

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -372,4 +372,36 @@ describe "Bolt::Outputter::Human" do
     outputter.print_guide(guide, 'boltymcboltface')
     expect(output.string).to eq(guide)
   end
+
+  context '#print_targets' do
+    let(:inventoryfile) { double('inventoryfile', to_s: '/path/to/inventory', exist?: true) }
+
+    let(:target_list) do
+      {
+        inventory: [double('target', name: 'target')],
+        adhoc:     [double('target', name: 'target')]
+      }
+    end
+
+    it 'prints adhoc targets' do
+      outputter.print_targets(target_list, inventoryfile)
+      expect(output.string).to match(/target\s*\(Not found in inventory file\)/)
+    end
+
+    it 'prints the inventory file path' do
+      outputter.print_targets(target_list, inventoryfile)
+      expect(output.string).to match(/INVENTORY FILE:\s*#{inventoryfile}/)
+    end
+
+    it 'prints a message that the inventory file does not exist' do
+      inventoryfile = double('inventoryfile', to_s: '/path/to/inventory', exist?: false)
+      outputter.print_targets(target_list, inventoryfile)
+      expect(output.string).to match(/INVENTORY FILE:.*does not exist/m)
+    end
+
+    it 'prints target counts' do
+      outputter.print_targets(target_list, inventoryfile)
+      expect(output.string).to match(/2 total, 1 from inventory, 1 adhoc/)
+    end
+  end
 end

--- a/spec/bolt/outputter/json_spec.rb
+++ b/spec/bolt/outputter/json_spec.rb
@@ -165,4 +165,44 @@ describe "Bolt::Outputter::JSON" do
     expect(parsed['topic']).to eq(topic)
     expect(parsed['guide']).to eq(guide)
   end
+
+  context '#print_targets' do
+    let(:inventoryfile) { '/path/to/inventory' }
+
+    let(:target_list) do
+      {
+        inventory: [double('target', name: 'target')],
+        adhoc:     [double('target', name: 'target')]
+      }
+    end
+
+    it 'outputs inventory targets with count and file' do
+      outputter.print_targets(target_list, inventoryfile)
+      parsed = JSON.parse(output.string)
+
+      expect(parsed['inventory']).to eq(
+        'targets' => ['target'],
+        'count'   => 1,
+        'file'    => inventoryfile
+      )
+    end
+
+    it 'outputs adhoc targets with count' do
+      outputter.print_targets(target_list, inventoryfile)
+      parsed = JSON.parse(output.string)
+
+      expect(parsed['adhoc']).to eq(
+        'targets' => ['target'],
+        'count'   => 1
+      )
+    end
+
+    it 'outputs all targets with count' do
+      outputter.print_targets(target_list, inventoryfile)
+      parsed = JSON.parse(output.string)
+
+      expect(parsed['targets']).to match_array(%w[target target])
+      expect(parsed['count']).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
This improves the output for the `bolt inventory show` command.

When using the `human` outputter, Bolt will now display each target's source
alongside the target. If the target was loaded from inventory, it will
show the path to the inventory file; if the target is an adhoc target,
it will say it was not loaded from inventory. The output will also show
where inventory was loaded from, and tell the user if the inventory file
it attempted to load does not exist. Lastly, the target count now lists
the total number of targets, the number loaded from inventory, and the
number of adhoc targets.

When using the `json` outputter, Bolt will now include `inventory` and
`adhoc` keys. The `inventory` key includes a list of targets loaded from
inventory, the number of targets loaded from inventory, and the path to
the inventory file. The `adhoc` key lists the names of adhoc targets,
and the total number of adhoc targets.

!feature

* **Improved output for `bolt inventory show` and `Get-BoltInventory`**
  ([#2205](https://github.com/puppetlabs/bolt/issues/2205))

  The `bolt inventory show` command and `Get-BoltInventory` cmdlet now
  show where each target was loaded from alongside the target's name.
  Output also includes the path to the loaded inventory file and the
  number of inventory targets and adhoc targets.