### PR TITLE
(PE-30716) raise error when inventory file is absent

### DIFF
--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -663,6 +663,9 @@ module BoltServer
           raise Bolt::ValidationError, "Project inventory must be defined in the " \
             "inventory.yaml file at the root of the project directory"
         end
+
+        Bolt::Util.validate_file('inventory file', context[:config].project.inventory_file)
+
         begin
           plugins = Bolt::Plugin.setup(context[:config], context[:pal], load_plugins: false)
           inventory = Bolt::Inventory.from_config(context[:config], plugins)

--- a/spec/bolt_server/transport_app_spec.rb
+++ b/spec/bolt_server/transport_app_spec.rb
@@ -847,6 +847,18 @@ describe "BoltServer::TransportApp" do
         end
       end
 
+      context 'when inventory file is absent' do
+        it 'responds with a 500 and error details' do
+          with_project(bolt_project, nil) do |path_to_tmp_project|
+            project_ref = path_to_tmp_project.split(File::SEPARATOR).last
+            post("/project_inventory_targets?project_ref=#{project_ref}")
+            expect(last_response.status).to eq(500)
+            error_hash = JSON.parse(last_response.body)
+            expect(error_hash['kind']).to eq('bolt/file-error')
+          end
+        end
+      end
+
       context 'with unknown plugin' do
         let(:targets) {
           [{ 'name' => { '_plugin' => 'foo' } }]


### PR DESCRIPTION
Prior to this commit, an error was raised upon inventory sync for
inventory files that were in a non-standard location, but projects
that did not contain an inventory file returned a 200. This commit
also adds a check for the presense of the inventory file.

!no-release-note