### PR TITLE
(docs) List which config options are pluggable

### DIFF
--- a/documentation/templates/bolt_configuration_reference.md.erb
+++ b/documentation/templates/bolt_configuration_reference.md.erb
@@ -26,6 +26,9 @@ _This option is deprecated. <%= data[:_deprecation] %>_
 <% if data.key?(:_default) -%>
 - **Default:** <%= data[:_default] %>
 <% end -%>
+<% if data[:_plugin] == true -%>
+- **Pluggable:** true
+<% end -%>
 
 <% if data.key?(:properties) -%>
 <% data[:properties].each do |option, data| -%>
@@ -39,6 +42,9 @@ _This option is deprecated. <%= data[:_deprecation] %>_
 <% end -%>
 <% if data.key?(:_default) -%>
 - **Default:** <%= data[:_default] %>
+<% end -%>
+<% if data[:_plugin] == true -%>
+- **Pluggable:** true
 <% end -%>
 <% end %>
 <% end -%>

--- a/documentation/templates/bolt_defaults_reference.md.erb
+++ b/documentation/templates/bolt_defaults_reference.md.erb
@@ -21,6 +21,9 @@ _This option is deprecated. <%= data[:_deprecation] %>_
 <% if data.key?(:_default) -%>
 - **Default:** <%= data[:_default] %>
 <% end -%>
+<% if data[:_plugin] == true -%>
+- **Pluggable:** true
+<% end -%>
 
 <% if option == 'inventory-config' %>
 For a detailed description of each option, their default values, and any available
@@ -38,6 +41,9 @@ sub-options, see [Transport configuration reference](bolt_transports_reference.m
 <% if data.key?(:_default) -%>
 - **Default:** <%= data[:_default] %>
 <% end %>
+<% if data[:_plugin] == true -%>
+- **Pluggable:** true
+<% end -%>
 <% end -%>
 <% end -%>
 

--- a/documentation/templates/bolt_project_reference.md.erb
+++ b/documentation/templates/bolt_project_reference.md.erb
@@ -21,6 +21,9 @@ _This option is deprecated. <%= data[:_deprecation] %>_
 <% if data.key?(:_default) -%>
 - **Default:** <%= data[:_default] %>
 <% end -%>
+<% if data[:_plugin] == true -%>
+- **Pluggable:** true
+<% end -%>
 
 <% if data.key?(:properties) -%>
 <% data[:properties].each do |option, data| -%>
@@ -34,6 +37,9 @@ _This option is deprecated. <%= data[:_deprecation] %>_
 <% end -%>
 <% if data.key?(:_default) -%>
 - **Default:** <%= data[:_default] %>
+<% end -%>
+<% if data[:_plugin] == true -%>
+- **Pluggable:** true
 <% end -%>
 <% end %>
 <% end -%>

--- a/documentation/templates/bolt_transports_reference.md.erb
+++ b/documentation/templates/bolt_transports_reference.md.erb
@@ -37,6 +37,10 @@ to targets. These options can be set in multiple locations:
 <% if data.key?(:_default) -%>
 - **Default:** <%= data[:_default] %>
 <% end -%>
+<% if data[:_plugin] == true -%>
+- **Pluggable:** true
+<% end -%>
+
 
 <% if data.key?(:_example) -%>
 ```yaml
@@ -135,6 +139,9 @@ ssh:
 <% end -%>
 <% if data.key?(:_default) -%>
 - **Default:** <%= data[:_default] %>
+<% end -%>
+<% if data[:_plugin] == true -%>
+- **Pluggable:** true
 <% end -%>
 
 <% if data.key?(:_example) -%>

--- a/documentation/using_plugins.md
+++ b/documentation/using_plugins.md
@@ -78,6 +78,13 @@ soon as the inventory file is loaded, whereas reference plugins under data keys
 such as `config` or `facts` are resolved once Bolt starts running an action on
 that target.
 
+While plugins are supported for configuration files, they're disabled for some settings. You can see
+which options are available on configuration references pages for
+[bolt-project.yaml](bolt_project_reference.md) and [bolt-defaults.yaml](bolt_defaults_reference.md).
+If you'd like another setting to have plugins enabled, let us know [in #bolt in
+slack](https://slack.puppet.com) or by [making an
+issue](https://github.com/puppetlabs/bolt/issues/new/choose).
+
 📖 **Related information**
 
 - [Configuring Bolt](configuring_bolt.md)


### PR DESCRIPTION
This updates the `Using Plugins` document to tell users that not all 
configuration options are pluggable, and how to request a new option be
made pluggable. This also updates the configuration reference templates
to add a `Pluggable` list item for configuration options that are 
pluggable. The `Using Plugins` page points to this reference for users
that want to see which options are pluggable.


!no-release-note