### PR TITLE
(PE-31148) Unwrap sensitive task output in bolt-server

### DIFF
--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -133,7 +133,14 @@ module BoltServer
       task_data = body['task']
       task = Bolt::Task::PuppetServer.new(task_data['name'], task_data['metadata'], task_data['files'], @file_cache)
       parameters = body['parameters'] || {}
-      [@executor.run_task(target, task, parameters), nil]
+      task_result = @executor.run_task(target, task, parameters)
+      task_result.each do |result|
+        value = result.value
+        next unless value.is_a?(Hash)
+        next unless value.key?('_sensitive')
+        value['_sensitive'] = value['_sensitive'].unwrap
+      end
+      [task_result, nil]
     end
 
     def run_command(target, body)

--- a/spec/fixtures/modules/sample/tasks/sensitive_task_output.sh
+++ b/spec/fixtures/modules/sample/tasks/sensitive_task_output.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [[ -z $PT_include_sensitive ]]; then
+  echo '{"user": "someone"}'
+else
+  echo '{"user": "someone", "_sensitive": { "password": "secretpassword" }}'
+fi


### PR DESCRIPTION
Orchestrator's transport API expects unwwrapped sensitive task output,
so we unwrap the sensitive task output in bolt-server to satisfy that
invariant.

Signed-off-by: Enis Inan <enis.inan@puppet.com>