### PR TITLE
(PE-30464) Change 'GET' => 'POST' for project_inventory_targets

### DIFF
--- a/developer-docs/bolt-api-servers.md
+++ b/developer-docs/bolt-api-servers.md
@@ -376,7 +376,7 @@ This returns a JSON object of the shape:
 
 This endpoint behaves identically to the /ssh/check_node_connections endpoint, but acts over WinRM instead.
 
-### GET /project_inventory_targets
+### POST /project_inventory_targets
 
 This endpoint parses a project inventory and returns a list of target hashes. Note that the only accepetable inventoryfile location is the default `inventory.yaml` at the root of the project.
 

--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -645,7 +645,7 @@ module BoltServer
     # Returns a list of targets parsed from a Project inventory
     #
     # @param project_ref [String] the project_ref to compute the inventory from
-    get '/project_inventory_targets' do
+    post '/project_inventory_targets' do
       return MISSING_PROJECT_REF_RESPONSE if params['project_ref'].nil?
       bolt_config = config_from_project(params['project_ref'])
       if bolt_config.inventoryfile && bolt_config.project.inventory_file.to_s != bolt_config.inventoryfile

--- a/spec/bolt_server/transport_app_spec.rb
+++ b/spec/bolt_server/transport_app_spec.rb
@@ -803,7 +803,7 @@ describe "BoltServer::TransportApp" do
       it 'parses inventory' do
         with_project(bolt_project, bolt_inventory) do |path_to_tmp_project|
           project_ref = path_to_tmp_project.split(File::SEPARATOR).last
-          get("/project_inventory_targets?project_ref=#{project_ref}")
+          post("/project_inventory_targets?project_ref=#{project_ref}")
           expect(last_response.status).to eq(200)
           target_list = JSON.parse(last_response.body)
           target_names = target_list.map do |targ|
@@ -827,7 +827,7 @@ describe "BoltServer::TransportApp" do
         it 'sets transport independent from protocol' do
           with_project(bolt_project, bolt_inventory) do |path_to_tmp_project|
             project_ref = path_to_tmp_project.split(File::SEPARATOR).last
-            get("/project_inventory_targets?project_ref=#{project_ref}")
+            post("/project_inventory_targets?project_ref=#{project_ref}")
             expect(last_response.status).to eq(200)
             target_list = JSON.parse(last_response.body)
             expect(target_list.first['transport']).to eq('remote')
@@ -843,7 +843,7 @@ describe "BoltServer::TransportApp" do
         it 'responds with a 500 and error details' do
           with_project(bolt_project, bolt_inventory) do |path_to_tmp_project|
             project_ref = path_to_tmp_project.split(File::SEPARATOR).last
-            get("/project_inventory_targets?project_ref=#{project_ref}")
+            post("/project_inventory_targets?project_ref=#{project_ref}")
             expect(last_response.status).to eq(500)
             error_hash = JSON.parse(last_response.body)
             expect(error_hash['kind']).to eq('bolt.inventory/validation-error')
@@ -856,14 +856,14 @@ describe "BoltServer::TransportApp" do
         non_default_inventoryfile_conf = bolt_project.merge({ 'inventoryfile' => non_default_inventoryfile })
         with_project(non_default_inventoryfile_conf, bolt_inventory, non_default_inventoryfile) do |path_to_tmp_project|
           project_ref = path_to_tmp_project.split(File::SEPARATOR).last
-          get("/project_inventory_targets?project_ref=#{project_ref}")
+          post("/project_inventory_targets?project_ref=#{project_ref}")
           expect(last_response.status).to eq(500)
           expect(last_response.body).to match(/Project inventory must be defined in .*inventory.yaml.*/)
         end
       end
 
       it 'errors when project_ref is invalid' do
-        get('/project_inventory_targets?project_ref=foo')
+        post('/project_inventory_targets?project_ref=foo')
         expect(last_response.status).to eq(500)
         expect(last_response.body).to match(/foo does not exist/)
       end


### PR DESCRIPTION
This endpoint will eventually accept a request body. Since it's
unidiomatic for 'GET' endpoints to accept a request body, we change the
project_inventory_targets to a 'POST' endpoint instead.

Signed-off-by: Enis Inan <enis.inan@puppet.com>