### PR TITLE
(maint) Update CI to use ruby/setup-ruby action

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     paths-ignore: ['**.md', 'schemas/*']
   pull_request:
-    type: [opened, reopened, edited]
+    types: [opened, reopened, edited, synchronize]
     paths-ignore: ['**.md', 'schemas/*']
 
 jobs:
@@ -17,24 +17,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7.x'
-      - name: Install bundler
-        run: |
-          gem install bundler
-          bundle config path vendor/bundle
-      - name: Cache gems
-        id: cache
-        uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
-      - name: Install gems
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: bundle install --jobs 4 --retry 3
+          ruby-version: 2.7
+          bundler-cache: true
       - name: Update gems
-        if: steps.cache.outputs.cache-hit == 'true'
         run: bundle update
       - name: Generate docs
         run: bundle exec rake docs:all

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
-    type: [opened, reopened, edited]
+    types: [opened, reopened, edited, synchronize]
     paths-ignore: ['**.md', '**.erb', 'schemas/*']
 
 jobs:
@@ -17,9 +17,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7.x'
+          ruby-version: 2.7
       - name: Install rubocop
         run: |
           gem install rubocop --version 1.9.1

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
-    type: [opened, reopened, edited]
+    types: [opened, reopened, edited, synchronize]
     paths-ignore: ['**.md', '**.erb', 'schemas/*']
 
 env:
@@ -21,24 +21,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7.x'
-      - name: Install bundler
-        run: |
-          gem install bundler
-          bundle config path vendor/bundle
-      - name: Cache gems
-        id: cache
-        uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
-      - name: Install gems
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: bundle install --jobs 4 --retry 3
+          ruby-version: 2.7
+          bundler-cache: true
       - name: Update gems
-        if: steps.cache.outputs.cache-hit == 'true'
         run: bundle update
       - name: Pre-test setup
         run: |
@@ -59,24 +46,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7.x'
-      - name: Install bundler
-        run: |
-          gem install bundler
-          bundle config path vendor/bundle
-      - name: Cache gems
-        id: cache
-        uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
-      - name: Install gems
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: bundle install --jobs 4 --retry 3
+          ruby-version: 2.7
+          bundler-cache: true
       - name: Update gems
-        if: steps.cache.outputs.cache-hit == 'true'
         run: bundle update
       - name: Pre-test setup
         run: |

--- a/.github/workflows/litmus_smoke.yaml
+++ b/.github/workflows/litmus_smoke.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
-    type: [opened, reopened, edited]
+    types: [opened, reopened, edited, synchronize]
     paths-ignore: ['**.md', '**.erb', 'schemas/*']
 
 jobs:

--- a/.github/workflows/modules.yaml
+++ b/.github/workflows/modules.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
-    type: [opened, reopened, edited]
+    types: [opened, reopened, edited, synchronize]
     paths-ignore: ['**.md', '**.erb', 'schemas/*']
 
 env:
@@ -20,24 +20,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7.x'
-      - name: Install bundler
-        run: |
-          gem install bundler
-          bundle config path vendor/bundle
-      - name: Cache gems
-        id: cache
-        uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
-      - name: Install gems
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: bundle install --jobs 4 --retry 3
+          ruby-version: 2.7
+          bundler-cache: true
       - name: Update gems
-        if: steps.cache.outputs.cache-hit == 'true'
         run: bundle update
       - name: Run module tests
         run: bundle exec rake ci:modules
@@ -51,24 +38,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
-      - name: Install bundler
-        run: |
-          gem install bundler
-          bundle config path vendor/bundle
-      - name: Cache gems
-        id: cache
-        uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
-      - name: Install gems
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: bundle install --jobs 4 --retry 3
+          ruby-version: 2.7
+          bundler-cache: true
       - name: Update gems
-        if: steps.cache.outputs.cache-hit == 'true'
         run: bundle update
       - name: Run module tests
         run: bundle exec rake ci:modules

--- a/.github/workflows/pwsh.yaml
+++ b/.github/workflows/pwsh.yaml
@@ -5,7 +5,7 @@ on:
     branches: [master]
     paths: ['pwsh_module/*']
   pull_request:
-    type: [opened, reopened, edited]
+    types: [opened, reopened, edited, synchronize]
     paths: ['pwsh_module/*', 'lib/bolt/bolt_option_parser.rb', 'rakelib/pwsh.rake']
 
 jobs:
@@ -21,30 +21,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
-      - name: Install bundler
-        run: |
-          gem install bundler
-          bundle config path vendor/bundle
-      - name: Cache gems
-        id: cache
-        uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
-      - name: Install gems
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: bundle install --jobs 4 --retry 3
+          ruby-version: 2.7
+          bundler-cache: true
+      - name: Update gems
+        run: bundle update
       - name: Install Pester
         shell: pwsh
-        run: |
-          Install-Module -Name Pester -Force
+        run: Install-Module -Name Pester -Force
       - name: Generate PowerShell Cmdlets
-        run: |
-          bundle exec rake pwsh:generate_module
+        run: bundle exec rake pwsh:generate_module
       - name: Run Pester
         shell: pwsh
-        run: |
-          Invoke-Pester -Path ./pwsh_module -CI
+        run: Invoke-Pester -Path ./pwsh_module -CI

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -2,7 +2,7 @@ name: Release Notes
 
 on:
   pull_request:
-    type: [opened, reopened, edited]
+    types: [opened, reopened, edited, synchronize]
     paths-ignore: 
       - '*.md'
       - '**.md'

--- a/.github/workflows/schemas.yaml
+++ b/.github/workflows/schemas.yaml
@@ -9,7 +9,7 @@ on:
       - 'lib/bolt/config/options.rb'
       - 'lib/bolt/config/transport/options.rb'
   pull_request:
-    type: [opened, reopened, edited]
+    types: [opened, reopened, edited, synchronize]
     paths:
       - 'rakelib/schemas.rake'
       - 'schemas/*.json'
@@ -25,24 +25,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7.x'
-      - name: Install bundler
-        run: |
-          gem install bundler
-          bundle config path vendor/bundle
-      - name: Cache gems
-        id: cache
-        uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
-      - name: Install gems
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: bundle install --jobs 4 --retry 3
+          ruby-version: 2.7
+          bundler-cache: true
       - name: Update gems
-        if: steps.cache.outputs.cache-hit == 'true'
         run: bundle update
       - name: Generate schemas
         run: bundle exec rake schemas:all
@@ -56,4 +43,3 @@ jobs:
             bundle exec rake schemas:all'
             exit 1
           fi
-

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
-    type: [opened, reopened, edited]
+    types: [opened, reopened, edited, synchronize]
     paths-ignore: ['**.md', '**.erb', 'schemas/*']
 
 env:
@@ -28,24 +28,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
-      - name: Install bundler
-        run: |
-          gem install bundler
-          bundle config path vendor/bundle
-      - name: Cache gems
-        id: cache
-        uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
-      - name: Install gems
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: bundle install --jobs 4 --retry 3
+          ruby-version: 2.7
+          bundler-cache: true
       - name: Update gems
-        if: steps.cache.outputs.cache-hit == 'true'
         run: bundle update
       - name: Cache modules
         id: modules
@@ -74,24 +61,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
-      - name: Install bundler
-        run: |
-          gem install bundler
-          bundle config path vendor/bundle
-      - name: Cache gems
-        id: cache
-        uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('lib/bolt/version.rb') }}-${{ hashFiles('Gemfile') }}-${{ hashFiles('bolt.gemspec') }}
-      - name: Install gems
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: bundle install --jobs 4 --retry 3
+          ruby-version: 2.7
+          bundler-cache: true
       - name: Update gems
-        if: steps.cache.outputs.cache-hit == 'true'
         run: bundle update
       - name: Cache modules
         id: modules


### PR DESCRIPTION
This updates the CI jobs to use the `ruby/setup-ruby` action as the
`actions/setup-ruby` action is now deprecated. The new action handles
installing and caching gems, so those steps in each job have been
removed.

!no-release-note