### PR TITLE
(GH-2452) Provision Docker containers with puppet-agent package

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -45,8 +45,8 @@ jobs:
           echo 'runner:runner' | sudo chpasswd
           sudo sh -c "echo 'Defaults authenticate' >> /etc/sudoers"
           sudo sh -c "echo 'runner  ALL=(ALL) PASSWD:ALL' >> /etc/sudoers"
-          docker-compose -f spec/docker-compose.yml build --parallel ubuntu_node puppet_5_node puppet_6_node
-          docker-compose -f spec/docker-compose.yml up -d ubuntu_node puppet_5_node puppet_6_node
+          docker-compose -f spec/docker-compose.yml build --parallel ubuntu_node puppet_5_node puppet_6_node puppet_7_node
+          docker-compose -f spec/docker-compose.yml up -d ubuntu_node puppet_5_node puppet_6_node puppet_7_node
           chmod 0600 spec/fixtures/keys/id_rsa
           bundle exec r10k puppetfile install
       - name: Run tests with minimal container infrastructure

--- a/spec/Dockerfile
+++ b/spec/Dockerfile
@@ -1,28 +1,50 @@
 FROM rastasheep/ubuntu-sshd:18.04
-RUN apt-get update && apt-get -y install sudo tree locales apt-transport-https
+
+ARG PUPPET_COLLECTION
+
+# Install required packages
+RUN apt-get update
+RUN apt-get -y install apt-transport-https locales sudo tree wget
+
+# Set the locale
 RUN locale-gen en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
 
-ENV LC_ALL="en_US.UTF-8"
-ENV LANG="en_US.UTF-8"
-ENV LANGUAGE="en_US.UTF-8"
+# Install the puppet-agent package
+# sudo is important here so puppet is added to the path
+RUN if [ -n "$PUPPET_COLLECTION" ]; then \
+    wget -q https://apt.puppetlabs.com/${PUPPET_COLLECTION}-release-bionic.deb \
+    && sudo dpkg -i ${PUPPET_COLLECTION}-release-bionic.deb \
+    && sudo apt-get update \
+    && sudo apt-get -y install puppet-agent ; \
+    fi
 
-# Add bolt user with authorized key
-RUN useradd bolt && echo "bolt:bolt" | chpasswd && adduser bolt sudo
-RUN mkdir -p /home/bolt/.ssh/
+# Add 'bolt' user
+RUN useradd bolt
+RUN echo "bolt:bolt" | chpasswd
+RUN adduser bolt sudo
+
+RUN mkdir -p /home/bolt/.ssh
 COPY fixtures/keys/id_rsa.pub /home/bolt/.ssh/id_rsa.pub
 COPY fixtures/keys/id_rsa.pub /home/bolt/.ssh/authorized_keys
-RUN chmod 700 /home/bolt/.ssh/
+RUN chmod 700 /home/bolt/.ssh
 RUN chmod 600 /home/bolt/.ssh/authorized_keys
 RUN chown -R bolt:sudo /home/bolt
 
-# Add test user without authorized key and different login shell
-RUN useradd test && echo "test:test" | chpasswd && adduser test sudo
+# Add 'test' user with different login shell
+RUN useradd test
+RUN echo "test:test" | chpasswd
+RUN adduser test sudo
 RUN echo test | chsh -s /bin/bash test
+
 RUN mkdir -p /home/test/.ssh
 COPY fixtures/keys/id_rsa.pub /home/test/.ssh/id_rsa.pub
 COPY fixtures/keys/id_rsa.pub /home/test/.ssh/authorized_keys
-RUN chmod 700 /home/test/.ssh/
+RUN chmod 700 /home/test/.ssh
 RUN chmod 600 /home/test/.ssh/authorized_keys
 RUN chown -R test:sudo /home/test
 
-CMD ["/usr/sbin/sshd", "-D"]
+# Run the sshd service in the background
+CMD [ "/usr/sbin/sshd", "-D" ]

--- a/spec/docker-compose.yml
+++ b/spec/docker-compose.yml
@@ -2,26 +2,34 @@ version: "3"
 services:
   ubuntu_node:
     build: .
-    image: bolt-spec
+    container_name: ubuntu_node
     ports:
       - "20022:22"
-    container_name: ubuntu_node
+
   puppet_5_node:
-    image:  bolt-spec
-    depends_on:
-      - ubuntu_node
+    build:
+      context: .
+      args:
+        PUPPET_COLLECTION: puppet5
+    container_name: puppet_5_node
     ports:
       - "20023:22"
+
   puppet_6_node:
-    image:  bolt-spec
-    depends_on:
-      - ubuntu_node
+    build:
+      context: .
+      args:
+        PUPPET_COLLECTION: puppet6
+    container_name: puppet_6_node
     ports:
       - "20024:22"
+
   puppet_7_node:
-    image: bolt-spec
-    depends_on:
-      - ubuntu_node
+    build:
+      context: .
+      args:
+        PUPPET_COLLECTION: puppet7
+    container_name: puppet_7_node
     ports:
       - "20025:22"
 
@@ -33,6 +41,7 @@ services:
       - POSTGRES_DB=puppetdb
     volumes:
       - ./fixtures/puppetdb/custom_source:/docker-entrypoint-initdb.d
+
   puppetdb:
     build:
       context: .

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -69,13 +69,6 @@ describe 'apply', expensive: true do
     # Run tests that require the puppet-agent package to be installed on the target.
     # Each test is run against all agent targets unless otherwise noted.
     context 'with puppet installed' do
-      # Install agents on the agent targets.
-      before(:all) do
-        TEST_VERSIONS.each do |version, collection|
-          install("puppet_#{version}_node", collection: collection, inventory: docker_inventory(root: true))
-        end
-      end
-
       # Set up a project directory for the tests. Include an inventory file so Bolt
       # can actually connect to the targets.
       around(:each) do |example|

--- a/spec/integration/parallel_spec.rb
+++ b/spec/integration/parallel_spec.rb
@@ -5,7 +5,6 @@ require 'bolt_spec/conn'
 require 'bolt_spec/files'
 require 'bolt_spec/integration'
 require 'bolt_spec/project'
-require 'bolt_spec/puppet_agent'
 
 describe 'plans' do
   include BoltSpec::Integration


### PR DESCRIPTION
This updates the Dockerfile and Docker compose files to provision the
agentful containers used in spec tests with the appropriate
`puppet-agent` package. Previously, the `puppet-agent` packages were
installed as part of the spec tests themselves.

!no-release-note