### PR TITLE
Add YAML anchor support for hiera.yaml

### DIFF
--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -100,9 +100,9 @@ module Bolt
       print_logs = stat.success?
       result = begin
         JSON.parse(out)
-               rescue JSON::ParserError
-                 print_logs = true
-                 { 'message' => "Something's gone terribly wrong! STDERR is logged." }
+      rescue JSON::ParserError
+        print_logs = true
+        { 'message' => "Something's gone terribly wrong! STDERR is logged." }
       end
 
       # Any messages logged by Puppet will be on stderr as JSON hashes, so we

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -100,9 +100,9 @@ module Bolt
       print_logs = stat.success?
       result = begin
         JSON.parse(out)
-      rescue JSON::ParserError
-        print_logs = true
-        { 'message' => "Something's gone terribly wrong! STDERR is logged." }
+               rescue JSON::ParserError
+                 print_logs = true
+                 { 'message' => "Something's gone terribly wrong! STDERR is logged." }
       end
 
       # Any messages logged by Puppet will be on stderr as JSON hashes, so we

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -131,7 +131,7 @@ module Bolt
 
     def validate_hiera_config(hiera_config)
       if File.exist?(File.path(hiera_config))
-        data = File.open(File.path(hiera_config), "r:UTF-8") { |f| YAML.safe_load(f.read, [Symbol]) }
+        data = File.open(File.path(hiera_config), "r:UTF-8") { |f| YAML.safe_load(f.read, [Symbol], [], true) }
         if data.nil?
           return nil
         elsif data['version'] != 5

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -168,7 +168,7 @@ describe Bolt::Applicator do
         expect(mock_logger).to_not receive(:trace).with(/Packing plugin/)
         expect(mock_logger).to receive(:debug).with('Syncing only required modules: just_a_module_name.')
 
-        applicator.apply_ast(:body, [target], { required_modules: ['just_a_module_name'] })
+        applicator.apply_ast(:body, [target], required_modules: ['just_a_module_name'])
       end
     end
 
@@ -296,9 +296,11 @@ describe Bolt::Applicator do
         allow(file_like_object).to receive(:read).and_return(hiera_yaml_string)
         allow(File).to receive(:path).with('hiera.yaml').and_return('/path/to/hiera.yaml')
         allow(File).to receive(:exist?).with('/path/to/hiera.yaml').and_return(true)
-        allow(File).to receive(:open).with('/path/to/hiera.yaml', 'r:UTF-8').and_yield( file_like_object )
-        applicator = Bolt::Applicator.new(inventory, executor, modulepath, plugindirs, 'hiera.yaml', pdb_client, nil, 2, {})
-        expect{applicator.validate_hiera_config('hiera.yaml')}.not_to raise_error
+        allow(File).to receive(:open).with('/path/to/hiera.yaml', 'r:UTF-8').and_yield(file_like_object)
+        applicator = Bolt::Applicator.new(
+          inventory, executor, modulepath, plugindirs, 'hiera.yaml', pdb_client, nil, 2, {}
+        )
+        expect { applicator.validate_hiera_config('hiera.yaml') }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
!feature

* **Add support for YAML anchors in `hiera.yaml`** 
   ([#2433](https://github.com/puppetlabs/bolt/issues/2433))

  Bolt projects' `hiera.yaml` files now support YAML anchors, which
  are useful to DRY up large and repetitive hierarchy sections.