### PR TITLE
(GH-2556) Remove support for Debian 8

### DIFF
--- a/acceptance/tests/apply_plan_ssh.rb
+++ b/acceptance/tests/apply_plan_ssh.rb
@@ -7,13 +7,7 @@ test_name "bolt plan run should apply manifest block on remote hosts via ssh" do
   extend Acceptance::BoltCommandHelper
 
   ssh_nodes = select_hosts(roles: ['ssh'])
-  skip_targets = select_hosts(platform: [/debian-8/])
   targets = "ssh_nodes"
-  if skip_targets.any?
-    ssh_nodes -= skip_targets
-    targets = ssh_nodes.each_with_object([]) { |node, acc| acc.push(node[:vmhostname]) }.join(",")
-  end
-
   skip_test('no applicable nodes to test on') if ssh_nodes.empty?
 
   dir = bolt.tmpdir('apply_ssh')

--- a/acceptance/tests/bolt_apply.rb
+++ b/acceptance/tests/bolt_apply.rb
@@ -9,10 +9,6 @@ test_name "bolt apply should apply manifest block on remote hosts via ssh and wi
   ssh_nodes = select_hosts(roles: ['ssh'])
   winrm_nodes = select_hosts(roles: ['winrm'])
   targets = ssh_nodes + winrm_nodes
-
-  # the puppet_agent::install task does not support osx1015 yet, so skip those hosts if present
-  targets -= select_hosts(platform: [/debian-8/])
-
   skip_test('no applicable nodes to test on') if targets.empty?
 
   def check_result(result, targets)

--- a/documentation/bolt_installing.md
+++ b/documentation/bolt_installing.md
@@ -220,24 +220,17 @@ Use one of the supported *nix installation methods to install Bolt.
 
 ### Install Bolt on Debian or Ubuntu
 
-Packaged versions of Bolt are available for Debian 8-10 and Ubuntu 16.04 and
+Packaged versions of Bolt are available for Debian 9-10 and Ubuntu 16.04 and
 18.04.
 
 The Puppet Tools repository for the APT package management system is
 [https://apt.puppet.com](https://apt.puppet.com). Packages are named using the
 convention `puppet-tools-release-<VERSION CODE NAME>.deb`. For example, the
-release package for Puppet Tools on Debian 8 “Jessie” is
-`puppet-tools-release-jessie.deb`.
+release package for Puppet Tools on Debian 9 “Stretch” is
+`puppet-tools-release-stretch.deb`.
 
 1.  Download and install the software and its dependencies. Use the commands
     appropriate to your system:
-    -   Debian 8
-        ```shell script
-        wget https://apt.puppet.com/puppet-tools-release-jessie.deb
-        sudo dpkg -i puppet-tools-release-jessie.deb
-        sudo apt-get update 
-        sudo apt-get install puppet-bolt
-        ```
     -   Debian 9
         ```shell script
         wget https://apt.puppet.com/puppet-tools-release-stretch.deb


### PR DESCRIPTION
This removes the install documentation for Debian 8, and additionally
removes some unneeded logic for skipping Debian 8 in our acceptance
tests. This is related to puppetlabs/ci-job-configs#7562 which removes
testing and building on Debian 8.

!removal

* **Remove support for Debian 8**

  Bolt will no longer build or test packages for the Debian 8 platform.