### PR TITLE
(PE-30382) Add project to task schema in bolt-server

### DIFF
--- a/lib/bolt_server/schemas/partials/task.json
+++ b/lib/bolt_server/schemas/partials/task.json
@@ -63,9 +63,24 @@
                   "environment": {
                     "description": "Environment the task is in",
                     "type": "string"
+                  },
+                  "project": {
+                    "description": "Project the task is in",
+                    "type": "string"
                   }
                 },
-                "required": ["environment"],
+                "oneOf": [
+                  {
+                    "required": [
+                      "environment"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "project"
+                    ]
+                  }
+                ],              
                 "additionalProperties": true
               }
             },
@@ -90,5 +105,5 @@
     }
   },
   "required": ["name", "files"],
-  "additionalProperties": false
+  "additionalProperties": true
 }


### PR DESCRIPTION
This commit updates the task metadata schema in bolt server to accept either an environment or project source for a task.