### PR TITLE
(GH-2422) Warn when puppet-agent version is < 6

### DIFF
--- a/documentation/upgrading_to_bolt_3.md
+++ b/documentation/upgrading_to_bolt_3.md
@@ -83,3 +83,64 @@ To migrate your system- or user-level Bolt configuration, make the following cha
     - `apply_settings` to `apply-settings`
     - `plugin_hooks` to `plugin-hooks`
 1. Rename the file to `bolt-project.yaml`.
+
+## Upgrading the puppet-agent package on targets
+
+Starting in Bolt 3.0, Bolt no longer supports puppet-agent versions earlier than
+6.0.0. While applying Puppet code to targets with an earlier version of the
+puppet-agent package might still succeed, Bolt does not guarantee compatibility.
+
+To upgrade the puppet-agent package version installed on a target, you can
+run the `puppet_agent::install` task, which is included in Bolt packages.
+
+- To update to the latest version of the puppet-agent package:
+
+  _\*nix shell command_
+
+  ```shell
+  bolt task run puppet_agent::install --targets <TARGETS> version=latest
+  ```
+
+  _PowerShell cmdlet_
+
+  ```powershell
+  Invoke-BoltTask -Task puppet_agent::install -Targets <TARGETS> version=latest
+  ```
+
+- To update to a specific version of the puppet-agent package:
+
+  ```shell
+  bolt task run puppet_agent::install --targets <TARGETS> version=<VERSION> collection=<COLLECTION>
+  ```
+
+  _PowerShell cmdlet_
+
+  ```powershell
+  Invoke-BoltTask -Task puppet_agent::install -Targets <TARGETS> version=<VERSION> collection=<COLLECTION>
+  ```
+
+  For task documentation, including a list of available collections, run `bolt
+  task show puppet_agent::install` or `Get-BoltTask -Name
+  puppet_agent::install` in PowerShell.
+
+### Suppress unsupported Puppet agent version warnings
+
+When Bolt detects a puppet-agent version earlier than 6.0.0 on a target, it
+logs a warning like this:
+
+```shell
+Detected unsupported Puppet agent version 5.22.0 on target my_target. Bolt supports
+Puppet agent 6.0.0 and higher. [ID: unsupported_puppet]
+```
+
+If you do not want to upgrade the puppet-agent package to a supported version
+and would like to stop seeing these warnings, you can configure your
+project to suppress them. To suppress these warnings, configure the
+`disable-warnings` option in your project configuration:
+
+```yaml
+---
+name: my_project
+disable-warnings:
+  - unsupported_puppet
+```


### PR DESCRIPTION
This adds a warning to the `apply_prep` function that is logged when a
target has puppet-agent < 6 installed. While puppet-agent < 6 may still
be compatible with Bolt, we no longer officially support or test it.

!deprecation

* **Drop support for puppet-agent < 6.0.0 on targets**
  ([#2422](https://github.com/puppetlabs/bolt/issues/2422))

  Bolt no longer supports puppet-agent versions earlier than 6.0.0.
  While applying Puppet code to targets with earlier versions of the
  puppet-agent package installed may still succeed, Bolt no longer
  guarantees compatibility.