### PR TITLE
(GH-2511) Only spin while executing run_* plan functions

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/parallelize.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/parallelize.rb
@@ -12,14 +12,12 @@ Puppet::Functions.create_function(:parallelize, Puppet::Functions::InternalFunct
   # @param data The array to apply the block to.
   # @return [Array] An array of PlanResult objects. Each input from the input
   #   array returns a corresponding PlanResult object.
-  # @example Execute two tasks on multiple targets. Once the task finishes on one
-  #   target, that target can move to the next step without waiting for the task
-  #   to finish on the second target.
-  # $targets = get_targets(["host1", "host2"])
-  # $result = parallelize ($targets) |$t| {
-  #   run_task('a', $t)
-  #   run_task('b', $t)
-  # }
+  # @example Execute two tasks on two targets.
+  #   $targets = get_targets(["host1", "host2"])
+  #   $result = parallelize ($targets) |$t| {
+  #     run_task('a', $t)
+  #     run_task('b', $t)
+  #   }
   dispatch :parallelize do
     scope_param
     param 'Array[Any]', :data

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -541,15 +541,12 @@ module Bolt
               validate_file('script', script)
               executor.run_script(targets, script, options[:leftovers], executor_opts)
             when 'task'
-              r = outputter.spin do
-                pal.run_task(options[:object],
-                             targets,
-                             options[:task_options],
-                             executor,
-                             inventory,
-                             options[:description])
-              end
-              r
+              pal.run_task(options[:object],
+                           targets,
+                           options[:task_options],
+                           executor,
+                           inventory,
+                           options[:description])
             when 'file'
               src = options[:object]
               dest = options[:leftovers].first
@@ -684,9 +681,7 @@ module Bolt
 
       executor.subscribe(log_outputter)
       executor.start_plan(plan_context)
-      result = outputter.spin do
-        pal.run_plan(plan_name, plan_arguments, executor, inventory, puppetdb_client)
-      end
+      result = pal.run_plan(plan_name, plan_arguments, executor, inventory, puppetdb_client)
 
       # If a non-bolt exception bubbles up the plan won't get finished
       executor.finish_plan(result)

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -32,8 +32,8 @@ module Bolt
       end
 
       def start_spin
-        return unless @spin && @stream.isatty
-        @spin = true
+        return unless @spin && @stream.isatty && !@spinning
+        @spinning = true
         @spin_thread = Thread.new do
           loop do
             sleep(0.1)
@@ -43,9 +43,9 @@ module Bolt
       end
 
       def stop_spin
-        return unless @spin && @stream.isatty
+        return unless @spin && @stream.isatty && @spinning
+        @spinning = false
         @spin_thread.terminate
-        @spin = false
         @stream.print("\b")
       end
 
@@ -81,6 +81,10 @@ module Bolt
             print_plan_start(event)
           when :plan_finish
             print_plan_finish(event)
+          when :start_spin
+            start_spin
+          when :stop_spin
+            stop_spin
           end
         end
       end

--- a/lib/bolt/outputter/rainbow.rb
+++ b/lib/bolt/outputter/rainbow.rb
@@ -63,12 +63,12 @@ module Bolt
       end
 
       def start_spin
-        return unless @spin && @stream.isatty
-        @spin = true
+        return unless @spin && @stream.isatty && !@spinning
+        @spinning = true
         @spin_thread = Thread.new do
           loop do
-            @stream.print(colorize(:rainbow, @pinwheel.rotate!.first + "\b"))
             sleep(0.1)
+            @stream.print(colorize(:rainbow, @pinwheel.rotate!.first + "\b"))
           end
         end
       end

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -863,7 +863,7 @@ describe "Bolt::Executor" do
       executor.round_robin([])
     end
 
-    it "starts and stops the spinner" do
+    it "stops the spinner" do
       skein = %w[a b c d].each_with_index.map do |val, index|
         fiber = Fiber.new do
           sleep(rand(0.01..0.1))
@@ -873,7 +873,7 @@ describe "Bolt::Executor" do
       end
 
       executor.round_robin(skein)
-      expect(collector.events).to include({ type: :start_spin })
+      expect(collector.events).to include({ type: :stop_spin })
     end
 
     it "returns results in the same order they were originally" do

--- a/spec/integration/plan_spec.rb
+++ b/spec/integration/plan_spec.rb
@@ -62,6 +62,24 @@ describe 'plans' do
       expect(json['value']).to eq("stdout" => "I am a yaml plan\n", "stderr" => "", "exit_code" => 0)
     end
 
+    context "using the human outputter" do
+      let(:config_flags) {
+        ['--project', fixtures_path('configs', 'empty'),
+         '--modulepath', modulepath,
+         '--no-host-key-check']
+      }
+
+      it "prints the spinner when running executor functions", ssh: true do
+        expect_any_instance_of(Bolt::Outputter::Human).to receive(:start_spin).at_least(:once)
+        run_cli(%w[plan run sample::noop --targets #{target}] + config_flags, outputter: Bolt::Outputter::Human)
+      end
+
+      it "doesn't print the spinner when running non-executor functions", ssh: true do
+        expect_any_instance_of(Bolt::Outputter::Human).not_to receive(:start_spin)
+        run_cli(%w[plan run output] + config_flags, outputter: Bolt::Outputter::Human)
+      end
+    end
+
     it 'runs a yaml plan', ssh: true do
       result = run_cli(['plan', 'run', 'sample::yaml', '--targets', target] + config_flags)
       expect(JSON.parse(result)).to eq('stdout' => "hello world\n", 'stderr' => '', 'exit_code' => 0)


### PR DESCRIPTION
Previously the spinner would spin for the entirety of a plan or task
run, starting and stopping from the Bolt CLI manager. This meant that if
the user was prompted during a plan run the spinner would spin in the
area of the terminal the user was supposed to input text. While this
didn't write to stdin or impact user input, it was annoying and
definitely wrong.

This modifies the spinner to be started and stopped from the executor,
impacting calls from the command line and plan functions. The executor
only starts and stops the spinner as part of `with_node_logging()`,
which affects `run_*` functions and `wait_until_available`. The spinner
still spins for module management and project updating commands, which
are unaffected by this change. The spinner will only be started and
stopped if Bolt is not executing inside a `parallelize` block - instead
the parallelize block itself (specifically `Bolt::Executor#round_robin`)
will manage starting and stopping the spinner. This is so that the first
element in the array that finishes doesn't signal to stop spinning
before other functions have completed, but the spinner will spin for the
entire parallelize block as expected.

Test cases:
- [x] The spinner spins while executing executor plan functions
- [x] The spinner spins while executing `bolt command run`, `bolt script
  run`, `bolt task run`, `bolt file upload`, and `bolt file download`,
  and module management commands
- [x] The spinner spins normally while running multiple functions in a
  parallelize block across multiple targets
- [x] Spinner does not spin when running other plan functions or Bolt
  commands (in particular when prompting for user input)

!bug

* **Only spin while executing run_* plan functions** ([#2511](https://github.com/puppetlabs/bolt/issues/2511))
  Bolt will now only print the spinner while executing `run_*`,
  `file_upload`, `file_download`, and`wait_until_available` plan
  functions. It also now spins while running those functions equivalent
  commandline commands. This prevents the spinner from spinning while
  prompting for output from a plan.