### PR TITLE
(docs) Add developer update on how to use Puppet 6 agents

### DIFF
--- a/documentation/developer_updates.md
+++ b/documentation/developer_updates.md
@@ -3,6 +3,50 @@
 Find out what the Bolt team is working on and why we're making the decisions
 we're making.
 
+## November 2020
+
+### Puppet 7 Release Prep
+
+[Puppet 7](https://puppet.com/docs/puppet/7.0/puppet_index.html) is set to be released November
+19th, 2020. While the Bolt package won't be pulling in Puppet 7 until early next year, the
+`puppet_agent::install` task bundled with Bolt will pick up Puppet 7 agents by default when the
+packages are available. This means that using the `apply_prep()` Bolt plan function or the install
+task directly will be pulling in a major version bump for the agent. While we don't anticipate any
+of the changes in the agent to affect Bolt users, if you find you need to use the Puppet 6 agent, you
+can configure `apply_prep()` and the `puppet_agent::install` task to do so.
+
+The `puppet_agent::install` task accepts a `collections` parameter that tells the task which
+collection to download the package from. This defaults to `puppet` which maps to the latest
+collection, but you can set this value to `puppet6` to pull in the latest Puppet 6 agent. You can
+pass this parameter on the command line:
+
+_\*nix shell command_
+```
+bolt task run puppet_agent::install -t mytargets collection='puppet6'
+```
+
+_PowerShell cmdlet_
+```
+Invoke-BoltTask -Name puppet_agent::install -Targets mytargets collection='puppet6'
+```
+
+Or to the `run_task()` plan function:
+```
+run_task('puppet_agent::install', $targets, { collection => 'puppet6' })
+```
+
+If you need the `apply_prep()` plan function to install the Puppet 6 agents instead of Puppet 7, you
+can configure this by [configuring the puppet_library plugin
+hook](using_plugins.md#puppet-library-plugins) in either `bolt-project.yaml` or
+`bolt-defaults.yaml`:
+
+```
+plugin_hooks:
+  puppet_library:
+    task: puppet_agent
+    collection: puppet6
+```
+
 ## September 2020
 
 ### Module management in Bolt projects


### PR DESCRIPTION
Puppet 7 agent and platform are scheduled for release tomorrow, and
while we're planning to hold off on picking up Puppet 7 in Bolt packages
until later the `puppet_agent::install` task will pick up Puppet 7 by
default once it's available. This should be fine for most users, but if
anything does break this developer update provides useful instructions
for how to use Puppet 6 agents instead for both apply_prep and direct
task use.

!no-release-note