### PR TITLE
(GH-2591) Fix get_targets example in docs

### DIFF
--- a/documentation/writing_plans.md
+++ b/documentation/writing_plans.md
@@ -789,7 +789,7 @@ plan create_targets(
   $target2 = get_target('2hostname2handle')
 
   # Create an array of Target objects
-  $target_list = get_targets('host1', 'host2', 'hostred', 'hostblue')
+  $target_list = get_targets(['host1', 'host2', 'hostred', 'hostblue'])
   # This also accepts TargetSpec objects
   $listy_list = get_targets($targetspecs)
   # And inventory group names


### PR DESCRIPTION
This fixes an example for `get_targets` in the Writing Plans doc to use
a `TargetSpec` parameter instead of four separate target names.

Fixes #2591 

!no-release-note