### PR TITLE
(GH-2542) Add disable-warnings config option to disable warnings

### DIFF
--- a/documentation/configuring_bolt.md
+++ b/documentation/configuring_bolt.md
@@ -221,12 +221,15 @@ from highest precedence to lowest:
 
 When merging configurations, Bolt's strategy is to shallow merge any options
 that accept hashes and to overwrite any options that do not accept hashes. There
-are two exceptions to this strategy:
+are a few exceptions to this strategy:
 
 - [Transport configuration](bolt_transports_reference.md) is deep-merged.
 
 - [Plugin configuration](using_plugins.md#configuring-plugins) is shallow-merged
   for _each individual plugin_.
+
+- All items under [disable-warnings](logs.md#suppress-warnings) are combined
+  into a single array.
 
 ### Transport configuration merge strategy
 
@@ -311,6 +314,37 @@ plugins:
       method: userpass
       user: bolt
       pass: bolt
+```
+
+### `disable-warnings` merge strategy
+
+The `disable-warnings` option accepts an array where each item in the array
+is the ID of a warning to suppress. When merging configurations, the
+array from each configuration layer is combined into a single array
+that includes all of the warning IDs.
+
+For example, given this configuration in a project configuration file:
+
+```yaml
+# ~/.puppetlabs/bolt/bolt-project.yaml
+disable-warnings:
+  - apples
+```
+
+And this plugin configuration in a system-wide configuration file:
+
+```yaml
+# /etc/puppetlabs/bolt/bolt-defaults.yaml
+disable-warnings:
+  - oranges
+```
+
+The merged Bolt configuration would look like this:
+
+```yaml
+disable-warnings:
+  - apples
+  - oranges
 ```
 
 📖 **Related information**

--- a/documentation/logs.md
+++ b/documentation/logs.md
@@ -178,6 +178,31 @@ Bolt to output additional information in a human-readable format. Verbose output
 useful for debugging your tasks and plans - if you're not sure why something is failing, try running
 it with `--verbose` to get more information.
 
+## Suppress warnings
+
+You can suppress warning messages from being logged by Bolt. To disable specific
+warnings, add a list of warning IDs to the `disable-warnings` configuration
+option in `bolt-project.yaml` or `bolt-defaults.yaml`. If defined in both files,
+the lists of warnings are concatenated per the [configuration merge
+strategy](configuring_bolt.md#merge-strategy). For example, if Bolt issues the
+following warning:
+
+```shell
+The configuration option 'apples' is deprecated. Use 'oranges' instead. [ID: fruit_option]
+```
+
+You could add the ID `fruit_option` under the `disable-warnings` configuration option:
+
+```
+# bolt-project.yaml
+---
+name: myproject
+disable-warnings:
+  - fruit_option
+```
+
+The next time you run Bolt, the warning message will not be logged.
+
 📖 **Related information**  
 
 - [Debugging tasks](writing_tasks.md#debugging-tasks)

--- a/lib/bolt/analytics.rb
+++ b/lib/bolt/analytics.rb
@@ -78,7 +78,7 @@ module Bolt
         Bolt::Util.read_optional_yaml_hash(filename, 'analytics')
       else
         unless ENV['BOLT_DISABLE_ANALYTICS']
-          Bolt::Logger.warn_once('analytics_opt_out', <<~ANALYTICS)
+          msg = <<~ANALYTICS
             Bolt collects data about how you use it. You can opt out of providing this data.
 
             To disable analytics data collection, add this line to ~/.puppetlabs/etc/bolt/analytics.yaml :
@@ -86,7 +86,8 @@ module Bolt
 
             Read more about what data Bolt collects and why here:
               https://puppet.com/docs/bolt/latest/bolt_installing.html#analytics-data-collection
-            ANALYTICS
+          ANALYTICS
+          Bolt::Logger.warn_once('analytics_opt_out', msg)
         end
 
         {}

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -760,13 +760,10 @@ module Bolt
             bolt task show canary
     HELP
 
-    attr_reader :deprecations
-
     def initialize(options)
       super()
 
       @options = options
-      @deprecations = []
 
       separator "\nINVENTORY OPTIONS"
       define('-t', '--targets TARGETS',
@@ -796,9 +793,11 @@ module Bolt
       end
       define('--description DESCRIPTION',
              'Deprecated. Description to use for the job') do |description|
-        msg = "Command line option '--description' is deprecated, and will be "\
+        Bolt::Logger.deprecate(
+          "description_cli_option",
+          "Command line option '--description' is deprecated, and will be "\
           "removed in Bolt 3.0."
-        @deprecations << { type: 'Using --description', msg: msg }
+        )
         @options[:description] = description
       end
       define('--params PARAMETERS',
@@ -881,8 +880,10 @@ module Bolt
       define('--boltdir PATH',
              'Deprecated. Specify what project to load config from (default:',
              'autodiscovered from current working dir)') do |path|
-        msg = "Command line option '--boltdir' is deprecated, use '--project' instead."
-        @deprecations << { type: 'Using --boltdir', msg: msg }
+        Bolt::Logger.deprecate(
+          "boltdir_cli_option",
+          "Command line option '--boltdir' is deprecated, use '--project' instead."
+        )
         @options[:boltdir] = path
       end
       define('--project PATH',
@@ -893,10 +894,12 @@ module Bolt
              'Deprecated. Specify where to load config from (default:',
              '~/.puppetlabs/bolt/bolt.yaml). Directory containing bolt.yaml will be',
              'used as the project directory.') do |path|
-        msg = "Command line option '--configfile' is deprecated, and " \
+        Bolt::Logger.deprecate(
+          "configfile_cli_option",
+          "Command line option '--configfile' is deprecated, and " \
           "will be removed in Bolt 3.0. Use '--project' and provide the "\
           "directory path instead."
-        @deprecations << { type: 'Using --configfile', msg: msg }
+        )
         @options[:configfile] = path
       end
       define('--hiera-config PATH',
@@ -915,10 +918,12 @@ module Bolt
              ' (default: ~/.puppetlabs/bolt/Puppetfile)',
              'Modules are installed in the current project.') do |path|
         command = Bolt::Util.powershell? ? 'Update-BoltProject' : 'bolt project migrate'
-        msg = "Command line option '--puppetfile' is deprecated, and will be removed "\
+        Bolt::Logger.deprecate(
+          "puppetfile_cli_option",
+          "Command line option '--puppetfile' is deprecated, and will be removed "\
           "in Bolt 3.0. You can migrate to using the new module management "\
           "workflow using '#{command}'."
-        @deprecations << { type: 'Using --puppetfile', msg: msg }
+        )
         @options[:puppetfile_path] = File.expand_path(path)
       end
       define('--[no-]save-rerun', 'Whether to update the rerun file after this command.') do |save|
@@ -1017,8 +1022,10 @@ module Bolt
         @options[:debug] = true
         # We don't actually set '--log-level debug' here, but once the options are evaluated by
         # the config class the end result is the same.
-        msg = "Command line option '--debug' is deprecated, set '--log-level debug' instead."
-        @deprecations << { type: 'Using --debug instead of --log-level debug', msg: msg }
+        Bolt::Logger.deprecate(
+          "debug_cli_option",
+          "Command line option '--debug' is deprecated, set '--log-level debug' instead."
+        )
       end
       define('--log-level LEVEL',
              "Set the log level for the console. Available options are",

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -147,10 +147,6 @@ module Bolt
       end
 
       validate(options)
-
-      # Deprecation warnings can't be issued until after config is loaded, so
-      # store them for later.
-      @parser_deprecations = parser.deprecations
     rescue Bolt::Error => e
       fatal_error(e)
       raise e
@@ -185,17 +181,13 @@ module Bolt
 
     # Completes the setup process by configuring Bolt and log messages
     def finalize_setup
-      Bolt::Logger.configure(config.log, config.color)
+      Bolt::Logger.configure(config.log, config.color, config.disable_warnings)
       Bolt::Logger.analytics = analytics
+      Bolt::Logger.flush_queue
 
       # Logger must be configured before checking path case and project file, otherwise logs will not display
       config.check_path_case('modulepath', config.modulepath)
       config.project.check_deprecated_file
-
-      # Log messages created during parser and config initialization
-      config.logs.each { |log| @logger.send(log.keys[0], log.values[0]) }
-      @parser_deprecations.each { |dep| Bolt::Logger.deprecation_warning(dep[:type], dep[:msg]) }
-      config.deprecations.each { |dep| Bolt::Logger.deprecation_warning(dep[:type], dep[:msg]) }
 
       if options[:clear_cache] && File.exist?(config.project.plugin_cache_file)
         FileUtils.rm(config.project.plugin_cache_file)
@@ -220,7 +212,7 @@ module Bolt
 
         msg = "Detected PowerShell 2 on controller. PowerShell 2 is deprecated and "\
               "support will be removed in Bolt 3.0."
-        Bolt::Logger.deprecation_warning("PowerShell 2 controller", msg)
+        Bolt::Logger.deprecate("powershell_2_controller", msg)
       end
     end
 
@@ -376,7 +368,10 @@ module Bolt
       conflicting_options = Set.new(opts.keys.map(&:to_s)).intersection(inventory_cli_opts)
 
       if inventory_source && conflicting_options.any?
-        @logger.warn("CLI arguments #{conflicting_options.to_a} may be overridden by Inventory: #{inventory_source}")
+        Bolt::Logger.warn(
+          "cli_overrides",
+          "CLI arguments #{conflicting_options.to_a} may be overridden by Inventory: #{inventory_source}"
+        )
       end
     end
 
@@ -662,7 +657,7 @@ module Bolt
         if node_param && target_param
           msg = "Plan parameters include both 'nodes' and 'targets' with type 'TargetSpec', " \
                 "neither will populated with the value for --nodes or --targets."
-          @logger.warn(msg)
+          Bolt::Logger.warn("nodes_targets_parameters", msg)
         elsif node_param
           plan_arguments['nodes'] = nodes.join(',')
         elsif target_param
@@ -709,7 +704,7 @@ module Bolt
                   "about defining and declaring classes and types in the Puppet documentation at "\
                   "https://puppet.com/docs/puppet/latest/lang_classes.html and "\
                   "https://puppet.com/docs/puppet/latest/lang_defined_types.html"
-        @logger.warn(message)
+        Bolt::Logger.warn("empty_manifest", message)
       end
 
       executor = Bolt::Executor.new(config.concurrency, analytics, noop, config.modified_concurrency)
@@ -861,7 +856,7 @@ module Bolt
       elsif modules.nil? && options[:subcommand] == 'puppetfile'
         msg = "Command '#{old_command}' is deprecated and will be removed in Bolt 3.0. Update your project to use "\
               "the module management feature. For more information, see https://pup.pt/bolt-module-migrate."
-        Bolt::Logger.deprecation_warning('puppetfile command', msg)
+        Bolt::Logger.deprecate("puppetfile_command", msg)
       elsif modules.nil? && options[:subcommand] == 'module'
         msg  = "Unable to use command '#{new_command}' when 'modules' is not configured in "\
                "bolt-project.yaml. "
@@ -966,7 +961,7 @@ module Bolt
           set the BOLT_GEM environment variable.
         MSG
 
-        @logger.warn(msg)
+        Bolt::Logger.warn("gem_install", msg)
       end
 
       # We only need to enumerate bundled content when running a task or plan

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -148,6 +148,17 @@ module Bolt
           _example: 50,
           _default: "100 or 1/7 the ulimit, whichever is lower."
         },
+        "disable-warnings" => {
+          description: "An array of IDs of warnings to suppress. Warnings with a matching ID will not be logged "\
+                       "by Bolt. If you are upgrading Bolt to a new major version, you should re-enable all warnings "\
+                       "until you have finished upgrading.",
+          type: Array,
+          items: {
+            type: String
+          },
+          _plugin: false,
+          _example: ["powershell_2"]
+        },
         "format" => {
           description: "The format to use when printing results.",
           type: String,
@@ -599,6 +610,7 @@ module Bolt
         color
         compile-concurrency
         concurrency
+        disable-warnings
         format
         inventory-config
         log
@@ -620,6 +632,7 @@ module Bolt
         color
         compile-concurrency
         concurrency
+        disable-warnings
         format
         hiera-config
         inventoryfile

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -119,11 +119,12 @@ module Bolt
     def queue_execute(targets)
       if @warn_concurrency && targets.length > @concurrency
         @warn_concurrency = false
-        @logger.warn("The ulimit is low, which may cause file limit issues. Default concurrency has been set to "\
-                     "'#{@concurrency}' to mitigate those issues, which may cause Bolt to run slow. "\
-                     "Disable this warning by configuring ulimit using 'ulimit -n <limit>' in your shell "\
-                     "configuration, or by configuring Bolt's concurrency. "\
-                     "See https://puppet.com/docs/bolt/latest/bolt_known_issues.html for details.")
+        msg = "The ulimit is low, which may cause file limit issues. Default concurrency has been set to "\
+              "'#{@concurrency}' to mitigate those issues, which may cause Bolt to run slow. "\
+              "Disable this warning by configuring ulimit using 'ulimit -n <limit>' in your shell "\
+              "configuration, or by configuring Bolt's concurrency. "\
+              "See https://puppet.com/docs/bolt/latest/bolt_known_issues.html for details."
+        Bolt::Logger.warn("low_ulimit", msg)
       end
 
       targets.group_by(&:transport).flat_map do |protocol, protocol_targets|

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -97,7 +97,7 @@ module Bolt
 
       Bolt::Validator.new.tap do |validator|
         validator.validate(data, schema, source)
-        validator.warnings.each { |warning| logger.warn(warning) }
+        validator.warnings.each { |warning| Bolt::Logger.warn(warning[:id], warning[:msg]) }
       end
 
       inventory = create_version(data, config.transport, config.transports, plugins)

--- a/lib/bolt/inventory/group.rb
+++ b/lib/bolt/inventory/group.rb
@@ -27,7 +27,10 @@ module Bolt
 
         if all_group
           if input.key?('name') && input['name'] != 'all'
-            @logger.warn("Top-level group '#{input['name']}' cannot specify a name, using 'all' instead.")
+            Bolt::Logger.warn(
+              "top_level_group_name",
+              "Top-level group '#{input['name']}' cannot specify a name, using 'all' instead."
+            )
           end
 
           input = input.merge('name' => 'all')
@@ -134,7 +137,7 @@ module Bolt
 
         unless (unexpected_keys = target.keys - TARGET_KEYS).empty?
           msg = "Found unexpected key(s) #{unexpected_keys.join(', ')} in target #{t_name}"
-          @logger.warn(msg)
+          Bolt::Logger.warn("unknown_target_keys", msg)
         end
 
         validate_data_keys(target, t_name)
@@ -261,7 +264,7 @@ module Bolt
 
         unless (unexpected_keys = input.keys - GROUP_KEYS).empty?
           msg = "Found unexpected key(s) #{unexpected_keys.join(', ')} in group #{@name}"
-          @logger.warn(msg)
+          Bolt::Logger.warn("unknown_group_keys", msg)
         end
       end
 
@@ -368,7 +371,7 @@ module Bolt
             msg = +"Found unexpected key(s) #{unexpected_keys.join(', ')} in config for"
             msg << " target #{target} in" if target
             msg << " group #{@name}"
-            @logger.warn(msg)
+            Bolt::Logger.warn("unknown_config_keys", msg)
           end
         end
       end

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -153,8 +153,10 @@ module Bolt
         Dir.children(path).select { |name| Puppet::Module.is_module_directory?(name, path) }
       end
       if modules.include?(project.name)
-        Bolt::Logger.warn_once("project shadows module",
-                               "The project '#{project.name}' shadows an existing module of the same name")
+        Bolt::Logger.warn_once(
+          "project_shadows_module",
+          "The project '#{project.name}' shadows an existing module of the same name"
+        )
       end
     end
 
@@ -395,7 +397,7 @@ module Bolt
         errors = []
         plans = compiler.list_plans(nil, errors).map { |plan| [plan.name] }.sort
         errors.each do |error|
-          @logger.warn(error.details['original_error'])
+          Bolt::Logger.warn("plan_load_error", error.details['original_error'])
         end
 
         filter_content ? filter_content(plans, @project&.plans) : plans
@@ -445,7 +447,10 @@ module Bolt
             params[name]['default_value'] = defaults[name] if defaults.key?(name)
             params[name]['description'] = param.text unless param.text.empty?
           else
-            @logger.warn("The documented parameter '#{name}' does not exist in plan signature")
+            Bolt::Logger.warn(
+              "missing_plan_parameter",
+              "The documented parameter '#{name}' does not exist in plan signature"
+            )
           end
         end
 

--- a/lib/bolt/pal/yaml_plan/evaluator.rb
+++ b/lib/bolt/pal/yaml_plan/evaluator.rb
@@ -157,13 +157,13 @@ module Bolt
           if plan.steps.any? { |step| step.body.key?('target') }
             msg = "The 'target' parameter for YAML plan steps is deprecated and will be removed "\
                   "in a future version of Bolt. Use the 'targets' parameter instead."
-            Bolt::Logger.deprecation_warning("Using 'target' parameter for YAML plan steps, not 'targets'", msg)
+            Bolt::Logger.deprecate("yaml_plan_target", msg)
           end
 
           if plan.steps.any? { |step| step.body.key?('source') }
             msg = "The 'source' parameter for YAML plan upload steps is deprecated and will be removed "\
                   "in a future version of Bolt. Use the 'upload' parameter instead."
-            Bolt::Logger.deprecation_warning("Using 'source' parameter for YAML upload steps, not 'upload'", msg)
+            Bolt::Logger.deprecate("yaml_plan_source", msg)
           end
 
           plan_result = closure_scope.with_local_scope(args_hash) do |scope|

--- a/lib/bolt/plugin/module.rb
+++ b/lib/bolt/plugin/module.rb
@@ -187,7 +187,7 @@ module Bolt
         if params.key?('private-key') || params.key?('public-key')
           message = "pkcs7 keys 'private-key' and 'public-key' have been deprecated and will be "\
                     "removed in a future version of Bolt; use 'private_key' and 'public_key' instead."
-          Bolt::Logger.deprecation_warning('PKCS7 keys using hyphens, not underscores', message)
+          Bolt::Logger.deprecate("pkcs7_params", message)
         end
 
         params['private_key'] = params.delete('private-key') if params.key?('private-key')

--- a/lib/bolt/plugin/puppetdb.rb
+++ b/lib/bolt/plugin/puppetdb.rb
@@ -31,7 +31,7 @@ module Bolt
       end
 
       def warn_missing_fact(certname, fact)
-        @logger.warn("Could not find fact #{fact} for node #{certname}")
+        Bolt::Logger.warn("puppetdb_missing_fact", "Could not find fact #{fact} for node #{certname}")
       end
 
       def fact_path(raw_fact)

--- a/lib/bolt/rerun.rb
+++ b/lib/bolt/rerun.rb
@@ -49,7 +49,7 @@ module Bolt
         end
       end
     rescue StandardError => e
-      Bolt::Logger.warn_once('unwriteable_file', "Failed to save result to #{@path}: #{e.message}")
+      Bolt::Logger.warn_once("unwriteable_file", "Failed to save result to #{@path}: #{e.message}")
     end
   end
 end

--- a/lib/bolt/shell/bash.rb
+++ b/lib/bolt/shell/bash.rb
@@ -299,7 +299,7 @@ module Bolt
           if target.options['cleanup']
             dir.delete
           else
-            @logger.warn("Skipping cleanup of tmpdir #{dir}")
+            Bolt::Logger.warn("skip_cleanup", "Skipping cleanup of tmpdir #{dir}")
           end
         end
       end

--- a/lib/bolt/shell/bash/tmpdir.rb
+++ b/lib/bolt/shell/bash/tmpdir.rb
@@ -48,7 +48,10 @@ module Bolt
         def delete
           result = @shell.execute(['rm', '-rf', @path], sudoable: true, run_as: @owner)
           if result.exit_code != 0
-            @logger.warn("Failed to clean up tmpdir '#{@path}': #{result.stderr.string}")
+            Bolt::Logger.warn(
+              "fail_cleanup",
+              "Failed to clean up tmpdir '#{@path}': #{result.stderr.string}"
+            )
           end
           # For testing
           result.stderr.string

--- a/lib/bolt/shell/powershell.rb
+++ b/lib/bolt/shell/powershell.rb
@@ -27,7 +27,7 @@ module Bolt
             "bolt-debug.log or run with '--log-level debug' to see the full "\
             "list of targets with PowerShell 2."
 
-          Bolt::Logger.deprecation_warning("PowerShell 2", msg)
+          Bolt::Logger.deprecate_once("powershell_2", msg)
           @logger.debug("Detected PowerShell 2 on #{target}.")
         end
       end
@@ -163,7 +163,7 @@ module Bolt
           if target.options['cleanup']
             rmdir(@tmpdir)
           else
-            @logger.warn("Skipping cleanup of tmpdir '#{@tmpdir}'")
+            Bolt::Logger.warn("Skipping cleanup of tmpdir '#{@tmpdir}'", "skip_cleanup")
           end
         end
       end

--- a/lib/bolt/task.rb
+++ b/lib/bolt/task.rb
@@ -149,7 +149,7 @@ module Bolt
       if unknown_keys.any?
         msg = "Metadata for task '#{@name}' contains unknown keys: #{unknown_keys.join(', ')}."
         msg += " This could be a typo in the task metadata or may result in incorrect behavior."
-        @logger.warn(msg)
+        Bolt::Logger.warn("unknown_task_metadata_keys", msg)
       end
     end
   end

--- a/lib/bolt/transport/docker/connection.rb
+++ b/lib/bolt/transport/docker/connection.rb
@@ -140,10 +140,10 @@ module Bolt
             if @target.options['cleanup']
               _, stderr, exitcode = execute('rm', '-rf', dir, {})
               if exitcode != 0
-                @logger.warn("Failed to clean up tmpdir '#{dir}': #{stderr}")
+                Bolt::Logger.warn("fail_cleanup", "Failed to clean up tmpdir '#{dir}': #{stderr}")
               end
             else
-              @logger.warn("Skipping cleanup of tmpdir '#{dir}'")
+              Bolt::Logger.warn("skip_cleanup", "Skipping cleanup of tmpdir '#{dir}'")
             end
           end
         end

--- a/lib/bolt/transport/local.rb
+++ b/lib/bolt/transport/local.rb
@@ -20,7 +20,7 @@ module Bolt
           msg = "The local transport will default to using Bolt's Ruby interpreter and "\
             "setting the 'puppet-agent' feature in Bolt 3.0. Enable or disable these "\
             "defaults by setting 'bundled-ruby' in the local transport config."
-          Bolt::Logger.warn_once('local default config', msg)
+          Bolt::Logger.warn_once("local_default_config", msg)
         end
 
         yield Connection.new(target)

--- a/lib/bolt/transport/ssh.rb
+++ b/lib/bolt/transport/ssh.rb
@@ -23,8 +23,7 @@ module Bolt
 
       def with_connection(target)
         if target.transport_config['ssh-command'] && !target.transport_config['native-ssh']
-          Bolt::Logger.warn_once("ssh-command and native-ssh conflict",
-                                 "native-ssh must be true to use ssh-command")
+          Bolt::Logger.warn_once("native_ssh_disabled", "native-ssh must be true to use ssh-command")
         end
 
         conn = if target.transport_config['native-ssh']

--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -34,7 +34,7 @@ module Bolt
             begin
               Bolt::Util.validate_file('ssh key', target.options['private-key'])
             rescue Bolt::FileError => e
-              @logger.warn(e.msg)
+              Bolt::Logger.warn("invalid_ssh_key", e.msg)
             end
           end
         end

--- a/lib/bolt/validator.rb
+++ b/lib/bolt/validator.rb
@@ -147,7 +147,7 @@ module Bolt
         message += " at '#{path}'" if @path.any?
         message += " at #{@location}" if @location
         message += "."
-        @warnings << message
+        @warnings << { id: 'unknown_option', msg: message }
       end
     end
 
@@ -160,7 +160,7 @@ module Bolt
         message  = "Option '#{path}' "
         message += "at #{@location} " if @location
         message += "is deprecated. #{definition[:_deprecation]}"
-        @deprecations << { option: key, message: message }
+        @deprecations << { id: "#{key}_option", msg: message }
       end
     end
 

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -13,6 +13,9 @@
     "concurrency": {
       "$ref": "#/definitions/concurrency"
     },
+    "disable-warnings": {
+      "$ref": "#/definitions/disable-warnings"
+    },
     "format": {
       "$ref": "#/definitions/format"
     },
@@ -64,6 +67,13 @@
       "description": "The number of threads to use when executing on remote targets.",
       "type": "integer",
       "minimum": 1
+    },
+    "disable-warnings": {
+      "description": "An array of IDs of warnings to suppress. Warnings with a matching ID will not be logged by Bolt. If you are upgrading Bolt to a new major version, you should re-enable all warnings until you have finished upgrading.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "format": {
       "description": "The format to use when printing results.",

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -19,6 +19,9 @@
     "concurrency": {
       "$ref": "#/definitions/concurrency"
     },
+    "disable-warnings": {
+      "$ref": "#/definitions/disable-warnings"
+    },
     "format": {
       "$ref": "#/definitions/format"
     },
@@ -155,6 +158,13 @@
       "description": "The number of threads to use when executing on remote targets.",
       "type": "integer",
       "minimum": 1
+    },
+    "disable-warnings": {
+      "description": "An array of IDs of warnings to suppress. Warnings with a matching ID will not be logged by Bolt. If you are upgrading Bolt to a new major version, you should re-enable all warnings until you have finished upgrading.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "format": {
       "description": "The format to use when printing results.",

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -763,7 +763,7 @@ describe "Bolt::CLI" do
 
     describe "console log level" do
       it "is not sensitive to ordering of debug and verbose" do
-        expect(Bolt::Logger).to receive(:configure).with(include('console' => { level: 'debug' }), true)
+        expect(Bolt::Logger).to receive(:configure).with(include('console' => { level: 'debug' }), true, Set.new)
 
         cli = Bolt::CLI.new(%w[command run uptime --targets foo --debug --verbose])
         cli.parse
@@ -775,14 +775,14 @@ describe "Bolt::CLI" do
       end
 
       it "warns when using debug" do
-        expect(Bolt::Logger).to receive(:deprecation_warning)
-          .with(anything, /Command line option '--debug' is deprecated/)
         cli = Bolt::CLI.new(%w[command run uptime --targets foo --debug])
         cli.parse
+
+        expect(@log_output.readlines).to include(/Command line option '--debug' is deprecated/)
       end
 
       it "log-level sets the log option" do
-        expect(Bolt::Logger).to receive(:configure).with(include('console' => { level: 'debug' }), true)
+        expect(Bolt::Logger).to receive(:configure).with(include('console' => { level: 'debug' }), true, Set.new)
 
         cli = Bolt::CLI.new(%w[command run uptime --targets foo --log-level debug])
         cli.parse

--- a/spec/bolt/inventory/group_spec.rb
+++ b/spec/bolt/inventory/group_spec.rb
@@ -738,8 +738,7 @@ describe Bolt::Inventory::Group do
     context 'with unexpected keys' do
       let(:mock_logger) { instance_double("Logging.logger") }
       before(:each) do
-        allow(Logging).to receive(:logger).and_return(mock_logger)
-        allow(mock_logger).to receive(:[]).and_return(mock_logger)
+        allow(Bolt::Logger).to receive(:logger).and_return(mock_logger)
       end
 
       it 'does not log when no unexpected keys are present' do

--- a/spec/bolt/project_spec.rb
+++ b/spec/bolt/project_spec.rb
@@ -99,16 +99,25 @@ describe Bolt::Project do
           .with(project_path + 'plans').and_return(true)
 
         FileUtils.mkdir_p(project_path)
+
+        expect(Bolt::Logger).to receive(:warn).with(
+          anything,
+          /No project name is specified in bolt-project.yaml/
+        )
+
         project = Bolt::Project.create_project(project_path)
         project.validate
-
-        expect(project.logs).to include({ warn: /No project name is specified in bolt-project.yaml/ })
       end
     end
 
     it "does not warn when content directories don't exist" do
       with_project do
-        expect(project.logs).not_to include({ warn: /No project name is specified in bolt-project.yaml/ })
+        expect(Bolt::Logger).not_to receive(:warn).with(
+          anything,
+          /No project name is specified in bolt-project.yaml/
+        )
+
+        project
       end
     end
   end
@@ -219,8 +228,7 @@ describe Bolt::Project do
     it 'warns and continues if project creation fails' do
       expect(FileUtils).to receive(:mkdir_p).with('myproject').and_raise(Errno::EACCES)
       # Ensure execution continues
-      expect(Bolt::Project).to receive(:new)
-        .with(anything, 'myproject', 'user', [{ warn: /Could not create default project / }], [])
+      expect(Bolt::Project).to receive(:new).with(anything, 'myproject', 'user')
       Bolt::Project.create_project('myproject', 'user')
     end
   end

--- a/spec/bolt/transport/local_spec.rb
+++ b/spec/bolt/transport/local_spec.rb
@@ -147,7 +147,7 @@ describe Bolt::Transport::Local do
 
     it 'warns that default config will be added in 3.0' do
       expect(Bolt::Logger).to receive(:warn_once)
-        .with('local default config', /The local transport will default/)
+        .with(anything, /The local transport will default/)
       subject.with_connection(get_target(inventory, uri)) do |conn|; end
     end
   end
@@ -166,7 +166,7 @@ describe Bolt::Transport::Local do
 
     it 'does not issue the warning' do
       expect(Bolt::Logger).not_to receive(:warn_once)
-        .with('local default config', /The local transport will default/)
+        .with(anything, /The local transport will default/)
       subject.with_connection(get_target(inventory, uri)) do |conn|; end
     end
   end

--- a/spec/bolt/validator_spec.rb
+++ b/spec/bolt/validator_spec.rb
@@ -449,14 +449,20 @@ describe Bolt::Validator do
       data['unknown'] = 'unknown key'
       validator       = validate
 
-      expect(validator.warnings).to include(/Unknown option 'unknown' at config./)
+      expect(validator.warnings).to include(
+        id:  anything,
+        msg: /Unknown option 'unknown' at config./
+      )
     end
 
     it 'warns with nested uknown key' do
       data['nested'] = { 'unknown' => 'unknown key' }
       validator      = validate
 
-      expect(validator.warnings).to include(/Unknown option 'unknown' at 'nested' at config./)
+      expect(validator.warnings).to include(
+        id:  anything,
+        msg: /Unknown option 'unknown' at 'nested' at config./
+      )
     end
 
     it 'does not warn when :properties is not defined' do
@@ -491,8 +497,8 @@ describe Bolt::Validator do
         described_class.new.tap do |validator|
           validator.validate(data, schema, location)
           expect(validator.deprecations).to include(
-            option:  'option',
-            message: /Option 'option' at config is deprecated. Donut use./
+            id:  anything,
+            msg: /Option 'option' at config is deprecated. Donut use./
           )
         end
       end

--- a/spec/integration/parsing_spec.rb
+++ b/spec/integration/parsing_spec.rb
@@ -101,7 +101,7 @@ describe "CLI parses input" do
     params = ['string="catdog"']
     run_cli(['task', 'run', 'sample::invalid', '--targets', target] + params + config_flags)
     logs = @log_output.readlines
-    expect(logs).to include(/WARN  Bolt::Task : Metadata for task 'sample::invalid' contains unknown keys: anything/)
+    expect(logs).to include(/WARN.*Metadata for task 'sample::invalid' contains unknown keys: anything/)
   end
 
   it 'parses script parameters without munging task parameters', ssh: true do

--- a/spec/integration/validator_spec.rb
+++ b/spec/integration/validator_spec.rb
@@ -290,7 +290,7 @@ describe 'validating config' do
 
     it 'does not error or raise warnings' do
       expect { run_cli(command) }.not_to raise_error
-      expect(@log_output.readlines).not_to include(/Unknown option/)
+      expect(@log_output.readlines).not_to include(/Unknown option.*inventory/)
     end
   end
 

--- a/spec/integration/yaml_plan_spec.rb
+++ b/spec/integration/yaml_plan_spec.rb
@@ -165,16 +165,12 @@ describe "running YAML plans", ssh: true do
   # TODO: Remove when 'target' parameter is removed
   it "warns when using deprecated 'target' parameter" do
     stub_logger
-    allow(Logging).to receive(:logger).and_return(mock_logger)
     allow(Puppet::Util::Log).to receive(:newdestination).with(mock_logger)
     allow(mock_logger).to receive(:notice)
     allow(mock_logger).to receive(:info)
     allow(mock_logger).to receive(:warn)
-      .with("No project name is specified in bolt-project.yaml. Project-level content will not be available.")
-    allow(mock_logger).to receive(:warn)
-      .with("bolt-project.yaml contains valid config keys, bolt.yaml will be ignored")
 
-    expect(Bolt::Logger).to receive(:deprecation_warning).with(anything, /Use the 'targets' parameter instead./)
+    expect(Bolt::Logger).to receive(:deprecate).with(anything, /Use the 'targets' parameter instead./)
 
     run_plan('yaml::target_param', targets: target)
   end

--- a/spec/lib/bolt_spec/integration.rb
+++ b/spec/lib/bolt_spec/integration.rb
@@ -20,6 +20,8 @@ module BoltSpec
       output =  StringIO.new
       outputter = outputter.new(false, false, false, false, output)
       allow(cli).to receive(:outputter).and_return(outputter)
+
+      # Don't allow tests to override the captured log config
       allow(Bolt::Logger).to receive(:configure)
 
       if rescue_exec

--- a/spec/lib/bolt_spec/logger.rb
+++ b/spec/lib/bolt_spec/logger.rb
@@ -6,7 +6,7 @@ module BoltSpec
   module Logger
     def stub_logger
       @mock_logger = instance_double("Logging.logger")
-      allow(Logging).to receive(:logger).and_return(mock_logger)
+      allow(Bolt::Logger).to receive(:logger).and_return(mock_logger)
       allow(@mock_logger).to receive(:[]).and_return(mock_logger)
       # These are allowed since we don't test them and the ssh library uses them
       allow(@mock_logger).to receive(:trace)


### PR DESCRIPTION
This adds a new `disable-warnings` config option that is available in
both `bolt-project.yaml` and `bolt-defaults.yaml`. This option accepts
an array of warning IDs that are used to suppress warnings issued by
Bolt. If a warning would otherwise be issued, and its ID is under the
`disable-warnings` option, Bolt will not print the warning to either the
CLI or a log file.

If `disable-warnings` is configured in multiple config layers, Bolt will
merge the arrays between config layers.

To enable this feature, a new `Bolt::Logger.warn` method was added that
accepts an ID and message. If the ID is present in the
`disable-warnings` config, the message will not be logged.

Lastly, this adds a queuing mechanic to `Bolt::Logger`. This work
includes the new methods `deprecate`, `deprecate_once`, `info`, and
`debug`; and updates the existing `warn_once` method. These methods now
log messages via the `log` method. If `Bolt::Logger` has been
configured, the messages are immediately logged. Otherwise, the messages
are added to a queue to be logged once `Bolt::Logger` is configured. The
`flush_queue` method can be called to flush the message queue and log
all messages in the queue.

!feature

* **Suppress warnings with `disable-warnings` config option**
  ([#2542](#2542))

  The `disable-warnings` configuration option accepts an array of
  warning IDs that are used to suppress warnings in both the CLI and log
  files. This configuration option is supported in both
  `bolt-project.yaml` and `bolt-defaults.yaml`.

---

### Acceptance critera

- [ ] Suppresses deprecation warnings with a matching ID
  - [ ] Does not print deprecation to console
  - [ ] Does not print deprecation to log file
- [ ] Suppresses regular warnings with a matching ID
  - [ ] Does not print deprecation to console
  - [ ] Does not print deprecation to log file
- [ ] Does not suppress warnings without a matching ID
- [ ] Merges warning IDs between multiple config layers
- [ ] Does not deadlock