### PR TITLE
(bug) Do not warn valid top level inventory config

### DIFF
--- a/lib/bolt/inventory/options.rb
+++ b/lib/bolt/inventory/options.rb
@@ -11,6 +11,7 @@ module Bolt
         facts
         features
         groups
+        plugin_hooks
         targets
         vars
       ].freeze


### PR DESCRIPTION
Setting `plugin_hooks` as a top level key in `inventory.yaml` is valid (I want to apply the same plugin hook config to every target). Previously a warning that `plugin_hooks` is an "unknown option" when set at the top level of an inventory file was raised. This commit stops that warning by allow listing the setting.

!bug

* **Do not warn on top level `plugin_hooks` config**

  Bolt no longer warns that `plugin_hooks` are an unknown option when configured in inventory file.