### PR TITLE
(bug) Install Puppetfile without 'modules' configured

### DIFF
--- a/documentation/bolt_installing_modules.md
+++ b/documentation/bolt_installing_modules.md
@@ -438,15 +438,6 @@ manually manage your project's Puppetfile.
 To manually manage a project's Puppetfile and install modules without resolving
 dependencies, follow these steps:
 
-1. Set the `modules` configuration option in your `bolt-project.yaml` file to an
-   empty array. For example:
-
-   ```yaml
-   # bolt-project.yaml
-   name: myproject
-   modules: []
-   ```
-
 1. Create a file named `Puppetfile` in your project directory and add the
    modules you want to install, including each module's dependencies, to
    the Puppetfile. For example:

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -709,9 +709,11 @@ module Bolt
     def install_project_modules(project, config, force, resolve)
       assert_project_file(project)
 
-      unless project.modules.any?
-        outputter.print_message "Project configuration file #{project.project_file} does not "\
-                                "specify any module dependencies. Nothing to do."
+      if project.modules.empty? && resolve != false
+        outputter.print_message(
+          "Project configuration file #{project.project_file} does not "\
+          "specify any module dependencies. Nothing to do."
+        )
         return 0
       end
 


### PR DESCRIPTION
This fixes a bug where Bolt would not install a Puppetfile with `bolt
module install --no-resolve` if the `modules` key is not configured or
is an empty array.

!bug

* **Install Puppetfile without `modules` configured**

  Bolt now correctly installs a Puppetfile with `bolt module install
  --no-resolve` and `Install-BoltModule -NoResolve` even if the
  `modules` key is not configured or is an empty array.