### PR TITLE
(maint) Ensure Bolt PATH environment variable in beaker

### DIFF
--- a/acceptance/setup/common/pre-suite/032_configure_windows_profile.rb
+++ b/acceptance/setup/common/pre-suite/032_configure_windows_profile.rb
@@ -5,6 +5,20 @@ require 'bolt_setup_helper'
 test_name "Configure Windows Profile" do
   extend Acceptance::BoltSetupHelper
 
+  step "Configure PATH environment variable" do
+    if bolt['platform'] =~ /windows/
+      execute_powershell_script_on(bolt, <<-PS)
+$boltpath = Join-Path $env:ProgramFiles "Puppet Labs" "Bolt" "bin"
+$envpath = $boltpath + ";" + $env:Path
+[System.Environment]::SetEnvironmentVariable(
+  'PATH',
+  $envpath,
+  [System.EnvironmentVariableTarget]::Machine
+)
+PS
+    end
+  end
+
   step "Configure a Windows Profile that contains will write to a file every time it is loaded" do
     if bolt['platform'] =~ /windows/
       execute_powershell_script_on(bolt, <<-PS)


### PR DESCRIPTION
This adds a step that adds the Bolt installation path to the PATH environment variable. This happens after the bolt msi install, so that subsequent commands will know where to find bolt.
