### PR TITLE
(GH-2424) Update 'source' to 'upload' in Getting started

### DIFF
--- a/documentation/getting_started_with_bolt.md
+++ b/documentation/getting_started_with_bolt.md
@@ -503,7 +503,7 @@ Now add the following step after the `start_apache` step:
 
 ```yaml
 - name: upload_homepage
-  source: $src
+  upload: $src
   destination: /var/www/html/index.html
   targets: $targets
   description: "Upload homepage"      
@@ -536,7 +536,7 @@ steps:
     description: "Start the Apache service"
 
   - name: upload_homepage
-    source: $src
+    upload: $src
     destination: /var/www/html/index.html
     targets: $targets
     description: "Upload site contents"                            


### PR DESCRIPTION
Updates the deprecated `source` key for the file upload step in YAML
plans to `upload` key. I opted to leave the `src` parameter name the
same, as I think it's more descriptive and clear for new YAML plan
authors.

Closes #2424

!no-release-note