### PR TITLE
(GH-2477) Allow any keys under `remote` transport config

### DIFF
--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -509,6 +509,7 @@ module Bolt
         "remote" => {
           description: "A map of configuration options for the remote transport.",
           type: Hash,
+          additionalProperties: true,
           _plugin: true,
           _example: { "run-on" => "proxy_target" }
         },

--- a/lib/bolt/config/transport/options.rb
+++ b/lib/bolt/config/transport/options.rb
@@ -143,7 +143,8 @@ module Bolt
                          "`task.py`) and the extension is case sensitive. When a target's name is `localhost`, "\
                          "Ruby tasks run with the Bolt Ruby interpreter by default.",
             additionalProperties: {
-              type: String
+              type: String,
+              _plugin: false
             },
             propertyNames: {
               pattern: "^.?[a-zA-Z0-9]+$"

--- a/lib/bolt/validator.rb
+++ b/lib/bolt/validator.rb
@@ -87,7 +87,7 @@ module Bolt
         if properties.include?(key)
           check_deprecated(key, definition[:properties][key])
           validate_value(val, definition[:properties][key])
-        elsif definition[:additionalProperties]
+        elsif definition[:additionalProperties].is_a?(Hash)
           validate_value(val, definition[:additionalProperties])
         end
       ensure

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -500,6 +500,7 @@
       "oneOf": [
         {
           "type": "object",
+          "additionalProperties": true,
           "properties": {
             "run-on": {
               "$ref": "#/transport_definitions/run-on"

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -496,6 +496,7 @@
       "oneOf": [
         {
           "type": "object",
+          "additionalProperties": true,
           "properties": {
             "run-on": {
               "$ref": "#/transport_definitions/run-on"

--- a/schemas/bolt-inventory.schema.json
+++ b/schemas/bolt-inventory.schema.json
@@ -352,6 +352,7 @@
               "oneOf": [
                 {
                   "type": "object",
+                  "additionalProperties": true,
                   "properties": {
                     "run-on": {
                       "description": "The proxy target that the task executes on.",

--- a/spec/integration/validator_spec.rb
+++ b/spec/integration/validator_spec.rb
@@ -144,8 +144,7 @@ describe 'validating config' do
             'targets' => [
               {
                 'name' => 'win1',
-                'uri' => 'win1-example.org',
-                'transport' => 'winrm'
+                'uri' => 'win1-example.org'
               }
             ],
             'groups' => [
@@ -169,6 +168,10 @@ describe 'validating config' do
           'ssh' => {
             'host-key-check' => false
           },
+          'remote' => {
+            'port' => 1234,
+            'token' => 5678
+          },
           'winrm' => {
             'user' => 'Administrator',
             'password' => 'bolt'
@@ -177,8 +180,9 @@ describe 'validating config' do
       }
     end
 
-    it 'does not error' do
+    it 'does not error or raise warnings' do
       expect { run_cli(command) }.not_to raise_error
+      expect(@log_output.readlines).not_to include(/Unknown option/)
     end
   end
 

--- a/spec/lib/bolt_spec/options.rb
+++ b/spec/lib/bolt_spec/options.rb
@@ -11,15 +11,30 @@ module BoltSpec
         expect(definition.key?(:type)).to be, "missing :type key for option '#{option}'"
 
         if definition.key?(:properties)
-          expect(definition[:properties].class).to eq(Hash), ":properties key for option '#{option}' must be a Hash"
+          msg = ":properties key for option '#{option}' must be a Hash"
+          expect(definition[:properties].class).to eq(Hash), msg
+
           assert_type_description(definition[:properties])
         end
 
-        %i[additionalProperties items].each do |key|
-          next unless definition.key?(key)
-          expect(definition[key].class).to eq(Hash), ":#{key} key for option '#{option}' must be a Hash"
-          expect(definition[key].key?(:type)).to be, "missing :type key for :#{key} in option '#{option}'"
+        if definition.key?(:additionalProperties)
+          addtl_prop_types = [TrueClass, FalseClass, Hash]
+          klass = definition[:additionalProperties].class
+          msg = ":additionalProperties key for option '#{option}' must be a Hash or Boolean"
+          expect(addtl_prop_types).to include(klass), msg
+
+          if klass.is_a?(Hash)
+            msg = "missing :type key for :additionalProperties in option '#{option}'"
+            expect(definition[:additionalProperties].key?(:type)).to be, msg
+          end
         end
+
+        next unless definition.key?(:items)
+        msg = ":items key for option '#{option}' must be a Hash"
+        expect(definition[:items].class).to eq(Hash), msg
+
+        msg = "missing :type key for :items in option '#{option}'"
+        expect(definition[:items].key?(:type)).to be, msg
       end
     end
   end


### PR DESCRIPTION
There was a bug in the configuration schema that warned when users would
set any configuration under the remote transport key. The key now
accepts a hash with any keys and values and does not warn.

Closes #2477

!bug

* **Fix bug warning about keys under 'remote' transport** ([#2477](https://github.com/puppetlabs/bolt/issues/2477))

  Bolt now will not warn when keys are configured for the `remote`
  transport in inventory.