### PR TITLE
(PE-31273) Collect analytics on source files for plan actions

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
@@ -80,7 +80,7 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
         Puppet::Pops::Issues::NOT_A_FILE, file: script
       )
     end
-
+    executor.report_file_source(self.class.name, script)
     # Ensure that given targets are all Target instances)
     targets = inventory.get_targets(targets)
 

--- a/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
@@ -76,7 +76,7 @@ Puppet::Functions.create_function(:upload_file, Puppet::Functions::InternalFunct
         Puppet::Pops::Issues::NO_SUCH_FILE_OR_DIRECTORY, file: source
       )
     end
-
+    executor.report_file_source(self.class.name, source)
     # Ensure that that given targets are all Target instances
     targets = inventory.get_targets(targets)
     if targets.empty?

--- a/bolt-modules/file/lib/puppet/functions/file/read.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/read.rb
@@ -17,7 +17,8 @@ Puppet::Functions.create_function(:'file::read', Puppet::Functions::InternalFunc
 
   def read(scope, filename)
     # Send Analytics Report
-    Puppet.lookup(:bolt_executor) {}&.report_function_call(self.class.name)
+    executor = Puppet.lookup(:bolt_executor) {}
+    executor&.report_function_call(self.class.name)
 
     found = Puppet::Parser::Files.find_file(filename, scope.compiler.environment)
     unless found && Puppet::FileSystem.exist?(found)
@@ -25,7 +26,7 @@ Puppet::Functions.create_function(:'file::read', Puppet::Functions::InternalFunc
         Puppet::Pops::Issues::NO_SUCH_FILE_OR_DIRECTORY, file: filename
       )
     end
-
+    executor&.report_file_source(self.class.name, filename)
     File.read(found)
   end
 end

--- a/documentation/analytics.md
+++ b/documentation/analytics.md
@@ -38,6 +38,8 @@ with a randomly generated, non-identifiable user UUID:
 - Which built-in plugins Bolt is using
 - Topics viewed with `bolt guide <TOPIC>`
 - IDs of any deprecation warnings
+- Whether source file for `upload_file`, `run_script`, or `file::read` plan
+  functions use an absolute path or a module path.
 
 ## Viewing collected data
 

--- a/documentation/analytics.md
+++ b/documentation/analytics.md
@@ -38,8 +38,8 @@ with a randomly generated, non-identifiable user UUID:
 - Which built-in plugins Bolt is using
 - Topics viewed with `bolt guide <TOPIC>`
 - IDs of any deprecation warnings
-- Whether source file for `upload_file`, `run_script`, or `file::read` plan
-  functions use an absolute path or a module path.
+- Whether the source file for `upload_file`, `run_script`, or `file::read` plan
+  functions uses an absolute path or a module path.
 
 ## Viewing collected data
 

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -4,6 +4,7 @@
 require 'English'
 require 'json'
 require 'logging'
+require 'pathname'
 require 'set'
 require 'bolt/analytics'
 require 'bolt/result'
@@ -230,6 +231,11 @@ module Bolt
 
     def report_bundled_content(mode, name)
       @analytics.report_bundled_content(mode, name)
+    end
+
+    def report_file_source(plan_function, source)
+      label = Pathname.new(source).absolute? ? 'absolute' : 'module'
+      @analytics&.event('Plan', plan_function, label: label)
     end
 
     def report_apply(statement_count, resource_counts)

--- a/lib/bolt_spec/plans/mock_executor.rb
+++ b/lib/bolt_spec/plans/mock_executor.rb
@@ -214,6 +214,8 @@ module BoltSpec
 
       def report_bundled_content(_mode, _name); end
 
+      def report_file_source(_plan_function, _source); end
+
       def report_apply(_statements, _resources); end
 
       def publish_event(event)

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -742,6 +742,22 @@ describe "Bolt::Executor" do
         executor.report_bundled_content('Task', 'facts')
       end
     end
+
+    context "#report_file_source" do
+      let(:executor) { Bolt::Executor.new(2, analytics) }
+
+      it 'reports when a file path is absolute' do
+        expect(analytics).to receive(:event).with('Plan', 'run_script', label: 'absolute')
+
+        executor.report_file_source('run_script', '/foo/bar')
+      end
+
+      it 'reports when a file path is module' do
+        expect(analytics).to receive(:event).with('Plan', 'run_script', label: 'module')
+
+        executor.report_file_source('run_script', 'my_module/my_file')
+      end
+    end
   end
 
   context "When running a plan" do


### PR DESCRIPTION
Collect analytics on whether absolute paths are uses as the source file for run_script, upload_file, or file::read.

!no-relase-note