### PR TITLE
(maint) Update puppet dep to 6.19.1

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-ssh", ">= 4.0"
   spec.add_dependency "net-ssh-krb", "~> 0.5"
   spec.add_dependency "orchestrator_client", "~> 0.4"
-  spec.add_dependency "puppet", ">= 6.18.0"
+  spec.add_dependency "puppet", ">= 6.19.1"
   spec.add_dependency "puppetfile-resolver", "~> 0.4"
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "puppet-strings", "~> 2.3"


### PR DESCRIPTION
PE services are failing to start up in the main branches because of a mismatch
between the puppet installed with bolt-server and the puppet.conf file changes
allowed in newer puppet versions.

This commit updates the puppet version dependency to the latest in the 6
series of puppet