### PR TITLE
(PE-31005) Add puppet_connect::test_input_data plan

### DIFF
--- a/modules/puppet_connect/README.md
+++ b/modules/puppet_connect/README.md
@@ -1,0 +1,26 @@
+# puppet_connect
+
+#### Table of Contents
+
+1. [Description](#description)
+2. [Requirements](#requirements)
+3. [Usage](#usage)
+4. [Reference](#reference)
+
+## Description
+
+This module provides the puppet_connect::test_input_data plan, which is used to test that the provided Puppet Connect input data is complete. The module should be used exactly as specified in the Puppet Connect docs since it is designed for a highly specialized workflow.
+
+## Requirements
+
+This module is compatible with the version of Puppet Bolt it ships with.
+
+## Usage
+
+See the Puppet Connect docs for the module's usage.
+
+### Parameters
+
+* **targets** - The set of targets to test. Usually this should be 'all', the default.
+
+## Reference

--- a/modules/puppet_connect/Rakefile
+++ b/modules/puppet_connect/Rakefile
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'puppetlabs_spec_helper/rake_tasks'

--- a/modules/puppet_connect/plans/test_input_data.pp
+++ b/modules/puppet_connect/plans/test_input_data.pp
@@ -1,0 +1,31 @@
+# @summary
+#   Tests that the provided Puppet Connect input data is complete, meaning that all consuming inventory targets are connectable.
+#
+# This plan should only be used as part of the copy-pastable "test input data"
+# workflow specified in the Puppet Connect docs.
+#
+# @param targets
+#   The set of targets to test. Usually this should be 'all', the default.
+#
+# @return ResultSet the result of invoking the 'is connectable?' query on all
+# the targets. Note that this query currently consists of running the 'echo'
+# command.
+#
+plan puppet_connect::test_input_data(TargetSpec $targets = 'all') {
+  $targs = get_targets($targets)
+  $targs.each |$target| {
+    if $target.transport != 'ssh' and $target.transport != 'winrm' {
+      fail_plan("Inventory contains target ${target} with unsupported transport, must be ssh or winrm")
+    }
+    if $target.transport == 'ssh' {
+      # Disable SSH autoloading to prevent false positive results
+      # (input data is wrong but target is still connectable due
+      # to autoloaded config)
+      set_config($target, ['ssh', 'load-config'], false)
+    }
+  }
+  # The SSH/WinRM transports will report an 'unknown host' error for targets where
+  # 'host' is unknown so run_command's implementation will take care of raising that
+  # error for us.
+  return run_command('echo Connected', $targs)
+}

--- a/modules/puppet_connect/spec/plans/test_input_data.rb
+++ b/modules/puppet_connect/spec/plans/test_input_data.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/plans'
+require 'bolt/target'
+
+describe 'puppet_connect::test_input_data' do
+  include BoltSpec::Plans
+
+  let(:inventory_data) do
+    {
+      'version' => 2,
+      'targets' => [
+        {
+          'name' => 'ssh_target',
+          'uri'  => 'ssh_uri',
+          'config' => {
+            'transport' => 'ssh',
+            'ssh'  => {
+              'load-config' => true
+            }
+          }
+        },
+        {
+          'name'   => 'winrm_target',
+          'uri'    => 'winrm_uri',
+          'config' => {
+            'transport' => 'winrm'
+          }
+        }
+      ]
+    }
+  end
+  let(:ssh_target) { inventory.get_target('ssh_target') }
+  let(:winrm_target) { inventory.get_target('winrm_target') }
+
+  context 'when the inventory contains an unsupported Puppet Connect transport' do
+    let(:inventory_data) do
+      sup = super()
+      sup['targets'].first['config']['transport'] = 'docker'
+      sup
+    end
+
+    it 'returns an error result' do
+      result = run_plan('puppet_connect::test_input_data', {})
+      expect(result.ok?).to be(false)
+      expect(result.value.msg).to match(%r{ssh_target.*ssh.*winrm})
+    end
+  end
+
+  it 'sets load-config to false for ssh targets' do
+    allow_command('echo Connected')
+      .always_return({})
+
+    winrm_config_before = winrm_target.config
+    run_plan('puppet_connect::test_input_data', {})
+
+    expect(ssh_target.config).to include('ssh' => { 'load-config' => false })
+    expect(winrm_target.config).to eql(winrm_config_before)
+  end
+
+  it 'checks if the targets are connectable' do
+    expect_command('echo Connected')
+      .be_called_times(1)
+      .with_targets(['ssh_target', 'winrm_target'])
+      .return_for_targets({
+        'ssh_target' => {
+          'stdout' => 'Connected'
+        },
+        'winrm_target' => {
+          'stdout' => 'Connected'
+        }
+      })
+
+    result = run_plan('puppet_connect::test_input_data', {}).value
+    expect(result.size).to eql(2)
+    ssh_result = result.first
+    winrm_result = result[1]
+    expect(ssh_result.value).to include('stdout' => 'Connected')
+    expect(winrm_result.value).to include('stdout' => 'Connected')
+  end
+end

--- a/modules/puppet_connect/spec/spec_helper.rb
+++ b/modules/puppet_connect/spec/spec_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'puppet_pal'
+
+# Ensure tasks are enabled when rspec-puppet sets up an environment
+# so we get task loaders.
+Puppet[:tasks] = true
+require 'puppetlabs_spec_helper/module_spec_helper'


### PR DESCRIPTION
This plan's used to test that the Puppet Connect input data is complete,
meaning that all consuming inventory targets are connectable.

!no-release-note

Signed-off-by: Enis Inan <enis.inan@puppet.com>