### PR TITLE
(GH-2553) Remove deprecated config options

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -492,7 +492,7 @@ module Bolt
           code = generate_types
         when 'install'
           code = install_puppetfile(
-            config.puppetfile_config,
+            {},
             config.puppetfile,
             config.modulepath.first
           )

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -53,42 +53,6 @@ module Bolt
       # Definitions used to validate config options.
       # https://github.com/puppetlabs/bolt/blob/main/schemas/README.md
       OPTIONS = {
-        "apply_settings" => {
-          description: "A map of Puppet settings to use when applying Puppet code using the `apply` "\
-                       "plan function or the `bolt apply` command.",
-          type: Hash,
-          properties: {
-            "evaltrace" => {
-              description: "Whether each resource should log when it is being evaluated.",
-              type: [TrueClass, FalseClass],
-              _example: true,
-              _default: false
-            },
-            "log_level" => {
-              description: "The log level for logs in apply reports from Puppet. These can be seen "\
-                           "in ApplyResults.",
-              type: String,
-              enum: %w[debug info notice warning err alert emerg crit],
-              _example: "debug",
-              _default: "notice"
-            },
-            "show_diff" => {
-              description: "Whether to log and report a contextual diff.",
-              type: [TrueClass, FalseClass],
-              _example: true,
-              _default: false
-            },
-            "trace" => {
-              description: "Whether to print stack traces on some errors. Will print internal Ruby "\
-                           "stack trace interleaved with Puppet function frames.",
-              type: [TrueClass, FalseClass],
-              _example: true,
-              _default: false
-            }
-          },
-          _plugin: false,
-          _deprecation: "This option will be removed in Bolt 3.0. Use `apply-settings` instead."
-        },
         "apply-settings" => {
           description: "A map of Puppet settings to use when applying Puppet code using the `apply` "\
                        "plan function or the `bolt apply` command.",
@@ -170,18 +134,6 @@ module Bolt
           type: Hash,
           _plugin: false,
           _example: {}
-        },
-        "inventoryfile" => {
-          description: "The path to a structured data inventory file used to refer to groups of targets on the "\
-                       "command line and from plans. Read more about using inventory files in [Inventory "\
-                       "files](inventory_file_v2.md).",
-          type: String,
-          _plugin: false,
-          _deprecation: "This option will be removed in Bolt 3.0. Use the `--inventoryfile` command-line option "\
-                        "to use a non-default inventory file or move the file contents to `inventory.yaml` in the "\
-                        "project directory.",
-          _example: "~/.puppetlabs/bolt/inventory.yaml",
-          _default: "project/inventory.yaml"
         },
         "plugin-cache" => {
           description: "This feature is experimental. Enable plugin caching and set the time-to-live.",
@@ -354,16 +306,6 @@ module Bolt
           _plugin: false,
           _example: ["myproject", "myproject::foo", "myproject::bar", "myproject::deploy::*"]
         },
-        "plugin_hooks" => {
-          description: "A map of [plugin hooks](writing_plugins.md#hooks) and which plugins a hook should use. "\
-                       "The only configurable plugin hook is `puppet_library`, which can use two possible plugins: "\
-                       "[`puppet_agent`](https://github.com/puppetlabs/puppetlabs-puppet_agent#puppet_agentinstall) "\
-                       "and [`task`](using_plugins.md#task).",
-          type: Hash,
-          _plugin: true,
-          _example: { "puppet_library" => { "plugin" => "puppet_agent", "version" => "6.15.0", "_run_as" => "root" } },
-          _deprecation: "This option will be removed in Bolt 3.0. Use `plugin-hooks` instead."
-        },
         "plugin-hooks" => {
           description: "A map of [plugin hooks](writing_plugins.md#hooks) and which plugins a hook should use. "\
                        "The only configurable plugin hook is `puppet_library`, which can use two possible plugins: "\
@@ -440,42 +382,6 @@ module Bolt
             }
           },
           _plugin: true
-        },
-        "puppetfile" => {
-          description: "A map containing options for the `bolt puppetfile install` command and "\
-                       "`Install-BoltPuppetfile` cmdlet.",
-          type: Hash,
-          properties: {
-            "forge" => {
-              description: "A subsection that can have its own `proxy` setting to set an HTTP proxy for Forge "\
-                           "operations only, and a `baseurl` setting to specify a different Forge host.",
-              type: Hash,
-              properties: {
-                "baseurl" => {
-                  description: "The URL to the Forge host.",
-                  type: String,
-                  format: "uri",
-                  _example: "https://forge.example.com"
-                },
-                "proxy" => {
-                  description: "The HTTP proxy to use for Forge operations.",
-                  type: String,
-                  format: "uri",
-                  _example: "https://my-forge-proxy.com:8080"
-                }
-              },
-              _example: { "baseurl" => "https://forge.example.com", "proxy" => "https://my-forge-proxy.com:8080" }
-            },
-            "proxy" => {
-              description: "The HTTP proxy to use for Git and Forge operations.",
-              type: String,
-              format: "uri",
-              _example: "https://my-proxy.com:8080"
-            }
-          },
-          _deprecation: "This option will be removed in Bolt 3.0. Update your project to use the module "\
-                        "management feature. For more information, see https://pup.pt/bolt-module-migrate.",
-          _plugin: false
         },
         "save-rerun" => {
           description: "Whether to update `.rerun.json` in the Bolt project directory. If "\
@@ -575,20 +481,16 @@ module Bolt
       # Options that are available in a bolt.yaml file
       BOLT_OPTIONS = %w[
         apply-settings
-        apply_settings
         color
         compile-concurrency
         concurrency
         format
         hiera-config
-        inventoryfile
         log
         modulepath
         plugin-hooks
-        plugin_hooks
         plugins
         puppetdb
-        puppetfile
         save-rerun
         spinner
         trusted-external-command
@@ -605,10 +507,8 @@ module Bolt
         module-install
         plugin-cache
         plugin-hooks
-        plugin_hooks
         plugins
         puppetdb
-        puppetfile
         save-rerun
         spinner
       ].freeze
@@ -616,13 +516,11 @@ module Bolt
       # Options that are available in a bolt-project.yaml file
       BOLT_PROJECT_OPTIONS = %w[
         apply-settings
-        apply_settings
         color
         compile-concurrency
         concurrency
         format
         hiera-config
-        inventoryfile
         log
         modulepath
         module-install
@@ -631,10 +529,8 @@ module Bolt
         plans
         plugin-cache
         plugin-hooks
-        plugin_hooks
         plugins
         puppetdb
-        puppetfile
         save-rerun
         spinner
         tasks

--- a/schemas/bolt-config.schema.json
+++ b/schemas/bolt-config.schema.json
@@ -7,9 +7,6 @@
     "apply-settings": {
       "$ref": "#/definitions/apply-settings"
     },
-    "apply_settings": {
-      "$ref": "#/definitions/apply_settings"
-    },
     "color": {
       "$ref": "#/definitions/color"
     },
@@ -25,9 +22,6 @@
     "hiera-config": {
       "$ref": "#/definitions/hiera-config"
     },
-    "inventoryfile": {
-      "$ref": "#/definitions/inventoryfile"
-    },
     "log": {
       "$ref": "#/definitions/log"
     },
@@ -37,17 +31,11 @@
     "plugin-hooks": {
       "$ref": "#/definitions/plugin-hooks"
     },
-    "plugin_hooks": {
-      "$ref": "#/definitions/plugin_hooks"
-    },
     "plugins": {
       "$ref": "#/definitions/plugins"
     },
     "puppetdb": {
       "$ref": "#/definitions/puppetdb"
-    },
-    "puppetfile": {
-      "$ref": "#/definitions/puppetfile"
     },
     "save-rerun": {
       "$ref": "#/definitions/save-rerun"
@@ -113,38 +101,6 @@
         }
       }
     },
-    "apply_settings": {
-      "description": "A map of Puppet settings to use when applying Puppet code using the `apply` plan function or the `bolt apply` command.",
-      "type": "object",
-      "properties": {
-        "evaltrace": {
-          "description": "Whether each resource should log when it is being evaluated.",
-          "type": "boolean"
-        },
-        "log_level": {
-          "description": "The log level for logs in apply reports from Puppet. These can be seen in ApplyResults.",
-          "type": "string",
-          "enum": [
-            "debug",
-            "info",
-            "notice",
-            "warning",
-            "err",
-            "alert",
-            "emerg",
-            "crit"
-          ]
-        },
-        "show_diff": {
-          "description": "Whether to log and report a contextual diff.",
-          "type": "boolean"
-        },
-        "trace": {
-          "description": "Whether to print stack traces on some errors. Will print internal Ruby stack trace interleaved with Puppet function frames.",
-          "type": "boolean"
-        }
-      }
-    },
     "color": {
       "description": "Whether to use colored output when printing messages to the console.",
       "type": "boolean"
@@ -170,10 +126,6 @@
     },
     "hiera-config": {
       "description": "The path to the Hiera configuration file.",
-      "type": "string"
-    },
-    "inventoryfile": {
-      "description": "The path to a structured data inventory file used to refer to groups of targets on the command line and from plans. Read more about using inventory files in [Inventory files](inventory_file_v2.md).",
       "type": "string"
     },
     "log": {
@@ -249,17 +201,6 @@
       }
     },
     "plugin-hooks": {
-      "description": "A map of [plugin hooks](writing_plugins.md#hooks) and which plugins a hook should use. The only configurable plugin hook is `puppet_library`, which can use two possible plugins: [`puppet_agent`](https://github.com/puppetlabs/puppetlabs-puppet_agent#puppet_agentinstall) and [`task`](using_plugins.md#task).",
-      "oneOf": [
-        {
-          "type": "object"
-        },
-        {
-          "$ref": "#/definitions/_plugin"
-        }
-      ]
-    },
-    "plugin_hooks": {
       "description": "A map of [plugin hooks](writing_plugins.md#hooks) and which plugins a hook should use. The only configurable plugin hook is `puppet_library`, which can use two possible plugins: [`puppet_agent`](https://github.com/puppetlabs/puppetlabs-puppet_agent#puppet_agentinstall) and [`task`](using_plugins.md#task).",
       "oneOf": [
         {
@@ -375,33 +316,6 @@
           "$ref": "#/definitions/_plugin"
         }
       ]
-    },
-    "puppetfile": {
-      "description": "A map containing options for the `bolt puppetfile install` command and `Install-BoltPuppetfile` cmdlet.",
-      "type": "object",
-      "properties": {
-        "forge": {
-          "description": "A subsection that can have its own `proxy` setting to set an HTTP proxy for Forge operations only, and a `baseurl` setting to specify a different Forge host.",
-          "type": "object",
-          "properties": {
-            "baseurl": {
-              "description": "The URL to the Forge host.",
-              "type": "string",
-              "format": "uri"
-            },
-            "proxy": {
-              "description": "The HTTP proxy to use for Forge operations.",
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        "proxy": {
-          "description": "The HTTP proxy to use for Git and Forge operations.",
-          "type": "string",
-          "format": "uri"
-        }
-      }
     },
     "save-rerun": {
       "description": "Whether to update `.rerun.json` in the Bolt project directory. If your target names include passwords, set this value to `false` to avoid writing passwords to disk.",

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -31,17 +31,11 @@
     "plugin-hooks": {
       "$ref": "#/definitions/plugin-hooks"
     },
-    "plugin_hooks": {
-      "$ref": "#/definitions/plugin_hooks"
-    },
     "plugins": {
       "$ref": "#/definitions/plugins"
     },
     "puppetdb": {
       "$ref": "#/definitions/puppetdb"
-    },
-    "puppetfile": {
-      "$ref": "#/definitions/puppetfile"
     },
     "save-rerun": {
       "$ref": "#/definitions/save-rerun"
@@ -215,17 +209,6 @@
         }
       ]
     },
-    "plugin_hooks": {
-      "description": "A map of [plugin hooks](writing_plugins.md#hooks) and which plugins a hook should use. The only configurable plugin hook is `puppet_library`, which can use two possible plugins: [`puppet_agent`](https://github.com/puppetlabs/puppetlabs-puppet_agent#puppet_agentinstall) and [`task`](using_plugins.md#task).",
-      "oneOf": [
-        {
-          "type": "object"
-        },
-        {
-          "$ref": "#/definitions/_plugin"
-        }
-      ]
-    },
     "plugins": {
       "description": "A map of plugins and their configuration data, where each key is the name of a plugin and its value is a map of configuration data. Configurable options are specified by the plugin. Read more about configuring plugins in [Using plugins](using_plugins.md#configuring-plugins).",
       "type": "object",
@@ -331,33 +314,6 @@
           "$ref": "#/definitions/_plugin"
         }
       ]
-    },
-    "puppetfile": {
-      "description": "A map containing options for the `bolt puppetfile install` command and `Install-BoltPuppetfile` cmdlet.",
-      "type": "object",
-      "properties": {
-        "forge": {
-          "description": "A subsection that can have its own `proxy` setting to set an HTTP proxy for Forge operations only, and a `baseurl` setting to specify a different Forge host.",
-          "type": "object",
-          "properties": {
-            "baseurl": {
-              "description": "The URL to the Forge host.",
-              "type": "string",
-              "format": "uri"
-            },
-            "proxy": {
-              "description": "The HTTP proxy to use for Forge operations.",
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        "proxy": {
-          "description": "The HTTP proxy to use for Git and Forge operations.",
-          "type": "string",
-          "format": "uri"
-        }
-      }
     },
     "save-rerun": {
       "description": "Whether to update `.rerun.json` in the Bolt project directory. If your target names include passwords, set this value to `false` to avoid writing passwords to disk.",

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -7,9 +7,6 @@
     "apply-settings": {
       "$ref": "#/definitions/apply-settings"
     },
-    "apply_settings": {
-      "$ref": "#/definitions/apply_settings"
-    },
     "color": {
       "$ref": "#/definitions/color"
     },
@@ -24,9 +21,6 @@
     },
     "hiera-config": {
       "$ref": "#/definitions/hiera-config"
-    },
-    "inventoryfile": {
-      "$ref": "#/definitions/inventoryfile"
     },
     "log": {
       "$ref": "#/definitions/log"
@@ -52,17 +46,11 @@
     "plugin-hooks": {
       "$ref": "#/definitions/plugin-hooks"
     },
-    "plugin_hooks": {
-      "$ref": "#/definitions/plugin_hooks"
-    },
     "plugins": {
       "$ref": "#/definitions/plugins"
     },
     "puppetdb": {
       "$ref": "#/definitions/puppetdb"
-    },
-    "puppetfile": {
-      "$ref": "#/definitions/puppetfile"
     },
     "save-rerun": {
       "$ref": "#/definitions/save-rerun"
@@ -84,38 +72,6 @@
       "properties": {
         "evaltrace": {
           "description": "Whether each resource should log when it is being evaluated. This allows you to interactively see exactly what is being done.",
-          "type": "boolean"
-        },
-        "log_level": {
-          "description": "The log level for logs in apply reports from Puppet. These can be seen in ApplyResults.",
-          "type": "string",
-          "enum": [
-            "debug",
-            "info",
-            "notice",
-            "warning",
-            "err",
-            "alert",
-            "emerg",
-            "crit"
-          ]
-        },
-        "show_diff": {
-          "description": "Whether to log and report a contextual diff.",
-          "type": "boolean"
-        },
-        "trace": {
-          "description": "Whether to print stack traces on some errors. Will print internal Ruby stack trace interleaved with Puppet function frames.",
-          "type": "boolean"
-        }
-      }
-    },
-    "apply_settings": {
-      "description": "A map of Puppet settings to use when applying Puppet code using the `apply` plan function or the `bolt apply` command.",
-      "type": "object",
-      "properties": {
-        "evaltrace": {
-          "description": "Whether each resource should log when it is being evaluated.",
           "type": "boolean"
         },
         "log_level": {
@@ -167,10 +123,6 @@
     },
     "hiera-config": {
       "description": "The path to the Hiera configuration file.",
-      "type": "string"
-    },
-    "inventoryfile": {
-      "description": "The path to a structured data inventory file used to refer to groups of targets on the command line and from plans. Read more about using inventory files in [Inventory files](inventory_file_v2.md).",
       "type": "string"
     },
     "log": {
@@ -348,17 +300,6 @@
         }
       ]
     },
-    "plugin_hooks": {
-      "description": "A map of [plugin hooks](writing_plugins.md#hooks) and which plugins a hook should use. The only configurable plugin hook is `puppet_library`, which can use two possible plugins: [`puppet_agent`](https://github.com/puppetlabs/puppetlabs-puppet_agent#puppet_agentinstall) and [`task`](using_plugins.md#task).",
-      "oneOf": [
-        {
-          "type": "object"
-        },
-        {
-          "$ref": "#/definitions/_plugin"
-        }
-      ]
-    },
     "plugins": {
       "description": "A map of plugins and their configuration data, where each key is the name of a plugin and its value is a map of configuration data. Configurable options are specified by the plugin. Read more about configuring plugins in [Using plugins](using_plugins.md#configuring-plugins).",
       "type": "object",
@@ -464,33 +405,6 @@
           "$ref": "#/definitions/_plugin"
         }
       ]
-    },
-    "puppetfile": {
-      "description": "A map containing options for the `bolt puppetfile install` command and `Install-BoltPuppetfile` cmdlet.",
-      "type": "object",
-      "properties": {
-        "forge": {
-          "description": "A subsection that can have its own `proxy` setting to set an HTTP proxy for Forge operations only, and a `baseurl` setting to specify a different Forge host.",
-          "type": "object",
-          "properties": {
-            "baseurl": {
-              "description": "The URL to the Forge host.",
-              "type": "string",
-              "format": "uri"
-            },
-            "proxy": {
-              "description": "The HTTP proxy to use for Forge operations.",
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        "proxy": {
-          "description": "The HTTP proxy to use for Git and Forge operations.",
-          "type": "string",
-          "format": "uri"
-        }
-      }
     },
     "save-rerun": {
       "description": "Whether to update `.rerun.json` in the Bolt project directory. If your target names include passwords, set this value to `false` to avoid writing passwords to disk.",

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -237,55 +237,6 @@ describe Bolt::Config do
         /The inventoryfile .* does not exist/
       )
     end
-
-    context 'puppetfile config' do
-      let(:data) do
-        {
-          'puppetfile' => {
-            'proxy' => 'https://proxy.example.com'
-          },
-          'module-install' => {
-            'proxy' => 'https://proxy.example.com'
-          }
-        }
-      end
-
-      let(:config) { Bolt::Config.new(project, data) }
-
-      context 'with modules configured' do
-        let(:project_config) { { 'modules' => [] } }
-
-        it 'warns when puppetfile is configured but not module-install' do
-          data.delete('module-install')
-
-          expect(config.logs).to include(
-            warn: /Detected configuration for 'puppetfile'.*'modules' is configured/
-          )
-        end
-
-        it 'warns when both puppetfile and module-install are configured' do
-          expect(config.logs).to include(
-            warn: /Detected configuration for 'puppetfile' and 'module-install'.*'modules' is also configured/
-          )
-        end
-      end
-
-      context 'without modules configured' do
-        it 'warns when module-install is configured but not puppetfile' do
-          data.delete('puppetfile')
-
-          expect(config.logs).to include(
-            warn: /Detected configuration for 'module-install'.*'modules' is not configured/
-          )
-        end
-
-        it 'warns when both puppetfile and module-install are configured' do
-          expect(config.logs).to include(
-            warn: /Detected configuration for 'puppetfile' and 'module-install'.*'modules' is not configured/
-          )
-        end
-      end
-    end
   end
 
   describe 'expanding paths' do

--- a/spec/bolt_server/transport_app_spec.rb
+++ b/spec/bolt_server/transport_app_spec.rb
@@ -1000,19 +1000,6 @@ describe "BoltServer::TransportApp" do
         end
       end
 
-      # TODO: Remove this test for Bolt 3.0. 'inventoryfile' will no longer be configurable
-      # in bolt-project.yaml.
-      it 'disallows non-default inventoryfiles' do
-        non_default_inventoryfile = 'foo.yaml'
-        non_default_inventoryfile_conf = bolt_project.merge({ 'inventoryfile' => non_default_inventoryfile })
-        with_project(non_default_inventoryfile_conf, bolt_inventory, non_default_inventoryfile) do |path_to_tmp_project|
-          versioned_project = path_to_tmp_project.split(File::SEPARATOR).last
-          post_to_project_inventory_targets(versioned_project)
-          expect(last_response.status).to eq(500)
-          expect(last_response.body).to match(/Project inventory must be defined in .*inventory.yaml.*/)
-        end
-      end
-
       it 'errors when versioned_project is invalid' do
         post_to_project_inventory_targets('foo')
         expect(last_response.status).to eq(500)


### PR DESCRIPTION
This removes support for deprecated config options:

- `apply_settings`
- `inventoryfile`
- `plugin_hooks`
- `puppetfile`

!removal

* **Remove deprecated configuration options**
  ([#2553](https://github.com/puppetlabs/bolt/issues/2553))

  The `apply_settings`, `inventoryfile`, `plugin_hooks`, and
  `puppetfile` configuration options have been removed.