### PR TITLE
(GH-2475) Allow entire inventory to be a plugin reference

### DIFF
--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -55,7 +55,8 @@ module Bolt
       schema = {
         type:        Hash,
         properties:  OPTIONS.map { |opt| [opt, _ref: opt] }.to_h,
-        definitions: DEFINITIONS
+        definitions: DEFINITIONS,
+        _plugin:     true
       }
 
       schema[:definitions]['config'][:properties] = Bolt::Config.transport_definitions

--- a/lib/bolt/inventory/group.rb
+++ b/lib/bolt/inventory/group.rb
@@ -18,11 +18,19 @@ module Bolt
       GROUP_KEYS = DATA_KEYS + %w[name groups targets]
       CONFIG_KEYS = Bolt::Config::INVENTORY_OPTIONS.keys
 
-      def initialize(input, plugins)
+      def initialize(input, plugins, all_group: false)
         @logger = Bolt::Logger.logger(self)
         @plugins = plugins
 
         input = @plugins.resolve_top_level_references(input) if @plugins.reference?(input)
+
+        if all_group
+          if input.key?('name') && input['name'] != 'all'
+            @logger.warn("Top-level group '#{input['name']}' cannot specify a name, using 'all' instead.")
+          end
+
+          input = input.merge('name' => 'all')
+        end
 
         raise ValidationError.new("Group does not have a name", nil) unless input.key?('name')
 

--- a/lib/bolt/inventory/inventory.rb
+++ b/lib/bolt/inventory/inventory.rb
@@ -21,7 +21,7 @@ module Bolt
         @transport    = transport
         @config       = transports
         @plugins      = plugins
-        @groups       = Group.new(@data.merge('name' => 'all'), plugins)
+        @groups       = Group.new(@data, plugins, all_group: true)
         @group_lookup = {}
         @targets      = {}
 

--- a/rakelib/schemas.rake
+++ b/rakelib/schemas.rake
@@ -211,7 +211,7 @@ end
 
 def add_plugin_reference(definition)
   definition, data = definition.partition do |k, _|
-    k == :description
+    %i[definitions description].include?(k)
   end.map(&:to_h)
 
   definition[:oneOf] = [

--- a/schemas/bolt-inventory.schema.json
+++ b/schemas/bolt-inventory.schema.json
@@ -1353,25 +1353,74 @@
       ]
     }
   },
-  "type": "object",
-  "properties": {
-    "config": {
-      "$ref": "#/definitions/config"
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "config": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/config"
+            },
+            {
+              "$ref": "#/definitions/_plugin"
+            }
+          ]
+        },
+        "facts": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/facts"
+            },
+            {
+              "$ref": "#/definitions/_plugin"
+            }
+          ]
+        },
+        "features": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/features"
+            },
+            {
+              "$ref": "#/definitions/_plugin"
+            }
+          ]
+        },
+        "groups": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/groups"
+            },
+            {
+              "$ref": "#/definitions/_plugin"
+            }
+          ]
+        },
+        "targets": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/targets"
+            },
+            {
+              "$ref": "#/definitions/_plugin"
+            }
+          ]
+        },
+        "vars": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/vars"
+            },
+            {
+              "$ref": "#/definitions/_plugin"
+            }
+          ]
+        }
+      }
     },
-    "facts": {
-      "$ref": "#/definitions/facts"
-    },
-    "features": {
-      "$ref": "#/definitions/features"
-    },
-    "groups": {
-      "$ref": "#/definitions/groups"
-    },
-    "targets": {
-      "$ref": "#/definitions/targets"
-    },
-    "vars": {
-      "$ref": "#/definitions/vars"
+    {
+      "$ref": "#/definitions/_plugin"
     }
-  }
+  ]
 }

--- a/spec/bolt/inventory/inventory_spec.rb
+++ b/spec/bolt/inventory/inventory_spec.rb
@@ -366,7 +366,6 @@ describe Bolt::Inventory::Inventory do
       context 'with targets at the top level' do
         let(:data) {
           {
-            'name' => 'group1',
             'targets' => [
               'target1',
               { 'uri' => 'target2' },
@@ -791,7 +790,6 @@ describe Bolt::Inventory::Inventory do
       context 'with targets at the top level' do
         let(:data) {
           {
-            'name' => 'group1',
             'targets' => [
               'target1',
               { 'uri' => 'target2' },

--- a/spec/bolt/transport/local_spec.rb
+++ b/spec/bolt/transport/local_spec.rb
@@ -44,8 +44,7 @@ describe Bolt::Transport::Local do
 
     context 'with group-level config' do
       let(:data) {
-        { 'name' => 'locomoco',
-          'targets' => [uri],
+        { 'targets' => [uri],
           'config' => {
             'transport' => 'ssh',
             'local' => {
@@ -100,8 +99,7 @@ describe Bolt::Transport::Local do
 
     context 'with group-level config' do
       let(:data) {
-        { 'name' => 'locomoco',
-          'targets' => [uri],
+        { 'targets' => [uri],
           'config' => {
             'local' => {
               'bundled-ruby' => true,

--- a/spec/lib/bolt_spec/env_var.rb
+++ b/spec/lib/bolt_spec/env_var.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module BoltSpec
+  module EnvVar
+    def with_env_vars(new_vars)
+      new_vars.transform_keys!(&:to_s)
+
+      begin
+        old_vars = new_vars.keys.collect { |var| [var, ENV[var]] }.to_h
+        ENV.update(new_vars)
+        yield
+      ensure
+        ENV.update(old_vars) if old_vars
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change allows an entire inventory to be a plugin reference. For
exmaple, the following inventory was previously invalid:

```yaml
---
_plugin: yaml
filepath: /path/to/inventory_partial.yaml
```

A top-level plugin like this used to be invalid as Bolt automatically
added `'name' => 'all'` to the top of the loaded inventory, which would
cause a plugin to receive a `name` parameter and (likely) error. Now,
Bolt will resolve a top-level plugin reference, validate that the
resolved data does not include a `name` key, and then merge in `'name'
=> 'all'`.

!bug

* **Allow entire inventory to be specified with a plugin**
  ([#2475](https://github.com/puppetlabs/bolt/issues/2475))

  Inventory files can now be specified with a plugin. For example, the
  following inventory file is now valid:

  ```yaml
  ---
  _plugin: yaml
  filepath: /path/to/inventory_partial.yaml
  ```