### PR TITLE
(GH-2304) Do not require `service-url` for pcp config

### DIFF
--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -10,11 +10,6 @@ require 'bolt/transport/orch/connection'
 module Bolt
   module Transport
     class Orch < Base
-      CONF_FILE = if ENV['HOME'].nil?
-                    '/etc/puppetlabs/client-tools/orchestrator.conf'
-                  else
-                    File.expand_path('~/.puppetlabs/client-tools/orchestrator.conf')
-                  end
       BOLT_COMMAND_TASK = Struct.new(:name).new('bolt_shim::command').freeze
       BOLT_SCRIPT_TASK = Struct.new(:name).new('bolt_shim::script').freeze
       BOLT_UPLOAD_TASK = Struct.new(:name).new('bolt_shim::upload').freeze

--- a/lib/bolt/transport/orch/connection.rb
+++ b/lib/bolt/transport/orch/connection.rb
@@ -23,13 +23,12 @@ module Bolt
           @key = self.class.get_key(opts)
           client_opts = opts.slice('token-file', 'cacert', 'job-poll-interval', 'job-poll-timeout')
 
-          unless opts['service-url'] && !opts['service-url'].empty?
-            raise Bolt::ValidationError, "must specify a value for service-url when using the PCP transport"
+          if opts['service-url']
+            uri = Addressable::URI.parse(opts['service-url'])
+            uri&.port ||= 8143
+            client_opts['service-url'] = uri.to_s
           end
 
-          uri = Addressable::URI.parse(opts['service-url'])
-          uri&.port ||= 8143
-          client_opts['service-url'] = uri.to_s
           client_opts['User-Agent'] = "Bolt/#{VERSION}"
 
           %w[token-file cacert].each do |f|

--- a/spec/integration/transport/orch_spec.rb
+++ b/spec/integration/transport/orch_spec.rb
@@ -66,21 +66,6 @@ describe Bolt::Transport::Orch, orchestrator: true do
       end
     end
 
-    it "errors when service-url is not set or empty" do
-      [nil, ''].each do |value|
-        with_tempfile_containing('token', 'faketoken') do |conf|
-          config = {
-            'service-url' => value,
-            'cacert' => conf.path,
-            'token-file' => conf.path
-          }
-          allow(OrchestratorClient).to receive(:new).and_call_original
-          expect { Bolt::Transport::Orch::Connection.new(config, nil, orch.logger) }
-            .to raise_error(/must specify a value for service-url/)
-        end
-      end
-    end
-
     it "sets the port to 8143 if one is not specified" do
       with_tempfile_containing('token', 'faketoken') do |conf|
         config = {


### PR DESCRIPTION
Given we allow reading orchestrator.conf in the orchestrator-client library, only add a default port to the service-url if one is specified in the pcp config from bolt transport config.