### PR TITLE
(GH-2299) Write Windows local transport commands to file

### DIFF
--- a/lib/bolt/shell/powershell.rb
+++ b/lib/bolt/shell/powershell.rb
@@ -177,7 +177,8 @@ module Bolt
       def run_command(command, options = {}, position = [])
         command = [*env_declarations(options[:env_vars]), command].join("\r\n") if options[:env_vars]
 
-        output = execute(command)
+        wrap_command = conn.is_a?(Bolt::Transport::Local::Connection)
+        output = execute(command, wrap_command)
         Bolt::Result.for_command(target,
                                  output.stdout.string,
                                  output.stderr.string,
@@ -268,8 +269,9 @@ module Bolt
         end
       end
 
-      def execute(command)
-        if conn.max_command_length && command.length > conn.max_command_length
+      def execute(command, wrap_command = false)
+        if (conn.max_command_length && command.length > conn.max_command_length) ||
+           wrap_command
           return with_tmpdir do |dir|
             command += "\r\nif (!$?) { if($LASTEXITCODE) { exit $LASTEXITCODE } else { exit 1 } }"
             script_file = File.join(dir, "#{SecureRandom.uuid}_wrapper.ps1")

--- a/spec/integration/transport/local_spec.rb
+++ b/spec/integration/transport/local_spec.rb
@@ -37,6 +37,13 @@ describe Bolt::Transport::Local do
 
   include_examples 'transport api'
 
+  it "can run a command with pipes" do
+    command, expected = os_context[:pipe_command]
+    result = runner.run_command(target, command, catch_errors: true)
+    expect(result.value['exit_code']).to eq(0)
+    expect(result.value['stdout']).to match(expected)
+  end
+
   context 'running as another user', sudo: true do
     include_examples 'with sudo'
 


### PR DESCRIPTION
This modifies the PowerShell shell to write commands to a file for 
execution when running over the local transport. This uses the same
logic we use when running commands greater than the max command length
to wrap the command in a script. This enables two necessary behaviors:
returning correct exit codes and allowing users to run commands with
pipes.

PowerShell will always exit 0 or 1 when running commands directly, even
when the command returns a different exit code (for example, running
`puppet agent --detailed-exitcodes`). However when executing a file with
`-File`, PowerShell will return the exit code returned by the script
[source](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_powershell_exe?view=powershell-5.1#-command).
Wrapping the command in a script also works around syntactic weirdness
(waves hands) that prevents users from easily running commands with
pipes.

Closes #2299

!bug

* **Windows local transport returns correct exit codes and accepts pipes** ([#2299](https://github.com/puppetlabs/bolt/issues/2299))

  When running commands over the local transport on Windows machines,
  Bolt now returns the exit code returned by the command as opposed to
  just 0 or 1. It also accepts pipes as part of the command. 