### PR TITLE
(maint) Consolidate BoltSpec::Config and BoltSpec::Files

### DIFF
--- a/spec/bolt/inventory/group_spec.rb
+++ b/spec/bolt/inventory/group_spec.rb
@@ -11,10 +11,11 @@ require 'bolt_spec/plugins'
 describe Bolt::Inventory::Group do
   include BoltSpec::Config
 
-  let(:data) { { 'name' => 'all' } }
-  let(:pal) { nil } # Not used
+  let(:data)    { { 'name' => 'all' } }
+  let(:pal)     { nil } # Not used
+  let(:config)  { make_config }
   let(:plugins) { Bolt::Plugin.setup(config, nil) }
-  let(:group) {
+  let(:group)   {
     # Inventory always resolves unknown labels to names or aliases from the top-down when constructed,
     # passing the collection of all aliases in it. Do that manually here to ensure plain target strings
     # are included as targets.

--- a/spec/bolt/inventory/inventory_spec.rb
+++ b/spec/bolt/inventory/inventory_spec.rb
@@ -16,6 +16,7 @@ describe Bolt::Inventory::Inventory do
   end
 
   let(:pal)          { nil }
+  let(:config)       { make_config }
   let(:plugins)      { Bolt::Plugin.setup(config, pal) }
   let(:target_name)  { "example.com" }
   let(:target_entry) { target_name }
@@ -240,7 +241,7 @@ describe Bolt::Inventory::Inventory do
           }
         }
       end
-      let(:config)    { Bolt::Config.new(Bolt::Project.new({}, '.'), data) }
+      let(:config)    { make_config(data) }
       let(:inventory) { Bolt::Inventory::Inventory.new({}, config.transport, config.transports, plugins) }
       let(:target)    { inventory.get_targets('notarget')[0] }
 

--- a/spec/bolt/inventory_spec.rb
+++ b/spec/bolt/inventory_spec.rb
@@ -10,6 +10,7 @@ describe Bolt::Inventory do
   include BoltSpec::Config
 
   let(:pal)     { nil } # Not used
+  let(:config)  { make_config }
   let(:plugins) { Bolt::Plugin.setup(config, pal) }
 
   context 'with BOLT_INVENTORY set' do

--- a/spec/bolt/plugin/module_spec.rb
+++ b/spec/bolt/plugin/module_spec.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/files'
 require 'bolt_spec/config'
+require 'bolt_spec/files'
 require 'bolt/plugin'
 require 'bolt/analytics'
 
 describe Bolt::Plugin::Module do
-  include BoltSpec::Files
   include BoltSpec::Config
+  include BoltSpec::Files
 
   let(:modulepath) { [fixtures_path('plugin_modules')] }
   let(:plugin_config) { {} }
   let(:config_data) { { 'modulepath' => modulepath, 'plugins' => plugin_config } }
 
   let(:pal) { Bolt::PAL.new(Bolt::Config::Modulepath.new(modulepath), {}, nil) }
-  let(:plugins) { Bolt::Plugin.setup(config(config_data), pal) }
+  let(:plugins) { Bolt::Plugin.setup(make_config(config_data), pal) }
 
   let(:module_name) { 'empty_plug' }
   let(:mod) { Bolt::Module.new(module_name, fixtures_path('plugin_modules', module_name)) }

--- a/spec/bolt/plugin/puppet_library_spec.rb
+++ b/spec/bolt/plugin/puppet_library_spec.rb
@@ -2,14 +2,12 @@
 
 require 'spec_helper'
 require 'bolt_spec/files'
-require 'bolt_spec/config'
 require 'bolt/plugin'
 require 'bolt/analytics'
 require 'bolt_spec/plans'
 
 describe Bolt::Plugin::Module do
   include BoltSpec::Files
-  include BoltSpec::Config
   # These tests to not actually use the plan mocking just the executor/inventory setup
   include BoltSpec::Plans
 

--- a/spec/bolt/plugin_spec.rb
+++ b/spec/bolt/plugin_spec.rb
@@ -1,23 +1,25 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/files'
 require 'bolt_spec/config'
+require 'bolt_spec/files'
+require 'bolt_spec/pal'
 require 'bolt/pal'
 require 'bolt/plugin'
 require 'bolt/plugin/env_var'
 require 'bolt/analytics'
 
 describe Bolt::Plugin do
-  include BoltSpec::Files
   include BoltSpec::Config
+  include BoltSpec::Files
+  include BoltSpec::PAL
 
-  let(:modulepath) { [fixtures_path('plugin_modules')] }
   let(:plugin_config) { {} }
-  let(:config_data) { { 'modulepath' => modulepath, 'plugins' => plugin_config } }
-  let(:pal) { Bolt::PAL.new(Bolt::Config::Modulepath.new(modulepath), nil, nil) }
-
-  let(:plugins) { Bolt::Plugin.setup(config(config_data), pal) }
+  let(:modulepath)    { [fixtures_path('plugin_modules')] }
+  let(:config_data)   { { 'modulepath' => modulepath, 'plugins' => plugin_config } }
+  let(:config)        { make_config(config_data) }
+  let(:pal)           { make_pal(modulepath) }
+  let(:plugins)       { Bolt::Plugin.setup(config, pal) }
 
   def identity(value, cache = nil)
     plugin = {
@@ -101,7 +103,7 @@ describe Bolt::Plugin do
   end
 
   context 'plugin loading is disabled' do
-    let(:plugins) { Bolt::Plugin.setup(config(config_data), pal, load_plugins: false) }
+    let(:plugins) { Bolt::Plugin.setup(config, pal, load_plugins: false) }
 
     it 'raises a plugin-loading-disabled error if it attempts to load a Ruby plugin' do
       expect { plugins.by_name('env_var') }.to raise_error(

--- a/spec/bolt/transport/local_spec.rb
+++ b/spec/bolt/transport/local_spec.rb
@@ -15,6 +15,7 @@ describe Bolt::Transport::Local do
   end
 
   let(:pal)          { nil }
+  let(:config)       { make_config }
   let(:plugins)      { Bolt::Plugin.setup(config, pal) }
   let(:transports)   { config.transports }
   let(:transport)    { config.transport }

--- a/spec/integration/cache_spec.rb
+++ b/spec/integration/cache_spec.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/config'
+require 'bolt_spec/files'
 require 'bolt_spec/integration'
 require 'bolt_spec/project'
 
 describe 'caching plugins' do
-  include BoltSpec::Config
+  include BoltSpec::Files
   include BoltSpec::Integration
   include BoltSpec::Project
 
   let(:project) { @project }
   let(:project_path) { @project.path }
   let(:inventory) { nil }
-  let(:mpath) { fixture_path('plugin_modules') }
+  let(:mpath) { fixtures_path('plugin_modules') }
   let(:plan) do
     <<~PLAN
       plan cache_test() {

--- a/spec/integration/catch_errors_spec.rb
+++ b/spec/integration/catch_errors_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/config'
 require 'bolt_spec/conn'
 require 'bolt_spec/files'
 require 'bolt_spec/integration'
@@ -9,19 +8,19 @@ require 'bolt/util'
 
 describe "catch_errors", ssh: true do
   include BoltSpec::Integration
-  include BoltSpec::Config
+  include BoltSpec::Files
   include BoltSpec::Conn
 
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
-  let(:modulepath) { [fixture_path('modules'), fixture_path('apply')].join(File::PATH_SEPARATOR) }
+  let(:modulepath) { [fixtures_path('modules'), fixtures_path('apply')].join(File::PATH_SEPARATOR) }
   let(:target) { conn_uri('ssh', include_password: true) }
 
   let(:transport_flags) { ['--no-host-key-check'] }
 
   let(:config_flags) {
     ['--format', 'json',
-     '--configfile', fixture_path('configs', 'empty.yml'),
+     '--configfile', fixtures_path('configs', 'empty.yml'),
      '--modulepath', modulepath,
      '--targets', target] + transport_flags
   }

--- a/spec/integration/fail_plan_spec.rb
+++ b/spec/integration/fail_plan_spec.rb
@@ -7,16 +7,17 @@ require 'bolt_spec/files'
 require 'bolt_spec/integration'
 
 describe "When a plan fails" do
-  include BoltSpec::Integration
   include BoltSpec::Config
   include BoltSpec::Conn
+  include BoltSpec::Files
+  include BoltSpec::Integration
 
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
-  let(:modulepath) { fixture_path('modules') }
-  let(:config_flags) {
+  let(:modulepath)    { fixtures_path('modules') }
+  let(:config_flags)  {
     ['--format', 'json',
-     '--configfile', fixture_path('configs', 'empty.yml'),
+     '--configfile', fixtures_path('configs', 'empty.yml'),
      '--modulepath', modulepath,
      '--no-host-key-check']
   }

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/config'
 require 'bolt_spec/conn'
 require 'bolt_spec/files'
 require 'bolt_spec/integration'
 require 'bolt_spec/puppetdb'
 
 describe 'running with an inventory file', reset_puppet_settings: true do
-  include BoltSpec::Config
   include BoltSpec::Conn
   include BoltSpec::Files
   include BoltSpec::Integration
@@ -62,11 +60,11 @@ describe 'running with an inventory file', reset_puppet_settings: true do
   end
   let(:target) { conn[:host] }
 
-  let(:modulepath) { fixture_path('modules') }
+  let(:modulepath) { fixtures_path('modules') }
   let(:config_flags) {
     ['--format', 'json',
      '--inventoryfile', @inventoryfile,
-     '--configfile', fixture_path('configs', 'empty.yml'),
+     '--configfile', fixtures_path('configs', 'empty.yml'),
      '--modulepath', modulepath,
      '--password', conn[:password]]
   }
@@ -375,7 +373,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
     let(:config_flags) {
       ['--format', 'json',
        '--inventoryfile', @inventoryfile,
-       '--configfile', fixture_path('configs', 'empty.yml'),
+       '--configfile', fixtures_path('configs', 'empty.yml'),
        '--modulepath', modulepath]
     }
 

--- a/spec/integration/lookup_spec.rb
+++ b/spec/integration/lookup_spec.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/config'
+require 'bolt_spec/files'
 require 'bolt_spec/integration'
 
 describe "lookup() in plans" do
-  include BoltSpec::Config
+  include BoltSpec::Files
   include BoltSpec::Integration
 
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
-  let(:boltdir)      { fixture_path('hiera') }
+  let(:boltdir)      { fixtures_path('hiera') }
   let(:hiera_config) { File.join(boltdir, 'hiera.yaml') }
   let(:plan)         { 'test::lookup' }
 

--- a/spec/integration/modules/facts_spec.rb
+++ b/spec/integration/modules/facts_spec.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/config'
 require 'bolt_spec/conn'
-require 'bolt_spec/integration'
 require 'bolt_spec/run'
 
 describe "running the facts plan" do

--- a/spec/integration/parallel_spec.rb
+++ b/spec/integration/parallel_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/config'
 require 'bolt_spec/conn'
 require 'bolt_spec/files'
 require 'bolt_spec/integration'
@@ -10,13 +9,13 @@ require 'bolt_spec/puppet_agent'
 
 describe 'plans' do
   include BoltSpec::Integration
-  include BoltSpec::Config
+  include BoltSpec::Files
   include BoltSpec::Conn
   include BoltSpec::Project
 
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
-  let(:modulepath) { fixture_path('modules') }
+  let(:modulepath) { fixtures_path('modules') }
 
   shared_examples "parallelize plan function" do
     let(:return_value) {
@@ -68,7 +67,7 @@ describe 'plans' do
   end
 
   context "over ssh", ssh: true do
-    let(:inv_path) { fixture_path('inventory', 'docker.yml') }
+    let(:inv_path) { fixtures_path('inventory', 'docker.yml') }
     let(:config_flags) {
       ['-t all',
        '--modulepath', modulepath,

--- a/spec/integration/plan_spec.rb
+++ b/spec/integration/plan_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/config'
 require 'bolt_spec/conn'
 require 'bolt_spec/files'
 require 'bolt_spec/integration'
@@ -9,23 +8,23 @@ require 'bolt_spec/project'
 require 'bolt_spec/puppet_agent'
 
 describe 'plans' do
-  include BoltSpec::Integration
-  include BoltSpec::Config
   include BoltSpec::Conn
+  include BoltSpec::Integration
+  include BoltSpec::Files
   include BoltSpec::Project
   include BoltSpec::PuppetAgent
 
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
-  let(:modulepath) { fixture_path('modules') }
-  let(:config_flags) {
+  let(:modulepath)      { fixtures_path('modules') }
+  let(:config_flags)    {
     ['--format', 'json',
-     '--configfile', fixture_path('configs', 'empty.yml'),
+     '--configfile', fixtures_path('configs', 'empty.yml'),
      '--modulepath', modulepath,
      '--no-host-key-check']
   }
-  let(:target) { conn_uri('ssh', include_password: true) }
-  let(:project_config) { { 'modules' => [] } }
+  let(:target)          { conn_uri('ssh', include_password: true) }
+  let(:project_config)  { { 'modules' => [] } }
 
   context "When a plan succeeds" do
     it 'prints the result', ssh: true do
@@ -75,7 +74,7 @@ describe 'plans' do
         install(conn_uri('ssh', include_password: true))
         example.run
       ensure
-        FileUtils.rm_rf(fixture_path('configs', '.resource_types'))
+        FileUtils.rm_rf(fixtures_path('configs', '.resource_types'))
         uninstall(conn_uri('ssh', include_password: true))
       end
 

--- a/spec/integration/project_spec.rb
+++ b/spec/integration/project_spec.rb
@@ -1,21 +1,19 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/config'
 require 'bolt_spec/conn'
 require 'bolt_spec/files'
 require 'bolt_spec/integration'
 require 'bolt_spec/project'
 
 describe "When loading content", ssh: true do
-  include BoltSpec::Config
   include BoltSpec::Conn
   include BoltSpec::Files
   include BoltSpec::Integration
   include BoltSpec::Project
 
   let(:local) { Bolt::Project.create_project(fixtures_path('projects', 'local'), 'local') }
-  let(:embedded) { fixture_path('projects/embedded') }
+  let(:embedded) { fixtures_path('projects/embedded') }
   let(:target) { conn_uri('ssh') }
   let(:config_flags) { %W[--no-host-key-check --password #{conn_info('ssh')[:password]}] }
 

--- a/spec/integration/remote_spec.rb
+++ b/spec/integration/remote_spec.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/config'
 require 'bolt_spec/conn'
 require 'bolt_spec/files'
-require 'bolt_spec/integration'
 require 'bolt_spec/run'
 
 describe 'running with an inventory file', reset_puppet_settings: true, ssh: true do
-  include BoltSpec::Config
   include BoltSpec::Conn
+  include BoltSpec::Files
   include BoltSpec::Run
 
+  let(:modulepath) { fixtures_path('modules') }
   let(:conn) { conn_info('ssh') }
   let(:inventory) do
     { 'targets' => [
@@ -43,7 +42,6 @@ describe 'running with an inventory file', reset_puppet_settings: true, ssh: tru
       } }
   end
 
-  let(:modulepath) { fixture_path('modules') }
   let(:config) { { 'modulepath' => modulepath } }
 
   it 'runs a remote task' do

--- a/spec/integration/transpiler_spec.rb
+++ b/spec/integration/transpiler_spec.rb
@@ -2,15 +2,15 @@
 
 require 'spec_helper'
 require 'bolt/pal/yaml_plan/transpiler'
-require 'bolt_spec/config'
+require 'bolt_spec/files'
 require 'bolt_spec/integration'
 
 describe "transpiling YAML plans" do
-  include BoltSpec::Config
+  include BoltSpec::Files
   include BoltSpec::Integration
 
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
-  let(:modulepath) { fixture_path('modules') }
+  let(:modulepath) { fixtures_path('modules') }
   let(:yaml_path) { File.join(modulepath, 'yaml', 'plans') }
   let(:plan_path) { File.join(yaml_path, 'conversion.yaml') }
   let(:output_plan) { <<~PLAN }

--- a/spec/integration/transport/local_spec.rb
+++ b/spec/integration/transport/local_spec.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt/transport/local'
-require 'bolt/target'
 require 'bolt/inventory'
+require 'bolt/transport/local'
 require 'bolt/util'
+require 'bolt_spec/pal'
 require 'bolt_spec/transport'
-require 'bolt_spec/conn'
 
 require 'shared_examples/transport'
 
 describe Bolt::Transport::Local do
+  include BoltSpec::PAL
   include BoltSpec::Transport
 
   let(:transport)     { :local }
@@ -19,13 +19,11 @@ describe Bolt::Transport::Local do
   let(:user)          { 'runner' }
   let(:password)      { 'runner' }
   let(:os_context)    { Bolt::Util.windows? ? windows_context : posix_context }
-  let(:config)        { make_config }
-  let(:project)       { Bolt::Project.new({}, '.') }
-  let(:plugins)       { Bolt::Plugin.setup(config, nil) }
-  let(:inventory)     { Bolt::Inventory.create_version({}, config.transport, config.transports, plugins) }
-  let(:target)        { make_target }
-
   let(:transport_config) { {} }
+  let(:config)        { make_config({ local: transport_config }) }
+  let(:plugins)       { make_plugins(config) }
+  let(:inventory)     { Bolt::Inventory::Inventory.new({}, config.transport, config.transports, plugins) }
+  let(:target)        { make_target }
 
   def make_target
     inventory.get_target(host_and_port)

--- a/spec/integration/transport/ssh_spec.rb
+++ b/spec/integration/transport/ssh_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 require 'net/ssh'
 require 'net/ssh/proxy/jump'
+require 'bolt_spec/config'
 require 'bolt_spec/conn'
 require 'bolt_spec/errors'
 require 'bolt_spec/logger'
@@ -15,6 +16,7 @@ require 'bolt/util'
 require 'shared_examples/transport'
 
 describe Bolt::Transport::SSH, ssh: true do
+  include BoltSpec::Config
   include BoltSpec::Conn
   include BoltSpec::Errors
   include BoltSpec::Files
@@ -48,19 +50,12 @@ describe Bolt::Transport::SSH, ssh: true do
   let(:stdin_task)        { "#!/bin/sh\ngrep data" }
   let(:env_task)          { "#!/bin/sh\necho $PT_data" }
 
-  let(:config)            { make_config }
-  let(:project)           { Bolt::Project.new({}, '.') }
+  let(:config)            { make_config({ ssh: transport_config }) }
   let(:plugins)           { Bolt::Plugin.setup(config, nil) }
   let(:inventory)         { Bolt::Inventory.create_version({}, config.transport, config.transports, plugins) }
   let(:target)            { make_target }
 
   let(:transport_config)  { {} }
-
-  def make_config(conf: transport_config)
-    conf = Bolt::Util.walk_keys(conf, &:to_s)
-    Bolt::Config.new(project, 'ssh' => conf)
-  end
-  alias_method :mk_config, :make_config
 
   def make_target(host_: hostname, port_: port)
     inventory.get_target("#{host_}:#{port_}")

--- a/spec/integration/transport/winrm_spec.rb
+++ b/spec/integration/transport/winrm_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/config'
 require 'bolt_spec/conn'
 require 'bolt_spec/errors'
 require 'bolt_spec/files'
@@ -13,7 +12,6 @@ require 'bolt/inventory'
 require 'winrm'
 
 describe Bolt::Transport::WinRM do
-  include BoltSpec::Config
   include BoltSpec::Conn
   include BoltSpec::Errors
   include BoltSpec::Files
@@ -29,7 +27,7 @@ describe Bolt::Transport::WinRM do
   let(:password)    { conn_info('winrm')[:password] }
   let(:command)     { "[Environment]::UserName" }
   let(:config)      { mk_config(ssl: false, user: user, password: password) }
-  let(:cacert_path) { fixture_path('ssl', 'ca.pem') }
+  let(:cacert_path) { fixtures_path('ssl', 'ca.pem') }
   let(:ssl_config)  { mk_config(cacert: cacert_path, user: user, password: password) }
   let(:winrm)       { Bolt::Transport::WinRM.new }
   let(:winrm_ssl)   { Bolt::Transport::WinRM.new }

--- a/spec/integration/yaml_plan_spec.rb
+++ b/spec/integration/yaml_plan_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/config'
 require 'bolt_spec/conn'
 require 'bolt_spec/files'
 require 'bolt_spec/integration'
@@ -9,25 +8,25 @@ require 'bolt_spec/logger'
 
 describe "running YAML plans", ssh: true do
   include BoltSpec::Integration
-  include BoltSpec::Config
   include BoltSpec::Conn
+  include BoltSpec::Files
   include BoltSpec::Logger
 
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
   # Don't print error messages to the console
   before(:each) { allow($stdout).to receive(:puts) }
 
-  let(:modulepath) { fixture_path('modules') }
-  let(:password) { conn_info('ssh')[:password] }
-  let(:config_flags) {
+  let(:modulepath)    { fixtures_path('modules') }
+  let(:password)      { conn_info('ssh')[:password] }
+  let(:target)        { conn_uri('ssh', include_password: true) }
+  let(:config_flags)  {
     ['--format', 'json',
-     '--project', fixture_path('configs', 'empty'),
+     '--project', fixtures_path('configs', 'empty'),
      '--modulepath', modulepath,
      '--run-as', 'root',
      '--sudo-password', password,
      '--no-host-key-check']
   }
-  let(:target) { conn_uri('ssh', include_password: true) }
 
   def run_plan(plan_name, params = {})
     result = run_cli(['plan', 'run', plan_name, '--params', params.to_json] + config_flags,

--- a/spec/lib/bolt_spec/config.rb
+++ b/spec/lib/bolt_spec/config.rb
@@ -1,29 +1,13 @@
 # frozen_string_literal: true
 
 require 'bolt/config'
-require 'bolt_spec/conn'
-require 'bolt_spec/files'
 
 module BoltSpec
   module Config
-    def fixture_path(*parts)
-      File.join(__dir__, '..', '..', 'fixtures', *parts)
-    end
-
-    def config(overrides = {})
-      empty = {
-        'inventoryfile' => fixture_path('inventory', 'empty.yml')
-      }
-      Bolt::Config.new(Bolt::Project.new({}, '.'), empty.merge(overrides))
-    end
-
-    def conn_config(overrides = {})
-      conn = BoltSpec.conn.new
-      conn_conf = {
-        ssh: conn.conn_info('ssh'),
-        winrm: conn.conn_info('winrm')
-      }
-      config(conn_conf.merge(overrides))
+    def make_config(overrides = {})
+      overrides = Bolt::Util.walk_keys(overrides, &:to_s)
+      project = Bolt::Project.new({}, '.')
+      Bolt::Config.new(project, overrides)
     end
   end
 end

--- a/spec/lib/bolt_spec/pal.rb
+++ b/spec/lib/bolt_spec/pal.rb
@@ -1,21 +1,31 @@
 # frozen_string_literal: true
 
-require 'bolt_spec/files'
 require 'bolt/config'
+require 'bolt/inventory/inventory'
 require 'bolt/pal'
+require 'bolt/plugin'
+require 'bolt_spec/config'
+require 'bolt_spec/files'
 
 module BoltSpec
   module PAL
+    include BoltSpec::Config
     include BoltSpec::Files
 
-    def config
-      conf = Bolt::Config.new
-      conf[:modulepath] = modulepath
-      conf
+    def make_pal(modulepath = nil)
+      modulepath ||= fixtures_path('modules')
+      Bolt::PAL.new(Bolt::Config::Modulepath.new(modulepath), nil, nil)
     end
 
-    def modulepath
-      [File.join(__FILE__, '..', '..', '..', 'fixtures', 'modules')]
+    def make_plugins(config = nil)
+      config ||= make_config
+      Bolt::Plugin.setup(config, nil)
+    end
+
+    def make_inventory(data = {})
+      config = make_config
+      plugins = make_plugins(config)
+      Bolt::Inventory::Inventory.new(data, config.transport, config.transports, plugins)
     end
 
     def peval(code, pal, executor = nil, inventory = nil, pdb_client = nil)

--- a/spec/pal/apply_result_spec.rb
+++ b/spec/pal/apply_result_spec.rb
@@ -1,24 +1,17 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/files'
 require 'bolt_spec/pal'
-require 'bolt_spec/config'
-
 require 'bolt/pal'
-require 'bolt/inventory'
-require 'bolt/plugin'
 
 describe 'ApplyResult DataType' do
-  include BoltSpec::Files
   include BoltSpec::PAL
-  include BoltSpec::Config
 
   before(:all) { Bolt::PAL.load_puppet }
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
-  let(:pal)     { Bolt::PAL.new(Bolt::Config::Modulepath.new(modulepath), nil, nil) }
-  let(:plugins) { Bolt::Plugin.setup(config, nil) }
+  let(:pal) { make_pal }
+  let(:inventory) { make_inventory }
 
   let(:result_code) do
     <<~PUPPET
@@ -28,7 +21,7 @@ describe 'ApplyResult DataType' do
 
   def result_attr(attr)
     code = result_code + attr
-    peval(code, pal, nil, Bolt::Inventory::Inventory.new({}, config.transport, config.transports, plugins))
+    peval(code, pal, nil, inventory)
   end
 
   it 'should expose target' do

--- a/spec/pal/facts_spec.rb
+++ b/spec/pal/facts_spec.rb
@@ -1,17 +1,11 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/files'
 require 'bolt_spec/pal'
-require 'bolt_spec/config'
 require 'bolt/pal'
-require 'bolt/inventory/inventory'
-require 'bolt/plugin'
 
 describe 'Facts functions' do
-  include BoltSpec::Files
   include BoltSpec::PAL
-  include BoltSpec::Config
 
   before(:all) { Bolt::PAL.load_puppet }
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
@@ -24,10 +18,8 @@ describe 'Facts functions' do
       'facts' => { 'hot' => 'chocolate' }
     }
   }
-  let(:pal)     { Bolt::PAL.new(Bolt::Config::Modulepath.new(modulepath), nil, nil) }
-  let(:plugins) { Bolt::Plugin.setup(config, nil) }
-  let(:inv)     { Bolt::Inventory::Inventory.new(data, config.transport, config.transports, plugins) }
-
+  let(:pal)       { make_pal }
+  let(:inv)       { make_inventory(data) }
   let(:executor)  { Bolt::Executor.new }
 
   let(:target_string) { "$t = get_targets(#{target})[0]\n" }

--- a/spec/pal/features_spec.rb
+++ b/spec/pal/features_spec.rb
@@ -1,26 +1,21 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/files'
 require 'bolt_spec/pal'
-require 'bolt_spec/config'
 require 'bolt/pal'
 require 'bolt/inventory/inventory'
 require 'bolt/plugin'
 
 describe 'set_features function' do
-  include BoltSpec::Files
   include BoltSpec::PAL
-  include BoltSpec::Config
 
   before(:all) { Bolt::PAL.load_puppet }
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
-  let(:executor) { Bolt::Executor.new(1) }
-
-  let(:pal) { Bolt::PAL.new(Bolt::Config::Modulepath.new(modulepath), nil, nil) }
+  let(:executor)  { Bolt::Executor.new(1) }
+  let(:pal)       { make_pal }
   let(:inventory) { Bolt::Inventory.empty }
-  let(:target) { inventory.get_targets('example')[0] }
+  let(:target)    { inventory.get_targets('example')[0] }
 
   it 'adds the feature to the target' do
     peval(<<-CODE, pal, executor, inventory)

--- a/spec/pal/result_set_spec.rb
+++ b/spec/pal/result_set_spec.rb
@@ -1,24 +1,17 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/files'
 require 'bolt_spec/pal'
-require 'bolt_spec/config'
-
 require 'bolt/pal'
-require 'bolt/inventory/inventory'
-require 'bolt/plugin'
 
 describe 'ResultSet DataType' do
-  include BoltSpec::Files
   include BoltSpec::PAL
-  include BoltSpec::Config
 
   before(:all) { Bolt::PAL.load_puppet }
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
-  let(:pal)     { Bolt::PAL.new(Bolt::Config::Modulepath.new(modulepath), nil, nil) }
-  let(:plugins) { Bolt::Plugin.setup(config, nil) }
+  let(:pal)       { make_pal }
+  let(:inventory) { make_inventory }
 
   let(:result_code) do
     <<~PUPPET
@@ -30,7 +23,7 @@ describe 'ResultSet DataType' do
 
   def result_set(attr)
     code = result_code + attr
-    peval(code, pal, nil, Bolt::Inventory::Inventory.new({}, config.transport, config.transports, plugins))
+    peval(code, pal, nil, inventory)
   end
 
   it 'should be ok' do

--- a/spec/pal/result_spec.rb
+++ b/spec/pal/result_spec.rb
@@ -1,24 +1,17 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/files'
 require 'bolt_spec/pal'
-require 'bolt_spec/config'
-
 require 'bolt/pal'
-require 'bolt/inventory/inventory'
-require 'bolt/plugin'
 
 describe 'Result DataType' do
-  include BoltSpec::Files
   include BoltSpec::PAL
-  include BoltSpec::Config
 
   before(:all) { Bolt::PAL.load_puppet }
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
-  let(:pal)     { Bolt::PAL.new(Bolt::Config::Modulepath.new(modulepath), nil, nil) }
-  let(:plugins) { Bolt::Plugin.setup(config, nil) }
+  let(:pal) { make_pal }
+  let(:inventory) { make_inventory }
 
   let(:result_code) do
     <<~PUPPET
@@ -28,7 +21,7 @@ describe 'Result DataType' do
 
   def result_attr(attr)
     code = result_code + attr
-    peval(code, pal, nil, Bolt::Inventory::Inventory.new({}, config.transport, config.transports, plugins))
+    peval(code, pal, nil, inventory)
   end
 
   it 'should expose target' do

--- a/spec/pal/target_spec.rb
+++ b/spec/pal/target_spec.rb
@@ -1,32 +1,25 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/files'
-require 'bolt_spec/pal'
 require 'bolt_spec/config'
-
+require 'bolt_spec/pal'
 require 'bolt/pal'
-require 'bolt/inventory'
-require 'bolt/plugin'
 
 describe 'Target DataType' do
-  include BoltSpec::Files
-  include BoltSpec::PAL
   include BoltSpec::Config
+  include BoltSpec::PAL
 
   before(:all) { Bolt::PAL.load_puppet }
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
-  let(:pal)     { Bolt::PAL.new(Bolt::Config::Modulepath.new(modulepath), nil, nil) }
-  let(:plugins) { Bolt::Plugin.setup(config, nil) }
-
-  let(:target_code) { "$target = Target('pcp://user1:pass1@example.com:33')\n" }
-
-  let(:default_config) { config.transports['pcp'].to_h }
+  let(:pal)             { make_pal }
+  let(:inventory)       { make_inventory }
+  let(:default_config)  { make_config.transports['pcp'].to_h }
+  let(:target_code)     { "$target = Target('pcp://user1:pass1@example.com:33')\n" }
 
   def target(attr)
     code = target_code + attr
-    peval(code, pal, nil, Bolt::Inventory::Inventory.new({}, config.transport, config.transports, plugins))
+    peval(code, pal, nil, inventory)
   end
 
   it 'should expose uri' do

--- a/spec/pal/vars_spec.rb
+++ b/spec/pal/vars_spec.rb
@@ -1,17 +1,11 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/files'
 require 'bolt_spec/pal'
-require 'bolt_spec/config'
 require 'bolt/pal'
-require 'bolt/inventory/inventory'
-require 'bolt/plugin'
 
 describe 'Vars function' do
-  include BoltSpec::Files
   include BoltSpec::PAL
-  include BoltSpec::Config
 
   before(:all) { Bolt::PAL.load_puppet }
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
@@ -22,11 +16,8 @@ describe 'Vars function' do
       'vars' => { 'pb' => 'jelly', 'mac' => 'cheese' }
     }
   }
-
-  let(:inventory) { Bolt::Inventory::Inventory.new(data, config.transport, config.transports, plugins) }
-  let(:pal)       { Bolt::PAL.new(Bolt::Config::Modulepath.new(modulepath), nil, nil) }
-  let(:plugins)   { Bolt::Plugin.setup(config, nil) }
-
+  let(:inventory) { make_inventory(data) }
+  let(:pal)       { make_pal }
   let(:executor)  { Bolt::Executor.new }
 
   let(:target)     { "$t = get_targets('example')[0]\n" }

--- a/spec/shared_examples/transport.rb
+++ b/spec/shared_examples/transport.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'bolt_spec/config'
 require 'bolt_spec/files'
 require 'bolt_spec/task'
 require 'bolt_spec/sensitive'
@@ -69,11 +70,6 @@ def windows_context
   }
 end
 
-def make_config(conf: transport_config)
-  conf = Bolt::Util.walk_keys(conf, &:to_s)
-  Bolt::Config.new(project, transport.to_s => conf)
-end
-
 def make_target
   inventory.get_target(host_and_port)
 end
@@ -91,6 +87,7 @@ end
 # - os_context: posix_context above
 # - transport_conf: a hash that can be overridden to specify the 'tmpdir' transport option
 shared_examples 'transport api' do
+  include BoltSpec::Config
   include BoltSpec::Files
   include BoltSpec::Sensitive
   include BoltSpec::Task


### PR DESCRIPTION
Previously, the `BoltSpec::Config` helper had a method `fixture_path()`
which was a stict subset of behavior from
`BoltSpec::Files#fixtures_path()` - the latter returns just the path to
`fixtures/` if no arguments are provided. This removes
`BoltSpec::Config#fixture_path()` in favor of
`BoltSpec::Files#fixtures_path()`. This also meant that the 
`BoltSpec::Config` class didn't have any methods that were being used,
however there was a method defined in a few different tests titled
`make_config()` which seemed like it fit that helper. This moves that
function to the `BoltSpec::Config` class and removes it from the spec
tests that defined it. The exception to this is
`spec/integration/transport/winrm_spec.rb`, which uses a custom
`mk_config()` function to return just the transport config as a hash,
not a `Bolt::Config` object. This also removes the `modulepath` helper
method, as it would opaquely set the modulepath (particularly in files
where the modulepath would sometimes come from the helper, then later be
overridden by an actual `let(:modulepath)` setting).

This also adds the following helpers to the BoltSpec::PAL helper:
- `make_pal()`: which accepts an optional modulepath. The modulepath
  defaults to `['spec/fixtures/modules/']`
- `make_plugins()`: which accepts an optional Bolt::Config instance. The 
  default config has no data, and uses a project with the CWD.
- `make_inventory()`: which accepts an optional data hash and uses the 
  default config and plugins to make a Bolt::Inventory::Inventory object.

!no-release-note
