### PR TITLE
(bug) Fix version computing in changelog task

### DIFF
--- a/scripts/generate_changelog.rb
+++ b/scripts/generate_changelog.rb
@@ -90,6 +90,7 @@ class ChangelogGenerator
     x, y, z = latest.split('.').map(&:to_i)
     if %w[feature deprecation removal].any? { |type| entries[type][:entries].any? }
       y += 1
+      z =  0
     else
       z += 1
     end


### PR DESCRIPTION
This fixes a minor bug in the changelog task that does not reset the `z`
segment of the version when the `y` segment is incremented. This results
in the changelog computing the wrong version when a new `y` version is
computed.

!no-release-note