### PR TITLE
(bug) Don't error when showing noop task info

### DIFF
--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -290,7 +290,7 @@ module Bolt
         end
 
         if task.supports_noop
-          usage << Bolt::Util.powershell? ? '[-Noop]' : '[--noop]'
+          usage << (Bolt::Util.powershell? ? ' [-Noop]' : ' [--noop]')
         end
 
         task_info << "\n#{task.name}"

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -226,6 +226,23 @@ describe "Bolt::Outputter::Human" do
     TASK_OUTPUT
   end
 
+  it 'prints noop option in the usage if task supports noop' do
+    name = 'test'
+    files = [{
+      'name' => 'test.rb',
+      'path' => '/path/to/test.rb'
+    }]
+    metadata = {
+      'description' => 'A test task',
+      'supports_noop' => true
+    }
+
+    option = (Bolt::Util.powershell? ? '[-Noop]' : '[--noop]')
+
+    outputter.print_task_info(Bolt::Task.new(name, metadata, files))
+    expect(output.string).to match(/#{option}/)
+  end
+
   it 'prints modulepath as builtin for builtin modules' do
     name = 'monkey_bread'
     files = [{ 'name' => 'monkey_bread.rb',


### PR DESCRIPTION
This fixes a bug that caused Bolt to error when showing info for a task
that supports running in noop mode.

!bug

* **Do not error when showing 'noop' task info**

  Bolt no longer errors when printing task information for a task that
  supports running in no-operation mode.