### PR TITLE
(GH-2659 Improve error messages for "bolt script run" on PowerShell

### DIFF
--- a/lib/bolt/shell/powershell/snippets.rb
+++ b/lib/bolt/shell/powershell/snippets.rb
@@ -61,8 +61,8 @@ module Bolt
             }
             catch
             {
-              Write-Error $_.Exception
-              exit 1
+              $Host.UI.WriteErrorLine("[$($_.FullyQualifiedErrorId)] Exception $($_.InvocationInfo.PositionMessage).`n$($_.Exception.Message)");
+              exit 1;
             }
             PS
           end
@@ -144,7 +144,7 @@ module Bolt
               [Parameter(Mandatory = $true)] $Text,
               [Parameter(Mandatory = $false)] [Text.Encoding] $Encoding = [Text.Encoding]::UTF8
             )
-          
+
             $Text | ConvertFrom-Json | ConvertFrom-PSCustomObject
             }
             PS

--- a/lib/bolt/shell/powershell/snippets.rb
+++ b/lib/bolt/shell/powershell/snippets.rb
@@ -72,7 +72,7 @@ module Bolt
             }
 
             if([string]::IsNullOrEmpty($invokeArgs.ScriptBlock)){
-              $Host.UI.WriteErrorLine("Error: Failed to obtain scriptblock from '#{script_path}'. Running scripts may be disabled on this system. For more information, see about_Execution_Policies at https:/go.microsoft.com/fwlink/?LinkID=135170");
+              $Host.UI.WriteErrorLine("Error: Failed to obtain scriptblock from '#{script_path}'. Running scripts might be disabled on this system. For more information, see about_Execution_Policies at https:/go.microsoft.com/fwlink/?LinkID=135170");
               exit 1;
             }
 


### PR DESCRIPTION
This PR modifies the error printed when a target system has an execution policy of `Restricted` or `AllSigned`

When the target has a `Restricted` or `AllSigned` execution policy, it prevents running scripts and prevents pulling info from a script, resulting in an empty `ScriptBlock`. We weren't checking whether it was null or not, so the attempt blows up with a non helpful message. This changes the message to point to the root cause instead of a long stacktrace without any error information.

- [ ] Ports the exception handling and formatting method from bolt task to bolt script.
- [ ] Improve error messages for bolt script in PowerShell when target system has an execution policy of `Restricted` or `AllSigned`
 

> Note: This is very hard to test on localhost due to the way execution policies work and how they have to be edited. Best to test using the winrm connection