### PR TITLE
(GH-2382) Add 'Packaged modules' docs page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ documentation/bolt_defaults_reference.md
 documentation/bolt_pwsh_reference.md
 documentation/bolt_project_reference.md
 documentation/bolt_transports_reference.md
+documentation/packaged_modules.md
 tasks/
 plans/
 

--- a/documentation/bolt.ditamap
+++ b/documentation/bolt.ditamap
@@ -76,6 +76,7 @@
                 <shortdesc>Use module structure if you use Forge modules with Bolt, or you want to develop your own modules to share tasks and plans.</shortdesc>
             </topicmeta>
         </topicref>
+        <topicref href="packaged_modules.md" format="markdown"/>
     </topicref>
     <topichead navtitle="Plugins">
       <topicref href="using_plugins.md" format="markdown"/>

--- a/documentation/templates/packaged_modules.md.erb
+++ b/documentation/templates/packaged_modules.md.erb
@@ -1,0 +1,24 @@
+# Packaged modules
+
+The following modules are shipped with Bolt packages.
+
+## Forge modules
+
+The following Forge modules are shipped with Bolt packages.
+
+| Module | Version | Description |
+| --- | --- | --- |
+<% for mod in @forge_modules -%>
+| [<%= mod[:name] %>](<%= mod[:url] %>) | <%= mod[:version] %> | <%= mod[:description] %> |
+<% end -%>
+
+## Local modules
+
+The following modules are shipped with Bolt packages and are not available
+on the Puppet Forge.
+
+| Module | Description |
+| --- | --- |
+<% for mod in @local_modules -%>
+| [<%= mod[:name] %>](<%= mod[:url] %>) | <%= mod[:description].gsub("\n", '') %> |
+<% end -%>


### PR DESCRIPTION
This adds a generated page to Bolt docs that lists the modules that are
shipped with Bolt packages. The list of modules is read directly from
Bolt's Puppetfile, while descriptions are retrieved from each module's
metadata or README file.

!no-release-note