### PR TITLE
(maint) Pick up new cops in Rubocop 1.4.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -273,6 +273,9 @@ Style/NumericPredicate:
 Style/OptionalBooleanParameter:
   Enabled: false
 
+Style/RedundantArgument:
+  Enabled: true
+
 Style/RedundantAssignment:
   Enabled: true
 

--- a/lib/bolt/analytics.rb
+++ b/lib/bolt/analytics.rb
@@ -137,7 +137,7 @@ module Bolt
       end
 
       def report_bundled_content(mode, name)
-        if bundled_content[mode.split(' ').first]&.include?(name)
+        if bundled_content[mode.split.first]&.include?(name)
           event('Bundled Content', mode, label: name)
         end
       end

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -30,6 +30,7 @@ require 'bolt/version'
 
 module Bolt
   class CLIExit < StandardError; end
+
   class CLI
     COMMANDS = {
       'command'    => %w[run],

--- a/lib/bolt/outputter/rainbow.rb
+++ b/lib/bolt/outputter/rainbow.rb
@@ -53,7 +53,7 @@ module Bolt
                 @state = :normal if c == 'm'
               end
             end
-            a.join('')
+            a.join
           else
             "\033[#{COLORS[color]}m#{string}\033[0m"
           end

--- a/lib/bolt/shell/bash.rb
+++ b/lib/bolt/shell/bash.rb
@@ -199,7 +199,7 @@ module Bolt
         lines = buffer.split(/(?<=\n)/)
         # handle_sudo will return the line if it is not a sudo prompt or error
         lines.map! { |line| handle_sudo(inp, line, stdin) }
-        lines.join("")
+        lines.join
       # If stream has reached EOF, no password prompt is expected
       # return an empty string
       rescue EOFError

--- a/rakelib/pwsh.rake
+++ b/rakelib/pwsh.rake
@@ -280,7 +280,7 @@ namespace :pwsh do
         # added twice
         help_text[:flags].reject { |o| o =~ /verbose|debug|help|version/ }.map do |option|
           ruby_param = parser.top.long[option]
-          pwsh_name = option.split("-").map(&:capitalize).join('')
+          pwsh_name = option.split("-").map(&:capitalize).join
           case pwsh_name
           when 'Tty'
             pwsh_name.upcase!

--- a/spec/integration/logging_spec.rb
+++ b/spec/integration/logging_spec.rb
@@ -50,7 +50,7 @@ describe "when logging executor activity", ssh: true do
   context 'with misconfigured ssh-command' do
     let(:log_level) { :warn }
     let(:conn) { conn_info('ssh') }
-    let(:second_uri) { [conn[:second_user], ':', conn[:second_pw], '@', conn[:host], ':', conn[:port]].join('') }
+    let(:second_uri) { [conn[:second_user], ':', conn[:second_pw], '@', conn[:host], ':', conn[:port]].join }
     let(:config_flags) {
       %W[--targets #{uri},#{second_uri} --no-host-key-check --modulepath #{modulepath} --ssh-command ssh]
     }

--- a/spec/integration/target_spec.rb
+++ b/spec/integration/target_spec.rb
@@ -46,7 +46,7 @@ describe "when running a plan that creates targets", ssh: true do
                  port: info[:port],
                  host: info[:host] }.to_json
       run_cli(['plan', 'run', 'results::test_printing', "--params", params] + config_flags)
-      logs = @log_output.readlines.join('')
+      logs = @log_output.readlines.join
       regex = Regexp.new(Regexp.quote("Connected to #{info[:host]}"))
       expect(logs).to match(regex)
     end

--- a/spec/integration/transport/winrm_spec.rb
+++ b/spec/integration/transport/winrm_spec.rb
@@ -763,7 +763,7 @@ describe Bolt::Transport::WinRM do
           "message 3\r\n",
           "message 4\r\n",
           "message 6\r\n"
-        ].join(''))
+        ].join)
       end
     end
 


### PR DESCRIPTION
This adds configuration for the new default cop in Rubocop 1.4.0,
`Style/RedundantArgument`, and updates files where there were
violations.

!no-release-note