### PR TITLE
(maint) Bump puppet module versions

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,7 +6,7 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '1.4.0'
-mod 'puppetlabs-puppet_agent', '4.3.0'
+mod 'puppetlabs-puppet_agent', '4.4.0'
 mod 'puppetlabs-facts', '1.3.0'
 
 # Core types and providers for Puppet 6
@@ -25,7 +25,7 @@ mod 'puppetlabs-zone_core', '1.0.3'
 mod 'puppetlabs-package', '1.4.0'
 mod 'puppetlabs-puppet_conf', '0.8.0'
 mod 'puppetlabs-python_task_helper', '0.4.3'
-mod 'puppetlabs-reboot', '3.1.0'
+mod 'puppetlabs-reboot', '3.2.0'
 mod 'puppetlabs-ruby_task_helper', '0.5.1'
 mod 'puppetlabs-ruby_plugin_helper', '0.1.0'
 mod 'puppetlabs-stdlib', '6.5.0'


### PR DESCRIPTION
There was an issue with the `puppet_agent` module not properly trying
all GPG keys in module version 4.3.0, which has been fixed in 4.4.0.
This updates the module, and also updates other modules with newer
versions.

!no-release-note