### PR TITLE
(GH-2505) Do not add localhost to the all group by default in PowerShell

### DIFF
--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -683,4 +683,13 @@ describe 'running with an inventory file', reset_puppet_settings: true do
       expect(result.dig('targets', 0, 'plugin_hooks')).to eq(plugin_hooks)
     end
   end
+
+  context 'with empty inventory' do
+    let(:inventory) { nil }
+
+    it 'does not add localhost to the all group by default' do
+      result = run_cli_json(%W[inventory show -t all --project #{@project.path}])
+      expect(result['targets'].empty?).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
This fixes a bug introduced in #2395 that adds the `localhost` target to
the inventory by default. This results in any use of the `all` group
when running in PowerShell to include the `localhost` target in
inventory. Now, Bolt will not add the `localhost` target to inventory by
default.

!bug

* **Do not add `localhost` target to the `all` group by default in
  PowerShell**
  ([#2505](https://github.com/puppetlabs/bolt/issues/2505))

  Bolt no longer adds the `localhost` target to the `all` group by
  default. Previously, when running Bolt in PowerShell, the `localhost`
  target would be added to the `all` group unintentionally.