### PR TITLE
(PE-31347) Load cloud inventory plugins in bolt-server

### DIFF
--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -703,6 +703,9 @@ module BoltServer
           connect_plugin = BoltServer::Plugin::PuppetConnectData.new(body['puppet_connect_data'])
           plugins = Bolt::Plugin.setup(context[:config], context[:pal], load_plugins: false)
           plugins.add_plugin(connect_plugin)
+          %w[aws_inventory azure_inventory gcloud_inventory].each do |plugin_name|
+            plugins.add_module_plugin(plugin_name) if plugins.known_plugin?(plugin_name)
+          end
           inventory = Bolt::Inventory.from_config(context[:config], plugins)
           target_list = inventory.get_targets('all').map do |targ|
             targ.to_h.merge({ 'transport' => targ.transport, 'plugin_hooks' => targ.plugin_hooks })


### PR DESCRIPTION
This slightly refactors the way that plugins are loaded so that the
`add_module_plugin` method can be called explicitly even if plugin
loading is disabled. Specifically, the `add_ruby_plugin` and
`add_module_plugin` methods now longer verify that the plugin exists or
that plugin loading is enabled. Those steps are now handled exclusively by
`by_name` and `get_hook`, which are the entry points into the plugin
system.

The resulting behavior is the same as before:
  1. If a plugin doesn't exist, `by_name` won't raise an error and
     `get_hook` will. This allows config to be set for a non-existent
     plugin as that will only call `by_name`, which will do nothing. If
     the plugin is later *used*, `get_hook` will raise an error.
  2. If a plugin does exist but loading is disabled, `by_name` will raise an
     error right away.