### PR TITLE
(GH-2547) Use Puppet 7

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-ssh", ">= 4.0"
   spec.add_dependency "net-ssh-krb", "~> 0.5"
   spec.add_dependency "orchestrator_client", "~> 0.5"
-  spec.add_dependency "puppet", ">= 6.18.0"
+  spec.add_dependency "puppet", "~> 7.0"
   spec.add_dependency "puppetfile-resolver", "~> 0.5"
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "puppet-strings", "~> 2.3"


### PR DESCRIPTION
This updates the version of Puppet used by Bolt to the 7.x series.

!feature

* **Ship with Puppet 7**
  ([#2547](https://github.com/puppetlabs/bolt/issues/2547))

  The Bolt gem and Bolt packages now ship with Puppet 7.