### PR TITLE
Added documentation on how to configure Bolt to install Puppet agent without internet

### DIFF
--- a/documentation/using_plugins.md
+++ b/documentation/using_plugins.md
@@ -183,6 +183,19 @@ plugin-hooks:
     task: <plugin name>
 ```
 
+The following example demonstrates using the `package` task as a `puppet_library`
+plugin to install the Puppet Agent directly via the package manager without setting
+up a repository (as is default with the `puppet_agent::install` task).
+
+```yaml
+plugin-hooks:
+  puppet_library:
+    plugin: task
+    task: package
+    parameters:
+      name: puppet-agent
+      action: install
+```
 
 ## Configuring plugins
 


### PR DESCRIPTION
The default `puppet_agent::install` task goes out to the internet and downloads things. This breaks in "air gapped" environments. I thought it would be an interesting example to add to the documentation in order to showcase the `plugin-hooks` feature using existing tasks.