### PR TITLE
(GH-2370) Add value() function for ApplyResult datatype

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/datatypes/applyresult.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/applyresult.rb
@@ -12,6 +12,7 @@ Puppet::DataTypes.create_type('ApplyResult') do
       message => Callable[[], Optional[String]],
       action => Callable[[], String],
       to_data => Callable[[], Hash],
+      value => Callable[[], Hash]
     }
   PUPPET
 

--- a/documentation/bolt_types_reference.md
+++ b/documentation/bolt_types_reference.md
@@ -19,9 +19,10 @@ The following functions are available to `ApplyResult` objects.
 | `error` | `Error` | An object constructed from the `_error` field of the result's value. |
 | `message` | `String` | The `_output` field of the result's value. |
 | `ok` | `Boolean` | Whether the result was successful. |
-| `report` | `Hash` | The Puppet report from the apply action. |
+| `report` | `Hash` | The Puppet report from the apply action. Equivalent to calling `$apply_result.value['report']`. |
 | `target` | `Target` | The target the result is from. |
 | `to_data` | `Hash` | A serialized representation of `ApplyResult`. |
+| `value` | `Hash` | A hash including the Puppet report from the apply action under a `report` key. |
 
 ## `ResourceInstance`
 

--- a/lib/bolt/apply_result.rb
+++ b/lib/bolt/apply_result.rb
@@ -96,9 +96,9 @@ module Bolt
       @target = target
       @value = {}
       @action = 'apply'
-      value['report'] = report if report
-      value['_error'] = error if error
-      value['_output'] = metrics_message if metrics_message
+      @value['report'] = report if report
+      @value['_error'] = error if error
+      @value['_output'] = metrics_message if metrics_message
     end
 
     def event_metrics

--- a/spec/bolt/apply_result_spec.rb
+++ b/spec/bolt/apply_result_spec.rb
@@ -101,5 +101,9 @@ describe Bolt::ApplyResult do
     it 'with to_data' do
       expect(apply_result.to_data).to eq(expected)
     end
+
+    it 'with value' do
+      expect(apply_result.value).to eq(expected['value'])
+    end
   end
 end


### PR DESCRIPTION
This adds a new `value()` function to the `ApplyResult` data type, which
returns a hash with the Puppet report under a `report` key.

!feature

* **Added `value()` function to `ApplyResult` datatype**
  ([#2370](https://github.com/puppetlabs/bolt/issues/2370))

  The `ApplyResult` datatype has a new `value()` function that returns a
  hash that includes the Puppet report from an apply under the `report`
  key.