### PR TITLE
(bug) Do not error in orchestrator connection when service-url not set

### DIFF
--- a/lib/bolt/transport/orch/connection.rb
+++ b/lib/bolt/transport/orch/connection.rb
@@ -23,13 +23,12 @@ module Bolt
           @key = self.class.get_key(opts)
           client_opts = opts.slice('token-file', 'cacert', 'job-poll-interval', 'job-poll-timeout')
 
-          unless opts['service-url'] && !opts['service-url'].empty?
-            raise Bolt::ValidationError, "must specify a value for service-url when using the PCP transport"
+          if client_opts.key?('service-url')
+            uri = Addressable::URI.parse(opts['service-url'])
+            uri.port ||= 8143
+            client_opts['service-url'] = uri.to_s
           end
 
-          uri = Addressable::URI.parse(opts['service-url'])
-          uri&.port ||= 8143
-          client_opts['service-url'] = uri.to_s
           client_opts['User-Agent'] = "Bolt/#{VERSION}"
 
           %w[token-file cacert].each do |f|

--- a/spec/integration/transport/orch_spec.rb
+++ b/spec/integration/transport/orch_spec.rb
@@ -66,21 +66,6 @@ describe Bolt::Transport::Orch, orchestrator: true do
       end
     end
 
-    it "errors when service-url is not set or empty" do
-      [nil, ''].each do |value|
-        with_tempfile_containing('token', 'faketoken') do |conf|
-          config = {
-            'service-url' => value,
-            'cacert' => conf.path,
-            'token-file' => conf.path
-          }
-          allow(OrchestratorClient).to receive(:new).and_call_original
-          expect { Bolt::Transport::Orch::Connection.new(config, nil, orch.logger) }
-            .to raise_error(/must specify a value for service-url/)
-        end
-      end
-    end
-
     it "sets the port to 8143 if one is not specified" do
       with_tempfile_containing('token', 'faketoken') do |conf|
         config = {


### PR DESCRIPTION
This fixes a bug introduced in #2334 that causes the orchestrator
transport connection to error when `service-url` is not configured. Bolt
should not raise an error here, since that configuration option might be
loaded from `orchestrator.conf`.

!no-release-note