### PR TITLE
(bug) Don't log task output from plugins

### DIFF
--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -293,6 +293,18 @@ module Bolt
       end
     end
 
+    def run_task_with_minimal_logging(targets, task, arguments, options = {})
+      description = options.fetch(:description, "task #{task.name}")
+      log_action(description, targets) do
+        options[:run_as] = run_as if run_as && !options.key?(:run_as)
+        arguments['_task'] = task.name
+
+        batch_execute(targets) do |transport, batch|
+          transport.batch_task(batch, task, arguments, options, [], &method(:publish_event))
+        end
+      end
+    end
+
     def run_task_with(target_mapping, task, options = {}, position = [])
       targets = target_mapping.keys
       description = options.fetch(:description, "task #{task.name}")

--- a/lib/bolt/task/run.rb
+++ b/lib/bolt/task/run.rb
@@ -42,7 +42,7 @@ module Bolt
         if targets.empty?
           Bolt::ResultSet.new([])
         else
-          result = executor.run_task(targets, task, params, options)
+          result = executor.run_task_with_minimal_logging(targets, task, params, options)
 
           if !result.ok && !options[:catch_errors]
             raise Bolt::RunFailure.new(result, 'run_task', task.name)

--- a/spec/bolt/plugin/module_spec.rb
+++ b/spec/bolt/plugin/module_spec.rb
@@ -140,4 +140,25 @@ describe Bolt::Plugin::Module do
       )
     end
   end
+
+  describe(:run_task) do
+    let(:files)       {
+      [{ 'name' => 'my_plug::resolve_reference',
+         'path' => fixtures_path('plugin_modules',
+                                 module_name,
+                                 'tasks',
+                                 'resolve_reference.sh') }]
+    }
+    let(:task)        { Bolt::Task.new('my_plug::resolve_reference', {}, files) }
+    let(:module_name) { 'my_plug' }
+    let(:target)      { Bolt::Target.new('localhost') }
+    let(:result)      { Bolt::Result.new(target, value: { "_output" => 'hi' }) }
+    let(:resultset)   { Bolt::ResultSet.new([result]) }
+
+    it 'does not log output' do
+      expect_any_instance_of(Bolt::Executor).to receive(:run_task_with_minimal_logging)
+        .and_return(resultset)
+      plugin.run_task(task, {})
+    end
+  end
 end

--- a/spec/integration/plugin/module_spec.rb
+++ b/spec/integration/plugin/module_spec.rb
@@ -81,6 +81,12 @@ describe 'using module based plugins' do
       expect(output.strip).to eq('"ssshhh"')
     end
 
+    it 'does not log task output' do
+      run_cli(['plan', 'run', 'test_plan', '--boltdir', project])
+      output = @log_output.readlines
+      expect(output).not_to include(/"value":{"value":"ssshhh"/)
+    end
+
     context 'with bad parameters' do
       let(:plugin) {
         {


### PR DESCRIPTION
Since plugins are simply tasks run through the executor, we would log
their runs like any other task. This included printing the results at
info level. This is a problem for tasks that return secrets, such as the
PKCS7 plugin. Instead of logging plugin output, plugins now use their
own method on the executor `run_task_with_minimal_logging()` to run
the plugin task without printing the result.

!bug

* **Don't log task output from plugins**

  Bolt will not log the output from plugin tasks, to avoid printing
  sensitive information to logs.