### PR TITLE
(GH-2230) Print Puppetfile diff when using 'module add'

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -938,6 +938,7 @@ module Bolt
     # Loads a Puppetfile and installs its modules.
     #
     def install_puppetfile(config, puppetfile, moduledir)
+      outputter.print_message("Installing modules from Puppetfile")
       installer = Bolt::ModuleInstaller.new(outputter, pal)
       ok = installer.install_puppetfile(puppetfile, moduledir, config)
       ok ? 0 : 1

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -413,7 +413,7 @@ module Bolt
         @stream.puts(colorize(:red, indent(4, message)))
       end
 
-      def print_migrate_step(step)
+      def print_action_step(step)
         first, *remaining = wrap(step, 76).lines
 
         first     = indent(2, "→ #{first}")
@@ -423,7 +423,7 @@ module Bolt
         @stream.puts(step)
       end
 
-      def print_migrate_error(error)
+      def print_action_error(error)
         # Running everything through 'wrap' messes with newlines. Separating
         # into lines and wrapping each individually ensures separate errors are
         # distinguishable.

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -137,10 +137,10 @@ module Bolt
       end
       alias print_error print_message
 
-      def print_migrate_step(step)
+      def print_action_step(step)
         $stderr.puts(step)
       end
-      alias print_migrate_error print_migrate_step
+      alias print_action_error print_action_step
     end
   end
 end

--- a/lib/bolt/project_migrator.rb
+++ b/lib/bolt/project_migrator.rb
@@ -21,7 +21,7 @@ module Bolt
 
       @outputter.print_message("Migrating project #{@config.project.path}\n\n")
 
-      @outputter.print_migrate_step(
+      @outputter.print_action_step(
         "Migrating a Bolt project may make irreversible changes to the project's "\
         "configuration and inventory files. Before continuing, make sure the "\
         "project has a backup or uses a version control system."

--- a/lib/bolt/project_migrator/base.rb
+++ b/lib/bolt/project_migrator/base.rb
@@ -12,7 +12,7 @@ module Bolt
 
       protected def backup_file(origin_path, backup_dir)
         unless File.exist?(origin_path)
-          @outputter.print_migrate_step(
+          @outputter.print_action_step(
             "Could not find file #{origin_path}, skipping backup."
           )
           return
@@ -24,7 +24,7 @@ module Bolt
         filename = File.basename(origin_path)
         backup_path = File.join(backup_dir, "#{filename}.#{date}.bak")
 
-        @outputter.print_migrate_step(
+        @outputter.print_action_step(
           "Backing up #{filename} from #{origin_path} to #{backup_path}"
         )
 

--- a/lib/bolt/project_migrator/config.rb
+++ b/lib/bolt/project_migrator/config.rb
@@ -39,7 +39,7 @@ module Bolt
           backup_file(config_file, backup_dir)
 
           begin
-            @outputter.print_migrate_step(
+            @outputter.print_action_step(
               "Moving transportation configuration options '#{transport_data.keys.join(', ')}' "\
               "from bolt.yaml to inventory.yaml"
             )
@@ -51,10 +51,10 @@ module Bolt
           end
         end
 
-        @outputter.print_migrate_step("Renaming bolt.yaml to bolt-project.yaml")
+        @outputter.print_action_step("Renaming bolt.yaml to bolt-project.yaml")
         FileUtils.mv(config_file, project_file)
 
-        @outputter.print_migrate_step(
+        @outputter.print_action_step(
           "Successfully migrated config. Please add a 'name' key to bolt-project.yaml "\
           "to use project-level tasks and plans. Learn more about projects by running "\
           "'bolt guide project'."

--- a/lib/bolt/project_migrator/inventory.rb
+++ b/lib/bolt/project_migrator/inventory.rb
@@ -28,7 +28,7 @@ module Bolt
 
         begin
           File.write(inventory_file, data.to_yaml)
-          @outputter.print_migrate_step(
+          @outputter.print_action_step(
             "Successfully migrated Bolt inventory to the latest version."
           )
           true

--- a/lib/bolt/project_migrator/modules.rb
+++ b/lib/bolt/project_migrator/modules.rb
@@ -19,7 +19,7 @@ module Bolt
 
         # Notify user to manually migrate modules if using non-default modulepath
         if configured_modulepath != modulepath
-          @outputter.print_migrate_step(
+          @outputter.print_action_step(
             "Project has a non-default configured modulepath, unable to automatically "\
             "migrate project modules. To migrate project modules manually, see "\
             "http://pup.pt/bolt-modules"
@@ -46,10 +46,10 @@ module Bolt
         require 'bolt/puppetfile/installer'
 
         begin
-          @outputter.print_migrate_step("Parsing Puppetfile at #{puppetfile_path}")
+          @outputter.print_action_step("Parsing Puppetfile at #{puppetfile_path}")
           puppetfile = Bolt::Puppetfile.parse(puppetfile_path, skip_unsupported_modules: true)
         rescue Bolt::Error => e
-          @outputter.print_migrate_error("#{e.message}\nSkipping module migration.")
+          @outputter.print_action_error("#{e.message}\nSkipping module migration.")
           return false
         end
 
@@ -62,10 +62,10 @@ module Bolt
         # Attempt to resolve dependencies
         begin
           @outputter.print_message('')
-          @outputter.print_migrate_step("Resolving module dependencies, this may take a moment")
+          @outputter.print_action_step("Resolving module dependencies, this may take a moment")
           puppetfile.resolve
         rescue Bolt::Error => e
-          @outputter.print_migrate_error("#{e.message}\nSkipping module migration.")
+          @outputter.print_action_error("#{e.message}\nSkipping module migration.")
           return false
         end
 
@@ -90,17 +90,17 @@ module Bolt
           # Show the new Puppetfile content
           message  = "Generated new Puppetfile content:\n\n"
           message += puppetfile.modules.map(&:to_spec).join("\n").to_s
-          @outputter.print_migrate_step(message)
+          @outputter.print_action_step(message)
 
           # Write Puppetfile
-          @outputter.print_migrate_step("Updating Puppetfile at #{puppetfile_path}")
+          @outputter.print_action_step("Updating Puppetfile at #{puppetfile_path}")
           puppetfile.write(puppetfile_path, managed_moduledir)
 
           # Install Puppetfile
-          @outputter.print_migrate_step("Syncing modules from #{puppetfile_path} to #{managed_moduledir}")
+          @outputter.print_action_step("Syncing modules from #{puppetfile_path} to #{managed_moduledir}")
           Bolt::Puppetfile::Installer.new({}).install(puppetfile_path, managed_moduledir)
         else
-          @outputter.print_migrate_step(
+          @outputter.print_action_step(
             "Project does not include any managed modules, deleting Puppetfile "\
             "at #{puppetfile_path}"
           )
@@ -112,7 +112,7 @@ module Bolt
       # the selected modules.
       #
       private def select_modules(modules)
-        @outputter.print_migrate_step(
+        @outputter.print_action_step(
           "Select modules that are direct dependencies of your project. Bolt will "\
           "automatically manage dependencies for each module selected, so do not "\
           "select a module's dependencies unless you use content from it directly "\
@@ -135,7 +135,7 @@ module Bolt
         sources.select! { |source| Dir.exist?(source) }
 
         if sources.any?
-          @outputter.print_migrate_step(
+          @outputter.print_action_step(
             "Moving modules from #{sources.join(', ')} to #{moduledir}"
           )
 
@@ -166,7 +166,7 @@ module Bolt
       # Deletes modules from a specified directory.
       #
       private def delete_modules(moduledir, modules)
-        @outputter.print_migrate_step("Cleaning up #{moduledir}")
+        @outputter.print_action_step("Cleaning up #{moduledir}")
         moduledir = Pathname.new(moduledir)
 
         modules.each do |mod|
@@ -178,7 +178,7 @@ module Bolt
       # Adds a list of modules to the project configuration file.
       #
       private def update_project_config(modules, config_file)
-        @outputter.print_migrate_step("Updating project configuration at #{config_file}")
+        @outputter.print_action_step("Updating project configuration at #{config_file}")
         data = Bolt::Util.read_optional_yaml_hash(config_file, 'project')
         data.merge!('modules' => modules)
         data.delete('modulepath')

--- a/lib/bolt/puppetfile/module.rb
+++ b/lib/bolt/puppetfile/module.rb
@@ -13,7 +13,10 @@ module Bolt
       def initialize(owner, name, version = nil)
         @owner   = owner
         @name    = name
-        @version = version unless version == :latest
+
+        if version.is_a?(String)
+          @version = version[0] == '=' ? version[1..-1] : version
+        end
       end
 
       # Creates a new module from a hash.

--- a/spec/bolt/module_installer_spec.rb
+++ b/spec/bolt/module_installer_spec.rb
@@ -13,10 +13,13 @@ describe Bolt::ModuleInstaller do
   let(:config)               { project_path + 'bolt-project.yaml' }
   let(:new_module)           { 'puppetlabs-pkcs7' }
   let(:project_config)       { [{ 'name' => 'puppetlabs-yaml' }] }
-  let(:outputter)            { double('outputter', print_message: nil, print_puppetfile_result: nil) }
   let(:pal)                  { double('pal', generate_types: nil) }
   let(:installer)            { described_class.new(outputter, pal) }
   let(:puppetfile_installer) { double('puppetfile_installer', install: true) }
+
+  let(:outputter) do
+    double('outputter', print_message: nil, print_puppetfile_result: nil, print_action_step: nil)
+  end
 
   around(:each) do |example|
     with_project do
@@ -113,6 +116,65 @@ describe Bolt::ModuleInstaller do
     it 'installs a Puppetfile' do
       expect(puppetfile_installer).to receive(:install)
       installer.install(project_config, puppetfile, moduledir)
+    end
+  end
+
+  context '#print_puppetfile_diff' do
+    let(:existing)         { double('existing', modules: existing_modules) }
+    let(:updated)          { double('updated', modules: updated_modules) }
+    let(:mod)              { double('existing_module', title: 'puppetlabs/foo', version: '1.0.0') }
+    let(:existing_modules) { [mod] }
+    let(:updated_modules)  { [] }
+
+    it 'prints added modules' do
+      updated_modules.concat([
+                               mod,
+                               double('updated_module', title: 'puppetlabs/bar', version: '1.0.0')
+                             ])
+
+      expect(outputter).to receive(:print_action_step).with(
+        %r{Adding the following modules:\s*puppetlabs/bar 1.0.0}
+      )
+
+      installer.print_puppetfile_diff(existing, updated)
+    end
+
+    it 'prints removed modules' do
+      expect(outputter).to receive(:print_action_step).with(
+        %r{Removing the following modules:\s*puppetlabs/foo 1.0.0}
+      )
+
+      installer.print_puppetfile_diff(existing, updated)
+    end
+
+    it 'prints upgraded modules' do
+      updated_modules.concat([
+                               double('updated_module', title: 'puppetlabs/foo', version: '2.0.0')
+                             ])
+
+      expect(outputter).to receive(:print_action_step).with(
+        %r{Upgrading the following modules:\s*puppetlabs/foo 1.0.0 to 2.0.0}
+      )
+
+      installer.print_puppetfile_diff(existing, updated)
+    end
+
+    it 'prints downgraded modules' do
+      updated_modules.concat([
+                               double('updated_module', title: 'puppetlabs/foo', version: '0.5.0')
+                             ])
+
+      expect(outputter).to receive(:print_action_step).with(
+        %r{Downgrading the following modules:\s*puppetlabs/foo 1.0.0 to 0.5.0}
+      )
+
+      installer.print_puppetfile_diff(existing, updated)
+    end
+
+    it 'prints nothing if there is no diff' do
+      expect(outputter).not_to receive(:print_action_step)
+
+      installer.print_puppetfile_diff(existing, existing)
     end
   end
 end

--- a/spec/bolt/project_migrator/config_spec.rb
+++ b/spec/bolt/project_migrator/config_spec.rb
@@ -9,7 +9,7 @@ describe Bolt::ProjectMigrator::Config do
     migrator.migrate(config_file, project_file, inventory_file, backup_dir)
   end
 
-  let(:outputter)      { double('outputter', print_message: nil, print_migrate_step: nil) }
+  let(:outputter)      { double('outputter', print_message: nil, print_action_step: nil) }
   let(:migrator)       { described_class.new(outputter) }
   let(:inventory_file) { @tmpdir + 'inventory.yaml' }
   let(:config_file)    { @tmpdir + 'bolt.yaml' }

--- a/spec/bolt/project_migrator/inventory_spec.rb
+++ b/spec/bolt/project_migrator/inventory_spec.rb
@@ -9,7 +9,7 @@ describe Bolt::ProjectMigrator::Inventory do
     migrator.migrate(inventory_file, backup_dir)
   end
 
-  let(:outputter)      { double('outputter', print_message: nil, print_migrate_step: nil) }
+  let(:outputter)      { double('outputter', print_message: nil, print_action_step: nil) }
   let(:migrator)       { described_class.new(outputter) }
   let(:inventory_file) { @tmpdir + 'inventory.yaml' }
   let(:backup_dir)     { @tmpdir + '.bolt-bak' }

--- a/spec/bolt/project_migrator/modules_spec.rb
+++ b/spec/bolt/project_migrator/modules_spec.rb
@@ -23,8 +23,8 @@ describe Bolt::ProjectMigrator::Modules do
   let(:outputter) {
     double('outputter',
            print_message: nil,
-           print_migrate_step: nil,
-           print_migrate_error: nil)
+           print_action_step: nil,
+           print_action_error: nil)
   }
   let(:project_config) { {} }
   let(:project)        { Bolt::Project.new(project_config, @tmpdir) }
@@ -133,7 +133,7 @@ describe Bolt::ProjectMigrator::Modules do
       expect(migrate).to be(true)
       data = Bolt::Util.read_yaml_hash(project.project_file, 'project')
       expect(data['modules']).to match_array([
-                                               { 'name' => 'puppetlabs-yaml', 'version_requirement' => '=0.1.0' }
+                                               { 'name' => 'puppetlabs-yaml', 'version_requirement' => '0.1.0' }
                                              ])
     end
 

--- a/spec/bolt/project_migrator_spec.rb
+++ b/spec/bolt/project_migrator_spec.rb
@@ -12,7 +12,7 @@ describe Bolt::ProjectMigrator do
   let(:outputter) {
     double('outputter',
            print_message: nil,
-           print_migrate_step: nil,
+           print_action_step: nil,
            print_prompt: nil,
            print_error: nil)
   }


### PR DESCRIPTION
This adds a new message to the outputter that describes changes made to
a Puppetfile when using the `bolt module add` / `Add-BoltModule`
command. The message will display which modules have been added,
removed, upgraded, and downgraded. Upgraded and downgraded modules will
have their old version and new version displayed, while added and
removed modules display the version of the module that was added or
removed.

!feature

* **Print changes made to Puppetfile when adding modules**
  ([#2230](https://github.com/puppetlabs/bolt/issues/2230))

  The `bolt module add` command and `Add-BoltModule` cmdlet now display
  a message describing changes made to the Puppetfile, including modules
  that have been added, removed, upgraded, or downgraded.