### PR TITLE
(GH-2438) Don't warn that project content won't be loaded if there's no project content

### DIFF
--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -227,7 +227,10 @@ module Bolt
           raise Bolt::ValidationError, "The project '#{name}' will not be loaded. The project name conflicts "\
             "with a built-in Bolt module of the same name."
         end
-      else
+      elsif name.nil? &&
+            (File.directory?(plans_path) ||
+            File.directory?(@path + 'tasks') ||
+            File.directory?(@path + 'files'))
         message = "No project name is specified in bolt-project.yaml. Project-level content will not be available."
         @logs << { warn: message }
       end

--- a/spec/bolt/project_spec.rb
+++ b/spec/bolt/project_spec.rb
@@ -83,6 +83,29 @@ describe Bolt::Project do
     end
   end
 
+  describe "with no name set" do
+    it "warns if content directories exist" do
+      Dir.mktmpdir(nil, Dir.pwd) do |tmpdir|
+        project_path = Pathname.new(tmpdir).expand_path + 'project'
+        allow(File).to receive(:directory?).and_call_original
+        allow(File).to receive(:directory?)
+          .with(project_path + 'plans').and_return(true)
+
+        FileUtils.mkdir_p(project_path)
+        project = Bolt::Project.create_project(project_path)
+        project.validate
+
+        expect(project.logs).to include({ warn: /No project name is specified in bolt-project.yaml/ })
+      end
+    end
+
+    it "does not warn when content directories don't exist" do
+      with_project do
+        expect(project.logs).not_to include({ warn: /No project name is specified in bolt-project.yaml/ })
+      end
+    end
+  end
+
   describe "::find_boltdir" do
     around(:each) do |example|
       with_boltdir do

--- a/spec/integration/project_spec.rb
+++ b/spec/integration/project_spec.rb
@@ -3,16 +3,18 @@
 require 'spec_helper'
 require 'bolt_spec/config'
 require 'bolt_spec/conn'
+require 'bolt_spec/files'
 require 'bolt_spec/integration'
 require 'bolt_spec/project'
 
 describe "When loading content", ssh: true do
   include BoltSpec::Config
   include BoltSpec::Conn
+  include BoltSpec::Files
   include BoltSpec::Integration
   include BoltSpec::Project
 
-  let(:local) { Bolt::Project.create_project(File.join(__dir__, '../fixtures/projects/local'), 'local') }
+  let(:local) { Bolt::Project.create_project(fixtures_path('projects', 'local'), 'local') }
   let(:embedded) { fixture_path('projects/embedded') }
   let(:target) { conn_uri('ssh') }
   let(:config_flags) { %W[--no-host-key-check --password #{conn_info('ssh')[:password]}] }


### PR DESCRIPTION
This limits the warning that project content won't be loaded if the
project doesn't have a name to only be raised if the project has a
`tasks/`, `plans/`, or `files/` directory.

!bug

* **Only warn that project content won't be loaded if there's project content**

  Bolt will now only warn that project content won't be loaded if the
  proejct directory has a `tasks/`, `plans/`, or `files/` directory that
  may contain content.