### PR TITLE
(docs) Fix broken built-in module links

### DIFF
--- a/rakelib/docs.rake
+++ b/rakelib/docs.rake
@@ -103,7 +103,7 @@ begin
         {
           name:        mod.first,
           description: match[:desc].strip,
-          url:         "https://github.com/puppetlabs/bolt/main/modules/#{mod.first}"
+          url:         "https://github.com/puppetlabs/bolt/tree/main/modules/#{mod.first}"
         }
       end
 


### PR DESCRIPTION
This fixes some broken links to built-in modules on the "Packaged
modules" docs page.

!no-release-note