### PR TITLE
(maint) Update puppetlabs-yaml branch to main in spec tests

### DIFF
--- a/spec/bolt/module_installer/specs/git_spec_spec.rb
+++ b/spec/bolt/module_installer/specs/git_spec_spec.rb
@@ -132,7 +132,7 @@ describe Bolt::ModuleInstaller::Specs::GitSpec do
     end
 
     context 'with a valid branch' do
-      let(:ref) { 'master' }
+      let(:ref) { 'main' }
 
       it 'resolves and returns a SHA' do
         expect(spec.sha).to be_a(String)


### PR DESCRIPTION
This updates the branch used for git_spec spec tests to use the `main`
branch instead of `master`, as the `master` branch has been renamed to
`main` for that repository.

!no-release-note