### PR TITLE
(maint) Don't use set-env to set env vars in Github Actions

### DIFF
--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -155,4 +155,4 @@ Enable-PSRemoting
 Set-WSManQuickConfig -Force
 Set-WinRMHostConfiguration
 Test-WinRMConfiguration @User | Out-Null
-Write-Output "::set-env name=BOLT_WINRM_PASSWORD::$pass"
+Add-Content -Path $ENV:GITHUB_ENV -Value "BOLT_WINRM_PASSWORD=$pass"

--- a/spec/fixtures/scripts/bolt_cli_loader.rb
+++ b/spec/fixtures/scripts/bolt_cli_loader.rb
@@ -7,13 +7,11 @@ require 'bolt'
 require 'bolt/cli'
 
 def suppress_outputs
-  # rubocop:disable Style/NegatedIfElseCondition
   null_io = !!File::ALT_SEPARATOR ? 'NUL' : '/dev/null'
   out = $stdout.clone
   err = $stderr.clone
   $stderr.reopen(null_io, 'w')
   $stdout.reopen(null_io, 'w')
-  # rubocop:enable Style/NegatedIfElseCondition
   yield
 ensure
   $stdout.reopen(out)


### PR DESCRIPTION
Github Actions environment [recently deprecated the use of set-env] in
their Windows environment due to a security vulnerability. We were using
this command to set the `BOLT_WINRM_PASSWORD` env var to a generated
password in our CI environment provisioning script. The script now
appends the env var and value to a file located at `$ENV:GITHUB_ENV`,
which Github Actions uses to set environment variables. This should set
the variable correctly without making us restructure how we provision
and run Github Actions.

This also fixes up some rubocop errors from the latest update

!no-release-note
