### PR TITLE
(Docs) 3.0 docs updates - modulepath, bolt.yaml

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -91,25 +91,6 @@ To generate this documentation, run:
 $ bundle exec rake docs:function_reference
 ```
 
-### ⛔ `bolt.yaml` options
-
-⛔ `bolt.yaml` is deprecated and will be removed in a future version of Bolt.
-
-**Documentation page**
-- https://puppet.com/docs/bolt/latest/bolt_configuration_reference.html
-
-**Template file**
-- [`bolt_configuration_reference.md.erb`](./templates/bolt_configuration_reference.md.erb)
-
-**Relevant source code**
-- [`config/options.rb`](../lib/bolt/config/options.rb)
-
-To generate this documentation, run:
-
-```shell
-$ bundle exec rake docs:config_reference
-```
-
 ### `bolt-defaults.yaml` options
 
 **Documentation page**

--- a/documentation/configuring_bolt.md
+++ b/documentation/configuring_bolt.md
@@ -16,10 +16,12 @@ project's needs. In general, Bolt configuration falls into four categories:
 - **Inventory data:** Group and configure the targets that you connect to and
   run commands on with Bolt.
 
-Each type of configuration can be set in a different file. You can configure
-Bolt's options and features at a project level, a user level, or a system-wide
-level. Unless your use case requires setting user-specific or system-wide
-configurations, configure Bolt at the project level.
+You can configure Bolt's options and features at a project level, a user level,
+or a system-wide level. At the project level, you set Bolt configuration in the
+`bolt-project.yaml` and `inventory.yaml` files. At the user and system-wide
+levels, set your configuration in the `bolt-defaults.yaml` file. Unless your use
+case requires setting user-specific or system-wide configurations, configure
+Bolt at the project level.
 
 | Type of Configuration | [inventory.yaml](bolt_inventory_reference.md) | [bolt-project.yaml](bolt_project_reference.md) | [bolt-defaults.yaml](bolt_defaults_reference.md) |
 | --- | :-: | :-: | :-: |
@@ -33,7 +35,7 @@ configurations, configure Bolt at the project level.
 
 Most of the time, you'll only need to set configuration at the project level. 
 You can set all configurable options in Bolt at the project level, and any options
-you set within a project only apply to that project. 
+you set within a project only apply to that project.
 
 Bolt loads project-level configuration files from the root of your [Bolt project
 directory](projects.md). If it can't find a project directory,
@@ -58,10 +60,6 @@ such as a list of plans and tasks that are visible to the user. Any directory
 containing a `bolt-project.yaml` file is automatically considered a [Project
 directory](projects.md).
 
-Project configuration files take precedence over `bolt.yaml` files. If a
-project directory contains both files, Bolt will only load and read
-configuration from `bolt-project.yaml`.
-
 You can view a full list of the available options in [`bolt-project.yaml`
 options](bolt_project_reference.md).
 
@@ -71,7 +69,7 @@ options](bolt_project_reference.md).
 
 The inventory file is a structured data file that contains groups of targets
 that you can run Bolt commands on, as well as configuration for the transports
-used to connect to the targets. Most projects will include an inventory file.
+used to connect to the targets. Most projects include an inventory file.
 
 Inventory configuration can be set at multiple levels in an inventory file
 under a `config` option. You can set the following options under `config`:
@@ -87,37 +85,13 @@ under a `config` option. You can set the following options under `config`:
 You can view a full list of the available options in [`inventory.yaml`
 fields](bolt_inventory_reference.md).
 
-### ⛔ `bolt.yaml`
-
-⛔ The `bolt.yaml` file is deprecated and will be removed in a
-future version of Bolt. Use `bolt-project.yaml` and `inventory.yaml` files
-instead.
-
-**Filepath:** `<PROJECT DIRECTORY>/bolt.yaml`
-
-The Bolt configuration file can be used to set all available configuration
-options, including default inventory configuration options. Any directory
-containing a `bolt.yaml` file is automatically considered a [Project
-directory](projects.md).
-
-You can view a full list of the available options in [`bolt.yaml`
-options](bolt_configuration_reference.md).
-
 ## User-level configuration
 
 Use this level to set configuration that should apply to all projects for a
 particular user. Options that you might set at the user-level include paths to
 private keys, credentials for a plugin,
 or default inventory configuration that is common to all of your projects.
-You can set most configurable options in Bolt at the user level. 
-
-
-You can set user-level configuration in two files:
-- Use `bolt-defaults.yaml` for configuration that is
-not project-specific.
-- You can set all configuration in a `bolt.yaml` file. **The user-level
-  `bolt.yaml` file is deprecated and will be removed in a future version of
-  Bolt. Use `bolt-defaults.yaml` instead.**
+You can set most configurable options in Bolt at the user level.
 
 The preferred method for setting user-level configuration is to use a
 `bolt-defaults.yaml` file. This file does not allow you to set project-specific
@@ -132,25 +106,8 @@ The defaults configuration file supports most of Bolt's configuration options,
 with the exception of options that are project-specific such as `modules` and
 `modulepath`.
 
-The `bolt-defaults.yaml` file takes precedence over a `bolt.yaml` file in the
-same directory. If the directory contains both files, Bolt will only load and 
-read configuration from `bolt-defaults.yaml`.
-
 You can view a full list of the available options in [`bolt-defaults.yaml`
 options](bolt_defaults_reference.md).
-
-### ⛔ `bolt.yaml`
-
-⛔ The user-level `bolt.yaml` file is deprecated and will be removed
-in a future version of Bolt. Use a `bolt-defaults.yaml` file instead.
-
-**Filepath:** `~/.puppetlabs/etc/bolt/bolt.yaml`
-
-The Bolt configuration file can be used to set all available configuration
-options, including project-specific configuration options.
-
-You can view a full list of the available options in [`bolt.yaml`
-options](bolt_configuration_reference.md).
 
 ## System-wide configuration
 
@@ -158,13 +115,7 @@ Use this level to set configuration that applies to all users and all projects.
 This might include configuration for connecting to an organization's Forge
 proxy, the number of threads Bolt should use when connecting to targets, or
 setting credentials for connecting to PuppetDB. You can set most configurable
-Bolt options at the system level. 
-
-System-wide configuration can be set in two files.
-- Use `bolt-defaults.yaml` for configuration that is not project-specific.
-- You can set all configuration in a `bolt.yaml` file. ⛔ **The system-level
-  `bolt.yaml` file is deprecated and will be removed in a future version of
-  Bolt. Use `bolt-defaults.yaml` instead.** 
+Bolt options at the system level.
 
 The preferred method for setting user-level configuration is to use a
 `bolt-defaults.yaml` file. This file does not allow you to set project-specific
@@ -181,27 +132,8 @@ The defaults configuration file supports most of Bolt's configuration options,
 with the exception of options that are project-specific such as `inventoryfile`
 and `modulepath`.
 
-The `bolt-defaults.yaml` file takes precedence over a `bolt.yaml` file in the
-same directory. If the directory contains both files, Bolt will only load and 
-read configuration from `bolt-defaults.yaml`.
-
 You can view a full list of the available options in [`bolt-defaults.yaml`
 options](bolt_defaults_reference.md).
-
-### ⛔ `bolt.yaml`
-
-⛔ The system-wide `bolt.yaml` file is deprecated and will be removed
-in a future version of Bolt. Use a `bolt-defaults.yaml` file instead.
-
-**\*nix Filepath:** `/etc/puppetlabs/bolt/bolt.yaml`
-
-**Windows Filepath:** `%PROGRAMDATA%\PuppetLabs\bolt\etc\bolt.yaml`
-
-You can set all available configuration
-options in `bolt.yaml`, including project-specific configuration options.
-
-You can view a full list of the available options in [`bolt.yaml`
-options](bolt_configuration_reference.md).
 
 ## Configuration precedence
 
@@ -350,7 +282,6 @@ disable-warnings:
 📖 **Related information**
 
 - [Bolt projects](projects.md)
-- [bolt.yaml options](bolt_configuration_reference.md)
 - [bolt-defaults.yaml options](bolt_defaults_reference.md)
 - [bolt-project.yaml options](bolt_project_reference.md)
 - [inventory.yaml fields](bolt_inventory_reference.md)

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -325,7 +325,7 @@ ensure that a file is present on each target:
 ```ruby
 $resource = {
   'type'  => File,
-  'title' => '/etc/puppetlabs/bolt.yaml',
+  'title' => '/etc/puppetlabs/bolt/bolt-defaults.yaml',
   'desired_state' => {
     'ensure'  => 'present',
     'content' => "..."
@@ -399,21 +399,24 @@ specified instead of using `net-ssh`. Essentially, using the native SSH
 transport is the same as running SSH on your command line, but with Bolt
 managing the connections.
 
-To use the native SSH transport, set `ssh-command: <SSH>` in
-[bolt.yaml](configuring_bolt.md), where `<SSH>` is the SSH command to run. For
-example:
+To use the native SSH transport, under the `config` option in your inventory
+file, set `native-ssh: true` and `ssh-command: <SSH COMMAND>`, where
+`<SSH COMMAND>` is your native SSH executable.
 
-```
+For example:
+
+```yaml
 ssh:
-  ssh-command: 'ssh'
+  native-ssh: true
+  ssh-command: 'ssh' 
 ```
 
 The value of `ssh-command` can be either a string or an array, and you can
-provide any command-line options to the command. Bolt will append
+provide any command-line options to the command. Bolt appends
 Bolt-configuration settings to the command, as well as the specified target,
 when connecting. Not all Bolt configuration options are supported using the
 native SSH transport, but you can configure most options in your OpenSSH Config.
-See [bolt configuration reference](bolt_configuration_reference.md) for the list
+See [Transport configuration options](bolt_transports_reference.md#ssh) for a list
 of supported Bolt SSH options.
 
 Bolt transports have two main functions: executing remotely, and copying files

--- a/documentation/inventory_file_v2.md
+++ b/documentation/inventory_file_v2.md
@@ -24,7 +24,7 @@ file:
 
 | Key | Description | Type |
 | --- | ----------- | ---- |
-| `config` | The configuration for the `all` group. Optional. For more information see [Bolt configuration options](bolt_configuration_reference.md).  | `Hash` |
+| `config` | The configuration for the `all` group. Optional. For more information see [Configuring Bolt](configuring_bolt.md#inventoryyaml).  | `Hash` |
 | `facts` | The facts for the `all` group. Optional. | `Hash` |
 | `features` | The features for the `all` group. Optional. | `Array[String]`
 | `groups` | A list of targets and groups and their associated configuration. Optional. | `Array[Group]` |
@@ -38,7 +38,7 @@ configuration. Each group is a map that can contain any of the following fields:
 
 | Key | Description | Type |
 | --- | ----------- | ---- |
-| `config` | The configuration for the group. Optional. For more information see [Bolt configuration options](bolt_configuration_reference.md). | `Hash` |
+| `config` | The configuration for the group. Optional. For more information see [Configuring Bolt](configuring_bolt.md#inventoryyaml). | `Hash` |
 | `facts` | The facts for the group. Optional. | `Hash` |
 | `features` | The features for the group. Optional. | `Array[String]`
 | `groups` | A list of groups and their associated configuration. Optional. | `Array[Group]` |
@@ -451,5 +451,4 @@ plugins:
 
 📖 **Related information**
 
-- For more information on configuration options, see [Bolt configuration
-  options](bolt_configuration_reference.md).
+- For more information on configuration options, see [Configuring Bolt](configuring_bolt.md).

--- a/documentation/module_structure.md
+++ b/documentation/module_structure.md
@@ -65,12 +65,12 @@ After you've published the module to the Forge, you can add it to a Bolt project
 using the Bolt command line. For more information, see [Installing
 modules](./bolt_installing_modules.md).
 
-Follow these tips for managing standalone modules:
+Follow these tips and best practices for managing standalone modules:
 -   If you're testing a standalone module inside a project, add `modules/*` to
     the project's `.gitignore` file to prevent accidentally committing the
     module.
--   As a best practice, write automated tests for the tasks and plans in your
-    module, if possible. For information about automated testing patterns, check
+-   Wherever possible, write automated tests for the tasks and plans in your
+    module. For information about automated testing patterns, check
     out these resources: [Example of unit testing plans and integration
     \(acceptance\) testing
     tasks](https://github.com/puppetlabs/puppetlabs-facts) (GitHub) and [Writing

--- a/documentation/projects.md
+++ b/documentation/projects.md
@@ -102,7 +102,7 @@ $ bolt plan show
 myproject::myplan
 
 MODULEPATH:
-/PATH/TO/BOLT_PROJECT/site
+/PATH/TO/BOLT_PROJECT/.modules
 
 Use `bolt plan show <plan-name>` to view details and parameters for a specific plan.
 ```
@@ -151,7 +151,6 @@ The following are common files and directories found in a Bolt project.
 |`hiera.yaml`|Contains the Hiera config to use for target-specific data when using `apply`.|
 |`data/`|The standard path to store static Hiera data files.|
 |`bolt-debug.log`|Contains debug log output for the most recent Bolt command.|
-|[`bolt.yaml`](bolt_configuration_reference.md)|Contains configuration options for Bolt. ⛔ **`bolt.yaml` is deprecated; use `bolt-project.yaml` instead.**|
 | `.modules/` |The directory where Bolt installs modules. Avoid committing this directory to source control.| 
 
 > **Remember:** A directory must have a `bolt-project.yaml` file before Bolt

--- a/documentation/upgrading_to_bolt_3.md
+++ b/documentation/upgrading_to_bolt_3.md
@@ -1,10 +1,11 @@
 # Upgrading to Bolt 3.0
 
-It's almost time for Bolt 3.0! This page contains a list of things you can do to prepare for the
-upcoming release. We'll add to this page as we near the release and implement more of the expected
-changes and deprecations, so if you're making the changes ahead of time, be sure to check in every
-couple weeks to see if we've added anything else to the instructions below. For an exhaustive list
-of the things we're changing, see [Changes coming in Bolt 3.0](developer_updates.md#changes-coming-in-bolt-30).
+Welcome to Bolt 3.0! This page contains a list of the most important things you
+need to know if you've just upgraded.
+
+For an exhaustive list of the things we've changed, see: 
+- [Changes coming in Bolt 3.0](developer_updates.md#changes-coming-in-bolt-30).
+- [Bolt 3.0 Changelog](TODO:insert-link-here)
 
 ## Migrating configuration files
 


### PR DESCRIPTION
- Update some docs that still refer to the old modulepath
- Remove references to bolt.yaml
- Updates Bolt 3.0 welcome page (I have some more updates to this one in a future PR)

Part of #2409
!no-release-note