### PR TITLE
(maint) Enable Rubocop 1.7.0 cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,11 +49,17 @@ Layout/LineLength:
 Layout/SpaceAroundMethodCallOperator:
   Enabled: true
 
+Layout/SpaceBeforeBrackets:
+  Enabled: true
+
 Layout/TrailingWhitespace:
   AllowInHeredoc: true
 
 # Lint cops
 # https://docs.rubocop.org/rubocop/cops_lint.html
+
+Lint/AmbiguousAssignment:
+  Enabled: true
 
 Lint/BinaryOperatorWithIdenticalOperands:
   Enabled: true
@@ -245,6 +251,9 @@ Style/HashAsLastArrayItem:
   Enabled: false
 
 Style/HashEachMethods:
+  Enabled: true
+
+Style/HashExcept:
   Enabled: true
 
 Style/HashLikeCase:

--- a/spec/bolt/module_installer/resolver_spec.rb
+++ b/spec/bolt/module_installer/resolver_spec.rb
@@ -69,7 +69,7 @@ describe Bolt::ModuleInstaller::Resolver do
     it 'errors' do
       expect { resolver.resolve(specs) }.to raise_error(
         Bolt::Error,
-        /could not find compatible versions for possibility named "dockerinstall"/
+        /could not find compatible versions for possibility named/
       )
     end
   end


### PR DESCRIPTION
This enables cops that were added to Rubocop 1.7.0. Enabling the cops
didn't result in any new errors, so just the configuration file change
is needed.

There was a separate issue where an integration test verifying the
Puppetfile resolver error when dependencies fail to resolve now fails
for a different module than the one the test checks. The failure is
still as expected, so this updates the check to just check for the error
message and not the module name.

!no-release-note