### PR TITLE
(GH-2314) Fix module name regex for Forge/Git specifications

### DIFF
--- a/lib/bolt/module_installer.rb
+++ b/lib/bolt/module_installer.rb
@@ -63,7 +63,7 @@ module Bolt
 
       data = Bolt::Util.read_yaml_hash(config_path, 'project')
       data['modules'] ||= []
-      data['modules'] << name
+      data['modules'] << name.tr('-', '/')
 
       begin
         File.write(config_path, data.to_yaml)

--- a/lib/bolt/module_installer/specs/forge_spec.rb
+++ b/lib/bolt/module_installer/specs/forge_spec.rb
@@ -11,7 +11,7 @@ module Bolt
   class ModuleInstaller
     class Specs
       class ForgeSpec
-        NAME_REGEX    = %r{\A[a-z][a-z0-9_]*[-/](?<name>[a-z][a-z0-9_]*)\z}.freeze
+        NAME_REGEX    = %r{\A[a-zA-Z0-9]+[-/](?<name>[a-z][a-z0-9_]*)\z}.freeze
         REQUIRED_KEYS = Set.new(%w[name]).freeze
         KNOWN_KEYS    = Set.new(%w[name version_requirement]).freeze
 
@@ -33,8 +33,9 @@ module Bolt
           unless (match = name.match(NAME_REGEX))
             raise Bolt::ValidationError,
                   "Invalid name for Forge module specification: #{name}. Name must match "\
-                  "'owner/name', must start with a lowercase letter, and may only include "\
-                  "lowercase letters, digits, and underscores."
+                  "'owner/name'. Owner segment may only include letters or digits. Name "\
+                  "segment must start with a lowercase letter and may only include lowercase "\
+                  "letters, digits, and underscores."
           end
 
           [name.tr('-', '/'), match[:name]]
@@ -54,7 +55,7 @@ module Bolt
         #
         def satisfied_by?(mod)
           @type == mod.type &&
-            @full_name == mod.full_name &&
+            @full_name.downcase == mod.full_name.downcase &&
             !mod.version.nil? &&
             @semantic_version.cover?(mod.version)
         end

--- a/lib/bolt/module_installer/specs/git_spec.rb
+++ b/lib/bolt/module_installer/specs/git_spec.rb
@@ -11,7 +11,7 @@ module Bolt
   class ModuleInstaller
     class Specs
       class GitSpec
-        NAME_REGEX    = %r{\A(?:[a-z][a-z0-9_]*[-/])?(?<name>[a-z][a-z0-9_]*)\z}.freeze
+        NAME_REGEX    = %r{\A(?:[a-zA-Z0-9]+[-/])?(?<name>[a-z][a-z0-9_]*)\z}.freeze
         REQUIRED_KEYS = Set.new(%w[git ref]).freeze
 
         attr_reader :git, :ref, :type
@@ -36,8 +36,9 @@ module Bolt
           unless (match = name.match(NAME_REGEX))
             raise Bolt::ValidationError,
                   "Invalid name for Git module specification: #{name}. Name must match "\
-                  "'name' or 'owner/name', must start with a lowercase letter, and may "\
-                  "only include lowercase letters, digits, and underscores."
+                  "'name' or 'owner/name'. Owner segment may only include letters or digits. "\
+                  "Name segment must start with a lowercase letter and may only include "\
+                  "lowercase letters, digits, and underscores."
           end
 
           match[:name]

--- a/spec/bolt/module_installer/specs/forge_spec_spec.rb
+++ b/spec/bolt/module_installer/specs/forge_spec_spec.rb
@@ -19,8 +19,21 @@ describe Bolt::ModuleInstaller::Specs::ForgeSpec do
       expect(spec.name).to eq('yaml')
     end
 
+    it 'allows uppercase letters for owner' do
+      init_hash['name'] = 'Puppetlabs/yaml'
+      expect { spec }.not_to raise_error
+    end
+
     it 'errors with an invalid name' do
       init_hash['name'] = 'yaml'
+      expect { spec }.to raise_error(
+        Bolt::ValidationError,
+        /Invalid name for Forge module/
+      )
+    end
+
+    it 'errors with an invalid owner' do
+      init_hash['name'] = 'puppet_labs/yaml'
       expect { spec }.to raise_error(
         Bolt::ValidationError,
         /Invalid name for Forge module/
@@ -101,6 +114,13 @@ describe Bolt::ModuleInstaller::Specs::ForgeSpec do
       mod     = double('mod', type: :forge, full_name: name, version: version)
 
       expect(spec.satisfied_by?(mod)).to be(false)
+    end
+
+    it 'is case insensitive when comparing names' do
+      version = SemanticPuppet::Version.parse('0.1.0')
+      mod     = double('mod', type: :forge, full_name: name.upcase, version: version)
+
+      expect(spec.satisfied_by?(mod)).to be(true)
     end
   end
 end

--- a/spec/bolt/module_installer/specs/git_spec_spec.rb
+++ b/spec/bolt/module_installer/specs/git_spec_spec.rb
@@ -16,8 +16,21 @@ describe Bolt::ModuleInstaller::Specs::GitSpec do
       expect(spec.name).to eq(name)
     end
 
+    it 'allows uppercase letters for owner' do
+      init_hash['name'] = 'Puppetlabs/yaml'
+      expect { spec }.not_to raise_error
+    end
+
     it 'errors with an invalid name' do
       init_hash['name'] = 'Yaml'
+      expect { spec }.to raise_error(
+        Bolt::ValidationError,
+        /Invalid name for Git module specification/
+      )
+    end
+
+    it 'errors with an invalid owner' do
+      init_hash['name'] = 'puppet_labs/yaml'
       expect { spec }.to raise_error(
         Bolt::ValidationError,
         /Invalid name for Git module specification/


### PR DESCRIPTION
This updates the regex used to validate module names for Forge and Git
specifications. Previously, the regex for validating the owner segment
of the module name was `[a-z][a-z0-9_]`, which is the same regex used
for module name segments. However, owner names follow different
requirements and can only include letters (uppercase and lowercase) and
digits.

!bug

* **Fix module name validation for Forge and Git module specifications**
  ([#2314](https://github.com/puppetlabs/bolt/issues/2314))

  Forge and Git module specifications now correctly validate the
  module's name and permit uppercase letters in the owner segment of the
  module name. Previously, if the owner segment of a module name
  included uppercase letters, Bolt would raise an error.