### PR TITLE
(bug) Fix 'Linux fast' workflow to run tests

### DIFF
--- a/rakelib/tests.rake
+++ b/rakelib/tests.rake
@@ -10,7 +10,7 @@ begin
 
     desc "Run RSpec tests that do not require VM fixtures or a particular shell"
     RSpec::Core::RakeTask.new(:unit) do |t|
-      t.rspec_opts = '--tag ~ssh --tag ~docker --tag ~lxd --tag ~bash --tag ~winrm ' \
+      t.rspec_opts = '--tag ~ssh --tag ~docker --tag ~lxd_transport --tag ~bash --tag ~winrm ' \
                      '--tag ~windows_agents --tag ~puppetserver --tag ~puppetdb ' \
                      '--tag ~omi --tag ~kerberos'
     end
@@ -32,7 +32,7 @@ begin
 
     desc 'Run tests that require a host System Under Test configured with LXD'
     RSpec::Core::RakeTask.new(:lxd) do |t|
-      t.rspec_opts = '--tag lxd'
+      t.rspec_opts = '--tag lxd_transport'
     end
 
     desc 'Run tests that require Bash on the local host'
@@ -58,8 +58,8 @@ begin
       # Run RSpec tests that do not require WinRM
       desc ''
       RSpec::Core::RakeTask.new(:fast) do |t|
-        t.rspec_opts = '--tag ~winrm --tag ~lxd --tag ~windows_agents --tag ~puppetserver --tag ~puppetdb ' \
-                       '--tag ~omi --tag ~windows --tag ~kerberos --tag ~expensive'
+        t.rspec_opts = '--tag ~winrm --tag ~lxd_transport --tag ~windows_agents --tag ~puppetserver ' \
+                       '--tag ~puppetdb --tag ~omi --tag ~windows --tag ~kerberos --tag ~expensive'
       end
 
       # Run RSpec tests that are slow or require slow to start containers for setup
@@ -73,7 +73,7 @@ begin
       # Run RSpec tests that do not require Puppet Agents on Windows
       desc ''
       RSpec::Core::RakeTask.new(:agentless) do |t|
-        t.rspec_opts = '--tag ~ssh --tag ~docker --tag ~lxd --tag ~bash --tag ~windows_agents ' \
+        t.rspec_opts = '--tag ~ssh --tag ~docker --tag ~lxd_transport --tag ~bash --tag ~windows_agents ' \
                        '--tag ~orchestrator --tag ~puppetserver --tag ~puppetdb --tag ~omi ' \
                        '--tag ~kerberos'
       end

--- a/spec/integration/transport/lxd_spec.rb
+++ b/spec/integration/transport/lxd_spec.rb
@@ -8,7 +8,7 @@ require 'bolt/inventory'
 
 require 'shared_examples/transport'
 
-describe Bolt::Transport::LXD, lxd: true do
+describe Bolt::Transport::LXD, lxd_transport: true do
   include BoltSpec::Conn
   include BoltSpec::Transport
 


### PR DESCRIPTION
This fixes a bug in the linux spec tests that was preventing any tests
from running in GitHub Actions. The issue specifically came about from
using the `:lxd` tag to mark LXD tests. Updating the tag to
`:lxd_transport` fixes the issue.

!no-release-note