### PR TITLE
(hack) Add YAML plan 'prompt' step

### DIFF
--- a/bolt-modules/prompt/lib/puppet/functions/prompt/menu.rb
+++ b/bolt-modules/prompt/lib/puppet/functions/prompt/menu.rb
@@ -12,7 +12,7 @@ Puppet::Functions.create_function(:'prompt::menu') do
   # @param menu A list of options to choose from.
   # @param options A hash of additional options.
   # @option options [String] default The default option to return if the user does not provide
-  #   input or if standard in (stdin) is not a tty. Must be an option present in the menu.
+  #   input or if stdin is not a tty. Must be an option present in the menu.
   # @return The selected option.
   # @example Prompt the user to select from a list of options
   #   $selection = prompt::menu('Select a fruit', ['apple', 'banana', 'carrot'])
@@ -30,7 +30,7 @@ Puppet::Functions.create_function(:'prompt::menu') do
   # @param menu A hash of options to choose from, where keys are the input used to select a value.
   # @param options A hash of additional options.
   # @option options [String] default The default option to return if the user does not provide
-  #   input or if standard in (stdin) is not a tty. Must be an option present in the menu.
+  #   input or if stdin is not a tty. Must be an option present in the menu.
   # @return The selected option.
   # @example Prompt the user to select from a list of options with custom inputs
   #   $menu = { 'y' => 'yes', 'n' => 'no' }

--- a/documentation/writing_yaml_plans.md
+++ b/documentation/writing_yaml_plans.md
@@ -372,15 +372,15 @@ For example:
 ```yaml
 steps:
   - resources:
-    # This resource is type 'package' and title 'nginx'
-    - package: nginx
-      parameters:
-        ensure: latest
-    # This resource is type 'service' and title 'nginx'
-    - type: service
-      title: nginx
-      parameters:
-        ensure: running
+      # This resource is type 'package' and title 'nginx'
+      - package: nginx
+        parameters:
+          ensure: latest
+      # This resource is type 'service' and title 'nginx'
+      - type: service
+        title: nginx
+        parameters:
+          ensure: running
     targets:
       - web1.example.com
       - web2.example.com
@@ -414,6 +414,50 @@ steps:
     targets: web1.example.com
     parameters:
       message: "The count is ${count}, and twice the count is ${double_count}"
+```
+
+### Prompt step
+
+The `prompt` step displays a prompt to the user and waits for input.
+
+Prompt steps support the following keys:
+
+| Key | Type | Description | Required |
+| --- | --- | --- | --- |
+| `default` | `Array`, `Boolean`, `Hash`, `Number`, `String` | The default value to use if the user does not provide input or if standard input (stdin) is not a tty. Must be a string value unless also using the `menu` key. | |
+| `menu` | `Array`, `Hash` | A list of options to choose from, or a hash of options to choose from where each key is the input used to select a value. | |
+| `name` | `String` | The name of the variable to save the step result to. | |
+| `prompt` | `String` | The prompt to display to the user. | ✓ |
+| `sensitive` | `Boolean` | Whether to redact the response and mark it as sensitive. Bolt wraps sensitive values in the Sensitive data type. | |
+
+For example, to prompt the user for input:
+
+```yaml
+steps:
+  - name: api_token
+    prompt: Enter your API token
+    default: "lookup('api_token')"
+  - name: result
+    task: make_request
+    targets: localhost
+    parameters:
+      api_token: $api_token
+
+return: $result
+```
+
+Or to prompt the user to choose from an option from a menu:
+
+```yaml
+steps:
+  - name: fruit
+    prompt: Select a fruit
+    menu:
+      - apple
+      - banana
+      - carrot
+
+return: $fruit
 ```
 
 ## Parameters

--- a/lib/bolt/pal/yaml_plan/step.rb
+++ b/lib/bolt/pal/yaml_plan/step.rb
@@ -14,6 +14,7 @@ module Bolt
           eval
           message
           plan
+          prompt
           resources
           script
           task
@@ -209,11 +210,12 @@ module Bolt
 end
 
 require 'bolt/pal/yaml_plan/step/command'
+require 'bolt/pal/yaml_plan/step/download'
 require 'bolt/pal/yaml_plan/step/eval'
+require 'bolt/pal/yaml_plan/step/message'
 require 'bolt/pal/yaml_plan/step/plan'
+require 'bolt/pal/yaml_plan/step/prompt'
 require 'bolt/pal/yaml_plan/step/resources'
 require 'bolt/pal/yaml_plan/step/script'
 require 'bolt/pal/yaml_plan/step/task'
 require 'bolt/pal/yaml_plan/step/upload'
-require 'bolt/pal/yaml_plan/step/download'
-require 'bolt/pal/yaml_plan/step/message'

--- a/lib/bolt/pal/yaml_plan/step/prompt.rb
+++ b/lib/bolt/pal/yaml_plan/step/prompt.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Bolt
+  class PAL
+    class YamlPlan
+      class Step
+        class Prompt < Step
+          def self.allowed_keys
+            super + Set['default', 'menu', 'sensitive']
+          end
+
+          def self.required_keys
+            Set['prompt']
+          end
+
+          def self.validate_step_keys(body, number)
+            super
+
+            if body.key?('menu') && ![Array, Hash].include?(body['menu'].class)
+              raise StepError.new("Menu key must be an array or hash", body['name'], number)
+            end
+          end
+
+          # Returns an array of arguments to pass to the step's function call
+          #
+          private def format_args(body)
+            args = [body['prompt']]
+
+            if body['menu']
+              opts = body.slice('default').compact
+              args << body['menu']
+            else
+              opts = body.slice('default', 'sensitive').compact
+            end
+
+            args << opts if opts.any?
+            args
+          end
+
+          # Returns the function corresponding to the step
+          #
+          private def function
+            body['menu'] ? 'prompt::menu' : 'prompt'
+          end
+        end
+      end
+    end
+  end
+end

--- a/schemas/bolt-yaml-plan.schema.json
+++ b/schemas/bolt-yaml-plan.schema.json
@@ -72,7 +72,7 @@
   },
   "steps": {
     "command": {
-      "description": "Runs a single command on a list of targets and returns the results. Results include output sent to standard out (stdout) and standard error (stderr), and the command's exit code.",
+      "description": "Runs a single command on a list of targets and returns the results. Results include output sent to stdout and stderr, and the command's exit code.",
       "type": "object",
       "additionalProperties": false,
       "required": ["command", "targets"],
@@ -133,7 +133,7 @@
       }
     },
     "message": {
-      "description": "Print a message. This will print a message to standard out (stdout) when using the 'human' output format or standard error (stderr) when using the 'json' output format.",
+      "description": "Print a message. This will print a message to stdout when using the 'human' output format or stderr when using the 'json' output format.",
       "type": "object",
       "additionalProperties": false,
       "required": ["message"],
@@ -177,6 +177,29 @@
         },
         "targets": {
           "$ref": "#/definitions/targets"
+        }
+      }
+    },
+    "prompt": {
+      "description": "Displays a prompt to the user and waits for input.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["prompt"],
+      "properties": {
+        "default": {
+          "description": "The default value to use if the user does not provide input or stdin is not a tty.",
+          "type": "string"
+        },
+        "name": {
+          "$ref": "#/definitions/name"
+        },
+        "prompt": {
+          "description": "The prompt to display to the user.",
+          "type": "string"
+        },
+        "sensitive": {
+          "description": "Whether to redact the response and mark it as sensitive. Bolt wraps sensitive values in the Sensitive data type.",
+          "type": "boolean"
         }
       }
     },

--- a/spec/bolt/pal/yaml_plan/step/prompt_spec.rb
+++ b/spec/bolt/pal/yaml_plan/step/prompt_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/pal/yaml_plan'
+
+describe Bolt::PAL::YamlPlan::Step::Prompt do
+  let(:evaluator) { double('evaluator') }
+  let(:scope)     { double('scope', call_function: nil) }
+  let(:step)      { Bolt::PAL::YamlPlan::Step.create(body, 0) }
+
+  context 'without menu' do
+    let(:body) do
+      {
+        'prompt'    => 'What is your favorite color',
+        'default'   => 'blue',
+        'sensitive' => true
+      }
+    end
+
+    it 'creates a step class' do
+      expect(step).to be_kind_of(described_class)
+    end
+
+    it 'evaluates prompt function' do
+      allow(evaluator).to receive(:evaluate_code_blocks).and_return(body)
+
+      args = ['What is your favorite color', { 'default' => 'blue', 'sensitive' => true }]
+      expect(scope).to receive(:call_function).with('prompt', args)
+
+      step.evaluate(scope, evaluator)
+    end
+
+    it 'transpiles prompt function' do
+      expect(step.transpile)
+        .to eq("  prompt('What is your favorite color', {'default' => 'blue', 'sensitive' => true})\n")
+    end
+  end
+
+  context 'with menu' do
+    let(:body) do
+      {
+        'prompt'  => 'Select a fruit',
+        'menu'    => %w[apple banana carrot],
+        'default' => 'apple'
+      }
+    end
+
+    it 'creates a step class' do
+      expect(step).to be_kind_of(described_class)
+    end
+
+    it 'errors if menu is not an array or hash' do
+      body['menu'] = false
+      expect { step }.to raise_error(/Menu key must be an array or hash/)
+    end
+
+    it 'evaluates prompt::menu function' do
+      allow(evaluator).to receive(:evaluate_code_blocks).and_return(body)
+
+      args = ['Select a fruit', %w[apple banana carrot], { 'default' => 'apple' }]
+      expect(scope).to receive(:call_function).with('prompt::menu', args)
+
+      step.evaluate(scope, evaluator)
+    end
+
+    it 'transpiles prompt::menu function' do
+      expect(step.transpile)
+        .to eq("  prompt::menu('Select a fruit', ['apple', 'banana', 'carrot'], {'default' => 'apple'})\n")
+    end
+  end
+end


### PR DESCRIPTION
This adds a new YAML plan `prompt` step, which can be used to prompt the
user for input.

* **YAML plan `prompt` step**

  YAML plans now support a `prompt` step, which can be used to prompt
  the user for input.

---

Blocked by #2713 and #2714