### PR TITLE
(SERVER-2914) Update bolt-server to generate correct ps param for file metadata

### DIFF
--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -543,7 +543,7 @@ module BoltServer
       return MISSING_PROJECT_REF_RESPONSE if params['project_ref'].nil?
       in_bolt_project(params['project_ref']) do |context|
         ps_parameters = {
-          'project' => params['project_ref']
+          'versioned_project' => params['project_ref']
         }
         task_info = pe_task_info(context[:pal], params[:module_name], params[:task_name], ps_parameters)
         task_info = allowed_helper(task_info, context[:config].project.tasks)

--- a/spec/bolt_server/transport_app_spec.rb
+++ b/spec/bolt_server/transport_app_spec.rb
@@ -369,7 +369,7 @@ describe "BoltServer::TransportApp" do
                 ),
                 "uri" => {
                   "path" => "/puppet/v3/file_content/tasks/bolt_server_test_project/hidden.sh",
-                  "params" => { "project" => 'bolt_server_test_project' }
+                  "params" => { "versioned_project" => 'bolt_server_test_project' }
                 }
               }
             ],
@@ -402,7 +402,7 @@ describe "BoltServer::TransportApp" do
                 ),
                 "uri" => {
                   "path" => "/puppet/v3/file_content/tasks/bolt_server_test_project/init.sh",
-                  "params" => { "project" => 'bolt_server_test_project' }
+                  "params" => { "versioned_project" => 'bolt_server_test_project' }
                 }
               }
             ],


### PR DESCRIPTION
This commit updates the bolt-server task metadata endpoint to generate the updated query parameter for requesting file_content from projects in puppetserver.