### PR TITLE
(GH-2730) Add future.file_paths config option

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -541,7 +541,11 @@ module Bolt
         end
         code = apply_manifest(options[:code], options[:targets], options[:object], options[:noop])
       else
-        executor = Bolt::Executor.new(config.concurrency, analytics, options[:noop], config.modified_concurrency)
+        executor = Bolt::Executor.new(config.concurrency,
+                                      analytics,
+                                      options[:noop],
+                                      config.modified_concurrency,
+                                      config.future)
         targets = options[:targets]
 
         results = nil
@@ -688,7 +692,11 @@ module Bolt
       plan_context = { plan_name: plan_name,
                        params: plan_arguments }
 
-      executor = Bolt::Executor.new(config.concurrency, analytics, options[:noop], config.modified_concurrency)
+      executor = Bolt::Executor.new(config.concurrency,
+                                    analytics,
+                                    options[:noop],
+                                    config.modified_concurrency,
+                                    config.future)
       if %w[human rainbow].include?(options.fetch(:format, 'human'))
         executor.subscribe(outputter)
       else
@@ -724,7 +732,11 @@ module Bolt
         Bolt::Logger.warn("empty_manifest", message)
       end
 
-      executor = Bolt::Executor.new(config.concurrency, analytics, noop, config.modified_concurrency)
+      executor = Bolt::Executor.new(config.concurrency,
+                                    analytics,
+                                    noop,
+                                    config.modified_concurrency,
+                                    config.future)
       executor.subscribe(outputter) if options.fetch(:format, 'human') == 'human'
       executor.subscribe(log_outputter)
       # apply logging looks like plan logging, so tell the outputter we're in a

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -328,13 +328,6 @@ module Bolt
     end
 
     def validate
-      if @data['future']
-        Bolt::Logger.warn(
-          "future_option",
-          "Configuration option 'future' no longer exposes future behavior."
-        )
-      end
-
       if @data['modulepath']&.include?(@project.managed_moduledir.to_s)
         raise Bolt::ValidationError,
               "Found invalid path in modulepath: #{@project.managed_moduledir}. This path "\
@@ -393,6 +386,10 @@ module Bolt
 
     def format=(value)
       @data['format'] = value
+    end
+
+    def future
+      @data['future']
     end
 
     def trace

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -133,6 +133,20 @@ module Bolt
           _example: "json",
           _default: "human"
         },
+        "future" => {
+          description: "Enable new Bolt features that may include breaking changes.",
+          type: Hash,
+          properties: {
+            "file_paths" => {
+              description: "Load scripts from the `scripts/` directory of a module",
+              type: [TrueClass, FalseClass],
+              _example: true,
+              _default: false
+            }
+          },
+          _plugin: false,
+          _example: { 'file_paths' => true }
+        },
         "hiera-config" => {
           description: "The path to the Hiera configuration file.",
           type: String,
@@ -557,6 +571,7 @@ module Bolt
         concurrency
         disable-warnings
         format
+        future
         hiera-config
         log
         modulepath

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -33,13 +33,14 @@ module Bolt
   }.freeze
 
   class Executor
-    attr_reader :noop, :transports, :in_parallel
+    attr_reader :noop, :transports, :in_parallel, :future
     attr_accessor :run_as
 
     def initialize(concurrency = 1,
                    analytics = Bolt::Analytics::NoopClient.new,
                    noop = false,
-                   modified_concurrency = false)
+                   modified_concurrency = false,
+                   future = {})
       # lazy-load expensive gem code
       require 'concurrent'
       @analytics = analytics
@@ -64,6 +65,7 @@ module Bolt
       @noop = noop
       @run_as = nil
       @in_parallel = false
+      @future = future
       @pool = if concurrency > 0
                 Concurrent::ThreadPoolExecutor.new(name: 'exec', max_threads: concurrency)
               else

--- a/lib/bolt_spec/plans/mock_executor.rb
+++ b/lib/bolt_spec/plans/mock_executor.rb
@@ -17,13 +17,14 @@ module BoltSpec
 
     # Nothing on the executor is 'public'
     class MockExecutor
-      attr_reader :noop, :error_message, :in_parallel, :transports
+      attr_reader :noop, :error_message, :in_parallel, :transports, :future
       attr_accessor :run_as, :transport_features, :execute_any_plan
 
       def initialize(modulepath)
         @noop = false
         @run_as = nil
         @in_parallel = false
+        @future = {}
         @error_message = nil
         @allow_apply = false
         @modulepath = [modulepath].flatten.map { |path| File.absolute_path(path) }

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -22,6 +22,9 @@
     "format": {
       "$ref": "#/definitions/format"
     },
+    "future": {
+      "$ref": "#/definitions/future"
+    },
     "hiera-config": {
       "$ref": "#/definitions/hiera-config"
     },
@@ -133,6 +136,16 @@
         "json",
         "rainbow"
       ]
+    },
+    "future": {
+      "description": "Enable new Bolt features that may include breaking changes.",
+      "type": "object",
+      "properties": {
+        "file_paths": {
+          "description": "Load scripts from the `scripts/` directory of a module",
+          "type": "boolean"
+        }
+      }
     },
     "hiera-config": {
       "description": "The path to the Hiera configuration file.",

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -330,6 +330,25 @@ describe "Bolt::CLI" do
     end
   end
 
+  context 'executor#future' do
+    let(:cli)     { Bolt::CLI.new(%w[command run uptime -t foo]) }
+    let(:config)  { { 'future' => { 'file_paths' => true } } }
+
+    around(:each) do |example|
+      in_project(config: config) do |project|
+        @project = project
+        example.run
+      end
+    end
+
+    it 'sets future on the executor' do
+      expect(Bolt::Executor).to receive(:new)
+        .with(100, any_args, nil, false, { 'file_paths' => true })
+        .and_call_original
+      cli.execute(cli.parse)
+    end
+  end
+
   context "without a config file" do
     let(:project) { Bolt::Project.new({}, '.') }
     before(:each) do
@@ -2252,7 +2271,8 @@ describe "Bolt::CLI" do
         expect(Bolt::Executor).to receive(:new).with(Bolt::Config.default.concurrency,
                                                      anything,
                                                      true,
-                                                     anything).and_return(executor)
+                                                     anything,
+                                                     nil).and_return(executor)
 
         plugins = Bolt::Plugin.setup(Bolt::Config.default, nil)
         allow(cli).to receive(:plugins).and_return(plugins)

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -190,20 +190,6 @@ describe Bolt::Config do
     end
   end
 
-  describe 'with future set' do
-    let(:future_config) { { 'future' => true } }
-    let(:config) { Bolt::Config.new(project, future_config) }
-
-    it 'logs a warning' do
-      expect(Bolt::Logger).to receive(:warn).with(
-        anything,
-        /Configuration option 'future'/
-      )
-
-      config
-    end
-  end
-
   describe 'merging config files' do
     let(:project_config) {
       {


### PR DESCRIPTION
This introduces a new project-level configuration option `future` which
contains a hash that can enable various features that may introduce
breaking changes in Bolt. The first suboption of `future` is
`file_paths`, which will enable loading scripts from the `scripts/`
subdirectory of a module once #2731 is complete. This doesn't include a
release note, preferring a larger release note once the whole feature is
implemented.

!no-release-note