### PR TITLE
(maint) Required ruby version 2.5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ AllCops:
     - site-modules/**/*
     - tasks/**/*
   SuggestExtensions: false
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 2.5
 
 # Layout cops
 # https://docs.rubocop.org/rubocop/cops_layout.html

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = "~> 2.7"
+  spec.required_ruby_version = "~> 2.5"
 
   spec.add_dependency "addressable", '~> 2.5'
   spec.add_dependency "aws-sdk-ec2", '~> 1'


### PR DESCRIPTION
We accidentally bumped the minimum ruby version in the bolt.gemspec from
ruby 2.7 to ruby 2.5. While Bolt will ship with Ruby 2.7 packages, Bolt
server will continue to ship with 2.5 and we will rely on PE testing to
catch any issues that arise from that.

!no-release-note