### PR TITLE
(GH-2358) Deprecate 'plugin_hooks' in favor of 'plugin-hooks'

### DIFF
--- a/documentation/using_plugins.md
+++ b/documentation/using_plugins.md
@@ -165,14 +165,14 @@ task as the default Puppet library plugin. However, you can configure Bolt to
 use another plugin instead.
 
 To configure Bolt to use a specific Puppet library plugin, configure the
-`puppet_library` plugin hook under the `plugin_hooks` key in a configuration
+`puppet_library` plugin hook under the `plugin-hooks` key in a configuration
 file. The `puppet_library` plugin hook accepts one of two different plugins.
 The `puppet_agent` plugin is the default plugin that Bolt is configured to use,
 while `task` can be used to specify a task to run as a plugin.
 
 ```yaml
 # bolt-defaults.yaml
-plugin_hooks:
+plugin-hooks:
   puppet_library:
     plugin: task
     task: <plugin name>

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -282,6 +282,7 @@ module Bolt
         'concurrency'         => default_concurrency,
         'format'              => 'human',
         'log'                 => { 'console' => {} },
+        'plugin-hooks'        => {},
         'plugin_hooks'        => {},
         'plugins'             => {},
         'puppetdb'            => {},
@@ -369,7 +370,7 @@ module Bolt
           when *TRANSPORT_CONFIG.keys
             Bolt::Util.deep_merge(val1, val2)
           # Hash values are shallow merged
-          when 'puppetdb', 'plugin_hooks', 'apply_settings', 'log'
+          when 'puppetdb', 'plugin-hooks', 'plugin_hooks', 'apply_settings', 'log'
             val1.merge(val2)
           # All other values are overwritten
           else
@@ -567,7 +568,18 @@ module Bolt
     end
 
     def plugin_hooks
-      @data['plugin_hooks']
+      if @data['plugin-hooks'].any? && @data['plugin_hooks'].any?
+        Bolt::Logger.warn_once(
+          "plugin-hooks and plugin_hooks set",
+          "Detected configuration for 'plugin-hooks' and 'plugin_hooks'. Bolt will ignore 'plugin_hooks'."
+        )
+
+        @data['plugin-hooks']
+      elsif @data['plugin-hooks'].any?
+        @data['plugin-hooks']
+      else
+        @data['plugin_hooks']
+      end
     end
 
     def trusted_external

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -304,6 +304,16 @@ module Bolt
                        "and [`task`](using_plugins.md#task).",
           type: Hash,
           _plugin: true,
+          _example: { "puppet_library" => { "plugin" => "puppet_agent", "version" => "6.15.0", "_run_as" => "root" } },
+          _deprecation: "This option will be removed in Bolt 3.0. Use `plugin-hooks` instead."
+        },
+        "plugin-hooks" => {
+          description: "A map of [plugin hooks](writing_plugins.md#hooks) and which plugins a hook should use. "\
+                       "The only configurable plugin hook is `puppet_library`, which can use two possible plugins: "\
+                       "[`puppet_agent`](https://github.com/puppetlabs/puppetlabs-puppet_agent#puppet_agentinstall) "\
+                       "and [`task`](using_plugins.md#task).",
+          type: Hash,
+          _plugin: true,
           _example: { "puppet_library" => { "plugin" => "puppet_agent", "version" => "6.15.0", "_run_as" => "root" } }
         },
         "plugins" => {
@@ -497,6 +507,7 @@ module Bolt
         inventoryfile
         log
         modulepath
+        plugin-hooks
         plugin_hooks
         plugins
         puppetdb
@@ -513,6 +524,7 @@ module Bolt
         format
         inventory-config
         log
+        plugin-hooks
         plugin_hooks
         plugins
         puppetdb
@@ -534,6 +546,7 @@ module Bolt
         modules
         name
         plans
+        plugin-hooks
         plugin_hooks
         plugins
         puppetdb

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -31,6 +31,9 @@
     "modulepath": {
       "$ref": "#/definitions/modulepath"
     },
+    "plugin-hooks": {
+      "$ref": "#/definitions/plugin-hooks"
+    },
     "plugin_hooks": {
       "$ref": "#/definitions/plugin_hooks"
     },
@@ -182,6 +185,17 @@
       "items": {
         "type": "string"
       }
+    },
+    "plugin-hooks": {
+      "description": "A map of [plugin hooks](writing_plugins.md#hooks) and which plugins a hook should use. The only configurable plugin hook is `puppet_library`, which can use two possible plugins: [`puppet_agent`](https://github.com/puppetlabs/puppetlabs-puppet_agent#puppet_agentinstall) and [`task`](using_plugins.md#task).",
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
     },
     "plugin_hooks": {
       "description": "A map of [plugin hooks](writing_plugins.md#hooks) and which plugins a hook should use. The only configurable plugin hook is `puppet_library`, which can use two possible plugins: [`puppet_agent`](https://github.com/puppetlabs/puppetlabs-puppet_agent#puppet_agentinstall) and [`task`](using_plugins.md#task).",

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -22,6 +22,9 @@
     "log": {
       "$ref": "#/definitions/log"
     },
+    "plugin-hooks": {
+      "$ref": "#/definitions/plugin-hooks"
+    },
     "plugin_hooks": {
       "$ref": "#/definitions/plugin_hooks"
     },
@@ -148,6 +151,17 @@
           }
         }
       }
+    },
+    "plugin-hooks": {
+      "description": "A map of [plugin hooks](writing_plugins.md#hooks) and which plugins a hook should use. The only configurable plugin hook is `puppet_library`, which can use two possible plugins: [`puppet_agent`](https://github.com/puppetlabs/puppetlabs-puppet_agent#puppet_agentinstall) and [`task`](using_plugins.md#task).",
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
     },
     "plugin_hooks": {
       "description": "A map of [plugin hooks](writing_plugins.md#hooks) and which plugins a hook should use. The only configurable plugin hook is `puppet_library`, which can use two possible plugins: [`puppet_agent`](https://github.com/puppetlabs/puppetlabs-puppet_agent#puppet_agentinstall) and [`task`](using_plugins.md#task).",

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -40,6 +40,9 @@
     "plans": {
       "$ref": "#/definitions/plans"
     },
+    "plugin-hooks": {
+      "$ref": "#/definitions/plugin-hooks"
+    },
     "plugin_hooks": {
       "$ref": "#/definitions/plugin_hooks"
     },
@@ -224,6 +227,17 @@
     "plans": {
       "description": "A list of plan names and glob patterns to filter the project's plans by. This option is used to limit the visibility of plans for users of the project. For example, project authors might want to limit the visibility of plans that are bundled with Bolt or plans that should only be run as part of another plan. When this option is not configured, all plans are visible. This option does not prevent users from running plans that are not part of this list.",
       "type": "array"
+    },
+    "plugin-hooks": {
+      "description": "A map of [plugin hooks](writing_plugins.md#hooks) and which plugins a hook should use. The only configurable plugin hook is `puppet_library`, which can use two possible plugins: [`puppet_agent`](https://github.com/puppetlabs/puppetlabs-puppet_agent#puppet_agentinstall) and [`task`](using_plugins.md#task).",
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
     },
     "plugin_hooks": {
       "description": "A map of [plugin hooks](writing_plugins.md#hooks) and which plugins a hook should use. The only configurable plugin hook is `puppet_library`, which can use two possible plugins: [`puppet_agent`](https://github.com/puppetlabs/puppetlabs-puppet_agent#puppet_agentinstall) and [`task`](using_plugins.md#task).",

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -328,7 +328,7 @@ describe Bolt::Config do
             }
           }
         },
-        'plugin_hooks' => {
+        'plugin-hooks' => {
           'puppet_library' => {
             'plugin' => 'puppet_agent',
             '_run_as' => 'root'
@@ -350,7 +350,7 @@ describe Bolt::Config do
             'credentials' => '~/aws/credentials'
           }
         },
-        'plugin_hooks' => {
+        'plugin-hooks' => {
           'puppet_library' => {
             'plugin' => 'task',
             'task' => 'bootstrap'

--- a/spec/bolt/plugin_spec.rb
+++ b/spec/bolt/plugin_spec.rb
@@ -63,7 +63,7 @@ describe Bolt::Plugin do
 
   context 'loading plugin_hooks' do
     it 'evaluates plugin references in the plugin_hooks configuration' do
-      config_data['plugin_hooks'] = {
+      config_data['plugin-hooks'] = {
         'puppet_library' => {
           'plugin' => 'my_hook',
           'param' => identity('foobar')
@@ -80,7 +80,7 @@ describe Bolt::Plugin do
         }
       }
 
-      config_data['plugin_hooks'] = identity(hooks)
+      config_data['plugin-hooks'] = identity(hooks)
 
       expect(plugins.plugin_hooks).to eq(
         'another_hook' => {

--- a/spec/integration/plugin/module_spec.rb
+++ b/spec/integration/plugin/module_spec.rb
@@ -28,7 +28,7 @@ describe 'using module based plugins' do
   let(:config) {
     { 'modulepath' => ['modules', File.join(__dir__, '../../fixtures/plugin_modules')],
       'plugins' => plugin_config,
-      'plugin_hooks' => plugin_hooks }
+      'plugin-hooks' => plugin_hooks }
   }
 
   let(:plan) do

--- a/spec/integration/plugin/task_spec.rb
+++ b/spec/integration/plugin/task_spec.rb
@@ -27,7 +27,7 @@ describe 'using the task plugin' do
   let(:config) {
     {
       'modulepath' => ['modules', File.join(__dir__, '../../fixtures/modules')],
-      'plugin_hooks' => plugin_hooks
+      'plugin-hooks' => plugin_hooks
     }
   }
 


### PR DESCRIPTION
This updates Bolt to issue a deprecation warning when a config file
includes the `plugin_hooks` option, which has been renamed to
`plugin-hooks`. When config is set for both of these options, Bolt
will issue another warning that `plugin_hooks` will be ignored.

!deprecation

* **Deprecate `plugin_hooks` in favor of `plugin-hooks`**
  ([#2358](#2358))

  The `plugin_hooks` configuration option has been deprecated in favor
  of `plugin-hooks`.