### PR TITLE
(feature) Add bolt plan new --pp flag

### DIFF
--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -326,10 +326,11 @@ To encrypt SSH connections using the unsupported algorithm
 This feature was introduced in [Bolt
 2.22.0](https://github.com/puppetlabs/bolt/blob/main/CHANGELOG.md#bolt-2220-2020-08-10).
 
-Use the `bolt plan new` command or `New-BoltPlan` PowerShell cmdlet to generate
-a new project-level YAML plan. The command accepts a single argument: the name
-of the plan. To use the `bolt plan new` command or `New-BoltPlan` PowerShell
-cmdlet, you must have a named [Bolt project](projects.md).
+Use the `bolt plan new` command or `New-BoltPlan` PowerShell cmdlet to generate a new project-level
+plan. The command will generate a YAML plan by default, or you can pass `--pp` on nix or
+`-Pp` in PowerShell to generate a Puppet plan. The command accepts a single argument: the name
+of the plan. To use the `bolt plan new` command or `New-BoltPlan` PowerShell cmdlet, you must have a
+named [Bolt project](projects.md).
 
 ### Naming plans
 

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -88,7 +88,7 @@ module Bolt
           { flags: OPTIONS[:global] + OPTIONS[:global_config_setters],
             banner: PLAN_CONVERT_HELP }
         when 'new'
-          { flags: OPTIONS[:global] + %w[configfile project],
+          { flags: OPTIONS[:global] + %w[configfile project pp],
             banner: PLAN_NEW_HELP }
         when 'run'
           { flags: ACTION_OPTS + %w[params compile-concurrency tmpdir hiera-config],
@@ -943,6 +943,11 @@ module Bolt
              'Use --no-resolve to install modules listed in the Puppetfile without resolving modules configured',
              'in Bolt project configuration') do |resolve|
         @options[:resolve] = resolve
+      end
+
+      separator "\nPLAN OPTIONS"
+      define('--pp', 'Create a new Puppet language plan.') do |pp|
+        @options[:puppet] = pp
       end
 
       separator "\nDISPLAY OPTIONS"

--- a/lib/bolt/plan_creator.rb
+++ b/lib/bolt/plan_creator.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require 'bolt/error'
+require 'bolt/logger'
+require 'bolt/module'
+require 'bolt/util'
+
+module Bolt
+  module PlanCreator
+    def self.validate_input(project, plan_name)
+      if project.name.nil?
+        raise Bolt::Error.new(
+          "Project directory '#{project.path}' is not a named project. Unable to create "\
+          "a project-level plan. To name a project, set the 'name' key in the 'bolt-project.yaml' "\
+          "configuration file.",
+          "bolt/unnamed-project-error"
+        )
+      end
+
+      if plan_name !~ Bolt::Module::CONTENT_NAME_REGEX
+        message = <<~MESSAGE.chomp
+          Invalid plan name '#{plan_name}'. Plan names are composed of one or more name segments
+          separated by double colons '::'.
+
+          Each name segment must begin with a lowercase letter, and may only include lowercase
+          letters, digits, and underscores.
+
+          Examples of valid plan names:
+              - #{project.name}
+              - #{project.name}::my_plan
+        MESSAGE
+
+        raise Bolt::ValidationError, message
+      end
+
+      prefix, _, basename = segment_plan_name(plan_name)
+
+      unless prefix == project.name
+        message = "First segment of plan name '#{plan_name}' must match project name '#{project.name}'. "\
+                  "Did you mean '#{project.name}::#{plan_name}'?"
+
+        raise Bolt::ValidationError, message
+      end
+
+      %w[pp yaml].each do |ext|
+        next unless (path = project.plans_path + "#{basename}.#{ext}").exist?
+        raise Bolt::Error.new(
+          "A plan with the name '#{plan_name}' already exists at '#{path}', nothing to do.",
+          'bolt/existing-plan-error'
+        )
+      end
+    end
+
+    def self.create_plan(plans_path, plan_name, outputter, is_puppet)
+      _, name_segments, basename = segment_plan_name(plan_name)
+      dir_path = plans_path.join(*name_segments)
+
+      begin
+        FileUtils.mkdir_p(dir_path)
+      rescue Errno::EEXIST => e
+        raise Bolt::Error.new(
+          "#{e.message}; unable to create plan directory '#{dir_path}'",
+          'bolt/existing-file-error'
+        )
+      end
+
+      type = is_puppet ? 'pp' : 'yaml'
+      plan_path = dir_path + "#{basename}.#{type}"
+      plan_template = is_puppet ? puppet_plan(plan_name) : yaml_plan(plan_name)
+
+      begin
+        File.write(plan_path, plan_template)
+      rescue Errno::EACCES => e
+        raise Bolt::FileError.new(
+          "#{e.message}; unable to create plan",
+          plan_path
+        )
+      end
+
+      output = <<~OUTPUT
+        Created plan '#{plan_name}' at '#{plan_path}'
+
+        Show this plan with:
+            bolt plan show #{plan_name}
+        Run this plan with:
+            bolt plan run #{plan_name}
+      OUTPUT
+
+      outputter.print_message(output)
+      0
+    end
+
+    def self.segment_plan_name(plan_name)
+      prefix, *name_segments, basename = plan_name.split('::')
+
+      # If the plan name is just the project name, then create an 'init' plan.
+      # Otherwise, use the last name segment for the plan's filename.
+      basename ||= 'init'
+
+      [prefix, name_segments, basename]
+    end
+
+    def self.yaml_plan(plan_name)
+      <<~YAML
+        # This is the structure of a simple plan. To learn more about writing
+        # YAML plans, see the documentation: http://pup.pt/bolt-yaml-plans
+
+        # The description sets the description of the plan that will appear
+        # in 'bolt plan show' output.
+        description: A plan created with bolt plan new
+
+        # The parameters key defines the parameters that can be passed to
+        # the plan.
+        parameters:
+          targets:
+            type: TargetSpec
+            description: A list of targets to run actions on
+            default: localhost
+
+        # The steps key defines the actions the plan will take in order.
+        steps:
+          - message: Hello from #{plan_name}
+          - name: command_step
+            command: whoami
+            targets: $targets
+
+        # The return key sets the return value of the plan.
+        return: $command_step
+      YAML
+    end
+
+    def self.puppet_plan(plan_name)
+      <<~PUPPET
+        # This is the structure of a simple plan. To learn more about writing
+        # Puppet plans, see the documentation: http://pup.pt/bolt-puppet-plans
+
+        # The summary sets the description of the plan that will appear
+        # in 'bolt plan show' output. Bolt uses puppet-strings to parse the
+        # summary and parameters from the plan.
+        # @summary A plan created with bolt plan new.
+        # @param targets The targets to run on.
+        plan #{plan_name} (
+          TargetSpec $targets = "localhost"
+        ) {
+          out::message("Hello from #{plan_name}")
+          $command_result = run_command('whoami', $targets)
+          return $command_result
+        }
+      PUPPET
+    end
+  end
+end

--- a/spec/bolt/plan_creator_spec.rb
+++ b/spec/bolt/plan_creator_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/plan_creator'
+require 'bolt_spec/project'
+
+describe Bolt::PlanCreator do
+  include BoltSpec::Project
+
+  let(:plan_name)    { 'project' }
+  let(:config)       { { 'name' => plan_name } }
+  let(:config_path)  { File.join(@project_path, 'bolt-project.yaml') }
+  let(:project)      { Bolt::Project.create_project(@project_path) }
+  let(:outputter)    { double('outputter', print_message: true) }
+
+  around :each do |example|
+    with_project do
+      example.run
+    end
+  end
+
+  before(:each) do
+    File.write(config_path, config.to_yaml)
+    allow(Bolt::Project).to receive(:create_project).and_return(project)
+  end
+
+  context "#validate_input" do
+    it 'errors without a named project' do
+      allow(project).to receive(:name).and_return(nil)
+      expect { subject.validate_input(project, plan_name) }.to raise_error(
+        Bolt::Error,
+        /Project directory '.*' is not a named project/
+      )
+    end
+
+    it 'errors when the plan name is invalid' do
+      %w[Foo foo-bar foo:: foo::Bar foo::1bar ::foo].each do |plan_name|
+        expect { subject.validate_input(project, plan_name) }.to raise_error(
+          Bolt::ValidationError,
+          /Invalid plan name '#{plan_name}'/
+        )
+      end
+    end
+
+    it 'errors if the first name segment is not the project name' do
+      expect { subject.validate_input(project, 'plan') }.to raise_error(
+        Bolt::ValidationError,
+        /First segment of plan name 'plan' must match project name/
+      )
+    end
+
+    %w[pp yaml].each do |ext|
+      it "errors if there is an existing #{ext} plan with the same name" do
+        plan_path = File.join(@project_path, 'plans', "init.#{ext}")
+        FileUtils.mkdir(File.dirname(plan_path))
+        FileUtils.touch(plan_path)
+
+        expect { subject.validate_input(project, plan_name) }.to raise_error(
+          Bolt::Error,
+          /A plan with the name '#{plan_name}' already exists/
+        )
+      end
+    end
+  end
+
+  context "#create_plan" do
+    it "creates a missing 'plans' directory" do
+      expect(Dir.exist?(project.plans_path)).to eq(false)
+      subject.create_plan(project.plans_path, plan_name, outputter, nil)
+      expect(Dir.exist?(project.plans_path)).to eq(true)
+    end
+
+    it 'creates a missing directory structure' do
+      plan_name = "#{project.name}::foo::bar"
+      expect(Dir.exist?(project.plans_path + 'foo')).to eq(false)
+      subject.create_plan(project.plans_path, plan_name, outputter, nil)
+      expect(Dir.exist?(project.plans_path + 'foo')).to eq(true)
+    end
+
+    it 'catches existing file errors when creating directories' do
+      plan_name = "#{project.name}::foo::bar"
+      FileUtils.mkdir(File.join(@project_path, 'plans'))
+      FileUtils.touch(File.join(@project_path, 'plans', 'foo'))
+
+      expect { subject.create_plan(project.plans_path, plan_name, outputter, nil) }
+        .to raise_error(Bolt::Error, /unable to create plan directory/)
+    end
+
+    it "creates an 'init' plan when the plan name matches the project name" do
+      subject.create_plan(project.plans_path, plan_name, outputter, nil)
+      expect(File.exist?(project.plans_path + 'init.yaml')).to eq(true)
+    end
+
+    it 'creates a yaml plan by default' do
+      plan_name = "#{project.name}::foo"
+
+      subject.create_plan(project.plans_path, plan_name, outputter, nil)
+      expect(File.read(project.plans_path + 'foo.yaml'))
+        .to eq(subject.yaml_plan(plan_name))
+    end
+
+    it 'creates a puppet plan when the flag is provided' do
+      plan_name = "#{project.name}::foo"
+
+      subject.create_plan(project.plans_path, plan_name, outputter, true)
+      expect(File.read(project.plans_path + 'foo.pp'))
+        .to eq(subject.puppet_plan(plan_name))
+    end
+
+    it 'outputs the path to the plan and other helpful information' do
+      allow(outputter).to receive(:print_message) do |output|
+        expect(output).to match(
+          /Created plan '#{plan_name}' at '#{project.plans_path + 'init.yaml'}'/
+        )
+        expect(output).to match(
+          /bolt plan show #{plan_name}/
+        )
+        expect(output).to match(
+          /bolt plan run #{plan_name}/
+        )
+      end
+      subject.create_plan(project.plans_path, plan_name, outputter, nil)
+    end
+  end
+end


### PR DESCRIPTION
This adds the flag `--pp` to the `bolt plan new` command, which
instructs the command to generate a new Puppet language plan instead of
a YAML plans. The YAML plan is still default, and the plans themselves
are equivalent. This additionally move the `plan new` handler from the 
CLI class into it's own `PlanCreator` class in order to separate
concerns.

!feature

* **'bolt plan new' now accepts '--pp' flag to generate Puppet plan**

  The 'bolt plan new' command now accepts a '--pp' flag to generate
  a Puppet plan.