### PR TITLE
(maint) Update rubocop to 1.3.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,6 +60,9 @@ Lint/ConstantDefinitionInBlock:
 Lint/DeprecatedOpenSSLConstant:
   Enabled: true
 
+Lint/DuplicateBranch:
+  Enabled: true
+
 Lint/DuplicateElsifCondition:
   Enabled: true
 
@@ -78,6 +81,9 @@ Lint/EmptyBlock:
     - bolt-modules/**/lib/puppet/functions/**/*
     - lib/bolt/transport/orch.rb
     - spec/**/*
+
+Lint/EmptyClass:
+  Enabled: true
 
 Lint/EmptyConditionalBody:
   Enabled: true
@@ -253,6 +259,9 @@ Style/MultilineBlockChain:
   Enabled: false
 
 Style/NegatedIfElseCondition:
+  Enabled: true
+
+Style/NilLambda:
   Enabled: true
 
 Style/NumericLiterals:

--- a/acceptance/setup/git/pre-suite/010_install_git.rb
+++ b/acceptance/setup/git/pre-suite/010_install_git.rb
@@ -8,11 +8,7 @@ test_name "Install Git" do
       # use chocolatey to install latest ruby
       on(bolt, powershell('choco install git -y'))
       result = on(bolt, powershell('git --version'))
-    when /debian|ubuntu/
-      # install system ruby packages
-      install_package(bolt, 'git')
-      result = on(bolt, 'git --version')
-    when /el-|centos|fedora/
+    when /debian|ubuntu|el-|centos|fedora/
       # install system ruby packages
       install_package(bolt, 'git')
       result = on(bolt, 'git --version')

--- a/bolt-modules/boltlib/lib/puppet/functions/catch_errors.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/catch_errors.rb
@@ -44,9 +44,7 @@ Puppet::Functions.create_function(:catch_errors) do
       yield
     rescue Puppet::PreformattedError => e
       if e.cause.is_a?(Bolt::Error)
-        if error_types.nil?
-          e.cause.to_puppet_error
-        elsif error_types.include?(e.cause.to_h['kind'])
+        if error_types.nil? || error_types.include?(e.cause.to_h['kind'])
           e.cause.to_puppet_error
         else
           raise e

--- a/lib/bolt_spec/plans/mock_executor.rb
+++ b/lib/bolt_spec/plans/mock_executor.rb
@@ -133,6 +133,7 @@ module BoltSpec
         # through to another conditional statement
         doub = @plan_doubles[plan_name] || @plan_doubles[:default]
 
+        # rubocop:disable Lint/DuplicateBranch
         # High level:
         #  - If we've explicitly allowed execution of the plan (normally the main plan
         #    passed into BoltSpec::Plan::run_plan()), then execute it
@@ -165,6 +166,7 @@ module BoltSpec
           @error_message = "Unexpected call to 'run_plan(#{plan_name}, #{params_str})'"
           raise UnexpectedInvocation, @error_message
         end
+        # rubocop:enable Lint/DuplicateBranch
         result
       end
 

--- a/rakelib/pwsh.rake
+++ b/rakelib/pwsh.rake
@@ -312,19 +312,9 @@ namespace :pwsh do
           # Only one of --targets , --rerun , or --query can be used
           # Only one of --configfile or --boltdir can be used
           case pwsh_name.downcase
-          when 'user'
-            pwsh_param[:validate_not_null_or_empty] = true
-          when 'password'
-            pwsh_param[:validate_not_null_or_empty] = true
-          when 'privatekey'
-            pwsh_param[:validate_not_null_or_empty] = true
-          when 'concurrency'
-            pwsh_param[:validate_not_null_or_empty] = true
-          when 'compileconcurrency'
-            pwsh_param[:validate_not_null_or_empty] = true
-          when 'connecttimeout'
-            pwsh_param[:validate_not_null_or_empty] = true
-          when 'modulepath'
+          when 'user', 'password', 'privatekey', 'concurrency',
+            'compileconcurrency', 'connecttimeout', 'modulepath', 'targets',
+            'query', 'configfile', 'boltdir'
             pwsh_param[:validate_not_null_or_empty] = true
           when 'transport'
             pwsh_param[:validate_set] = Bolt::Config::Options::TRANSPORT_CONFIG.keys
@@ -332,17 +322,9 @@ namespace :pwsh do
             pwsh_param[:validate_set] = %w[trace debug info notice warn error fatal any]
           when 'filter'
             pwsh_param[:validate_pattern] = '^[a-z0-9_:]+$'
-          when 'targets'
-            pwsh_param[:validate_not_null_or_empty] = true
-          when 'query'
-            pwsh_param[:validate_not_null_or_empty] = true
           when 'rerun'
             pwsh_param[:validate_not_null_or_empty] = true
             pwsh_param[:validate_set] = %w[all failure success]
-          when 'configfile'
-            pwsh_param[:validate_not_null_or_empty] = true
-          when 'boltdir'
-            pwsh_param[:validate_not_null_or_empty] = true
           when 'execute'
             pwsh_param[:parameter_set] = 'execute'
             pwsh_param[:mandatory] = true

--- a/spec/integration/transport/winrm_spec.rb
+++ b/spec/integration/transport/winrm_spec.rb
@@ -688,7 +688,7 @@ describe Bolt::Transport::WinRM do
         Height: $Height ($(if ($Height -ne $null) { $Height.GetType().Name } else { 'null' }))
         "@
       PS
-      # note that the order of the entries in this hash is not the same as
+      # NOTE: that the order of the entries in this hash is not the same as
       # the order of the task parameters
       arguments = { Age: 30,
                     Height: 5.75,
@@ -708,7 +708,7 @@ describe Bolt::Transport::WinRM do
 
         Write-Host "foo=$foo"
       PS
-      arguments = { foo: 30 } # note that the script doesn't recognize the 'bar' parameter
+      arguments = { foo: 30 } # NOTE: that the script doesn't recognize the 'bar' parameter
       with_task_containing('task-params-test-winrm', contents, 'powershell', '.ps1') do |task|
         expect(winrm.run_task(target, task, arguments).message).to eq("foo=30\r\n")
       end
@@ -727,10 +727,10 @@ describe Bolt::Transport::WinRM do
         bar: $bar ($(if ($bar -ne $null) { $bar.GetType().Name } else { 'null' }))
         "@
       PS
-      arguments = { bar: 30 } # note that the script doesn't recognize the 'bar' parameter
+      arguments = { bar: 30 } # NOTE: that the script doesn't recognize the 'bar' parameter
       with_task_containing('task-params-test-winrm', contents, 'environment', '.ps1') do |task|
         expect(winrm.run_task(target, task, arguments).message)
-          .to match(/\Afoo:  \(String\).*^bar: 30 \(String\).*\Z/m) # note that $foo is an empty string and not null
+          .to match(/\Afoo:  \(String\).*^bar: 30 \(String\).*\Z/m) # NOTE: that $foo is an empty string and not null
       end
     end
 


### PR DESCRIPTION
Rubocop released 1.3.0, this adds new cops to our rubocop config and
updates code to adhere to those cops. This includes just three cops:
Duplicate code branches (so if or case statements where the body of the
statement is the same for multiple conditions) which resulted in all of
the code changes, as well as a cop to catch empty classes an nil
lambdas.

!no-release-note