### PR TITLE
(GH-2346) Use target name as Puppet certname

### DIFF
--- a/libexec/apply_catalog.rb
+++ b/libexec/apply_catalog.rb
@@ -74,7 +74,7 @@ begin
     Puppet::ResourceApi::Transport.inject_device(type, transport)
 
     Puppet[:facts_terminus] = :network_device
-    Puppet[:certname] = conn_info['uri']
+    Puppet[:certname] = conn_info['name']
   end
 
   # Ensure custom facts are available for provider suitability tests

--- a/libexec/custom_facts.rb
+++ b/libexec/custom_facts.rb
@@ -51,7 +51,7 @@ Dir.mktmpdir do |puppet_root|
     Puppet::ResourceApi::Transport.inject_device(type, transport)
 
     Puppet[:facts_terminus] = :network_device
-    Puppet[:certname] = conn_info['uri']
+    Puppet[:certname] = conn_info['name']
   end
 
   facts = Puppet::Node::Facts.indirection.find(SecureRandom.uuid, environment: env)

--- a/libexec/query_resources.rb
+++ b/libexec/query_resources.rb
@@ -59,7 +59,7 @@ Dir.mktmpdir do |puppet_root|
     Puppet::ResourceApi::Transport.inject_device(type, transport)
 
     Puppet[:facts_terminus] = :network_device
-    Puppet[:certname] = conn_info['uri']
+    Puppet[:certname] = conn_info['name']
   end
 
   resources = args['resources'].flat_map do |resource_desc|


### PR DESCRIPTION
In the Bolt inventory, the Target object's host can be set either by
specifying `uri` or by specifying `host` under the transport
configuration for that target. This means that Target's will not always
have a `uri` specified. Target's will always have a `name` specified,
which is typically how users refer to the target anyway. This updates
the query_resource, custom_fact, and apply_catalog tasks we use when
applying Puppet catalogs or querying Puppet resources to set the Target
`name` as the Puppet certname instead of the `uri`. This is so that
Target's without a URI can use these tasks without failing, and also so
that certname is a bit more predictable for users.

Closes #2346

!bug

* **Targets without a uri can now use apply() and get_resources()** ([#2346](https://github.com/puppetlabs/bolt/issues/2346))

  Previously, if a target had a `host` set instead of a `uri` it would
  error when trying to set the Puppet certname to the target's URI. We now
  use the target's `name` instead of the `uri` as the Puppet certname when
  compiling catalogs.