### PR TITLE
(maint) Bump bundled modules

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -7,28 +7,28 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '1.3.0'
 mod 'puppetlabs-puppet_agent', '4.1.1'
-mod 'puppetlabs-facts', '1.0.0'
+mod 'puppetlabs-facts', '1.1.0'
 
 # Core types and providers for Puppet 6
-mod 'puppetlabs-augeas_core', '1.0.5'
+mod 'puppetlabs-augeas_core', '1.1.1'
 mod 'puppetlabs-host_core', '1.0.3'
-mod 'puppetlabs-scheduled_task', '2.0.1'
-mod 'puppetlabs-sshkeys_core', '1.0.3'
-mod 'puppetlabs-zfs_core', '1.0.4'
-mod 'puppetlabs-cron_core', '1.0.3'
+mod 'puppetlabs-scheduled_task', '2.2.1'
+mod 'puppetlabs-sshkeys_core', '2.1.0'
+mod 'puppetlabs-zfs_core', '1.1.0'
+mod 'puppetlabs-cron_core', '1.0.4'
 mod 'puppetlabs-mount_core', '1.0.4'
 mod 'puppetlabs-selinux_core', '1.0.4'
-mod 'puppetlabs-yumrepo_core', '1.0.6'
+mod 'puppetlabs-yumrepo_core', '1.0.7'
 mod 'puppetlabs-zone_core', '1.0.3'
 
 # Useful additional modules
-mod 'puppetlabs-package', '1.1.0'
+mod 'puppetlabs-package', '1.3.0'
 mod 'puppetlabs-puppet_conf', '0.6.0'
 mod 'puppetlabs-python_task_helper', '0.4.3'
 mod 'puppetlabs-reboot', '3.0.0'
 mod 'puppetlabs-ruby_task_helper', '0.5.1'
 mod 'puppetlabs-ruby_plugin_helper', '0.1.0'
-mod 'puppetlabs-stdlib', '6.3.0'
+mod 'puppetlabs-stdlib', '6.5.0'
 
 # Plugin modules
 mod 'puppetlabs-aws_inventory', '0.5.2'


### PR DESCRIPTION
This bumps several bundled modules to their latest versions.

* **Update bundled modules to latest versions**

  The following bundled modules have been updated to their latest
  versions:

  - [facts 1.1.0](https://forge.puppet.com/puppetlabs/facts)
  - [augeas_core 1.1.1](https://forge.puppet.com/puppetlabs/augeas_core)
  - [scheduled_task 2.2.1](https://forge.puppet.com/puppetlabs/scheduled_task)
  - [sshkeys_core 2.1.0](https://forge.puppet.com/puppetlabs/sshkeys_core)
  - [zfs_core 1.1.0](https://forge.puppet.com/puppetlabs/zfs_core)
  - [cron_core 1.0.4](https://forge.puppet.com/puppetlabs/cron_core)
  - [yumrepo_core 1.0.7](https://forge.puppet.com/puppetlabs/yumrepo_core)
  - [package 1.3.0](https://forge.puppet.com/puppetlabs/package)
  - [stdlib 6.5.0](https://forge.puppet.com/puppetlabs/stdlib)