### PR TITLE
(GH-2516) Support log_level, trace, evaltrace in apply-settings

### DIFF
--- a/documentation/applying_manifest_blocks.md
+++ b/documentation/applying_manifest_blocks.md
@@ -290,6 +290,9 @@ at the `info` level in Bolt. Log levels map as follows:
 | `notice` | `info` |
 | `warning` | `warn` |
 | `err` | `error` |
+| `alert` | `error` |
+| `emerg` | `fatal` |
+| `crit` | `fatal` |
 
 📖 **Related information**  
 

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -58,8 +58,29 @@ module Bolt
                        "plan function or the `bolt apply` command.",
           type: Hash,
           properties: {
+            "evaltrace" => {
+              description: "Whether each resource should log when it is being evaluated.",
+              type: [TrueClass, FalseClass],
+              _example: true,
+              _default: false
+            },
+            "log_level" => {
+              description: "The log level for logs in apply reports from Puppet. These can be seen "\
+                           "in ApplyResults.",
+              type: String,
+              enum: %w[debug info notice warning err alert emerg crit],
+              _example: "debug",
+              _default: "notice"
+            },
             "show_diff" => {
               description: "Whether to log and report a contextual diff.",
+              type: [TrueClass, FalseClass],
+              _example: true,
+              _default: false
+            },
+            "trace" => {
+              description: "Whether to print stack traces on some errors. Will print internal Ruby "\
+                           "stack trace interleaved with Puppet function frames.",
               type: [TrueClass, FalseClass],
               _example: true,
               _default: false
@@ -73,8 +94,30 @@ module Bolt
                        "plan function or the `bolt apply` command.",
           type: Hash,
           properties: {
+            "evaltrace" => {
+              description: "Whether each resource should log when it is being evaluated. This allows "\
+                           "you to interactively see exactly what is being done.",
+              type: [TrueClass, FalseClass],
+              _example: true,
+              _default: false
+            },
+            "log_level" => {
+              description: "The log level for logs in apply reports from Puppet. These can be seen "\
+                           "in ApplyResults.",
+              type: String,
+              enum: %w[debug info notice warning err alert emerg crit],
+              _example: "debug",
+              _default: "notice"
+            },
             "show_diff" => {
               description: "Whether to log and report a contextual diff.",
+              type: [TrueClass, FalseClass],
+              _example: true,
+              _default: false
+            },
+            "trace" => {
+              description: "Whether to print stack traces on some errors. Will print internal Ruby "\
+                           "stack trace interleaved with Puppet function frames.",
               type: [TrueClass, FalseClass],
               _example: true,
               _default: false

--- a/libexec/bolt_catalog
+++ b/libexec/bolt_catalog
@@ -56,7 +56,7 @@ when "compile"
               else
                 e.message
               end
-    puts({ message: message }.to_json)
+    puts({ message: message, backtrace: e.backtrace }.to_json)
     exit 1
   rescue StandardError => e
     puts({ message: e.message }.to_json)

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -85,8 +85,30 @@
       "description": "A map of Puppet settings to use when applying Puppet code using the `apply` plan function or the `bolt apply` command.",
       "type": "object",
       "properties": {
+        "evaltrace": {
+          "description": "Whether each resource should log when it is being evaluated. This allows you to interactively see exactly what is being done.",
+          "type": "boolean"
+        },
+        "log_level": {
+          "description": "The log level for logs in apply reports from Puppet. These can be seen in ApplyResults.",
+          "type": "string",
+          "enum": [
+            "debug",
+            "info",
+            "notice",
+            "warning",
+            "err",
+            "alert",
+            "emerg",
+            "crit"
+          ]
+        },
         "show_diff": {
           "description": "Whether to log and report a contextual diff.",
+          "type": "boolean"
+        },
+        "trace": {
+          "description": "Whether to print stack traces on some errors. Will print internal Ruby stack trace interleaved with Puppet function frames.",
           "type": "boolean"
         }
       }
@@ -95,8 +117,30 @@
       "description": "A map of Puppet settings to use when applying Puppet code using the `apply` plan function or the `bolt apply` command.",
       "type": "object",
       "properties": {
+        "evaltrace": {
+          "description": "Whether each resource should log when it is being evaluated.",
+          "type": "boolean"
+        },
+        "log_level": {
+          "description": "The log level for logs in apply reports from Puppet. These can be seen in ApplyResults.",
+          "type": "string",
+          "enum": [
+            "debug",
+            "info",
+            "notice",
+            "warning",
+            "err",
+            "alert",
+            "emerg",
+            "crit"
+          ]
+        },
         "show_diff": {
           "description": "Whether to log and report a contextual diff.",
+          "type": "boolean"
+        },
+        "trace": {
+          "description": "Whether to print stack traces on some errors. Will print internal Ruby stack trace interleaved with Puppet function frames.",
           "type": "boolean"
         }
       }

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -82,8 +82,30 @@
       "description": "A map of Puppet settings to use when applying Puppet code using the `apply` plan function or the `bolt apply` command.",
       "type": "object",
       "properties": {
+        "evaltrace": {
+          "description": "Whether each resource should log when it is being evaluated. This allows you to interactively see exactly what is being done.",
+          "type": "boolean"
+        },
+        "log_level": {
+          "description": "The log level for logs in apply reports from Puppet. These can be seen in ApplyResults.",
+          "type": "string",
+          "enum": [
+            "debug",
+            "info",
+            "notice",
+            "warning",
+            "err",
+            "alert",
+            "emerg",
+            "crit"
+          ]
+        },
         "show_diff": {
           "description": "Whether to log and report a contextual diff.",
+          "type": "boolean"
+        },
+        "trace": {
+          "description": "Whether to print stack traces on some errors. Will print internal Ruby stack trace interleaved with Puppet function frames.",
           "type": "boolean"
         }
       }
@@ -92,8 +114,30 @@
       "description": "A map of Puppet settings to use when applying Puppet code using the `apply` plan function or the `bolt apply` command.",
       "type": "object",
       "properties": {
+        "evaltrace": {
+          "description": "Whether each resource should log when it is being evaluated.",
+          "type": "boolean"
+        },
+        "log_level": {
+          "description": "The log level for logs in apply reports from Puppet. These can be seen in ApplyResults.",
+          "type": "string",
+          "enum": [
+            "debug",
+            "info",
+            "notice",
+            "warning",
+            "err",
+            "alert",
+            "emerg",
+            "crit"
+          ]
+        },
         "show_diff": {
           "description": "Whether to log and report a contextual diff.",
+          "type": "boolean"
+        },
+        "trace": {
+          "description": "Whether to print stack traces on some errors. Will print internal Ruby stack trace interleaved with Puppet function frames.",
           "type": "boolean"
         }
       }


### PR DESCRIPTION
This enables setting the `log_level`, `trace`, and `evaltrace` Puppet
settings under the `apply-settings` configuration option.

!feature

* **Support additional Puppet settings in `apply-settings`**
  ([#2516](https://github.com/puppetlabs/bolt/issues/2516))

  The `log_level`, `trace`, and `evaltrace` Puppet settings can now be
  configured under the `apply-settings` configuration option. These
  settings will be applied when executing an apply block.