### PR TITLE
(GH-2595) Unpin puppetdb Docker container

### DIFF
--- a/spec/Dockerfile.puppetdb
+++ b/spec/Dockerfile.puppetdb
@@ -1,4 +1,4 @@
-FROM puppet/puppetdb:6.13.1
+FROM puppet/puppetdb
 
 # Use our own certs so this doesn't have to wait for puppetserver startup
 COPY fixtures/ssl/ca.pem /opt/puppetlabs/server/data/puppetdb/certs/certs/ca.pem

--- a/spec/bolt/puppetdb/client_spec.rb
+++ b/spec/bolt/puppetdb/client_spec.rb
@@ -158,6 +158,7 @@ describe Bolt::PuppetDB::Client do
 
     before(:all) do
       wait_until_available(timeout: 30, interval: 1)
+      wait_until_pdb_available(timeout: 120, interval: 1)
       push_facts(facts_hash)
     end
 

--- a/spec/docker-compose.yml
+++ b/spec/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - "20025:22"
 
   postgres:
-    image: postgres:9.6
+    image: postgres:11.11
     environment:
       - POSTGRES_PASSWORD=puppetdb
       - POSTGRES_USER=puppetdb


### PR DESCRIPTION
This unpins the PuppetDB Docker container and bumps the postgres
container as PuppetDB is no longer compatible with postgres < 11.

!no-release-note