### PR TITLE
(GH-2372) Disable console logging in config

### DIFF
--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -183,7 +183,8 @@ module Bolt
           properties: {
             "console" => {
               description: "Configuration for logs output to the console.",
-              type: Hash,
+              type: [String, Hash],
+              enum: ['disable'],
               properties: {
                 "level" => {
                   description: "The type of information to log.",

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -119,7 +119,13 @@
       "properties": {
         "console": {
           "description": "Configuration for logs output to the console.",
-          "type": "object",
+          "type": [
+            "string",
+            "object"
+          ],
+          "enum": [
+            "disable"
+          ],
           "properties": {
             "level": {
               "description": "The type of information to log.",

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -95,7 +95,13 @@
       "properties": {
         "console": {
           "description": "Configuration for logs output to the console.",
-          "type": "object",
+          "type": [
+            "string",
+            "object"
+          ],
+          "enum": [
+            "disable"
+          ],
           "properties": {
             "level": {
               "description": "The type of information to log.",

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -110,7 +110,13 @@
       "properties": {
         "console": {
           "description": "Configuration for logs output to the console.",
-          "type": "object",
+          "type": [
+            "string",
+            "object"
+          ],
+          "enum": [
+            "disable"
+          ],
           "properties": {
             "level": {
               "description": "The type of information to log.",


### PR DESCRIPTION
This updates the schema for the `log` config option to allow `disable`
as a valid value for the `console` key. Setting this value will disable
logging to the console.

!no-release-note