### PR TITLE
(maint) Update Puppetfile to include puppet_connect module

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -45,3 +45,4 @@ mod 'puppetlabs-yaml', '0.2.0'
 mod 'canary', local: true
 mod 'aggregate', local: true
 mod 'puppetdb_fact', local: true
+mod 'puppet_connect', local: true

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -899,7 +899,8 @@ module Bolt
     # Gem installs include the aggregate, canary, and puppetdb_fact modules, while
     # package installs include modules listed in the Bolt repo Puppetfile
     def incomplete_install?
-      (Dir.children(Bolt::Config::Modulepath::MODULES_PATH) - %w[aggregate canary puppetdb_fact secure_env_vars]).empty?
+      builtin_module_list = %w[aggregate canary puppetdb_fact secure_env_vars puppet_connect]
+      (Dir.children(Bolt::Config::Modulepath::MODULES_PATH) - builtin_module_list).empty?
     end
 
     # Mimicks the output from Outputter::Human#fatal_error. This should be used to print

--- a/rakelib/tests.rake
+++ b/rakelib/tests.rake
@@ -92,7 +92,7 @@ begin
         end
       end
       # Test modules
-      %w[canary aggregate puppetdb_fact].each do |mod|
+      %w[canary aggregate puppetdb_fact puppet_connect].each do |mod|
         Dir.chdir("#{__dir__}/../modules/#{mod}") do
           sh 'rake spec' do |ok, _|
             success = false unless ok


### PR DESCRIPTION
This commit updates the Puppetfile bolt uses during packaging steps to include
the puppet_connect module so that it isn't overwritten by r10k during builds