### PR TITLE
(GH-2309) Error with invalid YAML plan step type

### DIFF
--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -26,7 +26,7 @@ module Bolt
         details[:line]   = err.line if defined?(err.line)
         details[:column] = err.pos if defined?(err.pos)
 
-        error.add_filelineno(details)
+        error.add_filelineno(details.compact)
         error
       end
 

--- a/lib/bolt/pal/yaml_plan.rb
+++ b/lib/bolt/pal/yaml_plan.rb
@@ -45,6 +45,13 @@ module Bolt
         used_names = Set.new(@parameters.map(&:name))
 
         @steps = plan['steps'].each_with_index.map do |step, index|
+          unless step.is_a?(Hash)
+            raise Bolt::Error.new(
+              "Parse error in step number #{index + 1}: Plan step must be an object with valid step keys.",
+              'bolt/invalid-plan'
+            )
+          end
+
           # Step keys also aren't allowed to be code and neither is the value of "name"
           stringified_step = Bolt::Util.walk_keys(step) { |key| stringify(key) }
           stringified_step['name'] = stringify(stringified_step['name']) if stringified_step.key?('name')

--- a/spec/bolt/pal/yaml_plan_spec.rb
+++ b/spec/bolt/pal/yaml_plan_spec.rb
@@ -204,6 +204,19 @@ describe Bolt::PAL::YamlPlan do
 
         expect { plan }.to raise_error(Bolt::Error, /Plan must specify an array of steps/)
       end
+
+      it 'fails if a step is not a hash' do
+        @plan_body = {
+          'steps' => [
+            'foo'
+          ]
+        }
+
+        expect { plan }.to raise_error do |error|
+          expect(error.kind).to eq('bolt/invalid-plan')
+          expect(error.message).to match(/Parse error in step number 1: Plan step must be an object/)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This updates Bolt to error when a YAML plan includes a plan step with
the wrong type. Previously, a YAML plan with a non-Hash step would still
execute. Now, if a step is anything except a Hash, the plan will error
and Bolt will provide a helpful error message.

!bug

* **Error with invalid YAML plan step type**
  ([#2309](https://github.com/puppetlabs/bolt/issues/2309))

  Bolt now errors if a YAML plan step is not a hash. Previously, YAML
  plans would execute even if a plan step was not a hash.