### PR TITLE
(GH-2278) Include file and line number in YAML plan eval errors

### DIFF
--- a/lib/bolt/pal/yaml_plan.rb
+++ b/lib/bolt/pal/yaml_plan.rb
@@ -98,10 +98,12 @@ module Bolt
       # subclasses this parent class in order to implement its own evaluation
       # logic.
       class EvaluableString
-        attr_reader :value
+        attr_reader :file, :line, :value
 
-        def initialize(value)
+        def initialize(value, file = nil, line = nil)
           @value = value
+          @file  = file
+          @line  = line
         end
 
         def ==(other)

--- a/spec/fixtures/modules/yaml/plans/eval_error_bare_string.yaml
+++ b/spec/fixtures/modules/yaml/plans/eval_error_bare_string.yaml
@@ -1,0 +1,5 @@
+steps:
+  - name: value
+    eval: $foo.map |$l| { $l *  2 }
+
+return: $value

--- a/spec/fixtures/modules/yaml/plans/eval_error_scalar_literal.yaml
+++ b/spec/fixtures/modules/yaml/plans/eval_error_scalar_literal.yaml
@@ -1,0 +1,7 @@
+steps:
+  - name: value
+    eval: |
+      $foo = 'foo'
+      $foo.map |$l| { $l *  2 }
+
+return: $value

--- a/spec/fixtures/modules/yaml/plans/eval_error_sub_plan.yaml
+++ b/spec/fixtures/modules/yaml/plans/eval_error_sub_plan.yaml
@@ -1,0 +1,5 @@
+steps:
+  - name: result
+    plan: yaml::eval_error_bare_string
+
+return: $result

--- a/spec/integration/yaml_plan_spec.rb
+++ b/spec/integration/yaml_plan_spec.rb
@@ -185,4 +185,30 @@ describe "running YAML plans", ssh: true do
     result = run_plan('yaml::target_preference', targets: target)
     expect(result.first['target']).to eq(target)
   end
+
+  context 'evaluating Puppet code' do
+    it 'includes file and line number for errors in bare strings' do
+      result = run_plan('yaml::eval_error_bare_string')
+
+      expect(result['kind']).to eq('bolt/evaluation-error')
+      expect(result['details']['file']).to match(/eval_error_bare_string\.yaml/)
+      expect(result['details']['line']).to eq(3)
+    end
+
+    it 'includes file and line number for errors in scalar literals' do
+      result = run_plan('yaml::eval_error_scalar_literal')
+
+      expect(result['kind']).to eq('bolt/evaluation-error')
+      expect(result['details']['file']).to match(/eval_error_scalar_literal\.yaml/)
+      expect(result['details']['line']).to eq(5)
+    end
+
+    it 'includes file and line number for errors in nested sub plans' do
+      result = run_plan('yaml::eval_error_sub_plan')
+
+      expect(result['kind']).to eq('bolt/evaluation-error')
+      expect(result['details']['file']).to match(/eval_error_bare_string\.yaml/)
+      expect(result['details']['line']).to eq(3)
+    end
+  end
 end


### PR DESCRIPTION
This adds the file path and line number of an error for evaluated code
in a YAML plan. Previously, if evaluated code resulted in an error, the
error would include no file path and the line number of the error within
the code itself (as though the code were in its own file). This made
these errors less helpful, as they did not correctly indicate where an
error in a YAML plan had occurred.

!feature

* **Include file and line number in YAML plan code evaluation errors**
  ([#2278](https://github.com/puppetlabs/bolt/issues/2278))

  Errors raised when evaluating code in a YAML plan now include the path
  to the YAML plan and the line number that the error occurred on in the
  plan.

!removal

* **Folded scalar values in YAML plans no longer evaluated**

  Folded scalar values in YAML plans are no longer evaluated and are
  instead treated as string literals.