### PR TITLE
(maint) Add plan descriptions to 'bolt plan show' output

### DIFF
--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -385,7 +385,7 @@ module Bolt
           plan_cache[plan_name] = info
         end
 
-        list << [plan_name] unless info['private']
+        list << [plan_name, info['description']] unless info['private']
       end
 
       File.write(@project.plan_cache_file, plan_cache.to_json) if updated

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1470,11 +1470,11 @@ describe "Bolt::CLI" do
           cli.execute(options)
           plan_list = JSON.parse(output.string)['plans']
           [
-            ['sample'],
-            ['sample::single_task'],
-            ['sample::three_tasks'],
-            ['sample::two_tasks'],
-            ['sample::yaml']
+            ['sample', anything],
+            ['sample::single_task', anything],
+            ['sample::three_tasks', anything],
+            ['sample::two_tasks', anything],
+            ['sample::yaml', anything]
           ].each do |plan|
             expect(plan_list).to include(plan)
           end
@@ -1607,13 +1607,13 @@ describe "Bolt::CLI" do
 
           cli.execute(options)
           json = JSON.parse(output.string)['plans']
-          expect(json).to include(["aggregate::count"],
-                                  ["aggregate::targets"],
-                                  ["canary"],
-                                  ["facts"],
-                                  ["facts::info"],
-                                  ["puppetdb_fact"],
-                                  ["sample::ok"])
+          expect(json).to include(["aggregate::count", anything],
+                                  ["aggregate::targets", anything],
+                                  ["canary", anything],
+                                  ["facts", anything],
+                                  ["facts::info", anything],
+                                  ["puppetdb_fact", anything],
+                                  ["sample::ok", anything])
 
           expect(@log_output.readlines.join).to match(/Syntax error at.*single_task.pp/m)
         end

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -85,8 +85,8 @@ describe "Bolt::Outputter::Human" do
   end
 
   it "formats a table" do
-    outputter.print_table([%w[a b], %w[c1 d]])
-    expect(output.string).to eq(<<~TABLE)
+    output = outputter.format_table([%w[a b], %w[c1 d]])
+    expect(output.to_s).to eq(<<~TABLE.chomp)
       a    b
       c1   d
     TABLE

--- a/spec/integration/private_plan_spec.rb
+++ b/spec/integration/private_plan_spec.rb
@@ -23,8 +23,9 @@ describe "with private plans" do
   context 'with a private YAML plan' do
     it 'does not show the private plan in plan show output' do
       result = run_cli_json(%W[plan show -m #{modulepath}])
-      expect(result['plans']).to include(["facts"])
-      expect(result['plans']).not_to include(["private::yaml"])
+      plans = result['plans'].map(&:first)
+      expect(plans).to include('facts')
+      expect(plans).not_to include('private::yaml')
     end
 
     it 'shows the private plan in plan show <plan> output' do
@@ -107,8 +108,9 @@ describe "with private plans" do
   context 'with a private Puppet plan' do
     it 'does not show the private plan in plan show output' do
       result = run_cli_json(%W[plan show -m #{modulepath}])
-      expect(result['plans']).to include(["facts"])
-      expect(result['plans']).not_to include(["private::puppet"])
+      plans = result['plans'].map(&:first)
+      expect(plans).to include('facts')
+      expect(plans).not_to include('private::puppet')
     end
 
     it 'shows the private plan in plan show <plan> output' do

--- a/spec/integration/project_spec.rb
+++ b/spec/integration/project_spec.rb
@@ -51,7 +51,8 @@ describe "When loading content", ssh: true do
 
   it "loads embedded plans from a project specified with --project" do
     result = run_cli_json(%W[plan show --project #{embedded}])
-    expect(result['plans']).to include(['embedded'])
+    plans = result['plans'].map(&:first)
+    expect(plans).to include('embedded')
   end
 
   it "project level content can reference other modules" do


### PR DESCRIPTION
This adds plan descriptions to `bolt plan show` and `Get-BoltPlan`
output.

!feature

* **Show plan descriptions in plan list**

  Plan descriptions now appear in `bolt plan show` and `Get-BoltPlan`
  output.