### PR TITLE
pwsh missing output

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,9 @@ Layout/LineLength:
 Layout/SpaceAroundMethodCallOperator:
   Enabled: true
 
+Layout/TrailingWhitespace:
+  AllowInHeredoc: true
+
 # Lint cops
 # https://docs.rubocop.org/rubocop/cops_lint.html
 
@@ -60,11 +63,21 @@ Lint/DeprecatedOpenSSLConstant:
 Lint/DuplicateElsifCondition:
   Enabled: true
 
+Lint/DuplicateRegexpCharacterClassElement:
+  Enabled: true
+
 Lint/DuplicateRequire:
   Enabled: true
 
 Lint/DuplicateRescueException:
   Enabled: true
+
+Lint/EmptyBlock:
+  Enabled: true
+  Exclude:
+    - bolt-modules/**/lib/puppet/functions/**/*
+    - lib/bolt/transport/orch.rb
+    - spec/**/*
 
 Lint/EmptyConditionalBody:
   Enabled: true
@@ -87,6 +100,9 @@ Lint/MissingSuper:
 Lint/MixedRegexpCaptureTypes:
   Enabled: false
 
+Lint/NoReturnInBeginEndBlocks:
+  Enabled: true
+
 Lint/OutOfRangeRegexpRef:
   Enabled: true
 
@@ -107,14 +123,17 @@ Lint/SuppressedException:
     - lib/bolt/shell/bash.rb
     - lib/bolt/module_installer.rb
 
+Lint/ToEnumArguments:
+  Enabled: true
+
 Lint/TopLevelReturnWithArgument:
   Enabled: true
 
 Lint/TrailingCommaInAttributeDeclaration:
   Enabled: true
 
-Layout/TrailingWhitespace:
-  AllowInHeredoc: true
+Lint/UnmodifiedReduceAccumulator:
+  Enabled: true
 
 Lint/UnreachableLoop:
   Enabled: true
@@ -164,6 +183,9 @@ Style/AccessModifierDeclarations:
 Style/AccessorGrouping:
   Enabled: true
 
+Style/ArgumentsForwarding:
+  Enabled: true
+
 Style/ArrayCoercion:
   Enabled: true
 
@@ -176,6 +198,9 @@ Style/BlockDelimiters:
 Style/CaseLikeIf:
   Enabled: true
 
+Style/CollectionCompact:
+  Enabled: true
+
 Style/ClassEqualityComparison:
   Enabled: true
 
@@ -184,6 +209,9 @@ Style/CombinableLoops:
 
 Style/Documentation:
   Enabled: false
+
+Style/DocumentDynamicEvalDefinition:
+  Enabled: true
 
 Style/DoubleNegation:
   Enabled: false
@@ -223,6 +251,9 @@ Style/KeywordParametersOrder:
 
 Style/MultilineBlockChain:
   Enabled: false
+
+Style/NegatedIfElseCondition:
+  Enabled: true
 
 Style/NumericLiterals:
   Enabled: false
@@ -275,3 +306,6 @@ Style/StringConcatenation:
 
 Style/StringLiterals:
   Enabled: false
+
+Style/SwapValues:
+  Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Bolt 2.33.2 (2020-11-04)
+
+### Bug fixes
+
+* **Fix module name validation for Forge and Git module specifications**
+  ([#2314](https://github.com/puppetlabs/bolt/issues/2314))
+
+  Forge and Git module specifications now correctly validate the
+  module's name and permit uppercase letters in the owner segment of the
+  module name. Previously, if the owner segment of a module name
+  included uppercase letters, Bolt would raise an error.
+
 ## Bolt 2.33.1 (2020-11-02)
 
 ### New features

--- a/Puppetfile
+++ b/Puppetfile
@@ -7,7 +7,7 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '1.3.0'
 mod 'puppetlabs-puppet_agent', '4.2.0'
-mod 'puppetlabs-facts', '1.1.0'
+mod 'puppetlabs-facts', '1.2.0'
 
 # Core types and providers for Puppet 6
 mod 'puppetlabs-augeas_core', '1.1.1'

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-ssh", ">= 4.0"
   spec.add_dependency "net-ssh-krb", "~> 0.5"
   spec.add_dependency "orchestrator_client", "~> 0.4"
-  spec.add_dependency "puppet", ">= 6.18.0", "<= 6.19"
+  spec.add_dependency "puppet", ">= 6.18.0", "< 6.20"
   spec.add_dependency "puppetfile-resolver", "~> 0.4"
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "puppet-strings", "~> 2.3"

--- a/documentation/running_bolt_commands.md
+++ b/documentation/running_bolt_commands.md
@@ -27,6 +27,31 @@ Invoke-BoltCommand -Command 'Get-Location' -Targets servers
 > 🔩 **Tip:** If a command contains spaces or special shell characters, wrap
 > the command in single quotation marks.
 
+### Run a quoted command
+
+If you need to run a command that uses quotation marks, you must properly escape
+the quotations. The way you escape the quotations depends on whether you're
+using Bash or PowerShell.
+
+In a Bash shell, use backslashes `\` or double the the quotation marks:
+
+_\*nix shell command_
+
+```shell
+bolt command run "Get-WMIObject Win32_Service -Filter ""Name like '%mon'""" -t localhost
+```
+
+In a PowerShell shell, use a combination of backslashes `\` and doubling of
+quotation marks. The example below uses two double quotation marks to quote the
+value being passed to `Filter`, however the example also uses a backslash so
+that Bolt's underlying Ruby argument parser accepts the command.
+
+_PowerShell cmdlet_
+
+```powershell
+Invoke-BoltCommand -Command "Get-WMIObject Win32_Service -Filter \""Name like '%mon'\""" -Targets localhost
+```
+
 ### Read a command from a file
 
 Reading a command from a file is useful when you need to run a script on a target 

--- a/lib/bolt/module_installer.rb
+++ b/lib/bolt/module_installer.rb
@@ -63,7 +63,7 @@ module Bolt
 
       data = Bolt::Util.read_yaml_hash(config_path, 'project')
       data['modules'] ||= []
-      data['modules'] << name
+      data['modules'] << name.tr('-', '/')
 
       begin
         File.write(config_path, data.to_yaml)

--- a/lib/bolt/module_installer/specs/forge_spec.rb
+++ b/lib/bolt/module_installer/specs/forge_spec.rb
@@ -11,7 +11,7 @@ module Bolt
   class ModuleInstaller
     class Specs
       class ForgeSpec
-        NAME_REGEX    = %r{\A[a-z][a-z0-9_]*[-/](?<name>[a-z][a-z0-9_]*)\z}.freeze
+        NAME_REGEX    = %r{\A[a-zA-Z0-9]+[-/](?<name>[a-z][a-z0-9_]*)\z}.freeze
         REQUIRED_KEYS = Set.new(%w[name]).freeze
         KNOWN_KEYS    = Set.new(%w[name version_requirement]).freeze
 
@@ -33,8 +33,9 @@ module Bolt
           unless (match = name.match(NAME_REGEX))
             raise Bolt::ValidationError,
                   "Invalid name for Forge module specification: #{name}. Name must match "\
-                  "'owner/name', must start with a lowercase letter, and may only include "\
-                  "lowercase letters, digits, and underscores."
+                  "'owner/name'. Owner segment may only include letters or digits. Name "\
+                  "segment must start with a lowercase letter and may only include lowercase "\
+                  "letters, digits, and underscores."
           end
 
           [name.tr('-', '/'), match[:name]]
@@ -54,7 +55,7 @@ module Bolt
         #
         def satisfied_by?(mod)
           @type == mod.type &&
-            @full_name == mod.full_name &&
+            @full_name.downcase == mod.full_name.downcase &&
             !mod.version.nil? &&
             @semantic_version.cover?(mod.version)
         end

--- a/lib/bolt/module_installer/specs/git_spec.rb
+++ b/lib/bolt/module_installer/specs/git_spec.rb
@@ -11,7 +11,7 @@ module Bolt
   class ModuleInstaller
     class Specs
       class GitSpec
-        NAME_REGEX    = %r{\A(?:[a-z][a-z0-9_]*[-/])?(?<name>[a-z][a-z0-9_]*)\z}.freeze
+        NAME_REGEX    = %r{\A(?:[a-zA-Z0-9]+[-/])?(?<name>[a-z][a-z0-9_]*)\z}.freeze
         REQUIRED_KEYS = Set.new(%w[git ref]).freeze
 
         attr_reader :git, :ref, :type
@@ -36,8 +36,9 @@ module Bolt
           unless (match = name.match(NAME_REGEX))
             raise Bolt::ValidationError,
                   "Invalid name for Git module specification: #{name}. Name must match "\
-                  "'name' or 'owner/name', must start with a lowercase letter, and may "\
-                  "only include lowercase letters, digits, and underscores."
+                  "'name' or 'owner/name'. Owner segment may only include letters or digits. "\
+                  "Name segment must start with a lowercase letter and may only include "\
+                  "lowercase letters, digits, and underscores."
           end
 
           match[:name]

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -390,7 +390,7 @@ module Bolt
                         plan.docstring
                       end
 
-        defaults = plan.parameters.reject { |_, value| value.nil? }.to_h
+        defaults = plan.parameters.to_h.compact
         signature_params = Set.new(plan.parameters.map(&:first))
         parameters = plan.tags(:param).each_with_object({}) do |param, params|
           name = param.name

--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -290,7 +290,7 @@ module Bolt
       begin
         validate_proc = get_hook(plugin_name, :validate_resolve_reference)
       rescue PluginError
-        validate_proc = proc { |*args| }
+        validate_proc = proc { |*args| } # Nothing to do
       end
 
       validate_proc.call(reference)

--- a/lib/bolt/project_migrator/inventory.rb
+++ b/lib/bolt/project_migrator/inventory.rb
@@ -6,12 +6,12 @@ module Bolt
   class ProjectMigrator
     class Inventory < Base
       def migrate(inventory_file, backup_dir)
-        inventory_1_to_2(inventory_file, backup_dir)
+        inventory1to2(inventory_file, backup_dir)
       end
 
       # Migrates an inventory v1 file to inventory v2.
       #
-      private def inventory_1_to_2(inventory_file, backup_dir)
+      private def inventory1to2(inventory_file, backup_dir)
         unless File.exist?(inventory_file)
           return true
         end

--- a/lib/bolt/puppetdb/config.rb
+++ b/lib/bolt/puppetdb/config.rb
@@ -6,14 +6,14 @@ require 'bolt/util'
 module Bolt
   module PuppetDB
     class Config
-      if !ENV['HOME'].nil?
-        DEFAULT_TOKEN = File.expand_path('~/.puppetlabs/token')
-        DEFAULT_CONFIG = { user: File.expand_path('~/.puppetlabs/client-tools/puppetdb.conf'),
-                           global: '/etc/puppetlabs/client-tools/puppetdb.conf' }.freeze
-      else
+      if ENV['HOME'].nil?
         DEFAULT_TOKEN = Bolt::Util.windows? ? 'nul' : '/dev/null'
         DEFAULT_CONFIG = { user: '/etc/puppetlabs/puppet/puppetdb.conf',
                            global: '/etc/puppetlabs/puppet/puppetdb.conf' }.freeze
+      else
+        DEFAULT_TOKEN = File.expand_path('~/.puppetlabs/token')
+        DEFAULT_CONFIG = { user: File.expand_path('~/.puppetlabs/client-tools/puppetdb.conf'),
+                           global: '/etc/puppetlabs/client-tools/puppetdb.conf' }.freeze
 
       end
 

--- a/lib/bolt/shell/powershell.rb
+++ b/lib/bolt/shell/powershell.rb
@@ -278,6 +278,8 @@ module Bolt
             script_invocation = ['powershell.exe', *PS_ARGS, '-File', *args].join(' ')
             execute(script_invocation)
           end
+        else
+          command = Bolt::Shell::Powershell::Snippets.exit_with_code(command)
         end
         inp, out, err, t = conn.execute(command)
 

--- a/lib/bolt/shell/powershell.rb
+++ b/lib/bolt/shell/powershell.rb
@@ -175,6 +175,7 @@ module Bolt
       end
 
       def run_command(command, options = {}, position = [])
+        command = Bolt::Shell::Powershell::Snippets.exit_with_code(command)
         command = [*env_declarations(options[:env_vars]), command].join("\r\n") if options[:env_vars]
 
         output = execute(command)
@@ -278,8 +279,6 @@ module Bolt
             script_invocation = ['powershell.exe', *PS_ARGS, '-File', *args].join(' ')
             execute(script_invocation)
           end
-        else
-          command = Bolt::Shell::Powershell::Snippets.exit_with_code(command)
         end
         inp, out, err, t = conn.execute(command)
 

--- a/lib/bolt/shell/powershell.rb
+++ b/lib/bolt/shell/powershell.rb
@@ -11,7 +11,7 @@ module Bolt
       def initialize(target, conn)
         super
 
-        extensions = [target.options['extensions'] || []].flatten.map { |ext| ext[0] != '.' ? '.' + ext : ext }
+        extensions = [target.options['extensions'] || []].flatten.map { |ext| ext[0] == '.' ? ext : '.' + ext }
         extensions += target.options['interpreters'].keys if target.options['interpreters']
         @extensions = DEFAULT_EXTENSIONS + extensions
       end

--- a/lib/bolt/shell/powershell/snippets.rb
+++ b/lib/bolt/shell/powershell/snippets.rb
@@ -22,7 +22,7 @@ module Bolt
 
           def exit_with_code(command)
             <<~PS
-            #{command}
+            #{command} | Out-String
             if (-not $? -and ($LASTEXITCODE -eq $null)) { exit 1 }
             exit $LASTEXITCODE
             PS

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -10,10 +10,10 @@ require 'bolt/transport/orch/connection'
 module Bolt
   module Transport
     class Orch < Base
-      CONF_FILE = if !ENV['HOME'].nil?
-                    File.expand_path('~/.puppetlabs/client-tools/orchestrator.conf')
-                  else
+      CONF_FILE = if ENV['HOME'].nil?
                     '/etc/puppetlabs/client-tools/orchestrator.conf'
+                  else
+                    File.expand_path('~/.puppetlabs/client-tools/orchestrator.conf')
                   end
       BOLT_COMMAND_TASK = Struct.new(:name).new('bolt_shim::command').freeze
       BOLT_SCRIPT_TASK = Struct.new(:name).new('bolt_shim::script').freeze

--- a/lib/bolt/transport/remote.rb
+++ b/lib/bolt/transport/remote.rb
@@ -29,7 +29,7 @@ module Bolt
       def run_task(target, task, arguments, options = {}, position = [])
         proxy_target = get_proxy(target)
         transport = @executor.transport(proxy_target.transport)
-        arguments = arguments.merge('_target' => target.to_h.reject { |_, v| v.nil? })
+        arguments = arguments.merge('_target' => target.to_h.compact)
 
         remote_task = task.remote_instance
 

--- a/lib/bolt/version.rb
+++ b/lib/bolt/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bolt
-  VERSION = '2.33.1'
+  VERSION = '2.33.2'
 end

--- a/lib/bolt_server/file_cache.rb
+++ b/lib/bolt_server/file_cache.rb
@@ -63,6 +63,7 @@ module BoltServer
     end
 
     def client
+      # rubocop:disable Naming/VariableNumber
       @client ||= begin
         uri = URI(@config['file-server-uri'])
         https = Net::HTTP.new(uri.host, uri.port)
@@ -75,6 +76,7 @@ module BoltServer
         https.open_timeout = @config['file-server-conn-timeout']
         https
       end
+      # rubocop:enable Naming/VariableNumber
     end
 
     def request_file(path, params, file)

--- a/pwsh_module/command.tests.ps1
+++ b/pwsh_module/command.tests.ps1
@@ -118,18 +118,22 @@ Describe "test all bolt command examples" {
   Context "bolt apply" {
     It "bolt apply manifest.pp -t target" {
       $result = Invoke-BoltApply -manifest 'manifest.pp' -target 'target'
-      $result | Should -Be "bolt apply 'manifest.pp' --targets 'target'"
+      $result | Should -Be "bolt apply manifest.pp --targets target"
     }
     It "bolt apply -e `"file { '/etc/puppetlabs': ensure => present }`" -t target" {
       $result = Invoke-BoltApply -execute "file { '/etc/puppetlabs': ensure => present }" -targets 'target'
-      $result | Should -Be "bolt apply --execute 'file { '/etc/puppetlabs': ensure => present }' --targets 'target'"
+      $result | Should -Be "bolt apply --execute 'file { '/etc/puppetlabs': ensure => present }' --targets target"
     }
   }
 
   Context "bolt command" {
     It "bolt command run 'uptime' -t target1,target2" {
       $result = Invoke-BoltCommand -command 'uptime' -target 'target1,target2'
-      $result | Should -Be "bolt command run 'uptime' --targets 'target1,target2'"
+      $result | Should -Be "bolt command run uptime --targets target1,target2"
+    }
+    It "bolt command run complicated quoting" {
+      $result = Invoke-BoltCommand -Command "Get-WMIObject Win32_Service -Filter \""Name like '%mon'\""" -Targets 'target1,target2'
+      $result | Should -Be 'bolt command run Get-WMIObject Win32_Service -Filter \"Name like ''%mon''\" --targets target1,target2'
     }
   }
 
@@ -138,7 +142,7 @@ Describe "test all bolt command examples" {
       $result = Send-BoltFile '/tmp/source' '/etc/profile.d/login.sh' -target 'target1'
       Write-Warning "this works but order is not same"
       # $result | Should -Be "bolt file upload /tmp/source /etc/profile.d/login.sh -t target1 warn on purpose"
-      $result | Should -Be "bolt file upload --targets 'target1' '/tmp/source' '/etc/profile.d/login.sh'"
+      $result | Should -Be "bolt file upload --targets target1 /tmp/source /etc/profile.d/login.sh"
     }
   }
 
@@ -146,7 +150,7 @@ Describe "test all bolt command examples" {
     It "bolt file download /etc/profile.d/login.sh login_script -t target1" {
       $result = Receive-BoltFile '/etc/profile.d/login.sh' 'login_script' -target 'target1'
       Write-Warning "this works but order is not same"
-      $result | Should -Be "bolt file download --targets 'target1' '/etc/profile.d/login.sh' 'login_script'"
+      $result | Should -Be "bolt file download --targets target1 /etc/profile.d/login.sh login_script"
     }
   }
 
@@ -173,25 +177,25 @@ Describe "test all bolt command examples" {
     }
     It "bolt plan show aggregate::count" {
       $result = Get-BoltPlan -name 'aggregate::count'
-      $result | Should -Be "bolt plan show 'aggregate::count'"
+      $result | Should -Be "bolt plan show aggregate::count"
     }
     It "bolt plan convert path/to/plan/myplan.yaml" {
       $result = Convert-BoltPlan -name 'path/to/plan/myplan.yaml'
-      $result | Should -Be "bolt plan convert 'path/to/plan/myplan.yaml'"
+      $result | Should -Be "bolt plan convert path/to/plan/myplan.yaml"
     }
     It "bolt plan run canary --targets target1,target2 command=hostname" {
       Write-Warning 'requires params to not be positionl...is that a problem'
       $result = Invoke-BoltPlan -name 'canary' -targets 'target1,target2' -params 'command=hostname'
-      $result | Should -Be "bolt plan run 'canary' --targets 'target1,target2' --params 'command=hostname'"
+      $result | Should -Be "bolt plan run canary --targets target1,target2 --params 'command=hostname'"
     }
     It "bolt plan run canary --targets target1,target2 command=hostname" {
       Write-Warning 'requires params to not be positionl...is that a problem'
       $result = Invoke-BoltPlan -name 'canary' -targets 'target1,target2' -params @{ 'command' = 'hostname' }
-      $result | Should -Be "bolt plan run 'canary' --targets 'target1,target2' --params '{`"command`":`"hostname`"}'"
+      $result | Should -Be "bolt plan run canary --targets target1,target2 --params '{`"command`":`"hostname`"}'"
     }
     It "bolt plan new myproject::myplan" {
       $result = New-BoltPlan -name 'myproject::myplan'
-      $result | Should -Be "bolt plan new 'myproject::myplan'"
+      $result | Should -Be "bolt plan new myproject::myplan"
     }
   }
 
@@ -213,11 +217,11 @@ Describe "test all bolt command examples" {
     }
     It "bolt project init myproject" {
       $result = New-BoltProject -name 'myproject'
-      $result | Should -Be "bolt project init 'myproject'"
+      $result | Should -Be "bolt project init myproject"
     }
     It "bolt project init --modules puppetlabs-apt,puppetlabs-ntp" {
       $result = New-BoltProject -modules 'puppetlabs-apt,puppetlabs-ntp'
-      $result | Should -Be "bolt project init --modules 'puppetlabs-apt,puppetlabs-ntp'"
+      $result | Should -Be "bolt project init --modules puppetlabs-apt,puppetlabs-ntp"
     }
   }
 
@@ -239,7 +243,7 @@ Describe "test all bolt command examples" {
   Context "bolt module" {
     It "bolt module add" {
       $result = Add-BoltModule -M puppetlabs-yaml
-      $result | Should -Be "bolt module add 'puppetlabs-yaml'"
+      $result | Should -Be "bolt module add puppetlabs-yaml"
     }
     It "bolt module generate-types" {
       $result = Register-BoltModuleTypes
@@ -260,34 +264,35 @@ Describe "test all bolt command examples" {
     It "bolt script run myscript.sh 'echo hello' --targets target1,target2" {
       $result = Invoke-BoltScript -script 'myscript.sh' -arguments 'echo hello' -targets 'target1,target2'
       Write-Warning "Verify this"
-      $result | Should -Be "bolt script run 'myscript.sh' 'echo hello' --targets 'target1,target2'"
+      # This does work without quotes being explicitly added here
+      $result | Should -Be "bolt script run myscript.sh echo hello --targets target1,target2"
     }
   }
 
   Context "bolt secret" {
     It "bolt secret decrypt ciphertext" {
-      $results = Unprotect-BoltSecret -text 'ciphertext'
-      $results | Should -Be "bolt secret decrypt 'ciphertext'"
+      $results = Unprotect-BoltSecret -Text 'ciphertext'
+      $results | Should -Be "bolt secret decrypt ciphertext"
     }
     It "bolt secret encrypt plaintext" {
-      $results = Protect-BoltSecret -text 'plaintext'
-      $results | Should -Be "bolt secret encrypt 'plaintext'"
+      $results = Protect-BoltSecret -Text 'plaintext'
+      $results | Should -Be "bolt secret encrypt plaintext"
     }
   }
 
   Context "bolt task" {
     It "bolt task run package --targets target1,target2 action=status name=bash" {
       $results = Invoke-BoltTask -name 'package' -targets 'target1,target2' action=status name=bash
-      $results | Should -Be "bolt task run 'package' --targets 'target1,target2' action=status name=bash"
+      $results | Should -Be "bolt task run package --targets target1,target2 action=status name=bash"
 
       $results = Invoke-BoltTask -name 'package' -targets 'target1,target2' -params '{"name":"bash","action":"status"}'
-      $results | Should -Be "bolt task run 'package' --targets 'target1,target2' --params '{`"name`":`"bash`",`"action`":`"status`"}'"
+      $results | Should -Be "bolt task run package --targets target1,target2 --params '{`"name`":`"bash`",`"action`":`"status`"}'"
 
       $results = Invoke-BoltTask -name 'package' -targets 'target1,target2' -params @{ 'name' = 'bash'; 'action' = 'status' }
       # We don't care about the order of JSON keys, and they might become out
       # of order due to ConvertToJson
-      $results | Should -BeIn @("bolt task run 'package' --targets 'target1,target2' --params '{`"name`":`"bash`",`"action`":`"status`"}'",
-          "bolt task run 'package' --targets 'target1,target2' --params '{`"action`":`"status`",`"name`":`"bash`"}'")
+      $results | Should -BeIn @("bolt task run package --targets target1,target2 --params '{`"name`":`"bash`",`"action`":`"status`"}'",
+        "bolt task run package --targets target1,target2 --params '{`"action`":`"status`",`"name`":`"bash`"}'")
 
     }
     It "bolt task show" {
@@ -296,7 +301,7 @@ Describe "test all bolt command examples" {
     }
     It "bolt task show canary" {
       $results = Get-BoltTask -name 'canary'
-      $results | Should -Be "bolt task show 'canary'"
+      $results | Should -Be "bolt task show canary"
     }
   }
 }

--- a/pwsh_module/pwsh_bolt_internal.ps1
+++ b/pwsh_module/pwsh_bolt_internal.ps1
@@ -88,7 +88,14 @@ function Get-BoltCommandline {
       if ($rubyParameter) {
         $params += "--$($rubyParameter)"
       }
-      $params += "'$($pwshValue)'"
+
+      $parsedValue = switch ($pwshParameter) {
+        'params' { "'$($pwshValue)'" }
+        'execute' { "'$($pwshValue)'" }
+        Default { $pwshValue }
+      }
+
+      $params += $parsedValue
     }
   }
 

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -584,7 +584,7 @@ describe "Bolt::CLI" do
             expect {
               cli.parse
             }.to raise_error(Bolt::CLIExit)
-          }.not_to output(/[parameters].*nodes/m).to_stdout
+          }.not_to output(/\[parameters\].*nodes/m).to_stdout
         end
 
         it 'accepts apply' do
@@ -2923,7 +2923,7 @@ describe "Bolt::CLI" do
       cli = Bolt::CLI.new(%w[command run whoami -t foo --password bar])
       cli.parse
       expect(@log_output.readlines.join)
-        .not_to match(/CLI arguments ["password"] may be overridden by Inventory/)
+        .not_to match(/CLI arguments \["password"\] may be overridden by Inventory/)
     end
 
     context 'when BOLT_INVENTORY is set' do

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -471,18 +471,18 @@ describe "Bolt::Executor" do
 
     context 'with batched execution with more than one target' do
       let(:pcp) { executor.transport('pcp') }
-      let(:target_1) { inventory.get_target('pcp://node1') }
-      let(:target_2) { inventory.get_target('pcp://node2') }
-      let(:targets) { [target_1, target_2] }
+      let(:target1) { inventory.get_target('pcp://node1') }
+      let(:target2) { inventory.get_target('pcp://node2') }
+      let(:targets) { [target1, target2] }
 
       it 'partitions failures and successes by batch' do
         allow(pcp).to receive(:batch_connected?).with(targets).and_return(false)
-        allow(pcp).to receive(:batch_connected?).with([target_1]).and_return(false)
-        allow(pcp).to receive(:batch_connected?).with([target_2]).and_return(true)
+        allow(pcp).to receive(:batch_connected?).with([target1]).and_return(false)
+        allow(pcp).to receive(:batch_connected?).with([target2]).and_return(true)
 
         results = executor.wait_until_available(targets, wait_time: 1, retry_interval: 1)
-        expect(results.error_set.targets).to include(target_1)
-        expect(results.ok_set.targets).to include(target_2)
+        expect(results.error_set.targets).to include(target1)
+        expect(results.ok_set.targets).to include(target2)
       end
     end
   end

--- a/spec/bolt/module_installer/specs/forge_spec_spec.rb
+++ b/spec/bolt/module_installer/specs/forge_spec_spec.rb
@@ -19,8 +19,21 @@ describe Bolt::ModuleInstaller::Specs::ForgeSpec do
       expect(spec.name).to eq('yaml')
     end
 
+    it 'allows uppercase letters for owner' do
+      init_hash['name'] = 'Puppetlabs/yaml'
+      expect { spec }.not_to raise_error
+    end
+
     it 'errors with an invalid name' do
       init_hash['name'] = 'yaml'
+      expect { spec }.to raise_error(
+        Bolt::ValidationError,
+        /Invalid name for Forge module/
+      )
+    end
+
+    it 'errors with an invalid owner' do
+      init_hash['name'] = 'puppet_labs/yaml'
       expect { spec }.to raise_error(
         Bolt::ValidationError,
         /Invalid name for Forge module/
@@ -101,6 +114,13 @@ describe Bolt::ModuleInstaller::Specs::ForgeSpec do
       mod     = double('mod', type: :forge, full_name: name, version: version)
 
       expect(spec.satisfied_by?(mod)).to be(false)
+    end
+
+    it 'is case insensitive when comparing names' do
+      version = SemanticPuppet::Version.parse('0.1.0')
+      mod     = double('mod', type: :forge, full_name: name.upcase, version: version)
+
+      expect(spec.satisfied_by?(mod)).to be(true)
     end
   end
 end

--- a/spec/bolt/module_installer/specs/git_spec_spec.rb
+++ b/spec/bolt/module_installer/specs/git_spec_spec.rb
@@ -16,8 +16,21 @@ describe Bolt::ModuleInstaller::Specs::GitSpec do
       expect(spec.name).to eq(name)
     end
 
+    it 'allows uppercase letters for owner' do
+      init_hash['name'] = 'Puppetlabs/yaml'
+      expect { spec }.not_to raise_error
+    end
+
     it 'errors with an invalid name' do
       init_hash['name'] = 'Yaml'
+      expect { spec }.to raise_error(
+        Bolt::ValidationError,
+        /Invalid name for Git module specification/
+      )
+    end
+
+    it 'errors with an invalid owner' do
+      init_hash['name'] = 'puppet_labs/yaml'
       expect { spec }.to raise_error(
         Bolt::ValidationError,
         /Invalid name for Git module specification/

--- a/spec/fixtures/scripts/bolt_cli_loader.rb
+++ b/spec/fixtures/scripts/bolt_cli_loader.rb
@@ -7,11 +7,13 @@ require 'bolt'
 require 'bolt/cli'
 
 def suppress_outputs
+  # rubocop:disable Style/NegatedIfElseCondition
   null_io = !!File::ALT_SEPARATOR ? 'NUL' : '/dev/null'
   out = $stdout.clone
   err = $stderr.clone
   $stderr.reopen(null_io, 'w')
   $stdout.reopen(null_io, 'w')
+  # rubocop:enable Style/NegatedIfElseCondition
   yield
 ensure
   $stdout.reopen(out)

--- a/spec/lib/bolt_spec/bolt_server.rb
+++ b/spec/lib/bolt_spec/bolt_server.rb
@@ -75,7 +75,9 @@ module BoltSpec
       uri = URI(uri || config_data['file-server-uri'])
       https = Net::HTTP.new(uri.host, uri.port)
       https.use_ssl = true
+      # rubocop:disable Naming/VariableNumber
       https.ssl_version = :TLSv1_2
+      # rubocop:enable Naming/VariableNumber
       https.ca_file = config_data['ssl-ca-cert']
       https.cert = OpenSSL::X509::Certificate.new(File.read(config_data['ssl-cert']))
       https.key = OpenSSL::PKey::RSA.new(File.read(config_data['ssl-key']))


### PR DESCRIPTION
- (bug) Allow Bolt to use Puppet 6.19.z releases
- (GH-2314) Fix module name regex for Forge/Git specifications
- (maint) Pick up puppetlabs-facts 1.2.0
- (maint) Update changelog to 2.33.2
- (GEM) update bolt version to 2.33.2
- (GH-2272) Fix complicated quoting in PowerShell Cmdlets
- (maint) Bump rubocop to 1.2.0
- (GH-1650) Handle exit codes greater than 1 in pwsh
- wip
