### PR TITLE
(maint) Standardize on using fixtures_path

### DIFF
--- a/spec/bolt/catalog_spec.rb
+++ b/spec/bolt/catalog_spec.rb
@@ -7,8 +7,10 @@ require 'bolt/executor'
 require 'bolt/inventory'
 require 'bolt/puppetdb'
 require 'bolt/target'
+require 'bolt_spec/files'
 
 describe Bolt::Catalog do
+  include BoltSpec::Files
   let(:uri) { 'catalog' }
   let(:target) { inventory.get_target(uri) }
   let(:inventory) { Bolt::Inventory.empty }
@@ -34,7 +36,7 @@ describe Bolt::Catalog do
     CODE
   }
 
-  let(:plan) { File.join(__FILE__, '../../fixtures/apply/basic/plans/trusted.pp') }
+  let(:plan) { fixtures_path('apply', 'basic', 'plans', 'trusted.pp') }
   let(:project) { Struct.new(:name, :path, :load_as_module?).new('project', '', false) }
 
   let(:request) do

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1336,7 +1336,7 @@ describe "Bolt::CLI" do
 
       context "when showing available tasks", :reset_puppet_settings do
         before :each do
-          cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
+          cli.config.modulepath = fixtures_path('modules')
           cli.config.format = 'json'
         end
 
@@ -1391,7 +1391,7 @@ describe "Bolt::CLI" do
           }
           cli.execute(options)
           modulepath = JSON.parse(output.string)['modulepath']
-          expect(modulepath).to include(File.join(__FILE__, '../../fixtures/modules').to_s)
+          expect(modulepath).to include(fixtures_path('modules'))
         end
 
         it "does not list a private task" do
@@ -1419,7 +1419,7 @@ describe "Bolt::CLI" do
             "metadata" => { "name" => "Private Task",
                             "description" => "Do not list this task",
                             "private" => true },
-            "module_dir" => File.absolute_path(File.join(__dir__, "..", "fixtures", "modules", "sample"))
+            "module_dir" => fixtures_path('modules', 'sample')
           )
         end
 
@@ -1435,7 +1435,7 @@ describe "Bolt::CLI" do
           json.delete("files")
           expect(json).to eq(
             "name" => "sample::params",
-            "module_dir" => File.absolute_path(File.join(__dir__, "..", "fixtures", "modules", "sample")),
+            "module_dir" => fixtures_path('modules', 'sample'),
             "metadata" => {
               "anything" => true,
               "description" => "Task with parameters",
@@ -1488,7 +1488,7 @@ describe "Bolt::CLI" do
 
       context "when available tasks include an error", :reset_puppet_settings do
         before :each do
-          cli.config.modulepath = [File.join(__FILE__, '../../fixtures/invalid_mods')]
+          cli.config.modulepath = fixtures_path('invalid_mods')
           cli.config.format = 'json'
         end
 
@@ -1513,7 +1513,7 @@ describe "Bolt::CLI" do
 
       context "when the task is not in the modulepath", :reset_puppet_settings do
         before :each do
-          cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
+          cli.config.modulepath = fixtures_path('modules')
         end
 
         it "task show displays an error" do
@@ -1533,7 +1533,7 @@ describe "Bolt::CLI" do
 
       context "when showing available plans", :reset_puppet_settings do
         before :each do
-          cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
+          cli.config.modulepath = fixtures_path('modules')
           cli.config.format = 'json'
         end
 
@@ -1562,7 +1562,7 @@ describe "Bolt::CLI" do
           }
           cli.execute(options)
           modulepath = JSON.parse(output.string)['modulepath']
-          expect(modulepath).to include(File.join(__FILE__, '../../fixtures/modules').to_s)
+          expect(modulepath).to include(fixtures_path('modules'))
         end
 
         it "shows an individual plan data" do
@@ -1577,7 +1577,7 @@ describe "Bolt::CLI" do
           expect(json).to eq(
             "name" => "sample::optional_params_task",
             "description" => "Demonstrates plans with optional parameters",
-            "module_dir" => File.absolute_path(File.join(__dir__, "..", "fixtures", "modules", "sample")),
+            "module_dir" => fixtures_path('modules', 'sample'),
             "parameters" => {
               "param_mandatory" => {
                 "type" => "String",
@@ -1610,7 +1610,7 @@ describe "Bolt::CLI" do
           json = JSON.parse(output.string)
           expect(json).to eq(
             "name" => plan_name,
-            "module_dir" => File.absolute_path(File.join(__dir__, "..", "fixtures", "modules", "sample")),
+            "module_dir" => fixtures_path('modules', 'sample'),
             "description" => nil,
             "parameters" => {
               "oops" => {
@@ -1636,7 +1636,7 @@ describe "Bolt::CLI" do
           expect(json).to eq(
             "name" => "sample::yaml",
             "description" => nil,
-            "module_dir" => File.absolute_path(File.join(__dir__, "..", "fixtures", "modules", "sample")),
+            "module_dir" => fixtures_path('modules', 'sample'),
             "parameters" => {
               "nodes" => {
                 "type" => "TargetSpec",
@@ -1670,7 +1670,7 @@ describe "Bolt::CLI" do
 
       context "when available plans include an error", :reset_puppet_settings do
         before :each do
-          cli.config.modulepath = [File.join(__FILE__, '../../fixtures/invalid_mods')]
+          cli.config.modulepath = fixtures_path('invalid_mods')
           cli.config.format = 'json'
         end
 
@@ -1710,7 +1710,7 @@ describe "Bolt::CLI" do
 
       context "when the plan is not in the modulepath", :reset_puppet_settings do
         before :each do
-          cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
+          cli.config.modulepath = fixtures_path('modules')
         end
 
         it "plan show displays an error" do
@@ -1747,7 +1747,7 @@ describe "Bolt::CLI" do
 
         before :each do
           allow(executor).to receive(:report_bundled_content)
-          cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
+          cli.config.modulepath = fixtures_path('modules')
         end
 
         it "runs a task given a name" do
@@ -2004,7 +2004,7 @@ describe "Bolt::CLI" do
         before :each do
           allow(executor).to receive(:report_function_call)
           allow(executor).to receive(:report_bundled_content)
-          cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
+          cli.config.modulepath = fixtures_path('modules')
         end
 
         context 'with TargetSpec $nodes plan param' do
@@ -2295,7 +2295,7 @@ describe "Bolt::CLI" do
         let(:task_t) { task_type(task_name, %r{modules/sample/tasks/noop.sh$}, nil) }
 
         before :each do
-          cli.config.modulepath = [File.join(__FILE__, '../../fixtures/modules')]
+          cli.config.modulepath = fixtures_path('modules')
         end
 
         it "runs a task that supports noop" do

--- a/spec/bolt_spec/plan_spec.rb
+++ b/spec/bolt_spec/plan_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'bolt_spec/files'
 require 'bolt_spec/plans'
 
 # Requires targets, plan_name, return_expects to be set.
@@ -44,10 +45,11 @@ shared_examples 'action tests' do
 end
 
 describe "BoltSpec::Plans" do
+  include BoltSpec::Files
   include BoltSpec::Plans
 
   def modulepath
-    File.join(__dir__, '../fixtures/bolt_spec')
+    fixtures_path('bolt_spec')
   end
 
   let(:targets) { %w[foo bar] }

--- a/spec/bolt_spec/run_spec.rb
+++ b/spec/bolt_spec/run_spec.rb
@@ -2,18 +2,18 @@
 
 require 'spec_helper'
 require 'bolt_spec/conn'
-require 'bolt_spec/run'
 require 'bolt_spec/files'
+require 'bolt_spec/run'
 
 # In order to speed up tests there are only ssh versions of these specs
 # While the target shouldn't matter this does mean this helper is not tested on
 # windows controllers.
 describe "BoltSpec::Run", ssh: true do
-  include BoltSpec::Run
   include BoltSpec::Conn
   include BoltSpec::Files
+  include BoltSpec::Run
 
-  let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
+  let(:modulepath) { fixtures_path('modules') }
   let(:bolt_config) {
     { "modulepath" => modulepath,
       "ssh" => { "host-key-check" => false },
@@ -50,7 +50,7 @@ describe "BoltSpec::Run", ssh: true do
   end
 
   describe 'run_script' do
-    let(:script) { File.join(bolt_config['modulepath'], '..', 'scripts', 'success.sh') }
+    let(:script) { fixtures_path('scripts', 'success.sh') }
 
     it 'should run a command on a node with an argument', ssh: true do
       result = run_script(script, 'ssh', ['hi'])
@@ -67,7 +67,7 @@ describe "BoltSpec::Run", ssh: true do
   end
 
   describe 'upload_file' do
-    let(:file) { File.join(bolt_config['modulepath'], '..', 'scripts', 'success.sh') }
+    let(:file) { fixtures_path('scripts', 'success.sh') }
     let(:dest) { "/tmp/#{SecureRandom.hex}" }
 
     it 'should upload a file to a node', ssh: true do

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -16,16 +16,18 @@ describe "passes parsed AST to the apply_catalog task" do
   include BoltSpec::Project
   include BoltSpec::PuppetDB
 
-  let(:modulepath) { File.join(__dir__, '../fixtures/apply') }
-  let(:trusted_external) { File.join(__dir__, '../fixtures/scripts/trusted_external_facts.sh') }
-  let(:config_flags) { %W[--format json --targets #{uri} --password #{password} --modulepath #{modulepath}] + tflags }
+  let(:modulepath)        { fixtures_path('apply') }
+  let(:trusted_external)  { fixtures_path('scripts', 'trusted_external_facts.sh') }
+  let(:config_flags) do
+    %W[--format json --targets #{uri} --password #{password} --modulepath #{modulepath}] + tflags
+  end
 
   before(:each) do
     allow(Bolt::ApplyResult).to receive(:from_task_result) { |r| r }
     # Don't print warnings
     allow($stdout).to receive(:puts)
     allow_any_instance_of(Bolt::Applicator).to receive(:catalog_apply_task) {
-      path = File.join(__dir__, "../fixtures/apply/#{apply_task}")
+      path = fixtures_path('apply', apply_task)
       impl = { 'name' => apply_task, 'path' => path }
       metadata = { 'supports_noop' => true, 'input_method' => 'environment' }
       Bolt::Task.new('apply_catalog', metadata, [impl])
@@ -231,36 +233,25 @@ describe "passes parsed AST to the apply_catalog task" do
     end
 
     context 'with hiera config stubbed' do
-      let(:default_datadir) {
-        {
-          'hiera-config' => File.join(__dir__, '../fixtures/apply/hiera.yaml').to_s
-        }
-      }
-      let(:custom_datadir) {
-        {
-          'hiera-config' => File.join(__dir__, '../fixtures/apply/hiera_datadir.yaml').to_s
-        }
-      }
-      let(:bad_hiera_version) {
-        {
-          'hiera-config' => File.join(__dir__, '../fixtures/apply/hiera_invalid.yaml').to_s
-        }
-      }
-      let(:eyaml_config) {
+      let(:default_datadir)   { { 'hiera-config' => fixtures_path('apply', 'hiera.yaml') } }
+      let(:custom_datadir)    { { 'hiera-config' => fixtures_path('apply', 'hiera_datadir.yaml') } }
+      let(:bad_hiera_version) { { 'hiera-config' => fixtures_path('apply', 'hiera_invalid.yaml') } }
+      let(:eyaml_config) do
         {
           "version" => 5,
-          "defaults" => { "data_hash" => "yaml_data", "datadir" => File.join(__dir__, '../fixtures/apply/data').to_s },
+          "defaults" => { "data_hash" => "yaml_data",
+                          "datadir" => fixtures_path('apply', 'data') },
           "hierarchy" => [{
             "name" => "Encrypted Data",
             "lookup_key" => "eyaml_lookup_key",
             "paths" => ["secure.eyaml"],
             "options" => {
-              "pkcs7_private_key" => File.join(__dir__, '../fixtures/keys/private_key.pkcs7.pem').to_s,
-              "pkcs7_public_key" => File.join(__dir__, '../fixtures/keys/public_key.pkcs7.pem').to_s
+              "pkcs7_private_key" => fixtures_path('keys', 'private_key.pkcs7.pem'),
+              "pkcs7_public_key" => fixtures_path('keys', 'public_key.pkcs7.pem')
             }
           }]
         }
-      }
+      end
 
       it 'default datadir is accessible' do
         with_project(config: default_datadir) do |project|

--- a/spec/integration/apply_error_spec.rb
+++ b/spec/integration/apply_error_spec.rb
@@ -10,8 +10,8 @@ describe "errors gracefully attempting to apply a manifest block" do
   include BoltSpec::Files
   include BoltSpec::Integration
 
-  let(:modulepath) { File.join(__dir__, '../fixtures/apply') }
-  let(:config_flags) { %W[--targets #{uri} --password #{password} --modulepath #{modulepath}] + tflags }
+  let(:modulepath)    { fixtures_path('apply') }
+  let(:config_flags)  { %W[--targets #{uri} --password #{password} --modulepath #{modulepath}] + tflags }
 
   describe 'over ssh', ssh: true do
     let(:uri) { conn_uri('ssh') }

--- a/spec/integration/device_spec.rb
+++ b/spec/integration/device_spec.rb
@@ -14,7 +14,7 @@ describe "devices" do
   include BoltSpec::PuppetAgent
   include BoltSpec::Run
 
-  let(:modulepath) { File.join(__dir__, '../fixtures/apply') }
+  let(:modulepath) { fixtures_path('apply') }
   let(:config_flags) { %W[--format json --targets #{uri} --password #{password} --modulepath #{modulepath}] + tflags }
 
   describe 'over ssh', ssh: true do

--- a/spec/integration/local_spec.rb
+++ b/spec/integration/local_spec.rb
@@ -8,7 +8,7 @@ describe "when running over the local transport" do
   include BoltSpec::Files
   include BoltSpec::Integration
 
-  let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
+  let(:modulepath) { fixtures_path('modules') }
   let(:uri) { 'localhost,local://foo' }
   let(:user) { ENV['USER'] }
   let(:sudo_user) { 'root' }
@@ -180,8 +180,8 @@ describe "when running over the local transport" do
     end
 
     it 'runs a task with complex parameters', :reset_puppet_settings do
-      complex_input_file = File.join(__dir__, '../fixtures/complex_params/input.json')
-      expected = File.open(File.join(__dir__, '../fixtures/complex_params/output'), 'rb', &:read)
+      complex_input_file = fixtures_path('complex_params', 'input.json')
+      expected = File.open(fixtures_path('complex_params', 'output'), 'rb', &:read)
       result = run_one_node(%W[task run sample::complex_params --params @#{complex_input_file}] + config_flags)
       expect(result['_output']).to eq(expected)
     end

--- a/spec/integration/logging_spec.rb
+++ b/spec/integration/logging_spec.rb
@@ -12,7 +12,7 @@ describe "when logging executor activity", ssh: true do
   include BoltSpec::Integration
 
   let(:whoami) { "whoami" }
-  let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
+  let(:modulepath) { fixtures_path('modules') }
   let(:stdin_task) { "sample::stdin" }
   let(:echo_plan) { "sample::single_task" }
   let(:without_default_plan) { "logging::without_default" }

--- a/spec/integration/output_spec.rb
+++ b/spec/integration/output_spec.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'bolt_spec/files'
 require 'bolt_spec/integration'
 
 describe "when sending an out::message event" do
+  include BoltSpec::Files
   include BoltSpec::Integration
 
-  let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
+  let(:modulepath) { fixtures_path('modules') }
   let(:config_flags) { %W[--modulepath #{modulepath}] }
 
   it "prints to stdout when format is human" do

--- a/spec/integration/parsing_spec.rb
+++ b/spec/integration/parsing_spec.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/integration'
 require 'bolt_spec/conn'
+require 'bolt_spec/files'
+require 'bolt_spec/integration'
 
 describe "CLI parses input" do
-  include BoltSpec::Integration
   include BoltSpec::Conn
+  include BoltSpec::Files
+  include BoltSpec::Integration
 
-  let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
-  let(:script_path) { File.join(__dir__, '../fixtures/scripts/success.sh') }
+  let(:modulepath) { fixtures_path('modules') }
+  let(:script_path) { fixtures_path('scripts', 'success.sh') }
   let(:config_flags) {
     %W[--format json
        --modulepath #{modulepath}
@@ -37,7 +39,7 @@ describe "CLI parses input" do
     expect(result).to eq(
       "name" => "parsing",
       "description" => nil,
-      "module_dir" => File.absolute_path(File.join(__dir__, '..', 'fixtures', 'modules', 'parsing')),
+      "module_dir" => fixtures_path('modules', 'parsing'),
       "parameters" => {
         "string" => { "type" => "String", "sensitive" => false },
         "string_bool" => { "type" => "Variant[String, Boolean]", "sensitive" => false },
@@ -109,7 +111,7 @@ describe "CLI parses input" do
   end
 
   it 'parses environment variables', ssh: true do
-    script = File.join(__dir__, '../fixtures/modules/env_var/tasks/get_var.sh')
+    script = fixtures_path('modules', 'env_var', 'tasks', 'get_var.sh')
     output = run_cli_json(%W[script run #{script} -t #{target} --env-var test_var=123] + config_flags)
     expect(output['items'][0]['value']['stdout'].strip).to eq('123')
   end

--- a/spec/integration/plan_spec.rb
+++ b/spec/integration/plan_spec.rb
@@ -16,13 +16,13 @@ describe 'plans' do
 
   after(:each) { Puppet.settings.send(:clear_everything_for_tests) }
 
-  let(:modulepath)      { fixtures_path('modules') }
-  let(:config_flags)    {
+  let(:config_flags) {
     ['--format', 'json',
      '--project', fixtures_path('configs', 'empty'),
      '--modulepath', modulepath,
      '--no-host-key-check']
   }
+  let(:modulepath)      { fixtures_path('modules') }
   let(:target)          { conn_uri('ssh', include_password: true) }
   let(:project_config)  { { 'modules' => [] } }
 

--- a/spec/integration/project_spec.rb
+++ b/spec/integration/project_spec.rb
@@ -65,13 +65,13 @@ describe "When loading content", ssh: true do
   end
 
   it "runs plans namespaced with embedded project type" do
-    embedded = Bolt::Project.create_project(File.join(__dir__, '../fixtures/projects/embedded/Boltdir'), 'embedded')
+    embedded = Bolt::Project.create_project(fixtures_path('projects', 'embedded', 'Boltdir'), 'embedded')
     result = run_cli_json(%W[plan run embedded -t #{target}] + config_flags, project: embedded)
     expect(result[0]['value']['stdout'].strip).to eq('polo')
   end
 
   it "runs plans namespaced to configured project name" do
-    named = Bolt::Project.create_project(File.join(__dir__, '../fixtures/projects/named'), 'local')
+    named = Bolt::Project.create_project(fixtures_path('projects', 'named'), 'local')
     result = run_cli_json(%W[plan run test_project -t #{target}] + config_flags, project: named)
     expect(result[0]['value']['stdout'].strip).to eq('polo')
   end
@@ -81,7 +81,7 @@ describe "When loading content", ssh: true do
 
     let(:project_config) do
       {
-        'modulepath' => File.join(__dir__, '../fixtures/modules'),
+        'modulepath' => fixtures_path('modules'),
         'plans' => [
           'sample',
           'error::catch*'

--- a/spec/integration/resource_instance_spec.rb
+++ b/spec/integration/resource_instance_spec.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/integration'
 require 'bolt_spec/conn'
+require 'bolt_spec/files'
+require 'bolt_spec/integration'
 
 describe "resource instance in plans", ssh: true do
-  include BoltSpec::Integration
   include BoltSpec::Conn
+  include BoltSpec::Files
+  include BoltSpec::Integration
 
-  let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
+  let(:modulepath) { fixtures_path('modules') }
   let(:config_flags) do
     %W[--format json --targets #{conn_uri('ssh')}] +
       %W[--password #{conn_info('ssh')[:password]}] +

--- a/spec/integration/result_set_spec.rb
+++ b/spec/integration/result_set_spec.rb
@@ -9,7 +9,7 @@ describe "when running a plan that manipulates an execution result", ssh: true d
   include BoltSpec::Files
   include BoltSpec::Integration
 
-  let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
+  let(:modulepath) { fixtures_path('modules') }
   let(:uri) { conn_uri('ssh', include_password: true) }
   let(:config_flags) { %W[--no-host-key-check --format json --modulepath #{modulepath}] }
 

--- a/spec/integration/run_as_spec.rb
+++ b/spec/integration/run_as_spec.rb
@@ -11,7 +11,7 @@ describe "when running a plan using run_as", ssh: true do
   include BoltSpec::Integration
   include BoltSpec::Project
 
-  let(:modulepath) { File.join(__dir__, '../fixtures/run_as') }
+  let(:modulepath) { fixtures_path('run_as') }
   let(:uri) { conn_uri('ssh', include_password: true) }
   let(:user) { conn_info('ssh')[:user] }
   let(:password) { conn_info('ssh')[:password] }
@@ -30,7 +30,7 @@ describe "when running a plan using run_as", ssh: true do
   end
 
   context 'when passing environment variables' do
-    let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
+    let(:modulepath) { fixtures_path('modules') }
 
     it 'correctly passes environment variables to a task' do
       output = run_cli_json(%W[task run sample message=tacos -t #{uri}] + config_flags)

--- a/spec/integration/shareable_task_spec.rb
+++ b/spec/integration/shareable_task_spec.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'bolt_spec/files'
 require 'bolt_spec/integration'
 require 'bolt/util'
 
 describe "Shareable tasks with files", bash: true do
+  include BoltSpec::Files
   include BoltSpec::Integration
 
-  let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
+  let(:modulepath) { fixtures_path('modules') }
   let(:config_flags) { %W[--format json --targets localhost --modulepath #{modulepath}] }
 
   it 'runs a task with multiple files' do

--- a/spec/integration/target_spec.rb
+++ b/spec/integration/target_spec.rb
@@ -6,9 +6,10 @@ require 'bolt_spec/integration'
 
 describe "when running a plan that creates targets", ssh: true do
   include BoltSpec::Conn
+  include BoltSpec::Files
   include BoltSpec::Integration
 
-  let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
+  let(:modulepath) { fixtures_path('modules') }
   let(:uri) { conn_uri('ssh', include_password: true) }
   let(:info) { conn_info('ssh') }
 

--- a/spec/integration/task_param.rb
+++ b/spec/integration/task_param.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt_spec/integration'
 require 'bolt_spec/conn'
+require 'bolt_spec/files'
+require 'bolt_spec/integration'
 
 describe "Passes the _task metaparameter" do
-  include BoltSpec::Integration
   include BoltSpec::Conn
+  include BoltSpec::Files
+  include BoltSpec::Integration
 
-  let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
-  let(:config_flags) { %W[--format json --targets #{target} --modulepath #{modulepath}] }
+  let(:modulepath)    { fixtures_path('modules') }
+  let(:config_flags)  { %W[--format json --targets #{target} --modulepath #{modulepath}] }
 
   describe 'over ssh', ssh: true do
     let(:target) { conn_uri('ssh', include_password: true) }

--- a/spec/integration/winrm_spec.rb
+++ b/spec/integration/winrm_spec.rb
@@ -11,7 +11,7 @@ describe "when runnning over the winrm transport", winrm: true do
   include BoltSpec::Integration
   include BoltSpec::Project
 
-  let(:modulepath) { File.join(__dir__, '../fixtures/modules') }
+  let(:modulepath) { fixtures_path('modules') }
   let(:whoami) { "echo $env:UserName" }
   let(:uri) { conn_uri('winrm') }
   let(:password) { conn_info('winrm')[:password] }
@@ -59,8 +59,8 @@ describe "when runnning over the winrm transport", winrm: true do
     end
 
     it 'runs a task with complex parameters', :reset_puppet_settings do
-      complex_input_file = File.join(__dir__, '../fixtures/complex_params/input.json')
-      expected = File.open(File.join(__dir__, '../fixtures/complex_params/output'), 'rb', &:read)
+      complex_input_file = fixtures_path('complex_params', 'input.json')
+      expected = File.open(fixtures_path('complex_params', 'output'), 'rb', &:read)
 
       result = run_one_node(%W[task run sample::complex_params --params @#{complex_input_file}] + config_flags)
       expect(result['_output']).to eq(expected)


### PR DESCRIPTION
We construct paths to fixtures throughout spec tests, and now that there
is One True `fixtures_path()` helper, this moves any fixture path
consturction to use the method. This is more readable and concise, and
provides uniformity in the spec tests.

Note: I tried not to have this overlap with #2484 

!no-release-note