### PR TITLE
(GH-2259) Explicitly describe retrieving facts for a target

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/facts.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/facts.rb
@@ -3,6 +3,12 @@
 require 'bolt/error'
 
 # Returns the facts hash for a target.
+#
+# Using the `facts` function does not automatically collect facts for a target,
+# and will only return facts that are currently set in the inventory. To collect
+# facts from a target and set them in the inventory, run the
+# [facts](writing_plans.md#collect-facts-from-targets) plan or
+# [puppetdb_fact](writing_plans.md#collect-facts-from-puppetdb) plan.
 Puppet::Functions.create_function(:facts) do
   # @param target A target.
   # @return The target's facts.

--- a/documentation/bolt_types_reference.md
+++ b/documentation/bolt_types_reference.md
@@ -119,7 +119,7 @@ The following functions are available to `Target` objects:
 | Function | Type returned | Description | Note |
 |---|---|---|---|
 | `config` | `Hash[String, Data]` | The inventory configuration for the target. | This function returns the configuration set directly on the target in `inventory.yaml` or set in a plan using `Target.new` or `set_config()`. It does not return default configuration values or configuration set in Bolt configuration files.  |
-| `facts` | `Hash[String, Data]` | The target's facts. | This function does not look up facts for a target and only returns the facts specified in an `inventory.yaml` file or set on a target during a plan run. |
+| `facts` | `Hash[String, Data]` | The target's facts. | This function does not look up facts for a target and only returns the facts specified in an `inventory.yaml` file or set on a target during a plan run. To retrieve facts for a target and set them in inventory, run the [facts](writing_plans.md#collect-facts-from-targets) plan or [puppetdb_fact](writing_plans.md#collect-facts-from-puppetdb) plan. |
 | `features` | `Array[String]` | The target's features. ||
 | `host` | `String` | The target's hostname. ||
 | `name` | `String` | The target's human-readable name, or its URI if a name was not given. ||

--- a/documentation/writing_plans.md
+++ b/documentation/writing_plans.md
@@ -715,6 +715,12 @@ facts or variables for any target. Facts usually come from running `facter` or
 another fact collection application on the target, or from a fact store like
 PuppetDB. Variables are computed externally or assigned directly.
 
+Using the `facts` plan function does not automatically collect facts for a
+target, and will only return facts that are currently set in the inventory. To
+collect facts from a target and set them in the inventory, run the
+[facts](#collect-facts-from-targets) plan or
+[puppetdb_fact](#collect-facts-from-puppetdb) plan.
+
 Set variables in a plan using `$target.set_var`:
 
 ```


### PR DESCRIPTION
This adds notes to documentation for the `facts` plan function that the
function does not retrieve facts and only returns what is set on the
target in inventory. It describes how to retrieve and set facts by
running the `facts` or `puppetdb_fact` plan.

!no-release-note