### PR TITLE
(maint) Bump bundled modules

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -5,14 +5,14 @@ forge "http://forge.puppetlabs.com"
 moduledir File.join(File.dirname(__FILE__), 'modules')
 
 # Core modules used by 'apply'
-mod 'puppetlabs-service', '1.3.0'
-mod 'puppetlabs-puppet_agent', '4.2.0'
-mod 'puppetlabs-facts', '1.2.0'
+mod 'puppetlabs-service', '1.4.0'
+mod 'puppetlabs-puppet_agent', '4.3.0'
+mod 'puppetlabs-facts', '1.3.0'
 
 # Core types and providers for Puppet 6
 mod 'puppetlabs-augeas_core', '1.1.1'
 mod 'puppetlabs-host_core', '1.0.3'
-mod 'puppetlabs-scheduled_task', '2.2.1'
+mod 'puppetlabs-scheduled_task', '2.3.1'
 mod 'puppetlabs-sshkeys_core', '2.2.0'
 mod 'puppetlabs-zfs_core', '1.2.0'
 mod 'puppetlabs-cron_core', '1.0.5'
@@ -22,10 +22,10 @@ mod 'puppetlabs-yumrepo_core', '1.0.7'
 mod 'puppetlabs-zone_core', '1.0.3'
 
 # Useful additional modules
-mod 'puppetlabs-package', '1.3.0'
-mod 'puppetlabs-puppet_conf', '0.6.0'
+mod 'puppetlabs-package', '1.4.0'
+mod 'puppetlabs-puppet_conf', '0.8.0'
 mod 'puppetlabs-python_task_helper', '0.4.3'
-mod 'puppetlabs-reboot', '3.0.0'
+mod 'puppetlabs-reboot', '3.1.0'
 mod 'puppetlabs-ruby_task_helper', '0.5.1'
 mod 'puppetlabs-ruby_plugin_helper', '0.1.0'
 mod 'puppetlabs-stdlib', '6.5.0'


### PR DESCRIPTION
This bumps the versions of several of the modules that ship with Bolt
packages.

!feature

* **Updated bundled modules to latest version**

  The following bundled modules have been updated to their latest
  versions:

  - [facts 1.3.0](https://forge.puppet.com/puppetlabs/facts/1.3.0)
  - [package 1.4.0](https://forge.puppet.com/puppetlabs/package/1.4.0)
  - [puppet_agent 4.3.0](https://forge.puppet.com/puppetlabs/puppet_agent/4.3.0)
  - [puppet_conf 0.8.0](https://forge.puppet.com/puppetlabs/puppet_conf/0.8.0)
  - [reboot 3.1.0](https://forge.puppet.com/puppetlabs/reboot/3.1.0)
  - [scheduled_task 2.3.1](https://forge.puppet.com/puppetlabs/scheduled_task/2.3.1)
  - [service 1.4.0](https://forge.puppet.com/puppetlabs/service/1.4.0)