### PR TITLE
(GH-2400) Add bundled-ruby option for local transport

### DIFF
--- a/documentation/developer_updates.md
+++ b/documentation/developer_updates.md
@@ -53,6 +53,24 @@ compiled a list of expected changes and removals.
   should instead use the built-in [PowerShell
   cmdlets](bolt_cmdlet_reference.md).
 
+- **New default configuration for the local transport**
+
+  In Bolt 2.x, Bolt applied the following settings to targets named `localhost` by default:
+  ```
+  targets:
+    - name: localhost
+      config:
+        transport: local
+        local:
+          interpreters:
+            .rb: RbConfig.ruby # This uses the Ruby we ship with Bolt
+      features:
+        - puppet-agent
+  ```
+  These settings will now be applied to all targets using the local transport. Settings can be
+  overridden at the target level in inventory. They can also be enabled or disabled starting in Bolt
+  2.37 using the `bundled-ruby` local transport config option.
+
 - **`apply_settings` configuration option renamed to `apply-settings`**
 
   Most other configuration options in Bolt use hyphens instead of underscores.

--- a/lib/bolt/config/transport/local.rb
+++ b/lib/bolt/config/transport/local.rb
@@ -8,6 +8,7 @@ module Bolt
     module Transport
       class Local < Base
         WINDOWS_OPTIONS = %w[
+          bundled-ruby
           cleanup
           interpreters
           tmpdir

--- a/lib/bolt/config/transport/options.rb
+++ b/lib/bolt/config/transport/options.rb
@@ -81,6 +81,13 @@ module Bolt
             _default: false,
             _example: true
           },
+          "bundled-ruby" => {
+            description: "Whether to use the Ruby bundled with Bolt packages for local targets.",
+            type: [TrueClass, FalseClass],
+            _plugin: false,
+            _example: true,
+            _default: false
+          },
           "cacert" => {
             type: String,
             description: "The path to the CA certificate.",

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -80,6 +80,10 @@ module Bolt
       inventory_target.resources
     end
 
+    def set_local_defaults
+      inventory_target.set_local_defaults
+    end
+
     # rubocop:disable Naming/AccessorMethodName
     def set_resource(resource)
       inventory_target.set_resource(resource)

--- a/lib/bolt/transport/local.rb
+++ b/lib/bolt/transport/local.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'bolt/logger'
 require 'bolt/transport/simple'
 
 module Bolt
@@ -10,6 +11,18 @@ module Bolt
       end
 
       def with_connection(target)
+        if target.transport_config['bundled-ruby'] || target.name == 'localhost'
+          target.set_local_defaults
+        end
+
+        if target.name != 'localhost' &&
+           !target.transport_config.key?('bundled-ruby')
+          msg = "The local transport will default to using Bolt's Ruby interpreter and "\
+            "setting the 'puppet-agent' feature in Bolt 3.0. Enable or disable these "\
+            "defaults by setting 'bundled-ruby' in the local transport config."
+          Bolt::Logger.warn_once('local default config', msg)
+        end
+
         yield Connection.new(target)
       end
     end

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -367,6 +367,9 @@
         {
           "type": "object",
           "properties": {
+            "bundled-ruby": {
+              "$ref": "#/transport_definitions/bundled-ruby"
+            },
             "cleanup": {
               "$ref": "#/transport_definitions/cleanup"
             },
@@ -625,6 +628,10 @@
           "$ref": "#/definitions/_plugin"
         }
       ]
+    },
+    "bundled-ruby": {
+      "description": "Whether to use the Ruby bundled with Bolt packages for local targets.",
+      "type": "boolean"
     },
     "cacert": {
       "description": "The path to the CA certificate.",

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -316,6 +316,9 @@
         {
           "type": "object",
           "properties": {
+            "bundled-ruby": {
+              "$ref": "#/transport_definitions/bundled-ruby"
+            },
             "cleanup": {
               "$ref": "#/transport_definitions/cleanup"
             },
@@ -574,6 +577,10 @@
           "$ref": "#/definitions/_plugin"
         }
       ]
+    },
+    "bundled-ruby": {
+      "description": "Whether to use the Ruby bundled with Bolt packages for local targets.",
+      "type": "boolean"
     },
     "cacert": {
       "description": "The path to the CA certificate.",

--- a/schemas/bolt-inventory.schema.json
+++ b/schemas/bolt-inventory.schema.json
@@ -309,6 +309,9 @@
         {
           "type": "object",
           "properties": {
+            "bundled-ruby": {
+              "$ref": "#/transport_definitions/bundled-ruby"
+            },
             "cleanup": {
               "$ref": "#/transport_definitions/cleanup"
             },
@@ -567,6 +570,10 @@
           "$ref": "#/definitions/_plugin"
         }
       ]
+    },
+    "bundled-ruby": {
+      "description": "Whether to use the Ruby bundled with Bolt packages for local targets.",
+      "type": "boolean"
     },
     "cacert": {
       "description": "The path to the CA certificate.",

--- a/spec/bolt/inventory/inventory_spec.rb
+++ b/spec/bolt/inventory/inventory_spec.rb
@@ -1034,66 +1034,6 @@ describe Bolt::Inventory::Inventory do
     end
   end
 
-  context 'with localhost' do
-    context 'with no additional config' do
-      let(:data) {
-        { 'targets' => ['localhost'] }
-      }
-
-      let(:inventory) { Bolt::Inventory::Inventory.new(data, transport, transports, plugins) }
-
-      it 'adds magic config options' do
-        target = get_target(inventory, 'localhost')
-        expect(target.transport).to eq('local')
-        expect(target.options['interpreters']).to include('.rb' => RbConfig.ruby)
-        expect(target.features).to include('puppet-agent')
-      end
-    end
-
-    context 'with group-level config' do
-      let(:data) {
-        { 'name' => 'locomoco',
-          'targets' => ['localhost'],
-          'config' => {
-            'transport' => 'ssh',
-            'local' => {
-              'interpreters' => { '.rb' => '/foo/ruby' }
-            }
-          } }
-      }
-      let(:inventory) { Bolt::Inventory::Inventory.new(data, transport, transports, plugins) }
-
-      it 'prefers default options' do
-        target = get_target(inventory, 'localhost')
-        expect(target.transport).to eq('local')
-        expect(target.options['interpreters']).to include('.rb' => RbConfig.ruby)
-        expect(target.features).to include('puppet-agent')
-      end
-    end
-
-    context 'with target-level config' do
-      let(:data) {
-        { 'targets' => [{
-          'name' => 'localhost',
-          'config' => {
-            'transport' => 'ssh',
-            'ssh' => {
-              'interpreters' => { '.rb' => '/foo/ruby' }
-            }
-          }
-        }] } # This has so many brackets it might be March Madness
-      }
-      let(:inventory) { Bolt::Inventory::Inventory.new(data, transport, transports, plugins) }
-
-      it 'prefers user-defined target-level config over defaults' do
-        target = get_target(inventory, 'localhost')
-        expect(target.transport).to eq('ssh')
-        expect(target.options['interpreters']).to include('.rb' => '/foo/ruby')
-        expect(target.features).to include('puppet-agent')
-      end
-    end
-  end
-
   describe 'set_config' do
     context 'when updating existing values' do
       let(:data) {
@@ -1404,12 +1344,10 @@ describe Bolt::Inventory::Inventory do
       expect { inventory.create_target_from_hash(hash) }.not_to raise_error
     end
 
-    it 'picks up localhost default config' do
+    it 'picks up localhost default transport' do
       hash = { 'name' => 'localhost' }
       target = inventory.create_target_from_hash(hash)
       expect(target.transport).to eq('local')
-      expect(target.transport_config['interpreters']).to include('.rb' => RbConfig.ruby)
-      expect(target.features).to include('puppet-agent')
     end
   end
 end

--- a/spec/bolt/transport/local_spec.rb
+++ b/spec/bolt/transport/local_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/inventory'
+require 'bolt_spec/config'
+
+describe Bolt::Transport::Local do
+  include BoltSpec::Config
+
+  def get_target(inventory, name, alia = nil)
+    targets = inventory.get_targets(alia || name)
+    expect(targets.size).to eq(1)
+    expect(targets[0].name).to eq(name)
+    targets[0]
+  end
+
+  let(:pal)          { nil }
+  let(:plugins)      { Bolt::Plugin.setup(config, pal) }
+  let(:transports)   { config.transports }
+  let(:transport)    { config.transport }
+  let(:inventory)    { Bolt::Inventory.create_version(data, transport, transports, plugins) }
+
+  around :each do |example|
+    target = get_target(inventory, uri)
+    subject.with_connection(target) do |conn|
+      @conn = conn
+      example.run
+    end
+  end
+
+  context 'with localhost' do
+    let(:uri) { 'localhost' }
+
+    context 'with no additional config' do
+      let(:data) { { 'targets' => [uri] } }
+
+      it 'adds magic config options' do
+        expect(@conn.target.transport).to eq('local')
+        expect(@conn.target.options['interpreters']).to include('.rb' => RbConfig.ruby)
+        expect(@conn.target.features).to include('puppet-agent')
+      end
+    end
+
+    context 'with group-level config' do
+      let(:data) {
+        { 'name' => 'locomoco',
+          'targets' => [uri],
+          'config' => {
+            'transport' => 'ssh',
+            'local' => {
+              'interpreters' => { '.rb' => '/foo/ruby' }
+            }
+          } }
+      }
+
+      it 'prefers default options' do
+        expect(@conn.target.transport).to eq('local')
+        expect(@conn.target.options['interpreters']).to include('.rb' => RbConfig.ruby)
+        expect(@conn.target.features).to include('puppet-agent')
+      end
+    end
+
+    context 'with target-level config' do
+      let(:data) {
+        { 'targets' => [{
+          'name' => uri,
+          'config' => {
+            'transport' => 'ssh',
+            'ssh' => {
+              'interpreters' => { '.rb' => '/foo/ruby' }
+            }
+          }
+        }] } # This has so many brackets it might be March Madness
+      }
+
+      it 'prefers user-defined target-level config over defaults' do
+        expect(@conn.target.transport).to eq('ssh')
+        expect(@conn.target.options['interpreters']).to include('.rb' => '/foo/ruby')
+        expect(@conn.target.features).to include('puppet-agent')
+      end
+    end
+  end
+
+  context 'with local target' do
+    let(:uri) { 'local://127.0.0.1' }
+
+    context 'with bundled-ruby' do
+      let(:data) {
+        { 'targets' => [uri],
+          'config' => { 'local' => { 'bundled-ruby' => true } } }
+      }
+
+      it 'adds local config options' do
+        expect(@conn.target.transport).to eq('local')
+        expect(@conn.target.options['interpreters']).to include('.rb' => RbConfig.ruby)
+        expect(@conn.target.features).to include('puppet-agent')
+      end
+    end
+
+    context 'with group-level config' do
+      let(:data) {
+        { 'name' => 'locomoco',
+          'targets' => [uri],
+          'config' => {
+            'local' => {
+              'bundled-ruby' => true,
+              'interpreters' => { '.rb' => '/foo/ruby' }
+            }
+          },
+          'features' => ['puppet-agent'] }
+      }
+
+      it 'prefers default options' do
+        expect(@conn.target.options['interpreters']).to include('.rb' => RbConfig.ruby)
+        expect(@conn.target.features).to eq(['puppet-agent'])
+      end
+    end
+
+    context 'with target-level config' do
+      let(:data) {
+        { 'targets' => [{
+          'name' => uri,
+          'config' => {
+            'transport' => 'local',
+            'local' => {
+              'bundled-ruby' => true,
+              'interpreters' => { '.rb' => '/foo/ruby' }
+            }
+          }
+        }] }
+      }
+
+      it 'prefers user-defined target-level config over defaults' do
+        expect(@conn.target.options['interpreters']).to include('.rb' => '/foo/ruby')
+        expect(@conn.target.features).to include('puppet-agent')
+      end
+    end
+  end
+
+  context 'without bundled-ruby' do
+    let(:uri) { 'local://127.0.0.1' }
+    let(:data) { { 'targets' => [uri] } }
+
+    it 'does not use default config' do
+      expect(@conn.target.options).not_to include('interpreters')
+      expect(@conn.target.features).not_to include('puppet-agent')
+    end
+
+    it 'warns that default config will be added in 3.0' do
+      expect(Bolt::Logger).to receive(:warn_once)
+        .with('local default config', /The local transport will default/)
+      subject.with_connection(get_target(inventory, uri)) do |conn|; end
+    end
+  end
+
+  context 'with bundled-ruby false' do
+    let(:uri) { 'local://127.0.0.1' }
+    let(:data) {
+      { 'targets' => [uri],
+        'config' => { 'local' => { 'bundled-ruby' => false } } }
+    }
+
+    it 'does not use default config' do
+      expect(@conn.target.options).not_to include('interpreters')
+      expect(@conn.target.features).not_to include('puppet-agent')
+    end
+
+    it 'does not issue the warning' do
+      expect(Bolt::Logger).not_to receive(:warn_once)
+        .with('local default config', /The local transport will default/)
+      subject.with_connection(get_target(inventory, uri)) do |conn|; end
+    end
+  end
+end

--- a/spec/integration/local_spec.rb
+++ b/spec/integration/local_spec.rb
@@ -45,6 +45,20 @@ describe "when running over the local transport" do
       expect(result['env']).to match(/somemessage/)
       expect(result['stdin']).to match(/somemessage/)
     end
+
+    context 'specifying transport on the CLI' do
+      let(:config_flags) { %W[--targets 127.0.0.1 -m #{modulepath} --transport local] }
+
+      it "applies bundled-ruby config" do
+        data = { 'config' => { 'local' => { 'bundled-ruby' => true } } }
+        with_tempfile_containing('inv', data.to_yaml) do |inv|
+          cmd = %W[task run sample::bolt_ruby message=somemessage --inventoryfile #{inv.path}]
+          result = run_one_node(cmd + config_flags)
+          expect(result['env']).to match(/somemessage/)
+          expect(result['stdin']).to match(/somemessage/)
+        end
+      end
+    end
   end
 
   context 'when using CLI options on POSIX OS', bash: true do


### PR DESCRIPTION
This introduces the `bundled-ruby` config option for the local
transport. The option enables merging default config values currently
used just for a target with name `localhost`. Those default config
values are:

```
config:
  local:
    interpreters:
      '.rb' => RbConfig.ruby # This is Bolt's bundled Ruby
features:
  - puppet-agent
```

The default config values are merged at the target config level, meaning
they are overridden by target-level config but not group-level config.
The 'features' array is appended, not overridden, and is a set so the
value will not be added twice.  The `localhost` target additionally
defaults to using the `local` transport as part of the "magic config",
however the `bundled-ruby` option will only apply to targets that are
already configured to use the local transport.

`bundled-ruby` currently defaults to false, but will default to `true`
in Bolt 3.0. A warning is issued for users who don't set the
conifguration and use the local transport that the default config will
be updated.

Closes #2400

!feature

* **bundled-ruby local transport config option enables local defaults** ((#2400)[https://github.com/puppetlabs/bolt/issues/2400)

  Set `bundled-ruby` in the local transport config to enable or disable
  the default config currently used for the 'localhost' target.