### PR TITLE
(bug) Allow _cache in PuppetDB plugin options

### DIFF
--- a/lib/bolt/plugin/puppetdb.rb
+++ b/lib/bolt/plugin/puppetdb.rb
@@ -12,7 +12,7 @@ module Bolt
       end
 
       TEMPLATE_OPTS = %w[alias config facts features name uri vars].freeze
-      PLUGIN_OPTS = %w[_plugin query target_mapping].freeze
+      PLUGIN_OPTS = %w[_plugin _cache query target_mapping].freeze
 
       attr_reader :puppetdb_client
 

--- a/spec/bolt/plugin/puppetdb_spec.rb
+++ b/spec/bolt/plugin/puppetdb_spec.rb
@@ -59,6 +59,18 @@ describe Bolt::Plugin::Puppetdb do
       end
     end
 
+    context 'with cache configured' do
+      let(:opts) do
+        { "query" => '',
+          '_cache' => { 'ttl' => 10 },
+          "target_mapping" => { "name" => 'facts.name_fact' } }
+      end
+
+      it "sets the cache" do
+        expect { plugin.resolve_reference(opts) }.not_to raise_error
+      end
+    end
+
     context "with a 'alias' configured" do
       let(:opts) do
         { "query" => '',


### PR DESCRIPTION
We validate that the PuppetDB plugin that ships with Bolt only contains
valid keys in the plugin class itself (not through schema validation).
We missed adding `_cache` as a valid key to the PuppetDB plugin options,
which resulted in an error when users try to configure a cache for the
PuppetDB plugin. This adds `_cache` as a valid key for the PuppetDB
plugin.

!bug

* **Allow caching for PuppetDB plugin**

  Previously, our configuration validation would raise an error if users
  supplied `_cache` to the PuppetDB plugin. Cache is now configurable
  for the plugin.