### PR TITLE
(maint) Test YAML plans with BoltSpec

### DIFF
--- a/lib/bolt_spec/plans/mock_executor.rb
+++ b/lib/bolt_spec/plans/mock_executor.rb
@@ -216,6 +216,8 @@ module BoltSpec
 
       def report_apply(_statements, _resources); end
 
+      def report_yaml_plan(_plan); end
+
       def publish_event(event)
         if event[:type] == :message
           unless @stub_out_message

--- a/spec/bolt_spec/plan_spec.rb
+++ b/spec/bolt_spec/plan_spec.rb
@@ -59,6 +59,11 @@ describe "BoltSpec::Plans" do
     expect(result.value).to eq(nil)
   end
 
+  it 'runs yaml plans' do
+    expect_out_message.with_params("I'm a YAML plan")
+    expect { run_plan('plans::yaml', {}) }.not_to raise_error
+  end
+
   context 'with commands' do
     let(:plan_name) { 'plans::command' }
     let(:return_expects) { { command: 'echo hello', params: {} } }

--- a/spec/fixtures/bolt_spec/plans/plans/yaml.yaml
+++ b/spec/fixtures/bolt_spec/plans/plans/yaml.yaml
@@ -1,0 +1,2 @@
+steps:
+  - message: I'm a YAML plan


### PR DESCRIPTION
This enables testing YAML plans with BoltSpec by adding a
`report_yaml_plan` method to the mock executor.

!bug

* **Test YAML plans with BoltSpec**

  YAML plans can now be tested with BoltSpec.