### PR TITLE
(maint) Upgrade bundled modules

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,7 +6,7 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '2.0.0'
-mod 'puppetlabs-puppet_agent', '4.4.0'
+mod 'puppetlabs-puppet_agent', '4.5.0'
 mod 'puppetlabs-facts', '1.4.0'
 
 # Core types and providers for Puppet 6
@@ -24,9 +24,9 @@ mod 'puppetlabs-zone_core', '1.0.3'
 # Useful additional modules
 mod 'puppetlabs-package', '2.0.0'
 mod 'puppetlabs-powershell_task_helper', '0.1.0'
-mod 'puppetlabs-puppet_conf', '1.0.0'
+mod 'puppetlabs-puppet_conf', '1.1.0'
 mod 'puppetlabs-python_task_helper', '0.5.0'
-mod 'puppetlabs-reboot', '4.0.0'
+mod 'puppetlabs-reboot', '4.0.2'
 mod 'puppetlabs-ruby_task_helper', '0.6.0'
 mod 'puppetlabs-ruby_plugin_helper', '0.2.0'
 mod 'puppetlabs-stdlib', '7.0.0'


### PR DESCRIPTION
This upgrades a few of Bolt's bundled modules to the latest versions.

!feature

* **Upgrade bundled modules**

  The following bundled modules have been updated to their latest
  versions:

  - [puppet_agent 4.5.0](https://forge.puppet.com/puppetlabs/puppet_agent/4.5.0)
  - [puppet_conf 1.1.0](https://forge.puppet.com/puppetlabs/puppet_conf/1.1.0)
  - [reboot 4.0.2](https://forge.puppet.com/puppetlabs/reboot/4.0.2)