### PR TITLE
(maint) Reset version to 2.44.0

### DIFF
--- a/lib/bolt/version.rb
+++ b/lib/bolt/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bolt
-  VERSION = '3.0.0-rc'
+  VERSION = '2.44.0'
 end


### PR DESCRIPTION
This resets the version in `Bolt::VERSION` to 2.44.0 from 3.0.0-rc. This
is required for the release pipeline to bump and tag the Bolt repo
successfully.

!no-release-note