### PR TITLE
(docs) Correct modulepath precedence documentation

### DIFF
--- a/documentation/modules.md
+++ b/documentation/modules.md
@@ -78,9 +78,9 @@ directory (moduledir) in your Bolt project directory (`.modules`):
 The list of directories where Bolt looks for content is called the modulepath.
 Bolt always loads content from:
 - The current Bolt project.
-- The Bolt-managed moduledir (`.modules`).
 - Any modules in the configurable modules directory. By default this is
   `modules/`.
+- The Bolt-managed moduledir (`.modules`).
 - Any modules that come bundled with Bolt.
 
 If you'd like to modify or add a directory to Bolt's modulepath, add the path to


### PR DESCRIPTION
The Modules overview document listed the wrong precedence of paths on
the modulepath, stating that `<project>/.modules/` would override
`<project>/modules`. This corrects the order to state that any modules
in `<project>/modules` will be used if they have the same name as
`<project>/.modules` - basically that user-created modules will override
installed modules.

!no-release-note