### PR TITLE
(GH-2552) bundled-ruby transport config now defaults to true

### DIFF
--- a/lib/bolt/config/transport/local.rb
+++ b/lib/bolt/config/transport/local.rb
@@ -17,6 +17,7 @@ module Bolt
         OPTIONS = WINDOWS_OPTIONS.dup.concat(RUN_AS_OPTIONS).sort.freeze
 
         DEFAULTS = {
+          'bundled-ruby' => true,
           'cleanup' => true
         }.freeze
 

--- a/lib/bolt/config/transport/options.rb
+++ b/lib/bolt/config/transport/options.rb
@@ -21,7 +21,7 @@ module Bolt
             type: [TrueClass, FalseClass],
             _plugin: false,
             _example: true,
-            _default: false
+            _default: true
           },
           "cacert" => {
             type: String,

--- a/lib/bolt/transport/local.rb
+++ b/lib/bolt/transport/local.rb
@@ -11,16 +11,8 @@ module Bolt
       end
 
       def with_connection(target)
-        if target.transport_config['bundled-ruby'] || target.name == 'localhost'
+        if target.transport_config['bundled-ruby']
           target.set_local_defaults
-        end
-
-        if target.name != 'localhost' &&
-           !target.transport_config.key?('bundled-ruby')
-          msg = "The local transport will default to using Bolt's Ruby interpreter and "\
-            "setting the 'puppet-agent' feature in Bolt 3.0. Enable or disable these "\
-            "defaults by setting 'bundled-ruby' in the local transport config."
-          Bolt::Logger.warn_once("local_default_config", msg)
         end
 
         yield Connection.new(target)

--- a/spec/bolt/transport/local_spec.rb
+++ b/spec/bolt/transport/local_spec.rb
@@ -73,10 +73,10 @@ describe Bolt::Transport::Local do
         }] } # This has so many brackets it might be March Madness
       }
 
-      it 'prefers user-defined target-level config over defaults' do
+      it 'does not apply local defaults' do
         expect(@conn.target.transport).to eq('ssh')
         expect(@conn.target.options['interpreters']).to include('.rb' => '/foo/ruby')
-        expect(@conn.target.features).to include('puppet-agent')
+        expect(@conn.target.features).not_to include('puppet-agent')
       end
     end
   end
@@ -85,10 +85,7 @@ describe Bolt::Transport::Local do
     let(:uri) { 'local://127.0.0.1' }
 
     context 'with bundled-ruby' do
-      let(:data) {
-        { 'targets' => [uri],
-          'config' => { 'local' => { 'bundled-ruby' => true } } }
-      }
+      let(:data) { { 'targets' => [uri] } }
 
       it 'adds local config options' do
         expect(@conn.target.transport).to eq('local')
@@ -102,7 +99,6 @@ describe Bolt::Transport::Local do
         { 'targets' => [uri],
           'config' => {
             'local' => {
-              'bundled-ruby' => true,
               'interpreters' => { '.rb' => '/foo/ruby' }
             }
           },
@@ -122,7 +118,6 @@ describe Bolt::Transport::Local do
           'config' => {
             'transport' => 'local',
             'local' => {
-              'bundled-ruby' => true,
               'interpreters' => { '.rb' => '/foo/ruby' }
             }
           }
@@ -133,22 +128,6 @@ describe Bolt::Transport::Local do
         expect(@conn.target.options['interpreters']).to include('.rb' => '/foo/ruby')
         expect(@conn.target.features).to include('puppet-agent')
       end
-    end
-  end
-
-  context 'without bundled-ruby' do
-    let(:uri) { 'local://127.0.0.1' }
-    let(:data) { { 'targets' => [uri] } }
-
-    it 'does not use default config' do
-      expect(@conn.target.options).not_to include('interpreters')
-      expect(@conn.target.features).not_to include('puppet-agent')
-    end
-
-    it 'warns that default config will be added in 3.0' do
-      expect(Bolt::Logger).to receive(:warn_once)
-        .with(anything, /The local transport will default/)
-      subject.with_connection(get_target(inventory, uri)) do |conn|; end
     end
   end
 


### PR DESCRIPTION
The local transport's `bundled-ruby` configuration option, which
determines whether to use the Ruby bundled with Bolt packages for local
targets, now defaults to 'true' instead of 'false'. The option can still
be configured as before.

!feature

* **Local transport's 'bundled-ruby' option defaults to true**
  The local transport's `bundled-ruby` configuration option, which
  determines whether to use the Ruby bundled with Bolt packages for local
  targets, now defaults to 'true' instead of 'false'. The option can still
  be configured as before.