### PR TITLE
(PE-30636) Add load_plugins option to Bolt::Plugin.setup

### DIFF
--- a/lib/bolt/plugin/module.rb
+++ b/lib/bolt/plugin/module.rb
@@ -12,15 +12,15 @@ module Bolt
         end
       end
 
-      def self.load(name, modules, opts)
-        mod = modules[name]
-        if mod&.plugin?
+      # mod should not be nil
+      def self.load(mod, opts)
+        if mod.plugin?
           opts[:mod] = mod
           plugin = Bolt::Plugin::Module.new(**opts)
           plugin.setup
           plugin
         else
-          raise PluginError::Unknown, name
+          raise PluginError::Unknown, mod.name
         end
       end
 


### PR DESCRIPTION
When set to true, the returned Bolt::Plugin object will load
plugins on-demand. This is what Bolt is already doing and hence
the default behavior.

When set to false, the returned Bolt::Plugin object will raise a new
PluginLoadingDisabled error indicating that plugin loading is disabled.
However, users can still add their statically loaded plugins via
Bolt::Plugin#add_plugin.

!no-release-note

Signed-off-by: Enis Inan <enis.inan@puppet.com>