### PR TITLE
(bug) Allow Bolt to use Puppet 6.19.z releases

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-ssh", ">= 4.0"
   spec.add_dependency "net-ssh-krb", "~> 0.5"
   spec.add_dependency "orchestrator_client", "~> 0.4"
-  spec.add_dependency "puppet", ">= 6.18.0", "<= 6.19"
+  spec.add_dependency "puppet", ">= 6.18.0", "< 6.20"
   spec.add_dependency "puppetfile-resolver", "~> 0.4"
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "puppet-strings", "~> 2.3"


### PR DESCRIPTION
Previously we had pinned Bolt to depend on Puppet >= 6.18.0 <=6.19.0
because when Puppet released 6.19.0 we picked it up before we had made
Bolt-side changes necessary to be compatible with the new Puppet
version. We restricted the Puppet gem to not pick up new versions so
that we could actively make similar updates in the future without
needing to do so immediately. However, this meant that some gems which
depend on Bolt and Puppet ended up resolving to an old version of Bolt,
which broke their use of the gem. This change means we'll pick up Z
releases of Puppet, but can still make any changes in Bolt we need to
before picking up the Y release.

!bug

* **Allow Puppet 6.19.1 as a dependency**

  This let's Bolt use Puppet 6.19.1 as a dependency.