### PR TITLE
(GH-2171) Do not override SSL variables in PowerShell module

### DIFF
--- a/documentation/troubleshooting.md
+++ b/documentation/troubleshooting.md
@@ -124,6 +124,27 @@ Use the Bolt-provided gem command to reinstall/install these gems. For example:
     sudo /opt/puppetlabs/bolt/bin/gem pristine unf_ext --version 0.0.7.5
 ```
 
+
+## Certificate verify failed when installing modules
+
+When running on Windows, Bolt automatically sets the `SSL_CERT_DIR` and
+`SSL_CERT_FILE` environment variables if they are not already set. Assuming a
+default install location, the variables are set to the following directory and
+certificate, which are installed with the Bolt package:
+
+- `SSL_CERT_DIR = C:\Program Files\Puppet Labs\Bolt\ssl\certs`
+- `SSL_CERT_FILE = C:\Program Files\Puppet Labs\Bolt\ssl\cert.pem`
+
+If you see an SSL connection error similar to the following when running on
+Windows:
+
+```
+SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate)
+```
+
+Set the `SSL_CERT_DIR` and `SSL_CERT_FILE` environment variables to use a valid
+certificate and certificate directory.
+
 ## I still need help
 
 Visit the **#bolt** channel in the [Puppet Community

--- a/pwsh_module/pwsh_bolt_internal.ps1
+++ b/pwsh_module/pwsh_bolt_internal.ps1
@@ -5,9 +5,14 @@ function bolt {
   # Windows API GetShortPathName requires inline C#, so use COM instead
   $script:BOLT_BASEDIR = $fso.GetFolder($script:BOLT_BASEDIR).ShortPath
   $script:RUBY_DIR = $script:BOLT_BASEDIR
-  # Set SSL variables to ensure trusted locations are used
-  $env:SSL_CERT_FILE = "$($script:BOLT_BASEDIR)\ssl\cert.pem"
-  $env:SSL_CERT_DIR = "$($script:BOLT_BASEDIR)\ssl\certs"
+
+  if (!$env:SSL_CERT_FILE) {
+    $env:SSL_CERT_FILE = "$($script:BOLT_BASEDIR)\ssl\cert.pem"
+  }
+  if (!$env:SSL_CERT_DIR) {
+    $env:SSL_CERT_DIR = "$($script:BOLT_BASEDIR)\ssl\certs"
+  }
+
   &$script:RUBY_DIR\bin\ruby -S -- $script:RUBY_DIR\bin\bolt ($args -replace '"', '"""')
 }
 
@@ -20,9 +25,13 @@ function Invoke-BoltCommandline {
   # Windows API GetShortPathName requires inline C#, so use COM instead
   $script:BOLT_BASEDIR = $fso.GetFolder($script:BOLT_BASEDIR).ShortPath
   $script:RUBY_DIR = $script:BOLT_BASEDIR
-  # Set SSL variables to ensure trusted locations are used
-  $env:SSL_CERT_FILE = "$($script:BOLT_BASEDIR)\ssl\cert.pem"
-  $env:SSL_CERT_DIR = "$($script:BOLT_BASEDIR)\ssl\certs"
+
+  if (!$env:SSL_CERT_FILE) {
+    $env:SSL_CERT_FILE = "$($script:BOLT_BASEDIR)\ssl\cert.pem"
+  }
+  if (!$env:SSL_CERT_DIR) {
+    $env:SSL_CERT_DIR = "$($script:BOLT_BASEDIR)\ssl\certs"
+  }
 
   $processArgs = @('-S', '--', "$script:RUBY_DIR\bin\bolt") + $params
 


### PR DESCRIPTION
This updates the PowerShell module to not override the `SSL_CERT_FILE`
and `SSL_CERT_DIR` environment variables if they are already set.
Previously, the PowerShell module would always override these
environment variables, which could lead to SSL errors if a user
attempted to provide a cert on the command line.
are not already set.

!bug

* **Do not override SSL variables in PowerShell module**
  ([#2171](https://github.com/puppetlabs/bolt/issues/2171))

  The PowerShell module no longer overrides the `SSL_CERT_FILE` and
  `SSL_CERT_DIR` environment variables if they are already set.