### PR TITLE
(GH-2338) Rename 'sensitive' plan in tests

### DIFF
--- a/bolt-modules/boltlib/spec/fixtures/modules/sensitive_test/plans/complex.pp
+++ b/bolt-modules/boltlib/spec/fixtures/modules/sensitive_test/plans/complex.pp
@@ -1,4 +1,4 @@
-plan sensitive::complex (
+plan sensitive_test::complex (
   Variant[Sensitive[String], Array[String]] $complex
 ) {
 }

--- a/bolt-modules/boltlib/spec/fixtures/modules/sensitive_test/plans/init.pp
+++ b/bolt-modules/boltlib/spec/fixtures/modules/sensitive_test/plans/init.pp
@@ -1,4 +1,4 @@
-plan sensitive (
+plan sensitive_test (
   Sensitive $array,
   Sensitive $hash,
   Sensitive $string

--- a/bolt-modules/boltlib/spec/fixtures/modules/sensitive_test/plans/no_api.pp
+++ b/bolt-modules/boltlib/spec/fixtures/modules/sensitive_test/plans/no_api.pp
@@ -1,4 +1,4 @@
-plan sensitive::no_api (
+plan sensitive_test::no_api (
   Sensitive[String] $string
 ) {
 }

--- a/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_plan_spec.rb
@@ -171,28 +171,31 @@ describe 'run_plan' do
       sensitive.expects(:new).with(input_params['string'])
                .returns(expected_params['string'])
 
-      is_expected.to run.with_params('sensitive', input_params.merge('_bolt_api_call' => true))
-                        .and_return(input_params)
+      is_expected.to run
+        .with_params('sensitive_test', input_params.merge('_bolt_api_call' => true))
+        .and_return(input_params)
     end
 
     it 'parameters are not wrapped from non-API calls' do
       sensitive.expects(:new).never
 
-      is_expected.to run.with_params('sensitive::no_api', 'string' => string)
-                        .and_raise_error(
-                          Puppet::ParseError,
-                          /parameter 'string' expects a Sensitive\[String\]/
-                        )
+      is_expected.to run
+        .with_params('sensitive_test::no_api', 'string' => string)
+        .and_raise_error(
+          Puppet::ParseError,
+          /parameter 'string' expects a Sensitive\[String\]/
+        )
     end
 
     it 'complex parameters using Sensitive are not wrapped' do
       sensitive.expects(:new).never
 
-      is_expected.to run.with_params('sensitive::complex', 'complex' => string)
-                        .and_raise_error(
-                          Puppet::ParseError,
-                          /parameter 'complex' expects a value of type Sensitive\[String\] or Array/
-                        )
+      is_expected.to run
+        .with_params('sensitive_test::complex', 'complex' => string)
+        .and_raise_error(
+          Puppet::ParseError,
+          /parameter 'complex' expects a value of type Sensitive\[String\] or Array/
+        )
     end
   end
 end

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-ssh", ">= 4.0"
   spec.add_dependency "net-ssh-krb", "~> 0.5"
   spec.add_dependency "orchestrator_client", "~> 0.4"
-  spec.add_dependency "puppet", ">= 6.18.0", "< 6.20"
+  spec.add_dependency "puppet", ">= 6.18.0"
   spec.add_dependency "puppetfile-resolver", "~> 0.4"
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "puppet-strings", "~> 2.3"


### PR DESCRIPTION
### Rename 'sensitive' plan in tests
'Sensitive' is a reserved word in Puppet 7 and cannot be used as a plan
name. We have a plan named 'sensitive' used for testing the `run_plan`
plan function. This renames the test fixture to 'sensitive_test'.

### Remove maximum version for Puppet gem
We will continue to ship Bolt with the puppet 6 gem, but we shouldn't
need to limit the maximum version of the Puppet gem for now. It seems
like Bolt is compatible with Puppet 7, and we don't have any breaking
changes going in to Puppet that we need to gate against. This also means
tools that use Bolt as a dependency won't be limited to using Puppet 6.x.

!no-release-note