### PR TITLE
Revert "(GH-2478) Support module-install config when resolving modules"

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-ssh-krb", "~> 0.5"
   spec.add_dependency "orchestrator_client", "~> 0.4"
   spec.add_dependency "puppet", ">= 6.18.0"
-  spec.add_dependency "puppetfile-resolver", "~> 0.5"
+  spec.add_dependency "puppetfile-resolver", "~> 0.4"
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "puppet-strings", "~> 2.3"
   spec.add_dependency "r10k", "~> 3.1"

--- a/documentation/bolt_installing_modules.md
+++ b/documentation/bolt_installing_modules.md
@@ -273,62 +273,6 @@ requirement.
 > documentation on [Specifying
 > versions](https://puppet.com/docs/puppet/latest/modules_metadata.html#specifying-versions).
 
-## Install Forge modules from an alternate Forge
-
-You can configure Bolt to use a Forge other than the [Puppet
-Forge](https://forge.puppet.com) when it installs Forge modules. To configure
-Bolt to use an alternate Forge, set the `module-install` configuration option in
-either your project configuration file, `bolt-project.yaml`, or the default
-configuration file, `bolt-defaults.yaml`.
-
-To use an alternate Forge for installing Forge modules, set the `baseurl` key
-under the `forge` section of the `module-install` option:
-
-```yaml
-# bolt-project.yaml
-module-install:
-  forge:
-    baseurl: https://forge.example.com
-```
-
-📖 **Related information**
-
-- [bolt-project.yaml options](bolt_project_reference.md#module-install)
-- [bolt-defaults.yaml options](bolt_defaults_reference.md#module-install)
-
-## Install modules using a proxy
-
-If your workstation cannot connect directly to the internet, you can configure
-Bolt to use a proxy when it installs modules. To configure Bolt to use a proxy
-when it installs modules, set the `module-install` configuration option in
-either your project configuration file, `bolt-project.yaml`, or the default
-configuration file, `bolt-defaults.yaml`.
-
-To set a global proxy that is used for installing Forge and git modules, set
-the `proxy` key under `module-install`:
-
-```yaml
-# bolt-project.yaml
-module-install:
-  proxy: https://proxy.com:8080
-```
-
-You can also set a proxy that is only used when installing Forge modules. To
-set a proxy for installing Forge modules, set the `proxy` key under the `forge`
-section of the `module-install` option:
-
-```yaml
-# bolt-project.yaml
-module-install:
-  forge:
-    proxy: https://forge-proxy.com:8080
-```
-
-📖 **Related information**
-
-- [bolt-project.yaml options](bolt_project_reference.md#module-install)
-- [bolt-defaults.yaml options](bolt_defaults_reference.md#module-install)
-
 ## ⛔ Manage modules with a Puppetfile
 
 ⛔ **DEPRECATED:** This method of installing and managing modules is deprecated.

--- a/documentation/bolt_known_issues.md
+++ b/documentation/bolt_known_issues.md
@@ -1,5 +1,94 @@
 # Known issues
 
+## Resolving module dependencies does not support proxies or alternate Forge
+
+When running the `bolt module add|install` commands or `Add|Install-BoltModule`
+cmdlets, Bolt does not support a configured proxy or alternate Forge when it
+resolves module dependencies, even if the `module-install` configuration
+option is set. Support for resolving module dependencies with proxies or an
+alternate Forge requires changes to one of Bolt's gem dependencies, which is
+currently in progress.
+
+While Bolt will not resolve module dependencies with proxies or an alternate
+Forge, it will respect this configuration when installing modules.
+
+If your project configures the `module-install` option, you may experience
+one of the following issues:
+
+- On a restricted network where a proxy is required, resolving modules may
+  cause Bolt to fail.
+
+- When an alternate Forge is specified, Bolt may resolve and install a
+  different set of modules than expected.
+
+### Install modules without resolving dependencies
+
+To avoid this limitation and any potential errors, you can manually edit your
+Puppetfile to add and install modules without resolving dependencies. This is a
+similar workflow to using the `bolt puppetfile install` and
+`Install-BoltPuppetfileModules` commands.
+
+For example, if your project requires the `puppetlabs/apache` module, but
+you need to download modules hosted on an alternate Forge, you should write
+your Puppetfile manually. That Puppetfile might look similar to this:
+
+```ruby
+mod 'puppetlabs/apache', '5.7.0'
+mod 'puppetlabs/stdlib', '6.5.0'
+mod 'puppetlabs/concat', '6.3.0'
+mod 'puppetlabs/translate', '2.2.0'
+```
+
+Once you have a Puppetfile, you can install modules without resolving
+dependencies using the `no-resolve` command-line option:
+
+_\*nix command_
+
+```shell
+bolt module install --no-resolve
+```
+
+_PowerShell cmdlet_
+
+```powershell
+Install-BoltModule -NoResolve
+```
+
+If you need to add a module to your project, manually add the module and
+its dependencies to your Puppetfile and then run the above command again.
+
+### Set the HTTP proxy environment variables
+
+If you only need to configure a proxy to work around network restrictions,
+you can set the HTTP proxy environment variables when you run Bolt. For
+example, if you only configure the `proxy` option under `module-install` like
+this:
+
+```yaml
+# bolt-project.yaml
+module-install:
+  proxy: http://myproxy.com
+```
+
+Then you can set the `HTTP_PROXY` and `HTTPS_PROXY` environment variables
+to this value when you run `bolt module add|install` or `Add|Install-BoltModule`.
+This will configure a proxy that Bolt will use when it makes requests to the
+Puppet Forge and GitHub when it resolves modules.
+
+_\*nix command_
+
+```shell
+HTTP_PROXY=http://myproxy.com HTTPS_PROXY=http://myproxy.com bolt module install
+```
+
+_PowerShell cmdlet_
+
+```powershell
+SET HTTP_PROXY=http://myproxy.com
+SET HTTPS_PROXY=http://myproxy.com
+Install-BoltModule
+```
+
 ## `facts` task fails on Windows targets with Facter 3 installed
 
 When running the `facts` task on a Windows target that has Facter 3 installed,

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -758,6 +758,14 @@ module Bolt
         return 0
       end
 
+      if resolve != false && config.any?
+        @logger.warn(
+          "Detected configuration for 'module-install'. This configuration is currently "\
+          "only supported when installing modules, not when resolving module dependencies. "\
+          "For more information, see https://pup.pt/bolt-module-install"
+        )
+      end
+
       modules   = project.modules || []
       installer = Bolt::ModuleInstaller.new(outputter, pal)
 
@@ -778,6 +786,14 @@ module Bolt
     def add_project_module(name, project, config)
       assert_project_file(project)
       assert_puppetfile_or_module_command(project.modules)
+
+      if config.any?
+        @logger.warn(
+          "Detected configuration for 'module-install'. This configuration is currently "\
+          "only supported when installing modules, not when resolving module dependencies. "\
+          "For more information, see https://pup.pt/bolt-module-install"
+        )
+      end
 
       modules   = project.modules || []
       installer = Bolt::ModuleInstaller.new(outputter, pal)

--- a/lib/bolt/module_installer/resolver.rb
+++ b/lib/bolt/module_installer/resolver.rb
@@ -9,7 +9,7 @@ module Bolt
     class Resolver
       # Resolves module specs and returns a Puppetfile object.
       #
-      def resolve(specs, config = {})
+      def resolve(specs, _config = {})
         require 'puppetfile-resolver'
 
         # Build the document model from the specs.
@@ -38,10 +38,10 @@ module Bolt
         # raised by puppetfile-resolver and re-raising them as Bolt errors.
         begin
           result = resolver.resolve(
-            cache:                       nil,
-            ui:                          nil,
-            allow_missing_modules:       false,
-            spec_searcher_configuration: spec_searcher_config(config)
+            cache:                 nil,
+            ui:                    nil,
+            module_paths:          [],
+            allow_missing_modules: false
           )
         rescue StandardError => e
           raise Bolt::Error.new(e.message, 'bolt/module-resolver-error')
@@ -70,14 +70,6 @@ module Bolt
 
         # Create the Puppetfile object.
         Bolt::ModuleInstaller::Puppetfile.new(modules)
-      end
-
-      private def spec_searcher_config(config)
-        PuppetfileResolver::SpecSearchers::Configuration.new.tap do |obj|
-          obj.forge.proxy     = config.dig('forge', 'proxy') || config.dig('proxy')
-          obj.git.proxy       = config.dig('proxy')
-          obj.forge.forge_api = config.dig('forge', 'baseurl')
-        end
       end
     end
   end

--- a/spec/integration/module_installer_spec.rb
+++ b/spec/integration/module_installer_spec.rb
@@ -38,7 +38,7 @@ describe 'installing modules' do
     context 'with Forge modules' do
       let(:project_config) { base_config.merge('modules' => ['puppetlabs-yaml']) }
 
-      it 'uses the forge configuration' do
+      xit 'uses the forge configuration' do
         expect { run_cli(command, project: project) }.to raise_error(
           Bolt::Error,
           %r{on https://forge.example.com with proxy https://myforgeproxy.example.com}
@@ -58,7 +58,7 @@ describe 'installing modules' do
         )
       end
 
-      it 'uses the global proxy' do
+      xit 'uses the global proxy' do
         expect { run_cli(command, project: project) }.to raise_error(
           Bolt::Error,
           %r{with proxy https://myproxy.example.com}


### PR DESCRIPTION
Reverts puppetlabs/bolt#2479

Puppetfile Resolver has a minimum ruby version of 2.5.3, which requires us to use an updated CI environment in Jenkins that uses Bundler 2.2.1, which may be incompatible for downstream projects (see https://github.com/puppetlabs/bolt/pull/2460). We're reverting this change for now to get a bug fix out, and will update after the holiday break.

!no-release-note