### PR TITLE
(GH-2337) Validate config using schemas

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -891,12 +891,12 @@ module Bolt
         if ENV.include?(Bolt::Inventory::ENVIRONMENT_VAR)
           raise Bolt::CLIError, "Cannot pass inventory file when #{Bolt::Inventory::ENVIRONMENT_VAR} is set"
         end
-        @options[:inventoryfile] = Pathname.new(File.expand_path(path))
+        @options[:inventoryfile] = File.expand_path(path)
       end
       define('--puppetfile PATH',
              'Specify a Puppetfile to use when installing modules. (default: ~/.puppetlabs/bolt/Puppetfile)',
              'Modules are installed in the current project.') do |path|
-        @options[:puppetfile_path] = Pathname.new(File.expand_path(path))
+        @options[:puppetfile_path] = File.expand_path(path)
       end
       define('--[no-]save-rerun', 'Whether to update the rerun file after this command.') do |save|
         @options[:'save-rerun'] = save

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -307,7 +307,11 @@ module Bolt
                        "its value is a map of configuration data. Configurable options are specified by the plugin. "\
                        "Read more about configuring plugins in [Using plugins](using_plugins.md#configuring-plugins).",
           type: Hash,
-          _plugin: true,
+          additionalProperties: {
+            type: Hash,
+            _plugin: true
+          },
+          _plugin: false,
           _example: { "pkcs7" => { "keysize" => 1024 } }
         },
         "puppetdb" => {

--- a/lib/bolt/config/transport/local.rb
+++ b/lib/bolt/config/transport/local.rb
@@ -29,13 +29,6 @@ module Bolt
           if @config['interpreters']
             @config['interpreters'] = normalize_interpreters(@config['interpreters'])
           end
-
-          if (run_as_cmd = @config['run-as-command'])
-            unless run_as_cmd.all? { |n| n.is_a?(String) }
-              raise Bolt::ValidationError,
-                    "run-as-command must be an Array of Strings, received #{run_as_cmd.class} #{run_as_cmd.inspect}"
-            end
-          end
         end
       end
     end

--- a/lib/bolt/config/validator.rb
+++ b/lib/bolt/config/validator.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require 'bolt/error'
+
+# This class validates config against a schema, raising an error that includes
+# details about any invalid configuration.
+#
+module Bolt
+  class Config
+    class Validator
+      def initialize
+        @errors = []
+        @path   = []
+      end
+
+      # This is the entry method for validating data against the schema.
+      # It loops over each key-value pair in the data hash and validates
+      # the value against the relevant schema definition.
+      #
+      def validate(data, schema, location = nil)
+        data.each_pair do |key, value|
+          next unless schema.key?(key)
+
+          @path.push(key)
+          validate_value(value, schema[key])
+        ensure
+          @path.pop
+        end
+
+        raise_error(location)
+      end
+
+      # Raises a ValidationError if there are any errors. All error messages
+      # created during validation are concatenated into a single error
+      # message.
+      #
+      private def raise_error(location)
+        return unless @errors.any?
+
+        message = "Invalid configuration"
+        message += " at #{location}" if location
+        message += ":\n"
+        message += @errors.map { |error| "\s\s#{error}" }.join("\n")
+
+        raise Bolt::ValidationError, message
+      end
+
+      # Validate an individual value. This performs validation that is
+      # common to all values, including type validation. After validating
+      # the value's type, the value is passed off to an individual
+      # validation method for the value's type.
+      #
+      private def validate_value(value, definition)
+        return if plugin_reference?(value, definition)
+        return unless valid_type?(value, definition)
+
+        case value
+        when Hash
+          validate_hash(value, definition)
+        when Array
+          validate_array(value, definition)
+        when String
+          validate_string(value, definition)
+        when Numeric
+          validate_number(value, definition)
+        end
+      end
+
+      # Validates a hash value, logging errors for any validations that fail.
+      # This will enumerate each key-value pair in the hash and validate each
+      # value individually.
+      #
+      private def validate_hash(value, definition)
+        properties = definition[:properties] ? definition[:properties].keys : []
+
+        if definition[:required] && (definition[:required] - value.keys).any?
+          missing = definition[:required] - value.keys
+          @errors << "Value at '#{path}' is missing required keys #{missing.join(', ')}"
+        end
+
+        value.each_pair do |key, val|
+          @path.push(key)
+
+          if properties.include?(key)
+            validate_value(val, definition[:properties][key])
+          elsif definition[:additionalProperties]
+            validate_value(val, definition[:additionalProperties])
+          end
+        ensure
+          @path.pop
+        end
+      end
+
+      # Validates an array value, logging errors for any validations that fail.
+      # This will enumerate the items in the array and validate each item
+      # individually.
+      #
+      private def validate_array(value, definition)
+        if definition[:uniqueItems] && value.size != value.uniq.size
+          @errors << "Value at '#{path}' must not include duplicate elements"
+          return
+        end
+
+        return unless definition.key?(:items)
+
+        value.each_with_index do |item, index|
+          @path.push(index)
+          validate_value(item, definition[:items])
+        ensure
+          @path.pop
+        end
+      end
+
+      # Validates a string value, logging errors for any validations that fail.
+      #
+      private def validate_string(value, definition)
+        if definition.key?(:enum) && !definition[:enum].include?(value)
+          @errors << "Value at '#{path}' must be one of #{definition[:enum].join(', ')}"
+        end
+      end
+
+      # Validates a numeric value, logging errors for any validations that fail.
+      #
+      private def validate_number(value, definition)
+        if definition.key?(:minimum) && value < definition[:minimum]
+          @errors << "Value at '#{path}' must be a minimum of #{definition[:minimum]}"
+        end
+      end
+
+      # Returns true if a value is a plugin reference. This also validates whether
+      # a value can be a plugin reference in the first place. If the value is a
+      # plugin reference but cannot be one according to the schema, then this will
+      # log an error.
+      #
+      private def plugin_reference?(value, definition)
+        if value.is_a?(Hash) && value.key?('_plugin')
+          unless definition[:_plugin]
+            @errors << "Value at '#{path}' is a plugin reference, which is unsupported at "\
+                       "this location"
+          end
+
+          true
+        else
+          false
+        end
+      end
+
+      # Asserts the type for each option against the type specified in the schema
+      # definition. The schema definition can specify multiple valid types, so the
+      # value needs to only match one of the types to be valid. Returns early if
+      # there is no type in the definition (in practice this shouldn't happen, but
+      # this will safeguard against any dev mistakes).
+      #
+      private def valid_type?(value, definition)
+        return unless definition.key?(:type)
+
+        types = Array(definition[:type])
+
+        if types.include?(value.class)
+          true
+        else
+          if types.include?(TrueClass) || types.include?(FalseClass)
+            types = types - [TrueClass, FalseClass] + ['Boolean']
+          end
+
+          @errors << "Value at '#{path}' must be of type #{types.join(', ')}"
+
+          false
+        end
+      end
+
+      # Returns the formatted path for the key.
+      #
+      private def path
+        @path.join('.')
+      end
+    end
+  end
+end

--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -122,13 +122,6 @@ module Bolt
     def self.setup(config, pal, analytics = Bolt::Analytics::NoopClient.new)
       plugins = new(config, pal, analytics)
 
-      # Initialize any plugins referenced in plugin config. This will also indirectly
-      # initialize any plugins they depend on.
-      if plugins.reference?(config.plugins)
-        msg = "The 'plugins' setting cannot be set by a plugin reference"
-        raise PluginError.new(msg, 'bolt/plugin-error')
-      end
-
       config.plugins.each_key do |plugin|
         plugins.by_name(plugin)
       end

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -190,14 +190,17 @@
     },
     "plugins": {
       "description": "A map of plugins and their configuration data, where each key is the name of a plugin and its value is a map of configuration data. Configurable options are specified by the plugin. Read more about configuring plugins in [Using plugins](using_plugins.md#configuring-plugins).",
-      "oneOf": [
-        {
-          "type": "object"
-        },
-        {
-          "$ref": "#/definitions/_plugin"
-        }
-      ]
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "type": "object"
+          },
+          {
+            "$ref": "#/definitions/_plugin"
+          }
+        ]
+      }
     },
     "puppetdb": {
       "description": "A map containing options for [configuring the Bolt PuppetDB client](bolt_connect_puppetdb.md).",

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -156,14 +156,17 @@
     },
     "plugins": {
       "description": "A map of plugins and their configuration data, where each key is the name of a plugin and its value is a map of configuration data. Configurable options are specified by the plugin. Read more about configuring plugins in [Using plugins](using_plugins.md#configuring-plugins).",
-      "oneOf": [
-        {
-          "type": "object"
-        },
-        {
-          "$ref": "#/definitions/_plugin"
-        }
-      ]
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "type": "object"
+          },
+          {
+            "$ref": "#/definitions/_plugin"
+          }
+        ]
+      }
     },
     "puppetdb": {
       "description": "A map containing options for [configuring the Bolt PuppetDB client](bolt_connect_puppetdb.md).",

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -232,14 +232,17 @@
     },
     "plugins": {
       "description": "A map of plugins and their configuration data, where each key is the name of a plugin and its value is a map of configuration data. Configurable options are specified by the plugin. Read more about configuring plugins in [Using plugins](using_plugins.md#configuring-plugins).",
-      "oneOf": [
-        {
-          "type": "object"
-        },
-        {
-          "$ref": "#/definitions/_plugin"
-        }
-      ]
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "type": "object"
+          },
+          {
+            "$ref": "#/definitions/_plugin"
+          }
+        ]
+      }
     },
     "puppetdb": {
       "description": "A map containing options for [configuring the Bolt PuppetDB client](bolt_connect_puppetdb.md).",

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -762,7 +762,7 @@ describe "Bolt::CLI" do
 
     describe "console log level" do
       it "is not sensitive to ordering of debug and verbose" do
-        expect(Bolt::Logger).to receive(:configure).with(include('console' => { level: :debug }), true)
+        expect(Bolt::Logger).to receive(:configure).with(include('console' => { level: 'debug' }), true)
 
         cli = Bolt::CLI.new(%w[command run uptime --targets foo --debug --verbose])
         cli.parse
@@ -789,7 +789,7 @@ describe "Bolt::CLI" do
 
       it "raises a Bolt error when the level is a stringified integer" do
         cli = Bolt::CLI.new(%w[command run uptime --targets foo --log-level 42])
-        expect { cli.parse }.to raise_error(Bolt::ValidationError, /level of log console must be one of/)
+        expect { cli.parse }.to raise_error(Bolt::ValidationError, /Value at 'log.console.level' must be one of/)
       end
     end
 

--- a/spec/bolt/config/validator_spec.rb
+++ b/spec/bolt/config/validator_spec.rb
@@ -1,0 +1,327 @@
+# frozen_string_literal: true
+
+require 'bolt/config/validator'
+
+describe Bolt::Config::Validator do
+  def validate
+    described_class.new.validate(data, schema, location)
+  end
+
+  let(:location) { 'config' }
+  let(:data)     { {} }
+
+  context 'validating types' do
+    context 'single type' do
+      let(:schema) do
+        {
+          'option' => {
+            type: String
+          }
+        }
+      end
+
+      it 'does not error with valid type' do
+        data['option'] = 'foo'
+
+        expect { validate }.not_to raise_error
+      end
+
+      it 'errors with invalid type' do
+        data['option'] = nil
+
+        expect { validate }.to raise_error(
+          Bolt::ValidationError,
+          /Value at 'option' must be of type String/
+        )
+      end
+    end
+
+    context 'multiple types' do
+      let(:schema) do
+        {
+          'option' => {
+            type: [String, Integer]
+          }
+        }
+      end
+
+      it 'does not error with valid type' do
+        data['option'] = 'foo'
+
+        expect { validate }.not_to raise_error
+      end
+
+      it 'errors with no valid type' do
+        data['option'] = nil
+
+        expect { validate }.to raise_error(
+          Bolt::ValidationError,
+          /Value at 'option' must be of type String, Integer/
+        )
+      end
+    end
+
+    context 'booleans' do
+      let(:schema) do
+        {
+          'option' => {
+            type: [TrueClass, FalseClass]
+          }
+        }
+      end
+
+      it 'includes Boolean in error message' do
+        data['option'] = nil
+
+        expect { validate }.to raise_error(
+          Bolt::ValidationError,
+          /Value at 'option' must be of type Boolean/
+        )
+      end
+    end
+
+    context 'without a type definition' do
+      let(:schema) do
+        {
+          'option' => {}
+        }
+      end
+
+      it 'does not error' do
+        data['option'] = 'foo'
+
+        expect { validate }.not_to raise_error
+      end
+    end
+  end
+
+  context 'validating plugins' do
+    let(:schema) do
+      {
+        'option' => {
+          type:    String,
+          _plugin: true
+        }
+      }
+    end
+
+    let(:data) do
+      {
+        'option' => {
+          '_plugin' => 'myplugin'
+        }
+      }
+    end
+
+    it 'does not error when option accepts plugin references' do
+      expect { validate }.not_to raise_error
+    end
+
+    it 'errors when option does not accept plugin references' do
+      schema['option'][:_plugin] = false
+
+      expect { validate }.to raise_error(
+        Bolt::ValidationError,
+        /Value at 'option' is a plugin reference, which is unsupported at this location/
+      )
+    end
+  end
+
+  context 'validating hashes' do
+    context ':required' do
+      let(:schema) do
+        {
+          'option' => {
+            type:     Hash,
+            required: ['foo']
+          }
+        }
+      end
+
+      it 'does not error if required key is present' do
+        data['option'] = { 'foo' => 'bar' }
+
+        expect { validate }.not_to raise_error
+      end
+
+      it 'errors if required key is missing' do
+        data['option'] = { 'bar' => 'foo' }
+
+        expect { validate }.to raise_error(
+          Bolt::ValidationError,
+          /Value at 'option' is missing required keys foo/
+        )
+      end
+    end
+
+    context ':properties' do
+      let(:schema) do
+        {
+          'option' => {
+            type: Hash,
+            properties: {
+              'foo' => {
+                type: String
+              }
+            }
+          }
+        }
+      end
+
+      it 'does not error if value for property is valid' do
+        data['option'] = { 'foo' => 'bar' }
+
+        expect { validate }.not_to raise_error
+      end
+
+      it 'errors if value for property is invalid' do
+        data['option'] = { 'foo' => nil }
+
+        expect { validate }.to raise_error(
+          Bolt::ValidationError,
+          /Value at 'option.foo' must be of type String/
+        )
+      end
+    end
+
+    context ':additionalProperties' do
+      let(:schema) do
+        {
+          'option' => {
+            type: Hash,
+            additionalProperties: {
+              type: String
+            }
+          }
+        }
+      end
+
+      it 'does not error if additional property is valid' do
+        data['option'] = { 'foo' => 'bar' }
+
+        expect { validate }.not_to raise_error
+      end
+
+      it 'errors if additional property is invalid' do
+        data['option'] = { 'foo' => nil }
+
+        expect { validate }.to raise_error(
+          Bolt::ValidationError,
+          /Value at 'option.foo' must be of type String/
+        )
+      end
+    end
+  end
+
+  context 'validating arrays' do
+    context ':uniqueItems' do
+      let(:schema) do
+        {
+          'option' => {
+            type:        Array,
+            uniqueItems: true
+          }
+        }
+      end
+
+      it 'does not error with unique items' do
+        data['option'] = [1, 2, 3]
+
+        expect { validate }.not_to raise_error
+      end
+
+      it 'errors with duplicate items' do
+        data['option'] = [1, 1, 2, 3]
+
+        expect { validate }.to raise_error(
+          Bolt::ValidationError,
+          /Value at 'option' must not include duplicate elements/
+        )
+      end
+    end
+
+    context ':items' do
+      let(:schema) do
+        {
+          'option' => {
+            type:  Array,
+            items: {
+              type: Integer
+            }
+          }
+        }
+      end
+
+      it 'does not error with valid items' do
+        data['option'] = [1, 2, 3]
+
+        expect { validate }.not_to raise_error
+      end
+
+      it 'errors with invalid items' do
+        data['option'] = [1, 2, '3']
+
+        expect { validate }.to raise_error(
+          Bolt::ValidationError,
+          /Value at 'option.2' must be of type Integer/
+        )
+      end
+    end
+  end
+
+  context 'validating strings' do
+    context ':enum' do
+      let(:schema) do
+        {
+          'option' => {
+            type: String,
+            enum: ['foo']
+          }
+        }
+      end
+
+      it 'does not error with valid value' do
+        data['option'] = 'foo'
+
+        expect { validate }.not_to raise_error
+      end
+
+      it 'errors with invalid value' do
+        data['option'] = 'bar'
+
+        expect { validate }.to raise_error(
+          Bolt::ValidationError,
+          /Value at 'option' must be one of foo/
+        )
+      end
+    end
+  end
+
+  context 'validating integers' do
+    context ':minimum' do
+      let(:schema) do
+        {
+          'option' => {
+            type:    Integer,
+            minimum: 1
+          }
+        }
+      end
+
+      it 'does not error with valid value' do
+        data['option'] = 10
+
+        expect { validate }.not_to raise_error
+      end
+
+      it 'errors with invalid value' do
+        data['option'] = 0
+
+        expect { validate }.to raise_error(
+          Bolt::ValidationError,
+          /Value at 'option' must be a minimum of 1/
+        )
+      end
+    end
+  end
+end

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -215,7 +215,7 @@ describe Bolt::Config do
     end
 
     it 'warns when project config keys are present' do
-      project_config = Bolt::Config::OPTIONS.slice(*Bolt::Config::BOLT_PROJECT_OPTIONS)
+      project_config = { 'name' => 'myproject' }
 
       allow(File).to receive(:exist?)
       allow(Bolt::Util).to receive(:read_yaml_hash).and_return(project_config)
@@ -232,33 +232,6 @@ describe Bolt::Config do
 
       data = Bolt::Config.load_bolt_defaults_yaml(path)[:data]
       expect(data).to eq(Bolt::Config::INVENTORY_OPTIONS)
-    end
-
-    it 'errors when inventory-config is not a Hash' do
-      allow(File).to receive(:exist?)
-      allow(Bolt::Util).to receive(:read_yaml_hash).and_return(
-        'inventory-config' => 'foo'
-      )
-
-      expect { Bolt::Config.load_bolt_defaults_yaml(path) }.to raise_error(
-        Bolt::ValidationError,
-        /must be of type Hash/
-      )
-    end
-
-    it 'errors when inventory-config is a plugin reference' do
-      allow(File).to receive(:exist?)
-      allow(Bolt::Util).to receive(:read_yaml_hash).and_return(
-        'inventory-config' => {
-          '_plugin'  => 'yaml',
-          'filepath' => '~/.puppetlabs/bolt/config.yaml'
-        }
-      )
-
-      expect { Bolt::Config.load_bolt_defaults_yaml(path) }.to raise_error(
-        Bolt::ValidationError,
-        /Found unsupported key '_plugin'/
-      )
     end
   end
 

--- a/spec/bolt/plugin_spec.rb
+++ b/spec/bolt/plugin_spec.rb
@@ -59,12 +59,6 @@ describe Bolt::Plugin do
                             'identity' => { 'foo' => { '_plugin' => 'pkcs7' } })
       expect { plugins }.to raise_error(/Configuration for plugin 'pkcs7' depends on the plugin itself/)
     end
-
-    it 'fails if the entire plugins key is set with a reference' do
-      plugin_config.replace(identity('pkcs7' => { 'keysize' => 1024 }))
-
-      expect { plugins }.to raise_error(/The 'plugins' setting cannot be set by a plugin reference/)
-    end
   end
 
   context 'loading plugin_hooks' do

--- a/spec/bolt/project_spec.rb
+++ b/spec/bolt/project_spec.rb
@@ -66,14 +66,6 @@ describe Bolt::Project do
       end
     end
 
-    describe "with invalid tasks config" do
-      let(:project_config) { { 'tasks' => 'foo' } }
-
-      it "raises an error" do
-        expect { project.validate }.to raise_error(/'tasks' in bolt-project.yaml must be an array/)
-      end
-    end
-
     describe "with invalid name config" do
       let(:project_config) { { 'name' => '_invalid' } }
 
@@ -87,28 +79,6 @@ describe Bolt::Project do
 
       it "raises an error" do
         expect { project.validate }.to raise_error(/Invalid project name 'puppetlabs-foo' in bolt-project.yaml/)
-      end
-    end
-
-    context 'with module delcarations' do
-      it 'errors if not an array' do
-        config = {
-          'modules' => {}
-        }
-
-        expect { Bolt::Project.new(config, project_path).validate }
-          .to raise_error(Bolt::ValidationError)
-      end
-
-      it 'errors if a module delcaration is not a hash or string' do
-        config = {
-          'modules' => [
-            23
-          ]
-        }
-
-        expect { Bolt::Project.new(config, project_path).validate }
-          .to raise_error(Bolt::ValidationError)
       end
     end
   end

--- a/spec/bolt/transport/ssh/exec_connection_spec.rb
+++ b/spec/bolt/transport/ssh/exec_connection_spec.rb
@@ -42,8 +42,7 @@ describe Bolt::Transport::SSH::ExecConnection do
         'copy-command' => 3
       )
 
-      expect { subject.upload_file('good', 'evening') }
-        .to raise_error(/copy-command must be of type Array, String; received Integer 3/)
+      expect { subject.upload_file('good', 'evening') }.to raise_error(Bolt::ValidationError)
     end
 
     it 'builds scp command with port' do
@@ -99,8 +98,7 @@ describe Bolt::Transport::SSH::ExecConnection do
       inventory.set_config(target, %w[ssh native-ssh], true)
       inventory.set_config(target, %w[ssh ssh-command], 3)
 
-      expect { subject.execute('ls') }
-        .to raise_error(/ssh-command must be of type Array, String; received Integer 3/)
+      expect { subject.execute('ls') }.to raise_error(Bolt::ValidationError)
     end
   end
 end

--- a/spec/integration/config/validator_spec.rb
+++ b/spec/integration/config/validator_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'bolt_spec/integration'
+require 'bolt_spec/project'
+
+describe 'validating config' do
+  include BoltSpec::Integration
+  include BoltSpec::Project
+
+  around(:each) do |example|
+    with_project do
+      example.run
+    end
+  end
+
+  let(:command) { %w[inventory show --targets all] }
+
+  context 'with valid config' do
+    let(:project_config) do
+      {
+        'apply_settings' => {
+          'show_diff' => true
+        },
+        'color' => false,
+        'compile-concurrency' => 2,
+        'format' => 'json',
+        'log' => {
+          'warn.log' => {
+            'level' => 'warn',
+            'append' => true
+          },
+          'bolt-debug.log' => 'disable'
+        },
+        'modulepath' => %w[
+          modules
+          site-modules
+        ],
+        'plans' => [
+          'myproject::deploy'
+        ],
+        'puppetdb' => {
+          'cacert' => '/path/to/cacert',
+          'connect-timeout' => 20,
+          'server_urls' => [
+            'https://example.com'
+          ]
+        },
+        'tasks' => [
+          'myproject::install_server'
+        ]
+      }
+    end
+
+    it 'does not error' do
+      expect { run_cli(command, project: project) }.not_to raise_error
+    end
+  end
+
+  context 'with invalid config' do
+    let(:project_config) do
+      {
+        'apply_settings' => {
+          'show_diff' => 'yes'
+        },
+        'color' => 100,
+        'compile-concurrency' => 0,
+        'format' => 'invisible',
+        'log' => {
+          'warn.log' => {
+            'level' => 'everything',
+            'append' => 'no'
+          },
+          'bolt-debug.log' => 'disabled'
+        },
+        'modulepath' => {
+          '_plugin' => 'yaml',
+          'filepath' => '/path/to/modulepath.yaml'
+        },
+        'plans' => [
+          'myproject::deploy',
+          nil
+        ],
+        'puppetdb' => {
+          'cacert' => [
+            '/path/to/cacert'
+          ],
+          'connect-timeout' => 0,
+          'server_urls' => 'https://example.com'
+        },
+        'tasks' => {
+          'myproject' => ['install_server']
+        }
+      }
+    end
+
+    it 'raises an error listing all errors in config' do
+      expect { run_cli(command, project: project) }.to raise_error do |error|
+        expect(error.kind).to eq('bolt/validation-error')
+
+        expect(error.message.lines).to include(
+          /Value at 'apply_settings.show_diff' must be of type Boolean/,
+          /Value at 'color' must be of type Boolean/,
+          /Value at 'compile-concurrency' must be a minimum of 1/,
+          /Value at 'format' must be one of human, json, rainbow/,
+          /Value at 'log.warn.log.level' must be one of trace, debug, error, info, warn, fatal, any/,
+          /Value at 'log.warn.log.append' must be of type Boolean/,
+          /Value at 'log.bolt-debug.log' must be one of disable/,
+          /Value at 'modulepath' is a plugin reference, which is unsupported at this location/,
+          /Value at 'puppetdb.cacert' must be of type String/,
+          /Value at 'puppetdb.server_urls' must be of type Array/,
+          /Value at 'tasks' must be of type Array/
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a new `Bolt::Config::Validator` class which validates config
against a schema. The validator will recurse through the config and
schema, validating each value against the corresponding definition in
the schema. If validation fails for a given value, the validator will
add a message to a list of errors. After the entire config has been
validated, and if any invalid values were detected, the validator will
raise an error that lists all of the invalid values.

The validator provides basic validation for config values, such as type
checking, ensuring required keys are present, and that items in an array
are unique. It does not provide more complex validation such as ensuring
a file exists at a given path or that a URL can be reached.

!feature

* **Improved config validation**
  ([#2337](https://github.com/puppetlabs/bolt/issues/2337))

  Bolt now validates config files against Bolt's schemas and indicates
  which config file an error is found in.