### PR TITLE
(GH-2500) Only print spinner if stdout is a TTY

### DIFF
--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -32,7 +32,7 @@ module Bolt
       end
 
       def start_spin
-        return unless @spin
+        return unless @spin && @stream.isatty
         @spin = true
         @spin_thread = Thread.new do
           loop do
@@ -43,7 +43,7 @@ module Bolt
       end
 
       def stop_spin
-        return unless @spin
+        return unless @spin && @stream.isatty
         @spin_thread.terminate
         @spin = false
         @stream.print("\b")

--- a/lib/bolt/outputter/rainbow.rb
+++ b/lib/bolt/outputter/rainbow.rb
@@ -63,7 +63,7 @@ module Bolt
       end
 
       def start_spin
-        return unless @spin
+        return unless @spin && @stream.isatty
         @spin = true
         @spin_thread = Thread.new do
           loop do

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -412,6 +412,7 @@ describe "Bolt::Outputter::Human" do
     let(:outputter) { Bolt::Outputter::Human.new(false, false, false, true, output) }
 
     it 'spins while executing with a block' do
+      expect(output).to receive(:isatty).twice.and_return(true)
       outputter.spin do
         sleep(0.3)
         expect(output.string).to include("\\\b|\b")
@@ -419,9 +420,18 @@ describe "Bolt::Outputter::Human" do
     end
 
     it 'spins between start and stop' do
+      expect(output).to receive(:isatty).twice.and_return(true)
       outputter.start_spin
       sleep(0.3)
       expect(output.string).to include("\\\b|\b")
+      outputter.stop_spin
+    end
+
+    it 'does not spin when stdout is not a TTY' do
+      expect(output).to receive(:isatty).twice.and_return(false)
+      outputter.start_spin
+      sleep(0.3)
+      expect(output.string).not_to include("\b\\\b|")
       outputter.stop_spin
     end
   end


### PR DESCRIPTION
Previously, we neglected to check if stdout was an interactive terminal
before printing the spinner. This caused the spinner to print a series
of characters in CI environments. While configurable, this is clearly
wrong. We now only print the spinner after checking that `$stdout` is a
TTY.

Closes #2500

!bug

* **Only print spinner when stdout is a TTY** ([#2500](https://github.com/puppletabs/bolt/issues/2500))

  We now only print the spinner when the STDOUT stream is a TTY.