### PR TITLE
 (GH-102) Prototype streaming remote output

### DIFF
--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -8,6 +8,28 @@ API may change, requiring the user to update their code or configuration. The
 Bolt team attempts to make these changes painless by providing useful warnings
 around breaking behavior where possible. 
 
+## Streaming output
+
+This feature was introduced in [Bolt 3.2.0](https://github.com/puppetlabs/bolt/blob/main/CHANGELOG.md#bolt-310-2021-3-08).
+
+You can set the new `stream` output option in `bolt-project.yaml` or `bolt-defaults.yaml`, or
+specify the option on the command line as `--stream`. Bolt streams results back to the console as
+they are received, with the target's safe name (the URI without the password included) and the
+stream (either 'out' or 'err') appended to the message, like so:
+```
+Started on docker://puppet_6_node...
+Started on docker://puppet_7_node...
+[docker://puppet_7_node] out: Hello!
+[docker://puppet_6_node] out: Hello!
+Finished on docker://puppet_7_node:
+  Hello!
+Finished on docker://puppet_6_node:
+  Hello!
+```
+
+As you can see, when you configure output to stream, Bolt might print to the console twice:
+once as the actions are running, and again after Bolt prints the results.
+
 ## LXD Transport
 
 This feature was introduced in [Bolt 3.2.0](https://github.com/puppetlabs/bolt/blob/main/CHANGELOG.md#bolt-310-2021-3-08).

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -13,7 +13,7 @@ module Bolt
                 run_context: %w[concurrency inventoryfile save-rerun cleanup],
                 global_config_setters: PROJECT_PATHS + %w[modulepath],
                 transports: %w[transport connect-timeout tty native-ssh ssh-command copy-command],
-                display: %w[format color verbose trace],
+                display: %w[format color verbose trace stream],
                 global: %w[help version log-level clear-cache] }.freeze
 
     ACTION_OPTS = OPTIONS.values.flatten.freeze
@@ -887,6 +887,9 @@ module Bolt
       end
       define('-v', '--[no-]verbose', 'Display verbose logging') do |value|
         @options[:verbose] = value
+      end
+      define('--stream', 'Stream output from scripts and commands to the console') do |_|
+        @options[:stream] = true
       end
       define('--trace', 'Display error stack traces') do |_|
         @options[:trace] = true

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -175,6 +175,7 @@ module Bolt
     # Completes the setup process by configuring Bolt and log messages
     def finalize_setup
       Bolt::Logger.configure(config.log, config.color, config.disable_warnings)
+      Bolt::Logger.stream = config.stream
       Bolt::Logger.analytics = analytics
       Bolt::Logger.flush_queue
 

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -419,6 +419,10 @@ module Bolt
       @data['spinner']
     end
 
+    def stream
+      @data['stream']
+    end
+
     def inventoryfile
       @data['inventoryfile']
     end

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -425,7 +425,14 @@ module Bolt
           _example: false,
           _default: true
         },
-
+        "stream" => {
+          description: "Whether to stream output from scripts and commands to the console. "\
+                       "**This option is experimental**.",
+          type: [TrueClass, FalseClass],
+          _plugin: false,
+          _default: false,
+          _example: true
+        },
         "tasks" => {
           description: "A list of task names and glob patterns to filter the project's tasks by. This option is used "\
                        "to limit the visibility of tasks for users of the project. For example, project authors "\
@@ -539,6 +546,7 @@ module Bolt
         puppetdb
         save-rerun
         spinner
+        stream
       ].freeze
 
       # Options that are available in a bolt-project.yaml file
@@ -562,6 +570,7 @@ module Bolt
         puppetdb
         save-rerun
         spinner
+        stream
         tasks
         trusted-external-command
       ].freeze

--- a/lib/bolt/config/transport/options.rb
+++ b/lib/bolt/config/transport/options.rb
@@ -32,7 +32,7 @@ module Bolt
           "cleanup" => {
             type: [TrueClass, FalseClass],
             description: "Whether to clean up temporary files created on targets. When running commands on a target, "\
-                         "Bolt may create temporary files. After completing the command, these files are "\
+                         "Bolt might create temporary files. After completing the command, these files are "\
                          "automatically deleted. This value can be set to 'false' if you wish to leave these "\
                          "temporary files on the target.",
             _plugin: true,

--- a/lib/bolt/logger.rb
+++ b/lib/bolt/logger.rb
@@ -91,6 +91,14 @@ module Bolt
       Logging.logger[:root].appenders.any?
     end
 
+    def self.stream
+      @stream
+    end
+
+    def self.stream=(stream)
+      @stream = stream
+    end
+
     # A helper to ensure the Logging library is always initialized with our
     # custom log levels before retrieving a Logger instance.
     def self.logger(name)

--- a/lib/bolt/shell.rb
+++ b/lib/bolt/shell.rb
@@ -8,6 +8,22 @@ module Bolt
       @target = target
       @conn = conn
       @logger = Bolt::Logger.logger(@target.safe_name)
+
+      if Bolt::Logger.stream
+        Bolt::Logger.warn_once("stream_experimental",
+                               "The 'stream' option is experimental, and might "\
+                               "include breaking changes between minor versions.")
+        @stream_logger = Bolt::Logger.logger(:stream)
+        # Don't send stream messages to the parent logger
+        @stream_logger.additive = false
+
+        # Log stream messages without any other data or color
+        pattern = Logging.layouts.pattern(pattern: '%m\n')
+        @stream_logger.appenders = Logging.appenders.stdout(
+          'console',
+          layout: pattern
+        )
+      end
     end
 
     def run_command(*_args)

--- a/lib/bolt/shell/powershell.rb
+++ b/lib/bolt/shell/powershell.rb
@@ -310,12 +310,26 @@ module Bolt
           # the proper encoding so the string isn't later misinterpreted
           encoding = out.external_encoding
           out.binmode
-          result.stdout << out.read.force_encoding(encoding)
+          to_print = out.read.force_encoding(encoding)
+          if !to_print.chomp.empty? && @stream_logger
+            formatted = to_print.lines.map do |msg|
+              "[#{@target.safe_name}] out: #{msg.chomp}"
+            end.join("\n")
+            @stream_logger.warn(formatted)
+          end
+          result.stdout << to_print
         end
         stderr = Thread.new do
           encoding = err.external_encoding
           err.binmode
-          result.stderr << err.read.force_encoding(encoding)
+          to_print = err.read.force_encoding(encoding)
+          if !to_print.chomp.empty? && @stream_logger
+            formatted = to_print.lines.map do |msg|
+              "[#{@target.safe_name}] err: #{msg.chomp}"
+            end.join("\n")
+            @stream_logger.warn(formatted)
+          end
+          result.stderr << to_print
         end
 
         stdout.join

--- a/pwsh_module/command.tests.ps1
+++ b/pwsh_module/command.tests.ps1
@@ -55,7 +55,7 @@ Describe "test bolt command syntax" {
     It "has correct number of parameters" {
       ($command.Parameters.Values | Where-Object {
           $_.name -notin $common
-      } | measure-object).Count | Should -Be 36
+      } | measure-object).Count | Should -Be 37
     }
   }
 
@@ -73,7 +73,7 @@ Describe "test bolt command syntax" {
     It "has correct number of parameters" {
       ($command.Parameters.Values | Where-Object {
         $_.name -notin $common
-      } | measure-object).Count | Should -Be 33
+      } | measure-object).Count | Should -Be 34
     }
   }
 
@@ -95,7 +95,7 @@ Describe "test bolt command syntax" {
     It "has correct number of parameters" {
       ($command.Parameters.Values | Where-Object {
         $_.name -notin $common
-      } | measure-object).Count | Should -Be 34
+      } | measure-object).Count | Should -Be 35
     }
   }
 

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -45,6 +45,9 @@
     },
     "spinner": {
       "$ref": "#/definitions/spinner"
+    },
+    "stream": {
+      "$ref": "#/definitions/stream"
     }
   },
   "definitions": {
@@ -332,6 +335,10 @@
     },
     "spinner": {
       "description": "Whether to print a spinner to the console for long-running Bolt operations.",
+      "type": "boolean"
+    },
+    "stream": {
+      "description": "Whether to stream output from scripts and commands to the console. **This option is experimental**.",
       "type": "boolean"
     },
     "transport": {
@@ -1192,7 +1199,7 @@
       ]
     },
     "cleanup": {
-      "description": "Whether to clean up temporary files created on targets. When running commands on a target, Bolt may create temporary files. After completing the command, these files are automatically deleted. This value can be set to 'false' if you wish to leave these temporary files on the target.",
+      "description": "Whether to clean up temporary files created on targets. When running commands on a target, Bolt might create temporary files. After completing the command, these files are automatically deleted. This value can be set to 'false' if you wish to leave these temporary files on the target.",
       "oneOf": [
         {
           "type": "boolean"

--- a/schemas/bolt-inventory.schema.json
+++ b/schemas/bolt-inventory.schema.json
@@ -62,7 +62,7 @@
                   "type": "object",
                   "properties": {
                     "cleanup": {
-                      "description": "Whether to clean up temporary files created on targets. When running commands on a target, Bolt may create temporary files. After completing the command, these files are automatically deleted. This value can be set to 'false' if you wish to leave these temporary files on the target.",
+                      "description": "Whether to clean up temporary files created on targets. When running commands on a target, Bolt might create temporary files. After completing the command, these files are automatically deleted. This value can be set to 'false' if you wish to leave these temporary files on the target.",
                       "oneOf": [
                         {
                           "type": "boolean"
@@ -163,7 +163,7 @@
                       "type": "boolean"
                     },
                     "cleanup": {
-                      "description": "Whether to clean up temporary files created on targets. When running commands on a target, Bolt may create temporary files. After completing the command, these files are automatically deleted. This value can be set to 'false' if you wish to leave these temporary files on the target.",
+                      "description": "Whether to clean up temporary files created on targets. When running commands on a target, Bolt might create temporary files. After completing the command, these files are automatically deleted. This value can be set to 'false' if you wish to leave these temporary files on the target.",
                       "oneOf": [
                         {
                           "type": "boolean"
@@ -269,7 +269,7 @@
                   "type": "object",
                   "properties": {
                     "cleanup": {
-                      "description": "Whether to clean up temporary files created on targets. When running commands on a target, Bolt may create temporary files. After completing the command, these files are automatically deleted. This value can be set to 'false' if you wish to leave these temporary files on the target.",
+                      "description": "Whether to clean up temporary files created on targets. When running commands on a target, Bolt might create temporary files. After completing the command, these files are automatically deleted. This value can be set to 'false' if you wish to leave these temporary files on the target.",
                       "oneOf": [
                         {
                           "type": "boolean"
@@ -435,7 +435,7 @@
                   "type": "object",
                   "properties": {
                     "cleanup": {
-                      "description": "Whether to clean up temporary files created on targets. When running commands on a target, Bolt may create temporary files. After completing the command, these files are automatically deleted. This value can be set to 'false' if you wish to leave these temporary files on the target.",
+                      "description": "Whether to clean up temporary files created on targets. When running commands on a target, Bolt might create temporary files. After completing the command, these files are automatically deleted. This value can be set to 'false' if you wish to leave these temporary files on the target.",
                       "oneOf": [
                         {
                           "type": "boolean"
@@ -906,7 +906,7 @@
                       ]
                     },
                     "cleanup": {
-                      "description": "Whether to clean up temporary files created on targets. When running commands on a target, Bolt may create temporary files. After completing the command, these files are automatically deleted. This value can be set to 'false' if you wish to leave these temporary files on the target.",
+                      "description": "Whether to clean up temporary files created on targets. When running commands on a target, Bolt might create temporary files. After completing the command, these files are automatically deleted. This value can be set to 'false' if you wish to leave these temporary files on the target.",
                       "oneOf": [
                         {
                           "type": "boolean"

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -61,6 +61,9 @@
     "spinner": {
       "$ref": "#/definitions/spinner"
     },
+    "stream": {
+      "$ref": "#/definitions/stream"
+    },
     "tasks": {
       "$ref": "#/definitions/tasks"
     },
@@ -438,6 +441,10 @@
     },
     "spinner": {
       "description": "Whether to print a spinner to the console for long-running Bolt operations.",
+      "type": "boolean"
+    },
+    "stream": {
+      "description": "Whether to stream output from scripts and commands to the console. **This option is experimental**.",
       "type": "boolean"
     },
     "tasks": {

--- a/spec/fixtures/modules/sample/tasks/multiline.json
+++ b/spec/fixtures/modules/sample/tasks/multiline.json
@@ -1,0 +1,7 @@
+{
+  "description": "Write a multiline string to the console",
+  "implementations": [
+    {"name": "multiline.ps1", "requirements": ["powershell"]},
+    {"name": "multiline.sh", "requirements": ["shell"]}
+  ]
+}

--- a/spec/fixtures/modules/sample/tasks/multiline.ps1
+++ b/spec/fixtures/modules/sample/tasks/multiline.ps1
@@ -1,0 +1,1 @@
+Write-Output "In like a lion`nOut like a lamb"

--- a/spec/fixtures/modules/sample/tasks/multiline.sh
+++ b/spec/fixtures/modules/sample/tasks/multiline.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "In like a lion\nOut like a lamb"


### PR DESCRIPTION
This adds a new configuration option `stream` that will enable
streaming output back to the console while Bolt is executing actions on
remote targets.

Streaming works by registering a new Ruby logger named 'stream' that is
not additive (so does not send log messages to the parent logger, which
prevents messages from being logged to files or to other Bolt logging
streams). It configures the stream logger to only print to the console
without much formatting. The stream logger is only created if `stream`
is configured. Bolt then prints output to the stream logger as it's
read, in addition to sending messages to the Result object to be
returned and printed when the action is finished.

Streaming messages are prepended with the target's safe name and the 
stream (stdout or stderr) the message came from. Streaming messages are 
generally printed twice, once when streaming and again as part of the 
result message.

This feature is experimental.

!feature

* **Add 'stream' option** ([#102](https://github.com/puppetlabs/bolt/issues/102))

  **This option is experimental**. New `stream` configuration option and
  `--stream` CLI flag enable streaming output from Bolt actions as they are running.