### PR TITLE
(GH-2559) Remove deprecated command-line options

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -6,15 +6,15 @@ require 'optparse'
 
 module Bolt
   class BoltOptionParser < OptionParser
-    PROJECT_PATHS = %w[project configfile boltdir].freeze
-    OPTIONS = { inventory: %w[targets query rerun description],
+    PROJECT_PATHS = %w[project].freeze
+    OPTIONS = { inventory: %w[targets query rerun],
                 authentication: %w[user password password-prompt private-key host-key-check ssl ssl-verify],
                 escalation: %w[run-as sudo-password sudo-password-prompt sudo-executable],
                 run_context: %w[concurrency inventoryfile save-rerun cleanup],
                 global_config_setters: PROJECT_PATHS + %w[modulepath],
                 transports: %w[transport connect-timeout tty native-ssh ssh-command copy-command],
                 display: %w[format color verbose trace],
-                global: %w[help version debug log-level clear-cache] }.freeze
+                global: %w[help version log-level clear-cache] }.freeze
 
     ACTION_OPTS = OPTIONS.values.flatten.freeze
 
@@ -117,7 +117,7 @@ module Bolt
       when 'puppetfile'
         case action
         when 'install'
-          { flags: OPTIONS[:global] + OPTIONS[:global_config_setters] + %w[puppetfile],
+          { flags: OPTIONS[:global] + OPTIONS[:global_config_setters],
             banner: PUPPETFILE_INSTALL_HELP }
         when 'show-modules'
           { flags: OPTIONS[:global] + OPTIONS[:global_config_setters],
@@ -794,13 +794,6 @@ module Bolt
       define('--noop', 'See what changes Bolt will make without actually executing the changes') do |_|
         @options[:noop] = true
       end
-      define('--description DESCRIPTION',
-             'Deprecated. Description to use for the job') do |description|
-        msg = "Command line option '--description' is deprecated, and will be "\
-          "removed in Bolt 3.0."
-        @deprecations << { type: 'Using --description', msg: msg }
-        @options[:description] = description
-      end
       define('--params PARAMETERS',
              "Parameters to a task or plan as json, a json file '@<file>', or on stdin '-'") do |params|
         @options[:task_options] = parse_params(params)
@@ -878,26 +871,9 @@ module Bolt
           File.expand_path(moduledir)
         end
       end
-      define('--boltdir PATH',
-             'Deprecated. Specify what project to load config from (default:',
-             'autodiscovered from current working dir)') do |path|
-        msg = "Command line option '--boltdir' is deprecated, use '--project' instead."
-        @deprecations << { type: 'Using --boltdir', msg: msg }
-        @options[:boltdir] = path
-      end
       define('--project PATH',
              'Path to load the Bolt project from (default: autodiscovered from current dir)') do |path|
         @options[:project] = path
-      end
-      define('--configfile PATH',
-             'Deprecated. Specify where to load config from (default:',
-             '~/.puppetlabs/bolt/bolt.yaml). Directory containing bolt.yaml will be',
-             'used as the project directory.') do |path|
-        msg = "Command line option '--configfile' is deprecated, and " \
-          "will be removed in Bolt 3.0. Use '--project' and provide the "\
-          "directory path instead."
-        @deprecations << { type: 'Using --configfile', msg: msg }
-        @options[:configfile] = path
       end
       define('--hiera-config PATH',
              'Specify where to load Hiera config from (default: ~/.puppetlabs/bolt/hiera.yaml)') do |path|
@@ -909,17 +885,6 @@ module Bolt
           raise Bolt::CLIError, "Cannot pass inventory file when #{Bolt::Inventory::ENVIRONMENT_VAR} is set"
         end
         @options[:inventoryfile] = File.expand_path(path)
-      end
-      define('--puppetfile PATH',
-             'Deprecated. Specify a Puppetfile to use when installing modules.',
-             ' (default: ~/.puppetlabs/bolt/Puppetfile)',
-             'Modules are installed in the current project.') do |path|
-        command = Bolt::Util.powershell? ? 'Update-BoltProject' : 'bolt project migrate'
-        msg = "Command line option '--puppetfile' is deprecated, and will be removed "\
-          "in Bolt 3.0. You can migrate to using the new module management "\
-          "workflow using '#{command}'."
-        @deprecations << { type: 'Using --puppetfile', msg: msg }
-        @options[:puppetfile_path] = File.expand_path(path)
       end
       define('--[no-]save-rerun', 'Whether to update the rerun file after this command.') do |save|
         @options[:'save-rerun'] = save
@@ -1012,13 +977,6 @@ module Bolt
       define('--version', 'Display the version') do |_|
         puts Bolt::VERSION
         raise Bolt::CLIExit
-      end
-      define('--debug', 'Display debug logging') do |_|
-        @options[:debug] = true
-        # We don't actually set '--log-level debug' here, but once the options are evaluated by
-        # the config class the end result is the same.
-        msg = "Command line option '--debug' is deprecated, set '--log-level debug' instead."
-        @deprecations << { type: 'Using --debug instead of --log-level debug', msg: msg }
       end
       define('--log-level LEVEL',
              "Set the log level for the console. Available options are",

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -159,25 +159,19 @@ module Bolt
     # Loads the project and configuration. All errors that are raised here are not
     # handled by the outputter, as it relies on config being loaded.
     def load_config
-      @config = if ENV['BOLT_PROJECT']
-                  project = Bolt::Project.create_project(ENV['BOLT_PROJECT'], 'environment')
-                  Bolt::Config.from_project(project, options)
-                elsif options[:configfile]
-                  Bolt::Config.from_file(options[:configfile], options)
+      project = if ENV['BOLT_PROJECT']
+                  Bolt::Project.create_project(ENV['BOLT_PROJECT'], 'environment')
+                elsif options[:project]
+                  dir = Pathname.new(options[:project])
+                  if (dir + Bolt::Project::BOLTDIR_NAME).directory?
+                    Bolt::Project.create_project(dir + Bolt::Project::BOLTDIR_NAME)
+                  else
+                    Bolt::Project.create_project(dir)
+                  end
                 else
-                  cli_flag = options[:project] || options[:boltdir]
-                  project = if cli_flag
-                              dir = Pathname.new(cli_flag)
-                              if (dir + Bolt::Project::BOLTDIR_NAME).directory?
-                                Bolt::Project.create_project(dir + Bolt::Project::BOLTDIR_NAME)
-                              else
-                                Bolt::Project.create_project(dir)
-                              end
-                            else
-                              Bolt::Project.find_boltdir(Dir.pwd)
-                            end
-                  Bolt::Config.from_project(project, options)
+                  Bolt::Project.find_boltdir(Dir.pwd)
                 end
+      @config = Bolt::Config.from_project(project, options)
     rescue Bolt::Error => e
       fatal_error(e)
       raise e
@@ -314,10 +308,6 @@ module Bolt
               "Unknown argument(s) #{options[:leftovers].join(', ')}"
       end
 
-      if options.slice(:boltdir, :configfile, :project).length > 1
-        raise Bolt::CLIError, "Only one of '--boltdir', '--project', or '--configfile' may be specified"
-      end
-
       if options[:noop] &&
          !(options[:subcommand] == 'task' && options[:action] == 'run') && options[:subcommand] != 'apply'
         raise Bolt::CLIError,
@@ -329,10 +319,6 @@ module Bolt
           raise Bolt::CLIError,
                 "Option '--env-var' may only be specified when running a command or script"
         end
-      end
-
-      if options.key?(:debug) && options.key?(:log)
-        raise Bolt::CLIError, "Only one of '--debug' or '--log-level' may be specified"
       end
     end
 
@@ -528,7 +514,6 @@ module Bolt
 
         elapsed_time = Benchmark.realtime do
           executor_opts = {}
-          executor_opts[:description] = options[:description] if options.key?(:description)
           executor_opts[:env_vars] = options[:env_vars] if options.key?(:env_vars)
           executor.subscribe(outputter)
           executor.subscribe(log_outputter)
@@ -545,8 +530,7 @@ module Bolt
                            targets,
                            options[:task_options],
                            executor,
-                           inventory,
-                           options[:description])
+                           inventory)
             when 'file'
               src = options[:object]
               dest = options[:leftovers].first
@@ -669,7 +653,6 @@ module Bolt
 
       plan_context = { plan_name: plan_name,
                        params: plan_arguments }
-      plan_context[:description] = options[:description] if options[:description]
 
       executor = Bolt::Executor.new(config.concurrency, analytics, options[:noop], config.modified_concurrency)
       if %w[human rainbow].include?(options.fetch(:format, 'human'))

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -66,42 +66,6 @@ module Bolt
       new(project, data, overrides)
     end
 
-    def self.from_file(configfile, overrides = {})
-      project      = Bolt::Project.create_project(Pathname.new(configfile).expand_path.dirname)
-      logs         = []
-      deprecations = []
-
-      conf = if project.project_file == project.config_file
-               project.data
-             else
-               c = Bolt::Util.read_yaml_hash(configfile, 'config')
-
-               # Validate the config against the schema. This will raise a single error
-               # with all validation errors.
-               Bolt::Validator.new.tap do |validator|
-                 validator.validate(c, bolt_schema, project.config_file.to_s)
-
-                 validator.warnings.each { |warning| logs << { warn: warning } }
-
-                 validator.deprecations.each do |dep|
-                   deprecations << { type: "#{BOLT_CONFIG_NAME} #{dep[:option]}", msg: dep[:message] }
-                 end
-               end
-
-               logs << { debug: "Loaded configuration from #{configfile}" }
-               c
-             end
-
-      data = load_defaults(project).push(
-        filepath:     configfile,
-        data:         conf,
-        logs:         logs,
-        deprecations: deprecations
-      )
-
-      new(project, data, overrides)
-    end
-
     # Builds a hash of definitions for transport configuration.
     #
     def self.transport_definitions
@@ -356,15 +320,6 @@ module Bolt
         overrides[transport] = opts.slice(*config.options)
       end
 
-      # Set console log to debug if in debug mode
-      if options[:debug]
-        overrides['log'] = { 'console' => { 'level' => 'debug' } }
-      end
-
-      if options[:puppetfile_path]
-        @puppetfile = options[:puppetfile_path]
-      end
-
       overrides['trace'] = opts['trace'] if opts.key?('trace')
 
       # Validate the overrides
@@ -517,7 +472,7 @@ module Bolt
     end
 
     def puppetfile
-      @puppetfile || @project.puppetfile
+      @project.puppetfile
     end
 
     def modulepath

--- a/pwsh_module/command.tests.ps1
+++ b/pwsh_module/command.tests.ps1
@@ -55,7 +55,7 @@ Describe "test bolt command syntax" {
     It "has correct number of parameters" {
       ($command.Parameters.Values | Where-Object {
           $_.name -notin $common
-      } | measure-object).Count | Should -Be 39
+      } | measure-object).Count | Should -Be 36
     }
   }
 
@@ -73,7 +73,7 @@ Describe "test bolt command syntax" {
     It "has correct number of parameters" {
       ($command.Parameters.Values | Where-Object {
         $_.name -notin $common
-      } | measure-object).Count | Should -Be 36
+      } | measure-object).Count | Should -Be 33
     }
   }
 
@@ -95,7 +95,7 @@ Describe "test bolt command syntax" {
     It "has correct number of parameters" {
       ($command.Parameters.Values | Where-Object {
         $_.name -notin $common
-      } | measure-object).Count | Should -Be 37
+      } | measure-object).Count | Should -Be 34
     }
   }
 
@@ -107,7 +107,7 @@ Describe "test bolt command syntax" {
     It "has correct number of parameters" {
       ($command.Parameters.Values | Where-Object {
         $_.name -notin $common
-      } | measure-object).Count | Should -Be 12
+      } | measure-object).Count | Should -Be 9
     }
 
   }

--- a/rakelib/pwsh.rake
+++ b/rakelib/pwsh.rake
@@ -276,10 +276,10 @@ namespace :pwsh do
           end
         end
 
-        # verbose and debug are commonparameters and are already present in the
-        # pwsh cmdlets, so they are omitted here to prevent them from being
+        # verbose is a commonparameter and is already present in the
+        # pwsh cmdlets, so it is omitted here to prevent it from being
         # added twice
-        help_text[:flags].reject { |o| o =~ /verbose|debug|help|version/ }.map do |option|
+        help_text[:flags].reject { |o| o =~ /verbose|help|version/ }.map do |option|
           ruby_param = parser.top.long[option]
           pwsh_name = option.split("-").map(&:capitalize).join
           case pwsh_name
@@ -311,11 +311,10 @@ namespace :pwsh do
           end
 
           # Only one of --targets , --rerun , or --query can be used
-          # Only one of --configfile or --boltdir can be used
           case pwsh_name.downcase
           when 'user', 'password', 'privatekey', 'concurrency',
             'compileconcurrency', 'connecttimeout', 'modulepath', 'targets',
-            'query', 'configfile', 'boltdir'
+            'query'
             pwsh_param[:validate_not_null_or_empty] = true
           when 'transport'
             pwsh_param[:validate_set] = Bolt::Config::Options::TRANSPORT_CONFIG.keys
@@ -344,10 +343,9 @@ namespace :pwsh do
           @pwsh_command[:options] << pwsh_param
         end
 
-        # we add debug and verbose back in when building the command to send to
-        # bolt, so add them back to the global mapping here
+        # we add verbose back in when building the command to send to
+        # bolt, so add it back to the global mapping here
         # this allows us to not have any filtering logic inside the erb
-        @mapped_options['Debug'] = 'debug'
         @mapped_options['Verbose'] = 'verbose'
 
         # maintain a global list of pwsh parameter => ruby parameter

--- a/resources/bolt_bash_completion.sh
+++ b/resources/bolt_bash_completion.sh
@@ -12,11 +12,11 @@ _bolt() {
 	[[ ${#COMP_WORDS[@]} -gt 2 ]] && local prevprev=${COMP_WORDS[COMP_CWORD - 2]}
 	local next=""
 
-	local all_options="--cleanup --color -c --concurrency --configfile --connect-timeout --debug --description --format -h --help --host-key-check -i --inventoryfile --log-level -m --modulepath --no-cleanup --no-color --no-host-key-check --no-ssl --no-ssl-verify --no-tty --noop -p --password --password-prompt --private-key --project -q --query --run-as --ssl --ssl-verify --sudo-executable --sudo-password --sudo-password-prompt --tmpdir --trace --transport --tty -u --user -v --verbose --version"
+	local all_options="--cleanup --color -c --concurrency --connect-timeout --format -h --help --host-key-check -i --inventoryfile --log-level -m --modulepath --no-cleanup --no-color --no-host-key-check --no-ssl --no-ssl-verify --no-tty --noop -p --password --password-prompt --private-key --project -q --query --run-as --ssl --ssl-verify --sudo-executable --sudo-password --sudo-password-prompt --tmpdir --trace --transport --tty -u --user -v --verbose --version"
 
-	local general_opts="-h --help --debug --format --version"
+	local general_opts="-h --help --format --version"
 	local targeting_opts="-t --targets -q --query --rerun --save-rerun --no-save-rerun"
-	local project_config_opts="--project --configfile"
+	local project_config_opts="--project"
 
 	local inventory_list_cache_file="/tmp/bolt_inventory_cache_list.$$.tmp"
 
@@ -62,7 +62,7 @@ _bolt() {
 		next="install show-modules generate-types"
 		;;
 	install)
-		next="--log-level -m --modulepath --puppetfile ${project_config_opts}"
+		next="--log-level -m --modulepath ${project_config_opts}"
 		;;
 	show-modules | generate-types)
 		next="--log-level -m --modulepath ${project_config_opts}"
@@ -74,7 +74,7 @@ _bolt() {
 		if [ "$prevprev" == "group" ]; then
 			next="${project_config_opts} -i --inventoryfile --log-level"
 		elif [ "$prevprev" == "inventory" ]; then
-			next="${targeting_opts} ${project_config_opts} --detail --description -i --inventoryfile --log-level"
+			next="${targeting_opts} ${project_config_opts} --detail -i --inventoryfile --log-level"
 		elif [ "$prevprev" == "plan" ] || [ "$prevprev" == "task" ]; then
 			next="${general_opts} ${project_config_opts} -m --modulepath --filter --format"
 		fi
@@ -124,7 +124,7 @@ _bolt() {
 	--rerun)
 		next="failure success"
 		;;
-	--query | -q | --description | --params | --user | -u | -p | --password | --private-key | --run-as | --sudo-password | --concurrency | -c | --modulepath | --configfile | --inventoryfile | --transport | --connect-timeout | --tmpdir | --format)
+	--query | -q | --params | --user | -u | -p | --password | --private-key | --run-as | --sudo-password | --concurrency | -c | --modulepath | --inventoryfile | --transport | --connect-timeout | --tmpdir | --format)
 		next=""
 		;;
 	*)

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -765,19 +765,7 @@ describe "Bolt::CLI" do
       it "is not sensitive to ordering of debug and verbose" do
         expect(Bolt::Logger).to receive(:configure).with(include('console' => { level: 'debug' }), true)
 
-        cli = Bolt::CLI.new(%w[command run uptime --targets foo --debug --verbose])
-        cli.parse
-      end
-
-      it "errors when debug and log-level are both set" do
-        cli = Bolt::CLI.new(%w[command run uptime --targets foo --debug --log-level notice])
-        expect { cli.parse }.to raise_error(Bolt::CLIError, /Only one of '--debug' or '--log-level' may be specified/)
-      end
-
-      it "warns when using debug" do
-        expect(Bolt::Logger).to receive(:deprecation_warning)
-          .with(anything, /Command line option '--debug' is deprecated/)
-        cli = Bolt::CLI.new(%w[command run uptime --targets foo --debug])
+        cli = Bolt::CLI.new(%w[command run uptime --targets foo --log-level debug --verbose])
         cli.parse
       end
 
@@ -850,19 +838,6 @@ describe "Bolt::CLI" do
           cli.parse
         }.to raise_error(Bolt::CLIError,
                          /Option '--modulepath' needs a parameter/)
-      end
-    end
-
-    describe "puppetfile" do
-      let(:puppetfile) { File.expand_path('/path/to/Puppetfile') }
-      let(:cli) { Bolt::CLI.new(%W[puppetfile install --puppetfile #{puppetfile}]) }
-
-      it 'uses a specified Puppetfile' do
-        cli.parse
-        expect(cli.config.puppetfile.to_s).to eq(puppetfile)
-        output = @log_output.readlines
-        # We'll have to remove this test soon anyway, may as well throw in a quick check
-        expect(output).to include(/Command line option '--puppetfile' is deprecated,/)
       end
     end
 

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -106,35 +106,6 @@ describe Bolt::Config do
     end
   end
 
-  describe "::from_file" do
-    let(:path) { File.expand_path('/path/to/config.yaml') }
-    let(:dir) { Bolt::Util.windows? ? "D:/path/to" : "/path/to" }
-    let(:proj_path) { File.join(dir, "bolt-project.yaml") }
-
-    it 'loads from the specified config file' do
-      allow(File).to receive(:directory?).with(Pathname.new(dir)).and_return(true)
-      allow(Bolt::Util).to receive(:read_optional_yaml_hash).and_return({})
-      allow(Bolt::Util).to receive(:read_yaml_hash).and_return({})
-      expect(Bolt::Util).to receive(:read_yaml_hash)
-        .with(path, 'config')
-        .and_return({})
-      expect(Bolt::Util).to receive(:read_optional_yaml_hash)
-        .with(proj_path, "project")
-        .and_return({})
-
-      Bolt::Config.from_file(path)
-    end
-
-    it "fails if the config file doesn't exist" do
-      allow(File).to receive(:directory?).with(Pathname.new(dir)).and_return(true)
-      expect(File).to receive(:open).with(path, anything).and_raise(Errno::ENOENT)
-
-      expect do
-        Bolt::Config.from_file(path)
-      end.to raise_error(Bolt::FileError)
-    end
-  end
-
   describe '::load_defaults' do
     shared_examples 'config defaults' do
       it 'defaults to bolt.yaml' do


### PR DESCRIPTION
This removes support for deprecated command-line options:

- `--boltdir`
- `--configfile`
- `--debug`
- `--description`
- `--puppetfile`

This also removes the `Bolt::Config.from_file` factory method, since it
is only used when using the `--configfile` command-line option.

!removal

* **Remove deprecated command-line options**
  ([#2559](#2559))

  The `--boltdir`, `--configfile`, `--debug`, `--description`, and
  `--puppetfile` command-line options have been removed.