### PR TITLE
(GH-2454) Remove redundant config validation

### DIFF
--- a/lib/bolt/config/transport/ssh.rb
+++ b/lib/bolt/config/transport/ssh.rb
@@ -111,11 +111,6 @@ module Bolt
             @config['interpreters'] = normalize_interpreters(@config['interpreters'])
           end
 
-          if @config['login-shell'] && !LOGIN_SHELLS.include?(@config['login-shell'])
-            raise Bolt::ValidationError,
-                  "Unsupported login-shell #{@config['login-shell']}. Supported shells are #{LOGIN_SHELLS.join(', ')}"
-          end
-
           if @config['login-shell'] == 'powershell'
             %w[tty run-as].each do |key|
               if @config[key]

--- a/lib/bolt/inventory/group.rb
+++ b/lib/bolt/inventory/group.rb
@@ -254,14 +254,6 @@ module Bolt
           msg = "Found unexpected key(s) #{unexpected_keys.join(', ')} in group #{@name}"
           @logger.warn(msg)
         end
-
-        Bolt::Util.walk_keys(input) do |key|
-          if @plugins.reference?(key)
-            raise ValidationError.new("Group keys cannot be specified as _plugin references", @name)
-          else
-            key
-          end
-        end
       end
 
       def validate(used_group_names = Set.new, used_target_names = Set.new, used_aliases = {})

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -256,30 +256,6 @@ describe Bolt::Config do
       expect(config.matching_paths(config.modulepath)).to include(modules)
     end
 
-    it "does not accept invalid log levels" do
-      config = {
-        'log' => {
-          "file:#{logfile}" => { 'level' => :foo }
-        }
-      }
-
-      expect { Bolt::Config.new(project, config) }.to raise_error(
-        /level of log file:.* must be one of .*; received foo/
-      )
-    end
-
-    it "does not accept invalid append flag values" do
-      config = {
-        'log' => {
-          "file:#{logfile}" => { 'append' => :foo }
-        }
-      }
-
-      expect { Bolt::Config.new(project, config) }.to raise_error(
-        /append flag of log file:.* must be a Boolean, received Symbol :foo/
-      )
-    end
-
     it "does not accept inventory files that don't exist" do
       config = {
         'inventoryfile' => 'fake.yaml'

--- a/spec/bolt/inventory/group_spec.rb
+++ b/spec/bolt/inventory/group_spec.rb
@@ -810,11 +810,6 @@ describe Bolt::Inventory::Group do
       { '_plugin' => 'constant', 'value' => value }
     end
 
-    it "fails if any keys are specified as plugins" do
-      data.replace('name' => 'testgroup', constant('groups') => [])
-      expect { group }.to raise_error(Bolt::Inventory::ValidationError, /keys cannot be specified as _plugin/)
-    end
-
     context "defining the entire group with a plugin" do
       it 'evaluates a single plugin' do
         data.replace(constant('name' => 'testgroup', 'config' => { 'transport' => 'ssh' }))


### PR DESCRIPTION
This removes some redundant validation for the `Bolt::Config` class that
is handled by the validator.

!no-release-note