### PR TITLE
Add puppet_connect_data plugin for bolt_server

### DIFF
--- a/lib/bolt_server/plugin/puppet_connect_data.rb
+++ b/lib/bolt_server/plugin/puppet_connect_data.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module BoltServer
+  class Plugin
+    class PuppetConnectData
+      def initialize(data, **_opts)
+        @data = data
+      end
+
+      def name
+        'puppet_connect_data'
+      end
+
+      def hooks
+        %i[resolve_reference validate_resolve_reference]
+      end
+
+      def resolve_reference(opts)
+        key = opts['key']
+
+        @data.dig(key, 'value')
+      end
+
+      def validate_resolve_reference(opts)
+        unless opts['key']
+          raise Bolt::ValidationError,
+                "puppet_connect_data plugin requires that 'key' be specified"
+        end
+
+        unless @data.key?(opts['key'])
+          raise Bolt::ValidationError,
+                "puppet_connect_data plugin tried to lookup key '#{opts['key']}' but no value was found"
+        end
+      end
+    end
+  end
+end

--- a/spec/bolt_server/plugin/puppet_connect_data_spec.rb
+++ b/spec/bolt_server/plugin/puppet_connect_data_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'bolt_server/plugin/puppet_connect_data'
+require 'spec_helper'
+
+describe BoltServer::Plugin::PuppetConnectData do
+  let(:data) do
+    { 'mykey' => { 'value' => 'somevalue' } }
+  end
+
+  subject { described_class.new(data) }
+  context 'initializing the plugin' do
+    it 'defines the correct plugin name' do
+      expect(subject.name).to eq('puppet_connect_data')
+    end
+
+    it 'defines resolve_reference hooks' do
+      expect(subject.hooks).to include(:resolve_reference, :validate_resolve_reference)
+    end
+  end
+
+  context 'validating references' do
+    it 'fails if no key is specified' do
+      reference = { '_plugin' => 'puppet_connect_data' }
+      expect { subject.validate_resolve_reference(reference) }.to raise_error(
+        Bolt::ValidationError, /requires.*key/
+      )
+    end
+
+    it 'fails if no value exists for the key' do
+      reference = { '_plugin' => 'puppet_connect_data', 'key' => 'nosuchkey' }
+      expect { subject.validate_resolve_reference(reference) }.to raise_error(
+        Bolt::ValidationError, /tried to lookup key 'nosuchkey'/
+      )
+    end
+
+    it 'succeeds if a value exists for the key' do
+      reference = { '_plugin' => 'puppet_connect_data', 'key' => 'mykey' }
+      expect { subject.validate_resolve_reference(reference) }.not_to raise_error
+    end
+  end
+
+  context 'looking up data' do
+    it 'returns the "value" field for the key' do
+      reference = { '_plugin' => 'puppet_connect_data', 'key' => 'mykey' }
+      expect(subject.resolve_reference(reference)).to eq('somevalue')
+    end
+  end
+end


### PR DESCRIPTION
This adds a basic implementation of the puppet_connect_data plugin that
takes a data hash and looks up keys in the hash. The data is expected to
be supplied as a map in the following structure:

    {
      "key1": {
        "value": "value1"
      },
      "key2": {
        "value": "value2"
      }
    }

The plugin will fail if no value is supplied for the key. It
specifically does *not* validate that each value map has a 'value' key,
as that validation should be done prior to passing the value to the
plugin constructor.

Currently, this plugin is not loaded anywhere.