### PR TITLE
(PE-30656) Allow project_inventory_targets to use PuppetConnectData

### DIFF
--- a/developer-docs/bolt-api-servers.md
+++ b/developer-docs/bolt-api-servers.md
@@ -380,7 +380,25 @@ This endpoint behaves identically to the /ssh/check_node_connections endpoint, b
 
 This endpoint parses a project inventory and returns a list of target hashes. Note that the only accepetable inventoryfile location is the default `inventory.yaml` at the root of the project.
 
+#### Query parameters
+
 - `project_ref`: String, *required* - Reference to the bolt project (in the form [PROJECT NAME]\_[REF])
+
+#### POST body
+
+- `connect_data`: Hash, *required* - Data for the Connect plugin to look up. Keys are the lookup in the inventoryfile which points to a hash with a required "value" key that points to the value to look up.
+
+#### Request
+
+```
+{
+  "connect_data": {
+    "ssh_password": {
+      "value": "foo"
+    }
+  }
+}
+```
 
 #### Response
 

--- a/lib/bolt_server/schemas/connect-data.json
+++ b/lib/bolt_server/schemas/connect-data.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "project_inventory_targets connect plugin data",
+  "description": "POST project_inventory_targets connect plugin data",
+  "type": "object",
+  "properties": {
+    "puppet_connect_data": {
+      "type": "object",
+      "patternProperties": {
+        ".*": {
+          "type": "object",
+          "properties": {
+            "value": {}
+          },
+          "required": ["value"]
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "required": ["puppet_connect_data"]
+}


### PR DESCRIPTION
This commit updates the `project_inventory_targets` endpoint to accept data from puppet connect and uses it to enable the connect plugin.