### PR TITLE
(hack) Add welcome message when users first run Bolt

### DIFF
--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -77,6 +77,14 @@ module Bolt
         File.exist?(path) ? read_yaml_hash(path, file_name) : {}
       end
 
+      def first_runs_free
+        Bolt::Config.user_path + '.first_runs_free'
+      end
+
+      def first_run?
+        Bolt::Config.user_path && !File.exist?(first_runs_free)
+      end
+
       # Accepts a path with either 'plans' or 'tasks' in it and determines
       # the name of the module
       def module_name(path)


### PR DESCRIPTION
This adds a nice welcome message when users first run the Bolt command.
The message is printed to stdout, and is only printed if the following
is true:
- The stdout stream is a tty
- The user runs `bolt`, `bolt help` or `bolt --help`. This should not
  print for any other Bolt commands, such as `bolt --version` or `bolt
  command --help`.
- The user has not run Bolt before. This is determined by the presence
  of a file `~/.puppetlabs/etc/bolt/.first_runs_free`.

!feature

* **Add welcome message when users first run Bolt**
  Bolt now prints a friendly welcome message when users first run Bolt
  if they run `bolt`, `bolt --help`, or `bolt help`.