### PR TITLE
(maint) Don't include password for Windows target

### DIFF
--- a/spec/integration/logging_spec.rb
+++ b/spec/integration/logging_spec.rb
@@ -179,19 +179,19 @@ shared_examples 'streaming output' do
     end
 
     it 'streams stdout to the console' do
-      expect(logger).to receive(:warn).with(/\[#{safe_name}\] out: #{user}/)
+      expect(logger).to receive(:warn).with(/\[#{uri}\] out: #{user}/)
       run_cli(%W[command run #{whoami} -t #{uri}] + config_flags, project: @project)
     end
 
     it 'streams stderr to the console' do
-      expect(logger).to receive(:warn).with(/\[#{safe_name}\] err: error/)
+      expect(logger).to receive(:warn).with(/\[#{uri}\] err: error/)
       run_cli(%W[command run #{err_cmd} -t #{uri}] + config_flags, project: @project)
     end
 
     it 'formats multi-line messages correctly' do
       expected = <<~OUTPUT
-      [#{safe_name}] out: In like a lion
-      [#{safe_name}] out: Out like a lamb
+      [#{uri}] out: In like a lion
+      [#{uri}] out: Out like a lamb
       OUTPUT
       expect(logger).to receive(:warn).with(expected.chomp)
       run_cli(%W[task run sample::multiline -t #{uri}] + config_flags, project: @project)
@@ -199,7 +199,7 @@ shared_examples 'streaming output' do
 
     it 'does not print streaming logs to log files' do
       run_cli(%W[command run #{whoami} -t #{uri}] + config_flags, project: @project)
-      expect(File.read(File.join(@project.path, 'bolt-debug.log'))).not_to include("[#{safe_name}] out: bolt")
+      expect(File.read(File.join(@project.path, 'bolt-debug.log'))).not_to include("[#{uri}] out: bolt")
     end
   end
 
@@ -217,12 +217,12 @@ end
 describe 'streaming output over SSH', ssh: true do
   include BoltSpec::Conn
 
-  let(:uri)           { conn_uri('ssh', include_password: true) }
-  let(:safe_name)     { conn_uri('ssh') }
+  let(:uri)           { conn_uri('ssh') }
+  let(:pw)            { conn_info('ssh')[:password] }
   let(:whoami)        { 'whoami' }
   let(:user)          { conn_info('ssh')[:user] }
   let(:err_cmd)       { "echo 'error' 1>&2" }
-  let(:config_flags)  { %w[--no-host-key-check] }
+  let(:config_flags)  { %W[--no-host-key-check --password #{pw}] }
 
   include_examples 'streaming output'
 end
@@ -230,12 +230,12 @@ end
 describe 'streaming output over WinRM', winrm: true do
   include BoltSpec::Conn
 
-  let(:uri)         { conn_uri('winrm', include_password: true) }
-  let(:safe_name)   { conn_uri('winrm') }
-  let(:user)        { conn_info('winrm')[:user] }
-  let(:whoami)      { '$env:UserName' }
-  let(:err_cmd)     { '$host.ui.WriteErrorLine("error")' }
-  let(:config_flags)  { %w[--no-ssl --no-ssl-verify] }
+  let(:uri)           { conn_uri('winrm') }
+  let(:pw)            { conn_info('winrm')[:password] }
+  let(:user)          { conn_info('winrm')[:user] }
+  let(:whoami)        { '$env:UserName' }
+  let(:err_cmd)       { '$host.ui.WriteErrorLine("error")' }
+  let(:config_flags)  { %W[--no-ssl --no-ssl-verify --password #{pw}] }
 
   include_examples 'streaming output'
 end

--- a/spec/lib/bolt_spec/project.rb
+++ b/spec/lib/bolt_spec/project.rb
@@ -18,12 +18,11 @@ module BoltSpec
         # Set default config and inventory if not provided
         cfg = { 'name' => name }
         cfg.merge!(config) if config
-        inventory ||= {}
 
         # Create project directory and files
         FileUtils.mkdir_p(project_path)
         File.write(config_path, cfg.to_yaml)
-        File.write(inventory_path, inventory.to_yaml)
+        File.write(inventory_path, inventory.to_yaml) unless inventory.nil?
 
         yield(project_path)
       end


### PR DESCRIPTION
The Windows testing password includes characters that aren't allowed in
target uris that are looked up in the inventory file. When we use the
full target uri (including password) from the `BoltSpec::Conn` module
along with a project created by `BoltSpec::Project#with_project` which
laid down an empty inventoryfile, Bolt would try to lookup the uri in
the empty inventory and fail.

This makes two changes to address this:
- First, it modifies the failing test to use `--password` instead of
  including the password in the URI.
- Second, it modifies `with_project` to only create an inventoryfile if
  any inventory data is passed to the function. This will prevent Bolt
  from trying to lookup targets in the inventory unnecessarily.

!no-release-note