### PR TITLE
(GH-2509) Improve Bolt PowerShell Task Error Formatting

### DIFF
--- a/lib/bolt/shell/powershell/snippets.rb
+++ b/lib/bolt/shell/powershell/snippets.rb
@@ -75,7 +75,12 @@ module Bolt
             $allowedArgs = (Get-Command "#{path}").Parameters.Keys
             $private:taskArgs = @{}
             $private:tempArgs.Keys | ? { $allowedArgs -contains $_ } | % { $private:taskArgs[$_] = $private:tempArgs[$_] }
-            try { & "#{path}" @taskArgs } catch { Write-Error $_.Exception; exit 1 }
+            try {
+              & "#{path}" @taskArgs
+            } catch {
+              $Host.UI.WriteErrorLine("[$($_.FullyQualifiedErrorId)] Exception $($_.InvocationInfo.PositionMessage).`n$($_.Exception.Message)");
+              exit 1;
+            }
             PS
           end
 


### PR DESCRIPTION
This formats the exception written to stderr so that the line and char position is written to bolt. This position is the actual location inside the script that the bolt task is executing, instead of a relative location inside the code block we 'send' over with all of our helper functions.

Note that this uses the `$host.UI` to 'write' the message we want. This works both in our winrm and local transports because both have a PSHost implementation. This could fail if somehow we don't have access to a `$host`, but this is not a common use case with our transports.

This also formats the message shown in a different order than what is shown normally. It prioritizes the exception type and position first, then shows the exception message. This may not be the best presentation of this information, so we may need to adjust this for different exception types in the future.

This produces the following output when there is a parsing error:

```
❯ bundle exec bolt task run testexception::foo -t winrm://example-foo.delivery.puppetlabs.net
Started on winrm://example-foo.delivery.puppetlabs.net...
Failed on winrm://example-foo.delivery.puppetlabs.net:
  The task failed with exit code 1 and no stdout, but stderr contained:
  [TypeNotFound] Exception At C:\Users\Administrator\AppData\Local\Temp\2igjoqo0.xif\foo.ps1:3 char:3
  +   [Integer]$foo
  +   ~~~~~~~~~.
  Unable to find type [Integer].
Failed on 1 target: winrm://example-foo.delivery.puppetlabs.net
Ran on 1 target in 5.76 sec

❯ bundle exec bolt task run testexception::foo -t localhost
Started on localhost...
Failed on localhost:
  The task failed with exit code 1 and no stdout, but stderr contained:
  [TypeNotFound] Exception At C:\Users\Administrator\AppData\Local\Temp\2igjoqo0.xif\foo.ps1:3 char:3
  +   [Integer]$foo
  +   ~~~~~~~~~.
  Unable to find type [Integer].
Failed on 1 target: localhost
Ran on 1 target in 1.97 sec
```

This produces the following output when there is an error in the command/script:

```
❯ bundle exec bolt task run testexception::foo -t localhost
Started on localhost...
Failed on localhost:
  The task failed with exit code 1 and no stdout, but stderr contained:
  [CommandNotFoundException] Exception At C:\Users\Administrator\AppData\Local\Temp\3spo14sb.gqe\foo.ps1:7 char:56
  + [System.Net.Dns]::GetHostByName(($env:computerName)) | out-strin
  +                                                        ~~~~~~~~~.
  The term 'out-strin' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
Failed on 1 target: winrm://glassy-beer.delivery.puppetlabs.net
Failed on 1 target: localhost
Ran on 1 target in 2.08 sec

❯ bundle exec bolt task run testexception::foo -t winrm://example-foo.delivery.puppetlabs.net
Started on winrm://example-foo.delivery.puppetlabs.net...
Failed on winrm://example-foo.delivery.puppetlabs.net:
  The task failed with exit code 1 and no stdout, but stderr contained:
  [CommandNotFoundException] Exception At C:\Users\Administrator\AppData\Local\Temp\3spo14sb.gqe\foo.ps1:7 char:56
  + [System.Net.Dns]::GetHostByName(($env:computerName)) | out-strin
  +                                                        ~~~~~~~~~.
  The term 'out-strin' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
Failed on 1 target: winrm://example-foo.delivery.puppetlabs.net
Ran on 1 target in 6.29 sec

```