### PR TITLE
(GH-2219) Add 'module' and 'modulepath' topic guides

### DIFF
--- a/guides/module.txt
+++ b/guides/module.txt
@@ -1,0 +1,19 @@
+TOPIC
+    module
+
+DESCRIPTION
+    Modules are shareable, reusable packages of Puppet content. They can include
+    tasks, plans, functions, and other types of content that you can use in your
+    project. You can download and install modules to your project from the
+    Puppet Forge or write your own modules. Bolt also ships with several helpful
+    modules pre-installed that are available to all of your projects.
+
+    Bolt makes it easy to manage the modules that your project depends on. You
+    can use Bolt commands to install a project's modules, add new modules to a
+    project, and view the modules that are available to the project.
+    
+    To learn more about managing modules in a project, see the documentation.
+    To learn how modules are loaded by Bolt, see the 'modulepath' guide.
+
+DOCUMENTATION
+    https://pup.pt/bolt-modules

--- a/guides/modulepath.txt
+++ b/guides/modulepath.txt
@@ -1,0 +1,25 @@
+TOPIC
+    modulepath
+
+DESCRIPTION
+    The modulepath is an ordered list of directories that Bolt loads modules
+    from. When Bolt runs a command, it automatically loads modules from the
+    modulepath.
+    
+    While Bolt has a default modulepath, you can also configure your own
+    modulepath, which can include directories within the project or directories
+    elsewhere on your system. Regardless of whether your project uses a default
+    or configured modulepath, Bolt automatically adds directories to the
+    modulepath. This includes modules containing core Bolt content, which is
+    added to the beginning of the modulepath, and bundled content, which is
+    added to the end of the modulepath.
+
+    Modules loaded from a directory listed earlier in the modulepath take
+    precedence over modules with the same name loaded from a directory later in
+    the modulepath. Bolt will not warn or error when two modules share a name
+    and instead will ignore modules with a lower precedence.
+
+    To learn more about modules, see the 'module' guide.
+
+DOCUMENTATION
+    https://pup.pt/bolt-project-reference#modulepath


### PR DESCRIPTION
This adds a new 'module' topic guide. It gives a brief description of
what a module is and how Bolt can manage a project's modules.

This also adds a new 'modulepath' topic guide that describes what the
modulepath is, precedence of modules on the modulepath, and how Bolt
adds directories to the modulepath.

!no-release-note