### PR TITLE
(maint) Refactor the Docker transport to use Shell class

### DIFF
--- a/lib/bolt/shell/bash.rb
+++ b/lib/bolt/shell/bash.rb
@@ -331,10 +331,15 @@ module Bolt
         # together multiple commands into a single sh invocation
         commands = [inject_interpreter(options[:interpreter], command)]
 
+        # Let the transport handle adding environment variables if it's custom.
         if options[:environment]
-          env_decl = options[:environment].map do |env, val|
-            "#{env}=#{Shellwords.shellescape(val)}"
-          end.join(' ')
+          if defined? conn.add_env_vars
+            conn.add_env_vars(options[:environment])
+          else
+            env_decl = options[:environment].map do |env, val|
+              "#{env}=#{Shellwords.shellescape(val)}"
+            end.join(' ')
+          end
         end
 
         if escalate

--- a/lib/bolt/transport/base.rb
+++ b/lib/bolt/transport/base.rb
@@ -74,15 +74,6 @@ module Bolt
         interpreters[Pathname(executable).extname] if interpreters
       end
 
-      # Transform a parameter map to an environment variable map, with parameter names prefixed
-      # with 'PT_' and values transformed to JSON unless they're strings.
-      def envify_params(params)
-        params.each_with_object({}) do |(k, v), h|
-          v = v.to_json unless v.is_a?(String)
-          h["PT_#{k}"] = v
-        end
-      end
-
       # Raises an error if more than one target was given in the batch.
       #
       # The default implementations of batch_* strictly assume the transport is

--- a/lib/bolt/transport/docker.rb
+++ b/lib/bolt/transport/docker.rb
@@ -6,7 +6,7 @@ require 'bolt/transport/base'
 
 module Bolt
   module Transport
-    class Docker < Base
+    class Docker < Simple
       def provided_features
         ['shell']
       end
@@ -15,130 +15,6 @@ module Bolt
         conn = Connection.new(target)
         conn.connect
         yield conn
-      end
-
-      def upload(target, source, destination, _options = {})
-        with_connection(target) do |conn|
-          conn.with_remote_tmpdir do |dir|
-            basename = File.basename(source)
-            tmpfile = "#{dir}/#{basename}"
-            if File.directory?(source)
-              conn.write_remote_directory(source, tmpfile)
-            else
-              conn.write_remote_file(source, tmpfile)
-            end
-
-            _, stderr, exitcode = conn.execute('mv', tmpfile, destination, {})
-            if exitcode != 0
-              message = "Could not move temporary file '#{tmpfile}' to #{destination}: #{stderr}"
-              raise Bolt::Node::FileError.new(message, 'MV_ERROR')
-            end
-          end
-          Bolt::Result.for_upload(target, source, destination)
-        end
-      end
-
-      def download(target, source, destination, _options = {})
-        with_connection(target) do |conn|
-          download = File.join(destination, Bolt::Util.unix_basename(source))
-          conn.download_remote_content(source, destination)
-          Bolt::Result.for_download(target, source, destination, download)
-        end
-      end
-
-      def run_command(target, command, options = {}, position = [])
-        execute_options = {}
-        execute_options[:tty] = target.options['tty']
-        execute_options[:environment] = options[:env_vars]
-
-        if target.options['shell-command'] && !target.options['shell-command'].empty?
-          # escape any double quotes in command
-          command = command.gsub('"', '\"')
-          command = "#{target.options['shell-command']} \" #{command}\""
-        end
-        with_connection(target) do |conn|
-          stdout, stderr, exitcode = conn.execute(*Shellwords.split(command), execute_options)
-          Bolt::Result.for_command(target,
-                                   stdout,
-                                   stderr,
-                                   exitcode,
-                                   'command',
-                                   command,
-                                   position)
-        end
-      end
-
-      def run_script(target, script, arguments, options = {}, position = [])
-        # unpack any Sensitive data
-        arguments = unwrap_sensitive_args(arguments)
-        execute_options = {}
-        execute_options[:environment] = options[:env_vars]
-
-        with_connection(target) do |conn|
-          conn.with_remote_tmpdir do |dir|
-            remote_path = conn.write_remote_executable(dir, script)
-            stdout, stderr, exitcode = conn.execute(remote_path, *arguments, execute_options)
-            Bolt::Result.for_command(target,
-                                     stdout,
-                                     stderr,
-                                     exitcode,
-                                     'script',
-                                     script,
-                                     position)
-          end
-        end
-      end
-
-      def run_task(target, task, arguments, _options = {}, position = [])
-        implementation = task.select_implementation(target, provided_features)
-        executable = implementation['path']
-        input_method = implementation['input_method']
-        extra_files = implementation['files']
-        input_method ||= 'both'
-
-        # unpack any Sensitive data
-        arguments = unwrap_sensitive_args(arguments)
-        with_connection(target) do |conn|
-          execute_options = {}
-          execute_options[:interpreter] = select_interpreter(executable, target.options['interpreters'])
-          conn.with_remote_tmpdir do |dir|
-            if extra_files.empty?
-              task_dir = dir
-            else
-              # TODO: optimize upload of directories
-              arguments['_installdir'] = dir
-              task_dir = File.join(dir, task.tasks_dir)
-              conn.mkdirs([task_dir] + extra_files.map { |file| File.join(dir, File.dirname(file['name'])) })
-              extra_files.each do |file|
-                conn.write_remote_file(file['path'], File.join(dir, file['name']))
-              end
-            end
-
-            remote_task_path = conn.write_remote_executable(task_dir, executable)
-
-            if Bolt::Task::STDIN_METHODS.include?(input_method)
-              execute_options[:stdin] = StringIO.new(JSON.dump(arguments))
-            end
-
-            if Bolt::Task::ENVIRONMENT_METHODS.include?(input_method)
-              execute_options[:environment] = envify_params(arguments)
-            end
-
-            stdout, stderr, exitcode = conn.execute(remote_task_path, execute_options)
-            Bolt::Result.for_task(target,
-                                  stdout,
-                                  stderr,
-                                  exitcode,
-                                  task.name,
-                                  position)
-          end
-        end
-      end
-
-      def connected?(target)
-        with_connection(target) { true }
-      rescue Bolt::Node::ConnectError
-        false
       end
     end
   end

--- a/lib/bolt/transport/docker/connection.rb
+++ b/lib/bolt/transport/docker/connection.rb
@@ -5,213 +5,26 @@ require 'bolt/node/errors'
 
 module Bolt
   module Transport
-    class Docker < Base
+    class Docker < Simple
       class Connection
+        attr_reader :user, :target
+
         def initialize(target)
           raise Bolt::ValidationError, "Target #{target.safe_name} does not have a host" unless target.host
           @target = target
+          @user = ENV['USER'] || Etc.getlogin
           @logger = Bolt::Logger.logger(target.safe_name)
-          @docker_host = @target.options['service-url']
-          @logger.trace("Initializing docker connection to #{@target.safe_name}")
+          @container_info = {}
+          @docker_host = target.options['service-url']
+          @logger.trace("Initializing docker connection to #{target.safe_name}")
         end
 
-        def connect
-          # We don't actually have a connection, but we do need to
-          # check that the container exists and is running.
-          output = execute_local_docker_json_command('ps')
-          index = output.find_index { |item| item["ID"] == @target.host || item["Names"] == @target.host }
-          raise "Could not find a container with name or ID matching '#{@target.host}'" if index.nil?
-          # Now find the indepth container information
-          output = execute_local_docker_json_command('inspect', [output[index]["ID"]])
-          # Store the container information for later
-          @container_info = output[0]
-          @logger.trace { "Opened session" }
-          true
-        rescue StandardError => e
-          raise Bolt::Node::ConnectError.new(
-            "Failed to connect to #{@target.safe_name}: #{e.message}",
-            'CONNECT_ERROR'
-          )
-        end
-
-        # Executes a command inside the target container
-        #
-        # @param command [Array] The command to run, expressed as an array of strings
-        # @param options [Hash] command specific options
-        # @option opts [String] :interpreter statements that are prefixed to the command e.g `/bin/bash` or `cmd.exe /c`
-        # @option opts [Hash] :environment A hash of environment variables that will be injected into the command
-        # @option opts [IO] :stdin An IO object that will be used to redirect STDIN for the docker command
-        def execute(*command, options)
-          command.unshift(options[:interpreter]) if options[:interpreter]
-          # Build the `--env` parameters
-          envs = []
-          if options[:environment]
-            options[:environment].each { |env, val| envs.concat(['--env', "#{env}=#{val}"]) }
-          end
-
-          command_options = []
-          # Need to be interactive if redirecting STDIN
-          command_options << '--interactive' unless options[:stdin].nil?
-          command_options << '--tty' if options[:tty]
-          command_options.concat(envs) unless envs.empty?
-          command_options << container_id
-          command_options.concat(command)
-
-          @logger.trace { "Executing: exec #{command_options}" }
-
-          stdout_str, stderr_str, status = execute_local_docker_command('exec', command_options, options[:stdin])
-
-          # The actual result is the exitstatus not the process object
-          status = status.nil? ? -32768 : status.exitstatus
-          if status == 0
-            @logger.trace { "Command returned successfully" }
-          else
-            @logger.trace { "Command failed with exit code #{status}" }
-          end
-          stdout_str.force_encoding(Encoding::UTF_8)
-          stderr_str.force_encoding(Encoding::UTF_8)
-          # Normalise line endings
-          stdout_str.gsub!("\r\n", "\n")
-          stderr_str.gsub!("\r\n", "\n")
-          [stdout_str, stderr_str, status]
-        rescue StandardError
-          @logger.trace { "Command aborted" }
-          raise
-        end
-
-        def write_remote_file(source, destination)
-          @logger.trace { "Uploading #{source} to #{destination}" }
-          _, stdout_str, status = execute_local_docker_command('cp', [source, "#{container_id}:#{destination}"])
-          unless status.exitstatus.zero?
-            raise "Error writing file to container #{@container_id}: #{stdout_str}"
-          end
-        rescue StandardError => e
-          raise Bolt::Node::FileError.new(e.message, 'WRITE_ERROR')
-        end
-
-        def write_remote_directory(source, destination)
-          @logger.trace { "Uploading #{source} to #{destination}" }
-          _, stdout_str, status = execute_local_docker_command('cp', [source, "#{container_id}:#{destination}"])
-          unless status.exitstatus.zero?
-            raise "Error writing directory to container #{@container_id}: #{stdout_str}"
-          end
-        rescue StandardError => e
-          raise Bolt::Node::FileError.new(e.message, 'WRITE_ERROR')
-        end
-
-        def download_remote_content(source, destination)
-          @logger.trace { "Downloading #{source} to #{destination}" }
-          # Create the destination directory, otherwise copying a source directory with Docker will
-          # copy the *contents* of the directory.
-          # https://docs.docker.com/engine/reference/commandline/cp/
-          FileUtils.mkdir_p(destination)
-          _, stdout_str, status = execute_local_docker_command('cp', ["#{container_id}:#{source}", destination])
-          unless status.exitstatus.zero?
-            raise "Error downloading content from container #{@container_id}: #{stdout_str}"
-          end
-        rescue StandardError => e
-          raise Bolt::Node::FileError.new(e.message, 'WRITE_ERROR')
-        end
-
-        def mkdirs(dirs)
-          _, stderr, exitcode = execute('mkdir', '-p', *dirs, {})
-          if exitcode != 0
-            message = "Could not create directories: #{stderr}"
-            raise Bolt::Node::FileError.new(message, 'MKDIR_ERROR')
-          end
-        end
-
-        def make_tmpdir
-          tmpdir = @target.options.fetch('tmpdir', container_tmpdir)
-          tmppath = "#{tmpdir}/#{SecureRandom.uuid}"
-
-          stdout, stderr, exitcode = execute('mkdir', '-m', '700', tmppath, {})
-          if exitcode != 0
-            raise Bolt::Node::FileError.new("Could not make tmpdir: #{stderr}", 'TMPDIR_ERROR')
-          end
-          tmppath || stdout.first
-        end
-
-        def with_remote_tmpdir
-          dir = make_tmpdir
-          yield dir
-        ensure
-          if dir
-            if @target.options['cleanup']
-              _, stderr, exitcode = execute('rm', '-rf', dir, {})
-              if exitcode != 0
-                Bolt::Logger.warn("fail_cleanup", "Failed to clean up tmpdir '#{dir}': #{stderr}")
-              end
-            else
-              Bolt::Logger.warn("skip_cleanup", "Skipping cleanup of tmpdir '#{dir}'")
-            end
-          end
-        end
-
-        def write_remote_executable(dir, file, filename = nil)
-          filename ||= File.basename(file)
-          remote_path = File.join(dir.to_s, filename)
-          write_remote_file(file, remote_path)
-          make_executable(remote_path)
-          remote_path
-        end
-
-        def make_executable(path)
-          _, stderr, exitcode = execute('chmod', 'u+x', path, {})
-          if exitcode != 0
-            message = "Could not make file '#{path}' executable: #{stderr}"
-            raise Bolt::Node::FileError.new(message, 'CHMOD_ERROR')
-          end
-        end
-
-        private
-
-        # Converts the JSON encoded STDOUT string from the docker cli into ruby objects
-        #
-        # @param stdout_string [String] The string to convert
-        # @return [Object] Ruby object representation of the JSON string
-        def extract_json(stdout_string)
-          # The output from the docker format command is a JSON string per line.
-          # We can't do a direct convert but this helper method will convert it into
-          # an array of Objects
-          stdout_string.split("\n")
-                       .reject { |str| str.strip.empty? }
-                       .map { |str| JSON.parse(str) }
-        end
-
-        # rubocop:disable Layout/LineLength
-        # Executes a Docker CLI command
-        #
-        # @param subcommand [String] The docker subcommand to run e.g. 'inspect' for `docker inspect`
-        # @param command_options [Array] Additional command options e.g. ['--size'] for `docker inspect --size`
-        # @param redir_stdin [IO] IO object which will be use to as STDIN in the docker command. Default is nil, which does not perform redirection
-        # @return [String, String, Process::Status] The output of the command:  STDOUT, STDERR, Process Status
-        # rubocop:enable Layout/LineLength
-        def execute_local_docker_command(subcommand, command_options = [], redir_stdin = nil)
-          env_hash = {}
-          # Set the DOCKER_HOST if we are using a non-default service-url
-          env_hash['DOCKER_HOST'] = @docker_host unless @docker_host.nil?
-
-          command_options = [] if command_options.nil?
-          docker_command = [subcommand].concat(command_options)
-
-          # Always use binary mode for any text data
-          capture_options = { binmode: true }
-          capture_options[:stdin_data] = redir_stdin unless redir_stdin.nil?
-          stdout_str, stderr_str, status = Open3.capture3(env_hash, 'docker', *docker_command, capture_options)
-          [stdout_str, stderr_str, status]
-        end
-
-        # Executes a Docker CLI command and parses the output in JSON format
-        #
-        # @param subcommand [String] The docker subcommand to run e.g. 'inspect' for `docker inspect`
-        # @param command_options [Array] Additional command options e.g. ['--size'] for `docker inspect --size`
-        # @return [Object] Ruby object representation of the JSON string
-        def execute_local_docker_json_command(subcommand, command_options = [])
-          command_options = [] if command_options.nil?
-          command_options = ['--format', '{{json .}}'].concat(command_options)
-          stdout_str, _stderr_str, _status = execute_local_docker_command(subcommand, command_options)
-          extract_json(stdout_str)
+        def shell
+          @shell ||= if Bolt::Util.windows?
+                       Bolt::Shell::Powershell.new(target, self)
+                     else
+                       Bolt::Shell::Bash.new(target, self)
+                     end
         end
 
         # The full ID of the target container
@@ -221,11 +34,123 @@ module Bolt
           @container_info["Id"]
         end
 
-        # The temp path inside the target container
+        def connect
+          # We don't actually have a connection, but we do need to
+          # check that the container exists and is running.
+          output = execute_local_json_command('ps')
+          index = output.find_index { |item| item["ID"] == target.host || item["Names"] == target.host }
+          raise "Could not find a container with name or ID matching '#{target.host}'" if index.nil?
+          # Now find the indepth container information
+          output = execute_local_json_command('inspect', [output[index]["ID"]])
+          # Store the container information for later
+          @container_info = output[0]
+          @logger.trace { "Opened session" }
+          true
+        rescue StandardError => e
+          raise Bolt::Node::ConnectError.new(
+            "Failed to connect to #{target.safe_name}: #{e.message}",
+            'CONNECT_ERROR'
+          )
+        end
+
+        def add_env_vars(env_vars)
+          @env_vars = env_vars.each_with_object([]) do |env_var, acc|
+            acc << "--env"
+            acc << "#{env_var[0]}=#{env_var[1]}"
+          end
+        end
+
+        # Executes a command inside the target container. This is called from the shell class.
         #
-        # @return [String] The absolute path to the temp directory
-        def container_tmpdir
-          '/tmp'
+        # @param command [string] The command to run
+        def execute(command)
+          args = []
+          # CODEREVIEW: Is it always safe to pass --interactive?
+          args += %w[--interactive]
+          args += %w[--tty] if target.options['tty']
+          args += %W[--env DOCKER_HOST=#{@docker_host}] if @docker_host
+          args += @env_vars if @env_vars
+
+          if target.options['shell-command'] && !target.options['shell-command'].empty?
+            # escape any double quotes in command
+            command = command.gsub('"', '\"')
+            command = "#{target.options['shell-command']} \"#{command}\""
+          end
+
+          docker_command = %w[docker exec] + args + [container_id] + Shellwords.split(command)
+          @logger.trace { "Executing: #{docker_command.join(' ')}" }
+
+          Open3.popen3(*docker_command)
+        rescue StandardError
+          @logger.trace { "Command aborted" }
+          raise
+        end
+
+        def upload_file(source, destination)
+          @logger.trace { "Uploading #{source} to #{destination}" }
+          _stdout, stderr, status = execute_local_command('cp', [source, "#{container_id}:#{destination}"])
+          unless status.exitstatus.zero?
+            raise "Error writing to container #{container_id}: #{stderr}"
+          end
+        rescue StandardError => e
+          raise Bolt::Node::FileError.new(e.message, 'WRITE_ERROR')
+        end
+
+        def download_file(source, destination, _download)
+          @logger.trace { "Downloading #{source} to #{destination}" }
+          # Create the destination directory, otherwise copying a source directory with Docker will
+          # copy the *contents* of the directory.
+          # https://docs.docker.com/engine/reference/commandline/cp/
+          FileUtils.mkdir_p(destination)
+          _stdout, stderr, status = execute_local_command('cp', ["#{container_id}:#{source}", destination])
+          unless status.exitstatus.zero?
+            raise "Error downloading content from container #{container_id}: #{stderr}"
+          end
+        rescue StandardError => e
+          raise Bolt::Node::FileError.new(e.message, 'WRITE_ERROR')
+        end
+
+        # Executes a Docker CLI command. This is useful for running commands as
+        # part of this class without having to go through the `execute`
+        # function and manage pipes.
+        #
+        # @param subcommand [String] The docker subcommand to run
+        #   e.g. 'inspect' for `docker inspect`
+        # @param arguments [Array] Arguments to pass to the docker command
+        #   e.g. 'src' and 'dest' for `docker cp <src> <dest>
+        # @return [String, String, Process::Status] The output of the command: STDOUT, STDERR, Process Status
+        private def execute_local_command(subcommand, arguments = [])
+          # Set the DOCKER_HOST if we are using a non-default service-url
+          env_hash = @docker_host.nil? ? {} : { 'DOCKER_HOST' => @docker_host }
+          docker_command = [subcommand].concat(arguments)
+
+          Open3.capture3(env_hash, 'docker', *docker_command, { binmode: true })
+        end
+
+        # Executes a Docker CLI command and parses the output in JSON format
+        #
+        # @param subcommand [String] The docker subcommand to run
+        #   e.g. 'inspect' for `docker inspect`
+        # @param arguments [Array] Arguments to pass to the docker command
+        #   e.g. 'src' and 'dest' for `docker cp <src> <dest>
+        # @return [Object] Ruby object representation of the JSON string
+        private def execute_local_json_command(subcommand, arguments = [])
+          command_options = ['--format', '{{json .}}'].concat(arguments)
+          stdout, _stderr, _status = execute_local_command(subcommand, command_options)
+          extract_json(stdout)
+        end
+
+        # Converts the JSON encoded STDOUT string from the docker cli into ruby objects
+        #
+        # @param stdout_string [String] The string to convert
+        # @return [Object] Ruby object representation of the JSON string
+        private def extract_json(stdout)
+          # The output from the docker format command is a JSON string per line.
+          # We can't do a direct convert but this helper method will convert it into
+          # an array of Objects
+          stdout.split("\n")
+                .reject { |str| str.strip.empty? }
+                .map { |str| JSON.parse(str) }
         end
       end
     end

--- a/spec/integration/transport/docker_spec.rb
+++ b/spec/integration/transport/docker_spec.rb
@@ -66,4 +66,19 @@ describe Bolt::Transport::Docker, docker: true do
       expect { docker.run_command(target, 'whoami') }.to raise_error(/does not have a host/)
     end
   end
+
+  context 'with shell-command specified' do
+    let(:target_data) {
+      { 'uri' => uri,
+        'config' => {
+          'docker' => { 'shell-command' => '/bin/bash -c' }
+        } }
+    }
+    let(:target) { Bolt::Target.from_hash(target_data, inventory) }
+
+    it 'uses the specified shell' do
+      result = docker.run_command(target, 'echo $SHELL')
+      expect(result.value['stdout'].strip).to eq('/bin/bash')
+    end
+  end
 end


### PR DESCRIPTION
This refactors the Docker transport to use the same code paths that
other transports do, in an effort to prove the viability of making
transports pluggable. The behavior of the transport should not change at
all.

The `Bolt::Transport::Docker` class now inherits from the `Simple`
transport class, and only overloads the `with_connection` function to
create a new `Bolt::Transport::Docker::Connection` instance and yield
it.

The `Bolt::Transport::Docker::Connection` class provides the functions
that the shell classes need to interact with Docker containers:
`connect`, `upload_file`, `download_file`, and `execute`. These are the 
functions we're hoping are needed for a stable API for making transports
pluggable. This update largely consists of renaming functions to match
the API, but also includes distinguishing the `execute` function that the 
shell classes use that must return pipes and the 
`execute_local_docker` functions that are used internally by the 
Connection class and just return strings.

!no-release-note