### PR TITLE
(maint) Pin PuppetDB container back

### DIFF
--- a/spec/Dockerfile.puppetdb
+++ b/spec/Dockerfile.puppetdb
@@ -1,4 +1,4 @@
-FROM puppet/puppetdb
+FROM puppet/puppetdb:6.13.1
 
 # Use our own certs so this doesn't have to wait for puppetserver startup
 COPY fixtures/ssl/ca.pem /opt/puppetlabs/server/data/puppetdb/certs/certs/ca.pem


### PR DESCRIPTION
We published PuppetDB 7.0.1 containers yesterday, which seem to not stay
alive as the 6.x containers did. This pins back to 6.13.1 until we can 
diagnose the issue

!no-release-note