### PR TITLE
(GH-2504) Support Puppet file syntax for project files in apply blocks

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -45,8 +45,8 @@ jobs:
           echo 'runner:runner' | sudo chpasswd
           sudo sh -c "echo 'Defaults authenticate' >> /etc/sudoers"
           sudo sh -c "echo 'runner  ALL=(ALL) PASSWD:ALL' >> /etc/sudoers"
-          docker-compose -f spec/docker-compose.yml build --parallel ubuntu_node puppet_5_node puppet_6_node puppet_7_node
-          docker-compose -f spec/docker-compose.yml up -d ubuntu_node puppet_5_node puppet_6_node puppet_7_node
+          docker-compose -f spec/docker-compose.yml build --parallel ubuntu_node puppet_6_node puppet_7_node
+          docker-compose -f spec/docker-compose.yml up -d ubuntu_node puppet_6_node puppet_7_node
           chmod 0600 spec/fixtures/keys/id_rsa
           bundle exec r10k puppetfile install
       - name: Run tests with minimal container infrastructure

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -215,6 +215,7 @@ module Bolt
     def with_bolt_executor(executor, inventory, pdb_client = nil, applicator = nil, &block)
       setup
       opts = {
+        bolt_project: @project,
         bolt_executor: executor,
         bolt_inventory: inventory,
         bolt_pdb_client: pdb_client,

--- a/spec/docker-compose.yml
+++ b/spec/docker-compose.yml
@@ -6,15 +6,6 @@ services:
     ports:
       - "20022:22"
 
-  puppet_5_node:
-    build:
-      context: .
-      args:
-        PUPPET_COLLECTION: puppet5
-    container_name: puppet_5_node
-    ports:
-      - "20023:22"
-
   puppet_6_node:
     build:
       context: .

--- a/spec/fixtures/apply/basic/plans/project_files.pp
+++ b/spec/fixtures/apply/basic/plans/project_files.pp
@@ -1,0 +1,18 @@
+plan basic::project_files (
+  TargetSpec $targets,
+  String     $project_name
+) {
+  $result = apply($targets) {
+    file { '/test.txt':
+      source => "puppet:///modules/${project_name}/testfile"
+    }
+  }
+
+  apply($targets) {
+    file { '/test.txt':
+      ensure => absent
+    }
+  }
+
+  return $result
+}

--- a/spec/fixtures/inventory/docker.yaml
+++ b/spec/fixtures/inventory/docker.yaml
@@ -8,10 +8,6 @@ groups:
     config:
       ssh:
         port: 20022
-  - name: puppet_5_node
-    config:
-      ssh:
-        port: 20023
   - name: puppet_6_node
     config:
       ssh:

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -9,7 +9,6 @@ require 'bolt_spec/puppet_agent'
 require 'bolt_spec/run'
 
 TEST_VERSIONS = [
-  [5, 'puppet5'],
   [6, 'puppet6'],
   [7, 'puppet']
 ].freeze
@@ -121,6 +120,16 @@ describe 'apply', expensive: true do
           user = conn_info('ssh')[:user]
           logs = run_cli_json(%W[plan run basic::run_as_apply user=#{user} -t nix_agents], project: project)
           expect(logs.first['message']).to eq(conn_info('ssh')[:user])
+        end
+
+        it 'can reference project files with Puppet file syntax' do
+          FileUtils.mkdir_p(project.path + 'files')
+          FileUtils.touch(project.path + 'files' + 'testfile')
+
+          result = run_cli_json(%W[plan run basic::project_files -t nix_agents project_name=#{project.name}],
+                                project: project)
+
+          expect(result.first).to include('status' => 'success')
         end
 
         context 'with show_diff configured' do

--- a/spec/integration/parallel_spec.rb
+++ b/spec/integration/parallel_spec.rb
@@ -81,7 +81,7 @@ describe 'plans' do
       expected_err = { "kind" => "bolt/parallel-failure",
                        "msg" => "Plan aborted: parallel block failed on 1 target" }
       expected_details = { "action" => "parallelize",
-                           "failed_indices" => [2] }
+                           "failed_indices" => [1] }
       expected_results = [[{ "target" => 'ubuntu_node',
                              "action" => "task",
                              "object" => "parallel",

--- a/spec/lib/bolt_spec/conn.rb
+++ b/spec/lib/bolt_spec/conn.rb
@@ -87,10 +87,6 @@ module BoltSpec
                 'name' => 'nix_agents',
                 'targets' => [
                   {
-                    'name' => 'puppet_5_node',
-                    'config' => { 'ssh' => { 'port' => 20023 } }
-                  },
-                  {
                     'name' => 'puppet_6_node',
                     'config' => { 'ssh' => { 'port' => 20024 } }
                   },


### PR DESCRIPTION
This adds support for using Puppet file syntax
(`puppet://modules/<MODULE>/<FILE>`) in an apply block for files that are
in a Bolt project.

This also removes the `puppet_5_node` Docker container from spec tests,
since Bolt no longer supports Puppet 5.

!bug

* **Support Puppet file syntax for files in a Bolt project**
  ([#2504](#2504))

  Bolt now supports Puppet file syntax
  (`puppet:///modules/<MODULE>/<FILE>`) in apply blocks for files in a
  Bolt project. Previously, apply blocks would not compile if using this
  syntax for files in a Bolt project.