### PR TITLE
(Docs) Harmful terminology changes

### DIFF
--- a/documentation/applying_manifest_blocks.md
+++ b/documentation/applying_manifest_blocks.md
@@ -37,7 +37,7 @@ have Puppet agents and runs the [`puppet_agent::install`
 task](https://forge.puppet.com/puppetlabs/puppet_agent) to install the agent.
 
 > **Note:** Bolt installs the Puppet agent package to enable the use of Puppet
-  code. It does not require setting up an agent-master architecture between the
+  code. It does not require setting up a server-agent architecture between the
   remote systems and the local system running Bolt.
 
 ### Applying manifest files
@@ -164,7 +164,7 @@ do not have Puppet agents and runs the [`puppet_agent::install`
 task](https://forge.puppet.com/puppetlabs/puppet_agent) to install the agent.
 
 > **Note:** Bolt installs the Puppet agent package to enable the use of Puppet
-  code. It does not require setting up an agent-master architecture between the
+  code. It does not require setting up a server-agent architecture between the
   remote systems and the local system running Bolt.
 
 ### Options

--- a/documentation/bolt_connect_puppetdb.md
+++ b/documentation/bolt_connect_puppetdb.md
@@ -10,7 +10,7 @@ RBAC token.
 ## Client certificate
 
 Add the certname for the certificate you want to authenticate with
-to `/etc/puppetlabs/puppetdb/certificate-whitelist`. This certificate has full
+to `/etc/puppetlabs/puppetdb/certificate-allowlist`. This certificate has full
 access to all PuppetDB API endpoints and can read all data, push new data, or
 run commands on PuppetDB. To test the certificate you run the following curl
 command.
@@ -48,7 +48,7 @@ config](configuring_bolt.md) with the following values:
 
 -   `server_urls`: An array containing the PuppetDB host to connect to. Include
     the protocol `https` and the port, which is usually `8081`. For example,
-    `https://my-master.example.com:8081`.
+    `https://my-puppetdb-server.example.com:8081`.
 -   `cacert`: The path to the ca certificate for PuppetDB.
 -   `connect_timeout`: How long to wait in seconds when establishing
     connections with PuppetDB.

--- a/documentation/bolt_installing.md
+++ b/documentation/bolt_installing.md
@@ -194,9 +194,10 @@ Use one of the supported *nix installation methods to install Bolt.
 
 > **CAUTION:** These instructions include enabling the Puppet Tools repository.
 > While Bolt can also be installed from the Puppet 6 or 5 platform repositories,
-> adding these repositories to a Puppet-managed target, especially a PE master,
-> might result in an unsupported version of a package like `puppet-agent` being
-> installed. This can cause downtime, especially on a PE master.
+> adding these repositories to a Puppet-managed target, especially a 
+> Puppet server, might result in an unsupported version of a package like 
+> `puppet-agent` being installed. This can cause downtime, especially on a 
+> Puppet server.
 
 ### Install Bolt on Debian or Ubuntu
 

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -329,7 +329,7 @@ module Bolt
             "server_urls" => {
               description: "An array containing the PuppetDB host to connect to. Include the protocol `https` "\
                            "and the port, which is usually `8081`. For example, "\
-                           "`https://my-master.example.com:8081`.",
+                           "`https://my-puppetdb-server.com:8081`.",
               type: Array,
               _example: ["https://puppet.example.com:8081"]
             },

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -228,7 +228,7 @@
               "minimum": 1
             },
             "server_urls": {
-              "description": "An array containing the PuppetDB host to connect to. Include the protocol `https` and the port, which is usually `8081`. For example, `https://my-master.example.com:8081`.",
+              "description": "An array containing the PuppetDB host to connect to. Include the protocol `https` and the port, which is usually `8081`. For example, `https://my-puppetdb-server.com:8081`.",
               "type": "array"
             },
             "token": {

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -194,7 +194,7 @@
               "minimum": 1
             },
             "server_urls": {
-              "description": "An array containing the PuppetDB host to connect to. Include the protocol `https` and the port, which is usually `8081`. For example, `https://my-master.example.com:8081`.",
+              "description": "An array containing the PuppetDB host to connect to. Include the protocol `https` and the port, which is usually `8081`. For example, `https://my-puppetdb-server.com:8081`.",
               "type": "array"
             },
             "token": {

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -250,7 +250,7 @@
               "minimum": 1
             },
             "server_urls": {
-              "description": "An array containing the PuppetDB host to connect to. Include the protocol `https` and the port, which is usually `8081`. For example, `https://my-master.example.com:8081`.",
+              "description": "An array containing the PuppetDB host to connect to. Include the protocol `https` and the port, which is usually `8081`. For example, `https://my-puppetdb-server.com:8081`.",
               "type": "array"
             },
             "token": {


### PR DESCRIPTION
I grepped through the docs and found a couple of lingering terms
that we need to change. Most are just examples. One is a DB
filename that is going to change soon. I'm on the fence about merging
this now or waiting for the Puppet 7 release when all of the other docs
changes (and a lot of the engineering work) will land.

!no-release-note