### PR TITLE
(GH-2561) Remove PowerShell 2.0

### DIFF
--- a/documentation/troubleshooting.md
+++ b/documentation/troubleshooting.md
@@ -50,6 +50,14 @@ system. For example, if you write a Python task and include the line:
 `#!/usr/bin/env python`, Bolt attempts to execute the script using the default
 `python` executable on the target system.
 
+## My task fails on Windows targets
+
+Bolt does not support PowerShell 2.0. If your task targets a Windows OS that has only PowerShell 2.0 installed, the task will fail.
+
+In 2017, Microsoft [deprecated PowerShell 2.0](https://docs.microsoft.com/en-US/windows/deployment/planning/windows-10-removed-features). For a more detailed explanation, see [Micosoft's blog post on the subject](https://devblogs.microsoft.com/powershell/windows-powershell-2-0-deprecation).
+
+Both Microsoft and Puppet recommend updating the target with Windows PowerShell 5.1, but versions 3.0 and 4.0 are also supported.
+
 ## Bolt can't connect to my hosts over SSH
 
 ### Host key verification failures

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -212,8 +212,7 @@ module Bolt
 
         return unless !stdout.empty? && stdout.to_i < 3
 
-        msg = "Detected PowerShell 2 on controller. PowerShell 2 is deprecated and "\
-              "support will be removed in Bolt 3.0."
+        msg = "Detected PowerShell 2 on controller. PowerShell 2 is unsupported."
         Bolt::Logger.deprecation_warning("PowerShell 2 controller", msg)
       end
     end

--- a/lib/bolt/shell/powershell.rb
+++ b/lib/bolt/shell/powershell.rb
@@ -23,8 +23,7 @@ module Bolt
           # This lets us know how many targets have Powershell 2, and lets the
           # user know how many targets they have with PS2
           msg = "Detected PowerShell 2 on one or more targets.\nPowerShell 2 "\
-            "is deprecated, and support will be removed in Bolt 3.0. See "\
-            "bolt-debug.log or run with '--log-level debug' to see the full "\
+            "is unsupported. See bolt-debug.log or run with '--log-level debug' to see the full "\
             "list of targets with PowerShell 2."
 
           Bolt::Logger.deprecation_warning("PowerShell 2", msg)

--- a/lib/bolt/shell/powershell/snippets.rb
+++ b/lib/bolt/shell/powershell/snippets.rb
@@ -70,7 +70,7 @@ module Bolt
           def ps_task(path, arguments)
             <<~PS
             $private:tempArgs = Get-ContentAsJson (
-              $utf8.GetString([System.Convert]::FromBase64String('#{Base64.encode64(JSON.dump(arguments))}'))
+              [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('#{Base64.encode64(JSON.dump(arguments))}'))
             )
             $allowedArgs = (Get-Command "#{path}").Parameters.Keys
             $private:taskArgs = @{}
@@ -102,151 +102,11 @@ module Bolt
             "${boltBaseDir}\\hiera\\lib;" +
             $ENV:RUBYLIB
 
-            Add-Type -AssemblyName System.ServiceModel.Web, System.Runtime.Serialization
-            $utf8 = [System.Text.Encoding]::UTF8
-
-            function Write-Stream {
-            PARAM(
-              [Parameter(Position=0)] $stream,
-              [Parameter(ValueFromPipeline=$true)] $string
-            )
-            PROCESS {
-              $bytes = $utf8.GetBytes($string)
-              $stream.Write( $bytes, 0, $bytes.Length )
-            }
-            }
-
-            function Convert-JsonToXml {
-            PARAM([Parameter(ValueFromPipeline=$true)] [string[]] $json)
-            BEGIN {
-              $mStream = New-Object System.IO.MemoryStream
-            }
-            PROCESS {
-              $json | Write-Stream -Stream $mStream
-            }
-            END {
-              $mStream.Position = 0
-              try {
-                $jsonReader = [System.Runtime.Serialization.Json.JsonReaderWriterFactory]::CreateJsonReader($mStream,[System.Xml.XmlDictionaryReaderQuotas]::Max)
-                $xml = New-Object Xml.XmlDocument
-                $xml.Load($jsonReader)
-                $xml
-              } finally {
-                $jsonReader.Close()
-                $mStream.Dispose()
-              }
-            }
-            }
-
-            Function ConvertFrom-Xml {
-            [CmdletBinding(DefaultParameterSetName="AutoType")]
-            PARAM(
-              [Parameter(ValueFromPipeline=$true,Mandatory=$true,Position=1)] [Xml.XmlNode] $xml,
-              [Parameter(Mandatory=$true,ParameterSetName="ManualType")] [Type] $Type,
-              [Switch] $ForceType
-            )
-            PROCESS{
-              if (Get-Member -InputObject $xml -Name root) {
-                return $xml.root.Objects | ConvertFrom-Xml
-              } elseif (Get-Member -InputObject $xml -Name Objects) {
-                return $xml.Objects | ConvertFrom-Xml
-              }
-              $propbag = @{}
-              foreach ($name in Get-Member -InputObject $xml -MemberType Properties | Where-Object{$_.Name -notmatch "^(__.*|type)$"} | Select-Object -ExpandProperty name) {
-                Write-Debug "$Name Type: $($xml.$Name.type)" -Debug:$false
-                $propbag."$Name" = Convert-Properties $xml."$name"
-              }
-              if (!$Type -and $xml.HasAttribute("__type")) { $Type = $xml.__Type }
-              if ($ForceType -and $Type) {
-                try {
-                  $output = New-Object $Type -Property $propbag
-                } catch {
-                  $output = New-Object PSObject -Property $propbag
-                  $output.PsTypeNames.Insert(0, $xml.__type)
-                }
-              } elseif ($propbag.Count -ne 0) {
-                $output = New-Object PSObject -Property $propbag
-                if ($Type) {
-                  $output.PsTypeNames.Insert(0, $Type)
-                }
-              }
-              return $output
-            }
-            }
-
-            Function Convert-Properties {
-            PARAM($InputObject)
-            switch ($InputObject.type) {
-              "object" {
-                return (ConvertFrom-Xml -Xml $InputObject)
-              }
-              "string" {
-                $MightBeADate = $InputObject.get_InnerText() -as [DateTime]
-                ## Strings that are actually dates (*grumble* JSON is crap)
-                if ($MightBeADate -and $propbag."$Name" -eq $MightBeADate.ToString("G")) {
-                  return $MightBeADate
-                } else {
-                  return $InputObject.get_InnerText()
-                }
-              }
-              "number" {
-                $number = $InputObject.get_InnerText()
-                if ($number -eq ($number -as [int])) {
-                  return $number -as [int]
-                } elseif ($number -eq ($number -as [double])) {
-                  return $number -as [double]
-                } else {
-                  return $number -as [decimal]
-                }
-              }
-              "boolean" {
-                return [bool]::parse($InputObject.get_InnerText())
-              }
-              "null" {
-                return $null
-              }
-              "array" {
-                [object[]]$Items = $(foreach( $item in $InputObject.GetEnumerator() ) {
-                  Convert-Properties $item
-                })
-                return $Items
-              }
-              default {
-                return $InputObject
-              }
-            }
-            }
-
-            Function ConvertFrom-Json2 {
-            [CmdletBinding()]
-            PARAM(
-              [Parameter(ValueFromPipeline=$true,Mandatory=$true,Position=1)] [string] $InputObject,
-              [Parameter(Mandatory=$true)] [Type] $Type,
-              [Switch] $ForceType
-            )
-            PROCESS {
-              $null = $PSBoundParameters.Remove("InputObject")
-              [Xml.XmlElement]$xml = (Convert-JsonToXml $InputObject).Root
-              if ($xml) {
-                if ($xml.Objects) {
-                  $xml.Objects.Item.GetEnumerator() | ConvertFrom-Xml @PSBoundParameters
-                } elseif ($xml.Item -and $xml.Item -isnot [System.Management.Automation.PSParameterizedProperty]) {
-                  $xml.Item | ConvertFrom-Xml @PSBoundParameters
-                } else {
-                  $xml | ConvertFrom-Xml @PSBoundParameters
-                }
-              } else {
-                Write-Error "Failed to parse JSON with JsonReader" -Debug:$false
-              }
-            }
-            }
-
             function ConvertFrom-PSCustomObject
             {
             PARAM([Parameter(ValueFromPipeline = $true)] $InputObject)
             PROCESS {
               if ($null -eq $InputObject) { return $null }
-
               if ($InputObject -is [System.Collections.IEnumerable] -and $InputObject -isnot [string]) {
                 $collection = @(
                   foreach ($object in $InputObject) { ConvertFrom-PSCustomObject $object }
@@ -273,13 +133,8 @@ module Bolt
               [Parameter(Mandatory = $true)] $Text,
               [Parameter(Mandatory = $false)] [Text.Encoding] $Encoding = [Text.Encoding]::UTF8
             )
-
-            # using polyfill cmdlet on PS2, so pass type info
-            if ($PSVersionTable.PSVersion -lt [Version]'3.0') {
-              $Text | ConvertFrom-Json2 -Type PSObject | ConvertFrom-PSCustomObject
-            } else {
-              $Text | ConvertFrom-Json | ConvertFrom-PSCustomObject
-            }
+          
+            $Text | ConvertFrom-Json | ConvertFrom-PSCustomObject
             }
             PS
           end


### PR DESCRIPTION
!removal

* **Descriptive title of changes** ([#2561](https://github.com/puppetlabs/bolt/issues/2561))

  Remove PowerShell 2.0 support


Acceptance Critera:

Bolt works on a target and localhost with PowerShell versions 3.0 and 5.1 (lowest and highest supported at the moment)

