### PR TITLE
(GH-2737) Deprecate dotted fact names

### DIFF
--- a/documentation/developer_updates.md
+++ b/documentation/developer_updates.md
@@ -3,6 +3,39 @@
 Find out what the Bolt team is working on and why we're making the decisions
 we're making.
 
+## March 2021
+
+### Deprecating dotted fact names
+
+With the release of Facter 4, dotted fact names are automatically converted to
+structured facts. For example, the custom fact `role.name = server` becomes the
+following structured fact:
+
+```
+{
+  "role" => {
+    "name" => "server"
+  }
+}
+```
+
+This is a significant change from earlier versions of Facter, which permitted
+dotted fact names.
+
+Because Bolt allows you to set facts in the inventory file or during a plan run,
+and uses Facter directly (such as when running the `apply_prep` function) and
+indirectly (such as when making a PuppetDB query), we've updated Bolt to warn
+you when it detects a dotted fact name.
+
+If Bolt detects that a target has a dotted fact name set in either the inventory
+or during a plan run, it displays a deprecation warning. Bolt does not
+automatically convert these facts to structured facts, which is inconsistent
+behavior with Facter 4.
+
+To suppress these deprecation warnings, you can either update your facts or add
+the `dotted_fact_name` ID to the `disable-warnings` option in your project
+configuration.
+
 ## November 2020
 
 ### Changes coming in Bolt 3.0

--- a/lib/bolt/inventory/target.rb
+++ b/lib/bolt/inventory/target.rb
@@ -92,6 +92,7 @@ module Bolt
       end
 
       def add_facts(new_facts = {})
+        validate_fact_names(new_facts)
         @facts = Bolt::Util.deep_merge(@facts, new_facts)
       end
 
@@ -153,7 +154,22 @@ module Bolt
           raise Bolt::UnknownTransportError.new(transport, uri)
         end
 
+        validate_fact_names(facts)
+
         transport_config
+      end
+
+      # Validate fact names and issue a deprecation warning if any fact names have a dot.
+      #
+      private def validate_fact_names(facts)
+        if (dotted = facts.keys.select { |name| name.include?('.') }).any?
+          Bolt::Logger.deprecate(
+            'dotted_fact_name',
+            "Target '#{safe_name}' includes dotted fact names: '#{dotted.join("', '")}'. Dotted fact "\
+            "names are deprecated and Bolt does not automatically convert facts with dotted names to "\
+            "structured facts. For more information, see https://pup.pt/bolt-dotted-facts"
+          )
+        end
       end
 
       def host

--- a/spec/bolt/inventory/target_spec.rb
+++ b/spec/bolt/inventory/target_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/inventory'
+require 'bolt/inventory/target'
+
+describe Bolt::Inventory::Target do
+  let(:inventory)   { Bolt::Inventory.empty }
+  let(:target)      { described_class.new(target_data, inventory) }
+  let(:target_data) { { 'name' => 'target' } }
+
+  context '#initialize' do
+    it 'warns when target has dotted facts' do
+      target_data['facts'] = {
+        'bing.bang' => 'bong',
+        'sing.sang' => 'song',
+        'ding.dang' => 'dong'
+      }
+
+      target
+
+      expect(@log_output.readlines).to include(
+        /WARN.*Target 'target' includes dotted fact names: 'bing.bang', 'sing.sang', 'ding.dang'/
+      )
+    end
+
+    it 'warns when target group has dotted facts' do
+      allow(inventory).to receive(:group_data_for).and_return(
+        'facts' => {
+          'bing.bang' => 'bong',
+          'sing.sang' => 'song',
+          'ding.dang' => 'dong'
+        }
+      )
+
+      target
+
+      expect(@log_output.readlines).to include(
+        /WARN.*Target 'target' includes dotted fact names: 'bing.bang', 'sing.sang', 'ding.dang'/
+      )
+    end
+  end
+
+  context '#add_facts' do
+    it 'warns when adding dotted facts' do
+      target.add_facts(
+        'bing.bang' => 'bong',
+        'sing.sang' => 'song',
+        'ding.dang' => 'dong'
+      )
+
+      expect(@log_output.readlines).to include(
+        /WARN.*Target 'target' includes dotted fact names: 'bing.bang', 'sing.sang', 'ding.dang'/
+      )
+    end
+  end
+end


### PR DESCRIPTION
This updates Bolt to log a deprecation warning when it detects a target
that has facts with dotted names. This warning is logged whether a
target is loaded with a dotted fact name (either in the inventory or
with `Target.new`) or when adding facts to a target (with
`$target.add_facts`).

!deprecation

* **Deprecate dotted fact names**
  ([#2737](https://github.com/puppetlabs/bolt/issues/2737))

  Dotted fact names (e.g. `foo.bar`) are now deprecated. Bolt issues a
  deprecation warning if it detects a target is loaded with these facts
  or has them added during a plan run.

--- 

### TODO

- [ ] Create pup.pt short link once approved

---

### Acceptance criteria

- [x] Warns when target has dotted facts in inventory
- [x] Warns when facter returns dotted facts, such as during an `apply_prep` (only applies to Facter 2 & 3)
- [x] Warns when adding facts in a plan with `$target.add_facts`