### PR TITLE
(Docs) Add port to service-urls

### DIFF
--- a/lib/bolt/config/transport/options.rb
+++ b/lib/bolt/config/transport/options.rb
@@ -357,7 +357,7 @@ module Bolt
             description: "The URL of the host used for API requests.",
             format: "uri",
             _plugin: true,
-            _example: "https://api.example.com"
+            _example: "https://api.example.com:<port>"
           },
           "shell-command" => {
             type: String,


### PR DESCRIPTION
Because we don't include `<port>` at the end of service-urls, users
might assume that they don't need to specify a port.

!no-release-note