### PR TITLE
Run 'plan convert' with plan name

### DIFF
--- a/lib/bolt/pal/yaml_plan/transpiler.rb
+++ b/lib/bolt/pal/yaml_plan/transpiler.rb
@@ -14,8 +14,8 @@ module Bolt
           end
         end
 
-        def transpile(relative_path)
-          @plan_path = File.expand_path(relative_path)
+        def transpile(plan_path)
+          @plan_path = plan_path
           @modulename = Bolt::Util.module_name(@plan_path)
           @filename = @plan_path.split(File::SEPARATOR)[-1]
           validate_path

--- a/spec/integration/transpiler_spec.rb
+++ b/spec/integration/transpiler_spec.rb
@@ -47,9 +47,15 @@ describe "transpiling YAML plans" do
   }
   PLAN
 
-  it 'transpiles a yaml plan' do
+  it 'transpiles a YAML plan from a path' do
     expect {
       run_cli(%W[plan convert #{plan_path}])
+    }.to output(output_plan).to_stdout
+  end
+
+  it 'transpiles a YAML plan from a plan name' do
+    expect {
+      run_cli(%W[plan convert yaml::conversion -m #{modulepath}])
     }.to output(output_plan).to_stdout
   end
 


### PR DESCRIPTION
This adds support for calling `bolt plan convert` and `Convert-BoltPlan`
with the name of a plan instead of just the path to a plan.

!feature

* **Convert YAML plans by name**

  The `bolt plan convert` and `Convert-BoltPlan` commands now accept the
  name of a YAML plan to convert instead of just a path to a YAML plan.