### PR TITLE
(GH-2363) Deprecate inventoryfile config option

### DIFF
--- a/documentation/configuring_bolt.md
+++ b/documentation/configuring_bolt.md
@@ -133,8 +133,8 @@ to lead to errors where Bolt loads content from another project.
 **Filepath:** `~/.puppetlabs/etc/bolt/bolt-defaults.yaml`
 
 The defaults configuration file supports most of Bolt's configuration options,
-with the exception of options that are project-specific such as `inventoryfile`
-and `modulepath`.
+with the exception of options that are project-specific such as `modules` and
+`modulepath`.
 
 The `bolt-defaults.yaml` file takes precedence over a `bolt.yaml` file in the
 same directory. If the directory contains both files, Bolt will only load and 

--- a/documentation/migrating_inventory_files.md
+++ b/documentation/migrating_inventory_files.md
@@ -39,7 +39,7 @@ following command:
 
 Bolt will locate the inventory file for the current Bolt project and migrate it
 in place. You can specify the projects and inventory files you want to migrate
-using the `project` and `inventoryfile` options.
+using the `--project` and `--inventoryfile` command-line options.
 
 > **Note:** This command modifies an inventory file in place and does not
 > preserve comments or formatting. Before using the command, make sure to backup

--- a/documentation/templates/bolt_configuration_reference.md.erb
+++ b/documentation/templates/bolt_configuration_reference.md.erb
@@ -11,7 +11,11 @@ The `bolt.yaml` configuration file is supported in all [project directories](con
 ## Options
 
 <% @opts.each do |option, data| -%>
-### `<%= option %>`
+### <% if data.key?(:_deprecation) %>⛔<% end %> `<%= option %>`
+
+<% if data.key?(:_deprecation) -%>
+_This option is deprecated. <%= data[:_deprecation] %>_
+<% end -%>
 
 <%= data[:description] %>
 

--- a/documentation/templates/bolt_defaults_reference.md.erb
+++ b/documentation/templates/bolt_defaults_reference.md.erb
@@ -6,7 +6,11 @@ which is supported in both the [system-wide and user-level configuration directo
 ## Options
 
 <% @opts.each do |option, data| -%>
-### `<%= option %>`
+### <% if data.key?(:_deprecation) %>⛔<% end %> `<%= option %>`
+
+<% if data.key?(:_deprecation) -%>
+_This option is deprecated. <%= data[:_deprecation] %>_
+<% end -%>
 
 <%= data[:description] %>
 

--- a/documentation/templates/bolt_project_reference.md.erb
+++ b/documentation/templates/bolt_project_reference.md.erb
@@ -6,7 +6,11 @@ For more information, see [Configuring Bolt](configuring_bolt.md).
 ## Options
 
 <% @opts.each do |option, data| -%>
-### `<%= option %>`
+### <% if data.key?(:_deprecation) %>⛔<% end %> `<%= option %>`
+
+<% if data.key?(:_deprecation) -%>
+_This option is deprecated. <%= data[:_deprecation] %>_
+<% end -%>
 
 <%= data[:description] %>
 

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -169,6 +169,9 @@ module Bolt
                        "files](inventory_file_v2.md).",
           type: String,
           _plugin: false,
+          _deprecation: "This option will be removed in Bolt 3.0. Use the `--inventoryfile` command-line option "\
+                        "to use a non-default inventory file or move the file contents to `inventory.yaml` in the "\
+                        "project directory.",
           _example: "~/.puppetlabs/bolt/inventory.yaml",
           _default: "project/inventory.yaml"
         },

--- a/spec/bolt/config/validator_spec.rb
+++ b/spec/bolt/config/validator_spec.rb
@@ -389,4 +389,29 @@ describe Bolt::Config::Validator do
       expect(validator.warnings.empty?).to be
     end
   end
+
+  context 'adding deprecations' do
+    context ':_deprecation' do
+      let(:schema) do
+        {
+          'option' => {
+            type:         Integer,
+            _deprecation: "Donut use."
+          }
+        }
+      end
+
+      it 'adds a deprecation warning' do
+        data['option'] = 100
+
+        described_class.new.tap do |validator|
+          validator.validate(data, schema, location)
+          expect(validator.deprecations).to include(
+            option:  'option',
+            message: /Option 'option' at config is deprecated. Donut use./
+          )
+        end
+      end
+    end
+  end
 end

--- a/spec/bolt/project_spec.rb
+++ b/spec/bolt/project_spec.rb
@@ -192,8 +192,8 @@ describe Bolt::Project do
     it 'warns and continues if project creation fails' do
       expect(FileUtils).to receive(:mkdir_p).with('myproject').and_raise(Errno::EACCES)
       # Ensure execution continues
-      expect(Bolt::Project).to receive(:new).with(anything, 'myproject', 'user',
-                                                  [{ warn: /Could not create default project / }])
+      expect(Bolt::Project).to receive(:new)
+        .with(anything, 'myproject', 'user', [{ warn: /Could not create default project / }], [])
       Bolt::Project.create_project('myproject', 'user')
     end
   end


### PR DESCRIPTION
This deprecates the `inventoryfile` config option, which is slated for
removal in Bolt 3.0.

!deprecation

* **Deprecate `inventoryfile` configuration option**
  ([#2363](https://github.com/puppetlabs/bolt/issues/2363))

  The `inventoryfile` configuration option has been deprecated and will
  be removed in Bolt 3.0. Users should move contents from non-default
  inventory files to the `inventory.yaml` file in a Bolt project, or can
  use the `--inventoryfile` command-line option to load a non-default
  inventory file.