### PR TITLE
(GH-2447) Ensure plugin-hooks config picked up by targets

### DIFF
--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -4,15 +4,16 @@ require 'spec_helper'
 require 'bolt_spec/conn'
 require 'bolt_spec/files'
 require 'bolt_spec/integration'
+require 'bolt_spec/project'
 require 'bolt_spec/puppetdb'
 
 describe 'running with an inventory file', reset_puppet_settings: true do
   include BoltSpec::Conn
   include BoltSpec::Files
   include BoltSpec::Integration
+  include BoltSpec::Project
   include BoltSpec::PuppetDB
 
-  let(:conn) { conn_info('ssh') }
   let(:inventory) do
     { targets: [
       { uri: conn[:host],
@@ -58,24 +59,24 @@ describe 'running with an inventory file', reset_puppet_settings: true do
         }
       } }
   end
-  let(:target) { conn[:host] }
 
-  let(:modulepath) { fixtures_path('modules') }
-  let(:config_flags) {
-    ['--format', 'json',
-     '--inventoryfile', @inventoryfile,
-     '--project', fixtures_path('configs', 'empty'),
-     '--modulepath', modulepath,
-     '--password', conn[:password]]
-  }
+  let(:base_config) do
+    {
+      'format'     => 'json',
+      'modulepath' => fixtures_path('modules')
+    }
+  end
 
-  let(:run_command) { ['command', 'run', shell_cmd, '--targets', target] + config_flags }
-
-  let(:run_plan) { ['plan', 'run', 'inventory', "command=#{shell_cmd}", "host=#{target}"] + config_flags }
+  let(:config)       { base_config }
+  let(:config_flags) { %W[--project #{@project.path} --password #{conn[:password]}] }
+  let(:conn)         { conn_info('ssh') }
+  let(:target)       { conn[:host] }
+  let(:run_command)  { %W[command run #{shell_cmd} --targets #{target}] + config_flags }
+  let(:run_plan)     { %W[plan run inventory command=#{shell_cmd} host=#{target}] + config_flags }
 
   around(:each) do |example|
-    with_tempfile_containing('inventory', inventory.to_json, '.yml') do |f|
-      @inventoryfile = f.path
+    with_project(config: config, inventory: Bolt::Util.walk_keys(inventory, &:to_s)) do |project|
+      @project = project
       example.run
     end
   end
@@ -370,12 +371,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
       {}
     end
 
-    let(:config_flags) {
-      ['--format', 'json',
-       '--inventoryfile', @inventoryfile,
-       '--project', fixtures_path('configs', 'empty'),
-       '--modulepath', modulepath]
-    }
+    let(:config_flags) { %W[--project #{@project.path}] }
 
     context 'with local://' do
       let(:target) { 'local://host' }
@@ -661,8 +657,30 @@ describe 'running with an inventory file', reset_puppet_settings: true do
 
   context 'when showing inventory targets' do
     it 'shows targets from a configured inventory' do
-      expect { run_cli(%W[inventory show -t all -i #{@inventoryfile}], outputter: Bolt::Outputter::Human) }
+      expect { run_cli(%w[inventory show -t all], outputter: Bolt::Outputter::Human) }
         .not_to raise_error
+    end
+  end
+
+  context 'with plugin-hooks configured' do
+    let(:plugin_hooks) do
+      {
+        'puppet_library' => {
+          'plugin'     => 'task',
+          'task'       => 'puppet_agent::install',
+          'parameters' => {
+            'version'    => '6.19.0',
+            'collection' => 'puppet6'
+          }
+        }
+      }
+    end
+
+    let(:config) { { 'plugin-hooks' => plugin_hooks } }
+
+    it 'targets pickup plugin-hooks configuration' do
+      result = run_cli_json(%W[inventory show --targets #{target} --detail] + config_flags)
+      expect(result.dig('targets', 0, 'plugin_hooks')).to eq(plugin_hooks)
     end
   end
 end


### PR DESCRIPTION
This adds a test to ensure that the `plugin-hooks` config option is
picked up by targets, which use the `plugin_hooks` field.

!no-release-note