### PR TITLE
(GH-2362) Deprecate boltdir, configfile, puppetfile, and description CLI flags

### DIFF
--- a/documentation/projects.md
+++ b/documentation/projects.md
@@ -271,7 +271,7 @@ BOLT_PROJECT='~/project/my_project' bolt command run uptime -t target1
 ```
 
 > **Note:** The `BOLT_PROJECT` environment variable takes precedence over the
-> `--configfile` CLI option. 
+> `--project` CLI option. 
 
 📖 **Related information**
 

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -164,8 +164,9 @@ module Bolt
                 elsif options[:configfile]
                   Bolt::Config.from_file(options[:configfile], options)
                 else
-                  project = if options[:boltdir]
-                              dir = Pathname.new(options[:boltdir])
+                  cli_flag = options[:project] || options[:boltdir]
+                  project = if cli_flag
+                              dir = Pathname.new(cli_flag)
                               if (dir + Bolt::Project::BOLTDIR_NAME).directory?
                                 Bolt::Project.create_project(dir + Bolt::Project::BOLTDIR_NAME)
                               else
@@ -293,7 +294,7 @@ module Bolt
               "Unknown argument(s) #{options[:leftovers].join(', ')}"
       end
 
-      if options[:boltdir] && options[:configfile]
+      if options.slice(:boltdir, :configfile, :project).length > 1
         raise Bolt::CLIError, "Only one of '--boltdir', '--project', or '--configfile' may be specified"
       end
 

--- a/pwsh_module/command.tests.ps1
+++ b/pwsh_module/command.tests.ps1
@@ -55,7 +55,7 @@ Describe "test bolt command syntax" {
     It "has correct number of parameters" {
       ($command.Parameters.Values | Where-Object {
           $_.name -notin $common
-      } | measure-object).Count | Should -Be 37
+      } | measure-object).Count | Should -Be 38
     }
   }
 
@@ -73,7 +73,7 @@ Describe "test bolt command syntax" {
     It "has correct number of parameters" {
       ($command.Parameters.Values | Where-Object {
         $_.name -notin $common
-      } | measure-object).Count | Should -Be 34
+      } | measure-object).Count | Should -Be 35
     }
   }
 
@@ -95,7 +95,7 @@ Describe "test bolt command syntax" {
     It "has correct number of parameters" {
       ($command.Parameters.Values | Where-Object {
         $_.name -notin $common
-      } | measure-object).Count | Should -Be 35
+      } | measure-object).Count | Should -Be 36
     }
   }
 
@@ -107,7 +107,7 @@ Describe "test bolt command syntax" {
     It "has correct number of parameters" {
       ($command.Parameters.Values | Where-Object {
         $_.name -notin $common
-      } | measure-object).Count | Should -Be 10
+      } | measure-object).Count | Should -Be 11
     }
 
   }

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -859,6 +859,9 @@ describe "Bolt::CLI" do
       it 'uses a specified Puppetfile' do
         cli.parse
         expect(cli.config.puppetfile.to_s).to eq(puppetfile)
+        output = @log_output.readlines
+        # We'll have to remove this test soon anyway, may as well throw in a quick check
+        expect(output).to include(/Command line option '--puppetfile' is deprecated,/)
       end
     end
 
@@ -2454,8 +2457,8 @@ describe "Bolt::CLI" do
       allow(Bolt::Util).to receive(:validate_file).and_return(true)
     end
 
-    it 'loads from BOLT_PROJECT environment variable over --configfile' do
-      cli = Bolt::CLI.new(%w[command run uptime --configfile /foo/bar --targets foo])
+    it 'loads from BOLT_PROJECT environment variable over --project' do
+      cli = Bolt::CLI.new(%w[command run uptime --project /foo/bar --targets foo])
       cli.parse
 
       expect(cli.config.project.path).to eq(pathname)

--- a/spec/integration/yaml_plan_spec.rb
+++ b/spec/integration/yaml_plan_spec.rb
@@ -21,7 +21,7 @@ describe "running YAML plans", ssh: true do
   let(:password) { conn_info('ssh')[:password] }
   let(:config_flags) {
     ['--format', 'json',
-     '--configfile', fixture_path('configs', 'empty.yml'),
+     '--project', fixture_path('configs', 'empty'),
      '--modulepath', modulepath,
      '--run-as', 'root',
      '--sudo-password', password,


### PR DESCRIPTION
This adds deprecation warnings for the `--boltdir`, `--configfile`,
`--puppetfile`, and `--description` command line flags. Whenever users
use any of these command line options - and only if the option is
specified on the CLI - a warning should be printed. This doesn't update
spec tests or other internal references to deprecated options, but it
does update the help text to not include deprecated flags.

Closes #2362

!deprecation

* **Add deprecation warnings for boltdir, configfile, puppetfile, and description** ([#2362](https://github.com/puppetlabs/bolt/issues/2362))

  We are planning to remove the `--boltdir`, `--configfile`,
  `--puppetfile`, and `--description` command line flags in the next major
  version of Bolt. This adds deprecation warnings that are printed when
  users specify any of these flags.