### PR TITLE
(GH-2429) Remove bolt.yaml from spec tests

### DIFF
--- a/spec/bolt/project_manager/config_migrator_spec.rb
+++ b/spec/bolt/project_manager/config_migrator_spec.rb
@@ -43,6 +43,7 @@ describe Bolt::ProjectManager::ConfigMigrator do
         'apply-settings' => {
           'show_diff' => true
         },
+        'name' => 'project',
         'plugin-hooks' => {
           'puppet_library' => {
             'collection' => 'puppet6'

--- a/spec/bolt/project_spec.rb
+++ b/spec/bolt/project_spec.rb
@@ -146,27 +146,27 @@ describe Bolt::Project do
     end
 
     describe "when using a control repo-style project" do
-      it 'uses the current directory if it has a bolt.yaml' do
-        FileUtils.touch(tmpdir + 'bolt.yaml')
+      it 'uses the current directory if it has a bolt-project.yaml' do
+        FileUtils.touch(tmpdir + 'bolt-project.yaml')
         expect(Bolt::Project.find_boltdir(tmpdir)).to eq(Bolt::Project.new({}, tmpdir))
       end
 
-      it 'ignores non-project children with bolt.yaml' do
+      it 'ignores non-project children with bolt-project.yaml' do
         FileUtils.mkdir_p(tmpdir + 'bar')
-        FileUtils.touch(tmpdir + 'bar' + 'bolt.yaml')
+        FileUtils.touch(tmpdir + 'bar' + 'bolt-project.yaml')
 
         expect(Bolt::Project.find_boltdir(tmpdir)).to eq(Bolt::Project.default_project)
       end
 
       it 'prefers a directory called Boltdir over the local directory' do
-        FileUtils.touch(project.path.parent + 'bolt.yaml')
+        FileUtils.touch(project.path.parent + 'bolt-project.yaml')
         expect(Bolt::Project.find_boltdir(project.path.parent)).to eq(project)
       end
 
       it 'prefers a directory called Boltdir over the parent directory' do
         sibling = project_path.parent + 'bar'
         FileUtils.mkdir_p(sibling)
-        FileUtils.touch(project_path.parent + 'bolt.yaml')
+        FileUtils.touch(project_path.parent + 'bolt-project.yaml')
         expect(Bolt::Project.find_boltdir(sibling)).to eq(project)
       end
     end
@@ -176,8 +176,8 @@ describe Bolt::Project do
         expect(Bolt::Project.find_boltdir(project_path.parent).type).to eq('embedded')
       end
 
-      it 'sets type to local when a bolt.yaml is used' do
-        FileUtils.touch(tmpdir + 'bolt.yaml')
+      it 'sets type to local when a bolt-project.yaml is used' do
+        FileUtils.touch(tmpdir + 'bolt-project.yaml')
         expect(Bolt::Project.find_boltdir(tmpdir).type).to eq('local')
       end
 

--- a/spec/fixtures/linuxdev/bolt-kerberos-test.sh
+++ b/spec/fixtures/linuxdev/bolt-kerberos-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-mkdir -p ~/.puppetlabs/bolt
-rm -f ~/.puppetlabs/bolt/bolt.yaml
+mkdir -p ~/.puppetlabs/etc/bolt
+rm -f ~/.puppetlabs/etc/bolt/bolt-defaults.yaml
 
 cd ~/bolt
 
@@ -36,10 +36,11 @@ EOF
 # set default kerb realm for testing this way
 
 
-cat << EOF>~/.puppetlabs/bolt/bolt.yaml
+cat << EOF>~/.puppetlabs/etc/bolt/bolt-defaults.yaml
 ---
-winrm:
-  realm: BOLT.TEST
+inventory-config:
+  winrm:
+    realm: BOLT.TEST
 EOF
 
 cat << EOF

--- a/spec/integration/lookup_spec.rb
+++ b/spec/integration/lookup_spec.rb
@@ -10,12 +10,12 @@ describe "lookup() in plans" do
 
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
-  let(:boltdir)      { fixtures_path('hiera') }
-  let(:hiera_config) { File.join(boltdir, 'hiera.yaml') }
+  let(:project)      { fixtures_path('hiera') }
+  let(:hiera_config) { File.join(project, 'hiera.yaml') }
   let(:plan)         { 'test::lookup' }
 
   let(:cli_command) {
-    %W[plan run #{plan} --project #{boltdir} --hiera-config #{hiera_config}]
+    %W[plan run #{plan} --project #{project} --hiera-config #{hiera_config}]
   }
 
   it 'returns a value' do
@@ -87,7 +87,7 @@ describe "lookup() in plans" do
   end
 
   context 'with interpolations' do
-    let(:hiera_config) { File.join(boltdir, 'hiera_interpolations.yaml') }
+    let(:hiera_config) { File.join(project, 'hiera_interpolations.yaml') }
 
     it 'returns an error' do
       result = run_cli_json(cli_command + %w[key=test::interpolations])
@@ -101,8 +101,8 @@ describe "lookup() in plans" do
   context 'with a builtin backend' do
     # Load pkcs7 keys as environment variables
     before(:each) do
-      ENV['BOLT_PKCS7_PUBLIC_KEY']  = File.read(File.expand_path('../keys/public_key.pkcs7.pem', boltdir))
-      ENV['BOLT_PKCS7_PRIVATE_KEY'] = File.read(File.expand_path('../keys/private_key.pkcs7.pem', boltdir))
+      ENV['BOLT_PKCS7_PUBLIC_KEY']  = File.read(File.expand_path('../keys/public_key.pkcs7.pem', project))
+      ENV['BOLT_PKCS7_PRIVATE_KEY'] = File.read(File.expand_path('../keys/private_key.pkcs7.pem', project))
     end
 
     after(:each) do
@@ -124,7 +124,7 @@ describe "lookup() in plans" do
   end
 
   context 'with a missing backend' do
-    let(:hiera_config) { File.join(boltdir, 'hiera_missing_backend.yaml') }
+    let(:hiera_config) { File.join(project, 'hiera_missing_backend.yaml') }
 
     it 'returns an error' do
       result = run_cli_json(cli_command + %w[key=test::backends])
@@ -136,7 +136,7 @@ describe "lookup() in plans" do
   end
 
   context 'with plan_hiera' do
-    let(:hiera_config) { File.join(boltdir, 'plan_hiera.yaml') }
+    let(:hiera_config) { File.join(project, 'plan_hiera.yaml') }
     let(:plan)         { 'test::plan_lookup' }
     let(:uri)          { 'localhost' }
 
@@ -148,7 +148,7 @@ describe "lookup() in plans" do
   end
 
   context 'with invalid plan_hierarchy' do
-    let(:hiera_config) { File.join(boltdir, 'plan_hiera_interpolations.yaml') }
+    let(:hiera_config) { File.join(project, 'plan_hiera_interpolations.yaml') }
     let(:plan)         { 'test::plan_lookup' }
     let(:uri)          { 'localhost' }
 

--- a/spec/integration/plugin/module_spec.rb
+++ b/spec/integration/plugin/module_spec.rb
@@ -4,42 +4,32 @@ require 'spec_helper'
 require 'bolt_spec/conn'
 require 'bolt_spec/files'
 require 'bolt_spec/integration'
+require 'bolt_spec/project'
 
 describe 'using module based plugins' do
   include BoltSpec::Conn
+  include BoltSpec::Files
   include BoltSpec::Integration
+  include BoltSpec::Project
 
-  def with_boltdir(config: nil, inventory: nil, plan: nil)
-    Dir.mktmpdir do |tmpdir|
-      File.write(File.join(tmpdir, 'bolt.yaml'), config.to_yaml) if config
-      File.write(File.join(tmpdir, 'inventory.yaml'), inventory.to_yaml) if inventory
-      if plan
-        plan_dir = File.join(tmpdir, 'modules', 'test_plan', 'plans')
-        FileUtils.mkdir_p(plan_dir)
-        File.write(File.join(plan_dir, 'init.pp'), plan)
-      end
-      yield tmpdir
-    end
-  end
-
+  let(:inventory)     { {} }
   let(:plugin_config) { {} }
-  let(:plugin_hooks) { {} }
-
-  let(:config) {
-    { 'modulepath' => ['modules', File.join(__dir__, '../../fixtures/plugin_modules')],
+  let(:plugin_hooks)  { {} }
+  let(:project_name)  { 'module_test' }
+  let(:command)       { %W[plan run #{project_name} --project #{@project.path}] }
+  let(:config) do
+    { 'modulepath' => [fixtures_path('plugin_modules')],
       'plugins' => plugin_config,
       'plugin-hooks' => plugin_hooks }
-  }
+  end
 
   let(:plan) do
     <<~PLAN
-      plan test_plan() {
+      plan #{project_name}() {
         return(get_target('node1').password)
       }
     PLAN
   end
-
-  let(:inventory) { {} }
 
   before :each do
     # Don't print error messages to the console
@@ -47,13 +37,14 @@ describe 'using module based plugins' do
   end
 
   around(:each) do |example|
-    with_boltdir(inventory: inventory, config: config, plan: plan) do |project|
+    with_project(project_name, inventory: inventory, config: config) do |project|
       @project = project
+      FileUtils.mkdir_p(project.plans_path)
+      File.write(File.join(project.plans_path, 'init.pp'), plan)
+
       example.run
     end
   end
-
-  let(:project) { @project }
 
   context 'when resolving references' do
     let(:plugin) {
@@ -76,13 +67,12 @@ describe 'using module based plugins' do
     }
 
     it 'supports a config lookup' do
-      output = run_cli(['plan', 'run', 'test_plan', '--project', project])
-
+      output = run_cli(command)
       expect(output.strip).to eq('"ssshhh"')
     end
 
     it 'logs task output at trace level' do
-      run_cli(['plan', 'run', 'test_plan', '--project', project])
+      run_cli(command)
       output = @log_output.readlines
       expect(output).to include(/TRACE.*"value":{"value":"ssshhh"/)
     end
@@ -97,7 +87,7 @@ describe 'using module based plugins' do
       }
 
       it 'errors when the parameters dont match' do
-        result = run_cli_json(['plan', 'run', 'test_plan', '--project', project], rescue_exec: true)
+        result = run_cli_json(command, rescue_exec: true)
 
         expect(result).to include('kind' => "bolt/validation-error")
         expect(result['msg']).to match(/Task identity::resolve_reference:\s*has no param/)
@@ -113,7 +103,7 @@ describe 'using module based plugins' do
       }
 
       it 'errors when the result is unexpected' do
-        result = run_cli_json(['plan', 'run', 'test_plan', '--project', project], rescue_exec: true)
+        result = run_cli_json(command, rescue_exec: true)
 
         expect(result).to include('kind' => "bolt/plugin-error")
         expect(result['msg']).to match(/did not include a value/)
@@ -128,7 +118,7 @@ describe 'using module based plugins' do
       }
 
       it 'errors when the task fails' do
-        result = run_cli_json(['plan', 'run', 'test_plan', '--project', project], rescue_exec: true)
+        result = run_cli_json(command, rescue_exec: true)
 
         expect(result).to include('kind' => "bolt/plugin-error")
         expect(result['msg']).to match(/The task failed/)
@@ -158,29 +148,31 @@ describe 'using module based plugins' do
 
     let(:plan) do
       <<~PLAN
-        plan test_plan() {
+        plan #{project_name}() {
           return(get_target('node1').config)
         }
       PLAN
     end
 
     it 'fails when config key is present in bolt_plugin.json' do
-      result = run_cli_json(['plan', 'run', 'test_plan', '--project', project], rescue_exec: true)
+      result = run_cli_json(command, rescue_exec: true)
 
       expect(result).to include('kind' => "bolt/invalid-plugin-data")
       expect(result['msg']).to match(/Found unsupported key 'config'/)
     end
 
-    context 'with values specified in both bolt.yaml and inventory.yaml' do
+    context 'with values specified in both bolt-project.yaml and inventory.yaml' do
+      let(:project_path) { @project.path.to_s }
+
       context 'and merging config' do
         let(:plugin) { { '_plugin' => 'task_conf_plug', 'optional_key' => 'keep' } }
         let(:plugin_config) { { 'task_conf_plug' => { 'required_key' => 'foo', 'optional_key' => 'clobber' } } }
 
         it 'merges parameters set in config and does not pass _config' do
-          result = run_cli_json(['plan', 'run', 'test_plan', '--project', project])
+          result = run_cli_json(command)
 
           expect(result['remote']['data']).not_to include('_config' => plugin_config['conf_plug'])
-          expect(result['remote']['data']).to include('_boltdir' => project)
+          expect(result['remote']['data']).to include('_boltdir' => project_path)
           expect(result['remote']['data']).to include('required_key' => 'foo')
           expect(result['remote']['data']).to include('optional_key' => 'keep')
         end
@@ -191,10 +183,10 @@ describe 'using module based plugins' do
         let(:plugin_config) { { 'task_conf_plug' => { 'optional_key' => 'bar' } } }
 
         it 'treats all required values from task paramter metadata as optional' do
-          result = run_cli_json(['plan', 'run', 'test_plan', '--project', project])
+          result = run_cli_json(command)
 
           expect(result['remote']['data']).not_to include('_config' => plugin_config['conf_plug'])
-          expect(result['remote']['data']).to include('_boltdir' => project)
+          expect(result['remote']['data']).to include('_boltdir' => project_path)
           expect(result['remote']['data']).to include('required_key' => 'foo')
           expect(result['remote']['data']).to include('optional_key' => 'bar')
         end
@@ -205,7 +197,7 @@ describe 'using module based plugins' do
         let(:plugin_config) { { 'task_conf_plug' => { 'random_key' => 'bar' } } }
 
         it 'forbids config entries that do not match task metadata schema' do
-          expect { run_cli(%W[plan run test_plan --project #{project}]) }
+          expect { run_cli(command) }
             .to raise_error(Bolt::ValidationError, /task_conf_plug plugin contains unexpected key random_key/)
         end
       end
@@ -213,6 +205,7 @@ describe 'using module based plugins' do
 
     context 'with multiple task schemas to validate against' do
       context 'with valid type String string set in config and overriden in inventory' do
+        let(:project_path) { @project.path.to_s }
         let(:plugin) {
           {
             '_plugin' => 'task_conf_plug',
@@ -222,9 +215,9 @@ describe 'using module based plugins' do
         }
         let(:plugin_config) { { 'task_conf_plug' => { 'intersection_key' => 'String' } } }
 
-        it 'allows valid type in bolt.yaml and expected value is overriden in inventory' do
-          result = run_cli_json(['plan', 'run', 'test_plan', '--project', project])
-          expect(result['remote']['data']).to include('_boltdir' => project)
+        it 'allows valid type in bolt-project.yaml and expected value is overriden in inventory' do
+          result = run_cli_json(command)
+          expect(result['remote']['data']).to include('_boltdir' => project_path)
           expect(result['remote']['data']).to include('required_key' => 'foo')
           expect(result['remote']['data']).to include('intersection_key' => 1)
         end
@@ -233,47 +226,44 @@ describe 'using module based plugins' do
   end
 
   context 'when handling secrets' do
+    let(:config_flags) { %W[--project #{@project.path}] }
+
     it 'calls the encrypt task' do
-      result = run_cli(['secret', 'encrypt', 'secret_msg', '--plugin', 'my_secret', '--project', project],
+      result = run_cli(%w[secret encrypt secret_msg --plugin my_secret] + config_flags,
                        outputter: Bolt::Outputter::Human)
       # This is kind of brittle and we look for plaintext_value because this is really the identity task
       expect(result).to match(/"plaintext_value"=>"secret_msg"/)
     end
 
     it 'calls the decrypt task' do
-      result = run_cli(['secret', 'decrypt', 'secret_msg', '--plugin', 'my_secret', '--project', project],
+      result = run_cli(%w[secret decrypt secret_msg --plugin my_secret] + config_flags,
                        outputter: Bolt::Outputter::Human)
       # This is kind of brittle and we look for "encrypted_value because this is really the identity task
       expect(result).to match(/"encrypted_value"=>"secret_msg"/)
     end
   end
 
-  context 'when managing puppet libraries' do
-    # TODO: how do we test this cheaply?
-  end
-
-  context 'when manageing puppet_library', docker: true do
+  context 'when managing puppet_library', docker: true do
+    let(:inventory) { docker_inventory(root: true) }
     let(:plan) do
       <<~PLAN
-        plan test_plan() {
+        plan #{project_name}() {
           apply_prep('ubuntu_node')
         }
       PLAN
     end
 
-    let(:inventory) { docker_inventory(root: true) }
-
     context 'with an unsupported hook' do
-      let(:plugin_hooks) {
+      let(:plugin_hooks) do
         {
           'puppet_library' => {
             'plugin' => 'identity'
           }
         }
-      }
+      end
 
       it 'fails cleanly' do
-        result = run_cli_json(['plan', 'run', 'test_plan', '--project', project], rescue_exec: true)
+        result = run_cli_json(command, rescue_exec: true)
 
         expect(result).to include('kind' => "bolt/run-failure")
         expect(result['msg']).to match(/Plan aborted: apply_prep failed on 1 target/)
@@ -284,16 +274,16 @@ describe 'using module based plugins' do
     end
 
     context 'with an unknown plugin' do
-      let(:plugin_hooks) {
+      let(:plugin_hooks) do
         {
           'puppet_library' => {
             'plugin' => 'does_not_exist'
           }
         }
-      }
+      end
 
       it 'fails cleanly' do
-        result = run_cli_json(['plan', 'run', 'test_plan', '--project', project], rescue_exec: true)
+        result = run_cli_json(command, rescue_exec: true)
 
         expect(result).to include('kind' => "bolt/run-failure")
         expect(result['msg']).to match(/Plan aborted: apply_prep failed on 1 target/)
@@ -311,7 +301,7 @@ describe 'using module based plugins' do
       }
 
       it 'fails cleanly' do
-        result = run_cli_json(['plan', 'run', 'test_plan', '--project', project], rescue_exec: true)
+        result = run_cli_json(command, rescue_exec: true)
 
         expect(result).to include('kind' => "bolt/run-failure")
         expect(result['msg']).to match(/Plan aborted: apply_prep failed on 1 target/)

--- a/spec/lib/bolt_spec/project.rb
+++ b/spec/lib/bolt_spec/project.rb
@@ -16,12 +16,13 @@ module BoltSpec
         inventory_path = project_path + 'inventory.yaml'
 
         # Set default config and inventory if not provided
-        config    ||= { 'name' => name }
+        cfg = { 'name' => name }
+        cfg.merge!(config) if config
         inventory ||= {}
 
         # Create project directory and files
         FileUtils.mkdir_p(project_path)
-        File.write(config_path, config.to_yaml)
+        File.write(config_path, cfg.to_yaml)
         File.write(inventory_path, inventory.to_yaml)
 
         yield(project_path)


### PR DESCRIPTION
This removes `bolt.yaml` and replaces it with `bolt-project.yaml` file
infrastructure for any tests that aren't explicitly testing behavior
around the presence of `bolt.yaml`. This mostly includes refactoring the
plugin integration test to use `with_project` instead of their own
custom functions.

This also edits the `with_project` spec test helper to set the project
name by default, and merge in the provided config over top of `{ 'name'
=> name }` if config is passed to the helper. This ensures the project
always has a name, and that the name can be overridden by the config 
hash if need be.

Closes #2429

!no-release-note