### PR TITLE
(maint) Bump rubocop to 1.2.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,9 @@ Layout/LineLength:
 Layout/SpaceAroundMethodCallOperator:
   Enabled: true
 
+Layout/TrailingWhitespace:
+  AllowInHeredoc: true
+
 # Lint cops
 # https://docs.rubocop.org/rubocop/cops_lint.html
 
@@ -60,11 +63,21 @@ Lint/DeprecatedOpenSSLConstant:
 Lint/DuplicateElsifCondition:
   Enabled: true
 
+Lint/DuplicateRegexpCharacterClassElement:
+  Enabled: true
+
 Lint/DuplicateRequire:
   Enabled: true
 
 Lint/DuplicateRescueException:
   Enabled: true
+
+Lint/EmptyBlock:
+  Enabled: true
+  Exclude:
+    - bolt-modules/**/lib/puppet/functions/**/*
+    - lib/bolt/transport/orch.rb
+    - spec/**/*
 
 Lint/EmptyConditionalBody:
   Enabled: true
@@ -87,6 +100,9 @@ Lint/MissingSuper:
 Lint/MixedRegexpCaptureTypes:
   Enabled: false
 
+Lint/NoReturnInBeginEndBlocks:
+  Enabled: true
+
 Lint/OutOfRangeRegexpRef:
   Enabled: true
 
@@ -107,14 +123,17 @@ Lint/SuppressedException:
     - lib/bolt/shell/bash.rb
     - lib/bolt/module_installer.rb
 
+Lint/ToEnumArguments:
+  Enabled: true
+
 Lint/TopLevelReturnWithArgument:
   Enabled: true
 
 Lint/TrailingCommaInAttributeDeclaration:
   Enabled: true
 
-Layout/TrailingWhitespace:
-  AllowInHeredoc: true
+Lint/UnmodifiedReduceAccumulator:
+  Enabled: true
 
 Lint/UnreachableLoop:
   Enabled: true
@@ -164,6 +183,9 @@ Style/AccessModifierDeclarations:
 Style/AccessorGrouping:
   Enabled: true
 
+Style/ArgumentsForwarding:
+  Enabled: true
+
 Style/ArrayCoercion:
   Enabled: true
 
@@ -176,6 +198,9 @@ Style/BlockDelimiters:
 Style/CaseLikeIf:
   Enabled: true
 
+Style/CollectionCompact:
+  Enabled: true
+
 Style/ClassEqualityComparison:
   Enabled: true
 
@@ -184,6 +209,9 @@ Style/CombinableLoops:
 
 Style/Documentation:
   Enabled: false
+
+Style/DocumentDynamicEvalDefinition:
+  Enabled: true
 
 Style/DoubleNegation:
   Enabled: false
@@ -223,6 +251,9 @@ Style/KeywordParametersOrder:
 
 Style/MultilineBlockChain:
   Enabled: false
+
+Style/NegatedIfElseCondition:
+  Enabled: true
 
 Style/NumericLiterals:
   Enabled: false
@@ -275,3 +306,6 @@ Style/StringConcatenation:
 
 Style/StringLiterals:
   Enabled: false
+
+Style/SwapValues:
+  Enabled: true

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -390,7 +390,7 @@ module Bolt
                         plan.docstring
                       end
 
-        defaults = plan.parameters.reject { |_, value| value.nil? }.to_h
+        defaults = plan.parameters.to_h.compact
         signature_params = Set.new(plan.parameters.map(&:first))
         parameters = plan.tags(:param).each_with_object({}) do |param, params|
           name = param.name

--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -290,7 +290,7 @@ module Bolt
       begin
         validate_proc = get_hook(plugin_name, :validate_resolve_reference)
       rescue PluginError
-        validate_proc = proc { |*args| }
+        validate_proc = proc { |*args| } # Nothing to do
       end
 
       validate_proc.call(reference)

--- a/lib/bolt/project_migrator/inventory.rb
+++ b/lib/bolt/project_migrator/inventory.rb
@@ -6,12 +6,12 @@ module Bolt
   class ProjectMigrator
     class Inventory < Base
       def migrate(inventory_file, backup_dir)
-        inventory_1_to_2(inventory_file, backup_dir)
+        inventory1to2(inventory_file, backup_dir)
       end
 
       # Migrates an inventory v1 file to inventory v2.
       #
-      private def inventory_1_to_2(inventory_file, backup_dir)
+      private def inventory1to2(inventory_file, backup_dir)
         unless File.exist?(inventory_file)
           return true
         end

--- a/lib/bolt/puppetdb/config.rb
+++ b/lib/bolt/puppetdb/config.rb
@@ -6,14 +6,14 @@ require 'bolt/util'
 module Bolt
   module PuppetDB
     class Config
-      if !ENV['HOME'].nil?
-        DEFAULT_TOKEN = File.expand_path('~/.puppetlabs/token')
-        DEFAULT_CONFIG = { user: File.expand_path('~/.puppetlabs/client-tools/puppetdb.conf'),
-                           global: '/etc/puppetlabs/client-tools/puppetdb.conf' }.freeze
-      else
+      if ENV['HOME'].nil?
         DEFAULT_TOKEN = Bolt::Util.windows? ? 'nul' : '/dev/null'
         DEFAULT_CONFIG = { user: '/etc/puppetlabs/puppet/puppetdb.conf',
                            global: '/etc/puppetlabs/puppet/puppetdb.conf' }.freeze
+      else
+        DEFAULT_TOKEN = File.expand_path('~/.puppetlabs/token')
+        DEFAULT_CONFIG = { user: File.expand_path('~/.puppetlabs/client-tools/puppetdb.conf'),
+                           global: '/etc/puppetlabs/client-tools/puppetdb.conf' }.freeze
 
       end
 

--- a/lib/bolt/shell/powershell.rb
+++ b/lib/bolt/shell/powershell.rb
@@ -11,7 +11,7 @@ module Bolt
       def initialize(target, conn)
         super
 
-        extensions = [target.options['extensions'] || []].flatten.map { |ext| ext[0] != '.' ? '.' + ext : ext }
+        extensions = [target.options['extensions'] || []].flatten.map { |ext| ext[0] == '.' ? ext : '.' + ext }
         extensions += target.options['interpreters'].keys if target.options['interpreters']
         @extensions = DEFAULT_EXTENSIONS + extensions
       end

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -10,10 +10,10 @@ require 'bolt/transport/orch/connection'
 module Bolt
   module Transport
     class Orch < Base
-      CONF_FILE = if !ENV['HOME'].nil?
-                    File.expand_path('~/.puppetlabs/client-tools/orchestrator.conf')
-                  else
+      CONF_FILE = if ENV['HOME'].nil?
                     '/etc/puppetlabs/client-tools/orchestrator.conf'
+                  else
+                    File.expand_path('~/.puppetlabs/client-tools/orchestrator.conf')
                   end
       BOLT_COMMAND_TASK = Struct.new(:name).new('bolt_shim::command').freeze
       BOLT_SCRIPT_TASK = Struct.new(:name).new('bolt_shim::script').freeze

--- a/lib/bolt/transport/remote.rb
+++ b/lib/bolt/transport/remote.rb
@@ -29,7 +29,7 @@ module Bolt
       def run_task(target, task, arguments, options = {}, position = [])
         proxy_target = get_proxy(target)
         transport = @executor.transport(proxy_target.transport)
-        arguments = arguments.merge('_target' => target.to_h.reject { |_, v| v.nil? })
+        arguments = arguments.merge('_target' => target.to_h.compact)
 
         remote_task = task.remote_instance
 

--- a/lib/bolt_server/file_cache.rb
+++ b/lib/bolt_server/file_cache.rb
@@ -63,6 +63,7 @@ module BoltServer
     end
 
     def client
+      # rubocop:disable Naming/VariableNumber
       @client ||= begin
         uri = URI(@config['file-server-uri'])
         https = Net::HTTP.new(uri.host, uri.port)
@@ -75,6 +76,7 @@ module BoltServer
         https.open_timeout = @config['file-server-conn-timeout']
         https
       end
+      # rubocop:enable Naming/VariableNumber
     end
 
     def request_file(path, params, file)

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -584,7 +584,7 @@ describe "Bolt::CLI" do
             expect {
               cli.parse
             }.to raise_error(Bolt::CLIExit)
-          }.not_to output(/[parameters].*nodes/m).to_stdout
+          }.not_to output(/\[parameters\].*nodes/m).to_stdout
         end
 
         it 'accepts apply' do
@@ -2923,7 +2923,7 @@ describe "Bolt::CLI" do
       cli = Bolt::CLI.new(%w[command run whoami -t foo --password bar])
       cli.parse
       expect(@log_output.readlines.join)
-        .not_to match(/CLI arguments ["password"] may be overridden by Inventory/)
+        .not_to match(/CLI arguments \["password"\] may be overridden by Inventory/)
     end
 
     context 'when BOLT_INVENTORY is set' do

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -471,18 +471,18 @@ describe "Bolt::Executor" do
 
     context 'with batched execution with more than one target' do
       let(:pcp) { executor.transport('pcp') }
-      let(:target_1) { inventory.get_target('pcp://node1') }
-      let(:target_2) { inventory.get_target('pcp://node2') }
-      let(:targets) { [target_1, target_2] }
+      let(:target1) { inventory.get_target('pcp://node1') }
+      let(:target2) { inventory.get_target('pcp://node2') }
+      let(:targets) { [target1, target2] }
 
       it 'partitions failures and successes by batch' do
         allow(pcp).to receive(:batch_connected?).with(targets).and_return(false)
-        allow(pcp).to receive(:batch_connected?).with([target_1]).and_return(false)
-        allow(pcp).to receive(:batch_connected?).with([target_2]).and_return(true)
+        allow(pcp).to receive(:batch_connected?).with([target1]).and_return(false)
+        allow(pcp).to receive(:batch_connected?).with([target2]).and_return(true)
 
         results = executor.wait_until_available(targets, wait_time: 1, retry_interval: 1)
-        expect(results.error_set.targets).to include(target_1)
-        expect(results.ok_set.targets).to include(target_2)
+        expect(results.error_set.targets).to include(target1)
+        expect(results.ok_set.targets).to include(target2)
       end
     end
   end

--- a/spec/fixtures/scripts/bolt_cli_loader.rb
+++ b/spec/fixtures/scripts/bolt_cli_loader.rb
@@ -7,11 +7,13 @@ require 'bolt'
 require 'bolt/cli'
 
 def suppress_outputs
+  # rubocop:disable Style/NegatedIfElseCondition
   null_io = !!File::ALT_SEPARATOR ? 'NUL' : '/dev/null'
   out = $stdout.clone
   err = $stderr.clone
   $stderr.reopen(null_io, 'w')
   $stdout.reopen(null_io, 'w')
+  # rubocop:enable Style/NegatedIfElseCondition
   yield
 ensure
   $stdout.reopen(out)

--- a/spec/lib/bolt_spec/bolt_server.rb
+++ b/spec/lib/bolt_spec/bolt_server.rb
@@ -75,7 +75,9 @@ module BoltSpec
       uri = URI(uri || config_data['file-server-uri'])
       https = Net::HTTP.new(uri.host, uri.port)
       https.use_ssl = true
+      # rubocop:disable Naming/VariableNumber
       https.ssl_version = :TLSv1_2
+      # rubocop:enable Naming/VariableNumber
       https.ca_file = config_data['ssl-ca-cert']
       https.cert = OpenSSL::X509::Certificate.new(File.read(config_data['ssl-cert']))
       https.key = OpenSSL::PKey::RSA.new(File.read(config_data['ssl-key']))


### PR DESCRIPTION
This picks up new cops introduced in rubocop 1.2.0 and modifies code to
fit the new cops.

!no-release-note