### PR TITLE
(bug-fix) Use file methods instead of Pathname methods in the outputter

### DIFF
--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -344,7 +344,7 @@ module Bolt
         end
 
         @stream.puts "INVENTORY FILE:"
-        if inventoryfile.exist?
+        if File.exist?(inventoryfile)
           @stream.puts inventoryfile
         else
           @stream.puts wrap("Tried to load inventory from #{inventoryfile}, but the file does not exist")

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -374,7 +374,7 @@ describe "Bolt::Outputter::Human" do
   end
 
   context '#print_targets' do
-    let(:inventoryfile) { double('inventoryfile', to_s: '/path/to/inventory', exist?: true) }
+    let(:inventoryfile) { '/path/to/inventory' }
 
     let(:target_list) do
       {
@@ -389,12 +389,13 @@ describe "Bolt::Outputter::Human" do
     end
 
     it 'prints the inventory file path' do
+      expect(File).to receive(:exist?).with(inventoryfile).and_return(true)
       outputter.print_targets(target_list, inventoryfile)
       expect(output.string).to match(/INVENTORY FILE:\s*#{inventoryfile}/)
     end
 
     it 'prints a message that the inventory file does not exist' do
-      inventoryfile = double('inventoryfile', to_s: '/path/to/inventory', exist?: false)
+      expect(File).to receive(:exist?).with(inventoryfile).and_return(false)
       outputter.print_targets(target_list, inventoryfile)
       expect(output.string).to match(/INVENTORY FILE:.*does not exist/m)
     end

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -660,4 +660,11 @@ describe 'running with an inventory file', reset_puppet_settings: true do
       expect(result).to include('stdout' => "bolt\n")
     end
   end
+
+  context 'when showing inventory targets' do
+    it 'shows targets from a configured inventory' do
+      expect { run_cli(%W[inventory show -t all -i #{@inventoryfile}], outputter: Bolt::Outputter::Human) }
+        .not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
Previously, the inventoryfile passed to the outputter for printing when
running `bolt inventory show` with the Human outputter could be either a
string or a Pathname, depending on whether the user had configured the 
inventory location (string) or was using the default project inventory
(Pathname). We erroneously assumed it would always be a
Pathname, which resulted in a 'method not found' error when we tried
calling `exist?` on the parameter. This uses the `File.exist?` method to
verify the path exists which will work for either object passed to the 
method.

!bug

* **Fix 'method not found' error running 'bolt inventory show'**

  Previously, when running 'bolt inventory show' with a configured
  inventory path and the human format a 'method not found' error was 
  raised. This now correctly prints the targets in the inventory.