### PR TITLE
(GH-2522) Add 'resolve' key to modules config

### DIFF
--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -303,6 +303,10 @@ module Bolt
                     description: "The name of the module.",
                     type: String
                   },
+                  "resolve" => {
+                    description: "Whether to resolve the module's dependencies when installing modules.",
+                    type: [TrueClass, FalseClass]
+                  },
                   "version_requirement" => {
                     description: "The version requirement for the module. Accepts a specific version (1.2.3), version "\
                                  "shorthand (1.2.x), or a version range (>= 1.2.0).",
@@ -317,9 +321,17 @@ module Bolt
                     description: "The URL to the public git repository.",
                     type: String
                   },
+                  "name" => {
+                    description: "The name of the module. Required when `resolve` is `false`.",
+                    type: String
+                  },
                   "ref" => {
                     description: "The git reference to check out. Can be either a branch, tag, or commit SHA.",
                     type: String
+                  },
+                  "resolve" => {
+                    description: "Whether to resolve the module's dependencies when installing modules.",
+                    type: [TrueClass, FalseClass]
                   }
                 }
               }

--- a/lib/bolt/module_installer.rb
+++ b/lib/bolt/module_installer.rb
@@ -195,8 +195,10 @@ module Bolt
       @outputter.stop_spin
 
       # Automatically generate types after installing modules
-      @outputter.print_action_step("Generating type references")
-      @pal.generate_types(cache: true)
+      if ok
+        @outputter.print_action_step("Generating type references")
+        @pal.generate_types(cache: true)
+      end
 
       @outputter.print_puppetfile_result(ok, path, moduledir)
 

--- a/lib/bolt/module_installer/resolver.rb
+++ b/lib/bolt/module_installer/resolver.rb
@@ -13,10 +13,15 @@ module Bolt
         require 'puppetfile-resolver'
 
         # Build the document model from the specs.
-        document = PuppetfileResolver::Puppetfile::Document.new('')
+        document   = PuppetfileResolver::Puppetfile::Document.new('')
+        unresolved = []
 
         specs.specs.each do |spec|
-          document.add_module(spec.to_resolver_module)
+          if spec.resolve
+            document.add_module(spec.to_resolver_module)
+          else
+            unresolved << spec
+          end
         end
 
         # Make sure the document model is valid.
@@ -47,20 +52,40 @@ module Bolt
           raise Bolt::Error.new(e.message, 'bolt/module-resolver-error')
         end
 
-        # Convert the specs returned from the resolver into Bolt module objects.
-        modules = result.specifications.values.each_with_object([]) do |mod, acc|
+        # Create the Puppetfile object.
+        generate_puppetfile(specs, result.specifications.values, unresolved)
+      end
+
+      # Creates a puppetfile-resolver config object.
+      #
+      private def spec_searcher_config(config)
+        PuppetfileResolver::SpecSearchers::Configuration.new.tap do |obj|
+          obj.forge.proxy     = config.dig('forge', 'proxy') || config.dig('proxy')
+          obj.git.proxy       = config.dig('proxy')
+          obj.forge.forge_api = config.dig('forge', 'baseurl')
+        end
+      end
+
+      # Creates a Puppetfile object with Module objects created from resolved and
+      # unresolved specs.
+      #
+      private def generate_puppetfile(specs, resolved, unresolved)
+        modules = []
+
+        # Convert the resolved specs into Bolt module objects.
+        resolved.each do |mod|
           # Skip over anything that isn't a module spec, such as a Puppet spec.
           next unless mod.is_a? PuppetfileResolver::Models::ModuleSpecification
 
           case mod.origin
           when :forge
-            acc << Bolt::ModuleInstaller::Puppetfile::ForgeModule.new(
+            modules << Bolt::ModuleInstaller::Puppetfile::ForgeModule.new(
               "#{mod.owner}/#{mod.name}",
               mod.version.to_s
             )
           when :git
             spec = specs.specs.find { |s| s.name == mod.name }
-            acc << Bolt::ModuleInstaller::Puppetfile::GitModule.new(
+            modules << Bolt::ModuleInstaller::Puppetfile::GitModule.new(
               spec.name,
               spec.git,
               spec.sha
@@ -68,16 +93,36 @@ module Bolt
           end
         end
 
-        # Create the Puppetfile object.
-        Bolt::ModuleInstaller::Puppetfile.new(modules)
-      end
-
-      private def spec_searcher_config(config)
-        PuppetfileResolver::SpecSearchers::Configuration.new.tap do |obj|
-          obj.forge.proxy     = config.dig('forge', 'proxy') || config.dig('proxy')
-          obj.git.proxy       = config.dig('proxy')
-          obj.forge.forge_api = config.dig('forge', 'baseurl')
+        # Error if there are any name conflicts between unresolved specs and
+        # resolved modules. r10k will error if a Puppetfile includes duplicate
+        # names, but we error early here to provide a more helpful message.
+        if (name_conflicts = modules.map(&:name) & unresolved.map(&:name)).any?
+          raise Bolt::Error.new(
+            "Detected unresolved module specifications with the same name as a resolved module "\
+            "dependency: #{name_conflicts.join(', ')}. Either remove the unresolved module specification "\
+            "or set the module with the conflicting dependency to not resolve.",
+            "bolt/module-name-conflict-error"
+          )
         end
+
+        # Convert the unresolved specs into Bolt module objects.
+        unresolved.each do |spec|
+          case spec.type
+          when :forge
+            modules << Bolt::ModuleInstaller::Puppetfile::ForgeModule.new(
+              spec.full_name,
+              spec.version_requirement
+            )
+          when :git
+            modules << Bolt::ModuleInstaller::Puppetfile::GitModule.new(
+              spec.name,
+              spec.git,
+              spec.ref
+            )
+          end
+        end
+
+        Bolt::ModuleInstaller::Puppetfile.new(modules)
       end
     end
   end

--- a/lib/bolt/module_installer/specs/forge_spec.rb
+++ b/lib/bolt/module_installer/specs/forge_spec.rb
@@ -13,14 +13,20 @@ module Bolt
       class ForgeSpec
         NAME_REGEX    = %r{\A[a-zA-Z0-9]+[-/](?<name>[a-z][a-z0-9_]*)\z}.freeze
         REQUIRED_KEYS = Set.new(%w[name]).freeze
-        KNOWN_KEYS    = Set.new(%w[name version_requirement]).freeze
+        KNOWN_KEYS    = Set.new(%w[name resolve version_requirement]).freeze
 
-        attr_reader :full_name, :name, :semantic_version, :type
+        attr_reader :full_name, :name, :resolve, :semantic_version, :type, :version_requirement
 
         def initialize(init_hash)
+          @resolve                                = init_hash.key?('resolve') ? init_hash['resolve'] : true
           @full_name, @name                       = parse_name(init_hash['name'])
           @version_requirement, @semantic_version = parse_version_requirement(init_hash['version_requirement'])
           @type                                   = :forge
+
+          unless @resolve == true || @resolve == false
+            raise Bolt::ValidationError,
+                  "Option 'resolve' for module spec #{@full_name} must be a Boolean"
+          end
         end
 
         def self.implements?(hash)

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -290,6 +290,13 @@
                 "description": "The name of the module.",
                 "type": "String"
               },
+              "resolve": {
+                "description": "Whether to resolve the module's dependencies when installing modules.",
+                "type": [
+                  "TrueClass",
+                  "FalseClass"
+                ]
+              },
               "version_requirement": {
                 "description": "The version requirement for the module. Accepts a specific version (1.2.3), version shorthand (1.2.x), or a version range (>= 1.2.0).",
                 "type": "String"
@@ -306,9 +313,20 @@
                 "description": "The URL to the public git repository.",
                 "type": "String"
               },
+              "name": {
+                "description": "The name of the module. Required when `resolve` is `false`.",
+                "type": "String"
+              },
               "ref": {
                 "description": "The git reference to check out. Can be either a branch, tag, or commit SHA.",
                 "type": "String"
+              },
+              "resolve": {
+                "description": "Whether to resolve the module's dependencies when installing modules.",
+                "type": [
+                  "TrueClass",
+                  "FalseClass"
+                ]
               }
             }
           }

--- a/spec/bolt/module_installer/specs/forge_spec_spec.rb
+++ b/spec/bolt/module_installer/specs/forge_spec_spec.rb
@@ -56,6 +56,14 @@ describe Bolt::ModuleInstaller::Specs::ForgeSpec do
         /Invalid version requirement for Forge module specification/
       )
     end
+
+    it 'errors with non-Boolean resolve value' do
+      init_hash['resolve'] = 'no'
+      expect { spec }.to raise_error(
+        Bolt::ValidationError,
+        /Option 'resolve'.*must be a Boolean/
+      )
+    end
   end
 
   context '#implements?' do

--- a/spec/bolt/module_installer/specs/git_spec_spec.rb
+++ b/spec/bolt/module_installer/specs/git_spec_spec.rb
@@ -44,6 +44,23 @@ describe Bolt::ModuleInstaller::Specs::GitSpec do
         /Invalid git source/
       )
     end
+
+    it 'errors if resolve is false and missing a name' do
+      init_hash.delete('name')
+      init_hash['resolve'] = false
+      expect { spec }.to raise_error(
+        Bolt::ValidationError,
+        /Missing name.*when 'resolve' is false/
+      )
+    end
+
+    it 'errors with non-Boolean resolve value' do
+      init_hash['resolve'] = 'no'
+      expect { spec }.to raise_error(
+        Bolt::ValidationError,
+        /Option 'resolve'.*must be a Boolean/
+      )
+    end
   end
 
   context '#to_hash' do


### PR DESCRIPTION
This adds support for a new `resolve` key for both Forge and git module
specs in `bolt-project.yaml`. It also adds support for a `name` key for
git module specs, which is required when setting the `resolve` key to
`false`.

When `resolve` is `false`, Bolt will skip dependency resolution for the
module. This allows users to include modules that would otherwise break
Bolt's dependency resolution in their Bolt projects, avoiding the need
to manually manage a Puppetfile. This includes modules with broken
metadata and git modules hosted in a repository other than a public
GitHub repository.

If a unresolved module shares the name of another module's dependency,
Bolt will error indicating that there is a name conflict. This is in
line with r10k's behavior when installing a Puppetfile that has
duplicate module names.

!feature

* **Add `resolve` key for Forge and git module specifications**
  ([#2522](https://github.com/puppetlabs/bolt/issues/2522))

  Forge and git module specifications in `bolt-project.yaml` now support
  a `resolve` key. When setting `resolve: false`, Bolt will skip
  dependency resolution for the module, allowing users to include
  modules with broken metadata or modules hosted in a repository other
  than a public GitHub repository in their project configuration.

---

### Test cases

- [ ] Requires git modules to have a `name` if `resolve: false`
- [ ] Skips resolution for modules with `resolve: false` when installing and adding modules
- [ ] Allows non-public or non-GitHub git modules to be installed without `--no-resolve`
- [ ] Allows modules with broken metadata to be installed
- [ ] Errors if no-resolve modules have a name conflict with resolved dependencies