### PR TITLE
(GH-2560) Remove 'notice' log level

### DIFF
--- a/documentation/running_bolt_in_docker.md
+++ b/documentation/running_bolt_in_docker.md
@@ -120,7 +120,7 @@ This is a basic [project configuration](configuring_bolt.md) file.
 ```yaml
 log:
   console:
-    level: notice
+    level: info
 ```
 
 **`inventory.yaml`**

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -324,13 +324,6 @@ module Bolt
 
         name = normalize_log(key)
         acc[name] = val.slice('append', 'level').transform_keys(&:to_sym)
-
-        next unless acc[name][:level] == 'notice'
-
-        Bolt::Logger.deprecate(
-          "notice_log_level",
-          "Log level 'notice' is deprecated and will be removed in Bolt 3.0. Use 'info' instead."
-        )
       end
     end
 

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -177,7 +177,7 @@ module Bolt
                 "level" => {
                   description: "The type of information to log.",
                   type: String,
-                  enum: %w[trace debug error info notice warn fatal any],
+                  enum: %w[trace debug error info warn fatal any],
                   _default: "warn"
                 }
               }
@@ -196,7 +196,7 @@ module Bolt
               "level" => {
                 description: "The type of information to log.",
                 type: String,
-                enum: %w[trace debug error info notice warn fatal any],
+                enum: %w[trace debug error info warn fatal any],
                 _default: "warn"
               }
             }

--- a/lib/bolt/logger.rb
+++ b/lib/bolt/logger.rb
@@ -4,7 +4,7 @@ require 'logging'
 
 module Bolt
   module Logger
-    LEVELS = %w[trace debug info notice warn error fatal].freeze
+    LEVELS = %w[trace debug info warn error fatal].freeze
 
     # This module is treated as a global singleton so that multiple classes
     # in Bolt can log warnings with IDs. Access to the following variables

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -127,7 +127,6 @@
                 "debug",
                 "error",
                 "info",
-                "notice",
                 "warn",
                 "fatal",
                 "any"
@@ -158,7 +157,6 @@
               "debug",
               "error",
               "info",
-              "notice",
               "warn",
               "fatal",
               "any"

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -157,7 +157,6 @@
                 "debug",
                 "error",
                 "info",
-                "notice",
                 "warn",
                 "fatal",
                 "any"
@@ -188,7 +187,6 @@
               "debug",
               "error",
               "info",
-              "notice",
               "warn",
               "fatal",
               "any"

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -87,10 +87,10 @@ describe Bolt::Applicator do
     expect(applicator.compile(target, input)).to eq({})
     expect(@log_output.readlines).to eq(
       [
-        " DEBUG  Bolt::Executor : Started with 1 max thread(s)\n",
-        " DEBUG  Bolt::Inventory::Inventory : Did not find config for #{target.uri} in inventory\n",
-        " TRACE  Bolt::Applicator : #{target.uri}: A message\n",
-        " DEBUG  Bolt::Applicator : #{target.uri}: Stuff happened\n"
+        "DEBUG  Bolt::Executor : Started with 1 max thread(s)\n",
+        "DEBUG  Bolt::Inventory::Inventory : Did not find config for #{target.uri} in inventory\n",
+        "TRACE  Bolt::Applicator : #{target.uri}: A message\n",
+        "DEBUG  Bolt::Applicator : #{target.uri}: Stuff happened\n"
       ]
     )
   end

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -749,7 +749,7 @@ describe "Bolt::Executor" do
     let(:plan_context) { { name: 'foo' } }
 
     before :all do
-      @log_output.level = :notice
+      @log_output.level = :info
     end
     after :all do
       @log_output.level = :all

--- a/spec/integration/yaml_plan_spec.rb
+++ b/spec/integration/yaml_plan_spec.rb
@@ -166,7 +166,6 @@ describe "running YAML plans", ssh: true do
   it "warns when using deprecated 'target' parameter" do
     stub_logger
     allow(Puppet::Util::Log).to receive(:newdestination).with(mock_logger)
-    allow(mock_logger).to receive(:notice)
     allow(mock_logger).to receive(:info)
     allow(mock_logger).to receive(:warn)
 


### PR DESCRIPTION
This removes the 'notice' log level, which means Bolt will error if the
logger is configured to 'notice' either via the command line or
configuration files.

!removal

* **Remove 'notice' log level**

  Bolt no longer accepts 'notice' as a log level, via the command line
  or configuration. Use 'info' instead.