### PR TITLE
(GH-2365) Deprecate Powershell 2 support

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -198,11 +198,23 @@ module Bolt
       config.deprecations.each { |dep| Bolt::Logger.deprecation_warning(dep[:type], dep[:msg]) }
 
       warn_inventory_overrides_cli(options)
+      validate_ps_version
 
       options
     rescue Bolt::Error => e
       outputter.fatal_error(e)
       raise e
+    end
+
+    private def validate_ps_version
+      if Bolt::Util.powershell?
+        target = inventory.get_target('localhost')
+        Bolt::Transport::Local.new.with_connection(target) do |conn|
+          # This will automatically validate the powershell version on the Bolt
+          # controller
+          Bolt::Shell::Powershell.new(target, conn)
+        end
+      end
     end
 
     def update_targets(options)

--- a/lib/bolt/shell/powershell.rb
+++ b/lib/bolt/shell/powershell.rb
@@ -14,6 +14,22 @@ module Bolt
         extensions = [target.options['extensions'] || []].flatten.map { |ext| ext[0] == '.' ? ext : '.' + ext }
         extensions += target.options['interpreters'].keys if target.options['interpreters']
         @extensions = DEFAULT_EXTENSIONS + extensions
+        validate_ps_version
+      end
+
+      def validate_ps_version
+        version = execute("$PSVersionTable.PSVersion.Major").stdout.string.chomp
+        if !version.empty? && version.to_i < 3
+          # This lets us know how many targets have Powershell 2, and lets the
+          # user know how many targets they have with PS2
+          msg = "Detected PowerShell 2 on one or more targets.\nPowerShell 2 "\
+            "is deprecated, and support will be removed in Bolt 3.0. See "\
+            "bolt-debug.log or run with '--log-level debug' to see the full "\
+            "list of targets with PowerShell 2."
+
+          Bolt::Logger.deprecation_warning("PowerShell 2", msg)
+          @logger.debug("Detected PowerShell 2 on #{target}.")
+        end
       end
 
       def provided_features


### PR DESCRIPTION
This adds a deprecation warning when users run Bolt from Powershell
version less than 3, and for each target users run against in Powershell
less than 3. This only applies to the shell Bolt is run from or
connected to, not all Powershell versions on the machine. A warning is
issued for each target the user connects to with a deprecated version so
that users know which targets have deprecated PS versions.

Closes #2365

!deprecation

* **Deprecate Powershell 2 support** ([2365](https://github.com/puppetlabs/bolt/issues/2365))

  Support for Powershell 2 on both Bolt targets and controllers is
  deprecated, and will be dropped in Bolt 3.0.