### PR TITLE
(GH-2057) Add file and line number to Bolt errors

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/download_file.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/download_file.rb
@@ -112,7 +112,7 @@ Puppet::Functions.create_function(:download_file, Puppet::Functions::InternalFun
       call_function('debug', "Simulating file download of '#{source}' - no targets given - no action taken")
       r = Bolt::ResultSet.new([])
     else
-      r = executor.download_file(targets, source, destination, options)
+      r = executor.download_file(targets, source, destination, options, Puppet::Pops::PuppetStack.top_of_stack)
     end
 
     if !r.ok && !options[:catch_errors]

--- a/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
@@ -69,7 +69,7 @@ Puppet::Functions.create_function(:run_command) do
       call_function('debug', "Simulating run_command('#{command}') - no targets given - no action taken")
       r = Bolt::ResultSet.new([])
     else
-      r = executor.run_command(targets, command, options)
+      r = executor.run_command(targets, command, options, Puppet::Pops::PuppetStack.top_of_stack)
     end
 
     if !r.ok && !options[:catch_errors]

--- a/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
@@ -87,7 +87,7 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
     r = if targets.empty?
           Bolt::ResultSet.new([])
         else
-          executor.run_script(targets, found, arguments, options)
+          executor.run_script(targets, found, arguments, options, Puppet::Pops::PuppetStack.top_of_stack)
         end
 
     if !r.ok && !options[:catch_errors]

--- a/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
@@ -133,7 +133,7 @@ Puppet::Functions.create_function(:run_task) do
     if targets.empty?
       Bolt::ResultSet.new([])
     else
-      result = executor.run_task(targets, task, params, options)
+      result = executor.run_task(targets, task, params, options, Puppet::Pops::PuppetStack.top_of_stack)
       if !result.ok && !options[:catch_errors]
         raise Bolt::RunFailure.new(result, 'run_task', task_name)
       end

--- a/bolt-modules/boltlib/lib/puppet/functions/run_task_with.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task_with.rb
@@ -180,7 +180,7 @@ Puppet::Functions.create_function(:run_task_with) do
     else
       # Combine the results from the task run with any failing results that were
       # generated earlier when creating the target mapping
-      task_result = executor.run_task_with(target_mapping, task, options)
+      task_result = executor.run_task_with(target_mapping, task, options, Puppet::Pops::PuppetStack.top_of_stack)
       result = Bolt::ResultSet.new(task_result.results + error_set)
 
       if !result.ok && !options[:catch_errors]

--- a/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
@@ -83,7 +83,7 @@ Puppet::Functions.create_function(:upload_file, Puppet::Functions::InternalFunct
       call_function('debug', "Simulating file upload of '#{found}' - no targets given - no action taken")
       r = Bolt::ResultSet.new([])
     else
-      r = executor.upload_file(targets, found, destination, options)
+      r = executor.upload_file(targets, found, destination, options, Puppet::Pops::PuppetStack.top_of_stack)
     end
 
     if !r.ok && !options[:catch_errors]

--- a/bolt-modules/boltlib/spec/functions/download_file_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/download_file_spec.rb
@@ -41,14 +41,16 @@ describe 'download_file' do
 
     it 'with path of source and destination' do
       executor.expects(:download_file)
-              .with([target], source, project_destination, {})
+              .with([target], source, project_destination, {}, [])
               .returns(result_set)
 
       inventory.stubs(:get_targets)
                .with(hostname)
                .returns([target])
 
-      is_expected.to run.with_params(source, destination, hostname).and_return(result_set)
+      is_expected.to run
+        .with_params(source, destination, hostname)
+        .and_return(result_set)
     end
 
     it 'raises an error when destination is an empty string' do
@@ -60,7 +62,9 @@ describe 'download_file' do
                .with(hostname)
                .returns([target])
 
-      is_expected.to run.with_params(source, destination, hostname).and_raise_error(Bolt::ValidationError)
+      is_expected.to run
+        .with_params(source, destination, hostname)
+        .and_raise_error(Bolt::ValidationError)
     end
 
     it 'raises an error when destination is an aboslute path' do
@@ -72,7 +76,9 @@ describe 'download_file' do
                .with(hostname)
                .returns([target])
 
-      is_expected.to run.with_params(source, destination, hostname).and_raise_error(Bolt::ValidationError)
+      is_expected.to run
+        .with_params(source, destination, hostname)
+        .and_raise_error(Bolt::ValidationError)
     end
 
     it 'raises an error when destination includes path traversal' do
@@ -84,7 +90,9 @@ describe 'download_file' do
                .with(hostname)
                .returns([target])
 
-      is_expected.to run.with_params(source, destination, hostname).and_raise_error(Bolt::ValidationError)
+      is_expected.to run
+        .with_params(source, destination, hostname)
+        .and_raise_error(Bolt::ValidationError)
     end
 
     it 'strips leading and trailing whitespace from the destination' do
@@ -92,14 +100,16 @@ describe 'download_file' do
       project_destination = project.downloads + destination.strip
 
       executor.expects(:download_file)
-              .with([target], source, project_destination, {})
+              .with([target], source, project_destination, {}, [])
               .returns(result_set)
 
       inventory.stubs(:get_targets)
                .with(hostname)
                .returns([target])
 
-      is_expected.to run.with_params(source, destination, hostname).and_return(result_set)
+      is_expected.to run
+        .with_params(source, destination, hostname)
+        .and_return(result_set)
     end
 
     it 'does not expand tilde in the destination' do
@@ -107,14 +117,16 @@ describe 'download_file' do
       project_destination = project.downloads + destination
 
       executor.expects(:download_file)
-              .with([target], source, project_destination, {})
+              .with([target], source, project_destination, {}, [])
               .returns(result_set)
 
       inventory.stubs(:get_targets)
                .with(hostname)
                .returns([target])
 
-      is_expected.to run.with_params(source, destination, hostname).and_return(result_set)
+      is_expected.to run
+        .with_params(source, destination, hostname)
+        .and_return(result_set)
     end
 
     it 'deletes contents of existing destination directory' do
@@ -125,7 +137,7 @@ describe 'download_file' do
       FileUtils.stubs(:rm_r)
 
       executor.expects(:download_file)
-              .with([target], source, project_destination, {})
+              .with([target], source, project_destination, {}, [])
               .returns(result_set)
 
       inventory.stubs(:get_targets)
@@ -135,36 +147,42 @@ describe 'download_file' do
       FileUtils.expects(:rm_r)
                .with([], secure: true)
 
-      is_expected.to run.with_params(source, destination, hostname).and_return(result_set)
+      is_expected.to run
+        .with_params(source, destination, hostname)
+        .and_return(result_set)
     end
 
     it 'with target specified as a Target' do
       executor.expects(:download_file)
-              .with([target], source, project_destination, {})
+              .with([target], source, project_destination, {}, [])
               .returns(result_set)
 
       inventory.stubs(:get_targets)
                .with(target)
                .returns([target])
 
-      is_expected.to run.with_params(source, destination, target).and_return(result_set)
+      is_expected.to run
+        .with_params(source, destination, target)
+        .and_return(result_set)
     end
 
     it 'runs as another user' do
       executor.expects(:download_file)
-              .with([target], source, project_destination, run_as: 'soandso')
+              .with([target], source, project_destination, { run_as: 'soandso' }, [])
               .returns(result_set)
 
       inventory.stubs(:get_targets)
                .with(target)
                .returns([target])
 
-      is_expected.to run.with_params(source, destination, target, '_run_as' => 'soandso').and_return(result_set)
+      is_expected.to run
+        .with_params(source, destination, target, '_run_as' => 'soandso')
+        .and_return(result_set)
     end
 
     it 'reports the call to analytics' do
       executor.expects(:download_file)
-              .with([target], source, project_destination, {})
+              .with([target], source, project_destination, {}, [])
               .returns(result_set)
 
       inventory.stubs(:get_targets)
@@ -174,7 +192,9 @@ describe 'download_file' do
       executor.expects(:report_function_call)
               .with('download_file')
 
-      is_expected.to run.with_params(source, destination, hostname).and_return(result_set)
+      is_expected.to run
+        .with_params(source, destination, hostname)
+        .and_return(result_set)
     end
 
     context 'with description' do
@@ -182,52 +202,60 @@ describe 'download_file' do
 
       it 'passes the description through if parameters are passed' do
         executor.expects(:download_file)
-                .with([target], source, project_destination, description: message)
+                .with([target], source, project_destination, { description: message }, [])
                 .returns(result_set)
 
         inventory.stubs(:get_targets)
                  .with(target)
                  .returns([target])
 
-        is_expected.to run.with_params(source, destination, target, message, {}).and_return(result_set)
+        is_expected.to run
+          .with_params(source, destination, target, message, {})
+          .and_return(result_set)
       end
 
       it 'passes the description through if no parameters are passed' do
         executor.expects(:download_file)
-                .with([target], source, project_destination, description: message)
+                .with([target], source, project_destination, { description: message }, [])
                 .returns(result_set)
 
         inventory.stubs(:get_targets)
                  .with(target)
                  .returns([target])
 
-        is_expected.to run.with_params(source, destination, target, message).and_return(result_set)
+        is_expected.to run
+          .with_params(source, destination, target, message)
+          .and_return(result_set)
       end
     end
 
     context 'without description' do
       it 'ignores description if parameters are passed' do
         executor.expects(:download_file)
-                .with([target], source, project_destination, {})
+                .with([target], source, project_destination, {}, [])
                 .returns(result_set)
 
         inventory.stubs(:get_targets)
                  .with(target)
                  .returns([target])
 
-        is_expected.to run.with_params(source, destination, target, {}).and_return(result_set)
+        is_expected.to run
+          .with_params(source, destination, target, {})
+          .and_return(result_set)
       end
 
       it 'ignores description if no parameters are passed' do
         executor.expects(:download_file)
-                .with([target], source, project_destination, {})
+                .with([target], source, project_destination, {}, [])
                 .returns(result_set)
 
         inventory.stubs(:get_targets)
                  .with(target)
                  .returns([target])
 
-        is_expected.to run.with_params(source, destination, target).and_return(result_set)
+        is_expected.to run
+          .with_params(source, destination, target)
+          .and_return(result_set)
       end
     end
 
@@ -240,15 +268,16 @@ describe 'download_file' do
 
       it 'propagates multiple hosts and returns multiple results' do
         executor.expects(:download_file)
-                .with([target, target2], source, project_destination, {})
+                .with([target, target2], source, project_destination, {}, [])
                 .returns(result_set)
 
         inventory.stubs(:get_targets)
                  .with([hostname, hostname2])
                  .returns([target, target2])
 
-        is_expected.to run.with_params(source, destination, [hostname, hostname2])
-                          .and_return(result_set)
+        is_expected.to run
+          .with_params(source, destination, [hostname, hostname2])
+          .and_return(result_set)
       end
 
       context 'when download fails on one target' do
@@ -256,28 +285,30 @@ describe 'download_file' do
 
         it 'errors by default' do
           executor.expects(:download_file)
-                  .with([target, target2], source, project_destination, {})
+                  .with([target, target2], source, project_destination, {}, [])
                   .returns(result_set)
 
           inventory.expects(:get_targets)
                    .with([hostname, hostname2])
                    .returns([target, target2])
 
-          is_expected.to run.with_params(source, destination, [hostname, hostname2])
-                            .and_raise_error(Bolt::RunFailure)
+          is_expected.to run
+            .with_params(source, destination, [hostname, hostname2])
+            .and_raise_error(Bolt::RunFailure)
         end
 
         it 'does not error with _catch_errors' do
           executor.expects(:download_file)
-                  .with([target, target2], source, project_destination, catch_errors: true)
+                  .with([target, target2], source, project_destination, { catch_errors: true }, [])
                   .returns(result_set)
 
           inventory.expects(:get_targets)
                    .with([hostname, hostname2])
                    .returns([target, target2])
 
-          is_expected.to run.with_params(source, destination, [hostname, hostname2],
-                                         '_catch_errors' => true)
+          is_expected.to run
+            .with_params(source, destination, [hostname, hostname2],
+                         '_catch_errors' => true)
         end
       end
     end
@@ -286,8 +317,9 @@ describe 'download_file' do
       executor.expects(:download_file).never
       inventory.expects(:get_targets).with([]).returns([])
 
-      is_expected.to run.with_params(source, destination, [])
-                        .and_return(Bolt::ResultSet.new([]))
+      is_expected.to run
+        .with_params(source, destination, [])
+        .and_return(Bolt::ResultSet.new([]))
     end
   end
 
@@ -295,8 +327,9 @@ describe 'download_file' do
     let(:tasks_enabled) { false }
 
     it 'fails and reports that download_file is not available' do
-      is_expected.to run.with_params('/path/to/source', 'downloads', [])
-                        .and_raise_error(/Plan language function 'download_file' cannot be used/)
+      is_expected.to run
+        .with_params('/path/to/source', 'downloads', [])
+        .and_raise_error(/Plan language function 'download_file' cannot be used/)
     end
   end
 end

--- a/bolt-modules/boltlib/spec/functions/run_command_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_command_spec.rb
@@ -31,65 +31,97 @@ describe 'run_command' do
     end
 
     it 'with given command and host' do
-      executor.expects(:run_command).with([target], command, {}).returns(result_set)
+      executor.expects(:run_command)
+              .with([target], command, {}, [])
+              .returns(result_set)
       inventory.expects(:get_targets).with(hostname).returns([target])
 
-      is_expected.to run.with_params(command, hostname).and_return(result_set)
+      is_expected.to run
+        .with_params(command, hostname)
+        .and_return(result_set)
     end
 
     it 'with given command and Target' do
-      executor.expects(:run_command).with([target], command, {}).returns(result_set)
+      executor.expects(:run_command)
+              .with([target], command, {}, [])
+              .returns(result_set)
       inventory.expects(:get_targets).with(target).returns([target])
 
-      is_expected.to run.with_params(command, target).and_return(result_set)
+      is_expected.to run
+        .with_params(command, target)
+        .and_return(result_set)
     end
 
     it 'with _run_as' do
-      executor.expects(:run_command).with([target], command, run_as: 'root').returns(result_set)
+      executor.expects(:run_command)
+              .with([target], command, { run_as: 'root' }, [])
+              .returns(result_set)
       inventory.expects(:get_targets).with(target).returns([target])
 
-      is_expected.to run.with_params(command, target, '_run_as' => 'root').and_return(result_set)
+      is_expected.to run
+        .with_params(command, target, '_run_as' => 'root')
+        .and_return(result_set)
     end
 
     it 'reports the call to analytics' do
       executor.expects(:report_function_call).with('run_command')
-      executor.expects(:run_command).with([target], command, {}).returns(result_set)
+      executor.expects(:run_command)
+              .with([target], command, {}, [])
+              .returns(result_set)
       inventory.expects(:get_targets).with(hostname).returns([target])
 
-      is_expected.to run.with_params(command, hostname).and_return(result_set)
+      is_expected.to run
+        .with_params(command, hostname)
+        .and_return(result_set)
     end
 
     context 'with description' do
       let(:message) { 'test message' }
 
       it 'passes the description through if parameters are passed' do
-        executor.expects(:run_command).with([target], command, description: message).returns(result_set)
+        executor.expects(:run_command)
+                .with([target], command, { description: message }, [])
+                .returns(result_set)
         inventory.expects(:get_targets).with(target).returns([target])
 
-        is_expected.to run.with_params(command, target, message, {}).and_return(result_set)
+        is_expected.to run
+          .with_params(command, target, message, {})
+          .and_return(result_set)
       end
 
       it 'passes the description through if no parameters are passed' do
-        executor.expects(:run_command).with([target], command, description: message).returns(result_set)
+        executor.expects(:run_command)
+                .with([target], command, { description: message }, [])
+                .returns(result_set)
         inventory.expects(:get_targets).with(target).returns([target])
 
-        is_expected.to run.with_params(command, target, message).and_return(result_set)
+        is_expected.to run
+          .with_params(command, target, message)
+          .and_return(result_set)
       end
     end
 
     context 'without description' do
       it 'ignores description if parameters are passed' do
-        executor.expects(:run_command).with([target], command, {}).returns(result_set)
+        executor.expects(:run_command)
+                .with([target], command, {}, [])
+                .returns(result_set)
         inventory.expects(:get_targets).with(target).returns([target])
 
-        is_expected.to run.with_params(command, target, {}).and_return(result_set)
+        is_expected.to run
+          .with_params(command, target, {})
+          .and_return(result_set)
       end
 
       it 'ignores description if no parameters are passed' do
-        executor.expects(:run_command).with([target], command, {}).returns(result_set)
+        executor.expects(:run_command)
+                .with([target], command, {}, [])
+                .returns(result_set)
         inventory.expects(:get_targets).with(target).returns([target])
 
-        is_expected.to run.with_params(command, target).and_return(result_set)
+        is_expected.to run
+          .with_params(command, target)
+          .and_return(result_set)
       end
     end
 
@@ -100,37 +132,49 @@ describe 'run_command' do
       let(:result_set) { Bolt::ResultSet.new([result, result2]) }
 
       it 'with propagates multiple hosts and returns multiple results' do
-        executor.expects(:run_command).with([target, target2], command, {}).returns(result_set)
+        executor.expects(:run_command)
+                .with([target, target2], command, {}, [])
                 .returns(result_set)
         inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 
-        is_expected.to run.with_params(command, [hostname, hostname2]).and_return(result_set)
+        is_expected.to run
+          .with_params(command, [hostname, hostname2])
+          .and_return(result_set)
       end
 
       it 'with propagates multiple Targets and returns multiple results' do
-        executor.expects(:run_command).with([target, target2], command, {}).returns(result_set)
+        executor.expects(:run_command)
+                .with([target, target2], command, {}, [])
+                .returns(result_set)
         inventory.expects(:get_targets).with([target, target2]).returns([target, target2])
 
-        is_expected.to run.with_params(command, [target, target2]).and_return(result_set)
+        is_expected.to run
+          .with_params(command, [target, target2])
+          .and_return(result_set)
       end
 
       context 'when a command fails on one target' do
         let(:result2) { Bolt::Result.new(target2, error: { 'message' => hostname2 }) }
 
         it 'errors by default' do
-          executor.expects(:run_command).with([target, target2], command, {})
+          executor.expects(:run_command)
+                  .with([target, target2], command, {}, [])
                   .returns(result_set)
           inventory.expects(:get_targets).with([target, target2]).returns([target, target2])
 
-          is_expected.to run.with_params(command, [target, target2]).and_raise_error(Bolt::RunFailure)
+          is_expected.to run
+            .with_params(command, [target, target2])
+            .and_raise_error(Bolt::RunFailure)
         end
 
         it 'does not error with _catch_errors' do
-          executor.expects(:run_command).with([target, target2], command, catch_errors: true)
+          executor.expects(:run_command)
+                  .with([target, target2], command, { catch_errors: true }, [])
                   .returns(result_set)
           inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 
-          is_expected.to run.with_params(command, [hostname, hostname2], '_catch_errors' => true)
+          is_expected.to run
+            .with_params(command, [hostname, hostname2], '_catch_errors' => true)
         end
       end
     end
@@ -139,15 +183,18 @@ describe 'run_command' do
       executor.expects(:run_command).never
       inventory.expects(:get_targets).with([]).returns([])
 
-      is_expected.to run.with_params(command, []).and_return(Bolt::ResultSet.new([]))
+      is_expected.to run
+        .with_params(command, [])
+        .and_return(Bolt::ResultSet.new([]))
     end
   end
 
   context 'without tasks enabled' do
     let(:tasks_enabled) { false }
     it 'fails and reports that run_command is not available' do
-      is_expected.to run.with_params('echo hello', [])
-                        .and_raise_error(/Plan language function 'run_command' cannot be used/)
+      is_expected.to run
+        .with_params('echo hello', [])
+        .and_raise_error(/Plan language function 'run_command' cannot be used/)
     end
   end
 end

--- a/bolt-modules/boltlib/spec/functions/run_script_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_script_spec.rb
@@ -33,81 +33,117 @@ describe 'run_script' do
     end
 
     it 'with fully resolved path of file' do
-      executor.expects(:run_script).with([target], full_path, [], {}).returns(result_set)
+      executor.expects(:run_script)
+              .with([target], full_path, [], {}, [])
+              .returns(result_set)
       inventory.expects(:get_targets).with(hostname).returns([target])
 
-      is_expected.to run.with_params('test/uploads/hostname.sh', hostname).and_return(result_set)
+      is_expected.to run
+        .with_params('test/uploads/hostname.sh', hostname)
+        .and_return(result_set)
     end
 
     it 'with host given as Target' do
-      executor.expects(:run_script).with([target], full_path, [], {}).returns(result_set)
+      executor.expects(:run_script)
+              .with([target], full_path, [], {}, [])
+              .returns(result_set)
       inventory.expects(:get_targets).with(target).returns([target])
 
-      is_expected.to run.with_params('test/uploads/hostname.sh', target).and_return(result_set)
+      is_expected.to run
+        .with_params('test/uploads/hostname.sh', target)
+        .and_return(result_set)
     end
 
     it 'with given arguments as a hash of {arguments => [value]}' do
-      executor.expects(:run_script).with([target], full_path, %w[hello world], {}).returns(result_set)
+      executor.expects(:run_script)
+              .with([target], full_path, %w[hello world], {}, [])
+              .returns(result_set)
       inventory.expects(:get_targets).with(hostname).returns([target])
 
-      is_expected.to run.with_params('test/uploads/hostname.sh',
-                                     hostname,
-                                     'arguments' => %w[hello world]).and_return(result_set)
+      is_expected.to run
+        .with_params('test/uploads/hostname.sh',
+                     hostname,
+                     { 'arguments' => %w[hello world] })
+        .and_return(result_set)
     end
 
     it 'with given arguments as a hash of {arguments => []}' do
-      executor.expects(:run_script).with([target], full_path, [], {}).returns(result_set)
+      executor.expects(:run_script)
+              .with([target], full_path, [], {}, [])
+              .returns(result_set)
       inventory.expects(:get_targets).with(target).returns([target])
 
-      is_expected.to run.with_params('test/uploads/hostname.sh', target, 'arguments' => []).and_return(result_set)
+      is_expected.to run
+        .with_params('test/uploads/hostname.sh', target, 'arguments' => [])
+        .and_return(result_set)
     end
 
     it 'with _run_as' do
-      executor.expects(:run_script).with([target], full_path, [], run_as: 'root').returns(result_set)
+      executor.expects(:run_script)
+              .with([target], full_path, [], { run_as: 'root' }, [])
+              .returns(result_set)
       inventory.expects(:get_targets).with(target).returns([target])
 
-      is_expected.to run.with_params('test/uploads/hostname.sh', target, '_run_as' => 'root').and_return(result_set)
+      is_expected.to run
+        .with_params('test/uploads/hostname.sh', target, '_run_as' => 'root')
+        .and_return(result_set)
     end
 
     it 'reports the call to analytics' do
       executor.expects(:report_function_call).with('run_script')
-      executor.expects(:run_script).with([target], full_path, [], {}).returns(result_set)
+      executor.expects(:run_script)
+              .with([target], full_path, [], {}, [])
+              .returns(result_set)
       inventory.expects(:get_targets).with(hostname).returns([target])
 
-      is_expected.to run.with_params('test/uploads/hostname.sh', hostname).and_return(result_set)
+      is_expected.to run
+        .with_params('test/uploads/hostname.sh', hostname)
+        .and_return(result_set)
     end
 
     context 'with description' do
       let(:message) { 'test message' }
 
       it 'passes the description through if parameters are passed' do
-        executor.expects(:run_script).with([target], full_path, [], description: message).returns(result_set)
+        executor.expects(:run_script)
+                .with([target], full_path, [], { description: message }, [])
+                .returns(result_set)
         inventory.expects(:get_targets).with(target).returns([target])
 
-        is_expected.to run.with_params('test/uploads/hostname.sh', target, message, {})
+        is_expected.to run
+          .with_params('test/uploads/hostname.sh', target, message, {})
       end
 
       it 'passes the description through if no parameters are passed' do
-        executor.expects(:run_script).with([target], full_path, [], description: message).returns(result_set)
+        executor.expects(:run_script)
+                .with([target], full_path, [], { description: message }, [])
+                .returns(result_set)
         inventory.expects(:get_targets).with(target).returns([target])
 
-        is_expected.to run.with_params('test/uploads/hostname.sh', target, message)
+        is_expected.to run
+          .with_params('test/uploads/hostname.sh', target, message)
       end
     end
 
     context 'without description' do
       it 'ignores description if parameters are passed' do
-        executor.expects(:run_script).with([target], full_path, [], {}).returns(result_set)
+        executor.expects(:run_script)
+                .with([target], full_path, [], {}, [])
+                .returns(result_set)
         inventory.expects(:get_targets).with(target).returns([target])
 
-        is_expected.to run.with_params('test/uploads/hostname.sh', target, {})
+        is_expected.to run
+          .with_params('test/uploads/hostname.sh', target, {})
       end
 
       it 'ignores description if no parameters are passed' do
-        executor.expects(:run_script).with([target], full_path, [], {}).returns(result_set)
+        executor.expects(:run_script)
+                .with([target], full_path, [], {}, [])
+                .returns(result_set)
         inventory.expects(:get_targets).with(target).returns([target])
 
-        is_expected.to run.with_params('test/uploads/hostname.sh', target)
+        is_expected.to run
+          .with_params('test/uploads/hostname.sh', target)
       end
     end
 
@@ -118,31 +154,38 @@ describe 'run_script' do
       let(:result_set) { Bolt::ResultSet.new([result, result2]) }
 
       it 'with propagated multiple hosts and returns multiple results' do
-        executor.expects(:run_script).with([target, target2], full_path, [], {})
+        executor.expects(:run_script)
+                .with([target, target2], full_path, [], {}, [])
                 .returns(result_set)
         inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 
-        is_expected.to run.with_params('test/uploads/hostname.sh', [hostname, hostname2]).and_return(result_set)
+        is_expected.to run
+          .with_params('test/uploads/hostname.sh', [hostname, hostname2])
+          .and_return(result_set)
       end
 
       context 'when a script fails on one target' do
         let(:result2) { Bolt::Result.new(target2, error: { 'message' => hostname2 }) }
 
         it 'errors by default' do
-          executor.expects(:run_script).with([target, target2], full_path, [], {})
+          executor.expects(:run_script)
+                  .with([target, target2], full_path, [], {}, [])
                   .returns(result_set)
           inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 
-          is_expected.to run.with_params('test/uploads/hostname.sh', [hostname, hostname2])
-                            .and_raise_error(Bolt::RunFailure)
+          is_expected.to run
+            .with_params('test/uploads/hostname.sh', [hostname, hostname2])
+            .and_raise_error(Bolt::RunFailure)
         end
 
         it 'does not error with _catch_errors' do
-          executor.expects(:run_script).with([target, target2], full_path, [], catch_errors: true)
+          executor.expects(:run_script)
+                  .with([target, target2], full_path, [], { catch_errors: true }, [])
                   .returns(result_set)
           inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 
-          is_expected.to run.with_params('test/uploads/hostname.sh', [hostname, hostname2], '_catch_errors' => true)
+          is_expected.to run
+            .with_params('test/uploads/hostname.sh', [hostname, hostname2], '_catch_errors' => true)
         end
       end
     end
@@ -152,20 +195,24 @@ describe 'run_script' do
       inventory.expects(:get_targets).with([]).returns([])
 
       is_expected.to run
-        .with_params('test/uploads/hostname.sh', []).and_return(Bolt::ResultSet.new([]))
+        .with_params('test/uploads/hostname.sh', [])
+        .and_return(Bolt::ResultSet.new([]))
     end
 
     it 'errors when script is not found' do
       executor.expects(:run_script).never
 
       is_expected.to run
-        .with_params('test/uploads/nonesuch.sh', []).and_raise_error(/No such file or directory: .*nonesuch\.sh/)
+        .with_params('test/uploads/nonesuch.sh', [])
+        .and_raise_error(/No such file or directory: .*nonesuch\.sh/)
     end
 
     it 'errors when script appoints a directory' do
       executor.expects(:run_script).never
 
-      is_expected.to run.with_params('test/uploads', []).and_raise_error(%r{.*/uploads is not a file})
+      is_expected.to run
+        .with_params('test/uploads', [])
+        .and_raise_error(%r{.*/uploads is not a file})
     end
   end
 

--- a/bolt-modules/boltlib/spec/functions/run_task_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_spec.rb
@@ -56,41 +56,54 @@ describe 'run_task' do
     it 'when running a task without metadata the input method is "both"' do
       executable = File.join(tasks_root, 'echo.sh')
 
-      executor.expects(:run_task).with([target], mock_task(executable, nil), default_args, {}).returns(result_set)
+      executor.expects(:run_task)
+              .with([target], mock_task(executable, nil), default_args, {}, [])
+              .returns(result_set)
       inventory.expects(:get_targets).with(hostname).returns([target])
 
-      is_expected.to run.with_params('Test::Echo', hostname, default_args).and_return(result_set)
+      is_expected.to run
+        .with_params('Test::Echo', hostname, default_args)
+        .and_return(result_set)
     end
 
     it 'when running a task with metadata - the input method is specified by the metadata' do
       executable = File.join(tasks_root, 'meta.sh')
 
-      executor.expects(:run_task).with([target], mock_task(executable, 'environment'), default_args, {})
+      executor.expects(:run_task)
+              .with([target], mock_task(executable, 'environment'), default_args, {}, [])
               .returns(result_set)
       inventory.expects(:get_targets).with(hostname).returns([target])
 
-      is_expected.to run.with_params('Test::Meta', hostname, default_args).and_return(result_set)
+      is_expected.to run
+        .with_params('Test::Meta', hostname, default_args)
+        .and_return(result_set)
     end
 
     it 'when called with _run_as - _run_as is passed to the executor' do
       executable = File.join(tasks_root, 'meta.sh')
 
       executor.expects(:run_task)
-              .with([target], mock_task(executable, 'environment'), default_args, run_as: 'root')
+              .with([target], mock_task(executable, 'environment'), default_args, { run_as: 'root' }, [])
               .returns(result_set)
       inventory.expects(:get_targets).with(hostname).returns([target])
 
       args = default_args.merge('_run_as' => 'root')
-      is_expected.to run.with_params('Test::Meta', hostname, args).and_return(result_set)
+      is_expected.to run
+        .with_params('Test::Meta', hostname, args)
+        .and_return(result_set)
     end
 
     it 'when called without without args hash (for a task where this is allowed)' do
       executable = File.join(tasks_root, 'yes.sh')
 
-      executor.expects(:run_task).with([target], mock_task(executable, nil), {}, {}).returns(result_set)
+      executor.expects(:run_task)
+              .with([target], mock_task(executable, nil), {}, {}, [])
+              .returns(result_set)
       inventory.expects(:get_targets).with(hostname).returns([target])
 
-      is_expected.to run.with_params('test::yes', hostname).and_return(result_set)
+      is_expected.to run
+        .with_params('test::yes', hostname)
+        .and_return(result_set)
     end
 
     it 'uses the default if a parameter is not specified' do
@@ -102,11 +115,13 @@ describe 'run_task' do
       }
 
       expected_args = args.merge('default_string' => 'hello', 'optional_default_string' => 'goodbye')
-      executor.expects(:run_task).with([target], mock_task(executable, 'stdin'), expected_args, {})
+      executor.expects(:run_task)
+              .with([target], mock_task(executable, 'stdin'), expected_args, {}, [])
               .returns(result_set)
       inventory.expects(:get_targets).with(hostname).returns([target])
 
-      is_expected.to run.with_params('Test::Params', hostname, args)
+      is_expected.to run
+        .with_params('Test::Params', hostname, args)
     end
 
     it 'does not use the default if a parameter is specified' do
@@ -119,11 +134,13 @@ describe 'run_task' do
         'optional_default_string' => 'something else'
       }
 
-      executor.expects(:run_task).with([target], mock_task(executable, 'stdin'), args, {})
+      executor.expects(:run_task)
+              .with([target], mock_task(executable, 'stdin'), args, {}, [])
               .returns(result_set)
       inventory.expects(:get_targets).with(hostname).returns([target])
 
-      is_expected.to run.with_params('Test::Params', hostname, args)
+      is_expected.to run
+        .with_params('Test::Params', hostname, args)
     end
 
     it 'uses the default if a parameter is specified as undef' do
@@ -137,18 +154,23 @@ describe 'run_task' do
         'undef_no_default' => nil
       }
 
-      executor.expects(:run_task).with([target], mock_task(executable, 'environment'), expected_args, {})
+      executor.expects(:run_task)
+              .with([target], mock_task(executable, 'environment'), expected_args, {}, [])
               .returns(result_set)
       inventory.expects(:get_targets).with(hostname).returns([target])
 
-      is_expected.to run.with_params('test::undef', hostname, args).and_return(result_set)
+      is_expected.to run
+        .with_params('test::undef', hostname, args)
+        .and_return(result_set)
     end
 
     it 'when called with no destinations - does not invoke bolt' do
       executor.expects(:run_task).never
       inventory.expects(:get_targets).with([]).returns([])
 
-      is_expected.to run.with_params('Test::Yes', []).and_return(Bolt::ResultSet.new([]))
+      is_expected.to run
+        .with_params('Test::Yes', [])
+        .and_return(Bolt::ResultSet.new([]))
     end
 
     it 'reports the function call and task name to analytics' do
@@ -156,10 +178,14 @@ describe 'run_task' do
       executor.expects(:report_bundled_content).with('Task', 'Test::Echo').once
       executable = File.join(tasks_root, 'echo.sh')
 
-      executor.expects(:run_task).with([target], mock_task(executable, nil), default_args, {}).returns(result_set)
+      executor.expects(:run_task)
+              .with([target], mock_task(executable, nil), default_args, {}, [])
+              .returns(result_set)
       inventory.expects(:get_targets).with(hostname).returns([target])
 
-      is_expected.to run.with_params('Test::Echo', hostname, default_args).and_return(result_set)
+      is_expected.to run
+        .with_params('Test::Echo', hostname, default_args)
+        .and_return(result_set)
     end
 
     it 'skips reporting the function call to analytics if called internally from Bolt' do
@@ -167,12 +193,13 @@ describe 'run_task' do
       executable = File.join(tasks_root, 'echo.sh')
 
       executor.expects(:run_task)
-              .with([target], mock_task(executable, nil), default_args, kind_of(Hash))
+              .with([target], mock_task(executable, nil), default_args, kind_of(Hash), [])
               .returns(result_set)
       inventory.expects(:get_targets).with(hostname).returns([target])
 
-      is_expected.to run.with_params('Test::Echo', hostname, default_args.merge('_bolt_api_call' => true))
-                        .and_return(result_set)
+      is_expected.to run
+        .with_params('Test::Echo', hostname, default_args.merge('_bolt_api_call' => true))
+        .and_return(result_set)
     end
 
     context 'without tasks enabled' do
@@ -180,7 +207,8 @@ describe 'run_task' do
 
       it 'fails and reports that run_task is not available' do
         is_expected.to run
-          .with_params('Test::Echo', hostname).and_raise_error(/Plan language function 'run_task' cannot be used/)
+          .with_params('Test::Echo', hostname)
+          .and_raise_error(/Plan language function 'run_task' cannot be used/)
       end
     end
 
@@ -188,33 +216,45 @@ describe 'run_task' do
       let(:message) { 'test message' }
 
       it 'passes the description through if parameters are passed' do
-        executor.expects(:run_task).with([target], anything, {}, description: message).returns(result_set)
+        executor.expects(:run_task)
+                .with([target], anything, {}, { description: message }, [])
+                .returns(result_set)
         inventory.expects(:get_targets).with(hostname).returns([target])
 
-        is_expected.to run.with_params('test::yes', hostname, message, {})
+        is_expected.to run
+          .with_params('test::yes', hostname, message, {})
       end
 
       it 'passes the description through if no parameters are passed' do
-        executor.expects(:run_task).with([target], anything, {}, description: message).returns(result_set)
+        executor.expects(:run_task)
+                .with([target], anything, {}, { description: message }, [])
+                .returns(result_set)
         inventory.expects(:get_targets).with(hostname).returns([target])
 
-        is_expected.to run.with_params('test::yes', hostname, message)
+        is_expected.to run
+          .with_params('test::yes', hostname, message)
       end
     end
 
     context 'without description' do
       it 'ignores description if parameters are passed' do
-        executor.expects(:run_task).with([target], anything, {}, {}).returns(result_set)
+        executor.expects(:run_task)
+                .with([target], anything, {}, {}, [])
+                .returns(result_set)
         inventory.expects(:get_targets).with(hostname).returns([target])
 
-        is_expected.to run.with_params('test::yes', hostname, {})
+        is_expected.to run
+          .with_params('test::yes', hostname, {})
       end
 
       it 'ignores description if no parameters are passed' do
-        executor.expects(:run_task).with([target], anything, {}, {}).returns(result_set)
+        executor.expects(:run_task)
+                .with([target], anything, {}, {}, [])
+                .returns(result_set)
         inventory.expects(:get_targets).with(hostname).returns([target])
 
-        is_expected.to run.with_params('test::yes', hostname)
+        is_expected.to run
+          .with_params('test::yes', hostname)
       end
     end
 
@@ -224,23 +264,27 @@ describe 'run_task' do
       it 'targets can be specified as repeated nested arrays and strings and combine into one list of targets' do
         executable = File.join(tasks_root, 'meta.sh')
 
-        executor.expects(:run_task).with([target, target2], mock_task(executable, 'environment'), default_args, {})
+        executor.expects(:run_task)
+                .with([target, target2], mock_task(executable, 'environment'), default_args, {}, [])
                 .returns(result_set)
         inventory.expects(:get_targets).with([hostname, [[hostname2]], []]).returns([target, target2])
 
-        is_expected.to run.with_params('Test::Meta', [hostname, [[hostname2]], []], default_args)
-                          .and_return(result_set)
+        is_expected.to run
+          .with_params('Test::Meta', [hostname, [[hostname2]], []], default_args)
+          .and_return(result_set)
       end
 
       it 'targets can be specified as repeated nested arrays and Targets and combine into one list of targets' do
         executable = File.join(tasks_root, 'meta.sh')
 
-        executor.expects(:run_task).with([target, target2], mock_task(executable, 'environment'), default_args, {})
+        executor.expects(:run_task)
+                .with([target, target2], mock_task(executable, 'environment'), default_args, {}, [])
                 .returns(result_set)
         inventory.expects(:get_targets).with([target, [[target2]], []]).returns([target, target2])
 
-        is_expected.to run.with_params('Test::Meta', [target, [[target2]], []], default_args)
-                          .and_return(result_set)
+        is_expected.to run
+          .with_params('Test::Meta', [target, [[target2]], []], default_args)
+          .and_return(result_set)
       end
 
       context 'when a command fails on one target' do
@@ -250,12 +294,14 @@ describe 'run_task' do
         it 'errors by default' do
           executable = File.join(tasks_root, 'meta.sh')
 
-          executor.expects(:run_task).with([target, target2], mock_task(executable, 'environment'), default_args, {})
+          executor.expects(:run_task)
+                  .with([target, target2], mock_task(executable, 'environment'), default_args, {}, [])
                   .returns(result_set)
           inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 
-          is_expected.to run.with_params('Test::Meta', [hostname, hostname2], default_args)
-                            .and_raise_error(Bolt::RunFailure)
+          is_expected.to run
+            .with_params('Test::Meta', [hostname, hostname2], default_args)
+            .and_raise_error(Bolt::RunFailure)
         end
 
         it 'does not error with _catch_errors' do
@@ -264,12 +310,14 @@ describe 'run_task' do
           executor.expects(:run_task).with([target, target2],
                                            mock_task(executable, 'environment'),
                                            default_args,
-                                           catch_errors: true)
+                                           { catch_errors: true },
+                                           [])
                   .returns(result_set)
           inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 
           args = default_args.merge('_catch_errors' => true)
-          is_expected.to run.with_params('Test::Meta', [hostname, hostname2], args)
+          is_expected.to run
+            .with_params('Test::Meta', [hostname, hostname2], args)
         end
       end
     end
@@ -279,7 +327,8 @@ describe 'run_task' do
         executor.expects(:run_task).never
         inventory.expects(:get_targets).with([]).returns([])
 
-        is_expected.to run.with_params('test::echo', [])
+        is_expected.to run
+          .with_params('test::echo', [])
       end
     end
 
@@ -287,19 +336,25 @@ describe 'run_task' do
       it 'finds task named after the module' do
         executable = File.join(tasks_root, 'init.sh')
 
-        executor.expects(:run_task).with([target], mock_task(executable, nil), {}, {}).returns(result_set)
+        executor.expects(:run_task)
+                .with([target], mock_task(executable, nil), {}, {}, [])
+                .returns(result_set)
         inventory.expects(:get_targets).with(hostname).returns([target])
 
-        is_expected.to run.with_params('test', hostname).and_return(result_set)
+        is_expected.to run
+          .with_params('test', hostname)
+          .and_return(result_set)
       end
     end
 
     it 'when called with non existing task - reports an unknown task error' do
       inventory.expects(:get_targets).with([]).returns([])
 
-      is_expected.to run.with_params('test::nonesuch', []).and_raise_error(
-        /Could not find a task named "test::nonesuch"/
-      )
+      is_expected.to run
+        .with_params('test::nonesuch', [])
+        .and_raise_error(
+          /Could not find a task named "test::nonesuch"/
+        )
     end
 
     context 'with sensitive data parameters' do
@@ -333,11 +388,14 @@ describe 'run_task' do
         sensitive.expects(:new).with(input_params['sensitive_hash'])
                  .returns(expected_params['sensitive_hash'])
 
-        executor.expects(:run_task).with([target], mock_task(executable, nil), expected_params, {})
+        executor.expects(:run_task)
+                .with([target], mock_task(executable, nil), expected_params, {}, [])
                 .returns(result_set)
         inventory.expects(:get_targets).with(hostname).returns([target])
 
-        is_expected.to run.with_params('Test::Sensitive_Meta', hostname, input_params).and_return(result_set)
+        is_expected.to run
+          .with_params('Test::Sensitive_Meta', hostname, input_params)
+          .and_return(result_set)
       end
     end
   end
@@ -354,23 +412,27 @@ describe 'run_task' do
         'bar' => 'bar'
       )
 
-      is_expected.to run.with_params(task_name, hostname, task_params).and_raise_error(
-        Puppet::ParseError,
-        %r{Task\ test::params:\n
-         \s*has\ no\ parameter\ named\ 'foo'\n
-         \s*has\ no\ parameter\ named\ 'bar'}x
-      )
+      is_expected.to run
+        .with_params(task_name, hostname, task_params)
+        .and_raise_error(
+          Puppet::ParseError,
+          %r{Task\ test::params:\n
+           \s*has\ no\ parameter\ named\ 'foo'\n
+           \s*has\ no\ parameter\ named\ 'bar'}x
+        )
     end
 
     it 'errors when required parameters are not specified' do
       task_params['mandatory_string'] = 'str'
 
-      is_expected.to run.with_params(task_name, hostname, task_params).and_raise_error(
-        Puppet::ParseError,
-        %r{Task\ test::params:\n
-         \s*expects\ a\ value\ for\ parameter\ 'mandatory_integer'\n
-         \s*expects\ a\ value\ for\ parameter\ 'mandatory_boolean'}x
-      )
+      is_expected.to run
+        .with_params(task_name, hostname, task_params)
+        .and_raise_error(
+          Puppet::ParseError,
+          %r{Task\ test::params:\n
+           \s*expects\ a\ value\ for\ parameter\ 'mandatory_integer'\n
+           \s*expects\ a\ value\ for\ parameter\ 'mandatory_boolean'}x
+        )
     end
 
     it "errors when the specified parameter values don't match the expected data types" do
@@ -381,13 +443,15 @@ describe 'run_task' do
         'optional_string' => 10
       )
 
-      is_expected.to run.with_params(task_name, hostname, task_params).and_raise_error(
-        Puppet::ParseError,
-        %r{Task\ test::params:\n
-         \s*parameter\ 'mandatory_boolean'\ expects\ a\ Boolean\ value,\ got\ String\n
-         \s*parameter\ 'optional_string'\ expects\ a\ value\ of\ type\ Undef\ or\ String,
-                                        \ got\ Integer}x
-      )
+      is_expected.to run
+        .with_params(task_name, hostname, task_params)
+        .and_raise_error(
+          Puppet::ParseError,
+          %r{Task\ test::params:\n
+           \s*parameter\ 'mandatory_boolean'\ expects\ a\ Boolean\ value,\ got\ String\n
+           \s*parameter\ 'optional_string'\ expects\ a\ value\ of\ type\ Undef\ or\ String,
+                                          \ got\ Integer}x
+        )
     end
 
     it 'errors when the specified parameter values are outside of the expected ranges' do
@@ -398,13 +462,15 @@ describe 'run_task' do
         'optional_integer' => 10
       )
 
-      is_expected.to run.with_params(task_name, hostname, task_params).and_raise_error(
-        Puppet::ParseError,
-        %r{Task\ test::params:\n
-         \s*parameter\ 'mandatory_string'\ expects\ a\ String\[1,\ 10\]\ value,\ got\ String\n
-         \s*parameter\ 'optional_integer'\ expects\ a\ value\ of\ type\ Undef\ or\ Integer\[-5,\ 5\],
-                                         \ got\ Integer\[10,\ 10\]}x
-      )
+      is_expected.to run
+        .with_params(task_name, hostname, task_params)
+        .and_raise_error(
+          Puppet::ParseError,
+          %r{Task\ test::params:\n
+           \s*parameter\ 'mandatory_string'\ expects\ a\ String\[1,\ 10\]\ value,\ got\ String\n
+           \s*parameter\ 'optional_integer'\ expects\ a\ value\ of\ type\ Undef\ or\ Integer\[-5,\ 5\],
+                                           \ got\ Integer\[10,\ 10\]}x
+        )
     end
 
     it "errors when a specified parameter value is not Data" do
@@ -415,9 +481,11 @@ describe 'run_task' do
         'optional_hash' => { now: Time.now }
       )
 
-      is_expected.to run.with_params(task_name, hostname, task_params).and_raise_error(
-        Puppet::ParseError, /Task parameters are not of type Data. run_task()/
-      )
+      is_expected.to run
+        .with_params(task_name, hostname, task_params)
+        .and_raise_error(
+          Puppet::ParseError, /Task parameters are not of type Data. run_task()/
+        )
     end
   end
 end

--- a/bolt-modules/boltlib/spec/functions/run_task_with_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_with_spec.rb
@@ -74,7 +74,7 @@ describe 'run_task_with' do
       }
 
       executor.expects(:run_task_with)
-              .with(target_mapping, mock_task(executable, 'environment'), {})
+              .with(target_mapping, mock_task(executable, 'environment'), {}, [])
               .returns(result_set)
 
       inventory.expects(:get_targets).with(hosts).returns(targets)
@@ -88,7 +88,7 @@ describe 'run_task_with' do
       executable = File.join(tasks_root, 'meta.sh')
 
       executor.expects(:run_task_with)
-              .with(target_mapping, mock_task(executable, 'environment'), run_as: 'root')
+              .with(target_mapping, mock_task(executable, 'environment'), { run_as: 'root' }, [])
               .returns(result_set)
 
       inventory.expects(:get_targets).with(hosts).returns(targets)
@@ -118,7 +118,9 @@ describe 'run_task_with' do
         target2 => args.merge(defaults)
       }
 
-      executor.expects(:run_task_with).with(target_mapping, mock_task(executable, 'stdin'), {}).returns(result_set)
+      executor.expects(:run_task_with)
+              .with(target_mapping, mock_task(executable, 'stdin'), {}, [])
+              .returns(result_set)
       inventory.expects(:get_targets).with(hosts).returns(targets)
 
       is_expected.to(run
@@ -139,7 +141,9 @@ describe 'run_task_with' do
 
       target_mapping = { target => args, target2 => args }
 
-      executor.expects(:run_task_with).with(target_mapping, mock_task(executable, 'stdin'), {}).returns(result_set)
+      executor.expects(:run_task_with)
+              .with(target_mapping, mock_task(executable, 'stdin'), {}, [])
+              .returns(result_set)
       inventory.expects(:get_targets).with(hosts).returns(targets)
 
       is_expected.to(run
@@ -162,7 +166,8 @@ describe 'run_task_with' do
         target2 => expected_args
       }
 
-      executor.expects(:run_task_with).with(target_mapping, mock_task(executable, 'environment'), {})
+      executor.expects(:run_task_with)
+              .with(target_mapping, mock_task(executable, 'environment'), {}, [])
               .returns(result_set)
       inventory.expects(:get_targets).with(hosts).returns(targets)
 
@@ -186,7 +191,9 @@ describe 'run_task_with' do
       executor.expects(:report_bundled_content).with('Task', 'Test::Echo').once
       executable = File.join(tasks_root, 'echo.sh')
 
-      executor.expects(:run_task_with).with(target_mapping, mock_task(executable, nil), {}).returns(result_set)
+      executor.expects(:run_task_with)
+              .with(target_mapping, mock_task(executable, nil), {}, [])
+              .returns(result_set)
       inventory.expects(:get_targets).with(hosts).returns(targets)
 
       is_expected.to(run
@@ -199,7 +206,9 @@ describe 'run_task_with' do
       let(:message) { 'test message' }
 
       it 'passes the description through' do
-        executor.expects(:run_task_with).with(target_mapping, anything, description: message).returns(result_set)
+        executor.expects(:run_task_with)
+                .with(target_mapping, anything, { description: message }, [])
+                .returns(result_set)
         inventory.expects(:get_targets).with(hosts).returns(targets)
 
         is_expected.to(run
@@ -210,7 +219,9 @@ describe 'run_task_with' do
 
     context 'without description' do
       it 'ignores description if options are passed' do
-        executor.expects(:run_task_with).with(target_mapping, anything, {}).returns(result_set)
+        executor.expects(:run_task_with)
+                .with(target_mapping, anything, {}, [])
+                .returns(result_set)
         inventory.expects(:get_targets).with(hosts).returns(targets)
 
         is_expected.to(run
@@ -219,7 +230,9 @@ describe 'run_task_with' do
       end
 
       it 'ignores description if no parameters are passed' do
-        executor.expects(:run_task_with).with(target_mapping, anything, {}).returns(result_set)
+        executor.expects(:run_task_with)
+                .with(target_mapping, anything, {}, [])
+                .returns(result_set)
         inventory.expects(:get_targets).with(hosts).returns(targets)
 
         is_expected.to(run
@@ -235,7 +248,7 @@ describe 'run_task_with' do
         executable = File.join(tasks_root, 'meta.sh')
 
         executor.expects(:run_task_with)
-                .with(target_mapping, mock_task(executable, 'environment'), {})
+                .with(target_mapping, mock_task(executable, 'environment'), {}, [])
                 .returns(result_set)
 
         inventory.expects(:get_targets).with([hostname, [[hostname2]], []]).returns(targets)
@@ -250,7 +263,7 @@ describe 'run_task_with' do
         executable = File.join(tasks_root, 'meta.sh')
 
         executor.expects(:run_task_with)
-                .with(target_mapping, mock_task(executable, 'environment'), {})
+                .with(target_mapping, mock_task(executable, 'environment'), {}, [])
                 .returns(result_set)
 
         inventory.expects(:get_targets).with([target, [[target2]], []]).returns(targets)
@@ -269,7 +282,7 @@ describe 'run_task_with' do
           executable = File.join(tasks_root, 'meta.sh')
 
           executor.expects(:run_task_with)
-                  .with(target_mapping, mock_task(executable, 'environment'), {})
+                  .with(target_mapping, mock_task(executable, 'environment'), {}, [])
                   .returns(result_set)
 
           inventory.expects(:get_targets).with(hosts).returns(targets)
@@ -284,7 +297,7 @@ describe 'run_task_with' do
           executable = File.join(tasks_root, 'meta.sh')
 
           executor.expects(:run_task_with)
-                  .with(target_mapping, mock_task(executable, 'environment'), catch_errors: true)
+                  .with(target_mapping, mock_task(executable, 'environment'), { catch_errors: true }, [])
                   .returns(result_set)
 
           inventory.expects(:get_targets).with(hosts).returns(targets)
@@ -313,7 +326,9 @@ describe 'run_task_with' do
       it 'finds task named after the module' do
         executable = File.join(tasks_root, 'init.sh')
 
-        executor.expects(:run_task_with).with(target_mapping, mock_task(executable, nil), {}).returns(result_set)
+        executor.expects(:run_task_with)
+                .with(target_mapping, mock_task(executable, nil), {}, [])
+                .returns(result_set)
         inventory.expects(:get_targets).with(hostname).returns([target])
 
         is_expected.to run
@@ -368,7 +383,9 @@ describe 'run_task_with' do
         sensitive.expects(:new).with(input_params['sensitive_hash'])
                  .returns(expected_params['sensitive_hash'])
 
-        executor.expects(:run_task_with).with(target_mapping, mock_task(executable, nil), {}).returns(result_set)
+        executor.expects(:run_task_with)
+                .with(target_mapping, mock_task(executable, nil), {}, [])
+                .returns(result_set)
         inventory.expects(:get_targets).with(hostname).returns(target)
 
         is_expected.to run

--- a/bolt-modules/boltlib/spec/functions/upload_file_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/upload_file_spec.rb
@@ -37,41 +37,59 @@ describe 'upload_file' do
     end
 
     it 'with fully resolved path of file and destination' do
-      executor.expects(:upload_file).with([target], full_path, destination, {}).returns(result_set)
+      executor.expects(:upload_file)
+              .with([target], full_path, destination, {}, [])
+              .returns(result_set)
       inventory.stubs(:get_targets).with(hostname).returns([target])
 
-      is_expected.to run.with_params('test/uploads/index.html', destination, hostname).and_return(result_set)
+      is_expected.to run
+        .with_params('test/uploads/index.html', destination, hostname)
+        .and_return(result_set)
     end
 
     it 'with fully resolved path of directory and destination' do
-      executor.expects(:upload_file).with([target], full_dir_path, destination, {}).returns(result_set)
+      executor.expects(:upload_file)
+              .with([target], full_dir_path, destination, {}, [])
+              .returns(result_set)
       inventory.stubs(:get_targets).with(hostname).returns([target])
 
-      is_expected.to run.with_params('test/uploads', destination, hostname).and_return(result_set)
+      is_expected.to run
+        .with_params('test/uploads', destination, hostname)
+        .and_return(result_set)
     end
 
     it 'with target specified as a Target' do
-      executor.expects(:upload_file).with([target], full_dir_path, destination, {}).returns(result_set)
+      executor.expects(:upload_file)
+              .with([target], full_dir_path, destination, {}, [])
+              .returns(result_set)
       inventory.stubs(:get_targets).with(target).returns([target])
 
-      is_expected.to run.with_params('test/uploads', destination, target).and_return(result_set)
+      is_expected.to run
+        .with_params('test/uploads', destination, target)
+        .and_return(result_set)
     end
 
     it 'runs as another user' do
       executor.expects(:upload_file)
-              .with([target], full_dir_path, destination, run_as: 'soandso')
+              .with([target], full_dir_path, destination, { run_as: 'soandso' }, [])
               .returns(result_set)
       inventory.stubs(:get_targets).with(target).returns([target])
 
-      is_expected.to run.with_params('test/uploads', destination, target, '_run_as' => 'soandso').and_return(result_set)
+      is_expected.to run
+        .with_params('test/uploads', destination, target, '_run_as' => 'soandso')
+        .and_return(result_set)
     end
 
     it 'reports the call to analytics' do
-      executor.expects(:upload_file).with([target], full_path, destination, {}).returns(result_set)
+      executor.expects(:upload_file)
+              .with([target], full_path, destination, {}, [])
+              .returns(result_set)
       inventory.stubs(:get_targets).with(hostname).returns([target])
       executor.expects(:report_function_call).with('upload_file')
 
-      is_expected.to run.with_params('test/uploads/index.html', destination, hostname).and_return(result_set)
+      is_expected.to run
+        .with_params('test/uploads/index.html', destination, hostname)
+        .and_return(result_set)
     end
 
     context 'with description' do
@@ -79,36 +97,48 @@ describe 'upload_file' do
 
       it 'passes the description through if parameters are passed' do
         executor.expects(:upload_file)
-                .with([target], full_dir_path, destination, description: message)
+                .with([target], full_dir_path, destination, { description: message }, [])
                 .returns(result_set)
         inventory.stubs(:get_targets).with(target).returns([target])
 
-        is_expected.to run.with_params('test/uploads', destination, target, message, {}).and_return(result_set)
+        is_expected.to run
+          .with_params('test/uploads', destination, target, message, {})
+          .and_return(result_set)
       end
 
       it 'passes the description through if no parameters are passed' do
         executor.expects(:upload_file)
-                .with([target], full_dir_path, destination, description: message)
+                .with([target], full_dir_path, destination, { description: message }, [])
                 .returns(result_set)
         inventory.stubs(:get_targets).with(target).returns([target])
 
-        is_expected.to run.with_params('test/uploads', destination, target, message).and_return(result_set)
+        is_expected.to run
+          .with_params('test/uploads', destination, target, message)
+          .and_return(result_set)
       end
     end
 
     context 'without description' do
       it 'ignores description if parameters are passed' do
-        executor.expects(:upload_file).with([target], full_dir_path, destination, {}).returns(result_set)
+        executor.expects(:upload_file)
+                .with([target], full_dir_path, destination, {}, [])
+                .returns(result_set)
         inventory.stubs(:get_targets).with(target).returns([target])
 
-        is_expected.to run.with_params('test/uploads', destination, target, {}).and_return(result_set)
+        is_expected.to run
+          .with_params('test/uploads', destination, target, {})
+          .and_return(result_set)
       end
 
       it 'ignores description if no parameters are passed' do
-        executor.expects(:upload_file).with([target], full_dir_path, destination, {}).returns(result_set)
+        executor.expects(:upload_file)
+                .with([target], full_dir_path, destination, {}, [])
+                .returns(result_set)
         inventory.stubs(:get_targets).with(target).returns([target])
 
-        is_expected.to run.with_params('test/uploads', destination, target).and_return(result_set)
+        is_expected.to run
+          .with_params('test/uploads', destination, target)
+          .and_return(result_set)
       end
     end
 
@@ -121,7 +151,7 @@ describe 'upload_file' do
 
       it 'propagates multiple hosts and returns multiple results' do
         executor
-          .expects(:upload_file).with([target, target2], full_path, destination, {})
+          .expects(:upload_file).with([target, target2], full_path, destination, {}, [])
           .returns(result_set)
         inventory.stubs(:get_targets).with([hostname, hostname2]).returns([target, target2])
 
@@ -133,21 +163,24 @@ describe 'upload_file' do
         let(:result2) { Bolt::Result.new(target2, error: { 'msg' => 'oops' }) }
 
         it 'errors by default' do
-          executor.expects(:upload_file).with([target, target2], full_path, destination, {})
+          executor.expects(:upload_file)
+                  .with([target, target2], full_path, destination, {}, [])
                   .returns(result_set)
           inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 
-          is_expected.to run.with_params('test/uploads/index.html', destination, [hostname, hostname2])
-                            .and_raise_error(Bolt::RunFailure)
+          is_expected.to run
+            .with_params('test/uploads/index.html', destination, [hostname, hostname2])
+            .and_raise_error(Bolt::RunFailure)
         end
 
         it 'does not error with _catch_errors' do
-          executor.expects(:upload_file).with([target, target2], full_path, destination, catch_errors: true)
+          executor.expects(:upload_file)
+                  .with([target, target2], full_path, destination, { catch_errors: true }, [])
                   .returns(result_set)
           inventory.expects(:get_targets).with([hostname, hostname2]).returns([target, target2])
 
-          is_expected.to run.with_params('test/uploads/index.html', destination, [hostname, hostname2],
-                                         '_catch_errors' => true)
+          is_expected.to run
+            .with_params('test/uploads/index.html', destination, [hostname, hostname2], '_catch_errors' => true)
         end
       end
     end

--- a/documentation/writing_tasks.md
+++ b/documentation/writing_tasks.md
@@ -421,6 +421,10 @@ end
 puts result.to_json
 ```
 
+Error results typically contain the file and line number under the `details` key of an
+error. Bolt merges the 'file' and 'line' keys with results unless 'file' is present in the
+`_error` hash returned from a task.
+
 ### Returning sensitive data
 
 To return secrets from a task, use the `_sensitive` key in the output. Bolt

--- a/lib/bolt/error.rb
+++ b/lib/bolt/error.rb
@@ -24,6 +24,10 @@ module Bolt
       h
     end
 
+    def add_filelineno(details)
+      @details.merge!(details) unless @details['file']
+    end
+
     def to_json(opts = nil)
       to_h.to_json(opts)
     end

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -253,33 +253,33 @@ module Bolt
       result
     end
 
-    def run_command(targets, command, options = {})
+    def run_command(targets, command, options = {}, position = [])
       description = options.fetch(:description, "command '#{command}'")
       log_action(description, targets) do
         options[:run_as] = run_as if run_as && !options.key?(:run_as)
 
         batch_execute(targets) do |transport, batch|
           with_node_logging("Running command '#{command}'", batch) do
-            transport.batch_command(batch, command, options, &method(:publish_event))
+            transport.batch_command(batch, command, options, position, &method(:publish_event))
           end
         end
       end
     end
 
-    def run_script(targets, script, arguments, options = {})
+    def run_script(targets, script, arguments, options = {}, position = [])
       description = options.fetch(:description, "script #{script}")
       log_action(description, targets) do
         options[:run_as] = run_as if run_as && !options.key?(:run_as)
 
         batch_execute(targets) do |transport, batch|
           with_node_logging("Running script #{script} with '#{arguments.to_json}'", batch) do
-            transport.batch_script(batch, script, arguments, options, &method(:publish_event))
+            transport.batch_script(batch, script, arguments, options, position, &method(:publish_event))
           end
         end
       end
     end
 
-    def run_task(targets, task, arguments, options = {})
+    def run_task(targets, task, arguments, options = {}, position = [])
       description = options.fetch(:description, "task #{task.name}")
       log_action(description, targets) do
         options[:run_as] = run_as if run_as && !options.key?(:run_as)
@@ -287,13 +287,13 @@ module Bolt
 
         batch_execute(targets) do |transport, batch|
           with_node_logging("Running task #{task.name} with '#{arguments.to_json}'", batch) do
-            transport.batch_task(batch, task, arguments, options, &method(:publish_event))
+            transport.batch_task(batch, task, arguments, options, position, &method(:publish_event))
           end
         end
       end
     end
 
-    def run_task_with(target_mapping, task, options = {})
+    def run_task_with(target_mapping, task, options = {}, position = [])
       targets = target_mapping.keys
       description = options.fetch(:description, "task #{task.name}")
 
@@ -303,26 +303,26 @@ module Bolt
 
         batch_execute(targets) do |transport, batch|
           with_node_logging("Running task #{task.name}'", batch) do
-            transport.batch_task_with(batch, task, target_mapping, options, &method(:publish_event))
+            transport.batch_task_with(batch, task, target_mapping, options, position, &method(:publish_event))
           end
         end
       end
     end
 
-    def upload_file(targets, source, destination, options = {})
+    def upload_file(targets, source, destination, options = {}, position = [])
       description = options.fetch(:description, "file upload from #{source} to #{destination}")
       log_action(description, targets) do
         options[:run_as] = run_as if run_as && !options.key?(:run_as)
 
         batch_execute(targets) do |transport, batch|
           with_node_logging("Uploading file #{source} to #{destination}", batch) do
-            transport.batch_upload(batch, source, destination, options, &method(:publish_event))
+            transport.batch_upload(batch, source, destination, options, position, &method(:publish_event))
           end
         end
       end
     end
 
-    def download_file(targets, source, destination, options = {})
+    def download_file(targets, source, destination, options = {}, position = [])
       description = options.fetch(:description, "file download from #{source} to #{destination}")
 
       begin
@@ -337,7 +337,7 @@ module Bolt
 
         batch_execute(targets) do |transport, batch|
           with_node_logging("Downloading file #{source} to #{destination}", batch) do
-            transport.batch_download(batch, source, destination, options, &method(:publish_event))
+            transport.batch_download(batch, source, destination, options, position, &method(:publish_event))
           end
         end
       end

--- a/lib/bolt/shell/bash.rb
+++ b/lib/bolt/shell/bash.rb
@@ -21,14 +21,16 @@ module Bolt
         ['shell']
       end
 
-      def run_command(command, options = {})
+      def run_command(command, options = {}, position = [])
         running_as(options[:run_as]) do
           output = execute(command, environment: options[:env_vars], sudoable: true)
           Bolt::Result.for_command(target,
                                    output.stdout.string,
                                    output.stderr.string,
                                    output.exit_code,
-                                   'command', command)
+                                   'command',
+                                   command,
+                                   position)
         end
       end
 
@@ -71,7 +73,7 @@ module Bolt
         end
       end
 
-      def run_script(script, arguments, options = {})
+      def run_script(script, arguments, options = {}, position = [])
         # unpack any Sensitive data
         arguments = unwrap_sensitive_args(arguments)
 
@@ -84,12 +86,14 @@ module Bolt
                                      output.stdout.string,
                                      output.stderr.string,
                                      output.exit_code,
-                                     'script', script)
+                                     'script',
+                                     script,
+                                     position)
           end
         end
       end
 
-      def run_task(task, arguments, options = {})
+      def run_task(task, arguments, options = {}, position = [])
         implementation = select_implementation(target, task)
         executable = implementation['path']
         input_method = implementation['input_method']
@@ -148,7 +152,8 @@ module Bolt
           Bolt::Result.for_task(target, output.stdout.string,
                                 output.stderr.string,
                                 output.exit_code,
-                                task.name)
+                                task.name,
+                                position)
         end
       end
 

--- a/lib/bolt/shell/powershell.rb
+++ b/lib/bolt/shell/powershell.rb
@@ -174,7 +174,7 @@ module Bolt
         Bolt::Result.for_download(target, source, destination, download)
       end
 
-      def run_command(command, options = {})
+      def run_command(command, options = {}, position = [])
         command = [*env_declarations(options[:env_vars]), command].join("\r\n") if options[:env_vars]
 
         output = execute(command)
@@ -182,10 +182,12 @@ module Bolt
                                  output.stdout.string,
                                  output.stderr.string,
                                  output.exit_code,
-                                 'command', command)
+                                 'command',
+                                 command,
+                                 position)
       end
 
-      def run_script(script, arguments, options = {})
+      def run_script(script, arguments, options = {}, position = [])
         # unpack any Sensitive data
         arguments = unwrap_sensitive_args(arguments)
         with_tmpdir do |dir|
@@ -204,11 +206,13 @@ module Bolt
                                    output.stdout.string,
                                    output.stderr.string,
                                    output.exit_code,
-                                   'script', script)
+                                   'script',
+                                   script,
+                                   position)
         end
       end
 
-      def run_task(task, arguments, _options = {})
+      def run_task(task, arguments, _options = {}, position = [])
         implementation = select_implementation(target, task)
         executable = implementation['path']
         input_method = implementation['input_method']
@@ -259,7 +263,8 @@ module Bolt
           Bolt::Result.for_task(target, output.stdout.string,
                                 output.stderr.string,
                                 output.exit_code,
-                                task.name)
+                                task.name,
+                                position)
         end
       end
 

--- a/lib/bolt/transport/remote.rb
+++ b/lib/bolt/transport/remote.rb
@@ -26,14 +26,14 @@ module Bolt
       end
 
       # Cannot batch because arugments differ
-      def run_task(target, task, arguments, options = {})
+      def run_task(target, task, arguments, options = {}, position = [])
         proxy_target = get_proxy(target)
         transport = @executor.transport(proxy_target.transport)
         arguments = arguments.merge('_target' => target.to_h.reject { |_, v| v.nil? })
 
         remote_task = task.remote_instance
 
-        result = transport.run_task(proxy_target, remote_task, arguments, options)
+        result = transport.run_task(proxy_target, remote_task, arguments, options, position)
         Bolt::Result.new(target, value: result.value, action: 'task', object: task.name)
       end
     end

--- a/lib/bolt/transport/simple.rb
+++ b/lib/bolt/transport/simple.rb
@@ -20,9 +20,9 @@ module Bolt
         false
       end
 
-      def run_command(target, command, options = {})
+      def run_command(target, command, options = {}, position = [])
         with_connection(target) do |conn|
-          conn.shell.run_command(command, options)
+          conn.shell.run_command(command, options, position)
         end
       end
 
@@ -38,15 +38,15 @@ module Bolt
         end
       end
 
-      def run_script(target, script, arguments, options = {})
+      def run_script(target, script, arguments, options = {}, position = [])
         with_connection(target) do |conn|
-          conn.shell.run_script(script, arguments, options)
+          conn.shell.run_script(script, arguments, options, position)
         end
       end
 
-      def run_task(target, task, arguments, options = {})
+      def run_task(target, task, arguments, options = {}, position = [])
         with_connection(target) do |conn|
-          conn.shell.run_task(task, arguments, options)
+          conn.shell.run_task(task, arguments, options, position)
         end
       end
     end

--- a/lib/bolt_spec/plans/action_stubs/command_stub.rb
+++ b/lib/bolt_spec/plans/action_stubs/command_stub.rb
@@ -29,7 +29,7 @@ module BoltSpec
       end
 
       def result_for(target, stdout: '', stderr: '')
-        Bolt::Result.for_command(target, stdout, stderr, 0, 'command', '')
+        Bolt::Result.for_command(target, stdout, stderr, 0, 'command', '', [])
       end
 
       # Public methods

--- a/lib/bolt_spec/plans/action_stubs/script_stub.rb
+++ b/lib/bolt_spec/plans/action_stubs/script_stub.rb
@@ -35,7 +35,7 @@ module BoltSpec
       end
 
       def result_for(target, stdout: '', stderr: '')
-        Bolt::Result.for_command(target, stdout, stderr, 0, 'script', '')
+        Bolt::Result.for_command(target, stdout, stderr, 0, 'script', '', [])
       end
 
       # Public methods

--- a/lib/bolt_spec/plans/mock_executor.rb
+++ b/lib/bolt_spec/plans/mock_executor.rb
@@ -48,7 +48,7 @@ module BoltSpec
         ([segments[0]] + segments[2..-1]).join('/')
       end
 
-      def run_command(targets, command, options = {})
+      def run_command(targets, command, options = {}, _position = [])
         result = nil
         if (doub = @command_doubles[command] || @command_doubles[:default])
           result = doub.process(targets, command, options)
@@ -61,7 +61,7 @@ module BoltSpec
         result
       end
 
-      def run_script(targets, script_path, arguments, options = {})
+      def run_script(targets, script_path, arguments, options = {}, _position = [])
         script = module_file_id(script_path)
         result = nil
         if (doub = @script_doubles[script] || @script_doubles[:default])
@@ -76,7 +76,7 @@ module BoltSpec
         result
       end
 
-      def run_task(targets, task, arguments, options = {})
+      def run_task(targets, task, arguments, options = {}, _position = [])
         result = nil
         if (doub = @task_doubles[task.name] || @task_doubles[:default])
           result = doub.process(targets, task.name, arguments, options)
@@ -90,7 +90,7 @@ module BoltSpec
         result
       end
 
-      def download_file(targets, source, destination, options = {})
+      def download_file(targets, source, destination, options = {}, _position = [])
         result = nil
         if (doub = @download_doubles[source] || @download_doubles[:default])
           result = doub.process(targets, source, destination, options)
@@ -103,7 +103,7 @@ module BoltSpec
         result
       end
 
-      def upload_file(targets, source_path, destination, options = {})
+      def upload_file(targets, source_path, destination, options = {}, _position = [])
         source = module_file_id(source_path)
         result = nil
         if (doub = @upload_doubles[source] || @upload_doubles[:default])

--- a/spec/bolt/apply_result_spec.rb
+++ b/spec/bolt/apply_result_spec.rb
@@ -12,22 +12,22 @@ describe Bolt::ApplyResult do
       "status" => "" }
   }
 
-  let(:task_result) { Bolt::Result.for_task(example_target, result_value.to_json, '', 0, 'catalog') }
+  let(:task_result) { Bolt::Result.for_task(example_target, result_value.to_json, '', 0, 'catalog', []) }
   let(:apply_result) { Bolt::ApplyResult.from_task_result(task_result) }
 
   describe '#puppet_missing_error' do
     it 'returns the nil if no identifiable errors are found' do
-      result = Bolt::Result.for_task(:target, '', 'blah', 1, 'catalog')
+      result = Bolt::Result.for_task(:target, '', 'blah', 1, 'catalog', [])
       expect(Bolt::ApplyResult.puppet_missing_error(result)).to be_nil
     end
 
     it 'returns nil if no errors are present' do
-      result = Bolt::Result.for_task(:target, 'hello', '', 0, 'catalog')
+      result = Bolt::Result.for_task(:target, 'hello', '', 0, 'catalog', [])
       expect(Bolt::ApplyResult.puppet_missing_error(result)).to be_nil
     end
 
     it 'errors if /opt/puppetlabs/puppet/bin/ruby not found on Linux' do
-      orig_result = Bolt::Result.for_task(:target, '', 'blah', 127, 'catalog')
+      orig_result = Bolt::Result.for_task(:target, '', 'blah', 127, 'catalog', [])
       error = Bolt::ApplyResult.puppet_missing_error(orig_result)
       expect(error['kind']).to eq('bolt/apply-error')
       expect(error['msg'])
@@ -35,7 +35,7 @@ describe Bolt::ApplyResult do
     end
 
     it 'errors if /opt/puppetlabs/puppet/bin/ruby not found on macOS' do
-      orig_result = Bolt::Result.for_task(:target, '', 'blah', 126, 'catalog')
+      orig_result = Bolt::Result.for_task(:target, '', 'blah', 126, 'catalog', [])
       error = Bolt::ApplyResult.puppet_missing_error(orig_result)
       expect(error['kind']).to eq('bolt/apply-error')
       expect(error['msg'])
@@ -43,7 +43,7 @@ describe Bolt::ApplyResult do
     end
 
     it 'errors if Ruby cannot be found on Windows' do
-      orig_result = Bolt::Result.for_task(:target, '', "Could not find executable 'ruby.exe'", 1, 'catalog')
+      orig_result = Bolt::Result.for_task(:target, '', "Could not find executable 'ruby.exe'", 1, 'catalog', [])
       error = Bolt::ApplyResult.puppet_missing_error(orig_result)
       expect(error['kind']).to eq('bolt/apply-error')
       expect(error['msg'])
@@ -51,7 +51,7 @@ describe Bolt::ApplyResult do
     end
 
     it 'errors if Puppet cannot be found on Windows' do
-      orig_result = Bolt::Result.for_task(:target, '', 'cannot load such file -- puppet (LoadError)', 1, 'catalog')
+      orig_result = Bolt::Result.for_task(:target, '', 'cannot load such file -- puppet (LoadError)', 1, 'catalog', [])
       error = Bolt::ApplyResult.puppet_missing_error(orig_result)
       expect(error['kind']).to eq('bolt/apply-error')
       expect(error['msg'])

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1849,7 +1849,7 @@ describe "Bolt::CLI" do
         it "runs a task given a name" do
           expect(executor)
             .to receive(:run_task)
-            .with(targets, task_t, task_params, kind_of(Hash))
+            .with(targets, task_t, task_params, kind_of(Hash), [])
             .and_return(Bolt::ResultSet.new([]))
           expect(cli.execute(options)).to eq(0)
           expect(JSON.parse(output.string)).to be
@@ -1858,7 +1858,7 @@ describe "Bolt::CLI" do
         it "returns 2 if any node fails" do
           expect(executor)
             .to receive(:run_task)
-            .with(targets, task_t, task_params, kind_of(Hash))
+            .with(targets, task_t, task_params, kind_of(Hash), [])
             .and_return(fail_set)
 
           expect(cli.execute(options)).to eq(2)
@@ -1887,7 +1887,7 @@ describe "Bolt::CLI" do
 
           expect(executor)
             .to receive(:run_task)
-            .with(targets, task_t, {}, kind_of(Hash))
+            .with(targets, task_t, {}, kind_of(Hash), [])
             .and_raise("Could not connect to target")
 
           expect { cli.execute(options) }.to raise_error(/Could not connect to target/)
@@ -1899,7 +1899,7 @@ describe "Bolt::CLI" do
 
           expect(executor)
             .to receive(:run_task)
-            .with(targets, task_t, task_params, kind_of(Hash))
+            .with(targets, task_t, task_params, kind_of(Hash), [])
             .and_return(Bolt::ResultSet.new([]))
 
           cli.execute(options)
@@ -1914,7 +1914,7 @@ describe "Bolt::CLI" do
 
             expect(executor)
               .to receive(:run_task)
-              .with(targets, task_t, task_params, kind_of(Hash))
+              .with(targets, task_t, task_params, kind_of(Hash), [])
               .and_return(Bolt::ResultSet.new([]))
 
             cli.execute(options)
@@ -1927,7 +1927,7 @@ describe "Bolt::CLI" do
 
             expect(executor)
               .to receive(:run_task)
-              .with(targets, task_t, task_params, kind_of(Hash))
+              .with(targets, task_t, task_params, kind_of(Hash), [])
               .and_return(Bolt::ResultSet.new([]))
 
             cli.execute(options)
@@ -2009,7 +2009,7 @@ describe "Bolt::CLI" do
           it "runs the task when the specified parameters are successfully validated" do
             expect(executor)
               .to receive(:run_task)
-              .with(targets, task_t, task_params, kind_of(Hash))
+              .with(targets, task_t, task_params, kind_of(Hash), [])
               .and_return(Bolt::ResultSet.new([]))
             task_params.merge!(
               'mandatory_string' => ' ',
@@ -2062,7 +2062,7 @@ describe "Bolt::CLI" do
 
                 expect(executor)
                   .to receive(:run_task)
-                  .with(targets, task_t, task_params, kind_of(Hash))
+                  .with(targets, task_t, task_params, kind_of(Hash), [])
                   .and_return(Bolt::ResultSet.new([]))
 
                 cli.execute(options)
@@ -2072,7 +2072,7 @@ describe "Bolt::CLI" do
               it "runs the task even when invalid (according to the local task definition) parameters are specified" do
                 expect(executor)
                   .to receive(:run_task)
-                  .with(targets, task_t, task_params, kind_of(Hash))
+                  .with(targets, task_t, task_params, kind_of(Hash), [])
                   .and_return(Bolt::ResultSet.new([]))
 
                 cli.execute(options)
@@ -2110,8 +2110,8 @@ describe "Bolt::CLI" do
 
             expect(executor)
               .to receive(:run_task)
-              .with(targets, task_t, { 'message' => 'hi there' }, kind_of(Hash))
-              .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'yes', '', 0, 'some_task')]))
+              .with(targets, task_t, { 'message' => 'hi there' }, kind_of(Hash), kind_of(Array))
+              .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'yes', '', 0, 'some_task', [])]))
 
             expect(executor).to receive(:start_plan)
             expect(executor).to receive(:log_plan)
@@ -2138,8 +2138,8 @@ describe "Bolt::CLI" do
 
             expect(executor)
               .to receive(:run_task)
-              .with(targets, task_t, { 'message' => 'hi there' }, kind_of(Hash))
-              .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'yes', '', 0, 'some_task')]))
+              .with(targets, task_t, { 'message' => 'hi there' }, kind_of(Hash), kind_of(Array))
+              .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'yes', '', 0, 'some_task', [])]))
 
             expect(executor).to receive(:start_plan)
             expect(executor).to receive(:log_plan)
@@ -2192,8 +2192,8 @@ describe "Bolt::CLI" do
         it "formats results of a passing task" do
           expect(executor)
             .to receive(:run_task)
-            .with(targets, task_t, { 'message' => 'hi there' }, kind_of(Hash))
-            .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'yes', '', 0, 'some_task')]))
+            .with(targets, task_t, { 'message' => 'hi there' }, kind_of(Hash), [/single_task.pp/, 9])
+            .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'yes', '', 0, 'some_task', [])]))
 
           expect(executor).to receive(:start_plan)
           expect(executor).to receive(:log_plan)
@@ -2213,7 +2213,7 @@ describe "Bolt::CLI" do
         it "raises errors from the executor" do
           expect(executor)
             .to receive(:run_task)
-            .with(targets, task_t, { 'message' => 'hi there' }, kind_of(Hash))
+            .with(targets, task_t, { 'message' => 'hi there' }, kind_of(Hash), [/single_task.pp/, 9])
             .and_raise("Could not connect to target")
 
           expect(executor).to receive(:start_plan)
@@ -2228,8 +2228,8 @@ describe "Bolt::CLI" do
         it "formats results of a failing task" do
           expect(executor)
             .to receive(:run_task)
-            .with(targets, task_t, { 'message' => 'hi there' }, kind_of(Hash))
-            .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'no', '', 1, 'some_task')]))
+            .with(targets, task_t, { 'message' => 'hi there' }, kind_of(Hash), kind_of(Array))
+            .and_return(Bolt::ResultSet.new([Bolt::Result.for_task(target, 'no', '', 1, 'some_task', ['/fail', 2])]))
 
           expect(executor).to receive(:start_plan)
           expect(executor).to receive(:log_plan)
@@ -2249,7 +2249,9 @@ describe "Bolt::CLI" do
                   "_error" => {
                     "msg" => "The task failed with exit code 1",
                     "kind" => "puppetlabs.tasks/task-error",
-                    "details" => { "exit_code" => 1 },
+                    "details" => { "exit_code" => 1,
+                                   "file" => "/fail",
+                                   "line" => 2 },
                     "issue_code" => "TASK_ERROR"
                   }
                 }
@@ -2395,7 +2397,7 @@ describe "Bolt::CLI" do
         it "runs a task that supports noop" do
           expect(executor)
             .to receive(:run_task)
-            .with(targets, task_t, task_params.merge('_noop' => true), kind_of(Hash))
+            .with(targets, task_t, task_params.merge('_noop' => true), kind_of(Hash), kind_of(Array))
             .and_return(Bolt::ResultSet.new([]))
 
           cli.execute(options)

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -238,7 +238,7 @@ describe "Bolt::Outputter::Human" do
   end
 
   it "prints CommandResults" do
-    outputter.print_result(Bolt::Result.for_command(target, "stout", "sterr", 2, 'command', "executed"))
+    outputter.print_result(Bolt::Result.for_command(target, "stout", "sterr", 2, 'command', "executed", []))
     lines = output.string
     expect(lines).to match(/STDOUT:\n    stout/)
     expect(lines).to match(/STDERR:\n    sterr/)
@@ -248,7 +248,7 @@ describe "Bolt::Outputter::Human" do
     result = { 'key' => 'val',
                '_error' => { 'msg' => 'oops' },
                '_output' => 'hello' }
-    outputter.print_result(Bolt::Result.for_task(target, result.to_json, "", 2, 'atask'))
+    outputter.print_result(Bolt::Result.for_task(target, result.to_json, "", 2, 'atask', []))
     lines = output.string
     expect(lines).to match(/^  oops\n  hello$/)
     expect(lines).to match(/^    "key": "val"$/)

--- a/spec/bolt_spec/run_spec.rb
+++ b/spec/bolt_spec/run_spec.rb
@@ -92,7 +92,7 @@ describe "BoltSpec::Run", ssh: true do
     end
 
     it 'should return a failure' do
-      result = run_plan('error::run_fail', 'target' => 'ssh')
+      result = run_plan('error::run_fail', 'targets' => 'ssh')
       expect(result['status']).to eq('failure')
       expect(result['value']['kind']).to eq('bolt/run-failure')
     end

--- a/spec/fixtures/modules/error/plans/call_run_fail.pp
+++ b/spec/fixtures/modules/error/plans/call_run_fail.pp
@@ -1,0 +1,5 @@
+plan error::call_run_fail (
+  TargetSpec $targets
+) {
+ run_plan('error::run_fail', 'target' => $target)
+}

--- a/spec/fixtures/modules/error/plans/catch_plan_run.pp
+++ b/spec/fixtures/modules/error/plans/catch_plan_run.pp
@@ -2,6 +2,6 @@
 plan error::catch_plan_run(
   String $target
 ) {
- $r = run_plan('error::run_fail', 'target' => $target, '_catch_errors' => true)
+ $r = run_plan('error::run_fail', 'targets' => $target, '_catch_errors' => true)
  return $r.details['result_set'].first.error
 }

--- a/spec/fixtures/modules/error/plans/no_task.pp
+++ b/spec/fixtures/modules/error/plans/no_task.pp
@@ -1,0 +1,5 @@
+plan error::no_task(
+  TargetSpec $targets
+) {
+  run_task("not::a_task", $targets)
+}

--- a/spec/fixtures/modules/error/plans/run_fail.pp
+++ b/spec/fixtures/modules/error/plans/run_fail.pp
@@ -1,5 +1,5 @@
 plan error::run_fail(
-  String $target
+  TargetSpec $targets
 ) {
- run_task('error::fail', $target)
+ run_task('error::fail', $targets)
 }

--- a/spec/integration/fail_plan_spec.rb
+++ b/spec/integration/fail_plan_spec.rb
@@ -24,16 +24,22 @@ describe "When a plan fails" do
 
   it 'returns the error object' do
     result = run_cli_json(['plan', 'run', 'error::args'] + config_flags, rescue_exec: true)
-    expect(result).to eq('msg' => 'oops',
-                         'kind' => 'test/oops',
-                         'details' => { 'some' => 'info' })
+    expect(result).to match('msg' => 'oops',
+                            'kind' => 'test/oops',
+                            'details' => { "column" => 3,
+                                           "file" => /args.pp/,
+                                           "line" => 2,
+                                           "some" => "info" })
   end
 
   it 'returns the error object' do
     result = run_cli_json(['plan', 'run', 'error::err'] + config_flags, rescue_exec: true)
-    expect(result).to eq('msg' => 'oops',
-                         'kind' => 'test/oops',
-                         'details' => { 'some' => 'info' })
+    expect(result).to match('msg' => 'oops',
+                            'kind' => 'test/oops',
+                            'details' => { "column" => 3,
+                                           "file" => /err.pp/,
+                                           "line" => 2,
+                                           "some" => "info" })
   end
 
   it 'catches plan failures' do
@@ -45,10 +51,12 @@ describe "When a plan fails" do
 
   it 'catches run failures', ssh: true do
     result = run_cli_json(['plan', 'run', 'error::catch_plan_run', "target=#{target}"] + config_flags)
-    expect(result).to eq("kind" => "puppetlabs.tasks/task-error",
-                         "issue_code" => "TASK_ERROR",
-                         "msg" => "The task failed with exit code 1",
-                         "details" => { "exit_code" => 1 })
+    expect(result).to match("kind" => "puppetlabs.tasks/task-error",
+                            "issue_code" => "TASK_ERROR",
+                            "msg" => "The task failed with exit code 1",
+                            "details" => { "exit_code" => 1,
+                                           "file" => /run_fail.pp/,
+                                           "line" => 4 })
   end
 
   it 'outputs nested errors' do


### PR DESCRIPTION
This gets the file and line number from the Puppet plan function and
passes it all the way through to the Result object, so that if an error
occurs we can include the file and line number it came from under the
`details` key of the result. This ensures that users can find where a
particular failure is coming from not just from Puppet errors (ie. the
wrong number of arguments to a function) but also to Bolt errors (ie.  a
task that exits 1). This gets the file and line number simply using
`Puppet::Pops::PuppetStack.top_of_stack`. This only modifies the Result
objects for Results that build an error hash: `run_task`, `run_command`,
and `run_script`, as well as failures from `upload_file` and
`download_file`. This does not currently work for YAML plans.

Closes #2057

!feature

* **File and line number included in plan function errors** ([2057](https://github.com/puppetlabs/bolt/issues/2057))

  If the plan functions `run_command`, `run_script`, or `run_task` fail
  they will now include the file and line number in the `details` key of
  the Result object. This information will also be printed when run with
  info level logging or higher.