### PR TITLE
(bug) Validate groups are an Array

### DIFF
--- a/lib/bolt/inventory/group.rb
+++ b/lib/bolt/inventory/group.rb
@@ -68,7 +68,7 @@ module Bolt
         # though, since that will resolve any nested references and we want to
         # leave it to the group to do that lazily.
         groups = @plugins.resolve_top_level_references(groups)
-
+        raise ValidationError.new("Groups must be an Array", nil) unless groups.is_a?(Array)
         @groups = Array(groups).map { |g| Group.new(g, plugins) }
       end
 

--- a/spec/bolt/inventory/group_spec.rb
+++ b/spec/bolt/inventory/group_spec.rb
@@ -469,6 +469,11 @@ describe Bolt::Inventory::Group do
       data['plugin_hooks'] = 'puppet_library'
       expect { group }.to raise_error(/Expected plugin_hooks to be of type Hash/)
     end
+
+    it 'fails if plugin_hooks is not a hash' do
+      data['groups'] = { 'forgot' => 'to make this a single element list' }
+      expect { group }.to raise_error(/Groups must be an Array/)
+    end
   end
 
   describe 'with aliases' do


### PR DESCRIPTION
After accidentally declaring a single element `group` as a Hash instead of a single element Array, The stack trace that resulted was difficult to troubleshoot. This commit adds validation that groups are always arrays.

!bug

* **Validate inventory groups are Arrays**
    Raise a validation error when a group resolves to a data structure other than an Array instead.