### PR TITLE
Document unwrapping a sensitive value from 'prompt' function

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -75,6 +75,7 @@ jobs:
         run: |
           docker-compose -f spec/docker-compose.yml build --parallel
           docker-compose -f spec/docker-compose.yml up -d
+          sleep 15
           bundle exec r10k puppetfile install
       - name: Run tests with expensive containers
         run: bundle exec rake ci:linux:slow

--- a/bolt-modules/prompt/lib/puppet/functions/prompt.rb
+++ b/bolt-modules/prompt/lib/puppet/functions/prompt.rb
@@ -9,11 +9,14 @@ Puppet::Functions.create_function(:prompt) do
   # @param prompt The prompt to display.
   # @param options A hash of additional options.
   # @option options [Boolean] sensitive Disable echo back and mark the response as sensitive.
+  #   The returned value will be wrapped by the `Sensitive` data type. To access the raw
+  #   value, use the `unwrap` function (i.e. `$sensitive_value.unwrap`).
   # @return The response to the prompt.
   # @example Prompt the user if plan execution should continue
   #   $response = prompt('Continue executing plan? [Y\N]')
   # @example Prompt the user for sensitive information
   #   $password = prompt('Enter your password', 'sensitive' => true)
+  #   out::message("Password is: ${password.unwrap}")
   dispatch :prompt do
     param 'String', :prompt
     optional_param 'Hash[String[1], Any]', :options


### PR DESCRIPTION
This adds documentation on unwrapping a sensitive value returned by the
`prompt` plan function.

!no-release-note