### PR TITLE
(GH-2517) Support project-level plugins

### DIFF
--- a/documentation/writing_plugins.md
+++ b/documentation/writing_plugins.md
@@ -37,7 +37,7 @@ my_plugin/
 
 Modules that include a plugin must have a plugin configuration file,
 `bolt_plugin.json`, in the module's root directory. Typically, the plugin
-configuration file is an empty JSON file:
+configuration file contains an empty JSON object:
 
 ```json
 {}
@@ -46,6 +46,35 @@ configuration file is an empty JSON file:
 📖 **Related information**
 
 - [Module structure](module_structure.md)
+
+### Project-level plugins
+
+You can also write plugins at the project level. To write a project-level
+plugin, you will first need to [create a Bolt
+project](https://puppet.com/docs/bolt/latest/projects.html#create-a-bolt-project).
+Project-level plugins are referred to by the project's name, similar to how
+module plugins are referred to by the module's name.
+
+A simple project named `my_project` with a plugin looks like this:
+
+```shell
+my_project/
+├── bolt_plugin.json
+├── bolt-project.yaml
+├── inventory.yaml
+└── tasks
+    ├── resolve_reference.py
+    └── resolve_reference.json
+```
+
+Similar to modules that include plugins, a project that includes plugins must
+include a plugin configuration file, `bolt_plugin.json`, in the project
+directory. Typically, the plugin configuration file contains an empty JSON
+object:
+
+```json
+{}
+```
 
 ## Plugin hooks
 

--- a/lib/bolt/module.rb
+++ b/lib/bolt/module.rb
@@ -6,8 +6,14 @@ module Bolt
     CONTENT_NAME_REGEX = /\A[a-z][a-z0-9_]*(::[a-z][a-z0-9_]*)*\z/.freeze
     MODULE_NAME_REGEX  = /\A[a-z][a-z0-9_]*\z/.freeze
 
-    def self.discover(modulepath)
-      modulepath.each_with_object({}) do |path, mods|
+    def self.discover(modulepath, project)
+      mods = {}
+
+      if project.load_as_module?
+        mods[project.name] = Bolt::Module.new(project.name, project.path.to_s)
+      end
+
+      modulepath.each do |path|
         next unless File.exist?(path) && File.directory?(path)
         Dir.children(path)
            .map { |dir| File.join(path, dir) }
@@ -20,6 +26,8 @@ module Bolt
           end
         end
       end
+
+      mods
     end
 
     attr_reader :name, :path

--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -170,7 +170,7 @@ module Bolt
     end
 
     def modules
-      @modules ||= Bolt::Module.discover(@pal.full_modulepath)
+      @modules ||= Bolt::Module.discover(@pal.full_modulepath, @config.project)
     end
 
     def add_plugin(plugin)

--- a/spec/bolt/module_spec.rb
+++ b/spec/bolt/module_spec.rb
@@ -8,7 +8,8 @@ describe Bolt::Module do
   include BoltSpec::Files
 
   let(:modulepath) { [fixtures_path('modules')] }
-  let(:mods) { Bolt::Module.discover(modulepath) }
+  let(:project)    { double('project', load_as_module?: false) }
+  let(:mods)       { Bolt::Module.discover(modulepath, project) }
 
   it 'returns the path' do
     expect(mods['vars'].name).to eq('vars')


### PR DESCRIPTION
This change adds support for project-level plugins. When Bolt loads
plugins, it now checks whether the project is a named project and is
loaded as a module. If the project is named, and contains a
`bolt_plugin.json` file, it is added as a plugin module in Bolt. All
plugin hooks are supported for project-level plugins.

!feature

* **Support for project-level plugins**
  ([#2517](https://github.com/puppetlabs/bolt/issues/2517))

  Bolt now supports project-level plugins. Similar to module plugins,
  project-level plugins are implemented as tasks that use specific hooks
  and are referred to using the name of the project.