### PR TITLE
(maint) Pin puppetlabs_spec_helper to <= 2.15.0

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -68,7 +68,7 @@ Gem::Specification.new do |spec|
   # there is a bug in puppetlabs_spec_helper for modules without fixtures
   spec.add_development_dependency "bundler", ">= 1.14"
   spec.add_development_dependency "octokit", "~> 4.0"
-  spec.add_development_dependency "puppetlabs_spec_helper", "~> 2.7"
+  spec.add_development_dependency "puppetlabs_spec_helper", "<= 2.15.0"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
This pins the `puppetlabs_spec_helper` gem to `<= 2.15.0`, as greater
versions have a dependency on `pathspec < 1.1.0`, which requires Ruby
2.7 or higher.

!no-release-note