### PR TITLE
(maint) Update Puppet modules

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -7,7 +7,7 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '1.4.0'
 mod 'puppetlabs-puppet_agent', '4.4.0'
-mod 'puppetlabs-facts', '1.3.0'
+mod 'puppetlabs-facts', '1.4.0'
 
 # Core types and providers for Puppet 6
 mod 'puppetlabs-augeas_core', '1.1.1'
@@ -24,21 +24,21 @@ mod 'puppetlabs-zone_core', '1.0.3'
 # Useful additional modules
 mod 'puppetlabs-package', '1.4.0'
 mod 'puppetlabs-puppet_conf', '0.8.0'
-mod 'puppetlabs-python_task_helper', '0.4.3'
+mod 'puppetlabs-python_task_helper', '0.5.0'
 mod 'puppetlabs-reboot', '3.2.0'
-mod 'puppetlabs-ruby_task_helper', '0.5.1'
-mod 'puppetlabs-ruby_plugin_helper', '0.1.0'
+mod 'puppetlabs-ruby_task_helper', '0.6.0'
+mod 'puppetlabs-ruby_plugin_helper', '0.2.0'
 mod 'puppetlabs-stdlib', '6.5.0'
 
 # Plugin modules
-mod 'puppetlabs-aws_inventory', '0.5.2'
-mod 'puppetlabs-azure_inventory', '0.4.1'
-mod 'puppetlabs-gcloud_inventory', '0.1.3'
+mod 'puppetlabs-aws_inventory', '0.6.0'
+mod 'puppetlabs-azure_inventory', '0.5.0'
+mod 'puppetlabs-gcloud_inventory', '0.2.0'
 mod 'puppetlabs-http_request', '0.2.1'
 mod 'puppetlabs-pkcs7', '0.1.1'
-mod 'puppetlabs-secure_env_vars', '0.1.0'
-mod 'puppetlabs-terraform', '0.5.0'
-mod 'puppetlabs-vault', '0.3.0'
+mod 'puppetlabs-secure_env_vars', '0.2.0'
+mod 'puppetlabs-terraform', '0.6.1'
+mod 'puppetlabs-vault', '0.4.0'
 mod 'puppetlabs-yaml', '0.2.0'
 
 # If we don't list these modules explicitly, r10k will purge them


### PR DESCRIPTION
This pulls in updates to the Puppet modules that include allowing them
to be used with Puppet 7.x. Updates are to the maximum Puppet version,
not the minimum, so this is safe to merge to the 2.x series.

!feature

* **Bolt modules usable with Puppet 7.x**

  Modules owned by the Bolt team now have a maximum Puppet version of 8,
  so are usable with Puppet 7 on the Bolt controller.