### PR TITLE
(bug-fix) Set _plugin for sub-keys in config

### DIFF
--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -61,6 +61,7 @@ module Bolt
             "show_diff" => {
               description: "Whether to log and report a contextual diff.",
               type: [TrueClass, FalseClass],
+              _plugin: false,
               _example: true,
               _default: false
             }
@@ -76,6 +77,7 @@ module Bolt
             "show_diff" => {
               description: "Whether to log and report a contextual diff.",
               type: [TrueClass, FalseClass],
+              _plugin: false,
               _example: true,
               _default: false
             }
@@ -148,7 +150,8 @@ module Bolt
             "ttl" => {
               description: "Time in seconds to keep the plugin cache.",
               type: Integer,
-              minimum: 0
+              minimum: 0,
+              _plugin: false
             }
           },
           _plugin: false,
@@ -172,7 +175,8 @@ module Bolt
                   description: "The type of information to log.",
                   type: String,
                   enum: %w[trace debug error info notice warn fatal any],
-                  _default: "warn"
+                  _default: "warn",
+                  _plugin: false
                 }
               }
             }
@@ -185,13 +189,15 @@ module Bolt
               "append" => {
                 description: "Whether to append output to an existing log file.",
                 type: [TrueClass, FalseClass],
-                _default: true
+                _default: true,
+                _plugin: false
               },
               "level" => {
                 description: "The type of information to log.",
                 type: String,
                 enum: %w[trace debug error info notice warn fatal any],
-                _default: "warn"
+                _default: "warn",
+                _plugin: false
               }
             }
           },
@@ -225,21 +231,25 @@ module Bolt
                   description: "The URL to the Forge host.",
                   type: String,
                   format: "uri",
+                  _plugin: false,
                   _example: "https://forge.example.com"
                 },
                 "proxy" => {
                   description: "The HTTP proxy to use for Forge operations.",
                   type: String,
                   format: "uri",
+                  _plugin: false,
                   _example: "https://my-forge-proxy.com:8080"
                 }
               },
+              _plugin: false,
               _example: { "baseurl" => "https://forge.example.com", "proxy" => "https://my-forge-proxy.com:8080" }
             },
             "proxy" => {
               description: "The HTTP proxy to use for Git and Forge operations.",
               type: String,
               format: "uri",
+              _plugin: false,
               _example: "https://my-proxy.com:8080"
             }
           },
@@ -258,12 +268,14 @@ module Bolt
                 properties: {
                   "name" => {
                     description: "The name of the module.",
-                    type: String
+                    type: String,
+                    _plugin: false
                   },
                   "version_requirement" => {
                     description: "The version requirement for the module. Accepts a specific version (1.2.3), version "\
                                  "shorthand (1.2.x), or a version range (>= 1.2.0).",
-                    type: String
+                    type: String,
+                    _plugin: false
                   }
                 }
               },
@@ -272,11 +284,13 @@ module Bolt
                 properties: {
                   "git" => {
                     description: "The URL to the public git repository.",
-                    type: String
+                    type: String,
+                    _plugin: false
                   },
                   "ref" => {
                     description: "The git reference to check out. Can be either a branch, tag, or commit SHA.",
-                    type: String
+                    type: String,
+                    _plugin: false
                   }
                 }
               }
@@ -412,21 +426,25 @@ module Bolt
                   description: "The URL to the Forge host.",
                   type: String,
                   format: "uri",
+                  _plugin: false,
                   _example: "https://forge.example.com"
                 },
                 "proxy" => {
                   description: "The HTTP proxy to use for Forge operations.",
                   type: String,
                   format: "uri",
+                  _plugin: false,
                   _example: "https://my-forge-proxy.com:8080"
                 }
               },
+              _plugin: false,
               _example: { "baseurl" => "https://forge.example.com", "proxy" => "https://my-forge-proxy.com:8080" }
             },
             "proxy" => {
               description: "The HTTP proxy to use for Git and Forge operations.",
               type: String,
               format: "uri",
+              _plugin: false,
               _example: "https://my-proxy.com:8080"
             }
           },

--- a/lib/bolt/config/transport/options.rb
+++ b/lib/bolt/config/transport/options.rb
@@ -143,7 +143,8 @@ module Bolt
                          "`task.py`) and the extension is case sensitive. When a target's name is `localhost`, "\
                          "Ruby tasks run with the Bolt Ruby interpreter by default.",
             additionalProperties: {
-              type: String
+              type: String,
+              _plugin: true
             },
             propertyNames: {
               pattern: "^.?[a-zA-Z0-9]+$"
@@ -239,7 +240,8 @@ module Bolt
             properties: {
               "key-data" => {
                 description: "The contents of the private key.",
-                type: String
+                type: String,
+                _plugin: true
               }
             },
             _plugin: true,

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -861,7 +861,14 @@
         {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
           },
           "propertyNames": {
             "pattern": "^.?[a-zA-Z0-9]+$"
@@ -997,7 +1004,14 @@
           "properties": {
             "key-data": {
               "description": "The contents of the private key.",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             }
           }
         },

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -857,7 +857,14 @@
         {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
           },
           "propertyNames": {
             "pattern": "^.?[a-zA-Z0-9]+$"
@@ -993,7 +1000,14 @@
           "properties": {
             "key-data": {
               "description": "The contents of the private key.",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             }
           }
         },

--- a/schemas/bolt-inventory.schema.json
+++ b/schemas/bolt-inventory.schema.json
@@ -88,7 +88,14 @@
                         {
                           "type": "object",
                           "additionalProperties": {
-                            "type": "string"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/_plugin"
+                              }
+                            ]
                           },
                           "propertyNames": {
                             "pattern": "^.?[a-zA-Z0-9]+$"
@@ -178,7 +185,14 @@
                         {
                           "type": "object",
                           "additionalProperties": {
-                            "type": "string"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/_plugin"
+                              }
+                            ]
                           },
                           "propertyNames": {
                             "pattern": "^.?[a-zA-Z0-9]+$"
@@ -486,7 +500,14 @@
                         {
                           "type": "object",
                           "additionalProperties": {
-                            "type": "string"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/_plugin"
+                              }
+                            ]
                           },
                           "propertyNames": {
                             "pattern": "^.?[a-zA-Z0-9]+$"
@@ -594,7 +615,14 @@
                           "properties": {
                             "key-data": {
                               "description": "The contents of the private key.",
-                              "type": "string"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "$ref": "#/definitions/_plugin"
+                                }
+                              ]
                             }
                           }
                         },
@@ -849,7 +877,14 @@
                         {
                           "type": "object",
                           "additionalProperties": {
-                            "type": "string"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/_plugin"
+                              }
+                            ]
                           },
                           "propertyNames": {
                             "pattern": "^.?[a-zA-Z0-9]+$"

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -244,11 +244,13 @@
             "properties": {
               "name": {
                 "description": "The name of the module.",
-                "type": "String"
+                "type": "String",
+                "_plugin": false
               },
               "version_requirement": {
                 "description": "The version requirement for the module. Accepts a specific version (1.2.3), version shorthand (1.2.x), or a version range (>= 1.2.0).",
-                "type": "String"
+                "type": "String",
+                "_plugin": false
               }
             }
           },
@@ -260,11 +262,13 @@
             "properties": {
               "git": {
                 "description": "The URL to the public git repository.",
-                "type": "String"
+                "type": "String",
+                "_plugin": false
               },
               "ref": {
                 "description": "The git reference to check out. Can be either a branch, tag, or commit SHA.",
-                "type": "String"
+                "type": "String",
+                "_plugin": false
               }
             }
           }


### PR DESCRIPTION
Previously, we didn't set `_plugin` for most `properties` definitions in
the configuration schema. Those sub-keys for top-level config options
were assumed to inherit the outer-configs `_plugin` key, which isn't the 
case. This was already addressed for the `puppetdb` configuration
options, but missed `transport.private-key.key-data` and 
`transport.interpreters`. This change explicitly sets `_plugin` to match
the 'outer' `_plugin` config for all `properties` of configuration
options.

!bug

* **Allow plugins for sub-option `key-data` and `interpreters**

  The configuration for SSH private key using `key-data` now accepts a
  plugin.