### PR TITLE
(GH-2364) Create inventory.yaml when creating new projects

### DIFF
--- a/documentation/inventory_file_v2.md
+++ b/documentation/inventory_file_v2.md
@@ -294,6 +294,9 @@ targets to the SSH protocol.
 The `windows` group lists its targets and sets the default transport for the
 targets to the WinRM protocol.
 
+The inventory file sets top-level configuration that applies to the `all` group.
+It sets default configuration for the `ssh` and `winrm` transports.
+
 ```yaml
 groups:
   - name: linux
@@ -302,14 +305,23 @@ groups:
       - target2.example.com
     config:
       transport: ssh
+      ssh:
+        private-key: /path/to/private_key.pem
   - name: windows
     targets:
-      - uri: target3.example.com
-        alias: windows1
-      - uri: target4.example.com
-        alias: windows2
+      - name: win1
+        uri: target3.example.com
+      - name: win2
+        uri: target4.example.com
     config:
       transport: winrm
+config:
+  ssh:
+    host-key-check: false
+  winrm:
+    user: Administrator
+    password: Bolt!
+    ssl: false
 ```
 
 ### Detailed inventory file

--- a/spec/bolt/project_manager_spec.rb
+++ b/spec/bolt/project_manager_spec.rb
@@ -53,6 +53,17 @@ describe Bolt::ProjectManager do
       expect(YAML.load_file(config_path)).to include('modules' => [])
     end
 
+    it 'creates an inventory.yaml' do
+      manager.create(project_path, 'myproject', nil)
+      expect(project.inventory_file.exist?).to be
+    end
+
+    it 'does not create an inventory.yaml if one already exists' do
+      FileUtils.touch(project.inventory_file)
+      expect(File).not_to receive(:write).with(project.inventory_file.to_path, anything)
+      manager.create(project_path, 'myproject', nil)
+    end
+
     it 'errors if the directory name is invalid' do
       dir = tmpdir + 'MyProject'
       FileUtils.mkdir(dir)


### PR DESCRIPTION
The `bolt project init` and `New-BoltProject` commands now create an
`inventory.yaml` file with an example inventory commented out. If a
directory already includes an `inventory.yaml` file, Bolt will not
create a new one.

!feature

* **Create `inventory.yaml` file when creating new projects**
  ([#2364](https://github.com/puppetlabs/bolt/issues/2364))

  The `bolt project init` and `New-BoltProject` commands now create an
  `inventory.yaml` file in the new project.