### PR TITLE
(GH-2669) Add 'remote' configuration for LXD transport

### DIFF
--- a/lib/bolt/config/transport/lxd.rb
+++ b/lib/bolt/config/transport/lxd.rb
@@ -9,11 +9,13 @@ module Bolt
       class LXD < Base
         OPTIONS = %w[
           cleanup
+          remote
           tmpdir
         ].freeze
 
         DEFAULTS = {
-          'cleanup' => true
+          'cleanup' => true,
+          'remote'  => 'local'
         }.freeze
       end
     end

--- a/lib/bolt/config/transport/options.rb
+++ b/lib/bolt/config/transport/options.rb
@@ -266,6 +266,13 @@ module Bolt
             _plugin: true,
             _example: "BOLT.PRODUCTION"
           },
+          "remote" => {
+            type: String,
+            description: "The LXD remote host to use.",
+            _default: "local",
+            _plugin: false,
+            _example: 'myremote'
+          },
           "run-as" => {
             type: String,
             description: "The user to run commands as after login. The run-as user must be different than the "\

--- a/lib/bolt/transport/lxd/connection.rb
+++ b/lib/bolt/transport/lxd/connection.rb
@@ -24,17 +24,17 @@ module Bolt
         end
 
         def container_id
-          "local:#{@target.host}"
+          "#{@target.transport_config['remote']}:#{@target.host}"
         end
 
         def connect
-          out, err, status = execute_local_command(%w[list --format json])
+          out, err, status = execute_local_command(%W[list #{container_id} --format json])
           unless status.exitstatus.zero?
             raise "Error listing available containers: #{err}"
           end
-          containers = JSON.parse(out).map { |c| c['name'] }
-          unless containers.include?(@target.host)
-            raise "Could not find a container with name or ID matching '#{@target.host}'"
+          containers = JSON.parse(out)
+          if containers.empty?
+            raise "Could not find a container with name or ID matching '#{container_id}'"
           end
           @logger.trace("Opened session")
           true

--- a/rakelib/tests.rake
+++ b/rakelib/tests.rake
@@ -12,7 +12,7 @@ begin
     RSpec::Core::RakeTask.new(:unit) do |t|
       t.rspec_opts = '--tag ~ssh --tag ~docker --tag ~lxd_transport --tag ~bash --tag ~winrm ' \
                      '--tag ~windows_agents --tag ~puppetserver --tag ~puppetdb ' \
-                     '--tag ~omi --tag ~kerberos'
+                     '--tag ~omi --tag ~kerberos --tag ~lxd_remote'
     end
 
     desc 'Run tests that require a host System Under Test configured with WinRM'
@@ -33,6 +33,11 @@ begin
     desc 'Run tests that require a host System Under Test configured with LXD'
     RSpec::Core::RakeTask.new(:lxd) do |t|
       t.rspec_opts = '--tag lxd_transport'
+    end
+
+    desc 'Run tests that require a host System Under Test configured with LXD remote'
+    RSpec::Core::RakeTask.new(:lxd_remote) do |t|
+      t.rspec_opts = '--tag lxd_remote'
     end
 
     desc 'Run tests that require Bash on the local host'
@@ -59,7 +64,8 @@ begin
       desc ''
       RSpec::Core::RakeTask.new(:fast) do |t|
         t.rspec_opts = '--tag ~winrm --tag ~lxd_transport --tag ~windows_agents --tag ~puppetserver ' \
-                       '--tag ~puppetdb --tag ~omi --tag ~windows --tag ~kerberos --tag ~expensive'
+                       '--tag ~puppetdb --tag ~omi --tag ~windows --tag ~kerberos --tag ~expensive ' \
+                       '--tag ~lxd_remote'
       end
 
       # Run RSpec tests that are slow or require slow to start containers for setup
@@ -75,7 +81,7 @@ begin
       RSpec::Core::RakeTask.new(:agentless) do |t|
         t.rspec_opts = '--tag ~ssh --tag ~docker --tag ~lxd_transport --tag ~bash --tag ~windows_agents ' \
                        '--tag ~orchestrator --tag ~puppetserver --tag ~puppetdb --tag ~omi ' \
-                       '--tag ~kerberos'
+                       '--tag ~kerberos --tag ~lxd_remote'
       end
 
       # Run RSpec tests that require Puppet Agents configured with Windows

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -553,6 +553,16 @@
                 }
               ]
             },
+            "remote": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/remote"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
             "tmpdir": {
               "oneOf": [
                 {
@@ -1566,6 +1576,10 @@
           "$ref": "#/definitions/_plugin"
         }
       ]
+    },
+    "remote": {
+      "type": "string",
+      "description": "The LXD remote host to use."
     },
     "run-as": {
       "description": "The user to run commands as after login. The run-as user must be different than the login user.",

--- a/schemas/bolt-inventory.schema.json
+++ b/schemas/bolt-inventory.schema.json
@@ -279,6 +279,10 @@
                         }
                       ]
                     },
+                    "remote": {
+                      "type": "string",
+                      "description": "The LXD remote host to use."
+                    },
                     "tmpdir": {
                       "description": "The directory to upload and execute temporary files on the target.",
                       "oneOf": [


### PR DESCRIPTION
This adds a new 'remote' configuration option for the LXD transport that
allows users to connect to LXD remote hosts. This option accepts a
string, and prepends the remote to the expected container name. This
requires that the remote is already configured with LXC.

!feature

* **LXD transport supports remote hosts** ([#2669](https://github.com/puppetlabs/bolt/issues/2669))

  The LXD transport includes a new option 'remote' to configure
  connecting to remote LXD servers.