### PR TITLE
(maint) Bolt PowerShell module metadata cleanup

### DIFF
--- a/pwsh_module/pwsh_bolt.psd1.erb
+++ b/pwsh_module/pwsh_bolt.psd1.erb
@@ -10,7 +10,6 @@
   CompanyName       = "Puppet, Inc"
   Copyright         = '(c) 2017 Puppet, Inc. All rights reserved'
   FunctionsToExport = @(
-    'bolt',
     '<%= @commands.sort_by { |cmd| cmd[:cmdlet] }.map{|cmd| cmd[:cmdlet] }.join("',\n    '") %>'
   )
   CmdletsToExport   = @()

--- a/pwsh_module/pwsh_bolt.psd1.erb
+++ b/pwsh_module/pwsh_bolt.psd1.erb
@@ -3,12 +3,14 @@
   version = Bolt::VERSION
 -%>
 @{
-  ModuleToProcess   = 'PuppetBolt.psm1'
+  RootModule        = 'PuppetBolt.psm1'
   ModuleVersion     = '<%= version %>'
   GUID              = 'CF5DDF2B-F69B-4A2B-B7E4-B9A981D7415D'
   Author            = "Puppet, Inc"
   CompanyName       = "Puppet, Inc"
+  Description       = "Puppet Bolt is an open source task runner that executes ad hoc tasks, scripts, and commands across your infrastructure and applications"
   Copyright         = '(c) 2017 Puppet, Inc. All rights reserved'
+  PowerShellVersion = '3.0'
   FunctionsToExport = @(
     '<%= @commands.sort_by { |cmd| cmd[:cmdlet] }.map{|cmd| cmd[:cmdlet] }.join("',\n    '") %>'
   )
@@ -17,7 +19,12 @@
   AliasesToExport   = @()
   PrivateData       = @{
     PSData = @{
-      # Tags = @()
+      Tags = @(
+        'Puppet',
+        'bolt',
+        'PSEdition_Desktop',
+        'Windows'
+      )
       LicenseUri   = 'https://github.com/puppetlabs/bolt/blob/main/LICENSE'
       ProjectUri   = 'https://github.com/puppetlabs/bolt'
       # IconUri = ''

--- a/pwsh_module/pwsh_bolt_internal.ps1
+++ b/pwsh_module/pwsh_bolt_internal.ps1
@@ -1,9 +1,6 @@
 function Invoke-BoltCommandline {
   [CmdletBinding()]
   param($params)
-  $script:BOLT_BASEDIR = (Get-ItemProperty -Path "HKLM:\Software\Puppet Labs\Bolt").RememberedInstallDir
-  
-  $env:PATH = "$($script:BOLT_BASEDIR)\bin;" + $env:PATH
 
   Write-Verbose "Executing bolt $($params -join ' ')"
 


### PR DESCRIPTION
- (maint) Remove last of bolt pwsh function
- (maint) Update PowerShell manifest to RootModule


Acceptance Criteria:

Setup:

1. Install Bolt 3.0 on test machine
1. Clone this PR on your machine
1. Execute `be rake pwsh:generate_module` on your machine
1. Replace `$env:ProgramFiles\WindowsPowerShell\Modules\PuppetBolt\PuppetBolt.psd1` and `$env:ProgramFiles\WindowsPowerShell\Modules\PuppetBolt\PuppetBolt.psm1` on test machine with generated files from your machine

Testing:

1. Execute any bolt powershell command in a new[*] powershell shell on test machine
2. There should be no errors loading the PuppetBolt module
3. The Bolt PowerShell cmdlets should still correctly find the bolt executables

[*] A new shell is needed to have the PATH environment variable populated before executing `bolt`. You can get around that by starting a new shell by modifying the path yourself