### PR TITLE
(GH-2629) Add top-level metaparameter keys to YAML plan steps

### DIFF
--- a/documentation/writing_yaml_plans.md
+++ b/documentation/writing_yaml_plans.md
@@ -77,40 +77,37 @@ Each plan name segment must begin with a lowercase letter and:
 
 ## Plan structure
 
-YAML plans contain a list of steps with optional parameters and results.
+YAML plans contain a list of steps and can include additional optional keys.
+The following top-level keys are available:
 
-YAML maps accept these keys:
+| Key | Type | Description | Required |
+| --- | --- | --- | --- |
+| `description` | `String` | The plan description. Appears in `bolt plan show <PLAN NAME>` and `Get-BoltPlan <PLAN NAME>` output. | |
+| `parameters` | `Hash` | A hash of plan parameters. Each key is the name of the parameter and the value is the parameter definition. | |
+| `private` | `Boolean` | Whether the plan should appear in `bolt plan show` and `Get-BoltPlan` output. | |
+| `return` | `Array`, `Boolean`, `Hash`, `Number`, `String` | The value to return from the plan. Must evaluate to a valid [PlanResult](bolt_types_reference.md#planresult). | |
+| `steps` | `Array` | The list of steps to run. | ✓ |
 
--   `steps`: The list of steps to perform
--   `parameters`: (Optional) The parameters accepted by the plan
--   `return`: (Optional) The value to return from the plan
-
-### Steps key
+## Steps
 
 The `steps` key is an array of step objects, each of which corresponds to a
 specific action to take.
 
-When the plan runs, each step is executed in order. If a step fails, the plan
-halts execution and raises an error containing the result of the step that
-failed.
+When the plan runs, each step is executed in order. By default, if a step fails
+the plan halts execution and raises an error containing the result of the step
+that failed.
 
-Steps use these fields:
-
--   `name`: (Optional) A unique name that can be used to refer to the result of
-    the step later.
--   `description`: (Optional) An explanation of what the step is doing.
-
-Other available keys depend on the type of step.
-
-#### Message step
+### Message step
 
 Use a `message` step to print a message. This will print a message to standard
 out (stdout) when using the `human` output format, and print to standard error
 (stderr) when using the `json` output format. 
 
-Message steps use a single field:
+Message steps support the following keys:
 
-- `message`: The message to print
+| Key | Type | Description | Required |
+| --- | --- | --- | --- |
+| `message` | `String` | The message to print. | ✓ |
 
 For example:
 
@@ -127,17 +124,23 @@ prints the object as a string.
 For information on printing a step result with `message`, see [Debugging
 plans](#debugging-plans).
 
-#### Command step
+### Command step
 
 Use a `command` step to run a single command on a list of targets and save the
-results, containing stdout, stderr, and exit code.
+results, containing stdout, stderr, and exit code. The step fails if the exit
+code of any command is non-zero.
 
-The step fails if the exit code of any command is non-zero.
+Command steps support the following keys:
 
-Command steps use these fields:
-
--   `command`: The command to run
--   `targets`: A target or list of targets to run the command on
+| Key | Type | Description | Required |
+| --- | --- | --- | --- |
+| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan will continue execution if the step fails. | |
+| `command` | `String` | The command to run. | ✓ |
+| `description` | `String` | The step's description. Logged by Bolt when the step is run. | |
+| `env_vars` | `Hash` | A map of environment variables to set on the target when running the command. | |
+| `name` | `String` | The name of the variable to save the step result to. | |
+| `run_as` | `String` | The user to run as when running the command on the target. Only applies to targets using a transport that supports `run-as` configuration. | |
+| `targets` | `Array`, `String` | A target or list of targets to run the command on. | ✓ |
 
 For example:
 
@@ -151,15 +154,22 @@ steps:
     description: "Get the webserver hostnames"
 ```
 
-#### Task step
+### Task step
 
 Use a `task` step to run a Bolt task on a list of targets and save the results.
 
-Task steps use these fields:
+Task steps support the following keys:
 
--   `task`: The task to run
--   `targets`: A target or list of targets to run the task on
--   `parameters`: (Optional) A map of parameter values to pass to the task
+| Key | Type | Description | Required |
+| --- | --- | --- | --- |
+| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan will continue execution if the step fails. | |
+| `description` | `String` | The step's description. Logged by Bolt when the step is run. | |
+| `name` | `String` | The name of the variable to save the step result to. | |
+| `noop` | `Boolean` | Whether to run in no-operation mode, if available. | |
+| `parameters` | `Hash` | A map of parameters to pass to the task. | |
+| `run_as` | `String` | The user to run as when running the task on the target. Only applies to targets using a transport that supports `run-as` configuration. | |
+| `targets` | `Array`, `String` | A target or list of targets to run the task on. | ✓ |
+| `task` | `String` | The task to run. | ✓ |
 
 For example:
 
@@ -176,7 +186,7 @@ steps:
       name: openssl
 ```
 
-#### Script step
+### Script step
 
 Use a `script` step to run a script on a list of targets and save the results.
 
@@ -184,12 +194,18 @@ The script must be in the `files/` directory of a module. The name of the script
 must be specified as `<modulename>/path/to/script`, omitting the `files`
 directory from the path.
 
-Script steps use these fields:
+Script steps support the following keys:
 
--   `script`: The script to run
--   `targets`: A target or list of targets to run the script on
--   `arguments`: (Optional) An array of command-line arguments to pass to the
-    script
+| Key | Type | Description | Required |
+| --- | --- | --- | --- |
+| `arguments` | `Array` | An array of command-line arguments to pass to the script. | |
+| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan will continue execution if the step fails. | |
+| `description` | `String` | The step's description. Logged by Bolt when the step is run. | |
+| `env_vars` | `Hash` | A map of environment variables to set on the target when running the script. | |
+| `name` | `String` | The name of the variable to save the step result to. | |
+| `run_as` | `String` | The user to run as when running the script on the target. Only applies to targets using a transport that supports `run-as` configuration. | |
+| `script` | `String` | The script to run. | ✓ |
+| `targets` | `Array`, `String` | A target or list of targets to run the script on. | ✓ |
 
 For example:
 
@@ -206,7 +222,7 @@ steps:
       - 60
 ```
 
-#### File download step
+### File download step
 
 Use a file download step to download a file or directory from a list of targets
 to a destination directory on the local host.
@@ -216,11 +232,17 @@ subdirectory matching the target's URL-encoded safe name. If the destination
 directory is a relative path, it will expand relative to the project's
 downloads directory, `<PROJECT DIRECTORY>/downloads`.
 
-File download steps use these fields:
+File download steps support the following keys:
 
-- `download`: The location of the remote file to download
-- `destination`: The destination directory to download the file to
-- `targets`: A target or list of targets to download the file from
+| Key | Type | Description | Required |
+| --- | --- | --- | --- |
+| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan will continue execution if the step fails. | |
+| `description` | `String` | The step's description. Logged by Bolt when the step is run. | |
+| `destination` | `String` | The destination directory to download the file to. | ✓ |
+| `download` | `String` | The location of the remote file to download. | ✓ |
+| `name` | `String` | The name of the variable to save the step result to. | |
+| `run_as` | `String` | The user to run as when downloading the file from the target. Only applies to targets using a transport that supports `run-as` configuration. | |
+| `targets` | `Array`, `String` | A target or list of targets to download the file from. | ✓ |
 
 For example:
 
@@ -248,7 +270,7 @@ target's safe name is URL encoded to ensure it's a valid directory name.
 > 🔩 **Tip:** To avoid URL encoding the target's safe name, give the target a
 > simple, human-readable name in your inventory file.
 
-#### File upload step
+### File upload step
 
 Use a file upload step to upload a file to a specific location on a list of
 targets.
@@ -257,7 +279,17 @@ The file to upload must be in the `files/` directory of a Puppet module. The
 source for the file must be specified as `<modulename>/path/to/file`, omitting
 the `files` directory from the path.
 
-File upload steps use these fields:
+File upload steps support the following keys:
+
+| Key | Type | Description | Required |
+| --- | --- | --- | --- |
+| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan will continue execution if the step fails. | |
+| `description` | `String` | The step's description. Logged by Bolt when the step is run. | |
+| `destination` | `String` | The remote location to upload the file to. | ✓ |
+| `name` | `String` | The name of the variable to save the step result to. | |
+| `run_as` | `String` | The user to run as when uploading the file to the target. Only applies to targets using a transport that supports `run-as` configuration. | |
+| `targets` | `Array`, `String` | A target or list of targets to upload the file to. | ✓ |
+| `upload` | `String` | The location of the local file to upload. | ✓ |
 
 -   `upload`: The location of the local file to be uploaded
 -   `destination`: The remote location to upload the file to
@@ -276,14 +308,21 @@ steps:
     description: "Upload motd to the webservers"
 ```
 
-#### Plan step
+### Plan step
 
 Use a `plan` step to run another plan and save its result.
 
-Plan steps use these fields:
+Plan steps support the following keys:
 
--   `plan`: The name of the plan to run
--   `parameters`: (Optional) A map of parameter values to pass to the plan
+| Key | Type | Description | Required |
+| --- | --- | --- | --- |
+| `catch_errors` | `Boolean` | Whether to catch raised errors. If set to true, the plan will continue execution if the step fails. | |
+| `description` | `String` | The step's description. Logged by Bolt when the step is run. | |
+| `name` | `String` | The name of the variable to save the step result to. | |
+| `parameters` | `Hash` | A map of parameters to pass to the plan. | |
+| `plan` | `String` | The plan to run. | ✓ |
+| `run_as` | `String` | The user to run as when connecting to targets. This is set for all steps or functions in the plan that connect to targets. Only applies to targets using a transport that supports `run-as` configuration. | |
+| `targets` | `Array`, `String` | A target or list of targets. Passed to the plan under the `targets` parameter. | |
 
 For example:
 
@@ -298,7 +337,7 @@ steps:
         - web3.example.com
 ```
 
-#### Resources step
+### Resources step
 
 Use a `resources` step to apply a list of Puppet resources. A resource defines
 the desired state for part of a target. Bolt ensures each resource is in its
@@ -310,10 +349,13 @@ the targets specified with the `targets` field. For more information about
 `apply_prep` see the [Applying manifest blocks](applying_manifest_blocks.md#)
 section.
 
-Resources steps use these fields:
+Resources steps support the following keys:
 
--   `resources`: An array of resources to apply
--   `targets`: A target or list of targets to apply the resources on
+| Key | Type | Description | Required |
+| --- | --- | --- | --- |
+| `name` | `String` | The name of the variable to save the step result to. | |
+| `resources` | `Array` | An array of resources to apply. | ✓ |
+| `targets` | `Array`, `String` | A target or list of targets to run the script on. | ✓ |
 
 Each resource is a YAML map with a type and title, and optionally a `parameters`
 key. The resource type and title can either be specified separately with the
@@ -341,7 +383,7 @@ steps:
     description: "Set up nginx on the webservers"
 ```
 
-### Parameters key
+## Parameters
 
 Plans accept parameters with the `parameters` key. The value of `parameters` is
 a map, where each key is the name of a parameter and the value is a map
@@ -375,7 +417,7 @@ parameters:
     description: "The new application version to deploy"
 ```
 
-### Private key
+## Private plans
 
 As a plan author, you may not want users to run your plan directly or know it exists. This is useful
 for plans that are used by other plans 'under the hood', but aren't designed to be run by a human.
@@ -407,7 +449,7 @@ If you manually edit a plan that is located outside of the `<PROJECT DIRECTORY>/
 still appears in the output of `bolt plan show` and `Get-BoltPlan`, clear the metadata cache by
 running with the `--clear-cache` flag.
 
-### How strings are evaluated
+## How strings are evaluated
 
 The behavior of strings is defined by how they're written in the plan.
 

--- a/lib/bolt/pal/yaml_plan.rb
+++ b/lib/bolt/pal/yaml_plan.rb
@@ -73,8 +73,7 @@ module Bolt
       def duplicate_check(used_names, name, step_number)
         if used_names.include?(name)
           error_message = "Duplicate step name or parameter detected: #{name.inspect}"
-          err = Step.step_error(error_message, name, step_number)
-          raise Bolt::Error.new(err, "bolt/invalid-plan")
+          raise Step::StepError.new(error_message, name, step_number)
         end
       end
 

--- a/lib/bolt/pal/yaml_plan/step/command.rb
+++ b/lib/bolt/pal/yaml_plan/step/command.rb
@@ -5,29 +5,30 @@ module Bolt
     class YamlPlan
       class Step
         class Command < Step
-          def self.allowed_keys
-            super + Set['command']
+          def self.option_keys
+            Set['catch_errors', 'env_vars', 'run_as']
           end
 
           def self.required_keys
-            Set['targets']
+            Set['command', 'targets']
           end
 
-          def initialize(step_body)
-            super
-            @command = step_body['command']
+          # Returns an array of arguments to pass to the step's function call
+          #
+          def args
+            args = [@body['command'], @body['targets']]
+            args << @body['description'] if @body['description']
+            args << options if options.any?
+
+            args
           end
 
+          # Transpiles the step into the plan language
+          #
           def transpile
             code = String.new("  ")
-            code << "$#{@name} = " if @name
-
-            fn = 'run_command'
-            args = [@command, @targets]
-            args << @description if @description
-
-            code << function_call(fn, args)
-
+            code << "$#{@body['name']} = " if @body['name']
+            code << function_call('run_command', args)
             code << "\n"
           end
         end

--- a/lib/bolt/pal/yaml_plan/step/download.rb
+++ b/lib/bolt/pal/yaml_plan/step/download.rb
@@ -5,30 +5,30 @@ module Bolt
     class YamlPlan
       class Step
         class Download < Step
-          def self.allowed_keys
-            super + Set['download', 'destination']
+          def self.option_keys
+            Set['catch_errors', 'run_as']
           end
 
           def self.required_keys
             Set['download', 'destination', 'targets']
           end
 
-          def initialize(step_body)
-            super
-            @source = step_body['download']
-            @destination = step_body['destination']
+          # Returns an array of arguments to pass to the step's function call
+          #
+          def args
+            args = [@body['download'], @body['destination'], @body['targets']]
+            args << @body['description'] if @body['description']
+            args << options if options.any?
+
+            args
           end
 
+          # Transpiles the step into the plan language
+          #
           def transpile
             code = String.new("  ")
             code << "$#{@name} = " if @name
-
-            fn = 'download_file'
-            args = [@source, @destination, @targets]
-            args << @description if @description
-
-            code << function_call(fn, args)
-
+            code << function_call('download_file', args)
             code << "\n"
           end
         end

--- a/lib/bolt/pal/yaml_plan/step/eval.rb
+++ b/lib/bolt/pal/yaml_plan/step/eval.rb
@@ -5,28 +5,21 @@ module Bolt
     class YamlPlan
       class Step
         class Eval < Step
-          def self.allowed_keys
-            super + Set['eval']
-          end
-
           def self.required_keys
-            Set.new
+            Set['eval']
           end
 
-          def initialize(step_body)
-            super
-            @eval = step_body['eval']
-          end
-
+          # Transpiles the step into the plan language
+          #
           def transpile
             code = String.new("  ")
-            code << "$#{@name} = " if @name
+            code << "$#{@body['name']} = " if @body['name']
 
-            code_body = Bolt::Util.to_code(@eval)
+            code_body = Bolt::Util.to_code(@body['eval'])
 
             # If we're trying to assign the result of a multi-line eval to a name
             # variable, we need to wrap it in `with()`.
-            if @name && code_body.lines.count > 1
+            if @body['name'] && code_body.lines.count > 1
               indented = code_body.gsub(/\n/, "\n    ").chomp("  ")
               code << "with() || {\n    #{indented}}"
             else

--- a/lib/bolt/pal/yaml_plan/step/message.rb
+++ b/lib/bolt/pal/yaml_plan/step/message.rb
@@ -13,14 +13,17 @@ module Bolt
             Set['message']
           end
 
-          def initialize(step_body)
-            super
-            @message = step_body['message']
+          # Returns an array of arguments to pass to the step's function call
+          #
+          def args
+            [@body['message']]
           end
 
+          # Transpiles the step into the plan language
+          #
           def transpile
             code = String.new("  ")
-            code << function_call('out::message', [@message])
+            code << function_call('out::message', args)
             code << "\n"
           end
         end

--- a/lib/bolt/pal/yaml_plan/step/plan.rb
+++ b/lib/bolt/pal/yaml_plan/step/plan.rb
@@ -6,29 +6,35 @@ module Bolt
       class Step
         class Plan < Step
           def self.allowed_keys
-            super + Set['plan', 'parameters']
+            super + Set['parameters']
+          end
+
+          def self.option_keys
+            Set['catch_errors', 'run_as']
           end
 
           def self.required_keys
-            Set.new
+            Set['plan']
           end
 
-          def initialize(step_body)
-            super
-            @plan = step_body['plan']
-            @parameters = step_body.fetch('parameters', {})
+          # Returns an array of arguments to pass to the step's function call
+          #
+          def args
+            params = (@body['parameters'] || {}).merge(options)
+
+            args = [@body['plan']]
+            args << @body['targets'] if @body['targets']
+            args << params if params.any?
+
+            args
           end
 
+          # Transpiles the step into the plan language
+          #
           def transpile
             code = String.new("  ")
-            code << "$#{@name} = " if @name
-
-            fn = 'run_plan'
-            args = [@plan]
-            args << @parameters unless @parameters.empty?
-
-            code << function_call(fn, args)
-
+            code << "$#{@body['name']} = " if @body['name']
+            code << function_call('run_plan', args)
             code << "\n"
           end
         end

--- a/lib/bolt/pal/yaml_plan/step/task.rb
+++ b/lib/bolt/pal/yaml_plan/step/task.rb
@@ -6,30 +6,35 @@ module Bolt
       class Step
         class Task < Step
           def self.allowed_keys
-            super + Set['task', 'parameters']
+            super + Set['parameters']
+          end
+
+          def self.option_keys
+            Set['catch_errors', 'noop', 'run_as']
           end
 
           def self.required_keys
-            Set['targets']
+            Set['targets', 'task']
           end
 
-          def initialize(step_body)
-            super
-            @task = step_body['task']
-            @parameters = step_body.fetch('parameters', {})
+          # Returns an array of arguments to pass to the step's function call
+          #
+          def args
+            params = (@body['parameters'] || {}).merge(options)
+
+            args = [@body['task'], @body['targets']]
+            args << @body['description'] if @body['description']
+            args << params if params.any?
+
+            args
           end
 
+          # Transpiles the step into the plan language
+          #
           def transpile
             code = String.new("  ")
-            code << "$#{@name} = " if @name
-
-            fn = 'run_task'
-            args = [@task, @targets]
-            args << @description if @description
-            args << @parameters unless @parameters.empty?
-
-            code << function_call(fn, args)
-
+            code << "$#{@body['name']} = " if @body['name']
+            code << function_call('run_task', args)
             code << "\n"
           end
         end

--- a/lib/bolt/pal/yaml_plan/step/upload.rb
+++ b/lib/bolt/pal/yaml_plan/step/upload.rb
@@ -5,30 +5,30 @@ module Bolt
     class YamlPlan
       class Step
         class Upload < Step
-          def self.allowed_keys
-            super + Set['destination', 'upload']
+          def self.option_keys
+            Set['catch_errors', 'run_as']
           end
 
           def self.required_keys
-            Set['upload', 'destination', 'targets']
+            Set['destination', 'targets', 'upload']
           end
 
-          def initialize(step_body)
-            super
-            @source = step_body['upload']
-            @destination = step_body['destination']
+          # Returns an array of arguments to pass to the step's function call
+          #
+          def args
+            args = [@body['upload'], @body['destination'], @body['targets']]
+            args << @body['description'] if @body['description']
+            args << options if options.any?
+
+            args
           end
 
+          # Transpiles the step into the plan language
+          #
           def transpile
             code = String.new("  ")
-            code << "$#{@name} = " if @name
-
-            fn = 'upload_file'
-            args = [@source, @destination, @targets]
-            args << @description if @description
-
-            code << function_call(fn, args)
-
+            code << "$#{@body['name']} = " if @body['name']
+            code << function_call('upload_file', args)
             code << "\n"
           end
         end

--- a/spec/bolt/pal/yaml_plan/evaluator_spec.rb
+++ b/spec/bolt/pal/yaml_plan/evaluator_spec.rb
@@ -11,6 +11,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
   # static loader and global scope
   let(:loader) { Puppet.lookup(:loaders).static_loader }
   let(:scope) { Puppet.lookup(:global_scope) }
+  let(:step) { Bolt::PAL::YamlPlan::Step.create(step_body, 1) }
 
   around :each do |example|
     pal.in_bolt_compiler do
@@ -183,7 +184,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
   end
 
   describe "#message_step" do
-    let(:step) do
+    let(:step_body) do
       {
         'message' => 'hello world'
       }
@@ -196,7 +197,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
   end
 
   describe "#task_step" do
-    let(:step) do
+    let(:step_body) do
       { 'task' => 'package',
         'targets' => 'foo.example.com',
         'parameters' => { 'action' => 'status',
@@ -204,21 +205,21 @@ describe Bolt::PAL::YamlPlan::Evaluator do
     end
 
     it 'succeeds if no parameters are specified' do
-      step.delete('parameters')
+      step_body.delete('parameters')
 
-      expect(scope).to receive(:call_function).with('run_task', ['package', 'foo.example.com', {}])
+      expect(scope).to receive(:call_function).with('run_task', ['package', 'foo.example.com'])
       subject.task_step(scope, step)
     end
 
-    it 'succeeds if nil parameters are specified' do
-      step['parameters'] = nil
+    it 'succeeds if empty parameters are specified' do
+      step_body['parameters'] = {}
 
-      expect(scope).to receive(:call_function).with('run_task', ['package', 'foo.example.com', {}])
+      expect(scope).to receive(:call_function).with('run_task', ['package', 'foo.example.com'])
       subject.task_step(scope, step)
     end
 
     it 'supports a description' do
-      step['description'] = 'run the thing'
+      step_body['description'] = 'run the thing'
 
       args = ['package', 'foo.example.com', 'run the thing', { 'action' => 'status', 'name' => 'openssl' }]
       expect(scope).to receive(:call_function).with('run_task', args)
@@ -228,7 +229,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
   end
 
   describe "#plan_step" do
-    let(:step) do
+    let(:step_body) do
       { 'plan' => 'testplan',
         'parameters' => { 'message' => 'hello',
                           'count' => 5 } }
@@ -241,29 +242,30 @@ describe Bolt::PAL::YamlPlan::Evaluator do
     end
 
     it 'succeeds if no parameters are specified' do
-      step.delete('parameters')
+      step_body.delete('parameters')
 
-      expect(scope).to receive(:call_function).with('run_plan', ['testplan', {}])
+      expect(scope).to receive(:call_function).with('run_plan', ['testplan'])
 
       subject.plan_step(scope, step)
     end
-    it 'succeeds if nil parameters are specified' do
-      step['parameters'] = nil
 
-      expect(scope).to receive(:call_function).with('run_plan', ['testplan', {}])
+    it 'succeeds if empty parameters are specified' do
+      step_body['parameters'] = {}
+
+      expect(scope).to receive(:call_function).with('run_plan', ['testplan'])
 
       subject.plan_step(scope, step)
     end
   end
 
   describe "#command_step" do
-    let(:step) do
+    let(:step_body) do
       { 'command' => 'hostname -f',
         'targets' => 'foo.example.com' }
     end
 
     it 'supports a description' do
-      step['description'] = 'run the thing'
+      step_body['description'] = 'run the thing'
 
       expect(scope).to receive(:call_function).with('run_command', ['hostname -f', 'foo.example.com', 'run the thing'])
       subject.command_step(scope, step)
@@ -271,7 +273,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
   end
 
   describe "#script_step" do
-    let(:step) do
+    let(:step_body) do
       { 'script' => 'mymodule/myscript.sh',
         'targets' => 'foo.example.com',
         'arguments' => %w[a b c] }
@@ -285,16 +287,16 @@ describe Bolt::PAL::YamlPlan::Evaluator do
     end
 
     it 'succeeds if no arguments are specified' do
-      step.delete('arguments')
+      step_body.delete('arguments')
 
-      args = ['mymodule/myscript.sh', 'foo.example.com', 'arguments' => []]
+      args = ['mymodule/myscript.sh', 'foo.example.com']
       expect(scope).to receive(:call_function).with('run_script', args)
 
       subject.script_step(scope, step)
     end
 
     it 'succeeds if empty arguments are specified' do
-      step['arguments'] = []
+      step_body['arguments'] = []
 
       args = ['mymodule/myscript.sh', 'foo.example.com', 'arguments' => []]
       expect(scope).to receive(:call_function).with('run_script', args)
@@ -303,7 +305,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
     end
 
     it 'succeeds if nil arguments are specified' do
-      step['arguments'] = nil
+      step_body['arguments'] = nil
 
       args = ['mymodule/myscript.sh', 'foo.example.com', 'arguments' => []]
       expect(scope).to receive(:call_function).with('run_script', args)
@@ -312,7 +314,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
     end
 
     it 'supports a description' do
-      step['description'] = 'run the script'
+      step_body['description'] = 'run the script'
 
       args = ['mymodule/myscript.sh', 'foo.example.com', 'run the script', 'arguments' => %w[a b c]]
       expect(scope).to receive(:call_function).with('run_script', args)
@@ -322,7 +324,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
   end
 
   describe "#upload_step" do
-    let(:step) do
+    let(:step_body) do
       { 'upload' => 'mymodule/file.txt',
         'destination' => '/path/to/file.txt',
         'targets' => 'foo.example.com' }
@@ -336,7 +338,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
     end
 
     it 'supports a description' do
-      step['description'] = 'upload the file'
+      step_body['description'] = 'upload the file'
 
       args = ['mymodule/file.txt', '/path/to/file.txt', 'foo.example.com', 'upload the file']
       expect(scope).to receive(:call_function).with('upload_file', args)
@@ -350,7 +352,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
     let(:destination) { 'downloads' }
     let(:target)      { 'foo.example.com' }
 
-    let(:step) do
+    let(:step_body) do
       {
         'download'    => source,
         'destination' => destination,
@@ -366,7 +368,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
     end
 
     it 'supports a description' do
-      step['description'] = 'download the file'
+      step_body['description'] = 'download the file'
 
       args = [source, destination, target, 'download the file']
       expect(scope).to receive(:call_function).with('download_file', args)
@@ -376,7 +378,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
   end
 
   describe "#eval_step" do
-    let(:step) do
+    let(:step_body) do
       { 'eval' => 55 }
     end
 
@@ -386,7 +388,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
   end
 
   describe "#resources_step" do
-    let(:step) do
+    let(:step_body) do
       { 'resources' => resources,
         'targets' => target }
     end
@@ -410,7 +412,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
 
     it 'builds and applies a manifest' do
       # We need to normalize the resources by creating a step instance
-      step_body = Bolt::PAL::YamlPlan::Step::Resources.new(step).body
+      step = Bolt::PAL::YamlPlan::Step::Resources.new(step_body)
 
       expected = [{ 'type' => 'package', 'title' => 'nginx', 'parameters' => {} },
                   { 'type' => 'service', 'title' => 'nginx', 'parameters' => {} }]
@@ -418,7 +420,7 @@ describe Bolt::PAL::YamlPlan::Evaluator do
       expect(subject).to receive(:generate_manifest).with(expected).and_return('mymanifest')
       expect(subject).to receive(:apply_manifest).with(scope, target, 'mymanifest')
 
-      subject.resources_step(scope, step_body)
+      subject.resources_step(scope, step)
     end
 
     it 'succeeds if no resources are specified' do


### PR DESCRIPTION
This adds keys to most YAML plan steps that correspond to plan function
metaparameters. For example, the script step now accepts an `env_vars`
key that corresponds to the `_env_vars` metaparameter, and allows users
to set environment variables on a target when executing the script.

This also fixes a bug where targets listed under the `targets` key in a
plan step were not being passed to the plan. Targets specified in this
manner are now passed to the plan correctly.

Lastly, this slightly refactors the `Bolt::PAL::YamlPlan::Step` classes.
This includes a new `args` method which formats the arguments for the
step's corresponding plan function. The motivation for this refactoring
was to reuse the same logic for evaluating and transpiling steps.

!feature

* **Support metaparameters as top-level keys in YAML plan steps**
  ([#2629](https://github.com/puppetlabs/bolt/issues/2629))

  YAML plan steps now support metaparameters as top-level keys. For
  example, the `script` step supports an `env_vars` key which accepts a
  hash of environment variables to set on the target when running the
  script.

!bug

* **Run YAML plan `plan` steps with `targets` key**

  YAML plans that have a `plan` step with a top-level `targets` key now
  pass the targets to the plan.