### PR TITLE
(POC) run_container plan function

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/datatypes/containerresult.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/containerresult.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+Puppet::DataTypes.create_type('ContainerResult') do
+  interface <<-PUPPET
+    attributes => {
+      'value' => Hash[String[1], Data],
+    },
+    functions => {
+      '[]' => Callable[[String[1]], Data],
+      error => Callable[[], Optional[Error]],
+      ok => Callable[[], Boolean],
+      status => Callable[[], String],
+      stdout => Callable[[], String],
+      stderr => Callable[[], String],
+      to_data => Callable[[], Hash]
+    }
+  PUPPET
+
+  load_file('bolt/container_result')
+
+  # Needed for Puppet to recognize Bolt::ContainerResult as a Puppet object when deserializing
+  Bolt::ContainerResult.include(Puppet::Pops::Types::PuppetObject)
+  implementation_class Bolt::ContainerResult
+end

--- a/bolt-modules/boltlib/lib/puppet/functions/run_container.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_container.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require 'bolt/container_result'
+require 'bolt/error'
+require 'bolt/util'
+
+# Run a container and return its output to stdout and stderr.
+#
+# > **Note:** Not available in apply block
+Puppet::Functions.create_function(:run_container) do
+  # Run a container.
+  # @param image The name of the image to run.
+  # @param options A hash of additional options.
+  # @option options [Boolean] _catch_errors Whether to catch raised errors.
+  # @option options [String] cmd A command to run in the container.
+  # @option options [Hash[String, Data]] env_vars Map of environment variables to set.
+  # @option options [Hash[Integer, Integer]] ports A map of container ports to
+  #   publish. Keys are the host port, values are the corresponding container
+  #   port.
+  # @option options [Boolean] rm Whether to remove the container once it exits.
+  # @option options [Hash[String, String]] volumes A map of absolute paths on
+  #   the host to absolute paths on the remote to mount.
+  # @option options [String] workdir The working directory within the container.
+  # @return Output from the container.
+  # @example Run Nginx proxy manager
+  #   run_container('jc21/nginx-proxy-manager', 'ports' => { 80 => 80, 81 => 81, 443 => 443 })
+  dispatch :run_container do
+    param 'String[1]', :image
+    optional_param 'Hash[String[1], Any]', :options
+    return_type 'ContainerResult'
+  end
+
+  def run_container(image, options = {})
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'run_container')
+    end
+
+    # Send Analytics Report
+    executor = Puppet.lookup(:bolt_executor)
+    executor.report_function_call(self.class.name)
+
+    options = options.transform_keys { |k| k.sub(/^_/, '').to_sym }
+    validate_options(options)
+
+    if options.key?(:env_vars)
+      options[:env_vars] = options[:env_vars].transform_values do |val|
+        [Array, Hash].include?(val.class) ? val.to_json : val
+      end
+    end
+
+    if options[:ports]
+      ports = options[:ports].each_with_object([]) do |(host_port, container_port), acc|
+        acc << "-p"
+        acc << "#{host_port}:#{container_port}"
+      end
+    end
+
+    if options[:volumes]
+      volumes = options[:volumes].each_with_object([]) do |(host_path, remote_path), acc|
+        begin
+          FileUtils.mkdir_p(host_path)
+        rescue StandardError => e
+          message = "Unable to create host volume directory #{host_path}: #{e.message}"
+          raise Bolt::Error.new(message, 'bolt/file-error')
+        end
+        acc << "-v"
+        acc << "#{host_path}:#{remote_path}"
+      end
+    end
+
+    # Run the container
+    # `docker run` will automatically pull the image if it isn't already downloaded
+    cmd = %w[run]
+    cmd += Bolt::Util.format_env_vars_for_cli(options[:env_vars]) if options[:env_vars]
+    cmd += volumes if volumes
+    cmd += ports if ports
+    cmd << "--rm" if options[:rm]
+    cmd += %W[-w #{options[:workdir]}] if options[:workdir]
+    cmd << image
+    cmd += Shellwords.shellsplit(options[:cmd]) if options[:cmd]
+
+    executor.publish_event(type: :container_start, image: image)
+    out, err, status = Bolt::Util.exec_docker(cmd)
+
+    o = out.is_a?(String) ? out.dup.force_encoding('utf-8') : out
+    e = err.is_a?(String) ? err.dup.force_encoding('utf-8') : err
+
+    unless status.exitstatus.zero?
+      result = Bolt::ContainerResult.from_exception(e,
+                                                    status.exitstatus,
+                                                    image,
+                                                    position: Puppet::Pops::PuppetStack.top_of_stack)
+      executor.publish_event(type: :container_finish, result: result)
+      if options[:catch_errors]
+        return result
+      else
+        raise Bolt::ContainerFailure, result
+      end
+    end
+
+    value = { 'stdout' => o, 'stderr' => e, 'exit_code' => status.exitstatus }
+    result = Bolt::ContainerResult.new(value, object: image)
+    executor.publish_event(type: :container_finish, result: result)
+    result
+  end
+
+  def validate_options(options)
+    if options.key?(:env_vars)
+      ev = options[:env_vars]
+      unless ev.is_a?(Hash)
+        msg = "Option 'env_vars' must be a hash. Received #{ev} which is a #{ev.class}"
+        raise Bolt::ValidationError, msg
+      end
+
+      if (bad_keys = ev.keys.reject { |k| k.is_a?(String) }).any?
+        msg = "Keys for option 'env_vars' must be strings: #{bad_keys.map(&:inspect).join(', ')}"
+        raise Bolt::ValidationError, msg
+      end
+    end
+
+    if options.key?(:volumes)
+      volumes = options[:volumes]
+      unless volumes.is_a?(Hash)
+        msg = "Option 'volumes' must be a hash. Received #{volumes} which is a #{volumes.class}"
+        raise Bolt::ValidationError, msg
+      end
+
+      if (bad_vs = volumes.reject { |k, v| k.is_a?(String) && v.is_a?(String) }).any?
+        msg = "Option 'volumes' only accepts strings for keys and values. "\
+          "Received: #{bad_vs.map(&:inspect).join(', ')}"
+        raise Bolt::ValidationError, msg
+      end
+    end
+
+    if options.key?(:cmd) && !options[:cmd].is_a?(String)
+      cmd = options[:cmd]
+      msg = "Option 'cmd' must be a string. Received #{cmd} which is a #{cmd.class}"
+      raise Bolt::ValidationError, msg
+    end
+
+    if options.key?(:workdir) && !options[:workdir].is_a?(String)
+      wd = options[:workdir]
+      msg = "Option 'workdir' must be a string. Received #{wd} which is a #{wd.class}"
+      raise Bolt::ValidationError, msg
+    end
+
+    if options.key?(:ports)
+      ports = options[:ports]
+      unless ports.is_a?(Hash)
+        msg = "Option 'ports' must be a hash. Received #{ports} which is a #{ports.class}"
+        raise Bolt::ValidationError, msg
+      end
+
+      if (bad_ps = ports.reject { |k, v| k.is_a?(Integer) && v.is_a?(Integer) }).any?
+        msg = "Option 'ports' only accepts integers for keys and values. "\
+          "Received: #{bad_ps.map(&:inspect).join(', ')}"
+        raise Bolt::ValidationError, msg
+      end
+    end
+  end
+end

--- a/bolt-modules/boltlib/spec/functions/run_container_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_container_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/executor'
+require 'bolt/container_result'
+
+describe 'run_container' do
+  let(:executor) { Bolt::Executor.new }
+  let(:tasks_enabled) { true }
+  let(:user) { Bolt::Util.windows? ? "user manager\\containeradministrator\r" : 'root' }
+  let(:image) do
+    if Bolt::Util.windows?
+      'mcr.microsoft.com/windows/servercore:ltsc2019'
+    else
+      'ubuntu:14.04'
+    end
+  end
+
+  around(:each) do |example|
+    Puppet[:tasks] = tasks_enabled
+    Puppet.override(bolt_executor: executor) do
+      example.run
+    end
+  end
+
+  context 'it runs the docker command' do
+    let(:mock_status) { mock('Process::Status') }
+    let(:value) do
+      { 'stdout' => "#{user}\n",
+        'stderr' => "",
+        'exit_code' => 0 }
+    end
+    let(:result) { Bolt::ContainerResult.new(value, object: image) }
+
+    before :each do
+      Puppet.features.stubs(:bolt?).returns(true)
+      mock_status.stubs(:exitstatus).returns(0)
+      mock_status.stubs(:success?).returns(true)
+    end
+
+    it 'with given image and command' do
+      # This image is cached in Github Actions environments, so we don't get
+      # downloading output
+      is_expected.to run
+        .with_params(image, { 'cmd' => 'whoami', 'rm' => true })
+        .and_return(result)
+    end
+
+    context 'with errors' do
+      before :each do
+        mock_status.stubs(:exitstatus).returns(127)
+        mock_status.stubs(:success?).returns(false)
+      end
+
+      let(:msg) {
+        "docker: Error response from daemon: OCI runtime create failed: "\
+                  "container_linux.go:367: starting container process caused: exec: "\
+                  "\"foo\": executable file not found in $PATH: unknown.\n"
+      }
+      let(:value) do
+        { "_error" =>
+         { "kind" => "puppetlabs.tasks/container-error",
+           "issue_code" => "CONTAINER_ERROR",
+           "msg" => "Error running container '#{image}': #{msg}",
+           "details" => { "exit_code" => 127 } } }
+      end
+
+      it 'raises an error if the container fails' do
+        is_expected.to run
+          .with_params(image, { 'cmd' => 'foo', 'rm' => true })
+          .and_raise_error(Bolt::ContainerFailure, /Plan aborted: Running container '#{image}' failed/)
+      end
+
+      it 'returns a ContainerResult with errors with _catch_errors' do
+        Bolt::Util.expects(:exec_docker)
+                  .with(%W[run --rm #{image} foo])
+                  .returns(["", msg, mock_status])
+
+        is_expected.to run
+          .with_params(image, { 'cmd' => 'foo',
+                                '_catch_errors' => true,
+                                'rm' => true })
+          .and_return(result)
+      end
+    end
+
+    context 'with options' do
+      it 'with given image and specified port' do
+        Bolt::Util.expects(:exec_docker)
+                  .with(%W[run -p 80:80 --rm #{image} whoami])
+                  .returns(["#{user}\n", "", mock_status])
+
+        is_expected.to run
+          .with_params(image, { 'cmd' => 'whoami',
+                                'ports' => { 80 => 80 },
+                                'rm' => true })
+          .and_return(result)
+      end
+
+      context 'with mounted volumes' do
+        let(:src) { File.expand_path('.') }
+        let(:value) do
+          { 'stdout' => "Rakefile\nlib\nspec\ntypes\n",
+            'stderr' => "",
+            'exit_code' => 0 }
+        end
+        let(:dest) { '/volume_mount' }
+
+        it 'with given image and specified volumes' do
+          Bolt::Util.expects(:exec_docker)
+                    .with(%W[run -v #{src}:#{dest} --rm #{image} ls /volume_mount])
+                    .returns([value['stdout'], "", mock_status])
+
+          is_expected.to run
+            .with_params(image, { 'cmd' => "ls #{dest}",
+                                  'rm' => true,
+                                  'volumes' => { src => dest } })
+            .and_return(result)
+        end
+      end
+
+      context 'with env_vars' do
+        let(:env_vars) { { 'FRUIT' => { 'apple' => 'banana' } } }
+        let(:value) do
+          { 'stdout' => env_vars['FRUIT'],
+            'stderr' => "",
+            'exit_code' => 0 }
+        end
+
+        it 'transforms values to json' do
+          Bolt::Util.expects(:exec_docker)
+                    .with(%W[run --env FRUIT={"apple":"banana"} --rm #{image} echo $FRUIT])
+                    .returns([env_vars['FRUIT'], "", mock_status])
+
+          is_expected.to run
+            .with_params(image, { 'cmd' => 'echo $FRUIT',
+                                  'env_vars' => env_vars,
+                                  'rm' => true })
+            .and_return(result)
+        end
+      end
+
+      it 'raises validation errors with invalid options' do
+        is_expected.to run
+          .with_params(image, { 'cmd' => 'whoami', 'ports' => true, 'rm' => true })
+          .and_raise_error(Bolt::ValidationError, /Option 'ports' must be a hash. Received/)
+      end
+    end
+
+    it 'reports the call to analytics' do
+      executor.expects(:report_function_call).with('run_container')
+
+      is_expected.to run
+        .with_params(image, { 'cmd' => 'whoami', 'rm' => true })
+        .and_return(result)
+    end
+
+    context 'without tasks enabled' do
+      let(:tasks_enabled) { false }
+
+      it 'fails and reports that run_container is not available' do
+        is_expected.to run
+          .with_params(image, { 'cmd' => 'whoami' })
+          .and_raise_error(/Plan language function 'run_container' cannot be used/)
+      end
+    end
+  end
+end

--- a/bolt-modules/boltlib/types/planresult.pp
+++ b/bolt-modules/boltlib/types/planresult.pp
@@ -12,5 +12,6 @@ type Boltlib::PlanResult = Variant[Boolean,
                                    ResultSet,
                                    Target,
                                    ResourceInstance,
+                                   ContainerResult,
                                    Array[Boltlib::PlanResult],
                                    Hash[String, Boltlib::PlanResult]]

--- a/documentation/bolt_types_reference.md
+++ b/documentation/bolt_types_reference.md
@@ -28,6 +28,27 @@ The following functions are available to `ApplyResult` objects.
 | `to_data` | `Hash` | A serialized representation of `ApplyResult`. |
 | `value` | `Hash` | A hash including the Puppet report from the apply action under a `report` key. |
 
+### `ContainerResult`
+
+The [run_container](plan_functions.md#run_container) plan function returns a `ContainerResult`
+object. A `ContainerResult` is a standalone object (not part of a `ResultSet`) that includes either
+the `stdout` and `stderr` values from running the container, or an `_error` object if the container
+exited with a nonzero exit code.
+
+The following functions are available to `ContainerResult` objects. 
+
+| Function | Type returned | Description |
+|---|---|---|
+| `[]` | `Data` | Accesses the value hash directly and returns the value for the key. This function does not use dot notation. Call the function directly on the `ContainerResult`. For example, `$result[key]`. |
+| `error` | `Error` | An object constructed from the `_error` field of the result's value. |
+| `ok` | `Boolean` | Whether the result was successful. |
+| `status` | `String` | Either `success` if the result was successful or `failure`. |
+| `stdout` | `String` | The value of 'stdout' output by the container. |
+| `stderr` | `String` | The value of 'stderr' output by the container. |
+| `to_data` | `Hash` | A serialized representation of `ContainerResult`. |
+| `value` | `Hash` | A hash including the `stdout`, `stderr`, and `exit_code` received from the
+container. |
+
 ### `ResourceInstance`
 
 `ResourceInstance` objects are used to store the observed and desired state of a

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -8,9 +8,39 @@ API might change, requiring the user to update their code or configuration. The
 Bolt team attempts to make these changes painless by providing useful warnings
 around breaking behavior where possible. 
 
+## `run_container` plan step
+
+This feature was introduced in [Bolt 3.5.0](https://github.com/puppetlabs/bolt/blob/main/CHANGELOG.md#bolt-350-2021-3-29).
+
+Currently available as a Puppet plan function, `run_container()` runs a provided image and
+returns the `stdout`, `stderr`, and `exit_code` for that image. The function supports several
+options, including `cmd` to specify a command to run in the container, `volumes` to mount volumes to
+the container, and `ports` to publish ports from the container on the host. You can see all the
+supported options in the [plan function documentation](plan_functions.md#run_container).
+
+The function runs the container on the Bolt controller, not on remote targets. This function is
+supported on both \*nix and Windows systems. 
+
+This plan clones the [Relay repository](https://github.com/puppetlabs/relay), builds the Go binary in a
+container that has all the dependencies in it, and installs the binary to a local path.
+
+```
+plan bolt (
+  TargetSpec $targets = 'localhost'
+) {
+  $relay_path = '/tmp/relay'
+  run_command("git clone git@github.com:puppetlabs/relay.git ${$relay_path}", 'localhost')
+  run_container('golang', 'volumes' => { $relay_path => '/relay' },
+                'workdir' => '/relay',
+                'rm' => true,
+                'cmd' => "/bin/sh -c \"./scripts/generate && ./scripts/build\"")
+  run_command("mv ${$relay_path}/bin/* /usr/bin", 'localhost')
+}
+```
+
 ## Streaming output
 
-This feature was introduced in [Bolt 3.2.0](https://github.com/puppetlabs/bolt/blob/main/CHANGELOG.md#bolt-310-2021-3-08).
+This feature was introduced in [Bolt 3.2.0](https://github.com/puppetlabs/bolt/blob/main/CHANGELOG.md#bolt-320-2021-3-08).
 
 You can set the new `stream` output option in `bolt-project.yaml` or `bolt-defaults.yaml`, or
 specify the option on the command line as `--stream`. Bolt streams results back to the console as
@@ -32,7 +62,7 @@ once as the actions are running, and again after Bolt prints the results.
 
 ## LXD Transport
 
-This feature was introduced in [Bolt 3.2.0](https://github.com/puppetlabs/bolt/blob/main/CHANGELOG.md#bolt-310-2021-3-08).
+This feature was introduced in [Bolt 3.2.0](https://github.com/puppetlabs/bolt/blob/main/CHANGELOG.md#bolt-320-2021-3-08).
 
 The LXD transport supports connecting to Linux containers on the local system. Similar to the Docker
 transport, The LXD transport accepts the name of the container as the URI, and connects to the

--- a/lib/bolt/container_result.rb
+++ b/lib/bolt/container_result.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'bolt/error'
+require 'bolt/result'
+
+module Bolt
+  class ContainerResult
+    attr_reader :value, :object
+
+    def self.from_exception(exception, exit_code, image, position: [])
+      details = Bolt::Result.create_details(position)
+      error = {
+        'kind' => 'puppetlabs.tasks/container-error',
+        'issue_code' => 'CONTAINER_ERROR',
+        'msg' => "Error running container '#{image}': #{exception}",
+        'details' => details
+      }
+      error['details']['exit_code'] = exit_code
+      ContainerResult.new({ '_error' => error }, object: image)
+    end
+
+    def _pcore_init_hash
+      { 'value' => @value,
+        'object' => @image }
+    end
+
+    # First argument can't be named given the way that Puppet deserializes variables
+    def initialize(value = nil, object: nil)
+      @value = value || {}
+      @object = object
+    end
+
+    def eql?(other)
+      self.class == other.class &&
+        value == other.value
+    end
+    alias == eql?
+
+    def [](key)
+      value[key]
+    end
+
+    def to_json(opts = nil)
+      to_data.to_json(opts)
+    end
+    alias to_s to_json
+
+    # This is the value with all non-UTF-8 characters removed, suitable for
+    # printing or converting to JSON. It *should* only be possible to have
+    # non-UTF-8 characters in stdout/stderr keys as they are not allowed from
+    # tasks but we scrub the whole thing just in case.
+    def safe_value
+      Bolt::Util.walk_vals(value) do |val|
+        if val.is_a?(String)
+          # Replace invalid bytes with hex codes, ie. \xDE\xAD\xBE\xEF
+          val.scrub { |c| c.bytes.map { |b| "\\x" + b.to_s(16).upcase }.join }
+        else
+          val
+        end
+      end
+    end
+
+    def stdout
+      value['stdout']
+    end
+
+    def stderr
+      value['stderr']
+    end
+
+    def to_data
+      {
+        "object" => object,
+        "status" => status,
+        "value" => safe_value
+      }
+    end
+
+    def status
+      ok? ? 'success' : 'failure'
+    end
+
+    def ok?
+      error_hash.nil?
+    end
+    alias ok ok?
+    alias success? ok?
+
+    # This allows access to errors outside puppet compilation
+    # it should be prefered over error in bolt code
+    def error_hash
+      value['_error']
+    end
+
+    # Warning: This will fail outside of a compilation.
+    # Use error_hash inside bolt.
+    # Is it crazy for this to behave differently outside a compiler?
+    def error
+      if error_hash
+        Puppet::DataTypes::Error.from_asserted_hash(error_hash)
+      end
+    end
+  end
+end

--- a/lib/bolt/error.rb
+++ b/lib/bolt/error.rb
@@ -61,6 +61,21 @@ module Bolt
     end
   end
 
+  class ContainerFailure < Bolt::Error
+    attr_reader :result
+
+    def initialize(result)
+      details = {
+        'value' => result.value,
+        'object' => result.object
+      }
+      message = "Plan aborted: Running container '#{result.object}' failed."
+      super(message, 'bolt/container-failure', details)
+      @result = result
+      @error_code = 2
+    end
+  end
+
   class RunFailure < Bolt::Error
     attr_reader :result_set
 

--- a/lib/bolt/outputter/logger.rb
+++ b/lib/bolt/outputter/logger.rb
@@ -20,6 +20,10 @@ module Bolt
           log_plan_start(event)
         when :plan_finish
           log_plan_finish(event)
+        when :container_start
+          log_container_start(event)
+        when :container_finish
+          log_container_finish(event)
         end
       end
 
@@ -47,6 +51,19 @@ module Bolt
         plan = event[:plan]
         duration = event[:duration]
         @logger.info("Finished: plan #{plan} in #{duration.round(2)} sec")
+      end
+
+      def log_container_start(event)
+        @logger.info("Starting: run container '#{event[:image]}'")
+      end
+
+      def log_container_finish(event)
+        result = event[:result]
+        if result.success?
+          @logger.info("Finished: run container '#{result.object}' succeeded.")
+        else
+          @logger.info("Finished: run container '#{result.object}' failed.")
+        end
       end
     end
   end

--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -164,13 +164,10 @@ module Bolt
         target == other.target &&
         value == other.value
     end
+    alias == eql?
 
     def [](key)
       value[key]
-    end
-
-    def ==(other)
-      eql?(other)
     end
 
     def to_json(opts = nil)

--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -332,6 +332,29 @@ module Bolt
         end
       end
 
+      # Executes a Docker CLI command. This is useful for running commands as
+      # part of this class without having to go through the `execute`
+      # function and manage pipes.
+      #
+      # @param cmd [String] The docker command and arguments to run
+      #   e.g. 'cp <src> <dest>' for `docker cp <src> <dest>`
+      # @return [String, String, Process::Status] The output of the command: STDOUT, STDERR, Process Status
+      def exec_docker(cmd, env = {})
+        Open3.capture3(env, 'docker', *cmd, { binmode: true })
+      end
+
+      # Formats a map of environment variables to be passed to a command that
+      # accepts repeated `--env` flags
+      #
+      # @param env_vars [Hash] A map of environment variables keys and their values
+      # @return [String]
+      def format_env_vars_for_cli(env_vars)
+        @env_vars = env_vars.each_with_object([]) do |(key, value), acc|
+          acc << "--env"
+          acc << "#{key}=#{value}"
+        end
+      end
+
       def unix_basename(path)
         raise Bolt::ValidationError, "path must be a String, received #{path.class} #{path}" unless path.is_a?(String)
         path.split('/').last

--- a/spec/fixtures/modules/container/plans/apply.pp
+++ b/spec/fixtures/modules/container/plans/apply.pp
@@ -1,0 +1,9 @@
+plan container::apply(
+  TargetSpec $targets
+) {
+  apply_prep($targets)
+  $r = run_container('ubuntu:14.04', 'rm' => true, 'cmd' => 'whoami')
+  return apply($targets) {
+    notify { $r.stdout: }
+  }
+}

--- a/spec/fixtures/modules/container/plans/init.pp
+++ b/spec/fixtures/modules/container/plans/init.pp
@@ -1,0 +1,5 @@
+plan container(
+  String $image = 'ubuntu:18.04'
+) {
+  return run_container($image, 'rm' => true)
+}

--- a/spec/fixtures/modules/container/plans/volume.pp
+++ b/spec/fixtures/modules/container/plans/volume.pp
@@ -1,0 +1,9 @@
+plan container::volume(
+  String $image = 'ubuntu:14.04',
+  String $ls,
+  String $src,
+  String $dest
+) {
+  $opts = { 'volumes' => { $src => $dest }, 'cmd' => "${$ls} ${$dest}", 'rm' => true}
+  return run_container($image, $opts)
+}

--- a/spec/integration/container_spec.rb
+++ b/spec/integration/container_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/conn'
+require 'bolt_spec/files'
+require 'bolt_spec/integration'
+require 'bolt_spec/project'
+
+describe 'plans' do
+  include BoltSpec::Conn
+  include BoltSpec::Files
+  include BoltSpec::Integration
+  include BoltSpec::Project
+
+  let(:mpath) { %W[-m #{fixtures_path('modules')}] }
+
+  it 'runs a command in a container' do
+    result = run_cli_json(%w[plan run container image=hello-world] + mpath)
+    expect(result['value']['stdout']).to include("Hello from Docker!\nThis message shows")
+    output = @log_output.readlines
+    expect(output).to include(/Starting: run container 'hello-world'/)
+    expect(output).to include(/Finished: run container 'hello-world' succeeded./)
+  end
+
+  it 'mounts a volume to the container' do
+    dest = Bolt::Util.windows? ? 'C:\volume' : '/volume'
+    ls = Bolt::Util.windows? ? "powershell -c 'ls'" : 'ls'
+    cmd = %W[plan run container::volume ls=#{ls} src=#{File.expand_path('.')} dest=#{dest}]
+    cmd << 'image=mcr.microsoft.com/windows/servercore:ltsc2019' if Bolt::Util.windows?
+    result = run_cli_json(cmd + mpath)
+    expect(result['value']['stdout']).to include("bolt.gemspec")
+  end
+
+  it 'serializes ContainerResults to apply blocks', ssh: true do
+    with_project(inventory: docker_inventory) do |project|
+      flags = %W[--project #{project} -t nix_agents] + mpath
+      result = run_cli_json(%w[plan run container::apply] + flags)
+      users = result.map do |hash|
+        hash.dig('value', 'report', 'resource_statuses').keys
+      end.flatten
+      expect(users).to eq(["Notify[root\n]", "Notify[root\n]"])
+    end
+  end
+end


### PR DESCRIPTION
This POC introduces the `run_container()` plan function. The function
accepts the name of an image (optionally with a registry prepended) to
run, and a hash of options to apply when running the container. For this
POC, Docker is the only supported container engine. The function returns
a new `ContainerResult` object that contains a `value`, `status`, and
`object`. This function is supported on both *nix and Windows systems.

Currently, supported options are:
* `cmd` - A command to run in the container
* `env_vars` - A hash of environment variables to set in the container
* `ports` - A hash of ports to publish from the container to the host
* `rm` - A boolean, whether to remove the container when it exits
* `volumes` - A hash of directories on the host and their corresponding
  directories in the container to mount into the container

If you have requests for more options to add, let us know in the
comments, in a new issue, or in Slack (and be sure to smash that 'star'
button 😉).

!feature

* **run_container() plan function**
  This introduces a new `run_container()` Puppet plan function that will
  run a container a return its output.