### PR TITLE
(GH-2595) Unpin PDB container in CI

### DIFF
--- a/spec/Dockerfile.puppetdb
+++ b/spec/Dockerfile.puppetdb
@@ -1,7 +1,8 @@
-FROM puppet/puppetdb:6.13.1
+FROM puppet/puppetdb
 
 # Use our own certs so this doesn't have to wait for puppetserver startup
 COPY fixtures/ssl/ca.pem /opt/puppetlabs/server/data/puppetdb/certs/certs/ca.pem
-COPY fixtures/ssl/cert.pem /opt/puppetlabs/server/data/puppetdb/certs/certs/pdb.pem
+COPY fixtures/ssl/cert.pem /opt/puppetlabs/server/data/puppetdb/certs/certs/server.crt
 COPY fixtures/ssl/key.pem /opt/puppetlabs/server/data/puppetdb/certs/private_keys/pdb.pem
+COPY fixtures/ssl/key.pem /opt/puppetlabs/server/data/puppetdb/certs/private_keys/server.key
 COPY fixtures/ssl/crl.pem /opt/puppetlabs/server/data/puppetdb/certs/ca/ca_crl.pem

--- a/spec/docker-compose.yml
+++ b/spec/docker-compose.yml
@@ -34,11 +34,11 @@ services:
       - "20025:22"
 
   postgres:
-    image: postgres:9.6
+    image: postgres:11.11
     environment:
-      - POSTGRES_PASSWORD=puppetdb
-      - POSTGRES_USER=puppetdb
-      - POSTGRES_DB=puppetdb
+      POSTGRES_PASSWORD: puppetdb
+      POSTGRES_USER: puppetdb
+      POSTGRES_DB: puppetdb
     volumes:
       - ./fixtures/puppetdb/custom_source:/docker-entrypoint-initdb.d
 
@@ -46,14 +46,13 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.puppetdb
-      args:
-        hostname: bolt-puppetdb
+    depends_on:
+      - postgres
+      - puppetserver
     environment:
-      - "USE_PUPPETSERVER=false"
-      - "CERTNAME=pdb"
-    image: puppetdb
+      USE_PUPPETSERVER: 'false'
+      CERTNAME: pdb
     ports:
-      # 8081 is a common port
       - "18081:8081"
 
   puppetserver:


### PR DESCRIPTION
This unpins the puppetdb container in CI. Previously, the 7.x series of
the puppetdb container would immediately close due to an error raised
by a missing certfile when starting puppetdb.

!no-release-note