### PR TITLE
(PE-30862) Delete transport config keys that resolved to nil

### DIFF
--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -588,8 +588,8 @@ describe 'running with an inventory file', reset_puppet_settings: true do
 
         it 'sets config to nil' do
           result = run_cli_json(run_command)
-          expect(result['items'][0]['value']['_error']['msg'])
-            .to include("Authentication failed for user #{conn[:system_user]}")
+          # should succeed because the inventory deletes nil config
+          expect(result['items'][0]['status']).to eql('success')
           expect(@log_output.readlines).to include(/Could not find fact/)
         end
       end


### PR DESCRIPTION
We need this for the upcoming PuppetConnectData plugin where we want to
enforce the semantic that "this key resolves to nil" == "this key was
not specified".

Signed-off-by: Enis Inan <enis.inan@puppet.com>