### PR TITLE
(GH-2357) Deprecate 'apply_settings' in favor of 'apply-settings'

### DIFF
--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -115,6 +115,21 @@ module Bolt
               _default: false
             }
           },
+          _plugin: false,
+          _deprecation: "This option will be removed in Bolt 3.0. Use `apply-settings` instead."
+        },
+        "apply-settings" => {
+          description: "A map of Puppet settings to use when applying Puppet code using the `apply` "\
+                       "plan function or the `bolt apply` command.",
+          type: Hash,
+          properties: {
+            "show_diff" => {
+              description: "Whether to log and report a contextual diff.",
+              type: [TrueClass, FalseClass],
+              _example: true,
+              _default: false
+            }
+          },
           _plugin: false
         },
         "color" => {
@@ -498,6 +513,7 @@ module Bolt
 
       # Options that are available in a bolt.yaml file
       BOLT_OPTIONS = %w[
+        apply-settings
         apply_settings
         color
         compile-concurrency
@@ -534,6 +550,7 @@ module Bolt
 
       # Options that are available in a bolt-project.yaml file
       BOLT_PROJECT_OPTIONS = %w[
+        apply-settings
         apply_settings
         color
         compile-concurrency

--- a/lib/bolt/project_manager/config_migrator.rb
+++ b/lib/bolt/project_manager/config_migrator.rb
@@ -72,9 +72,17 @@ module Bolt
         data     = Bolt::Util.read_yaml_hash(project_file, 'config')
         modified = false
 
-        if data.key?('plugin_hooks') && !data.key?('plugin-hooks')
-          @outputter.print_action_step("Updating 'plugin_hooks' option to 'plugin-hooks'")
-          data['plugin-hooks'] = data.delete('plugin_hooks')
+        [%w[apply_settings apply-settings], %w[plugin_hooks plugin-hooks]].each do |old, new|
+          next unless data.key?(old)
+
+          if data.key?(new)
+            @outputter.print_action_step("Removing deprecated option '#{old}'")
+            data.delete(old)
+          else
+            @outputter.print_action_step("Updating deprecated option '#{old}' to '#{new}'")
+            data[new] = data.delete(old)
+          end
+
           modified = true
         end
 

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -4,6 +4,9 @@
   "description": "Bolt Configuration bolt.yaml Schema",
   "type": "object",
   "properties": {
+    "apply-settings": {
+      "$ref": "#/definitions/apply-settings"
+    },
     "apply_settings": {
       "$ref": "#/definitions/apply_settings"
     },
@@ -75,6 +78,16 @@
     }
   },
   "definitions": {
+    "apply-settings": {
+      "description": "A map of Puppet settings to use when applying Puppet code using the `apply` plan function or the `bolt apply` command.",
+      "type": "object",
+      "properties": {
+        "show_diff": {
+          "description": "Whether to log and report a contextual diff.",
+          "type": "boolean"
+        }
+      }
+    },
     "apply_settings": {
       "description": "A map of Puppet settings to use when applying Puppet code using the `apply` plan function or the `bolt apply` command.",
       "type": "object",

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -4,6 +4,9 @@
   "description": "Bolt Project bolt-project.yaml Schema",
   "type": "object",
   "properties": {
+    "apply-settings": {
+      "$ref": "#/definitions/apply-settings"
+    },
     "apply_settings": {
       "$ref": "#/definitions/apply_settings"
     },
@@ -66,6 +69,16 @@
     }
   },
   "definitions": {
+    "apply-settings": {
+      "description": "A map of Puppet settings to use when applying Puppet code using the `apply` plan function or the `bolt apply` command.",
+      "type": "object",
+      "properties": {
+        "show_diff": {
+          "description": "Whether to log and report a contextual diff.",
+          "type": "boolean"
+        }
+      }
+    },
     "apply_settings": {
       "description": "A map of Puppet settings to use when applying Puppet code using the `apply` plan function or the `bolt apply` command.",
       "type": "object",

--- a/spec/bolt/project_manager/config_migrator_spec.rb
+++ b/spec/bolt/project_manager/config_migrator_spec.rb
@@ -2,73 +2,129 @@
 
 require 'pathname'
 require 'spec_helper'
+require 'bolt_spec/project'
 require 'bolt/project_manager/config_migrator'
 
 describe Bolt::ProjectManager::ConfigMigrator do
+  include BoltSpec::Project
+
   def migrate
     migrator.migrate(config_file, project_file, inventory_file, backup_dir)
   end
 
   let(:outputter)      { double('outputter', print_message: nil, print_action_step: nil) }
   let(:migrator)       { described_class.new(outputter) }
-  let(:inventory_file) { @tmpdir + 'inventory.yaml' }
-  let(:config_file)    { @tmpdir + 'bolt.yaml' }
-  let(:project_file)   { @tmpdir + 'bolt-project.yaml' }
-  let(:backup_dir)     { @tmpdir + '.bolt-bak' }
+  let(:inventory_file) { project_dir + 'inventory.yaml' }
+  let(:config_file)    { project_dir + 'bolt.yaml' }
+  let(:project_file)   { project_dir + 'bolt-project.yaml' }
+  let(:backup_dir)     { project_dir + '.bolt-bak' }
 
-  let(:inv_data) do
-    {
-      'config' => {
-        'ssh' => {
-          'user' => 'root',
-          'password' => 'bolt'
+  context "updating options" do
+    let(:project_dir) { project.path }
+
+    let(:old_config) do
+      {
+        'apply_settings' => {
+          'show_diff' => true
+        },
+        'plugin_hooks' => {
+          'puppet_library' => {
+            'collection' => 'puppet6'
+          }
         }
       }
-    }
-  end
+    end
 
-  let(:config_data) do
-    {
-      'color' => true,
-      'ssh' => {
-        'user' => 'bob',
-        'port' => 23
+    let(:new_config) do
+      {
+        'apply-settings' => {
+          'show_diff' => true
+        },
+        'plugin-hooks' => {
+          'puppet_library' => {
+            'collection' => 'puppet6'
+          }
+        }
       }
-    }
-  end
+    end
 
-  around :each do |example|
-    Dir.mktmpdir(nil, Dir.pwd) do |tmpdir|
-      @tmpdir = Pathname.new(tmpdir)
-      example.run
+    around :each do |example|
+      with_project do
+        example.run
+      end
+    end
+
+    context "with deprecated options" do
+      let(:project_config) { old_config }
+
+      it "updates configuration options" do
+        migrate
+        expect(YAML.load_file(project_file)).to eq(new_config)
+      end
+    end
+
+    context "with deprecated and non-deprecated options" do
+      let(:project_config) { old_config.merge(new_config) }
+
+      it "removes deprecated options" do
+        migrate
+        expect(YAML.load_file(project_file)).to eq(new_config)
+      end
     end
   end
 
-  it "does nothing if bolt-project.yaml exists, even if bolt.yaml exists" do
-    FileUtils.touch(project_file)
-    FileUtils.touch(config_file)
-    expect(Bolt::Util).not_to receive(:read_optional_yaml_hash).with(config_file, 'config')
-    migrate
-  end
-
-  it "does nothing if bolt.yaml does not exist" do
-    expect(Bolt::Util).not_to receive(:read_optional_yaml_hash).with(config_file, 'config')
-    migrate
-  end
-
-  it "doesn't write to inventoryfile if there's no transport config" do
-    FileUtils.touch(config_file)
-    expect(File).not_to receive(:write).with(inventory_file, any_args)
-    migrate
-  end
-
   context "when moving transport config" do
-    before :each do
-      File.write(config_file, config_data.to_yaml)
+    let(:project_dir) { @tmpdir }
+
+    let(:inv_data) do
+      {
+        'config' => {
+          'ssh' => {
+            'user' => 'root',
+            'password' => 'bolt'
+          }
+        }
+      }
+    end
+
+    let(:config_data) do
+      {
+        'color' => true,
+        'ssh' => {
+          'user' => 'bob',
+          'port' => 23
+        }
+      }
+    end
+
+    around :each do |example|
+      Dir.mktmpdir(nil, Dir.pwd) do |tmpdir|
+        @tmpdir = Pathname.new(tmpdir)
+        example.run
+      end
+    end
+
+    it "does nothing if bolt-project.yaml exists, even if bolt.yaml exists" do
+      FileUtils.touch(project_file)
+      FileUtils.touch(config_file)
+      expect(Bolt::Util).not_to receive(:read_optional_yaml_hash).with(config_file, 'config')
+      migrate
+    end
+
+    it "does nothing if bolt.yaml does not exist" do
+      expect(Bolt::Util).not_to receive(:read_optional_yaml_hash).with(config_file, 'config')
+      migrate
+    end
+
+    it "doesn't write to inventoryfile if there's no transport config" do
+      FileUtils.touch(config_file)
+      expect(File).not_to receive(:write).with(inventory_file, any_args)
+      migrate
     end
 
     context "with an existing inventory" do
       before :each do
+        File.write(config_file, config_data.to_yaml)
         File.write(inventory_file, inv_data.to_yaml)
       end
 
@@ -95,6 +151,10 @@ describe Bolt::ProjectManager::ConfigMigrator do
     end
 
     context "without an existing inventory" do
+      before :each do
+        File.write(config_file, config_data.to_yaml)
+      end
+
       it "does not back up inventory" do
         expect(migrator).not_to receive(:backup_file)
           .with(inventory_file, backup_dir)

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -369,7 +369,7 @@ describe "apply", expensive: true do
             +Silly string (get it?)
             \\ No newline at end of file
             DIFF
-          with_tempfile_containing('bolt', YAML.dump("apply_settings" => show_diff), '.yaml') do |conf|
+          with_tempfile_containing('bolt', YAML.dump("apply-settings" => show_diff), '.yaml') do |conf|
             result = run_cli_json(%W[plan run settings::show_diff --configfile #{conf.path}] + config_flags).first
             expect(result['status']).to eq('success')
             expect(result['value']['report']['logs'][0]['message']).to include(diff_string)
@@ -436,7 +436,7 @@ describe "apply", expensive: true do
             +Silly string (get it?)
             \\ No newline at end of file
             DIFF
-          with_tempfile_containing('bolt', YAML.dump("apply_settings" => show_diff), '.yaml') do |conf|
+          with_tempfile_containing('bolt', YAML.dump("apply-settings" => show_diff), '.yaml') do |conf|
             result = run_cli_json(%W[plan run settings::show_diff --configfile #{conf.path}] + config_flags).first
             expect(result['status']).to eq('success')
             expect(result['value']['report']['logs'][0]['message']).to include(diff_string)

--- a/spec/integration/config/validator_spec.rb
+++ b/spec/integration/config/validator_spec.rb
@@ -18,7 +18,7 @@ describe 'validating config' do
   context 'with valid config' do
     let(:project_config) do
       {
-        'apply_settings' => {
+        'apply-settings' => {
           'show_diff' => true
         },
         'color' => false,
@@ -59,7 +59,7 @@ describe 'validating config' do
   context 'with invalid config' do
     let(:project_config) do
       {
-        'apply_settings' => {
+        'apply-settings' => {
           'show_diff' => 'yes'
         },
         'color' => 100,
@@ -98,7 +98,7 @@ describe 'validating config' do
         expect(error.kind).to eq('bolt/validation-error')
 
         expect(error.message.lines).to include(
-          /Value at 'apply_settings.show_diff' must be of type Boolean/,
+          /Value at 'apply-settings.show_diff' must be of type Boolean/,
           /Value at 'color' must be of type Boolean/,
           /Value at 'compile-concurrency' must be a minimum of 1/,
           /Value at 'format' must be one of human, json, rainbow/,


### PR DESCRIPTION
This updates Bolt to issue a deprecation warning when a config file
includes the `apply_settings` option, which has been renamed to
`apply-settings`. When config is set for both of these options, Bolt
will issue another warning that `apply_settings` will be ignored.

!deprecation

* **Deprecate `apply_settings` in favor of `apply-settings`**
  ([#2357](https://github.com/puppetlabs/bolt/issues/2357))

  The `apply_settings` configuration option has been deprecated in favor
  of `apply-settings`.