### PR TITLE
(maint) Pin ffi to < 1.14.0

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-ec2", '~> 1'
   spec.add_dependency "CFPropertyList", "~> 2.2"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
-  spec.add_dependency "ffi", "~> 1.13.0"
+  spec.add_dependency "ffi", "< 1.14.0"
   spec.add_dependency "hiera-eyaml", "~> 3"
   spec.add_dependency "jwt", "~> 2.2"
   spec.add_dependency "logging", "~> 2.2"


### PR DESCRIPTION
This updates the gemspec to pin ffi to < 1.14.0, which includes some
breaking changes on Windows. Previously, ffi was pinned to ~> 1.13.0,
which caused our packaging pipeline to fail, as bolt-runtime only
includes ffi 1.9.25.

!no-release-note