### PR TITLE
(maint) Validate inventoryfile config

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -342,15 +342,10 @@ module Bolt
     def warn_inventory_overrides_cli(opts)
       inventory_source = if ENV[Bolt::Inventory::ENVIRONMENT_VAR]
                            Bolt::Inventory::ENVIRONMENT_VAR
-                         elsif config.inventoryfile && Bolt::Util.file_stat(config.inventoryfile)
+                         elsif config.inventoryfile
                            config.inventoryfile
-                         else
-                           begin
-                             Bolt::Util.file_stat(config.default_inventoryfile)
-                             config.default_inventoryfile
-                           rescue Errno::ENOENT
-                             nil
-                           end
+                         elsif File.exist?(config.default_inventoryfile)
+                           config.default_inventoryfile
                          end
 
       inventory_cli_opts = %i[authentication escalation transports].each_with_object([]) do |key, acc|

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -433,8 +433,13 @@ module Bolt
         raise Bolt::ValidationError, "Compilation is CPU-intensive, set concurrency less than #{compile_limit}"
       end
 
-      Bolt::Util.validate_file('hiera-config', @data['hiera-config']) if @data['hiera-config']
-      Bolt::Util.validate_file('trusted-external-command', trusted_external) if trusted_external
+      %w[hiera-config trusted-external-command inventoryfile].each do |opt|
+        Bolt::Util.validate_file(opt, @data[opt]) if @data[opt]
+      end
+
+      if File.exist?(default_inventoryfile)
+        Bolt::Util.validate_file('inventory file', default_inventoryfile)
+      end
 
       unless TRANSPORT_CONFIG.include?(transport)
         raise UnknownTransportError, transport

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -275,6 +275,17 @@ describe Bolt::Config do
         /append flag of log file:.* must be a Boolean, received Symbol :foo/
       )
     end
+
+    it "does not accept inventory files that don't exist" do
+      config = {
+        'inventoryfile' => 'fake.yaml'
+      }
+
+      expect { Bolt::Config.new(project, config) }.to raise_error(
+        Bolt::FileError,
+        /The inventoryfile .* does not exist/
+      )
+    end
   end
 
   describe 'expanding paths' do
@@ -282,10 +293,12 @@ describe Bolt::Config do
       data = {
         'inventoryfile' => 'targets.yml'
       }
+      f = File.expand_path(File.join(project.path, 'targets.yml'))
+      FileUtils.touch(f)
 
       config = Bolt::Config.new(project, data)
       expect(config.inventoryfile)
-        .to eq(File.expand_path('targets.yml', project.path))
+        .to eq(f)
     end
   end
 


### PR DESCRIPTION
Previously we tried to use `Bolt::Util.file_stat` to verify that a
configured inventoryfile existed before warning that CLI options may be
overridden by the inventoryfile. This would stacktrace if the file did
not exist. We now validate that the file exists and can be read when
loading config if `inventoryfile` is configured, validate
`default_inventoryfile` if the file exists, and use `File.exist?` in the
CLI when seeing if we need to warn that inventoryfile may override CLI
options. This provides more standard errors and prevents stacktracing.

!no-release-note