### PR TITLE
(GH-2295) Add 'Generating types' message to module installer

### DIFF
--- a/lib/bolt/module_installer.rb
+++ b/lib/bolt/module_installer.rb
@@ -187,6 +187,7 @@ module Bolt
       ok = Installer.new(config).install(path, moduledir)
 
       # Automatically generate types after installing modules
+      @outputter.print_action_step("Generating type references")
       @pal.generate_types
 
       @outputter.print_puppetfile_result(ok, path, moduledir)

--- a/spec/bolt_server/app_integration_spec.rb
+++ b/spec/bolt_server/app_integration_spec.rb
@@ -18,6 +18,10 @@ describe "BoltServer::TransportApp", puppetserver: true do
     BoltServer::TransportApp.new(config)
   end
 
+  before(:all) do
+    wait_until_available(timeout: 30, interval: 1)
+  end
+
   context 'with ssh target', ssh: true do
     describe "run_task" do
       let(:path) { '/ssh/run_task' }

--- a/spec/lib/bolt_spec/bolt_server.rb
+++ b/spec/lib/bolt_spec/bolt_server.rb
@@ -22,7 +22,7 @@ module BoltSpec
     private def healthy?
       response = puppet_server_get("/status/v1/simple", {})
       response.is_a?(Net::HTTPOK) && response.read_body == 'running'
-    rescue OpenSSL::SSL::SSLError
+    rescue OpenSSL::SSL::SSLError, Errno::ECONNRESET
       false
     end
 


### PR DESCRIPTION
This adds a message to the module installer that informs the user that
Bolt is generating types after installing modules.

!no-release-note