### PR TITLE
(maint) Configure Rubocop to enable new cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ require:
   - rubocop-rake
 
 AllCops:
+  NewCops: enable
   Exclude:
     - Boltdir/**/*
     - vendor/**/*

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -392,7 +392,7 @@ module Bolt
 
       def print_target_info(targets)
         @stream.puts ::JSON.pretty_generate(
-          "targets": targets.map(&:detail)
+          targets: targets.map(&:detail)
         )
         count = "#{targets.count} target#{'s' unless targets.count == 1}"
         @stream.puts colorize(:green, count)

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -95,38 +95,38 @@ module Bolt
       end
 
       def print_puppetfile_result(success, puppetfile, moduledir)
-        @stream.puts({ "success": success,
-                       "puppetfile": puppetfile,
-                       "moduledir": moduledir.to_s }.to_json)
+        @stream.puts({ success: success,
+                       puppetfile: puppetfile,
+                       moduledir: moduledir.to_s }.to_json)
       end
 
       def print_targets(target_list, inventoryfile)
         @stream.puts ::JSON.pretty_generate(
-          "inventory": {
-            "targets": target_list[:inventory].map(&:name),
-            "count": target_list[:inventory].count,
-            "file": inventoryfile.to_s
+          inventory: {
+            targets: target_list[:inventory].map(&:name),
+            count: target_list[:inventory].count,
+            file: inventoryfile.to_s
           },
-          "adhoc": {
-            "targets": target_list[:adhoc].map(&:name),
-            "count": target_list[:adhoc].count
+          adhoc: {
+            targets: target_list[:adhoc].map(&:name),
+            count: target_list[:adhoc].count
           },
-          "targets": target_list.values.flatten.map(&:name),
-          "count": target_list.values.flatten.count
+          targets: target_list.values.flatten.map(&:name),
+          count: target_list.values.flatten.count
         )
       end
 
       def print_target_info(targets)
         @stream.puts ::JSON.pretty_generate(
-          "targets": targets.map(&:detail),
-          "count": targets.count
+          targets: targets.map(&:detail),
+          count: targets.count
         )
       end
 
       def print_groups(groups)
         count = groups.count
-        @stream.puts({ "groups": groups,
-                       "count": count }.to_json)
+        @stream.puts({ groups: groups,
+                       count: count }.to_json)
       end
 
       def fatal_error(err)

--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -352,7 +352,7 @@ module BoltServer
     end
 
     def allowed_helper(metadata, allowlist)
-      allowed = allowlist.nil? || allowlist.include?(metadata['name']) ? true : false
+      allowed = allowlist.nil? || allowlist.include?(metadata['name'])
       metadata.merge({ 'allowed' => allowed })
     end
 

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -120,7 +120,7 @@ describe Bolt::Applicator do
       before do
         allow(Logging).to receive(:logger).and_return(mock_logger)
         allow(mock_logger).to receive(:[]).and_return(mock_logger)
-        allow(mock_logger).to receive(:'level=').with(any_args)
+        allow(mock_logger).to receive(:level=).with(any_args)
         allow(mock_logger).to receive(:debug).with(any_args)
         allow(mock_logger).to receive(:trace).with(any_args)
       end
@@ -148,7 +148,7 @@ describe Bolt::Applicator do
       before do
         allow(Logging).to receive(:logger).and_return(mock_logger)
         allow(mock_logger).to receive(:[]).and_return(mock_logger)
-        allow(mock_logger).to receive(:'level=').with(any_args)
+        allow(mock_logger).to receive(:level=).with(any_args)
         allow(mock_logger).to receive(:debug).with(any_args)
       end
 

--- a/spec/bolt_server/app_integration_spec.rb
+++ b/spec/bolt_server/app_integration_spec.rb
@@ -29,7 +29,7 @@ describe "BoltServer::TransportApp", puppetserver: true do
       it 'runs an echo task with a password' do
         body = build_task_request('sample::echo',
                                   conn_target('ssh', include_password: true),
-                                  "message": "Hello!")
+                                  message: "Hello!")
 
         post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
         expect(last_response).to be_ok
@@ -45,7 +45,7 @@ describe "BoltServer::TransportApp", puppetserver: true do
         target = conn_target('ssh', options: { 'private-key' => { 'key-data' => private_key_content } })
         body = build_task_request('sample::echo',
                                   target,
-                                  "message": "Hello!")
+                                  message: "Hello!")
 
         post path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json'
         expect(last_response).to be_ok

--- a/spec/bolt_server/transport_app_spec.rb
+++ b/spec/bolt_server/transport_app_spec.rb
@@ -86,7 +86,7 @@ describe "BoltServer::TransportApp" do
       }
     end
     let(:action) { 'run_task' }
-    let(:result) { double(Bolt::Result, to_data: { 'status': 'test_status' }) }
+    let(:result) { double(Bolt::Result, to_data: { status: 'test_status' }) }
 
     before(:each) do
       allow_any_instance_of(BoltServer::TransportApp)
@@ -462,11 +462,11 @@ describe "BoltServer::TransportApp" do
       end
 
       it 'performs the action when using a password and scrubs any stack traces' do
-        body = { 'target': {
-          'hostname': target[:host],
-          'user': target[:user],
-          'password': target[:password],
-          'port': target[:port]
+        body = { target: {
+          hostname: target[:host],
+          user: target[:user],
+          password: target[:password],
+          port: target[:port]
         } }
 
         expect_any_instance_of(BoltServer::TransportApp)
@@ -482,11 +482,11 @@ describe "BoltServer::TransportApp" do
         private_key = ENV['BOLT_SSH_KEY'] || Dir["spec/fixtures/keys/id_rsa"][0]
         private_key_content = File.read(private_key)
 
-        body = { 'target': {
-          'hostname': target[:host],
-          'user': target[:user],
+        body = { target: {
+          hostname: target[:host],
+          user: target[:user],
           'private-key-content': private_key_content,
-          'port': target[:port]
+          port: target[:port]
         } }
 
         expect_any_instance_of(BoltServer::TransportApp)


### PR DESCRIPTION
This configures Rubocop to automatically enable new cops, with the
understanding that we almost always enable new cops and can manually
disable new ones if they are added that we don't want to adopt. This
also updates the codebase to adhere to the newly added cops in Rubocop
1.9.0.

!no-release-note