### PR TITLE
(GH-2180) Filter project tasks and plans with glob patterns

### DIFF
--- a/documentation/projects.md
+++ b/documentation/projects.md
@@ -63,22 +63,24 @@ For a list of all the available project configuration options, see
 
 ### Limiting displayed plans and tasks
 
-Projects allow you to limit which plans and
-tasks a user can see when running `bolt plan show` or `bolt task show`. 
+Projects allow you to limit which plans and tasks a user can see when running
+`bolt plan|task show` and `Get-Bolt(Plan|Task)`. 
 
 Limiting tasks and plans is useful for the following reasons:
+
 - Bolt is bundled with several plans and tasks that might not be useful in your
   project. 
 - You might have written a task or plan that is only used by another task or
   plan, and you don't want your users to run that task or plan directly.
-- Displaying only specific content in the `show` commands makes it easier for
-  your users to find what they're looking for.
+- Displaying only specific content in the UI makes it easier for your users to
+  find what they're looking for.
 
-To control what plans and tasks appear when your users run `bolt plan show` or
-`bolt task show`, add `plans` and `tasks` keys to your `bolt-project.yaml` and
-include an array of plan and task names. For example, to surface a
-plan named `myproject::myplan`, and a task named `myproject::mytask`, you would
-use the following `bolt-project.yaml` file:
+To control which plans and tasks appear when your users show project content,
+add `plans` and `tasks` keys to your `bolt-project.yaml`. Both keys accept a list
+of names and glob patterns to filter content by.
+
+For example, to surface a plan named `myproject::myplan`, and a task named
+`myproject::mytask`, you would use the following `bolt-project.yaml` file:
 
 ```yaml
 name: myproject
@@ -87,8 +89,9 @@ plans:
 tasks:
 - myproject::mytask
 ```
-If your user runs the `bolt plan show` command, they'll get similar output to
-this:
+
+If your user runs the `bolt plan show` command or `Get-BoltPlan` PowerShell
+cmdlet, they'll get similar output to this:
 
 ```console
 $ bolt plan show
@@ -99,6 +102,33 @@ MODULEPATH:
 
 Use `bolt plan show <plan-name>` to view details and parameters for a specific plan.
 ```
+
+You can also use glob patterns to match multiple plan or task names. For
+example, to surface all tasks and plans in a project named `myproject`, you
+would use the following `bolt-project.yaml` file:
+
+```yaml
+name: myproject
+plans:
+- myproject::*
+tasks:
+- myproject::*
+```
+
+Glob patterns that begin with a metacharacter might cause problems when the
+configuration file is loaded and parsed, because the pattern might not be
+recognized as a string. To avoid this parsing issue, wrap any glob pattern that
+begins with a metacharacter in quotes. For example, you would write
+`"[abc]_module::*"` instead of `[abc]_module::*`.
+
+The following metacharacters can be used in a glob pattern:
+
+| Metacharacter | Description |
+| --- | --- |
+| `*` | Matches any number of characters. |
+| `?` | Matches any one character. |
+| `[set]` | Matches any one character in the set. |
+| `{a,b}` | Matches pattern a and pattern b. |
 
 ## Common files and directories in a project
 

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -575,10 +575,15 @@ module Bolt
       outputter.print_task_info(pal.get_task(task_name))
     end
 
+    # Filters a list of content by matching substring.
+    #
+    private def filter_content(content, filter)
+      return content unless content && filter
+      content.select { |name,| name.include?(filter) }
+    end
+
     def list_tasks
-      tasks = pal.list_tasks
-      tasks.select! { |task| task.first.include?(options[:filter]) } if options[:filter]
-      tasks.select! { |task| config.project.tasks.include?(task.first) } unless config.project.tasks.nil?
+      tasks = filter_content(pal.list_tasks(filter_content: true), options[:filter])
       outputter.print_tasks(tasks, pal.user_modulepath)
     end
 
@@ -587,9 +592,7 @@ module Bolt
     end
 
     def list_plans
-      plans = pal.list_plans
-      plans.select! { |plan| plan.first.include?(options[:filter]) } if options[:filter]
-      plans.select! { |plan| config.project.plans.include?(plan.first) } unless config.project.plans.nil?
+      plans = filter_content(pal.list_plans(filter_content: true), options[:filter])
       outputter.print_plans(plans, pal.user_modulepath)
     end
 

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -283,7 +283,7 @@ module Bolt
           _example: "myproject"
         },
         "plans" => {
-          description: "A list of plan names to show in `bolt plan show` output, if they exist. This option is used "\
+          description: "A list of plan names and glob patterns to filter the project's plans by. This option is used "\
                        "to limit the visibility of plans for users of the project. For example, project authors "\
                        "might want to limit the visibility of plans that are bundled with Bolt or plans that should "\
                        "only be run as part of another plan. When this option is not configured, all plans are "\
@@ -291,7 +291,7 @@ module Bolt
                        "list.",
           type: Array,
           _plugin: false,
-          _example: ["myproject", "myproject::foo", "myproject::bar"]
+          _example: ["myproject", "myproject::foo", "myproject::bar", "myproject::deploy::*"]
         },
         "plugin_hooks" => {
           description: "A map of [plugin hooks](writing_plugins.md#hooks) and which plugins a hook should use. "\
@@ -402,7 +402,7 @@ module Bolt
           _default: true
         },
         "tasks" => {
-          description: "A list of task names to show in `bolt task show` output, if they exist. This option is used "\
+          description: "A list of task names and glob patterns to filter the project's tasks by. This option is used "\
                        "to limit the visibility of tasks for users of the project. For example, project authors "\
                        "might want to limit the visibility of tasks that are bundled with Bolt or plans that should "\
                        "only be run as part of a larger workflow. When this option is not configured, all tasks "\
@@ -413,7 +413,7 @@ module Bolt
             type: String
           },
           _plugin: false,
-          _example: ["myproject", "myproject::foo", "myproject::bar"]
+          _example: ["myproject", "myproject::foo", "myproject::bar", "myproject::deploy_*"]
         },
         "trusted-external-command" => {
           description: "The path to an executable on the Bolt controller that can produce external trusted facts. "\

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -215,7 +215,7 @@ module Bolt
 
       def print_tasks(tasks, modulepath)
         command = Bolt::Util.powershell? ? 'Get-BoltTask -Task <TASK NAME>' : 'bolt task show <TASK NAME>'
-        print_table(tasks)
+        tasks.any? ? print_table(tasks) : print_message('No available tasks')
         print_message("\nMODULEPATH:\n#{modulepath.join(File::PATH_SEPARATOR)}\n"\
                         "\nUse '#{command}' to view "\
                         "details and parameters for a specific task.")
@@ -299,7 +299,7 @@ module Bolt
 
       def print_plans(plans, modulepath)
         command = Bolt::Util.powershell? ? 'Get-BoltPlan -Name <PLAN NAME>' : 'bolt plan show <PLAN NAME>'
-        print_table(plans)
+        plans.any? ? print_table(plans) : print_message('No available plans')
         print_message("\nMODULEPATH:\n#{modulepath.join(File::PATH_SEPARATOR)}\n"\
                         "\nUse '#{command}' to view "\
                         "details and parameters for a specific plan.")

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -216,7 +216,7 @@
       "type": "string"
     },
     "plans": {
-      "description": "A list of plan names to show in `bolt plan show` output, if they exist. This option is used to limit the visibility of plans for users of the project. For example, project authors might want to limit the visibility of plans that are bundled with Bolt or plans that should only be run as part of another plan. When this option is not configured, all plans are visible. This option does not prevent users from running plans that are not part of this list.",
+      "description": "A list of plan names and glob patterns to filter the project's plans by. This option is used to limit the visibility of plans for users of the project. For example, project authors might want to limit the visibility of plans that are bundled with Bolt or plans that should only be run as part of another plan. When this option is not configured, all plans are visible. This option does not prevent users from running plans that are not part of this list.",
       "type": "array"
     },
     "plugin_hooks": {
@@ -316,7 +316,7 @@
       "type": "boolean"
     },
     "tasks": {
-      "description": "A list of task names to show in `bolt task show` output, if they exist. This option is used to limit the visibility of tasks for users of the project. For example, project authors might want to limit the visibility of tasks that are bundled with Bolt or plans that should only be run as part of a larger workflow. When this option is not configured, all tasks are visible. This option does not prevent users from running tasks that are not part of this list.",
+      "description": "A list of task names and glob patterns to filter the project's tasks by. This option is used to limit the visibility of tasks for users of the project. For example, project authors might want to limit the visibility of tasks that are bundled with Bolt or plans that should only be run as part of a larger workflow. When this option is not configured, all tasks are visible. This option does not prevent users from running tasks that are not part of this list.",
       "type": "array",
       "items": {
         "type": "string"

--- a/spec/fixtures/scripts/bolt_cli_loader.rb
+++ b/spec/fixtures/scripts/bolt_cli_loader.rb
@@ -7,13 +7,11 @@ require 'bolt'
 require 'bolt/cli'
 
 def suppress_outputs
-  # rubocop:disable Style/NegatedIfElseCondition
   null_io = !!File::ALT_SEPARATOR ? 'NUL' : '/dev/null'
   out = $stdout.clone
   err = $stderr.clone
   $stderr.reopen(null_io, 'w')
   $stdout.reopen(null_io, 'w')
-  # rubocop:enable Style/NegatedIfElseCondition
   yield
 ensure
   $stdout.reopen(out)


### PR DESCRIPTION
The `plans` and `tasks` options in `bolt-project.yaml` now accept glob
patterns in addition to plan and task names. Plans and tasks that match
a glob pattern will be show in `bolt plan|task show` and
`Get-Bolt(Plan|Task)` output.

!feature

* **Filter project plans and tasks with glob patterns**
  ([#2180](https://github.com/puppetlabs/bolt/issues/2180))

  The `plans` and `tasks` options in `bolt-project.yaml` now support
  glob patterns in addition to plan and task names. Plans and tasks that
  match a glob pattern will appear in `bolt plan|task show` and
  `Get-Bolt(Plan|Task)` output.