### PR TITLE
(maint) Allow "both" in bolt-server task schema

### DIFF
--- a/lib/bolt_server/schemas/partials/task.json
+++ b/lib/bolt_server/schemas/partials/task.json
@@ -37,7 +37,7 @@
         },
         "input_method": {
           "type": "string",
-          "enum": ["stdin", "environment", "powershell"],
+          "enum": ["stdin", "environment", "powershell", "both"],
           "description": "What input method should be used to pass params to the task"
         }
       }


### PR DESCRIPTION
This commit adds "both" as a valid value for input_method in
bolt-server's task schema