### PR TITLE
Revert "(GH-1650) Handle exit codes greater than 1 in winrm transport"

### DIFF
--- a/lib/bolt/shell/powershell.rb
+++ b/lib/bolt/shell/powershell.rb
@@ -278,8 +278,6 @@ module Bolt
             script_invocation = ['powershell.exe', *PS_ARGS, '-File', *args].join(' ')
             execute(script_invocation)
           end
-        else
-          command = Bolt::Shell::Powershell::Snippets.exit_with_code(command)
         end
         inp, out, err, t = conn.execute(command)
 

--- a/spec/integration/transport/winrm_spec.rb
+++ b/spec/integration/transport/winrm_spec.rb
@@ -1022,29 +1022,8 @@ describe Bolt::Transport::WinRM do
           end
         end
 
-        it "Calling a working external binary", winrm: true do
-          contents = <<-PS
-          cmd.exe /c "exit 0"
-          # for desired behavior, a user must explicitly call
-          # exit $LASTEXITCODE
-          PS
-
-          with_tempfile_containing('script-test-winrm', contents, '.ps1') do |file|
-            result = winrm.run_script(target, file.path, [])
-            expect(result).to be_success
-          end
-        end
-
         it "Calling a failing external binary", winrm: true do
-          # In PR #2196 we added additional PowerShell logic to handle figuring
-          # out what the exit code is if the user did not specifically set it
-          # This results in this test correctly returning 42 to the spec test,
-          # which is a failure, so our test is 'succeeding' if the command
-          # 'fails'. Previously the test would pass because Bolt did not detect
-          # the 42, requiring the user to explicitly check themselves.
-          #
-          # In short, the correct behavior for this test is for it to return 42
-          # and fail.
+          # deriving meaning from $LASTEXITCODE requires a custom PS host
           contents = <<-PS
           cmd.exe /c "exit 42"
           # for desired behavior, a user must explicitly call
@@ -1053,7 +1032,7 @@ describe Bolt::Transport::WinRM do
 
           with_tempfile_containing('script-test-winrm', contents, '.ps1') do |file|
             result = winrm.run_script(target, file.path, [])
-            expect(result).to_not be_success
+            expect(result).to be_success
           end
         end
       end


### PR DESCRIPTION
Reverts puppetlabs/bolt#2196

This change is suppressing STDOUT output from being returned to Bolt, which is a breaking change in behavior. This isn't going to be simple to fix, so we're reverting this for now while we work on a solution.