### PR TITLE
(GH-2428) Update with_project method to be more transparent

### DIFF
--- a/spec/bolt/module_installer/puppetfile_spec.rb
+++ b/spec/bolt/module_installer/puppetfile_spec.rb
@@ -8,15 +8,17 @@ require 'bolt/module_installer/puppetfile'
 describe Bolt::ModuleInstaller::Puppetfile do
   include BoltSpec::Project
 
-  let(:path)       { project_path + 'Puppetfile' }
-  let(:moduledir)  { project_path + '.modules' }
+  let(:path)       { project.puppetfile }
+  let(:moduledir)  { project.managed_moduledir }
   let(:name)       { 'puppetlabs/yaml' }
   let(:version)    { '0.1.0' }
   let(:mod)        { [double('mod', name: name, version: version, to_spec: "mod '#{name}'")] }
   let(:puppetfile) { described_class.new(mod) }
+  let(:project)    { @project }
 
   around(:each) do |example|
-    with_project do
+    with_project do |project|
+      @project = project
       example.run
     end
   end

--- a/spec/bolt/module_installer_spec.rb
+++ b/spec/bolt/module_installer_spec.rb
@@ -7,6 +7,7 @@ require 'bolt_spec/project'
 describe Bolt::ModuleInstaller do
   include BoltSpec::Project
 
+  let(:project)        { @project }
   let(:puppetfile)     { project.puppetfile }
   let(:moduledir)      { project.managed_moduledir }
   let(:project_file)   { project.project_file }
@@ -15,6 +16,7 @@ describe Bolt::ModuleInstaller do
   let(:specs)          { [{ 'name' => 'puppetlabs/yaml' }] }
   let(:pal)            { double('pal', generate_types: nil) }
   let(:installer)      { described_class.new(outputter, pal) }
+  let(:project_config) { { 'modules' => [] } }
 
   let(:outputter) do
     double('outputter', print_message: nil,
@@ -25,14 +27,13 @@ describe Bolt::ModuleInstaller do
   end
 
   around(:each) do |example|
-    with_project do
+    with_project(config: project_config) do |project|
+      @project = project
       example.run
     end
   end
 
   before(:each) do
-    conf = { 'modules' => [] }
-    File.write(project_file, conf.to_yaml)
     allow(installer).to receive(:install_puppetfile).and_return(true)
   end
 

--- a/spec/bolt/project_manager/config_migrator_spec.rb
+++ b/spec/bolt/project_manager/config_migrator_spec.rb
@@ -20,7 +20,7 @@ describe Bolt::ProjectManager::ConfigMigrator do
   let(:backup_dir)     { project_dir + '.bolt-bak' }
 
   context "updating options" do
-    let(:project_dir) { project.path }
+    let(:project_dir) { @project.path }
 
     let(:old_config) do
       {
@@ -55,7 +55,8 @@ describe Bolt::ProjectManager::ConfigMigrator do
     end
 
     around :each do |example|
-      with_project do
+      with_project(config: project_config) do |project|
+        @project = project
         example.run
       end
     end

--- a/spec/bolt/project_manager_spec.rb
+++ b/spec/bolt/project_manager_spec.rb
@@ -9,8 +9,9 @@ require 'bolt_spec/project'
 describe Bolt::ProjectManager do
   include BoltSpec::Project
 
-  let(:config)    { Bolt::Config.from_project(project) }
-  let(:pal)       { double('pal', generate_types: nil) }
+  let(:config)  { Bolt::Config.from_project(project) }
+  let(:pal)     { double('pal', generate_types: nil) }
+  let(:project) { @project }
 
   let(:outputter) {
     double('outputter',
@@ -28,46 +29,47 @@ describe Bolt::ProjectManager do
   let(:module_migrator)    { double('module_migrator',    migrate: true) }
 
   around :each do |example|
-    with_project do
+    with_project do |project|
+      @project = project
       example.run
     end
   end
 
   context '#create' do
     before(:each) do
-      delete_config
+      FileUtils.rm(project.project_file)
     end
 
     it 'creates a new project' do
-      manager.create(project_path, nil, nil)
-      expect(config_path.exist?).to be
-      expect(YAML.load_file(config_path)).to include('name' => File.basename(project_path))
+      manager.create(project.path, nil, nil)
+      expect(project.project_file.exist?).to be
+      expect(YAML.load_file(project.project_file)).to include('name' => File.basename(project.path))
     end
 
     it 'creates a new project with the specified name' do
-      manager.create(project_path, 'myproject', nil)
-      expect(config_path.exist?).to be
-      expect(YAML.load_file(config_path)).to include('name' => 'myproject')
+      manager.create(project.path, 'myproject', nil)
+      expect(project.project_file.exist?).to be
+      expect(YAML.load_file(project.project_file)).to include('name' => 'myproject')
     end
 
     it 'configures modules with an empty array' do
-      manager.create(project_path, nil, nil)
-      expect(YAML.load_file(config_path)).to include('modules' => [])
+      manager.create(project.path, nil, nil)
+      expect(YAML.load_file(project.project_file)).to include('modules' => [])
     end
 
     it 'creates an inventory.yaml' do
-      manager.create(project_path, 'myproject', nil)
+      manager.create(project.path, 'myproject', nil)
       expect(project.inventory_file.exist?).to be
     end
 
     it 'does not create an inventory.yaml if one already exists' do
       FileUtils.touch(project.inventory_file)
       expect(File).not_to receive(:write).with(project.inventory_file.to_path, anything)
-      manager.create(project_path, 'myproject', nil)
+      manager.create(project.path, 'myproject', nil)
     end
 
     it 'errors if the directory name is invalid' do
-      dir = tmpdir + 'MyProject'
+      dir = project.path.parent + 'MyProject'
       FileUtils.mkdir(dir)
       expect { manager.create(dir, nil, nil) }.to raise_error(
         Bolt::ValidationError,
@@ -76,23 +78,23 @@ describe Bolt::ProjectManager do
     end
 
     it 'errors if the specified name is invalid' do
-      expect { manager.create(project_path, 'MyProject', nil) }.to raise_error(
+      expect { manager.create(project.path, 'MyProject', nil) }.to raise_error(
         Bolt::ValidationError,
         /The provided project name 'MyProject' is invalid/
       )
     end
 
     it 'errors if bolt-project.yaml already exists' do
-      FileUtils.touch(config_path)
-      expect { manager.create(project_path, nil, nil) }.to raise_error(
+      FileUtils.touch(project.project_file)
+      expect { manager.create(project.path, nil, nil) }.to raise_error(
         Bolt::Error,
         /Found existing project directory with bolt-project.yaml/
       )
     end
 
     it 'errors if bolt.yaml already exists' do
-      FileUtils.touch(project_path + 'bolt.yaml')
-      expect { manager.create(project_path, nil, nil) }.to raise_error(
+      FileUtils.touch(project.path + 'bolt.yaml')
+      expect { manager.create(project.path, nil, nil) }.to raise_error(
         Bolt::Error,
         /Found existing project directory with bolt.yaml/
       )
@@ -108,17 +110,17 @@ describe Bolt::ProjectManager do
 
       it 'creates a Puppetfile and installs modules' do
         expect(installer).to receive(:install).with(modules, project.puppetfile, project.managed_moduledir)
-        manager.create(project_path, nil, modules)
+        manager.create(project.path, nil, modules)
       end
 
       it 'configures modules with the specified modules' do
-        manager.create(project_path, nil, modules)
-        expect(YAML.load_file(config_path)).to include('modules' => modules)
+        manager.create(project.path, nil, modules)
+        expect(YAML.load_file(project.project_file)).to include('modules' => modules)
       end
 
       it 'errors if bolt-project.yaml already exists' do
-        FileUtils.touch(config_path)
-        expect { manager.create(project_path, nil, modules) }.to raise_error(
+        FileUtils.touch(project.project_file)
+        expect { manager.create(project.path, nil, modules) }.to raise_error(
           Bolt::Error,
           /Found existing project directory with bolt-project.yaml.*with modules/
         )
@@ -126,7 +128,7 @@ describe Bolt::ProjectManager do
 
       it 'errors with an existing Puppetfile' do
         FileUtils.touch(project.puppetfile)
-        expect { manager.create(project_path, nil, modules) }.to raise_error(
+        expect { manager.create(project.path, nil, modules) }.to raise_error(
           Bolt::Error,
           /Found existing Puppetfile/
         )

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -21,6 +21,8 @@ describe 'apply', expensive: true do
   include BoltSpec::PuppetAgent
   include BoltSpec::Run
 
+  let(:project) { @project }
+
   let(:project_config) do
     {
       'apply_settings' => { 'show_diff' => true },
@@ -77,8 +79,8 @@ describe 'apply', expensive: true do
       # Set up a project directory for the tests. Include an inventory file so Bolt
       # can actually connect to the targets.
       around(:each) do |example|
-        with_project do
-          File.write(project.inventory_file, docker_inventory(root: true).to_yaml)
+        with_project(config: project_config, inventory: docker_inventory(root: true)) do |project|
+          @project = project
           example.run
         end
       end
@@ -170,7 +172,7 @@ describe 'apply', expensive: true do
 
       context 'with the apply command' do
         it "applies a manifest" do
-          manifest = project_path + 'manifest.pp'
+          manifest = project.path + 'manifest.pp'
           File.write(manifest, 'include basic')
 
           results = run_cli_json(%W[apply #{manifest} -t nix_agents], project: project)
@@ -184,7 +186,7 @@ describe 'apply', expensive: true do
         end
 
         it "applies with noop" do
-          manifest = project_path + 'manifest.pp'
+          manifest = project.path + 'manifest.pp'
           File.write(manifest, 'include basic')
 
           results = run_cli_json(%W[apply #{manifest} --noop -t nix_agents], project: project)
@@ -262,8 +264,8 @@ describe 'apply', expensive: true do
       # Set up a project directory for the tests. Include an inventory file so Bolt
       # can actually connect to the target.
       around(:each) do |example|
-        with_project do
-          File.write(project.inventory_file, inventory.to_yaml)
+        with_project(config: project_config, inventory: inventory) do |project|
+          @project = project
           example.run
         end
       end
@@ -439,8 +441,8 @@ describe 'apply', expensive: true do
 
   describe 'over winrm on Windows with Puppet Agents', windows_agents: true do
     around(:each) do |example|
-      with_project do
-        File.write(project.inventory_file, conn_inventory.to_yaml)
+      with_project(config: project_config, inventory: conn_inventory) do |project|
+        @project = project
         example.run
       end
     end

--- a/spec/integration/cache_spec.rb
+++ b/spec/integration/cache_spec.rb
@@ -10,6 +10,9 @@ describe 'caching plugins' do
   include BoltSpec::Integration
   include BoltSpec::Project
 
+  let(:project) { @project }
+  let(:project_path) { @project.path }
+  let(:inventory) { nil }
   let(:mpath) { fixture_path('plugin_modules') }
   let(:plan) do
     <<~PLAN
@@ -20,14 +23,15 @@ describe 'caching plugins' do
   end
 
   around(:each) do |example|
-    with_project('cache_test') do
+    with_project('cache_test', inventory: inventory) do |project|
+      @project = project
+
       ENV['BOLT_TEST_PLUGIN_VALUE'] = 'player_one'
       if plan
         FileUtils.mkdir_p(File.join(project_path, 'plans'))
         File.write(File.join(project_path, 'plans', 'init.pp'), plan)
       end
 
-      File.write(File.join(project_path, 'inventory.yaml'), inventory.to_yaml) if inventory
       example.run
     end
   end

--- a/spec/integration/module_installer_spec.rb
+++ b/spec/integration/module_installer_spec.rb
@@ -8,9 +8,11 @@ describe 'installing modules' do
   include BoltSpec::Project
 
   let(:command) { %w[module install] }
+  let(:project) { @project }
 
   around(:each) do |example|
-    with_project do
+    with_project(config: project_config) do |project|
+      @project = project
       example.run
     end
   end

--- a/spec/integration/plan_spec.rb
+++ b/spec/integration/plan_spec.rb
@@ -87,7 +87,7 @@ describe 'plans' do
       end
 
       it 'runs registers types defined in $project/.resource_types', ssh: true do
-        with_project do
+        with_project(config: project_config) do |project|
           config_flags = %W[--format json -m #{modulepath} --project #{project.path} --no-host-key-check]
 
           # generate types based and save in project (based on value of --configfile)

--- a/spec/integration/project_manager_spec.rb
+++ b/spec/integration/project_manager_spec.rb
@@ -9,11 +9,13 @@ describe 'managing a project' do
 
   context 'creating a project' do
     let(:command) { %w[project init myproject --modules puppetlabs-yaml] }
+    let(:project) { @project }
 
     # Execute from a temporary project directory.
     around(:each) do |example|
-      in_project do
-        delete_config
+      in_project do |project|
+        @project = project
+        FileUtils.rm(project.project_file)
         example.run
       end
     end
@@ -27,9 +29,9 @@ describe 'managing a project' do
     it 'creates a project and installs modules' do
       run_cli(command)
 
-      expect(config_path.exist?).to be
+      expect(project.project_file.exist?).to be
 
-      expect(YAML.load_file(config_path)).to include(
+      expect(YAML.load_file(project.project_file)).to include(
         'name'    => 'myproject',
         'modules' => [{ 'name' => 'puppetlabs-yaml' }]
       )

--- a/spec/integration/project_spec.rb
+++ b/spec/integration/project_spec.rb
@@ -77,6 +77,8 @@ describe "When loading content", ssh: true do
   end
 
   context 'filtering project content' do
+    let(:project) { @project }
+
     let(:project_config) do
       {
         'modulepath' => File.join(__dir__, '../fixtures/modules'),
@@ -92,7 +94,8 @@ describe "When loading content", ssh: true do
     end
 
     around(:each) do |example|
-      with_project do
+      with_project(config: project_config) do |project|
+        @project = project
         example.run
       end
     end

--- a/spec/integration/validator_spec.rb
+++ b/spec/integration/validator_spec.rb
@@ -8,14 +8,20 @@ describe 'validating config' do
   include BoltSpec::Project
 
   around(:each) do |example|
-    with_project do
-      File.write((@project_path + 'inventory.yaml'), inventory.to_yaml)
+    with_project_directory(config: project_config, inventory: inventory) do |project_path|
+      @project_path = project_path
       example.run
     end
   end
 
-  let(:command)   { %w[inventory show --targets all] }
-  let(:inventory) { {} }
+  before(:each) do
+    allow($stderr).to receive(:puts)
+    allow($stdout).to receive(:puts)
+  end
+
+  let(:command)        { %W[inventory show --targets all --project #{@project_path}] }
+  let(:inventory)      { nil }
+  let(:project_config) { nil }
 
   context 'with valid config' do
     let(:project_config) do
@@ -54,7 +60,7 @@ describe 'validating config' do
     end
 
     it 'does not error' do
-      expect { run_cli(command, project: project) }.not_to raise_error
+      expect { run_cli(command) }.not_to raise_error
     end
   end
 
@@ -96,7 +102,7 @@ describe 'validating config' do
     end
 
     it 'raises an error listing all errors in config' do
-      expect { run_cli(command, project: project) }.to raise_error do |error|
+      expect { run_cli(command) }.to raise_error do |error|
         expect(error.kind).to eq('bolt/validation-error')
 
         expect(error.message.lines).to include(
@@ -172,7 +178,7 @@ describe 'validating config' do
     end
 
     it 'does not error' do
-      expect { run_cli(command, project: project) }.not_to raise_error
+      expect { run_cli(command) }.not_to raise_error
     end
   end
 
@@ -229,7 +235,7 @@ describe 'validating config' do
     end
 
     it 'raises an error listing all errors in inventory' do
-      expect { run_cli(command, project: project) }.to raise_error do |error|
+      expect { run_cli(command) }.to raise_error do |error|
         expect(error.kind).to eq('bolt/validation-error')
 
         expect(error.message.lines).to include(
@@ -257,7 +263,7 @@ describe 'validating config' do
     end
 
     it 'warns about unknown options' do
-      run_cli(command, project: project)
+      run_cli(command)
 
       expect(@log_output.readlines).to include(
         /WARN.*Unknown option 'unknown' at.*bolt-project.yaml/,
@@ -291,7 +297,7 @@ describe 'validating config' do
     end
 
     it 'warns about unknown options' do
-      run_cli(command, project: project)
+      run_cli(command)
 
       expect(@log_output.readlines).to include(
         /WARN.*Unknown option 'alias' at 'groups.0' at.*inventory.yaml/,
@@ -370,7 +376,7 @@ describe 'validating config' do
     end
 
     it 'does not error' do
-      expect { run_cli(command, project: project) }.not_to raise_error
+      expect { run_cli(command) }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
This updates the `BoltSpec::Project` method `with_project` to be more
transparent. Previously, the method used some magic to configure a
project by calling the `project_config` method. Additionally, the method
would also set several instance variables for spec tests to use.

The `with_project` method now includes a few keyword arguments that can
be used to modify the project directory structure that it creates:

- `config`

  A hash of config to write to `bolt-project.yaml`. If `nil`, writes a
  default config file with the project name set.

- `inventory`

  A hash of inventory data to write to `inventory.yaml`. If `nil`,
  writes an empty inventory file.

- `boltdir`

  A boolean. When true, creates the project inside a `Boltdir`.

The `with_project` method now yields a `Bolt::Project` instance for the
project directory. The `in_project` method was also updated to accept
the same keyword arguments and yield a `Bolt::Project` instance.

This also adds two new methods to `BoltSpec::Project`:
`with_project_directory` and `make_project`. The
`with_project_directory` method accepts all the same arguments as
`with_project`, but yields the project path instead of a `Bolt::Project`
instance. This method is helpful when writing tests that rely on errors
being raised when project config is loaded. The `make_project` method
accepts a path and returns a `Bolt::Project` instance for the project
directory.

!no-release-note