### PR TITLE
(bug) Allow 'version' key in inventory files

### DIFF
--- a/developer-docs/bolt-api-servers.md
+++ b/developer-docs/bolt-api-servers.md
@@ -378,7 +378,7 @@ This endpoint behaves identically to the /ssh/check_node_connections endpoint, b
 
 ### POST /project_inventory_targets
 
-This endpoint parses a project inventory and returns a list of target hashes. Note that the only accepetable inventoryfile location is the default `inventory.yaml` at the root of the project.
+This endpoint parses a project inventory and returns a list of target hashes. Note that the only accepetable inventory file location is the default `inventory.yaml` at the root of the project.
 
 #### Query parameters
 
@@ -386,7 +386,7 @@ This endpoint parses a project inventory and returns a list of target hashes. No
 
 #### POST body
 
-- `connect_data`: Hash, *required* - Data for the Connect plugin to look up. Keys are the lookup in the inventoryfile which points to a hash with a required "value" key that points to the value to look up.
+- `connect_data`: Hash, *required* - Data for the Connect plugin to look up. Keys are the lookup in the inventory file which points to a hash with a required "value" key that points to the value to look up.
 
 #### Request
 

--- a/lib/bolt/inventory/options.rb
+++ b/lib/bolt/inventory/options.rb
@@ -14,6 +14,7 @@ module Bolt
         plugin_hooks
         targets
         vars
+        version
       ].freeze
 
       # Definitions used to validate the data.
@@ -124,6 +125,13 @@ module Bolt
           description: "A map of variables for the group or target.",
           type: Hash,
           _plugin: true
+        },
+        "version" => {
+          description: "The version of the inventory file.",
+          type: Integer,
+          _plugin: false,
+          _example: 2,
+          _default: 2
         }
       }.freeze
     end

--- a/schemas/bolt-inventory.schema.json
+++ b/schemas/bolt-inventory.schema.json
@@ -1403,6 +1403,10 @@
           "$ref": "#/definitions/_plugin"
         }
       ]
+    },
+    "version": {
+      "description": "The version of the inventory file.",
+      "type": "integer"
     }
   },
   "oneOf": [
@@ -1449,6 +1453,16 @@
             }
           ]
         },
+        "plugin_hooks": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/plugin_hooks"
+            },
+            {
+              "$ref": "#/definitions/_plugin"
+            }
+          ]
+        },
         "targets": {
           "oneOf": [
             {
@@ -1463,6 +1477,16 @@
           "oneOf": [
             {
               "$ref": "#/definitions/vars"
+            },
+            {
+              "$ref": "#/definitions/_plugin"
+            }
+          ]
+        },
+        "version": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/version"
             },
             {
               "$ref": "#/definitions/_plugin"


### PR DESCRIPTION
When running `bolt project migrate` we don't remove the `version` key if
the value is `2`, but we still raise a warning that the `version` key
isn't recognized. This amends the inventoryfile schema to include the
`version` key so that users don't see a warning.

!bug

* **Allow 'version' key in inventory files**

  Bolt now recognizes the `version` configuration in an inventoryfile
  and doesn't raise a warning that the key is unknown.