### PR TITLE
(GH-2379) Suggest noexec may be an issue with exit code 126

### DIFF
--- a/documentation/troubleshooting.md
+++ b/documentation/troubleshooting.md
@@ -36,6 +36,18 @@ system. For example, if you write a Python task and include the line:
 `#!/usr/bin/env python`, Bolt attempts to execute the script using the default
 `python` executable on the target system.
 
+If your task fails with the following error, the issue may be that your temporary directory (tmpdir)
+is [mounted with noexec](https://superuser.com/questions/728127/what-does-noexec-flag-mean-when-mounting-directories-on-rhel).
+
+```
+The task failed with exit code 126 and no stdout but stderr contained: 
+.... <temp path to task>>.rb: Permission denied
+```
+
+You can resolve this by [configuring an alternate tmpdir](bolt_transports_reference.md) for the
+transport you're using, or by talking to your administrator about updating permissions for the
+directory.
+
 ## Bolt can't connect to my hosts over SSH
 
 ### Host key verification failures

--- a/lib/bolt/shell/bash.rb
+++ b/lib/bolt/shell/bash.rb
@@ -436,8 +436,14 @@ module Bolt
         result_output.stderr << read_streams[err]
         result_output.exit_code = t.value.respond_to?(:exitstatus) ? t.value.exitstatus : t.value
 
-        if result_output.exit_code == 0
+        case result_output.exit_code
+        when 0
           @logger.trace { "Command `#{command_str}` returned successfully" }
+        when 126
+          msg = "\n\nThis may be caused by the default tmpdir being mounted "\
+            "using 'noexec'. See http://pup.pt/task-failure for details and workarounds."
+          result_output.stderr << msg
+          @logger.trace { "Command #{command_str} failed with exit code #{result_output.exit_code}" }
         else
           @logger.trace { "Command #{command_str} failed with exit code #{result_output.exit_code}" }
         end

--- a/spec/bolt/shell/bash_spec.rb
+++ b/spec/bolt/shell/bash_spec.rb
@@ -176,6 +176,14 @@ describe Bolt::Shell::Bash do
       expect(connection).to receive(:execute).with('/path/to/my/ruby /path/to/my/script.rb')
       shell.execute('/path/to/my/script.rb', interpreter: "/path/to/my/ruby")
     end
+
+    it "appends noexec message when exit code is 126" do
+      execute_result = mock_result(stdout: "", stderr: "Permission denied", exitcode: 126)
+      expect(connection).to receive(:execute).and_return(execute_result)
+
+      result = shell.execute('my cool command')
+      expect(result.stderr.string).to include("This may be caused by the default tmpdir being mounted")
+    end
   end
 
   describe "when using run-as" do


### PR DESCRIPTION
Exit code 126 indicates that a file Bolt has written to the temporary
directory can't be executed because the user Bolt is running as doesn't
have permission to execute it. This can be caused by a variety of
issues, but one common cause is that administrators have mounted the
default tmpdir with `noexec`, meaning that users can't execute files in
the tmpdir. The recommended workaround for this is to configure an
alternative `tmpdir` for the transport(s) being used, or to contact the
administrator about modifying the permissions (though usually they're in
place for a reason). This appends a brief message that `noexec` may be
the issue to stderr output whenever exit code 126 is returned. This is
appended for bash shells. The message directs users
to our troubleshooting doc, which has been updated to include a note
about `noexec` and it's mitigation.

Closes #2379

!no-release-note