### PR TITLE
Show PowerShell cmdlets in output when running in PowerShell

### DIFF
--- a/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
@@ -77,7 +77,7 @@ describe 'run_plan' do
     context 'handles exceptions by' do
       it 'failing with error for non-existent plan name' do
         is_expected.to run.with_params('not_a_plan_name').and_raise_error(
-          /Could not find a plan named "not_a_plan_name"/
+          /Could not find a plan named 'not_a_plan_name'/
         )
       end
 

--- a/bolt-modules/boltlib/spec/functions/run_task_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_spec.rb
@@ -353,7 +353,7 @@ describe 'run_task' do
       is_expected.to run
         .with_params('test::nonesuch', [])
         .and_raise_error(
-          /Could not find a task named "test::nonesuch"/
+          /Could not find a task named 'test::nonesuch'/
         )
     end
 

--- a/bolt-modules/boltlib/spec/functions/run_task_with_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_task_with_spec.rb
@@ -345,7 +345,7 @@ describe 'run_task_with' do
         .with_params('test::nonesuch', [])
         .with_lambda { |_| {} }
         .and_raise_error(
-          /Could not find a task named "test::nonesuch"/
+          /Could not find a task named 'test::nonesuch'/
         )
     end
 

--- a/lib/bolt/error.rb
+++ b/lib/bolt/error.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bolt/util'
+
 module Bolt
   class Error < RuntimeError
     attr_reader :kind, :details, :issue_code, :error_code
@@ -37,13 +39,17 @@ module Bolt
     end
 
     def self.unknown_task(task)
-      new("Could not find a task named \"#{task}\". For a list of available tasks, run \"bolt task show\"",
-          'bolt/unknown-task')
+      command = Bolt::Util.powershell? ? "Get-BoltTask" : "bolt task show"
+      new(
+        "Could not find a task named '#{task}'. For a list of available tasks, run '#{command}'.",
+        'bolt/unknown-task'
+      )
     end
 
     def self.unknown_plan(plan)
+      command = Bolt::Util.powershell? ? "Get-BoltPlan" : "bolt plan show"
       new(
-        "Could not find a plan named \"#{plan}\". For a list of available plans, run \"bolt plan show\"",
+        "Could not find a plan named '#{plan}'. For a list of available plans, run '#{command}'.",
         'bolt/unknown-plan'
       )
     end

--- a/lib/bolt/inventory/group.rb
+++ b/lib/bolt/inventory/group.rb
@@ -241,10 +241,11 @@ module Bolt
         end
 
         if input.key?('nodes')
+          command = Bolt::Util.powershell? ? 'Update-BoltProject' : 'bolt project migrate'
           msg = <<~MSG.chomp
                 Found 'nodes' key in group #{@name}. This looks like a v1 inventory file, which is
                 no longer supported by Bolt. Migrate to a v2 inventory file automatically using
-                'bolt project migrate'.
+                '#{command}'.
                 MSG
           raise ValidationError.new(msg, nil)
         end

--- a/lib/bolt/plan_creator.rb
+++ b/lib/bolt/plan_creator.rb
@@ -77,13 +77,21 @@ module Bolt
         )
       end
 
+      if Bolt::Util.powershell?
+        show_command = 'Get-BoltPlan -Name '
+        run_command  = 'Invoke-BoltPlan -Name '
+      else
+        show_command = 'bolt plan show'
+        run_command  = 'bolt plan run'
+      end
+
       output = <<~OUTPUT
         Created plan '#{plan_name}' at '#{plan_path}'
 
         Show this plan with:
-            bolt plan show #{plan_name}
+            #{show_command} #{plan_name}
         Run this plan with:
-            bolt plan run #{plan_name}
+            #{run_command} #{plan_name}
       OUTPUT
 
       outputter.print_message(output)

--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -11,9 +11,9 @@ module Bolt
     PROJECT_SETTINGS = {
       "name"  => "The name of the project",
       "plans" => "An array of plan names to show, if they exist in the project."\
-                 "These plans are included in `bolt plan show` output",
+                 "These plans are included in `bolt plan show` and `Get-BoltPlan` output",
       "tasks" => "An array of task names to show, if they exist in the project."\
-                 "These tasks are included in `bolt task show` output"
+                 "These tasks are included in `bolt task show` and `Get-BoltTask` output"
     }.freeze
 
     attr_reader :path, :data, :config_file, :inventory_file, :hiera_config,

--- a/lib/bolt/project_migrator/config.rb
+++ b/lib/bolt/project_migrator/config.rb
@@ -54,10 +54,11 @@ module Bolt
         @outputter.print_action_step("Renaming bolt.yaml to bolt-project.yaml")
         FileUtils.mv(config_file, project_file)
 
+        command = Bolt::Util.powershell? ? 'Get-Help about_bolt_project' : 'bolt guide project'
         @outputter.print_action_step(
           "Successfully migrated config. Please add a 'name' key to bolt-project.yaml "\
           "to use project-level tasks and plans. Learn more about projects by running "\
-          "'bolt guide project'."
+          "'#{command}'."
         )
 
         true

--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -273,6 +273,11 @@ module Bolt
         !!File::ALT_SEPARATOR
       end
 
+      # Returns true if running in PowerShell.
+      def powershell?
+        !!ENV['PSModulePath']
+      end
+
       # Accept hash and return hash with top level keys of type "String" converted to symbols.
       def symbolize_top_level_keys(hsh)
         hsh.each_with_object({}) { |(k, v), h| k.is_a?(String) ? h[k.to_sym] = v : h[k] = v }

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -122,13 +122,20 @@ describe "Bolt::Outputter::Human" do
         }
       }
     }
+
+    command = if Bolt::Util.powershell?
+                'Invoke-BoltTask -Name cinnamon_roll -Targets <targets> icing=<value>'
+              else
+                'bolt task run cinnamon_roll --targets <targets> icing=<value>'
+              end
+
     outputter.print_task_info(Bolt::Task.new(name, metadata, files))
     expect(output.string).to eq(<<~TASK_OUTPUT)
 
       cinnamon_roll - A delicious sweet bun
 
       USAGE:
-      bolt task run --targets <node-name> cinnamon_roll icing=<value>
+      #{command}
 
       PARAMETERS:
       - icing: Cream cheese
@@ -158,13 +165,20 @@ describe "Bolt::Outputter::Human" do
         }
       }
     }
+
+    command = if Bolt::Util.powershell?
+                'Invoke-BoltTask -Name sticky_bun -Targets <targets> glaze=<value> pecans=<value>'
+              else
+                'bolt task run sticky_bun --targets <targets> glaze=<value> pecans=<value>'
+              end
+
     outputter.print_task_info(Bolt::Task.new(name, metadata, files))
     expect(output.string).to eq(<<~TASK_OUTPUT)
 
       sticky_bun - A delicious sweet bun with nuts
 
       USAGE:
-      bolt task run --targets <node-name> sticky_bun glaze=<value> pecans=<value>
+      #{command}
 
       PARAMETERS:
       - glaze: Sticky
@@ -182,13 +196,20 @@ describe "Bolt::Outputter::Human" do
     files = [{ 'name' => 'monkey_bread.rb',
                'path' => "#{Bolt::Config::Modulepath::MODULES_PATH}/monkey/bread" }]
     metadata = {}
+
+    command = if Bolt::Util.powershell?
+                'Invoke-BoltTask -Name monkey_bread -Targets <targets>'
+              else
+                'bolt task run monkey_bread --targets <targets>'
+              end
+
     outputter.print_task_info(Bolt::Task.new(name, metadata, files))
     expect(output.string).to eq(<<~TASK_OUTPUT)
 
       monkey_bread
 
       USAGE:
-      bolt task run --targets <node-name> monkey_bread
+      #{command}
 
       MODULE:
       built-in module
@@ -220,13 +241,20 @@ describe "Bolt::Outputter::Human" do
         }
       }
     }
+
+    command = if Bolt::Util.powershell?
+                'Invoke-BoltPlan -Name planity_plan foo=<value> [baz=<value>]'
+              else
+                'bolt plan run planity_plan foo=<value> [baz=<value>]'
+              end
+
     outputter.print_plan_info(plan)
     expect(output.string).to eq(<<~PLAN_OUTPUT)
 
       planity_plan
 
       USAGE:
-      bolt plan run planity_plan foo=<value> [baz=<value>]
+      #{command}
 
       PARAMETERS:
       - foo: Bar
@@ -363,7 +391,7 @@ describe "Bolt::Outputter::Human" do
       banana
       carrot
 
-      Use `bolt guide <topic>` to view a specific guide.
+      Use 'bolt guide <TOPIC>' to view a specific guide.
     OUTPUT
   end
 

--- a/spec/bolt/plan_creator_spec.rb
+++ b/spec/bolt/plan_creator_spec.rb
@@ -108,15 +108,23 @@ describe Bolt::PlanCreator do
     end
 
     it 'outputs the path to the plan and other helpful information' do
+      if Bolt::Util.powershell?
+        show_command = 'Get-BoltPlan -Name '
+        run_command  = 'Invoke-BoltPlan -Name '
+      else
+        show_command = 'bolt plan show'
+        run_command  = 'bolt plan run'
+      end
+
       allow(outputter).to receive(:print_message) do |output|
         expect(output).to match(
           /Created plan '#{plan_name}' at '#{project.plans_path + 'init.yaml'}'/
         )
         expect(output).to match(
-          /bolt plan show #{plan_name}/
+          /#{show_command} #{plan_name}/
         )
         expect(output).to match(
-          /bolt plan run #{plan_name}/
+          /#{run_command} #{plan_name}/
         )
       end
       subject.create_plan(project.plans_path, plan_name, outputter, nil)


### PR DESCRIPTION
When running certain commands or raising certain errors, Bolt will
output a command to run. This change checks whether Bolt is running in
PowerShell or not, and sets the command in the output to a PowerShell
cmdlet if it is or a *nix shell command if it is not.

!no-release-note