### PR TITLE
(GH-2554) Remove source, target YAML plan step keys

### DIFF
--- a/lib/bolt/pal/yaml_plan/evaluator.rb
+++ b/lib/bolt/pal/yaml_plan/evaluator.rb
@@ -24,7 +24,7 @@ module Bolt
 
         def task_step(scope, step)
           task = step['task']
-          targets = step['targets'] || step['target']
+          targets = step['targets']
           description = step['description']
           params = step['parameters'] || {}
 
@@ -48,7 +48,7 @@ module Bolt
 
         def script_step(scope, step)
           script = step['script']
-          targets = step['targets'] || step['target']
+          targets = step['targets']
           description = step['description']
           arguments = step['arguments'] || []
 
@@ -64,7 +64,7 @@ module Bolt
 
         def command_step(scope, step)
           command = step['command']
-          targets = step['targets'] || step['target']
+          targets = step['targets']
           description = step['description']
 
           args = [command, targets]
@@ -73,9 +73,9 @@ module Bolt
         end
 
         def upload_step(scope, step)
-          source = step['upload'] || step['source']
+          source = step['upload']
           destination = step['destination']
-          targets = step['targets'] || step['target']
+          targets = step['targets']
           description = step['description']
 
           args = [source, destination, targets]
@@ -86,7 +86,7 @@ module Bolt
         def download_step(scope, step)
           source = step['download']
           destination = step['destination']
-          targets = step['targets'] || step['target']
+          targets = step['targets']
           description = step['description']
 
           args = [source, destination, targets]
@@ -99,7 +99,7 @@ module Bolt
         end
 
         def resources_step(scope, step)
-          targets = step['targets'] || step['target']
+          targets = step['targets']
 
           # TODO: Only call apply_prep when needed
           scope.call_function('apply_prep', targets)
@@ -154,18 +154,6 @@ module Bolt
         # This is the method that Puppet calls to evaluate the plan. The name
         # makes more sense for .pp plans.
         def evaluate_block_with_bindings(closure_scope, args_hash, plan)
-          if plan.steps.any? { |step| step.body.key?('target') }
-            msg = "The 'target' parameter for YAML plan steps is deprecated and will be removed "\
-                  "in a future version of Bolt. Use the 'targets' parameter instead."
-            Bolt::Logger.deprecate("yaml_plan_target", msg)
-          end
-
-          if plan.steps.any? { |step| step.body.key?('source') }
-            msg = "The 'source' parameter for YAML plan upload steps is deprecated and will be removed "\
-                  "in a future version of Bolt. Use the 'upload' parameter instead."
-            Bolt::Logger.deprecate("yaml_plan_source", msg)
-          end
-
           plan_result = closure_scope.with_local_scope(args_hash) do |scope|
             plan.steps.each do |step|
               step_result = dispatch_step(scope, step)

--- a/lib/bolt/pal/yaml_plan/step/upload.rb
+++ b/lib/bolt/pal/yaml_plan/step/upload.rb
@@ -6,7 +6,7 @@ module Bolt
       class Step
         class Upload < Step
           def self.allowed_keys
-            super + Set['source', 'destination', 'upload']
+            super + Set['destination', 'upload']
           end
 
           def self.required_keys
@@ -15,7 +15,7 @@ module Bolt
 
           def initialize(step_body)
             super
-            @source = step_body['upload'] || step_body['source']
+            @source = step_body['upload']
             @destination = step_body['destination']
           end
 

--- a/spec/bolt/pal/yaml_plan/evaluator_spec.rb
+++ b/spec/bolt/pal/yaml_plan/evaluator_spec.rb
@@ -322,30 +322,26 @@ describe Bolt::PAL::YamlPlan::Evaluator do
   end
 
   describe "#upload_step" do
-    %w[source upload].each do |key|
-      context "with #{key} key" do
-        let(:step) do
-          { key => 'mymodule/file.txt',
-            'destination' => '/path/to/file.txt',
-            'targets' => 'foo.example.com' }
-        end
+    let(:step) do
+      { 'upload' => 'mymodule/file.txt',
+        'destination' => '/path/to/file.txt',
+        'targets' => 'foo.example.com' }
+    end
 
-        it 'uploads the file' do
-          args = ['mymodule/file.txt', '/path/to/file.txt', 'foo.example.com']
-          expect(scope).to receive(:call_function).with('upload_file', args)
+    it 'uploads the file' do
+      args = ['mymodule/file.txt', '/path/to/file.txt', 'foo.example.com']
+      expect(scope).to receive(:call_function).with('upload_file', args)
 
-          subject.upload_step(scope, step)
-        end
+      subject.upload_step(scope, step)
+    end
 
-        it 'supports a description' do
-          step['description'] = 'upload the file'
+    it 'supports a description' do
+      step['description'] = 'upload the file'
 
-          args = ['mymodule/file.txt', '/path/to/file.txt', 'foo.example.com', 'upload the file']
-          expect(scope).to receive(:call_function).with('upload_file', args)
+      args = ['mymodule/file.txt', '/path/to/file.txt', 'foo.example.com', 'upload the file']
+      expect(scope).to receive(:call_function).with('upload_file', args)
 
-          subject.upload_step(scope, step)
-        end
-      end
+      subject.upload_step(scope, step)
     end
   end
 

--- a/spec/integration/yaml_plan_spec.rb
+++ b/spec/integration/yaml_plan_spec.rb
@@ -162,24 +162,6 @@ describe "running YAML plans", ssh: true do
     expect(result).to eq([24, 36, 60, "60"])
   end
 
-  # TODO: Remove when 'target' parameter is removed
-  it "warns when using deprecated 'target' parameter" do
-    stub_logger
-    allow(Puppet::Util::Log).to receive(:newdestination).with(mock_logger)
-    allow(mock_logger).to receive(:info)
-    allow(mock_logger).to receive(:warn)
-
-    expect(Bolt::Logger).to receive(:deprecate).with(anything, /Use the 'targets' parameter instead./)
-
-    run_plan('yaml::target_param', targets: target)
-  end
-
-  # TODO: Remove when 'target' parameter is removed
-  it "prefers 'targets' parameter over 'target'" do
-    result = run_plan('yaml::target_preference', targets: target)
-    expect(result.first['target']).to eq(target)
-  end
-
   context 'evaluating Puppet code' do
     it 'includes file and line number for errors in bare strings' do
       result = run_plan('yaml::eval_error_bare_string')


### PR DESCRIPTION
This removes support for the `source` and `target` keys in YAML plan
steps. Previously, the `source` key could be used as an action instead
of `upload`, while `target` could be used instead of `targets`.

!removal

* **Remove `source` and `target` YAML plan step keys**
  ([#2554](https://github.com/puppetlabs/bolt/issues/2554))

  Support for the `source` and `target` keys in YAML plans has been
  removed. Use `upload` and `targets` instead.