### PR TITLE
(GH-2704) Add default value for 'prompt' plan function

### DIFF
--- a/bolt-modules/prompt/lib/puppet/functions/prompt.rb
+++ b/bolt-modules/prompt/lib/puppet/functions/prompt.rb
@@ -11,12 +11,24 @@ Puppet::Functions.create_function(:prompt) do
   # @option options [Boolean] sensitive Disable echo back and mark the response as sensitive.
   #   The returned value will be wrapped by the `Sensitive` data type. To access the raw
   #   value, use the `unwrap` function (i.e. `$sensitive_value.unwrap`).
+  # @option options [String] default The default value to return if the user does not provide
+  #   input or if stdin is not a tty.
   # @return The response to the prompt.
   # @example Prompt the user if plan execution should continue
   #   $response = prompt('Continue executing plan? [Y\N]')
   # @example Prompt the user for sensitive information
   #   $password = prompt('Enter your password', 'sensitive' => true)
   #   out::message("Password is: ${password.unwrap}")
+  # @example Prompt the user and provide a default value
+  #   $user = prompt('Enter your login username', 'default' => 'root')
+  # @example Prompt the user for sensitive information, returning a sensitive default if one is not provided
+  #   $token = prompt('Enter token', 'default' => lookup('default_token'), 'sensitive' => true)
+  #   out::message("Token is: ${token.unwrap}")
+  # @example Prompt the user and fail with a custom message if no input was provided
+  #   $response = prompt('Enter your name', 'default' => '')
+  #   if $response.empty {
+  #     fail_plan('Must provide your name')
+  #   }
   dispatch :prompt do
     param 'String', :prompt
     optional_param 'Hash[String[1], Any]', :options
@@ -30,14 +42,20 @@ Puppet::Functions.create_function(:prompt) do
                               action: 'prompt')
     end
 
-    options = options.transform_keys(&:to_sym)
-
+    options  = options.transform_keys(&:to_sym)
     executor = Puppet.lookup(:bolt_executor)
+
     # Send analytics report
     executor.report_function_call(self.class.name)
 
+    # Require default to be a string value
+    if options.key?(:default) && !options[:default].is_a?(String)
+      raise Bolt::ValidationError, "Option 'default' must be a string"
+    end
+
     response = executor.prompt(prompt, options)
 
+    # If sensitive, wrap it
     if options[:sensitive]
       Puppet::Pops::Types::PSensitiveType::Sensitive.new(response)
     else

--- a/bolt-modules/prompt/spec/functions/prompt_spec.rb
+++ b/bolt-modules/prompt/spec/functions/prompt_spec.rb
@@ -28,6 +28,20 @@ describe 'prompt' do
     expect(result.unwrap).to eq(response)
   end
 
+  it 'returns a default value if no input is provided' do
+    $stdin.expects(:tty?).returns(true)
+    $stdin.expects(:gets).returns('')
+    $stderr.expects(:print)
+
+    is_expected.to run.with_params(prompt, 'default' => response).and_return(response)
+  end
+
+  it 'errors if default value is not a string' do
+    is_expected.to run
+      .with_params(prompt, 'default' => 1)
+      .and_raise_error(/Option 'default' must be a string/)
+  end
+
   it 'errors when passed invalid data types' do
     is_expected.to run.with_params(1)
                       .and_raise_error(ArgumentError,

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -484,22 +484,30 @@ module Bolt
     end
 
     def prompt(prompt, options)
-      @prompting = true
       unless $stdin.tty?
+        return options[:default] if options[:default]
         raise Bolt::Error.new('STDIN is not a tty, unable to prompt', 'bolt/no-tty-error')
       end
 
-      $stderr.print("#{prompt}: ")
+      @prompting = true
+
+      if options[:default] && !options[:sensitive]
+        $stderr.print("#{prompt} [#{options[:default]}]: ")
+      else
+        $stderr.print("#{prompt}: ")
+      end
 
       value = if options[:sensitive]
                 $stdin.noecho(&:gets).to_s.chomp
               else
                 $stdin.gets.to_s.chomp
               end
+
       @prompting = false
 
       $stderr.puts if options[:sensitive]
 
+      value = options[:default] if value.empty?
       value
     end
 

--- a/spec/bolt/executor_spec.rb
+++ b/spec/bolt/executor_spec.rb
@@ -514,9 +514,34 @@ describe "Bolt::Executor" do
       executor.prompt(prompt, sensitive: true)
     end
 
+    it 'returns the default value if no input is provided' do
+      allow($stdin).to receive(:tty?).and_return(true)
+      allow($stderr).to receive(:print).with("#{prompt} [#{response}]: ")
+      expect($stdin).to receive(:gets).and_return('')
+
+      result = executor.prompt(prompt, default: response)
+      expect(result).to eq(response)
+    end
+
+    it 'does not display the default value when sensitive' do
+      allow($stdin).to receive(:tty?).and_return(true)
+      allow($stderr).to receive(:print).with("#{prompt}: ")
+      allow($stdin).to receive(:noecho).and_return('')
+
+      result = executor.prompt(prompt, default: response, sensitive: true)
+      expect(result).to eq(response)
+    end
+
     it 'errors if STDIN is not a tty' do
       allow($stdin).to receive(:tty?).and_return(false)
       expect { executor.prompt(prompt, {}) }.to raise_error(Bolt::Error, /STDIN is not a tty, unable to prompt/)
+    end
+
+    it 'returns the default value if STDIN is not a tty' do
+      allow($stdin).to receive(:tty?).and_return(false)
+
+      result = executor.prompt(prompt, default: response)
+      expect(result).to eq(response)
     end
   end
 


### PR DESCRIPTION
This adds a new `default` option for the `prompt` plan function. If a
user does not provide input when prompted, and the `default` option is
set, the function will return the `default` value. The prompt message
itself will display the default value, unless the `sensitive` value is
also set.

!feature

* **Add default value for `prompt` plan function**
  ([#2704](https://github.com/puppetlabs/bolt/issues/2704))

  The `prompt` plan function has a new `default` option which can be
  used to return a default value when a user does not provide input.