### PR TITLE
(maint) Pin puppetfile-resolver to 0.4.0

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-ssh-krb", "~> 0.5"
   spec.add_dependency "orchestrator_client", "~> 0.4"
   spec.add_dependency "puppet", ">= 6.18.0"
-  spec.add_dependency "puppetfile-resolver", "~> 0.4"
+  spec.add_dependency "puppetfile-resolver", "0.4.0"
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "puppet-strings", "~> 2.3"
   spec.add_dependency "r10k", "~> 3.1"


### PR DESCRIPTION
This pins the `puppetfile-resolver` gem to 0.4.0. Currently, the gem
build & stage job will fail because `puppetfile-resolver` will be
resolved to 0.5.0, which requires Ruby >= 2.5.3.

!no-release-note