### PR TITLE
(GH-2336) Log plugin task output at trace level

### DIFF
--- a/documentation/writing_plugins.md
+++ b/documentation/writing_plugins.md
@@ -309,6 +309,12 @@ The above plugin returns the value of the environment variable under the `value`
 key. Bolt automatically parses this object and adds the value wherever the
 plugin is used.
 
+Because plugins might return sensitive information, such as passwords, Bolt sets
+the log level for plugin task output to `trace`. This prevents Bolt from
+accidentally printing sensitive information to the command line or default
+debugging log, `bolt-debug.log`. If you need to see a plugin task's output, you
+can [set Bolt's log level](logs.md#setting-log-level).
+
 ### Returning target data
 
 A common application for plugins is to query an external service for a list of

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -246,10 +246,10 @@ module Bolt
       @logger.trace { "Failed to submit analytics event: #{e.message}" }
     end
 
-    def with_node_logging(description, batch)
-      @logger.info("#{description} on #{batch.map(&:safe_name)}")
+    def with_node_logging(description, batch, log_level = :info)
+      @logger.send(log_level, "#{description} on #{batch.map(&:safe_name)}")
       result = yield
-      @logger.info(result.to_json)
+      @logger.send(log_level, result.to_json)
       result
     end
 
@@ -279,28 +279,16 @@ module Bolt
       end
     end
 
-    def run_task(targets, task, arguments, options = {}, position = [])
+    def run_task(targets, task, arguments, options = {}, position = [], log_level = :info)
       description = options.fetch(:description, "task #{task.name}")
       log_action(description, targets) do
         options[:run_as] = run_as if run_as && !options.key?(:run_as)
         arguments['_task'] = task.name
 
         batch_execute(targets) do |transport, batch|
-          with_node_logging("Running task #{task.name} with '#{arguments.to_json}'", batch) do
+          with_node_logging("Running task #{task.name} with '#{arguments.to_json}'", batch, log_level) do
             transport.batch_task(batch, task, arguments, options, position, &method(:publish_event))
           end
-        end
-      end
-    end
-
-    def run_task_with_minimal_logging(targets, task, arguments, options = {})
-      description = options.fetch(:description, "task #{task.name}")
-      log_action(description, targets) do
-        options[:run_as] = run_as if run_as && !options.key?(:run_as)
-        arguments['_task'] = task.name
-
-        batch_execute(targets) do |transport, batch|
-          transport.batch_task(batch, task, arguments, options, [], &method(:publish_event))
         end
       end
     end

--- a/lib/bolt/task/run.rb
+++ b/lib/bolt/task/run.rb
@@ -42,7 +42,7 @@ module Bolt
         if targets.empty?
           Bolt::ResultSet.new([])
         else
-          result = executor.run_task_with_minimal_logging(targets, task, params, options)
+          result = executor.run_task(targets, task, params, options, [], :trace)
 
           if !result.ok && !options[:catch_errors]
             raise Bolt::RunFailure.new(result, 'run_task', task.name)

--- a/spec/bolt/plugin/module_spec.rb
+++ b/spec/bolt/plugin/module_spec.rb
@@ -155,8 +155,9 @@ describe Bolt::Plugin::Module do
     let(:result)      { Bolt::Result.new(target, value: { "_output" => 'hi' }) }
     let(:resultset)   { Bolt::ResultSet.new([result]) }
 
-    it 'does not log output' do
-      expect_any_instance_of(Bolt::Executor).to receive(:run_task_with_minimal_logging)
+    it 'logs output at trace level' do
+      expect_any_instance_of(Bolt::Executor).to receive(:run_task)
+        .with([target], task, anything, anything, [], :trace)
         .and_return(resultset)
       plugin.run_task(task, {})
     end

--- a/spec/integration/plugin/module_spec.rb
+++ b/spec/integration/plugin/module_spec.rb
@@ -81,10 +81,10 @@ describe 'using module based plugins' do
       expect(output.strip).to eq('"ssshhh"')
     end
 
-    it 'does not log task output' do
+    it 'logs task output at trace level' do
       run_cli(['plan', 'run', 'test_plan', '--boltdir', project])
       output = @log_output.readlines
-      expect(output).not_to include(/"value":{"value":"ssshhh"/)
+      expect(output).to include(/TRACE.*"value":{"value":"ssshhh"/)
     end
 
     context 'with bad parameters' do


### PR DESCRIPTION
This change logs plugin task output at `trace` level. A previous change
suppressed plugin task output, making it difficult for plugin authors to
debug their plugin tasks.

!feature

* **Log plugin task output at `trace` level**
  ([#2336](https://github.com/puppetlabs/bolt/issues/2336))

  Plugin task output is now logged at `trace` level.