### PR TITLE
(GH-2680) Do not send task parameters over stdin when using a tty

### DIFF
--- a/lib/bolt/shell/bash.rb
+++ b/lib/bolt/shell/bash.rb
@@ -144,7 +144,10 @@ module Bolt
 
             dir.chown(run_as)
 
-            execute_options[:stdin] = stdin
+            # Don't pass parameters on stdin if using a tty, as the parameters are
+            # already part of the wrapper script.
+            execute_options[:stdin] = stdin unless stdin && target.options['tty']
+
             execute_options[:sudoable] = true if run_as
             output = execute(remote_task_path, **execute_options)
           end

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -83,6 +83,14 @@ describe 'apply', expensive: true do
       # defined in inventory in BoltSpec::Conn.
       include_examples 'agentful tests', 'nix_agents'
 
+      it 'runs successfully with a tty' do
+        results = run_cli_json(%w[plan run basic::notify -t nix_agents --tty], project: project)
+
+        results.each do |result|
+          expect(result['status']).to eq('success')
+        end
+      end
+
       context 'in an apply block' do
         it 'gets resources' do
           results = run_cli_json(%w[plan run basic::resources -t nix_agents], project: project)


### PR DESCRIPTION
This fixes a bug with running tasks using the `stdin` input method when
using a `tty`. When the `tty` config option is set, Bolt creates a
wrapper script that executes the task and passes the task's parameters
over stdin. However, Bolt would still invoke this wrapper script on the
target and attempt to pass the parameters over stdin to the wrapper
script, even though the wrapper script already included the task
parameters. This resulted in the parameters being passed to the wrapper
script to print to stdout and be incorrectly returned as part of the
task's output.

!bug

* **Do not send task parameters over stdin when using a tty**
  ([#2680](https://github.com/puppetlabs/bolt/issues/2680))

  Tasks with a `stdin` input method that are run on targets with `tty:
  true` configuration no longer return the task's parameters as part of
  the task output. Previously, Bolt was sending these parameters to the
  task twice, causing them to be printed to standard out (stdout) and
  returned in the task output.