### PR TITLE
(PE-30638) Raise PluginNotSupported error for unsupported plugins

### DIFF
--- a/lib/bolt_server/plugin.rb
+++ b/lib/bolt_server/plugin.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'bolt/error'
+
+module BoltServer
+  class Plugin
+    class PluginNotSupported < Bolt::Error
+      def initialize(msg, plugin_name)
+        super(msg, 'bolt/plugin-not-supported', { "plugin_name" => plugin_name })
+      end
+    end
+  end
+end

--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -8,6 +8,7 @@ require 'bolt/inventory'
 require 'bolt/project'
 require 'bolt/target'
 require 'bolt_server/file_cache'
+require 'bolt_server/plugin'
 require 'bolt/task/puppet_server'
 require 'json'
 require 'json-schema'
@@ -655,16 +656,24 @@ module BoltServer
     # @param project_ref [String] the project_ref to compute the inventory from
     post '/project_inventory_targets' do
       return MISSING_PROJECT_REF_RESPONSE if params['project_ref'].nil?
-      bolt_config = config_from_project(params['project_ref'])
-      if bolt_config.inventoryfile && bolt_config.project.inventory_file.to_s != bolt_config.inventoryfile
-        raise Bolt::ValidationError, "Project inventory must be defined in the " \
-          "inventory.yaml file at the root of the project directory"
-      end
-      plugins = Bolt::Plugin.setup(bolt_config, nil)
-      inventory = Bolt::Inventory.from_config(bolt_config, plugins)
-      target_list = inventory.get_targets('all').map { |targ| targ.to_h.merge({ 'transport' => targ.transport }) }
+      in_bolt_project(params['project_ref']) do |context|
+        if context[:config].inventoryfile &&
+           context[:config].project.inventory_file.to_s !=
+           context[:config].inventoryfile
+          raise Bolt::ValidationError, "Project inventory must be defined in the " \
+            "inventory.yaml file at the root of the project directory"
+        end
+        begin
+          plugins = Bolt::Plugin.setup(context[:config], context[:pal], load_plugins: false)
+          inventory = Bolt::Inventory.from_config(context[:config], plugins)
+          target_list = inventory.get_targets('all').map { |targ| targ.to_h.merge({ 'transport' => targ.transport }) }
+        rescue Bolt::Plugin::PluginError::LoadingDisabled => e
+          msg = "Cannot load plugin #{e.details['plugin_name']}: plugin not supported"
+          raise BoltServer::Plugin::PluginNotSupported.new(msg, e.details['plugin_name'])
+        end
 
-      [200, target_list.to_json]
+        [200, target_list.to_json]
+      end
     rescue Bolt::Error => e
       [500, e.to_json]
     end

--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -285,8 +285,6 @@ module BoltServer
           config: bolt_config
         }
         yield context
-      rescue Bolt::Error => e
-        [400, e.to_json]
       end
     end
 
@@ -521,6 +519,8 @@ module BoltServer
         plan_info = allowed_helper(plan_info, context[:config].project.plans)
         [200, plan_info.to_json]
       end
+    rescue Bolt::Error => e
+      [400, e.to_json]
     end
 
     # Fetches the metadata for a single task
@@ -549,6 +549,8 @@ module BoltServer
         task_info = allowed_helper(task_info, context[:config].project.tasks)
         [200, task_info.to_json]
       end
+    rescue Bolt::Error => e
+      [400, e.to_json]
     end
 
     # Fetches the list of plans for an environment, optionally fetching all metadata for each plan
@@ -592,6 +594,8 @@ module BoltServer
         # to bolt-server smaller/simpler.
         [200, plans_response.to_json]
       end
+    rescue Bolt::Error => e
+      [400, e.to_json]
     end
 
     # Fetches the list of tasks for an environment
@@ -626,6 +630,8 @@ module BoltServer
         # to bolt-server smaller/simpler.
         [200, tasks_response.to_json]
       end
+    rescue Bolt::Error => e
+      [400, e.to_json]
     end
 
     # Implements puppetserver's file_metadatas endpoint for projects.
@@ -638,6 +644,8 @@ module BoltServer
         metadatas = file_metadatas(context[:pal], params[:module_name], file)
         [200, metadatas.to_json]
       end
+    rescue Bolt::Error => e
+      [400, e.to_json]
     rescue ArgumentError => e
       [400, e.message]
     end

--- a/spec/bolt_server/transport_app_spec.rb
+++ b/spec/bolt_server/transport_app_spec.rb
@@ -847,6 +847,53 @@ describe "BoltServer::TransportApp" do
         end
       end
 
+      context 'with unknown plugin' do
+        let(:targets) {
+          [{ 'name' => { '_plugin' => 'foo' } }]
+        }
+        it 'responds with a 500 and error details' do
+          with_project(bolt_project, bolt_inventory) do |path_to_tmp_project|
+            project_ref = path_to_tmp_project.split(File::SEPARATOR).last
+            post("/project_inventory_targets?project_ref=#{project_ref}")
+            expect(last_response.status).to eq(500)
+            error_hash = JSON.parse(last_response.body)
+            expect(error_hash['kind']).to eq('bolt/unknown-plugin')
+          end
+        end
+      end
+
+      context 'with disabled plugin in target list' do
+        let(:targets) {
+          [{ 'name' => { '_plugin' => 'prompt' } }]
+        }
+        it 'responds with a 500 and error details' do
+          with_project(bolt_project, bolt_inventory) do |path_to_tmp_project|
+            project_ref = path_to_tmp_project.split(File::SEPARATOR).last
+            post("/project_inventory_targets?project_ref=#{project_ref}")
+            expect(last_response.status).to eq(500)
+            error_hash = JSON.parse(last_response.body)
+            expect(error_hash['kind']).to eq('bolt/plugin-not-supported')
+            expect(error_hash.dig('details', 'plugin_name')).to eq('prompt')
+          end
+        end
+      end
+
+      context 'with disabled plugin in inventory config' do
+        let(:targets) {
+          [{ 'name' => 'foo', 'config' => { '_plugin' => 'prompt' } }]
+        }
+        it 'responds with a 500 and error details' do
+          with_project(bolt_project, bolt_inventory) do |path_to_tmp_project|
+            project_ref = path_to_tmp_project.split(File::SEPARATOR).last
+            post("/project_inventory_targets?project_ref=#{project_ref}")
+            expect(last_response.status).to eq(500)
+            error_hash = JSON.parse(last_response.body)
+            expect(error_hash['kind']).to eq('bolt/plugin-not-supported')
+            expect(error_hash.dig('details', 'plugin_name')).to eq('prompt')
+          end
+        end
+      end
+
       it 'disallows non-default inventoryfiles' do
         non_default_inventoryfile = 'foo.yaml'
         non_default_inventoryfile_conf = bolt_project.merge({ 'inventoryfile' => non_default_inventoryfile })


### PR DESCRIPTION
Update bolt-servers `project_inventory_targets` to raise informative errors when unsupported or unknown plugins are encountered in a project's inventoryfile.
