### PR TITLE
(hack) Improve 'inventory show' output

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -631,7 +631,18 @@ module Bolt
 
     def list_targets
       inventoryfile = config.inventoryfile || config.default_inventoryfile
+      outputter.print_targets(group_targets_by_source, inventoryfile)
+    end
 
+    def show_targets
+      inventoryfile = config.inventoryfile || config.default_inventoryfile
+      outputter.print_target_info(group_targets_by_source, inventoryfile)
+    end
+
+    # Returns a hash of targets sorted by those that are found in the
+    # inventory and those that are provided on the command line.
+    #
+    private def group_targets_by_source
       # Retrieve the known group and target names. This needs to be done before
       # updating targets, as that will add adhoc targets to the inventory.
       known_names = inventory.target_names
@@ -642,17 +653,7 @@ module Bolt
         known_names.include?(target.name)
       end
 
-      target_list = {
-        inventory: inventory_targets,
-        adhoc:     adhoc_targets
-      }
-
-      outputter.print_targets(target_list, inventoryfile)
-    end
-
-    def show_targets
-      update_targets(options)
-      outputter.print_target_info(options[:targets])
+      { inventory: inventory_targets, adhoc: adhoc_targets }
     end
 
     def list_groups

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -116,7 +116,9 @@ module Bolt
         )
       end
 
-      def print_target_info(targets)
+      def print_target_info(target_list, _inventoryfile)
+        targets = target_list.values.flatten
+
         @stream.puts ::JSON.pretty_generate(
           targets: targets.map(&:detail),
           count: targets.count

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -511,13 +511,13 @@ describe "Bolt::Outputter::Human" do
     it 'prints the inventory file path' do
       expect(File).to receive(:exist?).with(inventoryfile).and_return(true)
       outputter.print_targets(target_list, inventoryfile)
-      expect(output.string).to match(/INVENTORY FILE:\s*#{inventoryfile}/)
+      expect(output.string).to match(/Inventory file.*#{inventoryfile}/m)
     end
 
     it 'prints a message that the inventory file does not exist' do
       expect(File).to receive(:exist?).with(inventoryfile).and_return(false)
       outputter.print_targets(target_list, inventoryfile)
-      expect(output.string).to match(/INVENTORY FILE:.*does not exist/m)
+      expect(output.string).to match(/Inventory file.*does not exist/m)
     end
 
     it 'prints target counts' do


### PR DESCRIPTION
This updates the output for `bolt inventory show` and
`Get-BoltInventory` to better match the other `show` commands. Targets,
the inventory source, and the target count are now listed under
colorized headings.

This also updates the `--detail` view so that targets are listed in
alphabetical order and use each target's name as a heading for easy
reading. The target's configuration and data is also now displayed in
YAML in the human outputter, to better match the format of the inventory
file. The `--detail` view also now includes the same inventory source
and target count that are in the undetailed view.

!feature

* **Improved output for `inventory show`**

  The `bolt inventory show` and `Get-BoltInventory` command now display
  `human` output in the same format as other `show` commands.