### PR TITLE
(GH-2281) Add logging guide

### DIFF
--- a/guides/logging.txt
+++ b/guides/logging.txt
@@ -1,0 +1,18 @@
+TOPIC
+    logging
+
+DESCRIPTION
+    Bolt prints messages both to the console and to log files. Messages can
+    either come from Bolt's 'outputter', which logs user-facing messages like
+    progress and results, or from the 'logger', which logs warnings, errors, and
+    log-structured output to log files. Both of these message streams are
+    configurable.
+
+    By default, Bolt logs to the console at 'warn' level and writes a log file to
+    '<project>/bolt-debug.log' at 'debug' level. Unless you are running a plan,
+    Bolt runs in verbose mode by default.
+
+    To learn more about projects, see the 'project' guide.
+
+DOCUMENTATION
+    https://pup.pt/bolt-logging


### PR DESCRIPTION
This adds a brief guide to logging in Bolt, clarifying that there are
two output methods that are separate, and both configurable. This should
help clarify the difference between `--verbose` and `--log-level` for
users.

Note: This is from the hack day, I just forgot to demo + push

Closes #2281

!no-release-note