### PR TITLE
(GH-2079) Update Bolt commands docs

### DIFF
--- a/documentation/templates/bolt_command_reference.md.erb
+++ b/documentation/templates/bolt_command_reference.md.erb
@@ -1,10 +1,21 @@
 # Bolt command reference
 
+## Command syntax
+
+Bolt shell commands follow a noun-verb convention.
+
+To view a full list of
+available commands, use the `bolt help` command:
+
+```shell
+bolt help
+```
+
+## Commands
 These subcommands, actions, and options are available for Bolt.
 
-
 <% @commands.each do |key, val| %>
-## <%= key %>
+### <%= key %>
 
 <%= val[:desc] %>
 


### PR DESCRIPTION
This updates the 'Running basic Bolt commands' page. It reorganizes the
page to first cover command syntax and then commands that interact with
targets. Each command example includes both a Unix shell command and a
PowerShell cmdlet.

!no-release-note