### PR TITLE
(maint) Fix broken apply integration tests

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -33,5 +33,8 @@ jobs:
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3
+      - name: Update gems
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: bundle update
       - name: Generate docs
         run: bundle exec rake docs:all

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -37,6 +37,9 @@ jobs:
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3
+      - name: Update gems
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: bundle update
       - name: Pre-test setup
         run: |
           echo 'runner:runner' | sudo chpasswd
@@ -72,6 +75,9 @@ jobs:
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3
+      - name: Update gems
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: bundle update
       - name: Pre-test setup
         run: |
           docker-compose -f spec/docker-compose.yml build --parallel

--- a/.github/workflows/modules.yaml
+++ b/.github/workflows/modules.yaml
@@ -36,6 +36,9 @@ jobs:
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3
+      - name: Update gems
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: bundle update
       - name: Run module tests
         run: bundle exec rake ci:modules
 
@@ -64,5 +67,8 @@ jobs:
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3
+      - name: Update gems
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: bundle update
       - name: Run module tests
         run: bundle exec rake ci:modules

--- a/.github/workflows/schemas.yaml
+++ b/.github/workflows/schemas.yaml
@@ -41,6 +41,9 @@ jobs:
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3
+      - name: Update gems
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: bundle update
       - name: Generate schemas
         run: bundle exec rake schemas:all
       - name: Compare changes

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -44,6 +44,9 @@ jobs:
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3
+      - name: Update gems
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: bundle update
       - name: Cache modules
         id: modules
         uses: actions/cache@v1
@@ -87,6 +90,9 @@ jobs:
       - name: Install gems
         if: steps.cache.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3
+      - name: Update gems
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: bundle update
       - name: Cache modules
         id: modules
         uses: actions/cache@v1

--- a/spec/Dockerfile
+++ b/spec/Dockerfile
@@ -1,5 +1,4 @@
-# Travis not using 18.04 yet
-FROM rastasheep/ubuntu-sshd:16.04
+FROM rastasheep/ubuntu-sshd:18.04
 RUN apt-get update && apt-get -y install sudo tree locales apt-transport-https
 RUN locale-gen en_US.UTF-8
 

--- a/spec/docker-compose.yml
+++ b/spec/docker-compose.yml
@@ -18,6 +18,12 @@ services:
       - ubuntu_node
     ports:
       - "20024:22"
+  puppet_7_node:
+    image: bolt-spec
+    depends_on:
+      - ubuntu_node
+    ports:
+      - "20025:22"
 
   postgres:
     image: postgres:9.6

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -4,178 +4,93 @@ require 'spec_helper'
 require 'bolt_spec/conn'
 require 'bolt_spec/files'
 require 'bolt_spec/integration'
+require 'bolt_spec/project'
 require 'bolt_spec/puppet_agent'
 require 'bolt_spec/run'
 
-describe "apply", expensive: true do
+TEST_VERSIONS = [
+  [5, 'puppet5'],
+  [6, 'puppet6'],
+  [7, 'puppet']
+].freeze
+
+describe 'apply', expensive: true do
   include BoltSpec::Conn
-  include BoltSpec::Files
   include BoltSpec::Integration
+  include BoltSpec::Project
   include BoltSpec::PuppetAgent
   include BoltSpec::Run
 
-  let(:modulepath) { File.join(__dir__, '../fixtures/apply') }
-  let(:hiera_config) { File.join(__dir__, '../fixtures/configs/empty.yml') }
-  let(:config_flags) { %W[--format json --targets #{uri} --password #{password} --modulepath #{modulepath}] + tflags }
-  let(:apply_settings) { { 'show_diff' => true } }
+  let(:project_config) do
+    {
+      'apply_settings' => { 'show_diff' => true },
+      'hiera-config'   => File.join(__dir__, '../fixtures/configs/empty.yml'),
+      'modulepath'     => File.join(__dir__, '../fixtures/apply')
+    }
+  end
+
+  # The following are run with both *nix and Windows targets.
+  shared_examples 'agentful tests' do |targets|
+    it 'runs a ruby task' do
+      results = run_cli_json(%W[task run basic::ruby_task -t #{targets}], project: project)
+
+      results['items'].each do |result|
+        expect(result).to include('status' => 'success')
+        expect(result['value']).to eq('ruby' => 'Hi')
+      end
+    end
+
+    it 'runs an apply plan' do
+      results = run_cli_json(%W[plan run basic::notify -t #{targets}], project: project)
+
+      results.each do |result|
+        expect(result).to include('status' => 'success')
+        expect(result.dig('value', 'report', 'resource_statuses')).to include("Notify[Apply: Hi!]")
+      end
+    end
+
+    it 'succeeds with an empty hiera config' do
+      results = run_cli_json(%W[plan run prep -t #{targets}], project: project)
+
+      results.each do |result|
+        expect(result['status']).to eq('success')
+        expect(result.dig('value', 'report', 'resource_statuses')).to include(/Notify\[Hello .*\]/)
+      end
+    end
+  end
 
   describe 'over ssh', ssh: true do
-    let(:uri) { conn_uri('ssh') }
-    let(:user) { conn_info('winrm')[:user] }
+    let(:uri)      { conn_uri('ssh') }
+    let(:user)     { conn_info('ssh')[:user] }
     let(:password) { conn_info('ssh')[:password] }
-    let(:tflags) { %W[--no-host-key-check --run-as root --sudo-password #{password}] }
 
-    def root_config
-      { 'modulepath' => File.join(__dir__, '../fixtures/apply') }
-    end
-
-    def agent_version_inventory
-      inventory = docker_inventory(root: true)
-      inventory['groups'] << {
-        'name' => 'agent_targets',
-        'groups' => [
-          { 'name' => 'puppet_5',
-            'targets' => ['puppet_5_node'] },
-          { 'name' => 'puppet_6',
-            'targets' => ['puppet_6_node'] }
-        ]
-      }
-      inventory
-    end
-
-    def lib_plugin_inventory
-      { 'targets' => [{
-        'uri' => conn_uri('ssh'),
-        'plugin_hooks' => {
-          'puppet_library' => {
-            'plugin' => 'puppet_agent'
-          }
-        }
-      }] }
-    end
-
-    def error_plugin_inventory
-      { 'targets' => [{
-        'uri' => conn_uri('ssh'),
-        'name' => 'error',
-        'plugin_hooks' => {
-          'puppet_library' => {
-            'plugin' => 'task',
-            'task' => 'prep::error'
-          }
-        }
-      }, {
-        'uri' => conn_uri('ssh'),
-        'name' => 'success',
-        'plugin_hooks' => {
-          'puppet_library' => {
-            'plugin' => 'puppet_agent'
-          }
-        }
-      }, {
-        # These fail the puppet_agent::version check if they're fake. Seems
-        # like more effort than it's worth to mock them
-        'uri' => conn_uri('ssh'),
-        'name' => 'badparams',
-        'plugin_hooks' => {
-          'puppet_library' => {
-            'plugin' => 'task',
-            'task' => 'puppet_agent::install',
-            'parameters' => {
-              'collection' => 'The act or process of collecting.'
-            }
-          }
-        }
-      }, {
-        'uri' => conn_uri('ssh'),
-        'name' => 'badplugin',
-        'plugin_hooks' => {
-          'puppet_library' => {
-            'plugin' => 'what plugin?'
-          }
-        }
-      }] }
-    end
-
-    def task_plugin_inventory
-      { 'targets' => [{
-        'uri' => conn_uri('ssh'),
-        'plugin_hooks' => {
-          'puppet_library' => {
-            'plugin' => 'task',
-            'task' => 'puppet_agent::install',
-            'parameters' => { 'version' => '6.2.0' }
-          }
-        }
-      }],
-        'config' => root_config }
-    end
-
-    after(:all) do
-      ssh_node = conn_uri('ssh', include_password: true)
-      uninstall([ssh_node, 'agent_targets'], inventory: agent_version_inventory)
-    end
-
-    context "when running against puppet 5 or puppet 6" do
+    # Run tests that require the puppet-agent package to be installed on the target.
+    # Each test is run against all agent targets unless otherwise noted.
+    context 'with puppet installed' do
+      # Install agents on the agent targets.
       before(:all) do
-        # install puppet5
-        install('puppet_5', collection: 'puppet5', inventory: agent_version_inventory)
-
-        result = run_task('puppet_agent::version', 'puppet_5', {}, inventory: agent_version_inventory)
-        expect(result.count).to eq(1)
-        expect(result[0]).to include('status' => 'success')
-        expect(result[0]['value']['version']).to match(/^5/)
-
-        # install puppet6
-        result = run_task('puppet_agent::install', 'puppet_6', { 'collection' => 'puppet6' },
-                          config: root_config, inventory: agent_version_inventory)
-        expect(result.count).to eq(1)
-        expect(result[0]).to include('status' => 'success')
-
-        result = run_task('puppet_agent::version', 'puppet_6', {}, inventory: agent_version_inventory)
-        expect(result.count).to eq(1)
-        expect(result[0]).to include('status' => 'success')
-        expect(result[0]['value']['version']).to match(/^6/)
-      end
-
-      it 'runs a ruby task' do
-        with_tempfile_containing('inventory', YAML.dump(agent_version_inventory), '.yaml') do |inv|
-          results = run_cli_json(%W[task run basic::ruby_task --targets agent_targets
-                                    --modulepath #{modulepath} --inventoryfile #{inv.path}])
-          results['items'].each do |result|
-            expect(result['status']).to eq('success')
-            expect(result['value']).to eq('ruby' => 'Hi')
-          end
+        TEST_VERSIONS.each do |version, collection|
+          install("puppet_#{version}_node", collection: collection, inventory: docker_inventory(root: true))
         end
       end
 
-      it 'runs an apply plan' do
-        with_tempfile_containing('inventory', YAML.dump(agent_version_inventory), '.yaml') do |inv|
-          results = run_cli_json(%W[plan run basic::notify --targets agent_targets
-                                    --modulepath #{modulepath} --inventoryfile #{inv.path}])
-          results.each do |result|
-            expect(result['status']).to eq('success')
-            report = result['value']['report']
-            expect(report['resource_statuses']).to include("Notify[Apply: Hi!]")
-          end
+      # Set up a project directory for the tests. Include an inventory file so Bolt
+      # can actually connect to the targets.
+      around(:each) do |example|
+        with_project do
+          File.write(project.inventory_file, docker_inventory(root: true).to_yaml)
+          example.run
         end
       end
 
-      it 'succeeds with an empty hiera config' do
-        with_tempfile_containing('bolt', YAML.dump("hiera-config" => hiera_config), '.yaml') do |conf|
-          results = run_cli_json(%W[plan run prep --configfile #{conf.path}] + config_flags)
-          results.each do |result|
-            expect(result['status']).to eq('success')
-            report = result['value']['report']
-            expect(report['resource_statuses']).to include("Notify[Hello #{uri}]")
-          end
-        end
-      end
+      # Run shared tests against the 'nix_agents' group. This group is
+      # defined in inventory in BoltSpec::Conn.
+      include_examples 'agentful tests', 'nix_agents'
 
-      it 'gets resources' do
-        with_tempfile_containing('inventory', YAML.dump(agent_version_inventory), '.yaml') do |inv|
-          results = run_cli_json(%W[plan run basic::resources --targets agent_targets
-                                    --modulepath #{modulepath} --inventoryfile #{inv.path}])
+      context 'in an apply block' do
+        it 'gets resources' do
+          results = run_cli_json(%w[plan run basic::resources -t nix_agents], project: project)
+
           results.each do |result|
             expect(result['status']).to eq('success')
             resources = result['value']['resources']
@@ -184,86 +99,192 @@ describe "apply", expensive: true do
             expect(resources.select { |r| r['title'] == '/tmp' && r['type'] == 'File' }.count).to eq(1)
           end
         end
+
+        it 'errors when there are resource failures' do
+          result = run_cli_json(%w[plan run basic::failure -t nix_agents], project: project, rescue_exec: true)
+          expect(result).to include('kind' => 'bolt/apply-failure')
+          error = result['details']['result_set'][0]['value']['_error']
+          expect(error['kind']).to eq('bolt/resource-failure')
+          expect(error['msg']).to match(/Resources failed to apply/)
+        end
+
+        it 'applies a notify and ignores local settings' do
+          command = 'echo environment=doesnotexist > /etc/puppetlabs/puppet/puppet.conf'
+          run_cli_json(%W[command run #{command} -t nix_agents], project: project)
+
+          result = run_cli_json(%w[plan run basic::class -t nix_agents], project: project)
+          expect(result).not_to include('kind')
+          expect(result[0]).to include('status' => 'success')
+          expect(result[0]['value']['_output']).to eq('changed: 1, failed: 0, unchanged: 0 skipped: 0, noop: 0')
+          resources = result[0]['value']['report']['resource_statuses']
+          expect(resources).to include('Notify[hello world]')
+        end
+
+        it 'respects _run_as on a plan invocation' do
+          user = conn_info('ssh')[:user]
+          logs = run_cli_json(%W[plan run basic::run_as_apply user=#{user} -t nix_agents], project: project)
+          expect(logs.first['message']).to eq(conn_info('ssh')[:user])
+        end
+
+        it 'respects show_diff configuration' do
+          diff_string = <<~DIFF
+            @@ -1 +1 @@
+            -Silly string
+            \\ No newline at end of file
+            +Silly string (get it?)
+            \\ No newline at end of file
+          DIFF
+
+          results = run_cli_json(%w[plan run settings::show_diff -t nix_agents], project: project)
+
+          results.each do |result|
+            expect(result['status']).to eq('success')
+            expect(result['value']['report']['logs'][0]['message']).to include(diff_string)
+          end
+        end
+
+        it 'with a target with no uri it uses the name as the certname' do
+          results = run_cli_json(%w[plan run prep -t nix_agents], project: project)
+
+          results.each do |result|
+            expect(result['status']).to eq('success')
+            report = result['value']['report']
+            expect(report['resource_statuses']).to include(/Notify\[Hello puppet_[5-7]_node\]/)
+          end
+        end
+
+        # Run on puppet_6_node and puppet_7_node only, as deferred requires >= 6.
+        it 'applies the deferred type' do
+          result = run_cli_json(%w[plan run basic::defer -t puppet_6_node,puppet_7_node], project: project)
+          expect(result).not_to include('kind')
+          expect(result[0]['status']).to eq('success')
+          resources = result[0]['value']['report']['resource_statuses']
+
+          local_pid = resources['Notify[local pid]']['events'][0]['desired_value'][/(\d+)/, 1]
+          raise 'local pid was not found' if local_pid.nil?
+          remote_pid = resources['Notify[remote pid]']['events'][0]['desired_value'][/(\d+)/, 1]
+          raise 'remote pid was not found' if remote_pid.nil?
+          expect(local_pid).not_to eq(remote_pid)
+        end
       end
 
-      it 'does not create project' do
-        inventory_data = agent_version_inventory
-        is_project = "if [ -d ~/.puppetlabs ]; then echo 'exists'; else echo 'not found'; fi"
-        results = run_command(is_project, 'agent_targets', inventory: inventory_data)
-        results.each do |result|
-          expect(result['status']).to eq('success')
-          expect(result['value']['stdout']).to match(/not found/)
+      context 'with the apply command' do
+        it "applies a manifest" do
+          manifest = project_path + 'manifest.pp'
+          File.write(manifest, 'include basic')
+
+          results = run_cli_json(%W[apply #{manifest} -t nix_agents], project: project)
+
+          results.each do |result|
+            result = result['value']
+            expect(result).not_to include('kind')
+            expect(result['report']).to include('status' => 'changed')
+            expect(result['report']['resource_statuses']).to include('Notify[hello world]')
+          end
+        end
+
+        it "applies with noop" do
+          manifest = project_path + 'manifest.pp'
+          File.write(manifest, 'include basic')
+
+          results = run_cli_json(%W[apply #{manifest} --noop -t nix_agents], project: project)
+
+          results.each do |result|
+            result = result['value']
+            expect(result).not_to include('kind')
+            expect(result['report']).to include('status' => 'unchanged', 'noop' => true)
+            expect(result['report']['resource_statuses']).to include('Notify[hello world]')
+          end
+        end
+
+        it "applies a snippet of code" do
+          code = 'include basic'
+          results = run_cli_json(%W[apply -e #{code} -t nix_agents], project: project)
+
+          results.each do |result|
+            result = result['value']
+            expect(result).not_to include('kind')
+            expect(result['report']).to include('status' => 'changed')
+            expect(result['report']['resource_statuses']).to include('Notify[hello world]')
+          end
+        end
+
+        it "applies a node definition" do
+          code = 'node default { notify { "hello world": } }'
+          results = run_cli_json(%W[apply -e #{code} -t nix_agents], project: project)
+
+          results.each do |result|
+            result = result['value']
+            expect(result).not_to include('kind')
+            expect(result['report']).to include('status' => 'changed')
+            expect(result['report']['resource_statuses']).to include('Notify[hello world]')
+          end
+        end
+
+        it "fails if the manifest doesn't parse" do
+          expect { run_cli_json(%w[apply -e include(basic -t nix_agents], project: project) }
+            .to raise_error(/Syntax error/)
+        end
+
+        it "fails if the manifest doesn't compile" do
+          code = 'include shmasic'
+          results = run_cli_json(%W[apply -e #{code} -t nix_agents], project: project)
+
+          results.each do |result|
+            result = result['value']
+            expect(result).to include('_error')
+            expect(result['_error']['kind']).to eq('bolt/apply-error')
+            expect(result['_error']['msg']).to match(/failed to compile/)
+          end
         end
       end
     end
 
-    context "when installing puppet" do
-      before(:each) do
-        uninstall = '/opt/puppetlabs/bin/puppet resource package puppet-agent ensure=absent'
-        run_cli_json(%W[command run #{uninstall}] + config_flags)
+    # Run tests for installing the puppet-agent package using apply_prep.
+    context 'installing puppet' do
+      let(:config) do
+        {
+          'ssh' => {
+            'host-key-check' => false,
+            'run-as' => 'root',
+            'password' => password
+          }
+        }
       end
 
-      context 'with plugin configured' do
-        let(:config_flags) {
-          %W[--format json --targets all --password #{password}
-             --modulepath #{modulepath}] + tflags
+      let(:inventory) do
+        {
+          'targets' => [{ 'uri' => uri }],
+          'config' => config
         }
-        let(:ssh_node) { conn_uri('ssh', include_password: true) }
+      end
 
-        before(:each) do
-          uninstall(ssh_node)
+      # Set up a project directory for the tests. Include an inventory file so Bolt
+      # can actually connect to the target.
+      around(:each) do |example|
+        with_project do
+          File.write(project.inventory_file, inventory.to_yaml)
+          example.run
         end
+      end
 
-        it 'with puppet_agent plugin configured installs the agent' do
-          with_tempfile_containing('inventory', YAML.dump(lib_plugin_inventory), '.yaml') do |inv|
-            result = run_cli_json(%W[plan run prep -i #{inv.path}] + config_flags)
-            expect(result).not_to include('kind')
-            expect(result.count).to eq(1)
-            expect(result[0]['status']).to eq('success')
-            report = result[0]['value']['report']
-            expect(report['resource_statuses']).to include("Notify[Hello #{conn_uri('ssh')}]")
-          end
-        end
+      # Ensure puppet is uninstalled after each test.
+      after(:each) do
+        uninstall(uri, inventory: inventory)
+      end
 
-        it 'errors appropriately per target' do
-          with_tempfile_containing('inventory', YAML.dump(error_plugin_inventory), '.yaml') do |inv|
-            result = run_cli_json(%W[plan run prep -i #{inv.path}] + config_flags)
-            expect(result['kind']).to eq('bolt/run-failure')
-            expect(result['msg']).to eq("Plan aborted: apply_prep failed on 3 targets")
+      it 'installs puppet' do
+        result = run_cli_json(%W[plan run prep -t #{uri}], project: project)
 
-            result_set = result['details']['result_set']
-            task_error = result_set.select { |h| h['target'] == 'error' }[0]['value']['_error']
-            expect(task_error['kind']).to eq('puppetlabs.tasks/task-error')
-            expect(task_error['msg']).to include("The task failed with exit code 1")
-
-            param_error = result_set.select { |h| h['target'] == 'badparams' }[0]['value']['_error']
-            expect(param_error['kind']).to eq('bolt/plugin-error')
-            expect(param_error['msg']).to include("Invalid parameters for Task puppet_agent::install")
-
-            plugin_error = result_set.select { |h| h['target'] == 'badplugin' }[0]['value']['_error']
-            expect(plugin_error['kind']).to eq('bolt/unknown-plugin')
-            expect(plugin_error['msg']).to include("Unknown plugin: 'what plugin?'")
-          end
-        end
-
-        it 'with task plugin configured installs the agent' do
-          with_tempfile_containing('inventory', YAML.dump(task_plugin_inventory), '.yaml') do |inv|
-            result = run_cli_json(%W[plan run prep -i #{inv.path}] + config_flags)
-            expect(result).not_to include('kind')
-            expect(result.count).to eq(1)
-            expect(result[0]['status']).to eq('success')
-            report = result[0]['value']['report']
-            expect(report['resource_statuses']).to include("Notify[Hello #{conn_uri('ssh')}]")
-            result = run_cli_json(%W[task run puppet_agent::version -i #{inv.path}] + config_flags)['items']
-            expect(result.count).to eq(1)
-            expect(result[0]).to include('status' => 'success')
-            expect(result[0]['value']['version']).to match(/^6\.2/)
-          end
-        end
+        expect(result).not_to include('kind')
+        expect(result.count).to eq(1)
+        expect(result[0]['status']).to eq('success')
+        report = result[0]['value']['report']
+        expect(report['resource_statuses']).to include("Notify[Hello #{conn_uri('ssh')}]")
       end
 
       it 'succeeds when run twice' do
-        result = run_cli_json(%w[plan run prep] + config_flags)
+        result = run_cli_json(%W[plan run prep -t #{uri}], project: project)
         expect(result).not_to include('kind')
         expect(result.count).to eq(1)
         expect(result[0]['status']).to eq('success')
@@ -278,282 +299,163 @@ describe "apply", expensive: true do
         expect(agent_facts[3]).to eq(agent_facts[2])
         expect(agent_facts[4]).to eq('false')
 
-        result = run_cli_json(%w[plan run prep] + config_flags)
+        result = run_cli_json(%W[plan run prep -t #{uri}], project: project)
         expect(result.count).to eq(1)
         expect(result[0]['status']).to eq('success')
         report = result[0]['value']['report']
         expect(report['resource_statuses']).to include("Notify[Hello #{conn_uri('ssh')}]")
       end
-    end
 
-    context "with a puppet_agent installed" do
-      before(:all) do
-        # Deferred must use puppet >= 6
-        target = 'puppet_6'
-        install(target, inventory: agent_version_inventory)
-        result = run_task('puppet_agent::version', target, {}, config: root_config, inventory: agent_version_inventory)
-        major_version = result.first['value']['version'].split('.').first.to_i
-        expect(major_version).to be >= 6
-      end
-
-      context "apply() function" do
-        it 'errors when there are resource failures' do
-          result = run_cli_json(%w[plan run basic::failure] + config_flags, rescue_exec: true)
-          expect(result).to include('kind' => 'bolt/apply-failure')
-          error = result['details']['result_set'][0]['value']['_error']
-          expect(error['kind']).to eq('bolt/resource-failure')
-          expect(error['msg']).to match(/Resources failed to apply/)
-        end
-
-        it 'applies a notify and ignores local settings' do
-          run_command('echo environment=doesnotexist > /etc/puppetlabs/puppet/puppet.conf',
-                      uri, config: root_config, inventory: conn_inventory)
-
-          result = run_cli_json(%w[plan run basic::class] + config_flags)
-          expect(result).not_to include('kind')
-          expect(result[0]).to include('status' => 'success')
-          expect(result[0]['value']['_output']).to eq('changed: 1, failed: 0, unchanged: 0 skipped: 0, noop: 0')
-          resources = result[0]['value']['report']['resource_statuses']
-          expect(resources).to include('Notify[hello world]')
-        end
-
-        context 'with a target with no uri' do
-          let(:uri) { 'mytarget' }
-          it "uses the target name as the certname", ssh: true do
-            inv = { 'targets' => [{
-              'name' => 'mytarget',
-              'config' => {
-                'transport' => 'ssh',
-                'ssh' => {
-                  'host' => conn_info('ssh')[:host],
-                  'user' => conn_info('ssh')[:user],
-                  'password' => conn_info('ssh')[:password],
-                  'port' => conn_info('ssh')[:port]
+      context 'with plugin configured' do
+        let(:inventory) do
+          {
+            'targets' => [
+              {
+                'uri' => uri,
+                'plugin_hooks' => {
+                  'puppet_library' => {
+                    'plugin' => 'puppet_agent'
+                  }
                 }
               }
-            }] }
-            with_tempfile_containing('inventory', YAML.dump(inv), '.yaml') do |i|
-              result = run_cli_json(%W[plan run prep --inventoryfile #{i.path}] + config_flags).first
-              expect(result['status']).to eq('success')
-              report = result['value']['report']
-              expect(report['resource_statuses']).to include("Notify[Hello #{uri}]")
-            end
-          end
+            ],
+            'config' => config
+          }
         end
 
-        it 'applies the deferred type' do
-          result = run_cli_json(%w[plan run basic::defer] + config_flags)
+        it 'installs puppet' do
+          result = run_cli_json(%W[plan run prep -t #{uri}], project: project)
+
           expect(result).not_to include('kind')
+          expect(result.count).to eq(1)
           expect(result[0]['status']).to eq('success')
-          resources = result[0]['value']['report']['resource_statuses']
-
-          local_pid = resources['Notify[local pid]']['events'][0]['desired_value'][/(\d+)/, 1]
-          raise 'local pid was not found' if local_pid.nil?
-          remote_pid = resources['Notify[remote pid]']['events'][0]['desired_value'][/(\d+)/, 1]
-          raise 'remote pid was not found' if remote_pid.nil?
-          expect(local_pid).not_to eq(remote_pid)
-        end
-
-        it 'respects _run_as on a plan invocation' do
-          user = conn_info('ssh')[:user]
-          logs = run_cli_json(%W[plan run basic::run_as_apply user=#{user}] + config_flags)
-          expect(logs.first['message']).to eq(conn_info('ssh')[:user])
-        end
-
-        it 'respects show_diff configuration' do
-          show_diff = { "show_diff" => true }
-          diff_string = <<~DIFF
-            @@ -1 +1 @@
-            -Silly string
-            \\ No newline at end of file
-            +Silly string (get it?)
-            \\ No newline at end of file
-            DIFF
-          with_tempfile_containing('bolt', YAML.dump("apply-settings" => show_diff), '.yaml') do |conf|
-            result = run_cli_json(%W[plan run settings::show_diff --configfile #{conf.path}] + config_flags).first
-            expect(result['status']).to eq('success')
-            expect(result['value']['report']['logs'][0]['message']).to include(diff_string)
-          end
+          report = result[0]['value']['report']
+          expect(report['resource_statuses']).to include("Notify[Hello #{uri}]")
         end
       end
 
-      context "bolt apply command" do
-        it "applies a manifest" do
-          with_tempfile_containing('manifest', 'include basic', '.pp') do |manifest|
-            results = run_cli_json(['apply', manifest.path] + config_flags)
-            result = results[0]['value']
-            expect(result).not_to include('kind')
-            expect(result['report']).to include('status' => 'changed')
-            expect(result['report']['resource_statuses']).to include('Notify[hello world]')
-          end
+      context 'with task plugin configured' do
+        let(:inventory) do
+          {
+            'targets' => [
+              {
+                'uri' => uri,
+                'plugin_hooks' => {
+                  'puppet_library' => {
+                    'plugin' => 'task',
+                    'task' => 'puppet_agent::install',
+                    'parameters' => {
+                      'version' => '7.0.0'
+                    }
+                  }
+                }
+              }
+            ],
+            'config' => config
+          }
         end
 
-        it "applies with noop" do
-          with_tempfile_containing('manifest', 'include basic', '.pp') do |manifest|
-            results = run_cli_json(['apply', manifest.path, '--noop'] + config_flags)
-            result = results[0]['value']
-            expect(result).not_to include('kind')
-            expect(result['report']).to include('status' => 'unchanged', 'noop' => true)
-            expect(result['report']['resource_statuses']).to include('Notify[hello world]')
-          end
-        end
+        it 'installs puppet' do
+          result = run_cli_json(%W[plan run prep -t #{uri}], project: project)
 
-        it "applies a snippet of code" do
-          results = run_cli_json(['apply', '-e', 'include basic'] + config_flags)
-          result = results[0]['value']
           expect(result).not_to include('kind')
-          expect(result['report']).to include('status' => 'changed')
-          expect(result['report']['resource_statuses']).to include('Notify[hello world]')
+          expect(result.count).to eq(1)
+          expect(result[0]['status']).to eq('success')
+          report = result[0]['value']['report']
+          expect(report['resource_statuses']).to include("Notify[Hello #{uri}]")
+
+          results = run_cli_json(%W[task run puppet_agent::version -t #{uri}], project: project)
+
+          result = results['items']
+          expect(result.count).to eq(1)
+          expect(result[0]).to include('status' => 'success')
+          expect(result[0]['value']['version']).to match(/^7\.0/)
+        end
+      end
+
+      context 'with bad plugin configuration' do
+        let(:inventory) do
+          {
+            'targets' => [
+              {
+                'uri' => uri,
+                'name' => 'error',
+                'plugin_hooks' => {
+                  'puppet_library' => {
+                    'plugin' => 'task',
+                    'task' => 'prep::error'
+                  }
+                }
+              },
+              {
+                'uri' => uri,
+                'name' => 'badparams',
+                'plugin_hooks' => {
+                  'puppet_library' => {
+                    'plugin' => 'task',
+                    'task' => 'puppet_agent::install',
+                    'parameters' => {
+                      'collection' => 'The act or process of collecting.'
+                    }
+                  }
+                }
+              },
+              {
+                'uri' => uri,
+                'name' => 'badplugin',
+                'plugin_hooks' => {
+                  'puppet_library' => {
+                    'plugin' => 'what plugin?'
+                  }
+                }
+              }
+            ],
+            'config' => config
+          }
         end
 
-        it "applies a node definition" do
-          results = run_cli_json(['apply', '-e', 'node default { notify { "hello world": } }'] + config_flags)
-          result = results[0]['value']
-          expect(result).not_to include('kind')
-          expect(result['report']).to include('status' => 'changed')
-          expect(result['report']['resource_statuses']).to include('Notify[hello world]')
-        end
+        it 'errors appropriately for each target' do
+          result = run_cli_json(%w[plan run prep -t all], project: project)
 
-        it "fails if the manifest doesn't parse" do
-          expect { run_cli_json(['apply', '-e', 'include(basic'] + config_flags) }
-            .to raise_error(/Syntax error/)
-        end
+          expect(result['kind']).to eq('bolt/run-failure')
+          expect(result['msg']).to eq("Plan aborted: apply_prep failed on 3 targets")
 
-        it "fails if the manifest doesn't compile" do
-          results = run_cli_json(['apply', '-e', 'include shmasic'] + config_flags)
-          result = results[0]['value']
-          expect(result).to include('_error')
-          expect(result['_error']['kind']).to eq('bolt/apply-error')
-          expect(result['_error']['msg']).to match(/failed to compile/)
-        end
+          result_set = result['details']['result_set']
+          task_error = result_set.select { |h| h['target'] == 'error' }[0]['value']['_error']
+          expect(task_error['kind']).to eq('puppetlabs.tasks/task-error')
+          expect(task_error['msg']).to include("The task failed with exit code 1")
 
-        it 'respects show_diff configuration' do
-          show_diff = { "show_diff" => true }
-          diff_string = <<~DIFF
-            @@ -1 +1 @@
-            -Silly string
-            \\ No newline at end of file
-            +Silly string (get it?)
-            \\ No newline at end of file
-            DIFF
-          with_tempfile_containing('bolt', YAML.dump("apply-settings" => show_diff), '.yaml') do |conf|
-            result = run_cli_json(%W[plan run settings::show_diff --configfile #{conf.path}] + config_flags).first
-            expect(result['status']).to eq('success')
-            expect(result['value']['report']['logs'][0]['message']).to include(diff_string)
-          end
+          param_error = result_set.select { |h| h['target'] == 'badparams' }[0]['value']['_error']
+          expect(param_error['kind']).to eq('bolt/plugin-error')
+          expect(param_error['msg']).to include("Invalid parameters for Task puppet_agent::install")
+
+          plugin_error = result_set.select { |h| h['target'] == 'badplugin' }[0]['value']['_error']
+          expect(plugin_error['kind']).to eq('bolt/unknown-plugin')
+          expect(plugin_error['msg']).to include("Unknown plugin: 'what plugin?'")
         end
       end
     end
   end
 
   describe 'over winrm on Windows with Puppet Agents', windows_agents: true do
-    let(:uri) { conn_uri('winrm') }
-    let(:password) { conn_info('winrm')[:password] }
-    let(:user) { conn_info('winrm')[:user] }
-
-    def config
-      { 'modulepath' => File.join(__dir__, '../fixtures/apply'),
-        'winrm' => {
-          'ssl' => false,
-          'connect-timeout' => 30,
-          'ssl-verify' => false,
-          'user' => conn_info('winrm')[:user],
-          'password' => conn_info('winrm')[:password]
-        } }
-    end
-
-    context "when running against puppet 5" do
-      before(:all) do
-        result = run_task('puppet_agent::install', conn_uri('winrm'),
-                          { 'collection' => 'puppet5' }, config: config)
-        expect(result.count).to eq(1)
-        expect(result[0]).to include('status' => 'success')
-
-        result = run_task('puppet_agent::version', conn_uri('winrm'), {}, config: config)
-        expect(result.count).to eq(1)
-        expect(result[0]).to include('status' => 'success')
-        expect(result[0]['value']['version']).to match(/^5/)
-      end
-
-      it 'runs a ruby task' do
-        with_tempfile_containing('bolt', YAML.dump(config), '.yaml') do |conf|
-          results = run_cli_json(%W[task run basic::ruby_task --targets #{uri}
-                                    --configfile #{conf.path}])
-          results['items'].each do |result|
-            expect(result).to include('status' => 'success')
-            expect(result['value']).to eq('ruby' => 'Hi')
-          end
-        end
-      end
-
-      it 'runs an apply plan' do
-        with_tempfile_containing('bolt', YAML.dump(config), '.yaml') do |conf|
-          results = run_cli_json(%W[plan run basic::notify --targets #{uri}
-                                    --configfile #{conf.path}])
-          results.each do |result|
-            expect(result).to include('status' => 'success')
-            report = result['value']['report']
-            expect(report['resource_statuses']).to include("Notify[Apply: Hi!]")
-          end
-        end
-      end
-
-      it 'does not create project' do
-        is_project = "if (!(Test-Path ~/.puppetlabs)) {echo 'not found'}"
-        results = run_command(is_project, conn_uri('winrm'), config: config)
-        results.each do |result|
-          expect(result).to include('status' => 'success')
-          expect(result['value']['stdout']).to match(/not found/)
-        end
+    around(:each) do |example|
+      with_project do
+        File.write(project.inventory_file, conn_inventory.to_yaml)
+        example.run
       end
     end
 
-    context "when running against puppet 6" do
-      before(:all) do
-        # Stop the puppet service to avoid errors when upgrading
-        run_task('service', conn_uri('winrm'),
-                 { 'action' => 'stop', 'name' => 'puppet' }, config: config)
-        result = run_task('puppet_agent::install', conn_uri('winrm'),
-                          { 'collection' => 'puppet6', 'version' => 'latest' }, config: config)
-        expect(result.count).to eq(1)
-        expect(result[0]).to include('status' => 'success')
-
-        result = run_task('puppet_agent::version', conn_uri('winrm'), {}, config: config)
-        expect(result.count).to eq(1)
-        expect(result[0]).to include('status' => 'success')
-        expect(result[0]['value']['version']).to match(/^6/)
-      end
-
-      it 'runs a ruby task' do
-        with_tempfile_containing('bolt', YAML.dump(config), '.yaml') do |conf|
-          results = run_cli_json(%W[task run basic::ruby_task --targets #{uri}
-                                    --configfile #{conf.path}])
-          results['items'].each do |result|
-            expect(result).to include('status' => 'success')
-            expect(result['value']).to eq('ruby' => 'Hi')
-          end
+    TEST_VERSIONS.each do |version, collection|
+      context "with puppet#{version} installed" do
+        before(:all) do
+          install('winrm', collection: collection, inventory: conn_inventory)
         end
-      end
 
-      it 'runs an apply plan' do
-        with_tempfile_containing('bolt', YAML.dump(config), '.yaml') do |conf|
-          results = run_cli_json(%W[plan run basic::notify --targets #{uri}
-                                    --configfile #{conf.path}])
-          results.each do |result|
-            expect(result).to include('status' => 'success')
-            report = result['value']['report']
-            expect(report['resource_statuses']).to include("Notify[Apply: Hi!]")
-          end
+        after(:all) do
+          uninstall('winrm', inventory: conn_inventory)
         end
-      end
 
-      it 'does not create project' do
-        is_project = "if (!(Test-Path ~/.puppetlabs)) {echo 'not found'}"
-        results = run_command(is_project, conn_uri('winrm'), config: config)
-        results.each do |result|
-          expect(result).to include('status' => 'success')
-          expect(result['value']['stdout']).to match(/not found/)
-        end
+        include_examples 'agentful tests', 'winrm'
       end
     end
   end

--- a/spec/lib/bolt_spec/puppet_agent.rb
+++ b/spec/lib/bolt_spec/puppet_agent.rb
@@ -19,6 +19,9 @@ module BoltSpec
       }
       inventory ||= {}
 
+      params = { 'name' => 'puppet', 'action' => 'stop' }
+      run_task('service', target, params, config: config, inventory: inventory)
+
       uninstall = '/opt/puppetlabs/bin/puppet resource package puppet-agent ensure=absent'
       run_command(uninstall, target, config: config, inventory: inventory)
     end


### PR DESCRIPTION
This includes several changes to Bolt's spec tests and CI environment:

- **Fix broken apply integration tests**

  With the release of Puppet 7, the `puppet_agent::install` task now
  installs `puppet7` packages by default. This broke several of the
  apply integration tests that expected `puppet6` packages, or attempted
  to downgrade to the `puppet6` repo after having already installed the
  `puppet7` repo. This fixes the tests to assume `puppet7` is installed.

  Additionally, the apply integration tests were refactored slightly to
  make it easier to tell what is happening in setup, testing, and
  teardown for each spec test. Previously, the agent package was
  repeatedly installed and uninstalled between spec tests and inventory
  was sourced in multiple different ways. Now, agentful targets have the
  agent installed before all spec tests are run, and then the agent is
  uninstalled after the tests have all run. Additionally, inventory is
  sourced in one way for each group of spec tests.

- **Add puppet_7_node container**

  This adds a new `puppet_7_node` container that is used in apply
  integration testing and will have the agent package installed from the
  `puppet7` repo.

- **Update containers to Ubuntu 18.04**

  With Ubuntu 16.04 reaching EOL in 2021, I took the opportunity to
  update the containers to an Ubuntu 18.04 image.

- **Update gems when restoring gem cache**

  Bolt's CI caches installed gems after running `bundle install` in
  order to speed up setup for testing. However, this occasionally causes
  issues when running `bundle exec` and a newer version of a gem is
  expected than what is installed. To get around this, a `bundle update`
  step is now run whenever the cache is hit, ensuring gems are
  up-to-date.

!no-release-note