### PR TITLE
(GH-2562) Fix linking issues on plugins pages

### DIFF
--- a/documentation/inventory_file_v2.md
+++ b/documentation/inventory_file_v2.md
@@ -259,25 +259,12 @@ are implemented by plugin authors and called by Bolt.
 
 > **Note:** Plugins are only available in version 2 inventory files.
 
-For more information about plugins, see [Using plugins](./using_plugins.md).
+📖 **Related information**
 
-### Bundled plugins
-
-Bolt ships with several plugins.
-
-| Plugin | Description | Documentation |
-| ------ | ----------- | ---- |
-| `aws_inventory` | Generate targets from AWS EC2 instances. | [aws_inventory](https://forge.puppet.com/puppetlabs/aws_inventory) |
-| `azure_inventory` | Generate targets from Azure VMs and VM scale sets. | [azure_inventory](https://forge.puppet.com/puppetlabs/azure_inventory) |
-| `env_var` | Read a value from an environment variable. | [Using plugins](using_plugins.md#env_var) |
-| `gcloud_inventory` | Generate targets from Google Cloud compute engine instances. | [gcloud_inventory](https://forge.puppet.com/puppetlabs/gcloud_inventory) |
-| `pkcs7` | Use encrypted values for sensitive data. | [pkcs7](https://forge.puppet.com/puppetlabs/pkcs7) |
-| `prompt` | Prompt users to enter sensitive configuration information instead of storing it in a file. | [Using plugins](using_plugins.md#prompt) |
-| `puppetdb` | Query PuppetDB for a group of targets. | [Using plugins](using_plugins.md#puppetdb) |
-| `task` | Use a task to load targets, configuration, or other data. | [Using plugins](using_plugins.md#task) |
-| `terraform` | Generate targets from local and remote Terraform state files. | [terraform](https://forge.puppet.com/puppetlabs/terraform) |
-| `vault` | Set values by accessing secrets from a Key/Value engine on a Hashicorp Vault server. | [vault](https://forge.puppet.com/puppetlabs/vault) |
-| `yaml` | Compose multiple YAML files into a single file. | [yaml](https://forge.puppet.com/puppetlabs/yaml) |
+- For more information on plugins that ship with Bolt, see [Supported
+  plugins](supported_plugins.md).
+- For more information about how plugins work, see [Using
+  plugins](./using_plugins.md).
 
 ## Inventory file examples
 
@@ -388,7 +375,7 @@ groups:
         ssl: true
 ```
 
-### Using plugins
+### Inventory file with plugins
 
 The following inventory file uses several bundled plugins.
 

--- a/documentation/using_plugins.md
+++ b/documentation/using_plugins.md
@@ -3,9 +3,7 @@
 Bolt supports the use of plugins to dynamically load information during a Bolt
 run and change how Bolt executes certain actions. Bolt ships with some plugins,
 but you can also create your own plugins or install plugins created by other
-users. For information on how to write your own plugins, see [Writing
-plugins](writing_plugins.md). For information on how to install modules, which
-can include plugins, see [Installing modules](bolt_installing_modules.md).
+users.
 
 There are three types of plugins that you can use with Bolt:
 
@@ -228,4 +226,10 @@ plugins:
 
 📖 **Related information**
 
-- [Configuring Bolt](configuring_bolt.md)
+- For information on how to write your own plugins, see [Writing
+  plugins](writing_plugins.md).
+- For a list of supported plugins that ship with Bolt, see [Supported
+  plugins](supported_plugins.md).
+- For information on how to install modules, which can include plugins, see
+  [Installing modules](bolt_installing_modules.md).
+- [Configuring Bolt](configuring_bolt.md).


### PR DESCRIPTION
On the inventory page, we list bundled plugins, but some of the links for those
plugins go to the "Using plugins" page instead of linking to their entries in
supported plugins. These are links that we overlooked when we reshuffled the
plugins pages.

**Changes:**
- Remove the table on the inventory page and link to supported plugins instead.
- Add a general link to the supported plugins page from the Using plugins page.
- Rename the "Using plugins" inventory example entry to "Inventory file using
plugins".

!no-release-note
Closes #2562