### PR TITLE
(GH-2303) Add module-install config option

### DIFF
--- a/documentation/bolt_known_issues.md
+++ b/documentation/bolt_known_issues.md
@@ -1,5 +1,94 @@
 # Known issues
 
+## Resolving module dependencies does not support proxies or alternate Forge
+
+When running the `bolt module add|install` commands or `Add|Install-BoltModule`
+cmdlets, Bolt does not support a configured proxy or alternate Forge when it
+resolves module dependencies, even if the `module-install` configuration
+option is set. Support for resolving module dependencies with proxies or an
+alternate Forge requires changes to one of Bolt's gem dependencies, which is
+currently in progress.
+
+While Bolt will not resolve module dependencies with proxies or an alternate
+Forge, it will respect this configuration when installing modules.
+
+If your project configures the `module-install` option, you may experience
+one of the following issues:
+
+- On a restricted network where a proxy is required, resolving modules may
+  cause Bolt to fail.
+
+- When an alternate Forge is specified, Bolt may resolve and install a
+  different set of modules than expected.
+
+### Install modules without resolving dependencies
+
+To avoid this limitation and any potential errors, you can manually edit your
+Puppetfile to add and install modules without resolving dependencies. This is a
+similar workflow to using the `bolt puppetfile install` and
+`Install-BoltPuppetfileModules` commands.
+
+For example, if your project requires the `puppetlabs/apache` module, but
+you need to download modules hosted on an alternate Forge, you should write
+your Puppetfile manually. That Puppetfile might look similar to this:
+
+```ruby
+mod 'puppetlabs/apache', '5.7.0'
+mod 'puppetlabs/stdlib', '6.5.0'
+mod 'puppetlabs/concat', '6.3.0'
+mod 'puppetlabs/translate', '2.2.0'
+```
+
+Once you have a Puppetfile, you can install modules without resolving
+dependencies using the `no-resolve` command-line option:
+
+_\*nix command_
+
+```shell
+bolt module install --no-resolve
+```
+
+_PowerShell cmdlet_
+
+```powershell
+Install-BoltModule -NoResolve
+```
+
+If you need to add a module to your project, manually add the module and
+its dependencies to your Puppetfile and then run the above command again.
+
+### Set the HTTP proxy environment variables
+
+If you only need to configure a proxy to work around network restrictions,
+you can set the HTTP proxy environment variables when you run Bolt. For
+example, if you only configure the `proxy` option under `module-install` like
+this:
+
+```yaml
+# bolt-project.yaml
+module-install:
+  proxy: http://myproxy.com
+```
+
+Then you can set the `HTTP_PROXY` and `HTTPS_PROXY` environment variables
+to this value when you run `bolt module add|install` or `Add|Install-BoltModule`.
+This will configure a proxy that Bolt will use when it makes requests to the
+Puppet Forge and GitHub when it resolves modules.
+
+_\*nix command_
+
+```shell
+HTTP_PROXY=http://myproxy.com HTTPS_PROXY=http://myproxy.com bolt module install
+```
+
+_PowerShell cmdlet_
+
+```powershell
+SET HTTP_PROXY=http://myproxy.com
+SET HTTPS_PROXY=http://myproxy.com
+Install-BoltModule
+```
+
 ## `facts` task fails on Windows targets with Facter 3 installed
 
 When running the `facts` task on a Windows target that has Facter 3 installed,

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -272,6 +272,41 @@ module Bolt
           _example: ["~/.puppetlabs/bolt/modules", "~/.puppetlabs/bolt/site-modules"],
           _default: ["project/modules", "project/site-modules", "project/site"]
         },
+        "module-install" => {
+          description: "Options that configure where Bolt downloads modules from. This option is only used when "\
+                       "installing modules using the `bolt module add|install` commands and "\
+                       "`Add|Install-BoltModule` cmdlets.",
+          type: Hash,
+          properties: {
+            "forge" => {
+              description: "A subsection that can have its own `proxy` setting to set an HTTP proxy for Forge "\
+                           "operations only, and a `baseurl` setting to specify a different Forge host.",
+              type: Hash,
+              properties: {
+                "baseurl" => {
+                  description: "The URL to the Forge host.",
+                  type: String,
+                  format: "uri",
+                  _example: "https://forge.example.com"
+                },
+                "proxy" => {
+                  description: "The HTTP proxy to use for Forge operations.",
+                  type: String,
+                  format: "uri",
+                  _example: "https://my-forge-proxy.com:8080"
+                }
+              },
+              _example: { "baseurl" => "https://forge.example.com", "proxy" => "https://my-forge-proxy.com:8080" }
+            },
+            "proxy" => {
+              description: "The HTTP proxy to use for Git and Forge operations.",
+              type: String,
+              format: "uri",
+              _example: "https://my-proxy.com:8080"
+            }
+          },
+          _plugin: false
+        },
         "modules" => {
           description: "A list of module dependencies for the project. Each dependency is a map of data specifying "\
                        "the module to install. To install the project's module dependencies, run the `bolt module "\
@@ -419,7 +454,8 @@ module Bolt
           _plugin: true
         },
         "puppetfile" => {
-          description: "A map containing options for the `bolt puppetfile install` command.",
+          description: "A map containing options for the `bolt puppetfile install` command and "\
+                       "`Install-BoltPuppetfile` cmdlet.",
           type: Hash,
           properties: {
             "forge" => {
@@ -434,19 +470,19 @@ module Bolt
                   _example: "https://forge.example.com"
                 },
                 "proxy" => {
-                  description: "The HTTP proxy to use for Git and Forge operations.",
+                  description: "The HTTP proxy to use for Forge operations.",
                   type: String,
                   format: "uri",
-                  _example: "https://forgeapi.example.com"
+                  _example: "https://my-forge-proxy.com:8080"
                 }
               },
-              _example: { "baseurl" => "https://forge.example.com", "proxy" => "https://forgeapi.example.com" }
+              _example: { "baseurl" => "https://forge.example.com", "proxy" => "https://my-forge-proxy.com:8080" }
             },
             "proxy" => {
               description: "The HTTP proxy to use for Git and Forge operations.",
               type: String,
               format: "uri",
-              _example: "https://forgeapi.example.com"
+              _example: "https://my-proxy.com:8080"
             }
           },
           _plugin: false
@@ -566,6 +602,7 @@ module Bolt
         format
         inventory-config
         log
+        module-install
         plugin-cache
         plugin-hooks
         plugin_hooks
@@ -587,6 +624,7 @@ module Bolt
         inventoryfile
         log
         modulepath
+        module-install
         modules
         name
         plans

--- a/lib/bolt/module_installer/resolver.rb
+++ b/lib/bolt/module_installer/resolver.rb
@@ -9,7 +9,7 @@ module Bolt
     class Resolver
       # Resolves module specs and returns a Puppetfile object.
       #
-      def resolve(specs)
+      def resolve(specs, _config = {})
         require 'puppetfile-resolver'
 
         # Build the document model from the specs.

--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -196,6 +196,10 @@ module Bolt
       @data['plugin-cache']
     end
 
+    def module_install
+      @data['module-install']
+    end
+
     def modules
       @modules ||= @data['modules']&.map do |mod|
         if mod.is_a?(String)

--- a/lib/bolt/project_manager/config_migrator.rb
+++ b/lib/bolt/project_manager/config_migrator.rb
@@ -72,7 +72,15 @@ module Bolt
         data     = Bolt::Util.read_yaml_hash(project_file, 'config')
         modified = false
 
-        [%w[apply_settings apply-settings], %w[plugin_hooks plugin-hooks]].each do |old, new|
+        # Keys to update. The first element is the old key, while the second is
+        # the key update it to.
+        to_update = [
+          %w[apply_settings apply-settings],
+          %w[puppetfile module-install],
+          %w[plugin_hooks plugin-hooks]
+        ]
+
+        to_update.each do |old, new|
           next unless data.key?(old)
 
           if data.key?(new)

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -281,7 +281,7 @@
       ]
     },
     "puppetfile": {
-      "description": "A map containing options for the `bolt puppetfile install` command.",
+      "description": "A map containing options for the `bolt puppetfile install` command and `Install-BoltPuppetfile` cmdlet.",
       "type": "object",
       "properties": {
         "forge": {
@@ -294,7 +294,7 @@
               "format": "uri"
             },
             "proxy": {
-              "description": "The HTTP proxy to use for Git and Forge operations.",
+              "description": "The HTTP proxy to use for Forge operations.",
               "type": "string",
               "format": "uri"
             }

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -22,6 +22,9 @@
     "log": {
       "$ref": "#/definitions/log"
     },
+    "module-install": {
+      "$ref": "#/definitions/module-install"
+    },
     "plugin-cache": {
       "$ref": "#/definitions/plugin-cache"
     },
@@ -157,6 +160,33 @@
         }
       }
     },
+    "module-install": {
+      "description": "Options that configure where Bolt downloads modules from. This option is only used when installing modules using the `bolt module add|install` commands and `Add|Install-BoltModule` cmdlets.",
+      "type": "object",
+      "properties": {
+        "forge": {
+          "description": "A subsection that can have its own `proxy` setting to set an HTTP proxy for Forge operations only, and a `baseurl` setting to specify a different Forge host.",
+          "type": "object",
+          "properties": {
+            "baseurl": {
+              "description": "The URL to the Forge host.",
+              "type": "string",
+              "format": "uri"
+            },
+            "proxy": {
+              "description": "The HTTP proxy to use for Forge operations.",
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        "proxy": {
+          "description": "The HTTP proxy to use for Git and Forge operations.",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "plugin-cache": {
       "description": "This feature is experimental. Enable plugin caching and set the time-to-live.",
       "type": "object",
@@ -251,7 +281,7 @@
       ]
     },
     "puppetfile": {
-      "description": "A map containing options for the `bolt puppetfile install` command.",
+      "description": "A map containing options for the `bolt puppetfile install` command and `Install-BoltPuppetfile` cmdlet.",
       "type": "object",
       "properties": {
         "forge": {
@@ -264,7 +294,7 @@
               "format": "uri"
             },
             "proxy": {
-              "description": "The HTTP proxy to use for Git and Forge operations.",
+              "description": "The HTTP proxy to use for Forge operations.",
               "type": "string",
               "format": "uri"
             }

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -34,6 +34,9 @@
     "modulepath": {
       "$ref": "#/definitions/modulepath"
     },
+    "module-install": {
+      "$ref": "#/definitions/module-install"
+    },
     "modules": {
       "$ref": "#/definitions/modules"
     },
@@ -195,6 +198,33 @@
         "type": "string"
       }
     },
+    "module-install": {
+      "description": "Options that configure where Bolt downloads modules from. This option is only used when installing modules using the `bolt module add|install` commands and `Add|Install-BoltModule` cmdlets.",
+      "type": "object",
+      "properties": {
+        "forge": {
+          "description": "A subsection that can have its own `proxy` setting to set an HTTP proxy for Forge operations only, and a `baseurl` setting to specify a different Forge host.",
+          "type": "object",
+          "properties": {
+            "baseurl": {
+              "description": "The URL to the Forge host.",
+              "type": "string",
+              "format": "uri"
+            },
+            "proxy": {
+              "description": "The HTTP proxy to use for Forge operations.",
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        },
+        "proxy": {
+          "description": "The HTTP proxy to use for Git and Forge operations.",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "modules": {
       "description": "A list of module dependencies for the project. Each dependency is a map of data specifying the module to install. To install the project's module dependencies, run the `bolt module install` command.",
       "type": "array",
@@ -340,7 +370,7 @@
       ]
     },
     "puppetfile": {
-      "description": "A map containing options for the `bolt puppetfile install` command.",
+      "description": "A map containing options for the `bolt puppetfile install` command and `Install-BoltPuppetfile` cmdlet.",
       "type": "object",
       "properties": {
         "forge": {
@@ -353,7 +383,7 @@
               "format": "uri"
             },
             "proxy": {
-              "description": "The HTTP proxy to use for Git and Forge operations.",
+              "description": "The HTTP proxy to use for Forge operations.",
               "type": "string",
               "format": "uri"
             }

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -286,6 +286,55 @@ describe Bolt::Config do
         /The inventoryfile .* does not exist/
       )
     end
+
+    context 'puppetfile config' do
+      let(:data) do
+        {
+          'puppetfile' => {
+            'proxy' => 'https://proxy.example.com'
+          },
+          'module-install' => {
+            'proxy' => 'https://proxy.example.com'
+          }
+        }
+      end
+
+      let(:config) { Bolt::Config.new(project, data) }
+
+      context 'with modules configured' do
+        let(:project_config) { { 'modules' => [] } }
+
+        it 'warns when puppetfile is configured but not module-install' do
+          data.delete('module-install')
+
+          expect(config.logs).to include(
+            warn: /Detected configuration for 'puppetfile'.*'modules' is configured/
+          )
+        end
+
+        it 'warns when both puppetfile and module-install are configured' do
+          expect(config.logs).to include(
+            warn: /Detected configuration for 'puppetfile' and 'module-install'.*'modules' is also configured/
+          )
+        end
+      end
+
+      context 'without modules configured' do
+        it 'warns when module-install is configured but not puppetfile' do
+          data.delete('puppetfile')
+
+          expect(config.logs).to include(
+            warn: /Detected configuration for 'module-install'.*'modules' is not configured/
+          )
+        end
+
+        it 'warns when both puppetfile and module-install are configured' do
+          expect(config.logs).to include(
+            warn: /Detected configuration for 'puppetfile' and 'module-install'.*'modules' is not configured/
+          )
+        end
+      end
+    end
   end
 
   describe 'expanding paths' do

--- a/spec/bolt/project_manager/config_migrator_spec.rb
+++ b/spec/bolt/project_manager/config_migrator_spec.rb
@@ -31,6 +31,9 @@ describe Bolt::ProjectManager::ConfigMigrator do
           'puppet_library' => {
             'collection' => 'puppet6'
           }
+        },
+        'puppetfile' => {
+          'proxy' => 'http://myproxy.com:8080'
         }
       }
     end
@@ -44,6 +47,9 @@ describe Bolt::ProjectManager::ConfigMigrator do
           'puppet_library' => {
             'collection' => 'puppet6'
           }
+        },
+        'module-install' => {
+          'proxy' => 'http://myproxy.com:8080'
         }
       }
     end

--- a/spec/integration/module_installer_spec.rb
+++ b/spec/integration/module_installer_spec.rb
@@ -20,6 +20,51 @@ describe 'installing modules' do
     allow($stderr).to receive(:puts)
   end
 
+  context 'with install configuration' do
+    let(:base_config) do
+      {
+        'module-install' => {
+          'forge' => {
+            'baseurl' => 'https://forge.example.com',
+            'proxy'   => 'https://myforgeproxy.example.com'
+          },
+          'proxy' => 'https://myproxy.example.com'
+        }
+      }
+    end
+
+    context 'with Forge modules' do
+      let(:project_config) { base_config.merge('modules' => ['puppetlabs-yaml']) }
+
+      xit 'uses the forge configuration' do
+        expect { run_cli(command, project: project) }.to raise_error(
+          Bolt::Error,
+          %r{on https://forge.example.com with proxy https://myforgeproxy.example.com}
+        )
+      end
+    end
+
+    context 'with git modules' do
+      let(:project_config) do
+        base_config.merge(
+          'modules' => [
+            {
+              'git' => 'https://github.com/puppetlabs/puppetlabs-yaml',
+              'ref' => '0.1.0'
+            }
+          ]
+        )
+      end
+
+      xit 'uses the global proxy' do
+        expect { run_cli(command, project: project) }.to raise_error(
+          Bolt::Error,
+          %r{with proxy https://myproxy.example.com}
+        )
+      end
+    end
+  end
+
   context 'with forge and git modules' do
     let(:project_config) do
       {

--- a/spec/lib/bolt_spec/project.rb
+++ b/spec/lib/bolt_spec/project.rb
@@ -48,7 +48,7 @@ module BoltSpec
     end
 
     def project
-      Bolt::Project.create_project(project_path)
+      @project ||= Bolt::Project.create_project(project_path)
     end
 
     def delete_config


### PR DESCRIPTION
This adds a new `module-install` config option that is meant to replace
`puppetfile`. The config option accepts the same sub-options as
`puppetfile` does.

Currently, this config option is not respected when resolving module
dependencies, as changes need to be made to the `puppetfile-resolver`
library to support proxies and an alternate Forge. However, this config
is still passed to r10k, which will respect it when installing modules
from a Puppetfile.

If a user has `module-install` configured and then runs `bolt module
add|install` or `Add|Install-BoltModule`, Bolt will issue a warning
letting the user know that the config option will not be respected when
resolving modules, and then provides a link to a known issue with more
information.

This also adds a handful of warnings that are issued depending on
whether `puppetfile` or `module-install` are configured and if the user
runs `puppetfile install` or `module install`. If both options are
configured, Bolt will also warn and use `module-install`.

This also updates the project migrator to update the `puppetfile` option
to `module-install`.

!feature

* **Add `module-install` configuration option**
  ([#2303](#2303))

  Bolt now supports a `module-install` configuration option in
  `bolt-project.yaml` and `bolt-defaults.yaml`. This option is used to
  configure proxies and an alternate forge when installing modules using
  the `bolt module add|install` commands or `Add|Install-BoltModule`
  cmdlets.

  _This option is not currently supported when resolving module
  dependencies._