### PR TITLE
(GH-2636) Fix PowerShell Cmdlet Version detection

### DIFF
--- a/pwsh_module/command.tests.ps1
+++ b/pwsh_module/command.tests.ps1
@@ -34,7 +34,7 @@ Describe "test bolt module" {
 
     it "has the correct number of exported functions" {
       # should count of pwsh functions
-      @($commands).Count | Should -Be 22
+      @($commands).Count | Should -Be 23
     }
   }
 }

--- a/pwsh_module/pwsh_bolt.psd1.erb
+++ b/pwsh_module/pwsh_bolt.psd1.erb
@@ -12,6 +12,7 @@
   Copyright         = '(c) 2017 Puppet, Inc. All rights reserved'
   PowerShellVersion = '3.0'
   FunctionsToExport = @(
+    'Get-BoltVersion',
     '<%= @commands.sort_by { |cmd| cmd[:cmdlet] }.map{|cmd| cmd[:cmdlet] }.join("',\n    '") %>'
   )
   CmdletsToExport   = @()

--- a/pwsh_module/pwsh_bolt.psm1.erb
+++ b/pwsh_module/pwsh_bolt.psm1.erb
@@ -76,8 +76,7 @@ end
   )
 <% if pwsh_command[:verb] == 'Get' %>
   if($version){
-    $boltBasedir = (Get-ItemProperty -Path "HKLM:\Software\Puppet Labs\Bolt").RememberedInstallDir
-    return (Get-Content -Path $boltBasedir\misc\versions.txt)[0].split(" ")[1]
+    return Get-BoltVersion
   }
 <% end -%>
 

--- a/pwsh_module/pwsh_bolt_internal.ps1
+++ b/pwsh_module/pwsh_bolt_internal.ps1
@@ -68,3 +68,11 @@ function Get-BoltCommandline {
 
   Write-Output $params
 }
+
+function Get-BoltVersion{
+  [CmdletBinding()]
+  param()
+
+  $module = Get-Module -Name PuppetBolt
+  Write-Output [string]($module.Version)
+}


### PR DESCRIPTION
This removes the PowerShell cmdlets to call `bolt --version` on windows platforms. This was originally done for speed reasons, but can be removed to support cross platform use of the module since the ruby runtime will be patched to run faster on windows.
