### PR TITLE
(GH-2376) Warn about unknown configuration options

### DIFF
--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -92,10 +92,8 @@ module Bolt
 
     def self.defaults_schema
       base      = OPTIONS.slice(*BOLT_DEFAULTS_OPTIONS)
-      inventory = INVENTORY_OPTIONS.each do |option, definition|
-        if TRANSPORT_CONFIG.key?(option)
-          definition[:properties] = TRANSPORT_CONFIG[option].schema
-        end
+      inventory = INVENTORY_OPTIONS.each_with_object({}) do |(option, definition), acc|
+        acc[option] = TRANSPORT_CONFIG.key?(option) ? definition.merge(TRANSPORT_CONFIG[option].schema) : definition
       end
 
       base['inventory-config'][:properties] = inventory
@@ -103,10 +101,8 @@ module Bolt
     end
 
     def self.bolt_schema
-      inventory = INVENTORY_OPTIONS.each do |option, definition|
-        if TRANSPORT_CONFIG.key?(option)
-          definition[:properties] = TRANSPORT_CONFIG[option].schema
-        end
+      inventory = INVENTORY_OPTIONS.each_with_object({}) do |(option, definition), acc|
+        acc[option] = TRANSPORT_CONFIG.key?(option) ? definition.merge(TRANSPORT_CONFIG[option].schema) : definition
       end
 
       OPTIONS.slice(*BOLT_OPTIONS).merge(inventory)

--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -83,7 +83,11 @@ module Bolt
       # Validate the config against the schema. This will raise a single error
       # with all validation errors.
       schema = Bolt::Config::OPTIONS.slice(*Bolt::Config::BOLT_PROJECT_OPTIONS)
-      Bolt::Config::Validator.new.validate(data, schema, project_file)
+
+      Bolt::Config::Validator.new.tap do |validator|
+        validator.validate(data, schema, project_file)
+        validator.warnings.each { |warning| logs << { warn: warning } }
+      end
 
       new(data, path, type, logs)
     end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -23,8 +23,10 @@ describe "Bolt::CLI" do
 
     allow_any_instance_of(Bolt::CLI).to receive(:outputter).and_return(outputter)
     allow_any_instance_of(Bolt::CLI).to receive(:warn)
+
     # Don't print error messages to the console
     allow($stdout).to receive(:puts)
+    allow($stderr).to receive(:puts)
 
     # Don't allow tests to override the captured log config
     allow(Bolt::Logger).to receive(:configure)

--- a/spec/integration/config/validator_spec.rb
+++ b/spec/integration/config/validator_spec.rb
@@ -104,13 +104,33 @@ describe 'validating config' do
           /Value at 'format' must be one of human, json, rainbow/,
           /Value at 'log.warn.log.level' must be one of trace, debug, error, info, warn, fatal, any/,
           /Value at 'log.warn.log.append' must be of type Boolean/,
-          /Value at 'log.bolt-debug.log' must be one of disable/,
+          /Value at 'log.bolt-debug.log' must be disable or must be of type Hash/,
           /Value at 'modulepath' is a plugin reference, which is unsupported at this location/,
           /Value at 'puppetdb.cacert' must be of type String/,
           /Value at 'puppetdb.server_urls' must be of type Array/,
           /Value at 'tasks' must be of type Array/
         )
       end
+    end
+  end
+
+  context 'with unknown config options' do
+    let(:project_config) do
+      {
+        'unknown' => 'unknown',
+        'puppetfile' => {
+          'unknown' => 'unknown'
+        }
+      }
+    end
+
+    it 'warns about unknown options' do
+      run_cli(command, project: project)
+
+      expect(@log_output.readlines).to include(
+        /WARN.*Unknown option 'unknown' at.*bolt-project.yaml/,
+        /WARN.*Unknown option 'unknown' at 'puppetfile' at.*bolt-project.yaml/
+      )
     end
   end
 end

--- a/spec/lib/bolt_spec/options.rb
+++ b/spec/lib/bolt_spec/options.rb
@@ -6,7 +6,7 @@ module BoltSpec
     # has a :type and :description key, as they are required for
     # generating the JSON schemas and validating config.
     def assert_type_description(definitions)
-      definitions.each do |option, definition|
+      definitions.each_pair do |option, definition|
         expect(definition.key?(:description)).to be, "missing :description key for option '#{option}'"
         expect(definition.key?(:type)).to be, "missing :type key for option '#{option}'"
 


### PR DESCRIPTION
This updates the config validator to issue warnings for unknown
config options. When the validator encounters an unknown option, it
stores a warning indicating where the unknown option is specified, which
is later issued by the logger. Options are only reported as unknown if
the schema for the option defines the `:properties` key but _not_ the
`:additionalProperties` key.

!feature

* **Warn about unknown configuration options**
  ([#2376](https://github.com/puppetlabs/bolt/issues/2376))

  Bolt now issues a warning when it detects an unknown configuration
  option. The warning will indicate where the configuration option is
  located.