### PR TITLE
(GH-2461) Fix to allow puppetdb config to contain plugin references

### DIFF
--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -350,43 +350,50 @@ module Bolt
             "cacert" => {
               description: "The path to the ca certificate for PuppetDB.",
               type: String,
-              _example: "/etc/puppetlabs/puppet/ssl/certs/ca.pem"
+              _example: "/etc/puppetlabs/puppet/ssl/certs/ca.pem",
+              _plugin: true
             },
             "cert" => {
               description: "The path to the client certificate file to use for authentication.",
               type: String,
-              _example: "/etc/puppetlabs/puppet/ssl/certs/my-host.example.com.pem"
+              _example: "/etc/puppetlabs/puppet/ssl/certs/my-host.example.com.pem",
+              _plugin: true
             },
             "connect_timeout" => {
               description: "How long to wait in seconds when establishing connections with PuppetDB.",
               type: Integer,
               minimum: 1,
               _default: 60,
-              _example: 120
+              _example: 120,
+              _plugin: true
             },
             "key" => {
               description: "The private key for the certificate.",
               type: String,
-              _example: "/etc/puppetlabs/puppet/ssl/private_keys/my-host.example.com.pem"
+              _example: "/etc/puppetlabs/puppet/ssl/private_keys/my-host.example.com.pem",
+              _plugin: true
             },
             "read_timeout" => {
               description: "How long to wait in seconds for a response from PuppetDB.",
               type: Integer,
               minimum: 1,
               _default: 60,
-              _example: 120
+              _example: 120,
+              _plugin: true
             },
             "server_urls" => {
               description: "An array containing the PuppetDB host to connect to. Include the protocol `https` "\
                            "and the port, which is usually `8081`. For example, "\
                            "`https://my-puppetdb-server.com:8081`.",
               type: Array,
-              _example: ["https://puppet.example.com:8081"]
+              _example: ["https://puppet.example.com:8081"],
+              _plugin: true
             },
             "token" => {
               description: "The path to the PE RBAC Token.",
               type: String,
-              _example: "~/.puppetlabs/token"
+              _example: "~/.puppetlabs/token",
+              _plugin: true
             }
           },
           _plugin: true

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -248,33 +248,82 @@
           "properties": {
             "cacert": {
               "description": "The path to the ca certificate for PuppetDB.",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "cert": {
               "description": "The path to the client certificate file to use for authentication.",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "connect_timeout": {
               "description": "How long to wait in seconds when establishing connections with PuppetDB.",
-              "type": "integer",
-              "minimum": 1
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "key": {
               "description": "The private key for the certificate.",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "read_timeout": {
               "description": "How long to wait in seconds for a response from PuppetDB.",
-              "type": "integer",
-              "minimum": 1
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "server_urls": {
               "description": "An array containing the PuppetDB host to connect to. Include the protocol `https` and the port, which is usually `8081`. For example, `https://my-puppetdb-server.com:8081`.",
-              "type": "array"
+              "oneOf": [
+                {
+                  "type": "array"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "token": {
               "description": "The path to the PE RBAC Token.",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             }
           }
         },

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -248,33 +248,82 @@
           "properties": {
             "cacert": {
               "description": "The path to the ca certificate for PuppetDB.",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "cert": {
               "description": "The path to the client certificate file to use for authentication.",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "connect_timeout": {
               "description": "How long to wait in seconds when establishing connections with PuppetDB.",
-              "type": "integer",
-              "minimum": 1
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "key": {
               "description": "The private key for the certificate.",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "read_timeout": {
               "description": "How long to wait in seconds for a response from PuppetDB.",
-              "type": "integer",
-              "minimum": 1
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "server_urls": {
               "description": "An array containing the PuppetDB host to connect to. Include the protocol `https` and the port, which is usually `8081`. For example, `https://my-puppetdb-server.com:8081`.",
-              "type": "array"
+              "oneOf": [
+                {
+                  "type": "array"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "token": {
               "description": "The path to the PE RBAC Token.",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             }
           }
         },

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -337,33 +337,82 @@
           "properties": {
             "cacert": {
               "description": "The path to the ca certificate for PuppetDB.",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "cert": {
               "description": "The path to the client certificate file to use for authentication.",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "connect_timeout": {
               "description": "How long to wait in seconds when establishing connections with PuppetDB.",
-              "type": "integer",
-              "minimum": 1
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "key": {
               "description": "The private key for the certificate.",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "read_timeout": {
               "description": "How long to wait in seconds for a response from PuppetDB.",
-              "type": "integer",
-              "minimum": 1
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "server_urls": {
               "description": "An array containing the PuppetDB host to connect to. Include the protocol `https` and the port, which is usually `8081`. For example, `https://my-puppetdb-server.com:8081`.",
-              "type": "array"
+              "oneOf": [
+                {
+                  "type": "array"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "token": {
               "description": "The path to the PE RBAC Token.",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             }
           }
         },

--- a/spec/integration/validator_spec.rb
+++ b/spec/integration/validator_spec.rb
@@ -300,4 +300,77 @@ describe 'validating config' do
       )
     end
   end
+
+  context 'with plugins defined in puppetdb config' do
+    let(:project_config) do
+      {
+        'apply-settings' => {
+          'show_diff' => true
+        },
+        'color' => false,
+        'compile-concurrency' => 2,
+        'format' => 'json',
+        'log' => {
+          'warn.log' => {
+            'level' => 'warn',
+            'append' => true
+          },
+          'bolt-debug.log' => 'disable'
+        },
+        'modulepath' => %w[
+          modules
+          site-modules
+        ],
+        'plans' => [
+          'myproject::deploy'
+        ],
+        'puppetdb' => {
+          'cacert' => {
+            '_plugin' => 'envvar',
+            'var' => 'BOLT_PUPPETDB_CACERT',
+            'default' => '/path/to/cacert'
+          },
+          'cert' => {
+            '_plugin' => 'envvar',
+            'var' => 'BOLT_PUPPETDB_CERT',
+            'default' => '/path/to/cert'
+          },
+          'connect-timeout' => {
+            '_plugin' => 'envvar',
+            'var' => 'BOLT_PUPPETDB_CONNECT_TIMEOUT',
+            'default' => 20
+          },
+          'key' => {
+            '_plugin' => 'envvar',
+            'var' => 'BOLT_PUPPETDB_KEY',
+            'default' => '/path/to/key'
+          },
+          'read-timeout' => {
+            '_plugin' => 'envvar',
+            'var' => 'BOLT_PUPPETDB_READ_TIMEOUT',
+            'default' => 10
+          },
+          'server_urls' => {
+            '_plugin' => 'envvar',
+            'var' => 'BOLT_PUPPETDB_SERVER_URLS',
+            'default' => [
+              'https://example.com'
+            ]
+          },
+          'token' => {
+            '_plugin' => 'envvar',
+            'var' => 'BOLT_PUPPETDB_TOKEN',
+            'default' => '/path/to/token'
+          }
+        },
+        'tasks' => [
+          'myproject::install_server'
+        ]
+      }
+    end
+
+    it 'does not error' do
+      expect { run_cli(command, project: project) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
Closes #2461 

It looks like the `_plugin: true` validator definition wasn't propagated down into the sub-keys of the `puppetdb` hash. This change allows each of those sub-keys to contain `_plugin` references themselves.