### PR TITLE
(GH-2368) Add missing module directories to gemspec

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -23,11 +23,17 @@ Gem::Specification.new do |spec|
                        Dir['bolt-modules/*/types/**/*.pp'] +
                        Dir['modules/*/metadata.json'] +
                        Dir['modules/*/bolt_plugin.json'] +
+                       Dir['modules/*/data/**/*'] +
+                       Dir['modules/*/facts.d/**/*'] +
                        Dir['modules/*/files/**/*'] +
+                       Dir['modules/*/functions/**/*'] +
                        Dir['modules/*/lib/**/*.rb'] +
                        Dir['modules/*/locales/**/*'] +
+                       Dir['modules/*/manifests/**/*'] +
                        Dir['modules/*/plans/**/*.pp'] +
                        Dir['modules/*/tasks/**/*'] +
+                       Dir['modules/*/templates/**/*'] +
+                       Dir['modules/*/types/**/*'] +
                        Dir['Puppetfile'] +
                        Dir['guides/*.txt']
   spec.bindir        = "exe"


### PR DESCRIPTION
Puppet modules contain a [number of useful
directories](https://puppet.com/docs/puppet/6.19/modules_fundamentals.html#module_structure)
that provide features that can be used when applying puppet code using
Bolt. We don't package several directories (such as `spec/`) because we
don't need to, but there were a few useful directories missing from our
filelist in `bolt.gemspec`. This adds:
- `data/` to provide default parameter data if any module begins to include it
- `facts.d/` to provide an external facts users may expect from a
  packaged module
- `functions/` to provide custom puppet language functions
- `manifests/` to provide module classes
- `templates/` in case any module manifests use templates to generate
  content
- `types/` for resource type aliases

This ensures that the modules packaged with Bolt contain the necessary
files when shipped to behave as users would expect.

Closes #2368

!bug

* **Ship puppet_agent manifests directory** ([#2368](https://github.com/puppetlabs/bolt/issues/2368))

  Bolt now includes the `puppet_agent` module manifests directory and
  it's classes in the Bolt gem and packages.