### PR TITLE
(maint) Disable apply acceptance tests on Debian 8, enable on macOS 1015

### DIFF
--- a/acceptance/tests/apply_plan_ssh.rb
+++ b/acceptance/tests/apply_plan_ssh.rb
@@ -7,7 +7,7 @@ test_name "bolt plan run should apply manifest block on remote hosts via ssh" do
   extend Acceptance::BoltCommandHelper
 
   ssh_nodes = select_hosts(roles: ['ssh'])
-  skip_targets = select_hosts(platform: [/osx-10.15/])
+  skip_targets = select_hosts(platform: [/debian-8/])
   targets = "ssh_nodes"
   if skip_targets.any?
     ssh_nodes -= skip_targets

--- a/acceptance/tests/bolt_apply.rb
+++ b/acceptance/tests/bolt_apply.rb
@@ -11,7 +11,7 @@ test_name "bolt apply should apply manifest block on remote hosts via ssh and wi
   targets = ssh_nodes + winrm_nodes
 
   # the puppet_agent::install task does not support osx1015 yet, so skip those hosts if present
-  targets -= select_hosts(platform: [/osx-10.15/])
+  targets -= select_hosts(platform: [/debian-8/])
 
   skip_test('no applicable nodes to test on') if targets.empty?
 


### PR DESCRIPTION
This disables apply acceptance tests on Debian 8, as puppet7 packages
are not available for this platform and the tests install the latest
Puppet packages as part of `apply_prep`.

This enables apply acceptance tests for macOS 10.15, as packages for
that platform have been available for a while now.

!no-release-note