### PR TITLE
(GH-2653) Merge stdout and stderr for commands and scripts

### DIFF
--- a/documentation/bolt_types_reference.md
+++ b/documentation/bolt_types_reference.md
@@ -84,6 +84,27 @@ The following functions are available to `Result` objects.
 | `to_data` | `Hash` | A serialized representation of `Result`. |
 | `value` | `Hash` | The output or return of executing on the target. |
 
+#### Command and script result value keys
+
+The `Result` object returned by the `run_command` and `run_script` plan function
+includes the following keys on the `value` hash:
+
+| Key | Type | Description |
+| --- | --- | --- |
+| `exit_code` | `Number` | The command's or script's exit code. |
+| `merged_output` | `String` | Output written to both standard error (stderr) and standard out (stdout) in the order that Bolt received the output. |
+| `stderr` | `String` | Output written to standard error (stderr). |
+| `stdout` | `String` | Output written to standard out (stdout). |
+
+#### Download result value keys
+
+The `Result` object returned by the `download_file` plan function includes the
+following key on the `value` hash:
+
+| Key | Type | Description |
+| --- | --- | --- |
+| `path` | `String` | The path to the downloaded file on the local host. |
+
 ### `ResultSet`
 
 For each target that you execute an action on, Bolt returns a `Result` object

--- a/lib/bolt/node/output.rb
+++ b/lib/bolt/node/output.rb
@@ -6,13 +6,23 @@ require 'bolt/result'
 module Bolt
   class Node
     class Output
-      attr_reader :stdout, :stderr
+      attr_reader :stderr, :stdout, :merged_output
       attr_accessor :exit_code
 
       def initialize
-        @stdout = StringIO.new
-        @stderr = StringIO.new
-        @exit_code = 'unknown'
+        @stdout        = StringIO.new
+        @stderr        = StringIO.new
+        @merged_output = StringIO.new
+        @exit_code     = 'unknown'
+      end
+
+      def to_h
+        {
+          'stdout'        => @stdout.string,
+          'stderr'        => @stderr.string,
+          'merged_output' => @merged_output.string,
+          'exit_code'     => @exit_code
+        }
       end
     end
   end

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -142,16 +142,9 @@ module Bolt
           end
 
           # Use special handling if the result looks like a command or script result
-          if result.generic_value.keys == %w[stdout stderr exit_code]
+          if result.generic_value.keys == %w[stdout stderr merged_output exit_code]
             safe_value = result.safe_value
-            unless safe_value['stdout'].strip.empty?
-              @stream.puts(indent(2, "STDOUT:"))
-              @stream.puts(indent(4, safe_value['stdout']))
-            end
-            unless safe_value['stderr'].strip.empty?
-              @stream.puts(indent(2, "STDERR:"))
-              @stream.puts(indent(4, safe_value['stderr']))
-            end
+            @stream.puts(indent(2, safe_value['merged_output'])) unless safe_value['merged_output'].strip.empty?
           elsif result.generic_value.any?
             @stream.puts(indent(2, ::JSON.pretty_generate(result.generic_value)))
           end

--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -28,20 +28,14 @@ module Bolt
       %w[file line].zip(position).to_h.compact
     end
 
-    def self.for_command(target, stdout, stderr, exit_code, action, command, position)
-      value = {
-        'stdout' => stdout,
-        'stderr' => stderr,
-        'exit_code' => exit_code
-      }
-
+    def self.for_command(target, value, action, command, position)
       details = create_details(position)
-      unless exit_code == 0
-        details['exit_code'] = exit_code
+      unless value['exit_code'] == 0
+        details['exit_code'] = value['exit_code']
         value['_error'] = {
           'kind' => 'puppetlabs.tasks/command-error',
           'issue_code' => 'COMMAND_ERROR',
-          'msg' => "The command failed with exit code #{exit_code}",
+          'msg' => "The command failed with exit code #{value['exit_code']}",
           'details' => details
         }
       end

--- a/lib/bolt/shell/bash.rb
+++ b/lib/bolt/shell/bash.rb
@@ -24,9 +24,7 @@ module Bolt
         running_as(options[:run_as]) do
           output = execute(command, environment: options[:env_vars], sudoable: true)
           Bolt::Result.for_command(target,
-                                   output.stdout.string,
-                                   output.stderr.string,
-                                   output.exit_code,
+                                   output.to_h,
                                    'command',
                                    command,
                                    position)
@@ -82,9 +80,7 @@ module Bolt
             dir.chown(run_as)
             output = execute([path, *arguments], environment: options[:env_vars], sudoable: true)
             Bolt::Result.for_command(target,
-                                     output.stdout.string,
-                                     output.stderr.string,
-                                     output.exit_code,
+                                     output.to_h,
                                      'script',
                                      script,
                                      position)
@@ -405,7 +401,8 @@ module Bolt
               @stream_logger.warn(formatted)
             end
 
-            read_streams[stream] << to_print
+            read_streams[stream]        << to_print
+            result_output.merged_output << to_print
           rescue EOFError
           end
 
@@ -455,7 +452,8 @@ module Bolt
         when 126
           msg = "\n\nThis might be caused by the default tmpdir being mounted "\
             "using 'noexec'. See http://pup.pt/task-failure for details and workarounds."
-          result_output.stderr << msg
+          result_output.stderr        << msg
+          result_output.merged_output << msg
           @logger.trace { "Command #{command_str} failed with exit code #{result_output.exit_code}" }
         else
           @logger.trace { "Command #{command_str} failed with exit code #{result_output.exit_code}" }

--- a/lib/bolt/shell/powershell.rb
+++ b/lib/bolt/shell/powershell.rb
@@ -195,9 +195,7 @@ module Bolt
         wrap_command = conn.is_a?(Bolt::Transport::Local::Connection)
         output = execute(command, wrap_command)
         Bolt::Result.for_command(target,
-                                 output.stdout.string,
-                                 output.stderr.string,
-                                 output.exit_code,
+                                 output.to_h,
                                  'command',
                                  command,
                                  position)
@@ -224,9 +222,7 @@ module Bolt
           output = execute([shell_init, *env_assignments, command].join("\r\n"))
 
           Bolt::Result.for_command(target,
-                                   output.stdout.string,
-                                   output.stderr.string,
-                                   output.exit_code,
+                                   output.to_h,
                                    'script',
                                    script,
                                    position)
@@ -322,7 +318,8 @@ module Bolt
             end.join("\n")
             @stream_logger.warn(formatted)
           end
-          result.stdout << to_print
+          result.stdout        << to_print
+          result.merged_output << to_print
         end
         stderr = Thread.new do
           encoding = err.external_encoding
@@ -334,7 +331,8 @@ module Bolt
             end.join("\n")
             @stream_logger.warn(formatted)
           end
-          result.stderr << to_print
+          result.stderr        << to_print
+          result.merged_output << to_print
         end
 
         stdout.join

--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -252,11 +252,7 @@ module Bolt
 
         # If we get here, there's no error so we don't need the file or line
         # number
-        Bolt::Result.for_command(target,
-                                 result.value['stdout'],
-                                 result.value['stderr'],
-                                 result.value['exit_code'],
-                                 action, obj, [])
+        Bolt::Result.for_command(target, result.value, action, obj, [])
       end
     end
   end

--- a/lib/bolt_spec/plans/action_stubs/command_stub.rb
+++ b/lib/bolt_spec/plans/action_stubs/command_stub.rb
@@ -29,7 +29,14 @@ module BoltSpec
       end
 
       def result_for(target, stdout: '', stderr: '')
-        Bolt::Result.for_command(target, stdout, stderr, 0, 'command', '', [])
+        value = {
+          'stdout'        => stdout,
+          'stderr'        => stderr,
+          'merged_output' => "#{stdout}\n#{stderr}".strip,
+          'exit_code'     => 0
+        }
+
+        Bolt::Result.for_command(target, value, 'command', '', [])
       end
 
       # Public methods

--- a/lib/bolt_spec/plans/action_stubs/script_stub.rb
+++ b/lib/bolt_spec/plans/action_stubs/script_stub.rb
@@ -35,7 +35,14 @@ module BoltSpec
       end
 
       def result_for(target, stdout: '', stderr: '')
-        Bolt::Result.for_command(target, stdout, stderr, 0, 'script', '', [])
+        value = {
+          'stdout'        => stdout,
+          'stderr'        => stderr,
+          'merged_output' => "#{stdout}\n#{stderr}".strip,
+          'exit_code'     => 0
+        }
+
+        Bolt::Result.for_command(target, value, 'script', '', [])
       end
 
       # Public methods

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -612,8 +612,15 @@ describe "Bolt::Executor" do
     let(:executor) { Bolt::Executor.new(2, analytics) }
 
     it "batch_execute only creates 2 threads" do
+      value = {
+        'stdout'        => 'foo',
+        'stderr'        => 'bar',
+        'merged_output' => "foo\nbar",
+        'exit_code'     => 0
+      }
+
       state = targets.each_with_object({}) do |target, acc|
-        acc[target] = { promise: Concurrent::Promise.new { Bolt::Result.for_command(target, "foo", "bar", 0) },
+        acc[target] = { promise: Concurrent::Promise.new { Bolt::Result.for_command(target, value) },
                         running: false }
       end
 

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -266,10 +266,15 @@ describe "Bolt::Outputter::Human" do
   end
 
   it "prints CommandResults" do
-    outputter.print_result(Bolt::Result.for_command(target, "stout", "sterr", 2, 'command', "executed", []))
-    lines = output.string
-    expect(lines).to match(/STDOUT:\n    stout/)
-    expect(lines).to match(/STDERR:\n    sterr/)
+    value = {
+      'stdout'        => 'stdout',
+      'stderr'        => 'stderr',
+      'merged_output' => "stdout\nstderr",
+      'exit_code'     => 2
+    }
+
+    outputter.print_result(Bolt::Result.for_command(target, value, 'command', "executed", []))
+    expect(output.string).to match(/stdout.*stderr/m)
   end
 
   it "prints TaskResults" do

--- a/spec/bolt/result_spec.rb
+++ b/spec/bolt/result_spec.rb
@@ -73,12 +73,26 @@ describe Bolt::Result do
 
   describe :for_command do
     it 'exposes value' do
-      result = Bolt::Result.for_command(target, "stout", "sterr", 0, 'command', 'command', [])
-      expect(result.value).to eq('stdout' => 'stout', 'stderr' => 'sterr', 'exit_code' => 0)
+      value = {
+        'stdout'        => 'stdout',
+        'stderr'        => 'stderr',
+        'merged_output' => "stdout\nstderr",
+        'exit_code'     => 0
+      }
+
+      result = Bolt::Result.for_command(target, value, 'command', 'command', [])
+      expect(result.value).to eq(value)
     end
 
     it 'creates errors' do
-      result = Bolt::Result.for_command(target, "stout", "sterr", 1, 'command', 'command', ['/jacko/lantern', 6])
+      value = {
+        'stdout'        => 'stdout',
+        'stderr'        => 'stderr',
+        'merged_output' => "stdout\nstderr",
+        'exit_code'     => 1
+      }
+
+      result = Bolt::Result.for_command(target, value, 'command', 'command', ['/jacko/lantern', 6])
       expect(result.error_hash['kind']).to eq('puppetlabs.tasks/command-error')
       expect(result.error_hash['details']).to include({ 'file' => '/jacko/lantern', 'line' => 6 })
     end

--- a/spec/bolt_spec/plan_spec.rb
+++ b/spec/bolt_spec/plan_spec.rb
@@ -84,7 +84,7 @@ describe "BoltSpec::Plans" do
       expect(result).to be_ok
       expect(result.value.class).to eq(Bolt::ResultSet)
       results = result.value.result_hash
-      expected_result = { 'stdout' => 'done', 'stderr' => '', 'exit_code' => 0 }
+      expected_result = { 'stdout' => 'done', 'stderr' => '', 'merged_output' => 'done', 'exit_code' => 0 }
       targets.each { |target| expect(results[target].value).to eq(expected_result) }
     end
 

--- a/spec/integration/local_spec.rb
+++ b/spec/integration/local_spec.rb
@@ -71,7 +71,12 @@ describe "when running over the local transport" do
         results = run_cli_json(%W[script run #{script.path} param --targets localhost])
         results['items'].each do |result|
           expect(result['status']).to eq('success')
-          expect(result['value']).to eq("stdout" => "param\n", "stderr" => "", "exit_code" => 0)
+          expect(result['value']).to eq(
+            "stdout"        => "param\n",
+            "stderr"        => "",
+            "merged_output" => "param\n",
+            "exit_code"     => 0
+          )
         end
       end
     end
@@ -123,7 +128,12 @@ describe "when running over the local transport" do
         results = run_cli_json(%W[script run #{script.path} hello] + config_flags)
         results['items'].each do |result|
           expect(result['status']).to eq('success')
-          expect(result['value']).to eq("stdout" => "hello\n", "stderr" => "", "exit_code" => 0)
+          expect(result['value']).to eq(
+            "stdout"        => "hello\n",
+            "stderr"        => "",
+            "merged_output" => "hello\n",
+            "exit_code"     => 0
+          )
         end
       end
     end
@@ -139,7 +149,12 @@ describe "when running over the local transport" do
         results = run_cli_json(%W[script run #{script.path} param --targets localhost])
         results['items'].each do |result|
           expect(result['status']).to eq('success')
-          expect(result['value']).to eq("stdout" => "param\n", "stderr" => "", "exit_code" => 0)
+          expect(result['value']).to eq(
+            "stdout"        => "param\n",
+            "stderr"        => "",
+            "merged_output" => "param\n",
+            "exit_code"     => 0
+          )
         end
       end
     end
@@ -150,7 +165,12 @@ describe "when running over the local transport" do
         results = run_cli_json(%W[script run #{script.path} param --targets localhost])
         results['items'].each do |result|
           expect(result['status']).to eq('success')
-          expect(result['value']).to eq("stdout" => "Ruby\r\nparam\r\n", "stderr" => "", "exit_code" => 0)
+          expect(result['value']).to eq(
+            "stdout"        => "Ruby\r\nparam\r\n",
+            "stderr"        => "",
+            "merged_output" => "Ruby\r\nparam\r\n",
+            "exit_code"     => 0
+          )
         end
       end
     end

--- a/spec/integration/plan_spec.rb
+++ b/spec/integration/plan_spec.rb
@@ -59,7 +59,12 @@ describe 'plans' do
       json = JSON.parse(result)[0]
       expect(json['target']).to eq(target)
       expect(json['status']).to eq('success')
-      expect(json['value']).to eq("stdout" => "I am a yaml plan\n", "stderr" => "", "exit_code" => 0)
+      expect(json['value']).to eq(
+        "stdout"        => "I am a yaml plan\n",
+        "stderr"        => "",
+        "merged_output" => "I am a yaml plan\n",
+        "exit_code"     => 0
+      )
     end
 
     context "using the human outputter" do
@@ -82,7 +87,12 @@ describe 'plans' do
 
     it 'runs a yaml plan', ssh: true do
       result = run_cli(['plan', 'run', 'sample::yaml', '--targets', target] + config_flags)
-      expect(JSON.parse(result)).to eq('stdout' => "hello world\n", 'stderr' => '', 'exit_code' => 0)
+      expect(JSON.parse(result)).to eq(
+        'stdout'        => "hello world\n",
+        'stderr'        => '',
+        'merged_output' => "hello world\n",
+        'exit_code'     => 0
+      )
     end
 
     context 'with puppet-agent installed for get_resources' do

--- a/spec/integration/transport/ssh_spec.rb
+++ b/spec/integration/transport/ssh_spec.rb
@@ -70,6 +70,13 @@ describe Bolt::Transport::SSH, ssh: true do
 
     include_examples 'transport api'
     include_examples 'with sudo'
+
+    it 'merges stdout and stderr' do
+      command = "echo 'hello' && echo 'goodbye' 1>&2"
+      result  = ssh.run_command(target, command)
+      expect(result['merged_output']).to match(/hello/)
+      expect(result['merged_output']).to match(/goodbye/)
+    end
   end
 
   context 'with native ssh' do

--- a/spec/integration/transport/winrm_spec.rb
+++ b/spec/integration/transport/winrm_spec.rb
@@ -309,6 +309,13 @@ describe Bolt::Transport::WinRM do
       expect(winrm.run_command(target, command)['stdout']).to eq("#{user}\r\n")
     end
 
+    it "merges outputs and errors", winrm: true do
+      command = "Write-Output 'hello'; $host.ui.WriteErrorLine('goodbye')"
+      result = winrm.run_command(target, command)
+      expect(result['merged_output']).to match(/hello/)
+      expect(result['merged_output']).to match(/goodbye/)
+    end
+
     it "ignores run_as", winrm: true do
       expect(winrm.run_command(target, command, run_as: 'root')['stdout']).to eq("#{user}\r\n")
     end

--- a/spec/integration/yaml_plan_spec.rb
+++ b/spec/integration/yaml_plan_spec.rb
@@ -39,7 +39,12 @@ describe "running YAML plans", ssh: true do
 
     expect(result.first['target']).to eq(target)
     expect(result.first['status']).to eq('success')
-    expect(result.first['value']).to eq("stdout" => "hello world\n", "stderr" => "", "exit_code" => 0)
+    expect(result.first['value']).to eq(
+      "stdout"        => "hello world\n",
+      "stderr"        => "",
+      "merged_output" => "hello world\n",
+      "exit_code"     => 0
+    )
   end
 
   it 'runs a task' do

--- a/spec/shared_examples/transport.rb
+++ b/spec/shared_examples/transport.rb
@@ -23,7 +23,7 @@ def posix_context
                 end
 
   {
-    stdout_command: ['echo hello', /^hello$/],
+    stdout_command: ['echo "hello"', /hello/],
     stderr_command: ['ssh -V', /OpenSSH/],
     destination_dir: '/tmp',
     # Grep exits non-zero? This works locally, I'm not sure why it doesn't in CI
@@ -51,8 +51,8 @@ end
 
 def windows_context
   {
-    stdout_command: ['echo hello', /^hello\r$/],
-    stderr_command: ['echo oops 1>&2', /oops/],
+    stdout_command: ['echo hello', /hello/],
+    stderr_command: ['$host.ui.WriteErrorLine("oops")', /oops/],
     pipe_command: ["Get-Service | Where-Object {$_.Name -like \"*net*\"}", /Netman/],
     destination_dir: 'C:/mytmp',
     supported_req: 'powershell',


### PR DESCRIPTION
This updates the `bolt command|script run` commands to display
merged output from stdout and stderr on the CLI. When Bolt logs the
output from these two streams, it also adds each line to a
`merged_output` value in the order the lines are received. This
`merged_output` value is passed to the result for the command or script,
and can be accessed from both plans and the JSON output format. Lastly,
the human outputter has been updated to display the merged output by
default, resulting in output resembling what a user would see if they
ran the command or script directly on the target.

!feature

* **Display merged stdout and stderr output for commands and scripts**
  ([#2653](#2653))

  The `bolt command|script run` commands and `Invoke-BoltCommand|Script`
  cmdlets now display merged output from stdout and stderr in the CLI.
  This merged output is also available to the `Result` object in plans
  and in the JSON output format under the `merged_output` key.