### PR TITLE
Revert "(maint) Temporarily pin bundler to 2.1.4"

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,7 +22,7 @@ jobs:
           ruby-version: '2.5.x'
       - name: Install bundler
         run: |
-          gem install bundler -v 2.1.4
+          gem install bundler
           bundle config path vendor/bundle
       - name: Cache gems
         id: cache

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -26,7 +26,7 @@ jobs:
           ruby-version: '2.5.x'
       - name: Install bundler
         run: |
-          gem install bundler -v 2.1.4
+          gem install bundler
           bundle config path vendor/bundle
       - name: Cache gems
         id: cache
@@ -64,7 +64,7 @@ jobs:
           ruby-version: '2.5.x'
       - name: Install bundler
         run: |
-          gem install bundler -v 2.1.4
+          gem install bundler
           bundle config path vendor/bundle
       - name: Cache gems
         id: cache

--- a/.github/workflows/litmus_smoke.yaml
+++ b/.github/workflows/litmus_smoke.yaml
@@ -33,7 +33,7 @@ jobs:
           contents: "gem 'bolt', require: false, git: 'https://github.com/${{ github.repository }}', branch: '${{ github.ref }}'"
       - name: Install bundler
         run: |
-          gem install bundler -v 2.1.4
+          gem install bundler
           bundle config path vendor/bundle
           bundle config with development
       - name: Install gems

--- a/.github/workflows/modules.yaml
+++ b/.github/workflows/modules.yaml
@@ -25,7 +25,7 @@ jobs:
           ruby-version: '2.5.x'
       - name: Install bundler
         run: |
-          gem install bundler -v 2.1.4
+          gem install bundler
           bundle config path vendor/bundle
       - name: Cache gems
         id: cache
@@ -56,7 +56,7 @@ jobs:
           ruby-version: 2.5.x
       - name: Install bundler
         run: |
-          gem install bundler -v 2.1.4
+          gem install bundler
           bundle config path vendor/bundle
       - name: Cache gems
         id: cache

--- a/.github/workflows/pwsh.yaml
+++ b/.github/workflows/pwsh.yaml
@@ -22,7 +22,7 @@ jobs:
           ruby-version: 2.5.x
       - name: Install bundler
         run: |
-          gem install bundler -v 2.1.4
+          gem install bundler
           bundle config path vendor/bundle
       - name: Cache gems
         id: cache

--- a/.github/workflows/schemas.yaml
+++ b/.github/workflows/schemas.yaml
@@ -30,7 +30,7 @@ jobs:
           ruby-version: '2.5.x'
       - name: Install bundler
         run: |
-          gem install bundler -v 2.1.4
+          gem install bundler
           bundle config path vendor/bundle
       - name: Cache gems
         id: cache

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -33,7 +33,7 @@ jobs:
           ruby-version: 2.5.x
       - name: Install bundler
         run: |
-          gem install bundler -v 2.1.4
+          gem install bundler
           bundle config path vendor/bundle
       - name: Cache gems
         id: cache
@@ -79,7 +79,7 @@ jobs:
           ruby-version: 2.5.x
       - name: Install bundler
         run: |
-          gem install bundler -v 2.1.4
+          gem install bundler
           bundle config path vendor/bundle
       - name: Cache gems
         id: cache

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "winrm-fs", "~> 1.3"
 
   # there is a bug in puppetlabs_spec_helper for modules without fixtures
-  spec.add_development_dependency "bundler", ">= 1.14", "< 2.2.0"
+  spec.add_development_dependency "bundler", ">= 1.14"
   spec.add_development_dependency "octokit", "~> 4.0"
   spec.add_development_dependency "puppetlabs_spec_helper", "~> 2.7"
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
Reverts puppetlabs/bolt#2460.

It sounds like Bundler 2.2.1 [may have addressed the issue we were seeing](https://github.com/rubygems/rubygems/issues/4123) with Litmus.

!no-release-note