### PR TITLE
(GH-2268) Add 'wait_until_available' method for puppetserver tests

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -76,7 +76,6 @@ jobs:
         run: |
           docker-compose -f spec/docker-compose.yml build --parallel
           docker-compose -f spec/docker-compose.yml up -d
-          sleep 15
           bundle exec r10k puppetfile install
       - name: Run tests with expensive containers
         run: bundle exec rake ci:linux:slow

--- a/spec/bolt/puppetdb/client_spec.rb
+++ b/spec/bolt/puppetdb/client_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 require 'bolt/puppetdb/client'
 require 'bolt_spec/puppetdb'
+require 'bolt_spec/bolt_server'
 require 'httpclient'
 
 describe Bolt::PuppetDB::Client do
@@ -117,6 +118,8 @@ describe Bolt::PuppetDB::Client do
 
   context 'when connected to puppetdb', puppetdb: true do
     include BoltSpec::PuppetDB
+    include BoltSpec::BoltServer
+
     def facts_hash
       { 'node1' => {
         'foo' => 'bar',
@@ -154,6 +157,7 @@ describe Bolt::PuppetDB::Client do
     end
 
     before(:all) do
+      wait_until_available(timeout: 30, interval: 1)
       push_facts(facts_hash)
     end
 

--- a/spec/bolt_server/file_cache_spec.rb
+++ b/spec/bolt_server/file_cache_spec.rb
@@ -13,9 +13,7 @@ describe BoltServer::FileCache, puppetserver: true do
   include BoltSpec::BoltServer
 
   before(:all) do
-    get_task_data('sample::echo')
-  rescue StandardError => e
-    raise "Could not get sample::echo from puppetserver. Tests will fail: #{e}"
+    wait_until_available(timeout: 30, interval: 1)
   end
 
   before(:each) do


### PR DESCRIPTION
This adds a `wait_until_available` method to `BoltSpec::BoltServer` that
will wait until puppetserver is running and accepting requests.
This fixes an issue where tests might be run too soon after the
puppetserver container was started and before it was ready to accept
requests, causing the tests to fail.

!no-release-note