### PR TITLE
(maint) Cancel stale jobs in CI

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -18,6 +18,8 @@ jobs:
     name: Fast
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel stale jobs
+        uses: fkirc/skip-duplicate-actions@v3.3.0
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Setup Ruby
@@ -43,6 +45,8 @@ jobs:
     name: Slow
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel stale jobs
+        uses: fkirc/skip-duplicate-actions@v3.3.0
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Setup Ruby

--- a/.github/workflows/litmus_smoke.yaml
+++ b/.github/workflows/litmus_smoke.yaml
@@ -16,6 +16,8 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
+      - name: Cancel stale jobs
+        uses: fkirc/skip-duplicate-actions@v3.3.0
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:

--- a/.github/workflows/lxd.yaml
+++ b/.github/workflows/lxd.yaml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Cancel stale jobs
+        uses: fkirc/skip-duplicate-actions@master
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/modules.yaml
+++ b/.github/workflows/modules.yaml
@@ -17,6 +17,8 @@ jobs:
     name: Linux
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel stale jobs
+        uses: fkirc/skip-duplicate-actions@master
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Setup Ruby
@@ -35,6 +37,8 @@ jobs:
     env:
       BOLT_WINDOWS: true
     steps:
+      - name: Cancel stale jobs
+        uses: fkirc/skip-duplicate-actions@master
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Setup Ruby

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Cancel stale jobs
+        uses: technote-space/auto-cancel-redundant-workflow@v1
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -60,6 +62,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Cancel stale jobs
+        uses: technote-space/auto-cancel-redundant-workflow@v1
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
This updates long-running CI jobs to cancel stale jobs before running,
freeing up the pool of runners that Bolt has available to it.

!no-release-note