### PR TITLE
(maint) Pick up puppetlabs-facts 1.2.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -7,7 +7,7 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '1.3.0'
 mod 'puppetlabs-puppet_agent', '4.2.0'
-mod 'puppetlabs-facts', '1.1.0'
+mod 'puppetlabs-facts', '1.2.0'
 
 # Core types and providers for Puppet 6
 mod 'puppetlabs-augeas_core', '1.1.1'


### PR DESCRIPTION
The recent release of the puppetlabs-facts module includes updates to
the facts task to use the new `puppet fact show` when used with Puppet
versions where it's available, and remove `facter -p` when it's not
available.

!no-release-note