### PR TITLE
Add 'transport' to schema when validating config

### DIFF
--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -75,13 +75,25 @@ module Bolt
     end
 
     def self.defaults_schema
-      base = OPTIONS.slice(*BOLT_DEFAULTS_OPTIONS)
-      base['inventory-config'][:properties] = TRANSPORT_CONFIG.transform_values(&:schema)
+      base      = OPTIONS.slice(*BOLT_DEFAULTS_OPTIONS)
+      inventory = INVENTORY_OPTIONS.each do |option, definition|
+        if TRANSPORT_CONFIG.key?(option)
+          definition[:properties] = TRANSPORT_CONFIG[option].schema
+        end
+      end
+
+      base['inventory-config'][:properties] = inventory
       base
     end
 
     def self.bolt_schema
-      OPTIONS.slice(*BOLT_OPTIONS).merge(TRANSPORT_CONFIG.transform_values(&:schema))
+      inventory = INVENTORY_OPTIONS.each do |option, definition|
+        if TRANSPORT_CONFIG.key?(option)
+          definition[:properties] = TRANSPORT_CONFIG[option].schema
+        end
+      end
+
+      OPTIONS.slice(*BOLT_OPTIONS).merge(inventory)
     end
 
     def self.system_path

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -227,11 +227,21 @@ describe Bolt::Config do
     it 'puts keys under inventory-config at the top level' do
       allow(File).to receive(:exist?)
       allow(Bolt::Util).to receive(:read_yaml_hash).and_return(
-        'inventory-config' => Bolt::Config::INVENTORY_OPTIONS.dup
+        'inventory-config' => {
+          'transport' => 'ssh',
+          'ssh' => {
+            'password' => 'bolt'
+          }
+        }
       )
 
       data = Bolt::Config.load_bolt_defaults_yaml(path)[:data]
-      expect(data).to eq(Bolt::Config::INVENTORY_OPTIONS)
+      expect(data).to include(
+        'transport' => 'ssh',
+        'ssh' => {
+          'password' => 'bolt'
+        }
+      )
     end
   end
 


### PR DESCRIPTION
This adds the `transport` option to the schemas used to validate
`bolt-default.yaml` and `bolt.yaml` configuration files. Previously, the
schemas did not include the `transport` option, preventing it from being
automatically validated.

!no-release-note