### PR TITLE
(bug) Support plugins for suboptions when superoption supports plugins

### DIFF
--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -397,25 +397,74 @@
           "type": "object",
           "properties": {
             "cleanup": {
-              "$ref": "#/transport_definitions/cleanup"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/cleanup"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "host": {
-              "$ref": "#/transport_definitions/host"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/host"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "interpreters": {
-              "$ref": "#/transport_definitions/interpreters"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/interpreters"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "service-url": {
-              "$ref": "#/transport_definitions/service-url"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/service-url"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "shell-command": {
-              "$ref": "#/transport_definitions/shell-command"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/shell-command"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "tmpdir": {
-              "$ref": "#/transport_definitions/tmpdir"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/tmpdir"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "tty": {
-              "$ref": "#/transport_definitions/tty"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/tty"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             }
           }
         },
@@ -431,28 +480,84 @@
           "type": "object",
           "properties": {
             "bundled-ruby": {
-              "$ref": "#/transport_definitions/bundled-ruby"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/bundled-ruby"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "cleanup": {
-              "$ref": "#/transport_definitions/cleanup"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/cleanup"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "interpreters": {
-              "$ref": "#/transport_definitions/interpreters"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/interpreters"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "run-as": {
-              "$ref": "#/transport_definitions/run-as"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/run-as"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "run-as-command": {
-              "$ref": "#/transport_definitions/run-as-command"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/run-as-command"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "sudo-executable": {
-              "$ref": "#/transport_definitions/sudo-executable"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/sudo-executable"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "sudo-password": {
-              "$ref": "#/transport_definitions/sudo-password"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/sudo-password"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "tmpdir": {
-              "$ref": "#/transport_definitions/tmpdir"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/tmpdir"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             }
           }
         },
@@ -468,25 +573,74 @@
           "type": "object",
           "properties": {
             "cacert": {
-              "$ref": "#/transport_definitions/cacert"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/cacert"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "host": {
-              "$ref": "#/transport_definitions/host"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/host"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "job-poll-interval": {
-              "$ref": "#/transport_definitions/job-poll-interval"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/job-poll-interval"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "job-poll-timeout": {
-              "$ref": "#/transport_definitions/job-poll-timeout"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/job-poll-timeout"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "service-url": {
-              "$ref": "#/transport_definitions/service-url"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/service-url"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "task-environment": {
-              "$ref": "#/transport_definitions/task-environment"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/task-environment"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "token-file": {
-              "$ref": "#/transport_definitions/token-file"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/token-file"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             }
           }
         },
@@ -503,7 +657,14 @@
           "additionalProperties": true,
           "properties": {
             "run-on": {
-              "$ref": "#/transport_definitions/run-on"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/run-on"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             }
           }
         },
@@ -519,85 +680,274 @@
           "type": "object",
           "properties": {
             "ssh-command": {
-              "$ref": "#/transport_definitions/ssh-command"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/ssh-command"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "native-ssh": {
-              "$ref": "#/transport_definitions/native-ssh"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/native-ssh"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "cleanup": {
-              "$ref": "#/transport_definitions/cleanup"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/cleanup"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "connect-timeout": {
-              "$ref": "#/transport_definitions/connect-timeout"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/connect-timeout"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "disconnect-timeout": {
-              "$ref": "#/transport_definitions/disconnect-timeout"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/disconnect-timeout"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "encryption-algorithms": {
-              "$ref": "#/transport_definitions/encryption-algorithms"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/encryption-algorithms"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "extensions": {
-              "$ref": "#/transport_definitions/extensions"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/extensions"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "host": {
-              "$ref": "#/transport_definitions/host"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/host"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "host-key-algorithms": {
-              "$ref": "#/transport_definitions/host-key-algorithms"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/host-key-algorithms"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "host-key-check": {
-              "$ref": "#/transport_definitions/host-key-check"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/host-key-check"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "interpreters": {
-              "$ref": "#/transport_definitions/interpreters"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/interpreters"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "kex-algorithms": {
-              "$ref": "#/transport_definitions/kex-algorithms"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/kex-algorithms"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "load-config": {
-              "$ref": "#/transport_definitions/load-config"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/load-config"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "login-shell": {
-              "$ref": "#/transport_definitions/login-shell"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/login-shell"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "mac-algorithms": {
-              "$ref": "#/transport_definitions/mac-algorithms"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/mac-algorithms"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "password": {
-              "$ref": "#/transport_definitions/password"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/password"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "port": {
-              "$ref": "#/transport_definitions/port"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/port"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "private-key": {
-              "$ref": "#/transport_definitions/private-key"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/private-key"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "proxyjump": {
-              "$ref": "#/transport_definitions/proxyjump"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/proxyjump"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "run-as": {
-              "$ref": "#/transport_definitions/run-as"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/run-as"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "run-as-command": {
-              "$ref": "#/transport_definitions/run-as-command"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/run-as-command"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "script-dir": {
-              "$ref": "#/transport_definitions/script-dir"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/script-dir"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "sudo-executable": {
-              "$ref": "#/transport_definitions/sudo-executable"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/sudo-executable"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "sudo-password": {
-              "$ref": "#/transport_definitions/sudo-password"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/sudo-password"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "tmpdir": {
-              "$ref": "#/transport_definitions/tmpdir"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/tmpdir"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "tty": {
-              "$ref": "#/transport_definitions/tty"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/tty"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "user": {
-              "$ref": "#/transport_definitions/user"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/user"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             }
           }
         },
@@ -613,52 +963,164 @@
           "type": "object",
           "properties": {
             "basic-auth-only": {
-              "$ref": "#/transport_definitions/basic-auth-only"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/basic-auth-only"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "cacert": {
-              "$ref": "#/transport_definitions/cacert"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/cacert"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "cleanup": {
-              "$ref": "#/transport_definitions/cleanup"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/cleanup"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "connect-timeout": {
-              "$ref": "#/transport_definitions/connect-timeout"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/connect-timeout"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "extensions": {
-              "$ref": "#/transport_definitions/extensions"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/extensions"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "file-protocol": {
-              "$ref": "#/transport_definitions/file-protocol"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/file-protocol"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "host": {
-              "$ref": "#/transport_definitions/host"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/host"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "interpreters": {
-              "$ref": "#/transport_definitions/interpreters"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/interpreters"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "password": {
-              "$ref": "#/transport_definitions/password"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/password"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "port": {
-              "$ref": "#/transport_definitions/port"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/port"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "realm": {
-              "$ref": "#/transport_definitions/realm"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/realm"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "smb-port": {
-              "$ref": "#/transport_definitions/smb-port"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/smb-port"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "ssl": {
-              "$ref": "#/transport_definitions/ssl"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/ssl"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "ssl-verify": {
-              "$ref": "#/transport_definitions/ssl-verify"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/ssl-verify"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "tmpdir": {
-              "$ref": "#/transport_definitions/tmpdir"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/tmpdir"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "user": {
-              "$ref": "#/transport_definitions/user"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/user"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             }
           }
         },
@@ -754,7 +1216,14 @@
             "string"
           ],
           "items": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
           }
         },
         {
@@ -781,7 +1250,14 @@
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
           }
         },
         {
@@ -796,7 +1272,14 @@
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
           }
         },
         {
@@ -837,7 +1320,14 @@
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
           }
         },
         {
@@ -904,7 +1394,14 @@
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
           }
         },
         {
@@ -949,7 +1446,14 @@
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
           }
         },
         {
@@ -998,7 +1502,14 @@
           "properties": {
             "key-data": {
               "description": "The contents of the private key.",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             }
           }
         },
@@ -1047,7 +1558,14 @@
         {
           "type": "array",
           "items": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
           }
         },
         {
@@ -1122,7 +1640,14 @@
             "string"
           ],
           "items": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
           }
         },
         {

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -393,25 +393,74 @@
           "type": "object",
           "properties": {
             "cleanup": {
-              "$ref": "#/transport_definitions/cleanup"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/cleanup"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "host": {
-              "$ref": "#/transport_definitions/host"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/host"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "interpreters": {
-              "$ref": "#/transport_definitions/interpreters"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/interpreters"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "service-url": {
-              "$ref": "#/transport_definitions/service-url"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/service-url"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "shell-command": {
-              "$ref": "#/transport_definitions/shell-command"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/shell-command"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "tmpdir": {
-              "$ref": "#/transport_definitions/tmpdir"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/tmpdir"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "tty": {
-              "$ref": "#/transport_definitions/tty"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/tty"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             }
           }
         },
@@ -427,28 +476,84 @@
           "type": "object",
           "properties": {
             "bundled-ruby": {
-              "$ref": "#/transport_definitions/bundled-ruby"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/bundled-ruby"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "cleanup": {
-              "$ref": "#/transport_definitions/cleanup"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/cleanup"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "interpreters": {
-              "$ref": "#/transport_definitions/interpreters"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/interpreters"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "run-as": {
-              "$ref": "#/transport_definitions/run-as"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/run-as"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "run-as-command": {
-              "$ref": "#/transport_definitions/run-as-command"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/run-as-command"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "sudo-executable": {
-              "$ref": "#/transport_definitions/sudo-executable"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/sudo-executable"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "sudo-password": {
-              "$ref": "#/transport_definitions/sudo-password"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/sudo-password"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "tmpdir": {
-              "$ref": "#/transport_definitions/tmpdir"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/tmpdir"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             }
           }
         },
@@ -464,25 +569,74 @@
           "type": "object",
           "properties": {
             "cacert": {
-              "$ref": "#/transport_definitions/cacert"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/cacert"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "host": {
-              "$ref": "#/transport_definitions/host"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/host"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "job-poll-interval": {
-              "$ref": "#/transport_definitions/job-poll-interval"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/job-poll-interval"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "job-poll-timeout": {
-              "$ref": "#/transport_definitions/job-poll-timeout"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/job-poll-timeout"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "service-url": {
-              "$ref": "#/transport_definitions/service-url"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/service-url"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "task-environment": {
-              "$ref": "#/transport_definitions/task-environment"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/task-environment"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "token-file": {
-              "$ref": "#/transport_definitions/token-file"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/token-file"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             }
           }
         },
@@ -499,7 +653,14 @@
           "additionalProperties": true,
           "properties": {
             "run-on": {
-              "$ref": "#/transport_definitions/run-on"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/run-on"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             }
           }
         },
@@ -515,85 +676,274 @@
           "type": "object",
           "properties": {
             "ssh-command": {
-              "$ref": "#/transport_definitions/ssh-command"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/ssh-command"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "native-ssh": {
-              "$ref": "#/transport_definitions/native-ssh"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/native-ssh"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "cleanup": {
-              "$ref": "#/transport_definitions/cleanup"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/cleanup"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "connect-timeout": {
-              "$ref": "#/transport_definitions/connect-timeout"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/connect-timeout"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "disconnect-timeout": {
-              "$ref": "#/transport_definitions/disconnect-timeout"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/disconnect-timeout"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "encryption-algorithms": {
-              "$ref": "#/transport_definitions/encryption-algorithms"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/encryption-algorithms"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "extensions": {
-              "$ref": "#/transport_definitions/extensions"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/extensions"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "host": {
-              "$ref": "#/transport_definitions/host"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/host"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "host-key-algorithms": {
-              "$ref": "#/transport_definitions/host-key-algorithms"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/host-key-algorithms"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "host-key-check": {
-              "$ref": "#/transport_definitions/host-key-check"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/host-key-check"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "interpreters": {
-              "$ref": "#/transport_definitions/interpreters"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/interpreters"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "kex-algorithms": {
-              "$ref": "#/transport_definitions/kex-algorithms"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/kex-algorithms"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "load-config": {
-              "$ref": "#/transport_definitions/load-config"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/load-config"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "login-shell": {
-              "$ref": "#/transport_definitions/login-shell"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/login-shell"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "mac-algorithms": {
-              "$ref": "#/transport_definitions/mac-algorithms"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/mac-algorithms"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "password": {
-              "$ref": "#/transport_definitions/password"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/password"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "port": {
-              "$ref": "#/transport_definitions/port"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/port"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "private-key": {
-              "$ref": "#/transport_definitions/private-key"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/private-key"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "proxyjump": {
-              "$ref": "#/transport_definitions/proxyjump"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/proxyjump"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "run-as": {
-              "$ref": "#/transport_definitions/run-as"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/run-as"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "run-as-command": {
-              "$ref": "#/transport_definitions/run-as-command"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/run-as-command"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "script-dir": {
-              "$ref": "#/transport_definitions/script-dir"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/script-dir"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "sudo-executable": {
-              "$ref": "#/transport_definitions/sudo-executable"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/sudo-executable"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "sudo-password": {
-              "$ref": "#/transport_definitions/sudo-password"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/sudo-password"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "tmpdir": {
-              "$ref": "#/transport_definitions/tmpdir"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/tmpdir"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "tty": {
-              "$ref": "#/transport_definitions/tty"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/tty"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "user": {
-              "$ref": "#/transport_definitions/user"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/user"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             }
           }
         },
@@ -609,52 +959,164 @@
           "type": "object",
           "properties": {
             "basic-auth-only": {
-              "$ref": "#/transport_definitions/basic-auth-only"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/basic-auth-only"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "cacert": {
-              "$ref": "#/transport_definitions/cacert"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/cacert"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "cleanup": {
-              "$ref": "#/transport_definitions/cleanup"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/cleanup"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "connect-timeout": {
-              "$ref": "#/transport_definitions/connect-timeout"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/connect-timeout"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "extensions": {
-              "$ref": "#/transport_definitions/extensions"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/extensions"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "file-protocol": {
-              "$ref": "#/transport_definitions/file-protocol"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/file-protocol"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "host": {
-              "$ref": "#/transport_definitions/host"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/host"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "interpreters": {
-              "$ref": "#/transport_definitions/interpreters"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/interpreters"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "password": {
-              "$ref": "#/transport_definitions/password"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/password"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "port": {
-              "$ref": "#/transport_definitions/port"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/port"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "realm": {
-              "$ref": "#/transport_definitions/realm"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/realm"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "smb-port": {
-              "$ref": "#/transport_definitions/smb-port"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/smb-port"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "ssl": {
-              "$ref": "#/transport_definitions/ssl"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/ssl"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "ssl-verify": {
-              "$ref": "#/transport_definitions/ssl-verify"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/ssl-verify"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "tmpdir": {
-              "$ref": "#/transport_definitions/tmpdir"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/tmpdir"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             },
             "user": {
-              "$ref": "#/transport_definitions/user"
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/user"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             }
           }
         },
@@ -750,7 +1212,14 @@
             "string"
           ],
           "items": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
           }
         },
         {
@@ -777,7 +1246,14 @@
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
           }
         },
         {
@@ -792,7 +1268,14 @@
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
           }
         },
         {
@@ -833,7 +1316,14 @@
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
           }
         },
         {
@@ -900,7 +1390,14 @@
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
           }
         },
         {
@@ -945,7 +1442,14 @@
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
           }
         },
         {
@@ -994,7 +1498,14 @@
           "properties": {
             "key-data": {
               "description": "The contents of the private key.",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
             }
           }
         },
@@ -1043,7 +1554,14 @@
         {
           "type": "array",
           "items": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
           }
         },
         {
@@ -1118,7 +1636,14 @@
             "string"
           ],
           "items": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/_plugin"
+              }
+            ]
           }
         },
         {

--- a/schemas/bolt-inventory.schema.json
+++ b/schemas/bolt-inventory.schema.json
@@ -206,7 +206,14 @@
                         {
                           "type": "array",
                           "items": {
-                            "type": "string"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/_plugin"
+                              }
+                            ]
                           }
                         },
                         {
@@ -421,7 +428,14 @@
                           "type": "array",
                           "uniqueItems": true,
                           "items": {
-                            "type": "string"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/_plugin"
+                              }
+                            ]
                           }
                         },
                         {
@@ -436,7 +450,14 @@
                           "type": "array",
                           "uniqueItems": true,
                           "items": {
-                            "type": "string"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/_plugin"
+                              }
+                            ]
                           }
                         },
                         {
@@ -462,7 +483,14 @@
                           "type": "array",
                           "uniqueItems": true,
                           "items": {
-                            "type": "string"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/_plugin"
+                              }
+                            ]
                           }
                         },
                         {
@@ -505,7 +533,14 @@
                           "type": "array",
                           "uniqueItems": true,
                           "items": {
-                            "type": "string"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/_plugin"
+                              }
+                            ]
                           }
                         },
                         {
@@ -550,7 +585,14 @@
                           "type": "array",
                           "uniqueItems": true,
                           "items": {
-                            "type": "string"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/_plugin"
+                              }
+                            ]
                           }
                         },
                         {
@@ -595,7 +637,14 @@
                           "properties": {
                             "key-data": {
                               "description": "The contents of the private key.",
-                              "type": "string"
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "$ref": "#/definitions/_plugin"
+                                }
+                              ]
                             }
                           }
                         },
@@ -633,7 +682,14 @@
                         {
                           "type": "array",
                           "items": {
-                            "type": "string"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/_plugin"
+                              }
+                            ]
                           }
                         },
                         {
@@ -716,7 +772,14 @@
                             "string"
                           ],
                           "items": {
-                            "type": "string"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/_plugin"
+                              }
+                            ]
                           }
                         },
                         {
@@ -725,8 +788,15 @@
                       ]
                     },
                     "native-ssh": {
-                      "type": "boolean",
-                      "description": "This enables the native SSH transport, which shells out to SSH instead of using the net-ssh Ruby library"
+                      "description": "This enables the native SSH transport, which shells out to SSH instead of using the net-ssh Ruby library",
+                      "oneOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
                     },
                     "ssh-command": {
                       "description": "The command and options to use when SSHing. This option is used when you need support for features or algorithms that are not supported by the net-ssh Ruby library. **This option is experimental.** You can read more about this  option in [Native SSH transport](experimental_features.md#native-ssh-transport).",
@@ -737,7 +807,14 @@
                             "string"
                           ],
                           "items": {
-                            "type": "string"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/_plugin"
+                              }
+                            ]
                           }
                         },
                         {
@@ -810,7 +887,14 @@
                           "type": "array",
                           "uniqueItems": true,
                           "items": {
-                            "type": "string"
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/_plugin"
+                              }
+                            ]
                           }
                         },
                         {
@@ -1012,28 +1096,84 @@
                 ],
                 "properties": {
                   "config": {
-                    "$ref": "#/definitions/config"
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/config"
+                      },
+                      {
+                        "$ref": "#/definitions/_plugin"
+                      }
+                    ]
                   },
                   "facts": {
-                    "$ref": "#/definitions/facts"
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/facts"
+                      },
+                      {
+                        "$ref": "#/definitions/_plugin"
+                      }
+                    ]
                   },
                   "features": {
-                    "$ref": "#/definitions/features"
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/features"
+                      },
+                      {
+                        "$ref": "#/definitions/_plugin"
+                      }
+                    ]
                   },
                   "groups": {
-                    "$ref": "#/definitions/groups"
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/groups"
+                      },
+                      {
+                        "$ref": "#/definitions/_plugin"
+                      }
+                    ]
                   },
                   "name": {
-                    "$ref": "#/definitions/name"
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/name"
+                      },
+                      {
+                        "$ref": "#/definitions/_plugin"
+                      }
+                    ]
                   },
                   "plugin_hooks": {
-                    "$ref": "#/definitions/plugin_hooks"
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/plugin_hooks"
+                      },
+                      {
+                        "$ref": "#/definitions/_plugin"
+                      }
+                    ]
                   },
                   "targets": {
-                    "$ref": "#/definitions/targets"
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/targets"
+                      },
+                      {
+                        "$ref": "#/definitions/_plugin"
+                      }
+                    ]
                   },
                   "vars": {
-                    "$ref": "#/definitions/vars"
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/vars"
+                      },
+                      {
+                        "$ref": "#/definitions/_plugin"
+                      }
+                    ]
                   }
                 }
               },
@@ -1097,28 +1237,84 @@
                 ],
                 "properties": {
                   "alias": {
-                    "$ref": "#/definitions/alias"
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/alias"
+                      },
+                      {
+                        "$ref": "#/definitions/_plugin"
+                      }
+                    ]
                   },
                   "config": {
-                    "$ref": "#/definitions/config"
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/config"
+                      },
+                      {
+                        "$ref": "#/definitions/_plugin"
+                      }
+                    ]
                   },
                   "facts": {
-                    "$ref": "#/definitions/facts"
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/facts"
+                      },
+                      {
+                        "$ref": "#/definitions/_plugin"
+                      }
+                    ]
                   },
                   "features": {
-                    "$ref": "#/definitions/features"
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/features"
+                      },
+                      {
+                        "$ref": "#/definitions/_plugin"
+                      }
+                    ]
                   },
                   "name": {
-                    "$ref": "#/definitions/name"
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/name"
+                      },
+                      {
+                        "$ref": "#/definitions/_plugin"
+                      }
+                    ]
                   },
                   "plugin_hooks": {
-                    "$ref": "#/definitions/plugin_hooks"
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/plugin_hooks"
+                      },
+                      {
+                        "$ref": "#/definitions/_plugin"
+                      }
+                    ]
                   },
                   "uri": {
-                    "$ref": "#/definitions/uri"
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/uri"
+                      },
+                      {
+                        "$ref": "#/definitions/_plugin"
+                      }
+                    ]
                   },
                   "vars": {
-                    "$ref": "#/definitions/vars"
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/vars"
+                      },
+                      {
+                        "$ref": "#/definitions/_plugin"
+                      }
+                    ]
                   }
                 }
               },


### PR DESCRIPTION
This updates the validator to allow plugins for all items and suboptions
of a given option if that option supports plugins. Items and suboptions
do not need to explicitly set the `:_plugin` key to enable this
behavior.

!bug

* **Support plugins for suboptions under options that allow plugins**

  All suboptions for config options that support plugins once again
  support plugins. For example, the `key-data` suboption for the
  `private-key` option can use plugins again.