### PR TITLE
(maint) Bump puppet version to 6.19.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -113,6 +113,9 @@ Lint/TopLevelReturnWithArgument:
 Lint/TrailingCommaInAttributeDeclaration:
   Enabled: true
 
+Layout/TrailingWhitespace:
+  AllowInHeredoc: true
+
 Lint/UnreachableLoop:
   Enabled: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ group(:test) do
   gem "beaker-hostgenerator"
   gem "mocha", '~> 1.4.0'
   gem "rack-test", '~> 1.0'
-  gem "rubocop", '~> 0.61', require: false
+  gem "rubocop", require: false
 end
 
 group(:packaging) do

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-ssh", ">= 4.0"
   spec.add_dependency "net-ssh-krb", "~> 0.5"
   spec.add_dependency "orchestrator_client", "~> 0.4"
-  spec.add_dependency "puppet", "6.18.0"
+  spec.add_dependency "puppet", ">= 6.18.0", "<= 6.19"
   spec.add_dependency "puppetfile-resolver", "~> 0.4"
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "puppet-strings", "~> 2.3"


### PR DESCRIPTION
This bumps the maximum allowed Puppet gem version to 6.19, while still allowing for 6.18 to be installed as there are no required changes for us to pick up in the new Puppet version.