### PR TITLE
(GH-2639) Ship with powershell_task_helper

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -23,6 +23,7 @@ mod 'puppetlabs-zone_core', '1.0.3'
 
 # Useful additional modules
 mod 'puppetlabs-package', '1.4.0'
+mod 'puppetlabs-powershell_task_helper', '0.1.0'
 mod 'puppetlabs-puppet_conf', '0.8.0'
 mod 'puppetlabs-python_task_helper', '0.5.0'
 mod 'puppetlabs-reboot', '3.2.0'


### PR DESCRIPTION
This adds the `puppetlabs/powershell_task_helper` module to Bolt's
packaged modules.

!feature

* **Ship with `puppetlabs/powershell_task_helper` module**
  ([#2639](https://github.com/puppetlabs/bolt/issues/2639))

  Bolt now ships with the `puppetlabs/powershell_task_helper` module,
  which includes helpers for writing tasks in PowerShell.