### PR TITLE
Specify puppet6 collection when defaulting version to 6.2.0

### DIFF
--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -104,7 +104,7 @@ describe "apply", expensive: true do
           'puppet_library' => {
             'plugin' => 'task',
             'task' => 'puppet_agent::install',
-            'parameters' => { 'version' => '6.2.0' }
+            'parameters' => { 'collection' => 'puppet6', 'version' => '6.2.0' }
           }
         }
       }],


### PR DESCRIPTION
These tests set the default puppet version for the puppet_library hook
to 6.2.0 but don't set the default collection to puppet6 accordingly.
Now that the default collection 'puppet' points to puppet7, installing
the package fails. We now set the collection to match the version
explicitly.

!no-release-note