### PR TITLE
(GH-2291) Enable bootsnap loadpath caching

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "addressable", '~> 2.5'
   spec.add_dependency "aws-sdk-ec2", '~> 1'
+  spec.add_dependency "bootsnap", "~> 1.5"
   spec.add_dependency "CFPropertyList", "~> 2.2"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "ffi", "< 1.14.0"

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "addressable", '~> 2.5'
   spec.add_dependency "aws-sdk-ec2", '~> 1'
-  spec.add_dependency "bootsnap", "~> 1.5"
+  spec.add_dependency "bootsnap", "~> 1.7"
   spec.add_dependency "CFPropertyList", "~> 2.2"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "ffi", "< 1.14.0"

--- a/exe/bolt
+++ b/exe/bolt
@@ -1,6 +1,21 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+bootsnap_enabled = ENV['BOLT_BOOTSNAP'] || false
+if bootsnap_enabled
+  require 'bootsnap'
+  cache = File.join(ENV['USERPROFILE'], '.puppetlabs', 'etc', 'bolt')
+  Bootsnap.setup(
+    cache_dir:            cache, # Path to your cache
+    development_mode:     false, # Current working environment, e.g. RACK_ENV, RAILS_ENV, etc
+    load_path_cache:      true,  # Optimize the LOAD_PATH with a cache
+    autoload_paths_cache: false, # Optimize ActiveSupport autoloads with cache
+    disable_trace:        false, # Set `RubyVM::InstructionSequence.compile_option = { trace_instruction: false }`
+    compile_cache_iseq:   true,  # Compile Ruby code into ISeq cache, breaks coverage reporting.
+    compile_cache_yaml:   true   # Compile YAML into a cache
+  )
+end
+
 require 'bolt'
 require 'bolt/cli'
 

--- a/exe/bolt
+++ b/exe/bolt
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
-  ENV['BOOTSNAP_CACHE_DIR'] = File.join(ENV['ProgramData'], 'Puppetlabs', 'bolt', 'etc')
+  ENV['BOOTSNAP_CACHE_DIR'] = File.join(ENV['ProgramData'], 'Puppetlabs', 'bolt')
   require 'bootsnap/setup'
 end
 require 'bolt'

--- a/exe/bolt
+++ b/exe/bolt
@@ -1,21 +1,10 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-bootsnap_enabled = ENV['BOLT_BOOTSNAP'] || false
-if bootsnap_enabled
-  require 'bootsnap'
-  cache = File.join(ENV['USERPROFILE'], '.puppetlabs', 'etc', 'bolt')
-  Bootsnap.setup(
-    cache_dir:            cache, # Path to your cache
-    development_mode:     false, # Current working environment, e.g. RACK_ENV, RAILS_ENV, etc
-    load_path_cache:      true,  # Optimize the LOAD_PATH with a cache
-    autoload_paths_cache: false, # Optimize ActiveSupport autoloads with cache
-    disable_trace:        false, # Set `RubyVM::InstructionSequence.compile_option = { trace_instruction: false }`
-    compile_cache_iseq:   true,  # Compile Ruby code into ISeq cache, breaks coverage reporting.
-    compile_cache_yaml:   true   # Compile YAML into a cache
-  )
+if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
+  ENV['BOOTSNAP_CACHE_DIR'] = File.join(ENV['ProgramData'], 'Puppetlabs', 'bolt', 'etc')
+  require 'bootsnap/setup'
 end
-
 require 'bolt'
 require 'bolt/cli'
 


### PR DESCRIPTION
Depends on

- [x] https://github.com/puppetlabs/puppet-runtime/pull/384
- [ ] https://github.com/puppetlabs/bolt-vanagon/pull/156
- [x] Change bolt bootsnap cache dir to $env:ProgramData/Puppetlabs/bolt in bolt project