### PR TITLE
(GH-2450) Remove deprecated yaml plan keys from spec tests 

### DIFF
--- a/spec/bolt/pal/yaml_plan/evaluator_spec.rb
+++ b/spec/bolt/pal/yaml_plan/evaluator_spec.rb
@@ -79,12 +79,12 @@ describe Bolt::PAL::YamlPlan::Evaluator do
           type: TargetSpec
       steps:
         - task: package
-          target: $nodes
+          targets: $nodes
           parameters:
             action: status
             name: $package
         - command: hostname -f
-          target: $nodes
+          targets: $nodes
       YAML
 
       nodes = %w[foo.example.com bar.example.com]
@@ -102,7 +102,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
           type: TargetSpec
       steps:
         - command: hostname -f
-          target: $nodes
+          targets: $nodes
       YAML
 
       expect(scope).to receive(:call_function).with('run_command', ['hostname -f', ['foo.example.com']])
@@ -198,7 +198,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
   describe "#task_step" do
     let(:step) do
       { 'task' => 'package',
-        'target' => 'foo.example.com',
+        'targets' => 'foo.example.com',
         'parameters' => { 'action' => 'status',
                           'name' => 'openssl' } }
     end
@@ -259,7 +259,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
   describe "#command_step" do
     let(:step) do
       { 'command' => 'hostname -f',
-        'target' => 'foo.example.com' }
+        'targets' => 'foo.example.com' }
     end
 
     it 'supports a description' do
@@ -273,7 +273,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
   describe "#script_step" do
     let(:step) do
       { 'script' => 'mymodule/myscript.sh',
-        'target' => 'foo.example.com',
+        'targets' => 'foo.example.com',
         'arguments' => %w[a b c] }
     end
 
@@ -327,7 +327,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
         let(:step) do
           { key => 'mymodule/file.txt',
             'destination' => '/path/to/file.txt',
-            'target' => 'foo.example.com' }
+            'targets' => 'foo.example.com' }
         end
 
         it 'uploads the file' do
@@ -358,7 +358,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
       {
         'download'    => source,
         'destination' => destination,
-        'target'      => target
+        'targets'     => target
       }
     end
 
@@ -392,7 +392,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
   describe "#resources_step" do
     let(:step) do
       { 'resources' => resources,
-        'target' => target }
+        'targets' => target }
     end
     let(:resources) do
       [{ 'package' => 'nginx' },
@@ -448,7 +448,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
           eval: $input + 5
         - name: bar
           command: "echo ${$foo*2}"
-          target: foo.example.com
+          targets: foo.example.com
       YAML
 
       expect(scope).to receive(:call_function).with('run_command', ['echo 34', 'foo.example.com'])

--- a/spec/bolt/pal/yaml_plan/loader_spec.rb
+++ b/spec/bolt/pal/yaml_plan/loader_spec.rb
@@ -31,7 +31,7 @@ describe Bolt::PAL::YamlPlan::Loader do
       plan_body = <<-YAML
       steps:
         - command: $
-          target: foo
+          targets: foo
       YAML
 
       expect { described_class.create(loader, plan_name, 'test.yaml', plan_body) }.to raise_error do |error|

--- a/spec/bolt/pal/yaml_plan/step_spec.rb
+++ b/spec/bolt/pal/yaml_plan/step_spec.rb
@@ -28,7 +28,7 @@ describe Bolt::PAL::YamlPlan::Step do
     context 'with command step' do
       let(:step_body) do
         { "command" => make_string("echo peanut butter"),
-          "target" => make_string("$bread") }
+          "targets" => make_string("$bread") }
       end
       let(:output) { "  run_command('echo peanut butter', $bread)\n" }
 
@@ -40,7 +40,7 @@ describe Bolt::PAL::YamlPlan::Step do
     context 'with script step' do
       let(:step_body) do
         { "script" => make_string("bananas.pb"),
-          "target" => make_string("$bread"),
+          "targets" => make_string("$bread"),
           "arguments" => [make_string("--with cinnamon"), make_string("--and honey")] }
       end
       let(:output) { "  run_script('bananas.pb', $bread, {'arguments' => ['--with cinnamon', '--and honey']})\n" }
@@ -53,7 +53,7 @@ describe Bolt::PAL::YamlPlan::Step do
     context 'with task step' do
       let(:step_body) do
         { "task" => make_string("jam::raspberry"),
-          "target" => make_string("$bread"),
+          "targets" => make_string("$bread"),
           "description" => 'delicious',
           "parameters" => { "butter" => "crunchy peanut" } }
       end
@@ -81,9 +81,9 @@ describe Bolt::PAL::YamlPlan::Step do
 
     context 'with upload step' do
       let(:step_body) do
-        { "source" => make_string("lucys/kitchen/counter"),
+        { "upload" => make_string("lucys/kitchen/counter"),
           "destination" => make_string("/lucys/stomach"),
-          "target" => make_string("$sandwich") }
+          "targets" => make_string("$sandwich") }
       end
       let(:output) { "  upload_file('lucys/kitchen/counter', '/lucys/stomach', $sandwich)\n" }
 
@@ -97,7 +97,7 @@ describe Bolt::PAL::YamlPlan::Step do
         {
           "download"    => make_string("/etc/ssh/ssh_config"),
           "destination" => make_string("downloads"),
-          "target"      => make_string("$foo")
+          "targets"     => make_string("$foo")
         }
       end
 
@@ -159,7 +159,7 @@ OUT
 
       let(:step_body) do
         { 'resources' => resources,
-          'target' => make_string('$bread') }
+          'targets' => make_string('$bread') }
       end
 
       context "#validate" do
@@ -276,7 +276,7 @@ OUT
     context "with string parameters key" do
       let(:step_body) do
         { "task" => make_string("jam::raspberry"),
-          "target" => make_string("$bread"),
+          "targets" => make_string("$bread"),
           "description" => 'delicious',
           "parameters" => "deceptive peanut butter" }
       end

--- a/spec/fixtures/modules/sample/plans/yaml.yaml
+++ b/spec/fixtures/modules/sample/plans/yaml.yaml
@@ -11,11 +11,11 @@ parameters:
 
 steps:
   - task: sample::echo
-    target: $nodes
+    targets: $nodes
     parameters:
       message: hello world
   - name: echo_message
     command: echo hello world
-    target: $nodes
+    targets: $nodes
 
 return: $echo_message.first.value

--- a/spec/fixtures/modules/yaml/plans/command.yml
+++ b/spec/fixtures/modules/yaml/plans/command.yml
@@ -5,6 +5,6 @@ parameters:
 steps:
   - name: run_command
     command: echo hello world
-    target: $nodes
+   targets: $nodes
 
 return: $run_command

--- a/spec/fixtures/modules/yaml/plans/subdir/init.yaml
+++ b/spec/fixtures/modules/yaml/plans/subdir/init.yaml
@@ -5,6 +5,6 @@ parameters:
 steps:
   - name: run_command
     command: echo I am a yaml plan
-    target: $targets
+    targets: $targets
 
 return: $run_command

--- a/spec/fixtures/modules/yaml/plans/upload.yaml
+++ b/spec/fixtures/modules/yaml/plans/upload.yaml
@@ -4,7 +4,7 @@ parameters:
 
 steps:
   - name: upload_file
-    source: 'yaml/test.sh'
+    upload: 'yaml/test.sh'
     destination: '/tmp/test_upload.sh'
     targets: $targets
   - name: cleanup


### PR DESCRIPTION
This replaces deprecated YAML plan keys `source` with `upload` and
`target` with `targets` in the spec tests, so that these tests continue
to work once the deprecated keys are removed.

!no-release-note