### PR TITLE
(GH-2518) Add read-timeout config for PCP transport

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-scp", "~> 1.2"
   spec.add_dependency "net-ssh", ">= 4.0"
   spec.add_dependency "net-ssh-krb", "~> 0.5"
-  spec.add_dependency "orchestrator_client", "~> 0.4"
+  spec.add_dependency "orchestrator_client", "~> 0.5"
   spec.add_dependency "puppet", ">= 6.18.0"
   spec.add_dependency "puppetfile-resolver", "~> 0.5"
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"

--- a/lib/bolt/config/transport/options.rb
+++ b/lib/bolt/config/transport/options.rb
@@ -253,6 +253,13 @@ module Bolt
             _plugin: true,
             _example: "jump.example.com"
           },
+          "read-timeout" => {
+            type: Integer,
+            description: "How long to wait in seconds when making requests to the Orchestrator.",
+            minimum: 1,
+            _plugin: true,
+            _example: 15
+          },
           "realm" => {
             type: String,
             description: "The Kerberos realm (Active Directory domain) to authenticate against.",

--- a/lib/bolt/config/transport/orch.rb
+++ b/lib/bolt/config/transport/orch.rb
@@ -12,6 +12,7 @@ module Bolt
           host
           job-poll-interval
           job-poll-timeout
+          read-timeout
           service-url
           task-environment
           token-file

--- a/lib/bolt/transport/orch/connection.rb
+++ b/lib/bolt/transport/orch/connection.rb
@@ -21,7 +21,7 @@ module Bolt
 
           @logger = logger
           @key = self.class.get_key(opts)
-          client_opts = opts.slice('token-file', 'cacert', 'job-poll-interval', 'job-poll-timeout')
+          client_opts = opts.slice('token-file', 'cacert', 'job-poll-interval', 'job-poll-timeout', 'read-timeout')
 
           if opts['service-url']
             uri = Addressable::URI.parse(opts['service-url'])

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -612,6 +612,16 @@
                 }
               ]
             },
+            "read-timeout": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/read-timeout"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
             "service-url": {
               "oneOf": [
                 {
@@ -1524,6 +1534,18 @@
         {
           "type": "string",
           "format": "uri"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "read-timeout": {
+      "description": "How long to wait in seconds when making requests to the Orchestrator.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
         },
         {
           "$ref": "#/definitions/_plugin"

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -608,6 +608,16 @@
                 }
               ]
             },
+            "read-timeout": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/read-timeout"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
             "service-url": {
               "oneOf": [
                 {
@@ -1520,6 +1530,18 @@
         {
           "type": "string",
           "format": "uri"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "read-timeout": {
+      "description": "How long to wait in seconds when making requests to the Orchestrator.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
         },
         {
           "$ref": "#/definitions/_plugin"

--- a/schemas/bolt-inventory.schema.json
+++ b/schemas/bolt-inventory.schema.json
@@ -313,6 +313,18 @@
                         }
                       ]
                     },
+                    "read-timeout": {
+                      "description": "How long to wait in seconds when making requests to the Orchestrator.",
+                      "oneOf": [
+                        {
+                          "type": "integer",
+                          "minimum": 1
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
                     "service-url": {
                       "description": "The URL of the host used for API requests.",
                       "oneOf": [

--- a/spec/bolt/config/transport/orch_spec.rb
+++ b/spec/bolt/config/transport/orch_spec.rb
@@ -20,20 +20,6 @@ describe Bolt::Config::Transport::Orch do
   end
 
   context 'validating' do
-    %w[cacert host service-url task-environment token-file].each do |opt|
-      it "#{opt} errors with wrong type" do
-        data[opt] = 100
-        expect { transport.new(data) }.to raise_error(Bolt::ValidationError)
-      end
-    end
-
-    %w[job-poll-interval job-poll-timeout].each do |opt|
-      it "#{opt} errors with wrong type" do
-        data[opt] = '100'
-        expect { transport.new(data) }.to raise_error(Bolt::ValidationError)
-      end
-    end
-
     context 'cacert' do
       it 'expands path relative to project' do
         allow(Bolt::Util).to receive(:validate_file).and_return(true)

--- a/spec/integration/transport/orch_spec.rb
+++ b/spec/integration/transport/orch_spec.rb
@@ -66,6 +66,20 @@ describe Bolt::Transport::Orch, orchestrator: true do
       end
     end
 
+    it "bolt sets read-timeout" do
+      with_tempfile_containing('token', 'faketoken') do |conf|
+        config = {
+          'service-url' => 'https://foo.bar:8143',
+          'cacert' => conf.path,
+          'token-file' => conf.path,
+          'read-timeout' => 30
+        }
+        allow(OrchestratorClient).to receive(:new).and_call_original
+        c = Bolt::Transport::Orch::Connection.new(config, nil, orch.logger)
+        expect(c.instance_variable_get(:@client).config['read-timeout']).to eq(30)
+      end
+    end
+
     it "sets the port to 8143 if one is not specified" do
       with_tempfile_containing('token', 'faketoken') do |conf|
         config = {


### PR DESCRIPTION
This adds a `read-timeout` configuration setting for the PCP transport,
which accepts an integer and passes the configuration to
`OrchestratorClient.new()`. Although the option is an integer, it
should be nil if a value is not provided, as there's no static default
for `Net::Http::Persistent#read_timeout`, so we should not set one
unless it's configured. This allows users to configure either failing
quickly if the Orchestrator is busy (such as during code deploys), or to
extend the time if they'd like to wait for the jobs to finish.
`read-timeout` configures the length of time to wait for a response from
the Orchestrator before raising a timeout error when making HTTP
requests.

Relies on:
- [x] [orchestrator_client-ruby PR](https://github.com/puppetlabs/orchestrator_client-ruby/pull/27)

!feature

* **Add read-timeout configuration option for PCP transport** ([#2518](https://github.com/puppetlabs/bolt/issues/2518))

  Users can now configure a `read-timeout` for HTTP requests to the
  Orchestrator, which defines how long to wait for a response before
  raising a Timeout error.