### PR TITLE
(PE-31142) Serialize sensitive output from task Result

### DIFF
--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -203,12 +203,17 @@ module Bolt
     end
 
     def to_data
+      serialized_value = safe_value
+      if serialized_value.key?('_sensitive') &&
+         serialized_value['_sensitive'].is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive)
+        serialized_value['_sensitive'] = serialized_value['_sensitive'].to_s
+      end
       {
         "target" => @target.name,
         "action" => action,
         "object" => object,
         "status" => status,
-        "value" => safe_value
+        "value" => serialized_value
       }
     end
 

--- a/spec/bolt/result_spec.rb
+++ b/spec/bolt/result_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 require 'json'
 require 'bolt'
+require 'bolt/target'
 require 'bolt/result'
 
 describe Bolt::Result do
@@ -115,6 +116,13 @@ describe Bolt::Result do
       result = Bolt::Result.for_task(target, obj.to_json, '', 0, 'atask', [])
       expect(result.sensitive).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result.sensitive.unwrap).to eq('password' => 'sosecretive')
+    end
+
+    it 'to_data serializes _sensitve output' do
+      obj = { "user" => "someone", "_sensitive" => { "password" => "sosecretive" } }
+      result = Bolt::Result.for_task(Bolt::Target.new('foo'), obj.to_json, '', 0, 'atask', [])
+      serialzed = result.to_data
+      expect(serialzed['value']['_sensitive']).to eq("Sensitive [value redacted]")
     end
 
     it 'excludes _output and _error from generic_value' do


### PR DESCRIPTION
This commit updates the `to_data` method for the Result class to serialize sensitive task output by calling the `to_s` value explictly on the sensitive output.