### PR TITLE
(PE-30686) Make codedir in bolt-server configurable

### DIFF
--- a/lib/bolt_server/base_config.rb
+++ b/lib/bolt_server/base_config.rb
@@ -7,7 +7,9 @@ module BoltServer
   class BaseConfig
     def config_keys
       %w[host port ssl-cert ssl-key ssl-ca-cert
-         ssl-cipher-suites loglevel logfile allowlist projects-dir]
+         ssl-cipher-suites loglevel logfile allowlist
+         projects-dir environments-codedir
+         environmentpath basemodulepath]
     end
 
     def env_keys

--- a/lib/bolt_server/config.rb
+++ b/lib/bolt_server/config.rb
@@ -7,7 +7,9 @@ require 'bolt/error'
 module BoltServer
   class Config < BoltServer::BaseConfig
     def config_keys
-      super + %w[concurrency cache-dir file-server-conn-timeout file-server-uri projects-dir]
+      super + %w[concurrency cache-dir file-server-conn-timeout
+                 file-server-uri projects-dir environments-codedir
+                 environmentpath basemodulepath]
     end
 
     def env_keys

--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -235,9 +235,9 @@ module BoltServer
     #
     # WARNING: THIS FUNCTION SHOULD ONLY BE CALLED INSIDE A SYNCHRONIZED PAL MUTEX
     def modulepath_from_environment(environment_name)
-      codedir = DEFAULT_BOLT_CODEDIR
-      environmentpath = "#{codedir}/environments"
-      basemodulepath = "#{codedir}/modules:/opt/puppetlabs/puppet/modules"
+      codedir = @config['environments-codedir'] || DEFAULT_BOLT_CODEDIR
+      environmentpath = @config['environmentpath'] || "#{codedir}/environments"
+      basemodulepath = @config['basemodulepath'] || "#{codedir}/modules:/opt/puppetlabs/puppet/modules"
       modulepath_dirs = nil
       with_pe_pal_init_settings(codedir, environmentpath, basemodulepath) do
         environment = Puppet.lookup(:environments).get!(environment_name)

--- a/spec/bolt_server/transport_app_spec.rb
+++ b/spec/bolt_server/transport_app_spec.rb
@@ -27,7 +27,7 @@ describe "BoltServer::TransportApp" do
     # execution tests. Everything else uses the fixtures above.
     moduledir = File.join(__dir__, '..', 'fixtures', 'modules')
     mock_file_cache(moduledir)
-    config = BoltServer::Config.new({ 'projects-dir' => project_dir })
+    config = BoltServer::Config.new({ 'projects-dir' => project_dir, 'environments-codedir' => basedir })
     BoltServer::TransportApp.new(config)
   end
 
@@ -47,10 +47,6 @@ describe "BoltServer::TransportApp" do
       File.write(File.join(tmpdir, inventory_name), inventory_content.to_yaml) unless inventory_content.nil?
       yield tmpdir
     end
-  end
-
-  before(:each) do
-    stub_const('BoltServer::TransportApp::DEFAULT_BOLT_CODEDIR', basedir)
   end
 
   it 'responds ok' do


### PR DESCRIPTION
This commit updates the transport app and config classes used in bolt-server
to allow the codedir for environments to be configurable.

Three new conf settings have been added:

environments-codedir
environmentpath
basemodulepath