### PR TITLE
(GH-2302) Send analytics about how many plan types exist in each project

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -392,7 +392,7 @@ module Bolt
         output_format: config.format,
         # For continuity
         boltdir_type: config.project.type
-      }
+      }.merge!(analytics.plan_counts(config.project.plans_path))
 
       # Only include target and inventory info for commands that take a targets
       # list. This avoids loading inventory for commands that don't need it.

--- a/spec/bolt/analytics_spec.rb
+++ b/spec/bolt/analytics_spec.rb
@@ -107,11 +107,8 @@ describe Bolt::Analytics do
     end
 
     it 'returns an empty hash if config file is empty', :load_config do
-      logger = double('logger')
-      allow(logger).to receive(:warn)
-
       Tempfile.create('analytics.yaml', Dir.pwd) do |file|
-        expect(subject.load_config(file, logger)).to eq({})
+        expect(subject.load_config(file)).to eq({})
       end
     end
   end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1366,6 +1366,7 @@ describe "Bolt::CLI" do
             project_file?: true,
             load_as_module?: true,
             name: nil,
+            plans_path: '',
             to_h: {}
           }
           proj = double('project', mocks)


### PR DESCRIPTION
This adds two new GA dimensions to the data we send for user screenviews
when Bolt is run on the CLI: puppet plan count and yaml plan count.
These dimensions simply count the number of files in the project's
`plans` directory (including subdirs) to provide analytics for how many
project-level plans in each language the user has. The dimension is a
user-level metric, meaning that whenever the values for a particular
user change they will get updated in GA and the old value will be
removed. This poses a problem for users with multiple projects, as each
time they run Bolt from a different project their values will get
updated. However the tradeoff is that we get per-project values as
opposed to aggregated values, and we don't get multiple values when a
user adds a new plan.

Closes #2302

!no-release-note