### PR TITLE
(GH-2719) Correctly show task info if task parameters don't have a type

### DIFF
--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -282,7 +282,7 @@ module Bolt
           pretty_params << "- #{k}: #{v['type'] || 'Any'}\n"
           pretty_params << "    Default: #{v['default'].inspect}\n" if v.key?('default')
           pretty_params << "    #{v['description']}\n" if v['description']
-          usage << if v['type'].start_with?("Optional")
+          usage << if v['type']&.start_with?("Optional")
                      " [#{k}=<value>]"
                    else
                      " #{k}=<value>"

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -146,6 +146,41 @@ describe "Bolt::Outputter::Human" do
     TASK_OUTPUT
   end
 
+  it 'succeeds if task parameters do not have a type' do
+    name = 'donut'
+    files = [{ 'name' => 'glazed.rb',
+               'path' => '/path/to/glazed.rb' }]
+    metadata = {
+      'parameters' => {
+        'flavor' => {
+          'description' => 'What flavor of donut'
+        }
+      }
+    }
+
+    command = if Bolt::Util.powershell?
+                'Invoke-BoltTask -Name donut -Targets <targets> flavor=<value>'
+              else
+                'bolt task run donut --targets <targets> flavor=<value>'
+              end
+
+    outputter.print_task_info(Bolt::Task.new(name, metadata, files))
+    expect(output.string).to eq(<<~TASK_OUTPUT)
+
+       donut
+
+       USAGE:
+       #{command}
+
+       PARAMETERS:
+       - flavor: Any
+           What flavor of donut
+
+       MODULE:
+       /path/to/glazed.rb
+    TASK_OUTPUT
+  end
+
   it 'converts Data (undef) to Any' do
     name = 'sticky_bun'
     files = [{ 'name' => 'sticky.rb',


### PR DESCRIPTION
Previously, Bolt assumed that task parameters included the `type` key
when checking to see if the `type` was optional to format it for
printing in `bolt task show` output. If the task included parameters
that didn't specify a type, Bolt would stacktrace. This now only adds
the `optional` parameter formatting if the parameter has a type defined
and that type includes 'Optional', otherwise it formats the type as
required. This prevents Bolt from stacktracing.

!bug

* **Don't stacktrace when showing tasks that include untyped parameters** ([#2719](https://github.com/puppetlabs/bolt/issues/2719))
  Bolt will now correctly show task details for tasks that include
  parameters that do not specify a type, instead of stacktracing.