### PR TITLE
(GH-2000) Deprecate bolt.yaml

### DIFF
--- a/documentation/bolt.ditamap
+++ b/documentation/bolt.ditamap
@@ -5,7 +5,7 @@
         <topicref href="developer_updates.md" format="markdown"/>
         <topicref navtitle="Changelog" href="https://github.com/puppetlabs/bolt/blob/main/CHANGELOG.md" format="html" scope="external" />
         <topicref href="bolt_versioning.md" format="markdown"/>
-        <topicref href="migrating_inventory_files.md" format="markdown"/>   
+        <topicref href="upgrading_to_bolt_3.md" format="markdown"/>   
         <topicref href="bolt_known_issues.md" format="markdown"/>
     </topicref>
     <topicref href="bolt_installing.md" format="markdown" linking="targetonly">

--- a/documentation/configuring_bolt.md
+++ b/documentation/configuring_bolt.md
@@ -39,13 +39,9 @@ Bolt loads project-level configuration files from the root of your [Bolt project
 directory](projects.md). If it can't find a project directory,
 Bolt uses the default project directory: `~/.puppetlabs/bolt/`.
 
-You can set project-level configuration in three files: 
+You can set project-level configuration in two files: 
 - For Bolt configuration, use `bolt-project.yaml`.
 - For inventory configuration, use `inventory.yaml`.
-- You can set all configuration in a `bolt.yaml` file at the root of your
-  project directory. ⛔ **The project-level `bolt.yaml` file is deprecated and
-  will be removed in a future version of Bolt.** Use `bolt-project.yaml` and
-  `inventory.yaml` files instead.
 
 The preferred method for setting project-level configuration is to use a
 combination of `bolt-project.yaml` and `inventory.yaml` files. This maintains
@@ -93,7 +89,7 @@ fields](bolt_inventory_reference.md).
 
 ### ⛔ `bolt.yaml`
 
-⛔ The project-level `bolt.yaml` file is deprecated and will be removed in a
+⛔ The `bolt.yaml` file is deprecated and will be removed in a
 future version of Bolt. Use `bolt-project.yaml` and `inventory.yaml` files
 instead.
 

--- a/documentation/templates/bolt_transports_reference.md.erb
+++ b/documentation/templates/bolt_transports_reference.md.erb
@@ -98,7 +98,7 @@ ssh:
 
 ## Example files
 
-### `bolt.yaml`
+### ⛔ `bolt.yaml`
 
 ```yaml
 # bolt.yaml

--- a/documentation/upgrading_to_bolt_3.md
+++ b/documentation/upgrading_to_bolt_3.md
@@ -1,0 +1,84 @@
+# Upgrading to Bolt 3.0
+
+It's almost time for Bolt 3.0! This page contains a list of things you can do to prepare for the
+upcoming release. We'll add to this page as we near the release and implement more of the expected
+changes and deprecations, so if you're making the changes ahead of time, be sure to check in every
+couple weeks to see if we've added anything else to the instructions below. For an exhaustive list
+of the things we're changing, see [Changes coming in Bolt 3.0](developer_updates.md#changes-coming-in-bolt-30).
+
+## Migrating configuration files
+
+Bolt 3.0 introduces changes to Bolt's configuration file layout and content, including
+removing `bolt.yaml` and renaming several configuration options. Here's how to transition to the new
+world order.
+
+## Automated migration
+
+The migration command updates your project-level configuration files to use the latest Bolt best practices:
+
+_\*nix shell command_
+
+```shell
+bolt project migrate
+```
+
+_PowerShell cmdlet_
+
+```powershell
+Update-BoltProject
+```
+
+## Manual migration
+
+If you need user- or system-level configuration, use the following manual migration steps to 
+migrate the relevant configuration files. You can also follow these steps for your project-level 
+configuration files if you're not comfortable having Bolt rewrite your files.
+
+### User- and system-level config
+
+To migrate your system- or user-level Bolt configuration, make the following changes to the relevant `bolt.yaml` file:
+
+1. Move any [transport configuration](bolt_transports_reference.md) to be under an
+   `inventory-config` key, like so:
+
+   ```
+   inventory-config:
+       ssh:
+         password: hunter2!
+         user: bolt
+       winrm:
+         password: hunter2!
+         user: bolt
+   ```
+   Transport configuration keys are `ssh`, `winrm`, `pcp`, `local`, `docker`, `remote`, and
+   `transport`.
+1. Rename the following configuration options:
+    - `plugin_hooks` to `plugin-hooks`
+1. Rename `apply_settings` to `apply_settings` and move the `apply_settings` configuration to
+   your project directory at `<PROJECT DIRECTORY>/bolt-project.yaml`. If you'd rather use the
+   default Bolt project directory, place the file in `~/.puppetlabs/bolt/`.
+1. Rename the file to `bolt-defaults.yaml`.
+
+### Project-level config
+
+1. Move any [transport configuration](bolt_transports_reference.md) to the top-level `config` key of
+   the inventory file. This should be at `<PROJECT DIRECTORY>/inventory.yaml`.
+
+   ```
+    targets:
+      - my target
+
+    config:
+       ssh:
+         password: hunter2!
+         user: bolt
+       winrm:
+         password: hunter2!
+         user: bolt
+   ```
+   Transport configuration keys are `ssh`, `winrm`, `pcp`, `local`, `docker`, `remote`, and
+   `transport`.
+1. Rename the following configuration options:
+    - `apply_settings` to `apply-settings`
+    - `plugin_hooks` to `plugin-hooks`
+1. Rename the file to `bolt-project.yaml`.

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -216,8 +216,8 @@ module Bolt
       data         = Bolt::Util.read_yaml_hash(filepath, 'config')
       logs         = [{ debug: "Loaded configuration from #{filepath}" }]
       deprecations = [{ type: 'Using bolt.yaml for system configuration',
-                        msg: "Configuration file #{filepath} is deprecated and will be removed in a future version "\
-                        "of Bolt. Use '#{dir + BOLT_DEFAULTS_NAME}' instead." }]
+                        msg: "Configuration file #{filepath} is deprecated and will be removed in Bolt 3.0. "\
+                        "See https://pup.pt/update-bolt-config for how to update to the latest Bolt practices." }]
 
       # Validate the config against the schema. This will raise a single error
       # with all validation errors.


### PR DESCRIPTION
This adds a deprecation warning for bolt.yaml at the project-level, and
updates the existing deprecation warning at the user/system level to
point to documentation on how to update their Bolt files.

Closes #2000

!deprecation

* **Deprecate bolt.yaml** ([#2000](https://github.com/puppetlabs/issues/2000))

  The `bolt.yaml` configuration file is now deprecated, both at
  project-level and user/system-level.