### PR TITLE
(GH-2109) Document running multiline commands against Network devices

### DIFF
--- a/documentation/applying_manifest_blocks.md
+++ b/documentation/applying_manifest_blocks.md
@@ -490,32 +490,7 @@ Create a manifest that sets up a web server with IIS and run it as a plan.
 - [Specify targets](running_bolt_commands.md#adding-options-to-bolt-commands)
 - [Bolt projects](projects.md)
 
-## 🧪 Using Puppet device modules from an apply statement
-
-🧪 **Note:** Support for device modules is experimental and might change in
-future minor (y) releases.
-
-Puppet device modules based on remote transports allow network devices and other
-targets that can't run a Puppet agent to be managed from a proxy.
-
-To use device modules from an apply statement, the devices must be added to the
-Bolt inventory as remote targets. The `name` of the target will be used to
-auto-populate the `name`, `uri`, `user`, `password`, `host`, and `port` fields
-of the remote transport's connection info. You must set the `remote-transport`
-option and any other connection info under the `remote` section of config.
-
-```yaml
-targets:
-  - name: "https://username:password@panos-device.example.com"
-    config:
-      transport: remote
-      remote:
-        remote-transport: panos
-```
-
-When you set the `run-on` option with a device module, the `puppet-resource_api`
-Gem must be installed with the Puppet agent on the proxy target and it must be
-version 1.8.1 or later.
-
 📖 **Related information**
 - For information on how Bolt loads the modulepath, see [Modules overview](modules.md#modulepath).
+- To learn more about using Puppet device modules, see [Running Bolt on network
+  devices](running_bolt_networkd.md#-using-puppet-device-modules-from-an-apply-block)

--- a/documentation/bolt.ditamap
+++ b/documentation/bolt.ditamap
@@ -20,7 +20,18 @@
         <topicref href="privilege_escalation.md" format="markdown"/>
         <topicref href="vscode_and_bolt.md" format="markdown"/>
     </topichead>
-    <topicref href="running_bolt_commands.md" format="markdown" linking="targetonly"/>
+    <topicref href="running_bolt.md" format="markdown" navtitle="Running Bolt" locktitle="yes">
+      <topicref href="running_bolt_commands.md" format="markdown">
+        <topicmeta>
+          <shortdesc>How Bolt commands are constructed, and what they can do</shortdesc>
+        </topicmeta>
+      </topicref>
+      <topicref href="running_bolt_network.md" format="markdown">
+        <topicmeta>
+          <shortdesc>Tips for running Bolt when targetting network devices</shortdesc>
+        </topicmeta>
+      </topicref>
+    </topicref>
     <topicref href="plans.md" format="markdown" navtitle="Plans" locktitle="yes">
         <topicref href="inspecting_plans.md" format="markdown">
             <topicmeta>

--- a/documentation/bolt.ditamap
+++ b/documentation/bolt.ditamap
@@ -20,18 +20,18 @@
         <topicref href="privilege_escalation.md" format="markdown"/>
         <topicref href="vscode_and_bolt.md" format="markdown"/>
     </topichead>
-    <topicref href="running_bolt.md" format="markdown" navtitle="Running Bolt" locktitle="yes">
+    <topichead navtitle="Running Bolt">
       <topicref href="running_bolt_commands.md" format="markdown">
         <topicmeta>
-          <shortdesc>How Bolt commands are constructed, and what they can do</shortdesc>
+          <shortdesc>How to construct and run Bolt commands.</shortdesc>
         </topicmeta>
       </topicref>
       <topicref href="running_bolt_network.md" format="markdown">
         <topicmeta>
-          <shortdesc>Tips for running Bolt when targetting network devices</shortdesc>
+          <shortdesc>Tips for running Bolt when targeting network devices</shortdesc>
         </topicmeta>
       </topicref>
-    </topicref>
+    </topichead>
     <topicref href="plans.md" format="markdown" navtitle="Plans" locktitle="yes">
         <topicref href="inspecting_plans.md" format="markdown">
             <topicmeta>

--- a/documentation/running_bolt.md
+++ b/documentation/running_bolt.md
@@ -1,8 +1,0 @@
-# Run Bolt
-
-You can use Bolt commands to connect to remote targets and perform actions on
-them. These actions range in complexity from invoking a simple command to
-running a series of commands and tasks as part of an orchestration workflow. 
-
-For a full list of available Bolt commands, see the [Bolt command
-reference](bolt_command_reference.md).

--- a/documentation/running_bolt.md
+++ b/documentation/running_bolt.md
@@ -1,0 +1,8 @@
+# Run Bolt
+
+You can use Bolt commands to connect to remote targets and perform actions on
+them. These actions range in complexity from invoking a simple command to
+running a series of commands and tasks as part of an orchestration workflow. 
+
+For a full list of available Bolt commands, see the [Bolt command
+reference](bolt_command_reference.md).

--- a/documentation/running_bolt_commands.md
+++ b/documentation/running_bolt_commands.md
@@ -1,6 +1,6 @@
-# Run commands on remote targets
+# Run Bolt
 
-You can use Bolt commands to connect to remote targets and perform actions on
+You can use Bolt commands to connect to targets and perform actions on
 them. These actions range in complexity from invoking a simple command to
 running a series of commands and tasks as part of an orchestration workflow. 
 
@@ -9,7 +9,7 @@ reference](bolt_command_reference.md).
 
 ## Run a command
 
-Bolt can run arbitrary commands on remote targets. To run a command, provide a
+Bolt can run arbitrary commands on targets. To run a command, provide a
 command and a list of targets to run the command on.
 
 _\*nix shell command_

--- a/documentation/running_bolt_commands.md
+++ b/documentation/running_bolt_commands.md
@@ -298,15 +298,14 @@ Invoke-BoltCommand -Command 'Get-Location' -Targets windows.example.org -Transpo
 
 ## Run a script
 
-When you run a script on a remote target, Bolt copies the script from your
-workstation to a temporary directory on the target, runs the script, and then
-deletes the script from the target.
+When you run a script on a target Bolt copies the script from your
+Bolt controller to a temporary directory on the target, runs the script, and then
+deletes the script from the temporary directory.
 
 You can run scripts in any language, as long as the appropriate interpreter is
-installed on the remote system. This includes scripting languages such as Bash,
-PowerShell, Python, and Ruby.
+installed on the system. This includes any scripting language the system can run.
 
-To run a script, provide the path to the script on the workstation and a list of
+To run a script, provide the path to the script on the Bolt controller and a list of
 targets to run the script on.
 
 _\*nix shell command_
@@ -324,7 +323,7 @@ Invoke-BoltScript -Script ./scripts/configure.ps1 -Targets servers
 ### Pass arguments to a script
 
 Argument values are passed literally and are not interpolated by the shell on
-the remote host.
+the target.
 
 _\*nix shell command_
 
@@ -494,9 +493,9 @@ Invoke-BoltPlan -Name reboot -Targets servers
 
 ## Upload a file or directory
 
-Bolt can copy files and directories from your workstation to remote targets. To
-upload a file or directory, provide the `source` path on your workstation, the
-`destination` path on the remote target that it should be copied to, and a
+Bolt can copy files and directories from your Bolt controller to targets. To
+upload a file or directory, provide the `source` path on your Bolt controller, the
+`destination` path on the target that it should be copied to, and a
 list of targets.
 
 Both the `source` and `destination` accept absolute and relative paths. If you
@@ -518,10 +517,10 @@ Send-BoltFile -Source /path/to/source -Destination /path/to/destination -Targets
 
 ## Download a file or directory
 
-Bolt can copy files and directories from remote targets to a destination
-directory on your workstation. To download a file or directory, provide the
-`source` path on the remote target, the path to the `destination` directory on
-the workstation, and a list of targets.
+Bolt can copy files and directories from targets to a destination
+directory on your Bolt controller. To download a file or directory, provide the
+`source` path on the target, the path to the `destination` directory on
+the Bolt controller, and a list of targets.
 
 Both the `source` and `destination` accept absolute and relative paths. If you
 provide a relative path as the `source`, Bolt will copy the file relative to the
@@ -540,7 +539,7 @@ _PowerShell cmdlet_
 Receive-BoltFile -Source /path/to/source -Destination /path/to/destination -Targets servers
 ```
 
-The `destination` on the workstation is a path to a directory that the downloaded
+The `destination` on the Bolt controller is a path to a directory that the downloaded
 file or directory is copied to. If the `destination` directory does not exist,
 Bolt will create it for you.
 

--- a/documentation/running_bolt_network.md
+++ b/documentation/running_bolt_network.md
@@ -1,14 +1,14 @@
-# Run Bolt on Network Devices
+# Run Bolt on network devices
 
 You can run Bolt commands that target network devices in order to configure, provision, and make
 other changes to those devices. However, interacting with network devices through Bolt can be
-different than interacting with other types of targets. These are some use cases and workflows that
-are useful when running against network devices.
+different than interacting with other types of targets. Here are some use cases and workflows that
+are useful when executing Bolt against network devices.
 
 ## Run multiline commands
 
-Files can't be written on certain devices, which prevents users from using `bolt script run` or
-`Invoke-BoltScript` to run multiline commands. With Bolt you can pass a file to `bolt command run`
+Because some devices don't allow you to write files, you might not be able to use `bolt script run`
+or `Invoke-BoltScript` to run multiline commands. Instead, you can pass a file to `bolt command run`
 or `Invoke-BoltCommand` in order to execute multiline commands.
 
 For example, the following file `configure-vap` configures two virtual access points on a Fortinet
@@ -18,7 +18,7 @@ device:
 config wireless-controller vap
     edit WMI
     set fast-roaming enable
-    set external-fast-roaming  disable
+    set external-fast-roaming disable
     set max-client 0
     set voice-enterprise enable
     set fast-bss-transition enable
@@ -26,13 +26,15 @@ config wireless-controller vap
 next
     edit WM-GUEST
     set fast-roaming enable
-    set external-fast-roaming  disable
+    set external-fast-roaming disable
     set max-client 0
     set broadcast-suppression dhcp-up dhcp-down dhcp-starvation arp-known arp-unknown arp-reply arp-poison arp-proxy netbios-ns netbios-ds ipv6 all-other-bc
 end
 ```
 
-With the file in the same directory Bolt is run from you can execute the configuration.
+### Execute from the Bolt CLI
+
+To run multiline commands from a file, run Bolt from the directory where the file exists:
 
 _\*nix shell command_
 
@@ -44,6 +46,16 @@ _PowerShell cmdlet_
 
 ```powershell
 Invoke-BoltCommand -Command '@configure-vap' -Targets servers
+```
+
+### Execute in a Bolt plan
+
+You can provide the absolute path to the file or the Puppet file path (`<mymodule>/<myfile>` for
+files stored in the `files/` directory of modules on the modulepath) to the `file::read()` plan
+function, and pass that output to the `run_command()` plan function.
+
+```
+run_command(file::read('/path/to/configure-vap'), $target)
 ```
 
 ## 🧪 Using Puppet network device modules from an apply block
@@ -60,7 +72,7 @@ managed from a proxy. Check out the [Puppet
 Forge](https://forge.puppet.com/modules?utf-8=%E2%9C%93&page_size=25&sort=rank&q=network&endorsements=partner+supported)
 to find an up to date list of modules for managing network devices.
 
-To use device modules from an apply statement, the devices must be added to the
+To use device modules from an apply statement, you must add the devices to the
 Bolt inventory as remote targets. The `name` of the target will be used to
 auto-populate the `name`, `uri`, `user`, `password`, `host`, and `port` fields
 of the remote transport's connection info. You must set the `remote-transport`

--- a/documentation/running_bolt_network.md
+++ b/documentation/running_bolt_network.md
@@ -1,0 +1,80 @@
+# Run Bolt on Network Devices
+
+You can run Bolt commands that target network devices in order to configure, provision, and make
+other changes to those devices. However, interacting with network devices through Bolt can be
+different than interacting with other types of targets. These are some use cases and workflows that
+are useful when running against network devices.
+
+## Run multiline commands
+
+Files can't be written on certain devices, which prevents users from using `bolt script run` or
+`Invoke-BoltScript` to run multiline commands. With Bolt you can pass a file to `bolt command run`
+or `Invoke-BoltCommand` in order to execute multiline commands.
+
+For example, the following file `configure-vap` configures two virtual access points on a Fortinet
+device:
+
+```
+config wireless-controller vap
+    edit WMI
+    set fast-roaming enable
+    set external-fast-roaming  disable
+    set max-client 0
+    set voice-enterprise enable
+    set fast-bss-transition enable
+    set broadcast-suppression dhcp-up dhcp-down dhcp-starvation arp-known arp-unknown arp-reply arp-poison arp-proxy netbios-ns netbios-ds ipv6 all-other-bc
+next
+    edit WM-GUEST
+    set fast-roaming enable
+    set external-fast-roaming  disable
+    set max-client 0
+    set broadcast-suppression dhcp-up dhcp-down dhcp-starvation arp-known arp-unknown arp-reply arp-poison arp-proxy netbios-ns netbios-ds ipv6 all-other-bc
+end
+```
+
+With the file in the same directory Bolt is run from you can execute the configuration.
+
+_\*nix shell command_
+
+```shell
+bolt command run @configure-vap --targets servers
+```
+
+_PowerShell cmdlet_
+
+```powershell
+Invoke-BoltCommand -Command '@configure-vap' -Targets servers
+```
+
+## 🧪 Using Puppet network device modules from an apply block
+
+🧪 **Note:** Support for device modules is experimental and might change in
+future minor (y) releases.
+
+[Bolt plans](plans.md) can execute Puppet code from [apply
+blocks](applying_manifest_blocks#applying-manifest-blocks-from-a-puppet-plan), including applying
+classes from Puppet network device modules like the [PanOS
+module](https://forge.puppet.com/modules/puppetlabs/panos). Puppet device modules based on
+remote transports allow network devices and other targets that can't run a Puppet agent to be
+managed from a proxy. Check out the [Puppet
+Forge](https://forge.puppet.com/modules?utf-8=%E2%9C%93&page_size=25&sort=rank&q=network&endorsements=partner+supported)
+to find an up to date list of modules for managing network devices.
+
+To use device modules from an apply statement, the devices must be added to the
+Bolt inventory as remote targets. The `name` of the target will be used to
+auto-populate the `name`, `uri`, `user`, `password`, `host`, and `port` fields
+of the remote transport's connection info. You must set the `remote-transport`
+option and any other connection info under the `remote` section of config.
+
+```yaml
+targets:
+  - name: "https://username:password@panos-device.example.com"
+    config:
+      transport: remote
+      remote:
+        remote-transport: panos
+```
+
+When you set the `run-on` option with a device module, the `puppet-resource_api`
+Gem must be installed with the Puppet agent on the proxy target and it must be
+version 1.8.1 or later.


### PR DESCRIPTION
This adds a new document with information specifically helpful to
running Bolt when targetting network devices. For now I opted to just
include running mulitline commands using `@file`, and expect we will
build this file up as more use cases arise. The example demonstrates
configuring a virtual access point for a Fortinet device.

This also moves the documentation for using network device modules from
the 'Applying Puppet code' document to the new network device document,
and includes a 'Related Information' link on the 'Applying Puppet code'
page.

Closes #2109

!no-release-note