### PR TITLE
(GH-2689) Ensure env_vars is a hash, convert values to JSON

### DIFF
--- a/lib/bolt/pal/yaml_plan/step/command.rb
+++ b/lib/bolt/pal/yaml_plan/step/command.rb
@@ -13,6 +13,14 @@ module Bolt
             Set['command', 'targets']
           end
 
+          def self.validate_step_keys(body, number)
+            super
+
+            if body.key?('env_vars') && ![Hash, String].include?(body['env_vars'].class)
+              raise StepError.new('env_vars key must be a hash or evaluable string', body['name'], number)
+            end
+          end
+
           # Returns an array of arguments to pass to the step's function call
           #
           private def format_args(body)

--- a/lib/bolt/pal/yaml_plan/step/script.rb
+++ b/lib/bolt/pal/yaml_plan/step/script.rb
@@ -27,6 +27,10 @@ module Bolt
             if body.key?('pwsh_params') && !body['pwsh_params'].nil? && !body['pwsh_params'].is_a?(Hash)
               raise StepError.new('pwsh_params key must be a hash', body['name'], number)
             end
+
+            if body.key?('env_vars') && ![Hash, String].include?(body['env_vars'].class)
+              raise StepError.new('env_vars key must be a hash or evaluable string', body['name'], number)
+            end
           end
 
           # Returns an array of arguments to pass to the step's function call


### PR DESCRIPTION
This updates the `run_command` and `run_script` plan functions to ensure
the `_env_vars` option is a hash. It also transforms any hash values in
the `env_vars` hash to JSON before calling the executor function,
ensuring that the environment variable is not a Ruby-style hash.

!bug

* **Ensure `env_vars` is a hash in commands and scripts**
  ([#2689](#2689))

  Bolt now ensures that the `env_vars` option passed to commands and
  scripts in plans is a hash and will raise a helpful error message
  otherwise.

* **Convert `env_vars` hash values to JSON**
  ([#2689](#2689))

  Bolt now converts hash values for an environment variable passed to a
  command or script to JSON. Previously, a hash value would be passed
  with Ruby-style syntax.