### PR TITLE
(GH-2588) Add plan name to missing_plan_parameter warning

### DIFF
--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -449,7 +449,7 @@ module Bolt
           else
             Bolt::Logger.warn(
               "missing_plan_parameter",
-              "The documented parameter '#{name}' does not exist in plan signature"
+              "The documented parameter '#{name}' does not exist in signature for plan '#{plan.name}'"
             )
           end
         end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1591,7 +1591,7 @@ describe "Bolt::CLI" do
               }
             }
           )
-          expected_log = /The documented parameter 'not_oops' does not exist in plan signature/m
+          expected_log = /parameter 'not_oops' does not exist.*sample::documented_param_typo/m
           expect(@log_output.readlines.join).to match(expected_log)
         end
 


### PR DESCRIPTION
This adds the name of the plan to the `missing_plan_parameter` warning,
which is logged when a plan documents a parameter that is not present in
the plan's signature. This makes it easier for users to locate which
plan documents a missing parameter.

!bug

* **Include plan name in `missing_plan_parameter` warnings**
  ([#2588](https://github.com/puppetlabs/bolt/issues/2588))

  The `missing_plan_parameter` warning now includes the name of the plan
  that the message was logged for.