### PR TITLE
(maint) Pin ffi to avoid test failures

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-ec2", '~> 1'
   spec.add_dependency "CFPropertyList", "~> 2.2"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
+  spec.add_dependency "ffi", "~> 1.13.0"
   spec.add_dependency "hiera-eyaml", "~> 3"
   spec.add_dependency "jwt", "~> 2.2"
   spec.add_dependency "logging", "~> 2.2"


### PR DESCRIPTION
Loading `puppet_pal` fails on Windows with FFI 1.14.2 with `cannot load such file -- ffi_c`. This doesn't cause issues in our package builds, which use the Bolt package built using Puppet runtime gems which pulls in FFI 1.13.1, but it does cause our component acceptance tests to fail which build the gem from `puppetlabs/bolt.git` `main` branch. This pins FFI until we can safely upgrade it. This seems most related to a change that removes `win32/stdint.h` in [FFI 1.14.0](https://github.com/ffi/ffi/blob/master/CHANGELOG.md#1140--2020-12-18), but could be related to something else.

[Pasing Jenkins build with this change](https://jenkins-master-prod-1.delivery.puppetlabs.net/view/__experimental%20automatic/job/experimental_auto_bolt_vanagon-integration-component_main_project-main/12/)

!no-release-note