### PR TITLE
(bug) Add 'notice' log level to schema and deprecate

### DIFF
--- a/documentation/developer_updates.md
+++ b/documentation/developer_updates.md
@@ -158,6 +158,12 @@ compiled a list of expected changes and removals.
   non-default inventory file for a single run. However, there is little value in
   configuring a permanent non-default inventoryfile for a project.
 
+- **`notice` log level will be removed**
+
+  The `notice` log level has already been soft-deprecated. Bolt does not log
+  any messages at this level. Messages logged in apply blocks using the `notice()`
+  function are logged by Bolt at the `info` level.
+
 #### Updating your project
 
 While some of these changes will require you to manually update files, others

--- a/documentation/templates/bolt_configuration_reference.md.erb
+++ b/documentation/templates/bolt_configuration_reference.md.erb
@@ -11,7 +11,7 @@ The `bolt.yaml` configuration file is supported in all [project directories](con
 ## Options
 
 <% @opts.each do |option, data| -%>
-### <% if data.key?(:_deprecation) %>⛔<% end %> `<%= option %>`
+### <% if data.key?(:_deprecation) %>⛔ <% end %>`<%= option %>`
 
 <% if data.key?(:_deprecation) -%>
 _This option is deprecated. <%= data[:_deprecation] %>_

--- a/documentation/templates/bolt_defaults_reference.md.erb
+++ b/documentation/templates/bolt_defaults_reference.md.erb
@@ -6,7 +6,7 @@ which is supported in both the [system-wide and user-level configuration directo
 ## Options
 
 <% @opts.each do |option, data| -%>
-### <% if data.key?(:_deprecation) %>⛔<% end %> `<%= option %>`
+### <% if data.key?(:_deprecation) %>⛔ <% end %>`<%= option %>`
 
 <% if data.key?(:_deprecation) -%>
 _This option is deprecated. <%= data[:_deprecation] %>_

--- a/documentation/templates/bolt_project_reference.md.erb
+++ b/documentation/templates/bolt_project_reference.md.erb
@@ -6,7 +6,7 @@ For more information, see [Configuring Bolt](configuring_bolt.md).
 ## Options
 
 <% @opts.each do |option, data| -%>
-### <% if data.key?(:_deprecation) %>⛔<% end %> `<%= option %>`
+### <% if data.key?(:_deprecation) %>⛔ <% end %>`<%= option %>`
 
 <% if data.key?(:_deprecation) -%>
 _This option is deprecated. <%= data[:_deprecation] %>_

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -448,9 +448,17 @@ module Bolt
             raise Bolt::ValidationError,
                   "level of log #{name} must be a String or Symbol, received #{v.class} #{v.inspect}"
           end
+
           unless Bolt::Logger.valid_level?(v)
             raise Bolt::ValidationError,
                   "level of log #{name} must be one of #{Bolt::Logger.levels.join(', ')}; received #{v}"
+          end
+
+          if v == 'notice'
+            @deprecations << {
+              type: 'notice log level',
+              msg:  "Log level 'notice' is deprecated and will be removed in Bolt 3.0. Use 'info' instead."
+            }
           end
         end
 

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -207,7 +207,7 @@ module Bolt
                 "level" => {
                   description: "The type of information to log.",
                   type: String,
-                  enum: %w[trace debug error info warn fatal any],
+                  enum: %w[trace debug error info notice warn fatal any],
                   _default: "warn"
                 }
               }
@@ -226,7 +226,7 @@ module Bolt
               "level" => {
                 description: "The type of information to log.",
                 type: String,
-                enum: %w[trace debug error info warn fatal any],
+                enum: %w[trace debug error info notice warn fatal any],
                 _default: "warn"
               }
             }

--- a/rakelib/docs.rake
+++ b/rakelib/docs.rake
@@ -176,6 +176,10 @@ begin
       # 'console' and filepath
       @opts['log'][:properties] = @opts['log'][:additionalProperties][:properties]
 
+      # Remove 'notice' log level. This is soft-deprecated and shouldn't appear
+      # in documentation.
+      @opts['log'][:properties]['level'][:enum].delete('notice')
+
       # Stringify data types
       @opts.transform_values! { |data| stringify_types(data) }
       @inventory.transform_values! { |data| stringify_types(data) }
@@ -199,6 +203,14 @@ begin
       @opts       = Bolt::Config::OPTIONS.slice(*Bolt::Config::BOLT_DEFAULTS_OPTIONS)
       inventory   = Bolt::Config::INVENTORY_OPTIONS.dup
       @transports = Bolt::Config::TRANSPORT_CONFIG.keys
+
+      # Move sub-options for 'log' option up one level, as they're nested under
+      # 'console' and filepath
+      @opts['log'][:properties] = @opts['log'][:additionalProperties][:properties]
+
+      # Remove 'notice' log level. This is soft-deprecated and shouldn't appear
+      # in documentation.
+      @opts['log'][:properties]['level'][:enum].delete('notice')
 
       # Stringify data types
       @opts.transform_values! { |data| stringify_types(data) }
@@ -410,6 +422,10 @@ begin
       # Move sub-options for 'log' option up one level, as they're nested under
       # 'console' and filepath
       @opts['log'][:properties] = @opts['log'][:additionalProperties][:properties]
+
+      # Remove 'notice' log level. This is soft-deprecated and shouldn't appear
+      # in documentation.
+      @opts['log'][:properties]['level'][:enum].delete('notice')
 
       # Stringify data types
       @opts.transform_values! { |data| stringify_types(data) }

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -151,6 +151,7 @@
                 "debug",
                 "error",
                 "info",
+                "notice",
                 "warn",
                 "fatal",
                 "any"
@@ -181,6 +182,7 @@
               "debug",
               "error",
               "info",
+              "notice",
               "warn",
               "fatal",
               "any"

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -114,6 +114,7 @@
                 "debug",
                 "error",
                 "info",
+                "notice",
                 "warn",
                 "fatal",
                 "any"
@@ -144,6 +145,7 @@
               "debug",
               "error",
               "info",
+              "notice",
               "warn",
               "fatal",
               "any"

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -142,6 +142,7 @@
                 "debug",
                 "error",
                 "info",
+                "notice",
                 "warn",
                 "fatal",
                 "any"
@@ -172,6 +173,7 @@
               "debug",
               "error",
               "info",
+              "notice",
               "warn",
               "fatal",
               "any"

--- a/spec/integration/config/validator_spec.rb
+++ b/spec/integration/config/validator_spec.rb
@@ -102,7 +102,7 @@ describe 'validating config' do
           /Value at 'color' must be of type Boolean/,
           /Value at 'compile-concurrency' must be a minimum of 1/,
           /Value at 'format' must be one of human, json, rainbow/,
-          /Value at 'log.warn.log.level' must be one of trace, debug, error, info, warn, fatal, any/,
+          /Value at 'log.warn.log.level' must be one of/,
           /Value at 'log.warn.log.append' must be of type Boolean/,
           /Value at 'log.bolt-debug.log' must be disable or must be of type Hash/,
           /Value at 'modulepath' is a plugin reference, which is unsupported at this location/,


### PR DESCRIPTION
This adds the `notice` log level back to the config schema, which was
removed in #2098. Because we now use the schema for config validation,
the absence of `notice` as a valid option resulted in Bolt raising an
error for any user that had that log level configured. Now, Bolt will
instead issue a deprecation warning that the log level is deprecated and
will be removed in 3.0.

!bug

* **Support `notice` log level**

  Log levels can now be set to `notice`. Previously, Bolt would raise an
  error saying that `notice` was not a supported log level.

!deprecation

* **Deprecate `notice` log level**

  The `notice` log level is deprecated and will be removed in Bolt 3.0.
  Use the `info` log level instead.