### PR TITLE
(GH-2448) Remove deprecated config options from spec tests

### DIFF
--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -257,11 +257,11 @@ describe Bolt::Config do
     end
 
     it "does not accept inventory files that don't exist" do
-      config = {
+      overrides = {
         'inventoryfile' => 'fake.yaml'
       }
 
-      expect { Bolt::Config.new(project, config) }.to raise_error(
+      expect { Bolt::Config.new(project, [], overrides) }.to raise_error(
         Bolt::FileError,
         /The inventoryfile .* does not exist/
       )
@@ -319,13 +319,13 @@ describe Bolt::Config do
 
   describe 'expanding paths' do
     it "expands inventoryfile relative to project" do
-      data = {
+      overrides = {
         'inventoryfile' => 'targets.yml'
       }
       f = File.expand_path(File.join(project.path, 'targets.yml'))
       FileUtils.touch(f)
 
-      config = Bolt::Config.new(project, data)
+      config = Bolt::Config.new(project, [], overrides)
       expect(config.inventoryfile)
         .to eq(f)
     end

--- a/spec/bolt/plugin_spec.rb
+++ b/spec/bolt/plugin_spec.rb
@@ -68,8 +68,8 @@ describe Bolt::Plugin do
     end
   end
 
-  context 'loading plugin_hooks' do
-    it 'evaluates plugin references in the plugin_hooks configuration' do
+  context 'loading plugin hooks' do
+    it 'evaluates plugin references in the plugin hooks configuration' do
       config_data['plugin-hooks'] = {
         'puppet_library' => {
           'plugin' => 'my_hook',
@@ -79,7 +79,7 @@ describe Bolt::Plugin do
       expect(plugins.plugin_hooks['puppet_library']).to eq('plugin' => 'my_hook', 'param' => 'foobar')
     end
 
-    it 'allows the whole plugin_hooks value to be set with a reference' do
+    it 'allows the whole plugin hooks value to be set with a reference' do
       hooks = {
         'another_hook' => {
           'plugin' => 'my_hook',

--- a/spec/bolt_server/transport_app_spec.rb
+++ b/spec/bolt_server/transport_app_spec.rb
@@ -1000,6 +1000,8 @@ describe "BoltServer::TransportApp" do
         end
       end
 
+      # TODO: Remove this test for Bolt 3.0. 'inventoryfile' will no longer be configurable
+      # in bolt-project.yaml.
       it 'disallows non-default inventoryfiles' do
         non_default_inventoryfile = 'foo.yaml'
         non_default_inventoryfile_conf = bolt_project.merge({ 'inventoryfile' => non_default_inventoryfile })

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -309,10 +309,10 @@ describe "passes parsed AST to the apply_catalog task" do
     end
 
     context 'with inventoryfile stubbed' do
-      let(:inventory) { { 'inventoryfile' => fixtures_path('inventory', 'apply.yaml') } }
+      let(:inventory) { YAML.load_file(fixtures_path('inventory', 'apply.yaml')) }
 
       it 'vars cannot be set on the target' do
-        with_project(config: inventory) do |project|
+        with_project(inventory: inventory) do |project|
           result = run_cli_json(%W[plan run basic::xfail_set_var --project #{project.path}] + config_flags)
           expect(result['kind']).to eq('bolt/apply-failure')
           expect(result['msg']).to match(/Apply failed to compile for/)
@@ -320,7 +320,7 @@ describe "passes parsed AST to the apply_catalog task" do
       end
 
       it 'features cannot be set on the target' do
-        with_project(config: inventory) do |project|
+        with_project(inventory: inventory) do |project|
           result = run_cli_json(%W[plan run basic::xfail_set_feature --project #{project.path}] + config_flags)
           expect(result['kind']).to eq('bolt/apply-failure')
           expect(result['msg']).to match(/Apply failed to compile for/)

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -25,7 +25,7 @@ describe 'apply', expensive: true do
   let(:project) { @project }
   let(:project_config) do
     {
-      'apply_settings' => { 'show_diff' => true },
+      'apply-settings' => { 'show_diff' => true },
       'hiera-config'   => fixtures_path('hiera', 'empty.yaml'),
       'modulepath'     => fixtures_path('apply')
     }

--- a/spec/integration/validator_spec.rb
+++ b/spec/integration/validator_spec.rb
@@ -368,7 +368,7 @@ describe 'validating config' do
     let(:project_config) do
       {
         'unknown' => 'unknown',
-        'puppetfile' => {
+        'module-install' => {
           'unknown' => 'unknown'
         }
       }
@@ -379,7 +379,7 @@ describe 'validating config' do
 
       expect(@log_output.readlines).to include(
         /WARN.*Unknown option 'unknown' at.*bolt-project.yaml/,
-        /WARN.*Unknown option 'unknown' at 'puppetfile' at.*bolt-project.yaml/
+        /WARN.*Unknown option 'unknown' at 'module-install' at.*bolt-project.yaml/
       )
     end
   end


### PR DESCRIPTION
This removes deprecated config options from our spec tests and replaces
them with the 'new' config option if applicable.

!no-release-note