### PR TITLE
(GH-2692) Support 'run_task_with' and 'parallelize' in BoltSpec

### DIFF
--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -217,7 +217,7 @@ module Bolt
       results
     end
 
-    def report_transport(transport, count)
+    private def report_transport(transport, count)
       name = transport.class.name.split('::').last.downcase
       unless @reported_transports.include?(name)
         @analytics&.event('Transport', 'initialize', label: name, value: count)
@@ -475,7 +475,7 @@ module Bolt
       Time.now
     end
 
-    def wait_until(timeout, retry_interval)
+    private def wait_until(timeout, retry_interval)
       start = wait_now
       until yield
         raise(TimeoutError, 'Timed out waiting for target') if (wait_now - start).to_i >= timeout

--- a/lib/bolt_spec/plans/mock_executor.rb
+++ b/lib/bolt_spec/plans/mock_executor.rb
@@ -17,7 +17,7 @@ module BoltSpec
 
     # Nothing on the executor is 'public'
     class MockExecutor
-      attr_reader :noop, :error_message, :in_parallel
+      attr_reader :noop, :error_message, :in_parallel, :transports
       attr_accessor :run_as, :transport_features, :execute_any_plan
 
       def initialize(modulepath)
@@ -210,16 +210,6 @@ module BoltSpec
         yield
       end
 
-      def report_function_call(_function); end
-
-      def report_bundled_content(_mode, _name); end
-
-      def report_file_source(_plan_function, _source); end
-
-      def report_apply(_statements, _resources); end
-
-      def report_yaml_plan(_plan); end
-
       def publish_event(event)
         if event[:type] == :message
           unless @stub_out_message
@@ -257,6 +247,41 @@ module BoltSpec
         end.new(transport_features)
       end
       # End apply_prep mocking
+
+      # Public methods on Bolt::Executor that need to be mocked so there aren't
+      # "undefined method" errors.
+
+      def batch_execute(_targets); end
+
+      def create_yarn(_scope, _block, _object, _index); end
+
+      def finish_plan(_plan_result); end
+
+      def handle_event(_event); end
+
+      def prompt(_prompt, _options); end
+
+      def report_function_call(_function); end
+
+      def report_bundled_content(_mode, _name); end
+
+      def report_file_source(_plan_function, _source); end
+
+      def report_apply(_statements, _resources); end
+
+      def report_yaml_plan(_plan); end
+
+      def round_robin(_skein); end
+
+      def run_task_with(_target_mapping, _task, _options = {}, _position = []); end
+
+      def shutdown; end
+
+      def start_plan(_plan_context); end
+
+      def subscribe(_subscriber, _types = nil); end
+
+      def unsubscribe(_subscriber, _types = nil); end
     end
   end
 end

--- a/spec/bolt_spec/plans/mock_executor_spec.rb
+++ b/spec/bolt_spec/plans/mock_executor_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/plans/mock_executor'
+require 'bolt/executor'
+
+describe BoltSpec::Plans::MockExecutor do
+  it 'defines all public methods on Bolt::Executor' do
+    missing_methods = Bolt::Executor.instance_methods - described_class.instance_methods
+    message = "#{described_class} is missing definitions for public methods #{missing_methods.join(', ')}"
+
+    expect(missing_methods.empty?).to be(true), message
+  end
+end


### PR DESCRIPTION
(GH-2692) Support 'parallelize' in BoltSpec

This adds support for testing plans that use the `parallelize()` plan
function in BoltSpec. The block passed to the function is evaluated
using each object sequentially instead of in parallel.

!feature

* **Test plans that use `parallelize()` plan function in BoltSpec**
  ([#2692](#2692))

  Plans that use the `parallelize()` plan function can now be tested
  with BoltSpec.

---

(GH-2692) Support 'run_task_with' in BoltSpec

This adds support for testing plans that use the `run_task_with()` plan
function to BoltSpec. When BoltSpec runs a plan with this function, it
will execute a separate task run for each target. Users making
assertions about tasks run with `run_task_with()` should make an
assertion about each individual target that the task runs against, or an
assertion about the number of times that the task is run. This includes
an example in the 'Testing plans' documentation that details how to test
these types of plans.

!feature

* **Test plans that use `run_task_with()` plan function in BoltSpec*
  ([#2692](#2692))

  Plans that use the `run_task_with()` plan function can now be tested
  with BoltSpec.

---

(GH-2692) Add test for BoltSpec mock executor method definitions

This adds a test that checks that all public methods on the
`Bolt::Executor` class are defined on the
`BoltSpec::Plans::MockExecutor` class. This is to ensure that if tests
run with BoltSpec invoke any methods on the executor that it will not
result in an "undefined method" error.

!no-release-note

---

### Acceptance criteria

- [x] Public methods on `Bolt::Executor` but not `BoltSpec::Plans::MockExecutor` result in failed spec test
- [x] Private methods on `Bolt::Executor` but not `BoltSpec::Plans::MockExecutor` do not result in failed spec test
- [x] Plans with a `run_task_with()` function can be tested in BoltSpec
- [x] Plans with a `parallelize()` function can be tested in BoltSpec