### PR TITLE
(maint) Unpin bundler for Bolt

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,7 +22,7 @@ jobs:
           ruby-version: '2.5.x'
       - name: Install bundler
         run: |
-          gem install bundler -v 2.1.4
+          gem install bundler
           bundle config path vendor/bundle
       - name: Cache gems
         id: cache

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -26,7 +26,7 @@ jobs:
           ruby-version: '2.5.x'
       - name: Install bundler
         run: |
-          gem install bundler -v 2.1.4
+          gem install bundler
           bundle config path vendor/bundle
       - name: Cache gems
         id: cache
@@ -64,7 +64,7 @@ jobs:
           ruby-version: '2.5.x'
       - name: Install bundler
         run: |
-          gem install bundler -v 2.1.4
+          gem install bundler
           bundle config path vendor/bundle
       - name: Cache gems
         id: cache

--- a/.github/workflows/litmus_smoke.yaml
+++ b/.github/workflows/litmus_smoke.yaml
@@ -33,7 +33,7 @@ jobs:
           contents: "gem 'bolt', require: false, git: 'https://github.com/${{ github.repository }}', branch: '${{ github.ref }}'"
       - name: Install bundler
         run: |
-          gem install bundler -v 2.1.4
+          gem install bundler
           bundle config path vendor/bundle
           bundle config with development
       - name: Install gems

--- a/.github/workflows/modules.yaml
+++ b/.github/workflows/modules.yaml
@@ -25,7 +25,7 @@ jobs:
           ruby-version: '2.5.x'
       - name: Install bundler
         run: |
-          gem install bundler -v 2.1.4
+          gem install bundler
           bundle config path vendor/bundle
       - name: Cache gems
         id: cache
@@ -56,7 +56,7 @@ jobs:
           ruby-version: 2.5.x
       - name: Install bundler
         run: |
-          gem install bundler -v 2.1.4
+          gem install bundler
           bundle config path vendor/bundle
       - name: Cache gems
         id: cache

--- a/.github/workflows/pwsh.yaml
+++ b/.github/workflows/pwsh.yaml
@@ -22,7 +22,7 @@ jobs:
           ruby-version: 2.5.x
       - name: Install bundler
         run: |
-          gem install bundler -v 2.1.4
+          gem install bundler
           bundle config path vendor/bundle
       - name: Cache gems
         id: cache

--- a/.github/workflows/schemas.yaml
+++ b/.github/workflows/schemas.yaml
@@ -30,7 +30,7 @@ jobs:
           ruby-version: '2.5.x'
       - name: Install bundler
         run: |
-          gem install bundler -v 2.1.4
+          gem install bundler
           bundle config path vendor/bundle
       - name: Cache gems
         id: cache

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -33,7 +33,7 @@ jobs:
           ruby-version: 2.5.x
       - name: Install bundler
         run: |
-          gem install bundler -v 2.1.4
+          gem install bundler
           bundle config path vendor/bundle
       - name: Cache gems
         id: cache
@@ -79,7 +79,7 @@ jobs:
           ruby-version: 2.5.x
       - name: Install bundler
         run: |
-          gem install bundler -v 2.1.4
+          gem install bundler
           bundle config path vendor/bundle
       - name: Cache gems
         id: cache

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "winrm-fs", "~> 1.3"
 
   # there is a bug in puppetlabs_spec_helper for modules without fixtures
-  spec.add_development_dependency "bundler", ">= 1.14", "< 2.2.0"
+  spec.add_development_dependency "bundler", ">= 1.14"
   spec.add_development_dependency "octokit", "~> 4.0"
   spec.add_development_dependency "puppetlabs_spec_helper", "~> 2.7"
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
We have a CI test that verifies that Litmus works with each Bolt PR by
adding a gem declaration to the Gemfile of
[puppetlabs/puppetlabs-package](https://github.com/puppetlabs/puppetlabs-package)
that pulls in the Bolt PR as a gem and runs tests in the module.
Installing gems in the module was hanging in Github Actions when Bundler 2.2.0
was released, due to [this
issue](https://github.com/rubygems/rubygems/issues/4123). We originally
pinned all of Bolt back to bundler < 2.2.0, however now the Jenkins CI
environment has been updated to only include Bundler 2.2.1. In order to
be able to test and build Bolt in Jenkins we need to unpin the bundler
version so we can use 2.2.1.

The original issue has also been fixed now, so we can unpin bundler
entirely.

!no-release-note