### PR TITLE
(Docs) remove bolt.yaml example in transports ref

### DIFF
--- a/documentation/templates/bolt_transports_reference.md.erb
+++ b/documentation/templates/bolt_transports_reference.md.erb
@@ -160,13 +160,6 @@ ssh:
 
 ## Example files
 
-### ⛔ `bolt.yaml`
-
-```yaml
-# bolt.yaml
-<%= @yaml.to_yaml(indentation: 2).split("\n").drop(1).join("\n") %>
-```
-
 ### `bolt-defaults.yaml`
 
 ```yaml


### PR DESCRIPTION
!no-release-note