### PR TITLE
(GH-2672) Handle plan parameter tags without descriptions

### DIFF
--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -445,7 +445,7 @@ module Bolt
             params[name] = { 'type' => param.types.first }
             params[name]['sensitive'] = param.types.first =~ /\ASensitive(\[.*\])?\z/ ? true : false
             params[name]['default_value'] = defaults[name] if defaults.key?(name)
-            params[name]['description'] = param.text unless param.text.empty?
+            params[name]['description'] = param.text if param.text && !param.text.empty?
           else
             Bolt::Logger.warn(
               "missing_plan_parameter",


### PR DESCRIPTION
This fixes a bug where a plan with a Puppet strings `@param` tag that
did not include a description would cause a plan to error.

!bug

* **Handle plan parameter tags without descriptions**
  ([#2672](https://github.com/puppetlabs/bolt/issues/2672))

  Bolt no longer errors if a plan includes a Puppet strings `@param` tag
  that does not have a description.