### PR TITLE
(bug) Handle malformed `_error` values in task result in Orchestrator

### DIFF
--- a/lib/bolt/transport/orch.rb
+++ b/lib/bolt/transport/orch.rb
@@ -59,6 +59,18 @@ module Bolt
           # the result otherwise make sure an error is generated
           if state == 'finished' || (result && result['_error'])
             if result['_error']
+              unless result['_error'].is_a?(Hash)
+                result['_error'] = { 'kind' => 'puppetlabs.tasks/task-error',
+                                     'issue_code' => 'TASK_ERROR',
+                                     'msg' => result['_error'],
+                                     'details' => {} }
+              end
+
+              result['_error']['details'] ||= {}
+              unless result['_error']['details'].is_a?(Hash)
+                deets = result['_error']['details']
+                result['_error']['details'] = { 'msg' => deets }
+              end
               file_line = %w[file line].zip(position).to_h.compact
               result['_error']['details'].merge!(file_line) unless result['_error']['details']['file']
             end

--- a/spec/integration/transport/orch_spec.rb
+++ b/spec/integration/transport/orch_spec.rb
@@ -211,6 +211,26 @@ describe Bolt::Transport::Orch, orchestrator: true do
         expect(node_results[1].error_hash).to eq(error_result['_error'])
       end
 
+      context 'with malformed _error key' do
+        it 'handles _error values that are not a hash' do
+          error_result = { '_error' => 'something went wrong' }
+          results = [{ 'name' => 'node1', 'state' => 'failed', 'result' => error_result }]
+          node_result = orch.process_run_results(targets, results, 'thetask').first
+
+          expect(node_result).not_to be_success
+          expect(node_result.error_hash).to eq(error_result['_error'])
+        end
+
+        it 'handles _error values where details is not a hash' do
+          error_result = { '_error' => { 'details' => 'something went wrong' } }
+          results = [{ 'name' => 'node1', 'state' => 'failed', 'result' => error_result }]
+          node_result = orch.process_run_results(targets, results, 'thetask').first
+
+          expect(node_result).not_to be_success
+          expect(node_result.error_hash).to eq(error_result['_error'])
+        end
+      end
+
       it "returns an error for skipped nodes" do
         results = [{ 'name' => 'node1', 'state' => 'finished', 'result' => { '_output' => 'hello' } },
                    # XXX double-check that this is the correct result for a skipped node


### PR DESCRIPTION
Previously, we assumed that if a task returned with an `_error` key that
it would be a hash and include the `details` key, and that that
`details` key would also have a hash value. Any of these assumptions
might be wrong. This amends the Orchestrator transport to handle
`_error` values that:
* Are not a hash, by placing the provided value under the `message` key
* Is a hash that doesn't have the `details` key by setting the details
  key to an empty hash
* Is a hash with a `details` key that is not itself a hash by not trying
  to merge our own keys into it.

!bug

* **Handle malformed `_error` values in task results in Orchestrator**

  Bolt now handles `_error` from task results in the Orchestrator
  transport when the value of the key is not a hash, does not include the
  `details` key, or the `details` key is not a hash. Previously Bolt would
  error if any of these conditions was true.