### PR TITLE
(GH-2633) Add Bolt Task directory to PSModulePath

### DIFF
--- a/documentation/writing_tasks.md
+++ b/documentation/writing_tasks.md
@@ -967,6 +967,91 @@ Successful on 1 target: localhost
 Ran on 1 target in 0.12 seconds
 ```
 
+### PowerShell example
+
+Create task and metadata in your project at
+`<PROJECT DIRECTORY>/tasks/mytask.{json,ps1}`.
+
+**Metadata**
+
+```json
+{
+  "files": [
+    "powershell_task_helper/files/BoltPwshHelper/"
+  ],
+  "input_method": "powershell",
+  "parameters": {
+    "name": {
+      "description": "Name of user to run command",
+      "type": "String"
+    }
+  }
+}
+```
+
+**Task**
+
+```powershell
+#!/usr/bin/env pwsh
+[CmdletBinding()]
+Param(
+  [Parameter(Mandatory = $True)]
+  [String]
+  $Name
+)
+
+<#
+If using PowerShell 3.0, you will need to add an import statement here:
+Import-Module BoltPwshHelper
+#>
+​
+<#
+Handle unhandled exceptions using the `trap` keyword
+#>
+trap {
+  Write-BoltError -Message "Generic trap handler" -Exception $_
+}
+
+<#
+A example of a custom error messages based on a specific use case
+#>
+if ($name -eq 'Robert') {
+  Write-BoltError -Message "User ${name} not allowed"
+}
+else {
+  # TODO
+}
+
+<#
+An exmaple of returning a full exception stacktrace in Bolt formatted json
+You can add a `-Message` if you want
+#>
+try {
+  Write-Output (@{ "greeting" = "Hi, my name is ${name}"} | ConvertTo-JSON)
+}
+catch {
+  Write-BoltError -Exception $_
+}
+```
+
+> **Note**: If you're using a version of PowerShell more recent than 3.0, 
+  you don't have to write an import statement to load your PowerShell module. 
+  Bolt automatically loads the module by adding your task directory to 
+  `$env:PSModulePath`.
+
+**Output**
+
+```console
+$ bolt task run mymodule::mytask -n localhost name="Robert'); DROP TABLE Students;--"
+Started on localhost...
+Finished on localhost:
+  {
+    "greeting": "Hi, my name is Robert'); DROP TABLE Students;--"
+  }
+Successful on 1 target: localhost
+Ran on 1 target in 0.12 seconds
+```
+
 ## Secure coding practices for tasks
 
 Use secure coding practices when you write tasks and help protect your system.

--- a/lib/bolt/shell/powershell.rb
+++ b/lib/bolt/shell/powershell.rb
@@ -274,7 +274,12 @@ module Bolt
                               []
                             end
 
-          output = execute([Snippets.shell_init, *env_assignments, command].join("\n"))
+          output = execute([
+            Snippets.shell_init,
+            Snippets.append_ps_module_path(dir),
+            *env_assignments,
+            command
+          ].join("\n"))
 
           Bolt::Result.for_task(target, output.stdout.string,
                                 output.stderr.string,

--- a/lib/bolt/shell/powershell/snippets.rb
+++ b/lib/bolt/shell/powershell/snippets.rb
@@ -67,6 +67,12 @@ module Bolt
             PS
           end
 
+          def append_ps_module_path(directory)
+            <<~PS
+            $env:PSModulePath += ";#{directory}"
+            PS
+          end
+
           def ps_task(path, arguments)
             <<~PS
             $private:tempArgs = Get-ContentAsJson (


### PR DESCRIPTION
This commit adds the bolt task target directory to the PSModulePath environment variable for the currently executing session. This will allow Bolt tasks to ship powershell modules that can be automatically imported during runtime instead of having to calculate relative paths.

To use this feature add any powershell module to the `files` metadata in the task.json file:

```
"files": [
  "<BOLT MODULE NAME>/files/<PWSH MODULE NAME>/"
],
```

Then inside your Bolt PowerShell task start using the content from that PowerShell module without having to write `Import-Module` statements with fully qualified paths to the temp directory Bolt operates in.