### PR TITLE
Support plugins under 'private-key.key-data' and 'interpreters' in transport config

### DIFF
--- a/lib/bolt/config/transport/options.rb
+++ b/lib/bolt/config/transport/options.rb
@@ -143,7 +143,8 @@ module Bolt
                          "`task.py`) and the extension is case sensitive. When a target's name is `localhost`, "\
                          "Ruby tasks run with the Bolt Ruby interpreter by default.",
             additionalProperties: {
-              type: String
+              type: String,
+              _plugin: true
             },
             propertyNames: {
               pattern: "^.?[a-zA-Z0-9]+$"

--- a/lib/bolt/config/transport/options.rb
+++ b/lib/bolt/config/transport/options.rb
@@ -239,7 +239,8 @@ module Bolt
             properties: {
               "key-data" => {
                 description: "The contents of the private key.",
-                type: String
+                type: String,
+                _plugin: true
               }
             },
             _plugin: true,

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -997,7 +997,14 @@
           "properties": {
             "key-data": {
               "description": "The contents of the private key.",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             }
           }
         },

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -861,7 +861,14 @@
         {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
           },
           "propertyNames": {
             "pattern": "^.?[a-zA-Z0-9]+$"

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -993,7 +993,14 @@
           "properties": {
             "key-data": {
               "description": "The contents of the private key.",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             }
           }
         },

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -857,7 +857,14 @@
         {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
           },
           "propertyNames": {
             "pattern": "^.?[a-zA-Z0-9]+$"

--- a/schemas/bolt-inventory.schema.json
+++ b/schemas/bolt-inventory.schema.json
@@ -594,7 +594,14 @@
                           "properties": {
                             "key-data": {
                               "description": "The contents of the private key.",
-                              "type": "string"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "$ref": "#/definitions/_plugin"
+                                }
+                              ]
                             }
                           }
                         },

--- a/schemas/bolt-inventory.schema.json
+++ b/schemas/bolt-inventory.schema.json
@@ -88,7 +88,14 @@
                         {
                           "type": "object",
                           "additionalProperties": {
-                            "type": "string"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/_plugin"
+                              }
+                            ]
                           },
                           "propertyNames": {
                             "pattern": "^.?[a-zA-Z0-9]+$"
@@ -178,7 +185,14 @@
                         {
                           "type": "object",
                           "additionalProperties": {
-                            "type": "string"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/_plugin"
+                              }
+                            ]
                           },
                           "propertyNames": {
                             "pattern": "^.?[a-zA-Z0-9]+$"
@@ -486,7 +500,14 @@
                         {
                           "type": "object",
                           "additionalProperties": {
-                            "type": "string"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/_plugin"
+                              }
+                            ]
                           },
                           "propertyNames": {
                             "pattern": "^.?[a-zA-Z0-9]+$"
@@ -856,7 +877,14 @@
                         {
                           "type": "object",
                           "additionalProperties": {
-                            "type": "string"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/_plugin"
+                              }
+                            ]
                           },
                           "propertyNames": {
                             "pattern": "^.?[a-zA-Z0-9]+$"


### PR DESCRIPTION
This allows the `key-data` suboption for the `private-key` config option
to be a plugin reference.

!bug

* **Allow plugins under `key-data` in `private-key` config**

  The `key-data` suboption for the `private-key` config option once
  again supports plugins.

This allows plugins to be set under individual interpreters in transport
config.

!bug

* **Allow plugins under individual interpreters in transport config**

  Individual interpreters under the `interpreters` transport config
  option once again support plugins.