### PR TITLE
(GH-2361) Deprecate puppetfile commands and config option

### DIFF
--- a/documentation/modules.md
+++ b/documentation/modules.md
@@ -142,9 +142,3 @@ modulepath = site:dist:modules:$basemodulepath:.modules
 
 You can learn more about the module changes introduced in Bolt 2.23.0 in the
 [September 2020 developer update](./developer_updates.md#september-2020).
- 
-
-📖 **Related information**
-
-- For a list of modules that are shipped with Bolt, see [Packaged modules](packaged_modules.md).
-- For a list of plugins that Bolt maintains, see [Supported plugins](supported_plugins.md).

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -858,6 +858,10 @@ module Bolt
         raise Bolt::CLIError,
               "Unable to use command '#{old_command}' when 'modules' is configured in "\
               "bolt-project.yaml. Use '#{new_command}' instead."
+      elsif modules.nil? && options[:subcommand] == 'puppetfile'
+        msg = "Command '#{old_command}' is deprecated and will be removed in Bolt 3.0. Update your project to use "\
+              "the module management feature. For more information, see https://pup.pt/bolt-module-migrate."
+        Bolt::Logger.deprecation_warning('puppetfile command', msg)
       elsif modules.nil? && options[:subcommand] == 'module'
         msg  = "Unable to use command '#{new_command}' when 'modules' is not configured in "\
                "bolt-project.yaml. "

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -430,6 +430,8 @@ module Bolt
               _example: "https://my-proxy.com:8080"
             }
           },
+          _deprecation: "This option will be removed in Bolt 3.0. Update your project to use the module "\
+                        "management feature. For more information, see https://pup.pt/bolt-module-migrate.",
           _plugin: false
         },
         "save-rerun" => {


### PR DESCRIPTION
This deprecates the `puppetfile` CLI commands and the `puppetfile`
configuration option. If any configuration file includes the
`puppetfile` option or if the user runs any `puppetfile` command,
Bolt will issue a deprecation warning telling the user to update
their project to use the module management feature with a link to
documentation.

!deprecation

* **Deprecate `puppetfile` in favor of `module-install`**
  ([#2361](https://github.com/puppetlabs/bolt/issues/2361))

  The `puppetfile` configuration option has been deprecated in favor of
  `module-install` and will be removed in Bolt 3.0. Users should update
  their projects to use the module management feature, which uses the
  `module-install` option.

* **Deprecate `puppetfile` commands**
  ([#2361](https://github.com/puppetlabs/bolt/issues/2361))

  The `bolt puppetfile *` commands and `*-BoltPuppetfile` cmdlets have
  been deprecated and will be removed in Bolt 3.0. Users should update
  their projects to use the module management feature, which uses the
  `bolt module *` commands and `*-BoltModule` cmdlets.