### PR TITLE
(GH-2111) Shadow fact/variable collisions in PAL catalog compiler

### DIFF
--- a/spec/bolt/catalog_spec.rb
+++ b/spec/bolt/catalog_spec.rb
@@ -145,30 +145,5 @@ describe Bolt::Catalog do
       )
       expect { catalog.compile_catalog(request) }.not_to raise_error
     end
-
-    # This test checks that the order of plan_vars is not modified
-    # when merging with target_vars during catalog compilation.
-    # Plan vars may have local references to other plan vars. Because
-    # variables are deserialized in the order they appear in a hash,
-    # changing the order of plan variables may result in Puppet being
-    # unable to deserialize them, since a local reference may appear
-    # before the variable it references.
-    it 'does not change the order of plan_vars' do
-      plan_vars.merge!(
-        'roles' => {
-          '__ptype'  => 'LocalRef',
-          '__pvalue' => "$['t1'][0]['vars']['roles']"
-        }
-      )
-
-      request.merge!('plan_vars' => plan_vars)
-
-      allow(Puppet::Pal).to receive(:in_tmp_environment) do |_type, env_conf|
-        expect(env_conf[:variables].to_a).to eq(plan_vars.to_a)
-        expect(env_conf[:variables]['roles']).to eq(plan_vars['roles'])
-      end
-
-      catalog.compile_catalog(request)
-    end
   end
 end

--- a/spec/fixtures/apply/basic/plans/collisions.pp
+++ b/spec/fixtures/apply/basic/plans/collisions.pp
@@ -1,0 +1,20 @@
+plan basic::collisions(
+  TargetSpec $targets
+) {
+  $target = get_target($targets)
+
+  $target.add_facts(
+    'fact_plan'   => '',
+    'fact_target' => ''
+  )
+
+  $target.set_var('fact_target', '')
+  $target.set_var('plan_target', '')
+
+  $fact_plan   = ''
+  $plan_target = ''
+
+  return apply($target) {
+    notice('Collisions everywhere!')
+  }
+}

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -477,5 +477,19 @@ describe "passes parsed AST to the apply_catalog task" do
         expect(lines).to include(/FATAL.*Roll/)
       end
     end
+
+    context 'with fact/variable collisions' do
+      let(:lines)  { @log_output.readlines }
+      after(:each) { @log_output.level = :all }
+
+      it 'warns about collisions' do
+        @log_output.level = :warn
+        run_cli(%w[plan run basic::collisions] + config_flags)
+
+        expect(lines).to include(/WARN.*Plan variable \$fact_plan will be overridden/)
+        expect(lines).to include(/WARN.*Target variable \$fact_target will be overridden/)
+        expect(lines).to include(/WARN.*Target variable \$plan_target will be overridden/)
+      end
+    end
   end
 end


### PR DESCRIPTION
This updates the `Bolt::Catalog.compile_catalog` method to pass target
and plan variables to the catalog compiler, which will then deserialize
plan variables and shadow any variables that collide with facts of the
same name. This change fixes a bug where a plan variable 'foo' that
collided with a fact 'foo' would not be passed to the compiler, so any
plan variable 'bar' that had a local reference to 'foo' would not be
deserialized correctly.

Blocked by https://github.com/puppetlabs/puppet/pull/8412

!bug

* **Correctly shadow fact/variable collisions in apply blocks**
  ([#2111](https://github.com/puppetlabs/bolt/issues/2111))

  Bolt now correctly shadows target and plan variables that collide with
  facts of the same name when running apply blocks.