### PR TITLE
(feature) Print spinner to the console for long operations

### DIFF
--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -303,6 +303,7 @@ module Bolt
         'puppetdb'            => {},
         'puppetfile'          => {},
         'save-rerun'          => true,
+        'spinner'             => true,
         'transport'           => 'ssh'
       }
 
@@ -596,6 +597,10 @@ module Bolt
 
     def save_rerun
       @data['save-rerun']
+    end
+
+    def spinner
+      @data['spinner']
     end
 
     def inventoryfile

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -434,6 +434,14 @@ module Bolt
           _example: false,
           _default: true
         },
+        "spinner" => {
+          description: "Whether to print a spinner to the console for long-running Bolt operations.",
+          type: [TrueClass, FalseClass],
+          _plugin: false,
+          _example: false,
+          _default: true
+        },
+
         "tasks" => {
           description: "A list of task names and glob patterns to filter the project's tasks by. This option is used "\
                        "to limit the visibility of tasks for users of the project. For example, project authors "\
@@ -529,6 +537,7 @@ module Bolt
         puppetdb
         puppetfile
         save-rerun
+        spinner
         trusted-external-command
       ].freeze
 
@@ -548,6 +557,7 @@ module Bolt
         puppetdb
         puppetfile
         save-rerun
+        spinner
       ].freeze
 
       # Options that are available in a bolt-project.yaml file
@@ -573,6 +583,7 @@ module Bolt
         puppetdb
         puppetfile
         save-rerun
+        spinner
         tasks
         trusted-external-command
       ].freeze

--- a/lib/bolt/module_installer.rb
+++ b/lib/bolt/module_installer.rb
@@ -47,6 +47,7 @@ module Bolt
       # a version conflict.
       @outputter.print_action_step("Resolving module dependencies, this may take a moment")
 
+      @outputter.start_spin
       begin
         resolve_specs.add_specs('name' => name)
         puppetfile = Resolver.new.resolve(resolve_specs, config)
@@ -54,6 +55,7 @@ module Bolt
         project_specs.add_specs('name' => name)
         puppetfile = Resolver.new.resolve(project_specs, config)
       end
+      @outputter.stop_spin
 
       # Display the diff between the existing Puppetfile and the new Puppetfile.
       print_puppetfile_diff(existing_puppetfile, puppetfile)
@@ -155,7 +157,11 @@ module Bolt
         # and write a Puppetfile.
         if force || !path.exist?
           @outputter.print_action_step("Resolving module dependencies, this may take a moment")
+
+          # This doesn't use the block as it's more testable to just mock *_spin
+          @outputter.start_spin
           puppetfile = Resolver.new.resolve(specs, config)
+          @outputter.stop_spin
 
           # We get here either through 'bolt module install' which uses the
           # managed modulepath (which isn't configurable) or through bolt
@@ -184,7 +190,9 @@ module Bolt
     #
     def install_puppetfile(path, moduledir, config = {})
       @outputter.print_action_step("Syncing modules from #{path} to #{moduledir}")
+      @outputter.start_spin
       ok = Installer.new(config).install(path, moduledir)
+      @outputter.stop_spin
 
       # Automatically generate types after installing modules
       @outputter.print_action_step("Generating type references")

--- a/lib/bolt/outputter.rb
+++ b/lib/bolt/outputter.rb
@@ -2,24 +2,25 @@
 
 module Bolt
   class Outputter
-    def self.for_format(format, color, verbose, trace)
+    def self.for_format(format, color, verbose, trace, spin)
       case format
       when 'human'
-        Bolt::Outputter::Human.new(color, verbose, trace)
+        Bolt::Outputter::Human.new(color, verbose, trace, spin)
       when 'json'
-        Bolt::Outputter::JSON.new(color, verbose, trace)
+        Bolt::Outputter::JSON.new(color, verbose, trace, false)
       when 'rainbow'
-        Bolt::Outputter::Rainbow.new(color, verbose, trace)
+        Bolt::Outputter::Rainbow.new(color, verbose, trace, spin)
       when nil
         raise "Cannot use outputter before parsing."
       end
     end
 
-    def initialize(color, verbose, trace, stream = $stdout)
+    def initialize(color, verbose, trace, spin, stream = $stdout)
       @color = color
       @verbose = verbose
       @trace = trace
       @stream = stream
+      @spin = spin
     end
 
     def indent(indent, string)
@@ -33,6 +34,19 @@ module Bolt
 
     def print_error
       raise NotImplementedError, "print_error() must be implemented by the outputter class"
+    end
+
+    def start_spin; end
+
+    def stop_spin; end
+
+    def spin
+      start_spin
+      begin
+        yield
+      ensure
+        stop_spin
+      end
     end
   end
 end

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -14,12 +14,13 @@ module Bolt
 
       def print_head; end
 
-      def initialize(color, verbose, trace, stream = $stdout)
+      def initialize(color, verbose, trace, spin, stream = $stdout)
         super
         # Plans and without_default_logging() calls can both be nested, so we
         # track each of them with a "stack" consisting of an integer.
         @plan_depth = 0
         @disable_depth = 0
+        @pinwheel = %w[- \\ | /]
       end
 
       def colorize(color, string)
@@ -28,6 +29,24 @@ module Bolt
         else
           string
         end
+      end
+
+      def start_spin
+        return unless @spin
+        @spin = true
+        @spin_thread = Thread.new do
+          loop do
+            sleep(0.1)
+            @stream.print(colorize(:cyan, @pinwheel.rotate!.first + "\b"))
+          end
+        end
+      end
+
+      def stop_spin
+        return unless @spin
+        @spin_thread.terminate
+        @spin = false
+        @stream.print("\b")
       end
 
       def remove_trail(string)

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -3,7 +3,7 @@
 module Bolt
   class Outputter
     class JSON < Bolt::Outputter
-      def initialize(color, verbose, trace, stream = $stdout)
+      def initialize(color, verbose, trace, spin, stream = $stdout)
         super
         @items_open = false
         @object_open = false

--- a/lib/bolt/outputter/logger.rb
+++ b/lib/bolt/outputter/logger.rb
@@ -6,7 +6,7 @@ module Bolt
   class Outputter
     class Logger < Bolt::Outputter
       def initialize(verbose, trace)
-        super(false, verbose, trace)
+        super(false, verbose, trace, false)
         @logger = Bolt::Logger.logger(self)
       end
 

--- a/lib/bolt/outputter/rainbow.rb
+++ b/lib/bolt/outputter/rainbow.rb
@@ -5,7 +5,7 @@ require 'bolt/pal'
 module Bolt
   class Outputter
     class Rainbow < Bolt::Outputter::Human
-      def initialize(color, verbose, trace, stream = $stdout)
+      def initialize(color, verbose, trace, spin, stream = $stdout)
         begin
           require 'paint'
           if Bolt::Util.windows?
@@ -59,6 +59,17 @@ module Bolt
           end
         else
           string
+        end
+      end
+
+      def start_spin
+        return unless @spin
+        @spin = true
+        @spin_thread = Thread.new do
+          loop do
+            @stream.print(colorize(:rainbow, @pinwheel.rotate!.first + "\b"))
+            sleep(0.1)
+          end
         end
       end
 

--- a/lib/bolt/project_manager.rb
+++ b/lib/bolt/project_manager.rb
@@ -103,7 +103,9 @@ module Bolt
       # early here and not initialize the project if the modules cannot be
       # resolved and installed.
       if modules
+        @outputter.start_spin
         Bolt::ModuleInstaller.new(@outputter, @pal).install(modules, puppetfile, moduledir)
+        @outputter.stop_spin
       end
 
       data = { 'name' => project_name }

--- a/lib/bolt/project_manager/module_migrator.rb
+++ b/lib/bolt/project_manager/module_migrator.rb
@@ -61,6 +61,7 @@ module Bolt
         # Create specs to resolve from
         specs = Bolt::ModuleInstaller::Specs.new(modules.map(&:to_hash))
 
+        @outputter.start_spin
         # Attempt to resolve dependencies
         begin
           @outputter.print_message('')
@@ -72,6 +73,7 @@ module Bolt
         end
 
         migrate_managed_modules(puppetfile, puppetfile_path, managed_moduledir)
+        @outputter.stop_spin
 
         # Move remaining modules to 'modules'
         consolidate_modules(modulepath)

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -52,6 +52,9 @@
     "save-rerun": {
       "$ref": "#/definitions/save-rerun"
     },
+    "spinner": {
+      "$ref": "#/definitions/spinner"
+    },
     "trusted-external-command": {
       "$ref": "#/definitions/trusted-external-command"
     },
@@ -309,6 +312,10 @@
     },
     "save-rerun": {
       "description": "Whether to update `.rerun.json` in the Bolt project directory. If your target names include passwords, set this value to `false` to avoid writing passwords to disk.",
+      "type": "boolean"
+    },
+    "spinner": {
+      "description": "Whether to print a spinner to the console for long-running Bolt operations.",
       "type": "boolean"
     },
     "trusted-external-command": {

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -45,6 +45,9 @@
     },
     "save-rerun": {
       "$ref": "#/definitions/save-rerun"
+    },
+    "spinner": {
+      "$ref": "#/definitions/spinner"
     }
   },
   "definitions": {
@@ -309,6 +312,10 @@
     },
     "save-rerun": {
       "description": "Whether to update `.rerun.json` in the Bolt project directory. If your target names include passwords, set this value to `false` to avoid writing passwords to disk.",
+      "type": "boolean"
+    },
+    "spinner": {
+      "description": "Whether to print a spinner to the console for long-running Bolt operations.",
       "type": "boolean"
     },
     "transport": {

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -67,6 +67,9 @@
     "save-rerun": {
       "$ref": "#/definitions/save-rerun"
     },
+    "spinner": {
+      "$ref": "#/definitions/spinner"
+    },
     "tasks": {
       "$ref": "#/definitions/tasks"
     },
@@ -398,6 +401,10 @@
     },
     "save-rerun": {
       "description": "Whether to update `.rerun.json` in the Bolt project directory. If your target names include passwords, set this value to `false` to avoid writing passwords to disk.",
+      "type": "boolean"
+    },
+    "spinner": {
+      "description": "Whether to print a spinner to the console for long-running Bolt operations.",
       "type": "boolean"
     },
     "tasks": {

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -19,7 +19,7 @@ describe "Bolt::CLI" do
   let(:target) { inventory.get_target('foo') }
 
   before(:each) do
-    outputter = Bolt::Outputter::Human.new(false, false, false, StringIO.new)
+    outputter = Bolt::Outputter::Human.new(false, false, false, false, StringIO.new)
 
     allow_any_instance_of(Bolt::CLI).to receive(:outputter).and_return(outputter)
     allow_any_instance_of(Bolt::CLI).to receive(:warn)
@@ -1244,7 +1244,7 @@ describe "Bolt::CLI" do
           plan.call_by_name_with_scope(scope, params, true)
         end
 
-        outputter = Bolt::Outputter::JSON.new(false, false, false, output)
+        outputter = Bolt::Outputter::JSON.new(false, false, false, false, output)
 
         allow(cli).to receive(:outputter).and_return(outputter)
       end
@@ -2274,7 +2274,7 @@ describe "Bolt::CLI" do
         plugins = Bolt::Plugin.setup(Bolt::Config.default, nil)
         allow(cli).to receive(:plugins).and_return(plugins)
 
-        outputter = Bolt::Outputter::JSON.new(false, false, false, output)
+        outputter = Bolt::Outputter::JSON.new(false, false, false, false, output)
         allow(cli).to receive(:outputter).and_return(outputter)
         allow(executor).to receive(:report_bundled_content)
         allow(cli).to receive(:config).and_return(Bolt::Config.default)
@@ -2337,7 +2337,8 @@ describe "Bolt::CLI" do
       let(:cli) { Bolt::CLI.new(%W[puppetfile install --project #{project_path} -m #{modulepath}]) }
 
       before :each do
-        allow(cli).to receive(:outputter).and_return(Bolt::Outputter::JSON.new(false, false, false, output))
+        allow(cli).to receive(:outputter)
+          .and_return(Bolt::Outputter::JSON.new(false, false, false, false, output))
         allow_any_instance_of(Bolt::PAL).to receive(:generate_types)
         allow(R10K::Action::Puppetfile::Install).to receive(:new).and_return(action_stub)
       end
@@ -2398,7 +2399,8 @@ describe "Bolt::CLI" do
       end
 
       it 'lists modules in the puppetfile' do
-        allow(cli).to receive(:outputter).and_return(Bolt::Outputter::Human.new(false, false, false, output))
+        allow(cli).to receive(:outputter)
+          .and_return(Bolt::Outputter::Human.new(false, false, false, false, output))
         cli.parse
         modules = cli.list_modules
         expect(modules.keys.first).to match(/bolt-modules/)
@@ -2429,7 +2431,8 @@ describe "Bolt::CLI" do
       let(:cli) { Bolt::CLI.new([]) }
 
       before :each do
-        allow(cli).to receive(:outputter).and_return(Bolt::Outputter::JSON.new(false, false, false, output))
+        allow(cli).to receive(:outputter)
+          .and_return(Bolt::Outputter::JSON.new(false, false, false, false, output))
         allow(cli).to receive(:config).and_return(Bolt::Config.default)
       end
 

--- a/spec/bolt/module_installer/installer_spec.rb
+++ b/spec/bolt/module_installer/installer_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-
 require 'bolt/module_installer/installer'
 
 describe Bolt::ModuleInstaller::Installer do

--- a/spec/bolt/module_installer_spec.rb
+++ b/spec/bolt/module_installer_spec.rb
@@ -17,7 +17,11 @@ describe Bolt::ModuleInstaller do
   let(:installer)      { described_class.new(outputter, pal) }
 
   let(:outputter) do
-    double('outputter', print_message: nil, print_puppetfile_result: nil, print_action_step: nil)
+    double('outputter', print_message: nil,
+                        print_puppetfile_result: nil,
+                        start_spin: nil,
+                        stop_spin: nil,
+                        print_action_step: nil)
   end
 
   around(:each) do |example|

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -7,7 +7,7 @@ require 'bolt/plan_result'
 
 describe "Bolt::Outputter::Human" do
   let(:output) { StringIO.new }
-  let(:outputter) { Bolt::Outputter::Human.new(false, false, false, output) }
+  let(:outputter) { Bolt::Outputter::Human.new(false, false, false, false, output) }
   let(:inventory) { Bolt::Inventory.empty }
   let(:target) { inventory.get_target('target1') }
   let(:target2) { inventory.get_target('target2') }
@@ -399,6 +399,31 @@ describe "Bolt::Outputter::Human" do
     guide = "The trials and tribulations of Bolty McBoltface\n"
     outputter.print_guide(guide, 'boltymcboltface')
     expect(output.string).to eq(guide)
+  end
+
+  it 'does not spin when spinner is set to false' do
+    outputter.start_spin
+    sleep(0.3)
+    expect(output.string).not_to include("\b\\\b|")
+    outputter.stop_spin
+  end
+
+  context 'with spinner enabled' do
+    let(:outputter) { Bolt::Outputter::Human.new(false, false, false, true, output) }
+
+    it 'spins while executing with a block' do
+      outputter.spin do
+        sleep(0.3)
+        expect(output.string).to include("\\\b|\b")
+      end
+    end
+
+    it 'spins between start and stop' do
+      outputter.start_spin
+      sleep(0.3)
+      expect(output.string).to include("\\\b|\b")
+      outputter.stop_spin
+    end
   end
 
   context '#print_targets' do

--- a/spec/bolt/outputter/json_spec.rb
+++ b/spec/bolt/outputter/json_spec.rb
@@ -6,7 +6,7 @@ require 'bolt/cli'
 
 describe "Bolt::Outputter::JSON" do
   let(:output) { StringIO.new }
-  let(:outputter) { Bolt::Outputter::JSON.new(false, false, false, output) }
+  let(:outputter) { Bolt::Outputter::JSON.new(false, false, false, false, output) }
   let(:inventory) { Bolt::Inventory.empty }
   let(:target1) { inventory.get_target('target1') }
   let(:target2) { inventory.get_target('target2') }

--- a/spec/bolt/outputter/rainbow_spec.rb
+++ b/spec/bolt/outputter/rainbow_spec.rb
@@ -7,7 +7,7 @@ require 'bolt/plan_result'
 
 describe "Bolt::Outputter::Rainbow" do
   let(:output) { StringIO.new }
-  let(:outputter) { Bolt::Outputter::Rainbow.new(false, false, false, output) }
+  let(:outputter) { Bolt::Outputter::Rainbow.new(false, false, false, false, output) }
   let(:inventory) { Bolt::Inventory.empty }
   let(:target) { inventory.get_target('target1') }
   let(:target2) { inventory.get_target('target2') }

--- a/spec/bolt/project_manager/module_migrator_spec.rb
+++ b/spec/bolt/project_manager/module_migrator_spec.rb
@@ -24,6 +24,7 @@ describe Bolt::ProjectManager::ModuleMigrator do
     double('outputter',
            print_message: nil,
            print_action_step: nil,
+           spin: nil,
            print_action_error: nil)
   }
   let(:project_config) { {} }
@@ -40,6 +41,8 @@ describe Bolt::ProjectManager::ModuleMigrator do
 
   before(:each) do
     File.write(project.project_file, project_config)
+    allow(outputter).to receive(:start_spin)
+    allow(outputter).to receive(:stop_spin)
   end
 
   context 'with modules configured' do

--- a/spec/bolt/project_manager_spec.rb
+++ b/spec/bolt/project_manager_spec.rb
@@ -17,6 +17,8 @@ describe Bolt::ProjectManager do
            print_message: nil,
            print_action_step: nil,
            print_prompt: nil,
+           start_spin: nil,
+           stop_spin: nil,
            print_error: nil)
   }
 

--- a/spec/bolt/rerun_spec.rb
+++ b/spec/bolt/rerun_spec.rb
@@ -47,7 +47,7 @@ describe 'rerun' do
     # Don't allow tests to override the captured log config
     allow(Bolt::Logger).to receive(:configure)
     allow_any_instance_of(Bolt::CLI).to receive(:warn)
-    outputter = Bolt::Outputter::JSON.new(false, false, false, output)
+    outputter = Bolt::Outputter::JSON.new(false, false, false, false, output)
     allow_any_instance_of(Bolt::CLI).to receive(:outputter).and_return(outputter)
   end
 

--- a/spec/lib/bolt_spec/integration.rb
+++ b/spec/lib/bolt_spec/integration.rb
@@ -18,7 +18,7 @@ module BoltSpec
       allow(cli).to receive(:analytics).and_return(Bolt::Analytics::NoopClient.new)
 
       output =  StringIO.new
-      outputter = outputter.new(false, false, false, output)
+      outputter = outputter.new(false, false, false, false, output)
       allow(cli).to receive(:outputter).and_return(outputter)
       allow(Bolt::Logger).to receive(:configure)
 


### PR DESCRIPTION
(feature) Print spinner to the console for long operations

This introducs a spinner which spins while Bolt performs long
operations. Currently the spinner is added for installing modules,
running plans, and running tasks.

The spinner works by creating a new thread and continuously printing a
series of messages, where each message includes a backspace and the 
next character from an array of characters. The spinner is a function of
the outputters, which each have their own `start_spin` and `stop_spin`
functions that open and close the spinner thread respectively.

The spinner is enabled by default, and can be disabled by setting
`spinner: false` in any of `bolt.yaml`, `bolt-project.yaml`, or
`bolt-default.yaml`.

Closes #606

!feature

* **CLI spinner for long running operations**

  Bolt now has a spinner printed to the CLI for long-running operations,
  so that users know the Bolt process has not hung. Disable the spinner
  by setting `spinner: false` in any Bolt configuration file.