### PR TITLE
(GH-2456) Add Podman transport

### DIFF
--- a/.github/workflows/podman.yaml
+++ b/.github/workflows/podman.yaml
@@ -1,0 +1,31 @@
+name: Podman
+
+on:
+  push:
+    branches: [main]
+    paths: ['lib/bolt/config*', 'lib/bolt/executor.rb', 'lib/bolt/transport/podman*', 'spec/**/*/podman_spec.rb']
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+    paths: ['lib/bolt/config*', 'lib/bolt/executor.rb', 'lib/bolt/transport/podman*', 'spec/**/*/podman_spec.rb']
+
+jobs:
+  podman:
+    name: Podman
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - name: Update gems
+        run: bundle update
+      - name: Pre-test setup
+        run: |
+          podman build -f spec/Dockerfile -t spec_ubuntu_node
+          podman run -d --name ubuntu_node spec_ubuntu_node
+          bundle exec r10k puppetfile install
+      - name: Run tests with expensive containers
+        run: bundle exec rake tests:podman

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -38,6 +38,28 @@ plan bolt (
 }
 ```
 
+## Podman support
+
+Bolt now has experimental support for [Podman](https://podman.io/), a daemonless container engine.
+The Podman transport supports connecting to containers managed by Podman on the local system.
+The Podman transport accepts many of the same configuration options as the Docker transport. You can
+see the full list of supported configuration options [on the transport reference
+page](bolt_transports_reference.md). The Podman transport doesn't support the `service-url`
+configuration options as the transport doesn't support remote connections. If this is a feature
+you're interested in, let us know [in Slack](https://slack.puppet.com) or submit a [Github
+issue](https://github.com/puppetlabs/bolt/issues).
+
+The example inventory file below demonstrates connecting to a Podman container target named
+`postgres_db`.
+
+```
+targets:
+  - uri: podman://postgres_db
+    config:
+      podman:
+        tmpdir: /root/tmp
+```
+
 ## Streaming output
 
 This feature was introduced in [Bolt 3.2.0](https://github.com/puppetlabs/bolt/blob/main/CHANGELOG.md#bolt-320-2021-3-08).
@@ -65,7 +87,7 @@ once as the actions are running, and again after Bolt prints the results.
 This feature was introduced in [Bolt 3.2.0](https://github.com/puppetlabs/bolt/blob/main/CHANGELOG.md#bolt-320-2021-3-08).
 
 The LXD transport supports connecting to Linux containers on the local system. Similar to the Docker
-transport, The LXD transport accepts the name of the container as the URI, and connects to the
+transport, the LXD transport accepts the name of the container as the URI, and connects to the
 container by shelling out to the `lxc` command. The example inventory file below demonstrates
 connecting to a Linux container target named `ubuntuone`.
 

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
-require 'bolt/config/transport/ssh'
-require 'bolt/config/transport/winrm'
-require 'bolt/config/transport/orch'
+require 'bolt/config/transport/docker'
 require 'bolt/config/transport/local'
 require 'bolt/config/transport/lxd'
-require 'bolt/config/transport/docker'
+require 'bolt/config/transport/orch'
+require 'bolt/config/transport/podman'
 require 'bolt/config/transport/remote'
+require 'bolt/config/transport/ssh'
+require 'bolt/config/transport/winrm'
 
 module Bolt
   class Config
@@ -14,13 +15,14 @@ module Bolt
       # Transport config classes. Used to load default transport config which
       # gets passed along to the inventory.
       TRANSPORT_CONFIG = {
-        'ssh'    => Bolt::Config::Transport::SSH,
-        'winrm'  => Bolt::Config::Transport::WinRM,
-        'pcp'    => Bolt::Config::Transport::Orch,
+        'docker' => Bolt::Config::Transport::Docker,
         'local'  => Bolt::Config::Transport::Local,
         'lxd'    => Bolt::Config::Transport::LXD,
-        'docker' => Bolt::Config::Transport::Docker,
-        'remote' => Bolt::Config::Transport::Remote
+        'pcp'    => Bolt::Config::Transport::Orch,
+        'podman' => Bolt::Config::Transport::Podman,
+        'remote' => Bolt::Config::Transport::Remote,
+        'ssh'    => Bolt::Config::Transport::SSH,
+        'winrm'  => Bolt::Config::Transport::WinRM
       }.freeze
 
       # Plugin definition. This is used by the JSON schemas to indicate that an option
@@ -496,6 +498,12 @@ module Bolt
           type: Hash,
           _plugin: true,
           _example: { "job-poll-interval" => 15, "job-poll-timeout" => 30 }
+        },
+        "podman" => {
+          description: "A map of configuration options for the podman transport.",
+          type: Hash,
+          _plugin: true,
+          _example: { "cleanup" => false, "tmpdir" => "/mount/tmp" }
         },
         "remote" => {
           description: "A map of configuration options for the remote transport.",

--- a/lib/bolt/config/transport/podman.rb
+++ b/lib/bolt/config/transport/podman.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'bolt/error'
+require 'bolt/config/transport/base'
+
+module Bolt
+  class Config
+    module Transport
+      class Podman < Base
+        OPTIONS = %w[
+          cleanup
+          host
+          interpreters
+          shell-command
+          tmpdir
+          tty
+        ].freeze
+
+        DEFAULTS = {
+          'cleanup' => true
+        }.freeze
+
+        private def validate
+          super
+
+          if @config['interpreters']
+            @config['interpreters'] = normalize_interpreters(@config['interpreters'])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -12,24 +12,26 @@ require 'bolt/config'
 require 'bolt/result_set'
 require 'bolt/puppetdb'
 # Load transports
-require 'bolt/transport/ssh'
-require 'bolt/transport/winrm'
-require 'bolt/transport/orch'
+require 'bolt/transport/docker'
 require 'bolt/transport/local'
 require 'bolt/transport/lxd'
-require 'bolt/transport/docker'
+require 'bolt/transport/orch'
+require 'bolt/transport/podman'
 require 'bolt/transport/remote'
+require 'bolt/transport/ssh'
+require 'bolt/transport/winrm'
 require 'bolt/yarn'
 
 module Bolt
   TRANSPORTS = {
-    ssh: Bolt::Transport::SSH,
-    winrm: Bolt::Transport::WinRM,
-    pcp: Bolt::Transport::Orch,
+    docker: Bolt::Transport::Docker,
     local: Bolt::Transport::Local,
     lxd: Bolt::Transport::LXD,
-    docker: Bolt::Transport::Docker,
-    remote: Bolt::Transport::Remote
+    pcp: Bolt::Transport::Orch,
+    podman: Bolt::Transport::Podman,
+    remote: Bolt::Transport::Remote,
+    ssh: Bolt::Transport::SSH,
+    winrm: Bolt::Transport::WinRM
   }.freeze
 
   class Executor

--- a/lib/bolt/transport/podman.rb
+++ b/lib/bolt/transport/podman.rb
@@ -2,15 +2,11 @@
 
 require 'json'
 require 'shellwords'
-require 'bolt/transport/simple'
+require 'bolt/transport/base'
 
 module Bolt
   module Transport
-    class Docker < Simple
-      def provided_features
-        ['shell']
-      end
-
+    class Podman < Docker
       def with_connection(target)
         conn = Connection.new(target)
         conn.connect
@@ -20,4 +16,4 @@ module Bolt
   end
 end
 
-require 'bolt/transport/docker/connection'
+require 'bolt/transport/podman/connection'

--- a/lib/bolt/transport/podman/connection.rb
+++ b/lib/bolt/transport/podman/connection.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'logging'
+require 'bolt/node/errors'
+
+module Bolt
+  module Transport
+    class Podman < Docker
+      class Connection < Connection
+        attr_reader :user, :target
+
+        def initialize(target)
+          raise Bolt::ValidationError, "Target #{target.safe_name} does not have a host" unless target.host
+          @target = target
+          @user = ENV['USER'] || Etc.getlogin
+          @logger = Bolt::Logger.logger(target.safe_name)
+          @container_info = {}
+          @logger.trace("Initializing podman connection to #{target.safe_name}")
+        end
+
+        def run_cmd(cmd, env_vars)
+          Bolt::Util.exec_podman(cmd, env_vars)
+        end
+
+        def shell
+          @shell ||= if Bolt::Util.windows?
+                       Bolt::Shell::Powershell.new(target, self)
+                     else
+                       Bolt::Shell::Bash.new(target, self)
+                     end
+        end
+
+        def connect
+          # We don't actually have a connection, but we do need to
+          # check that the container exists and is running.
+          ps = execute_local_json_command('ps')
+          container = Array(ps).find { |item|
+            item["ID"].to_s.eql?(@target.host) ||
+              item["Id"].to_s.start_with?(@target.host) ||
+              Array(item["Names"]).include?(@target.host)
+          }
+          raise "Could not find a container with name or ID matching '#{@target.host}'" if container.nil?
+          # Now find the indepth container information
+          id = container["ID"] || container["Id"]
+          output = execute_local_json_command('inspect', [id])
+          # Store the container information for later
+          @container_info = output.first
+          @logger.trace { "Opened session" }
+          true
+        rescue StandardError => e
+          raise Bolt::Node::ConnectError.new(
+            "Failed to connect to #{target.safe_name}: #{e.message}",
+            'CONNECT_ERROR'
+          )
+        end
+
+        # Executes a command inside the target container. This is called from the shell class.
+        #
+        # @param command [string] The command to run
+        def execute(command)
+          args = []
+          args += %w[--interactive]
+          args += %w[--tty] if target.options['tty']
+          args += @env_vars if @env_vars
+
+          if target.options['shell-command'] && !target.options['shell-command'].empty?
+            # escape any double quotes in command
+            command = command.gsub('"', '\"')
+            command = "#{target.options['shell-command']} \"#{command}\""
+          end
+
+          podman_command = %w[podman exec] + args + [container_id] + Shellwords.split(command)
+          @logger.trace { "Executing: #{podman_command.join(' ')}" }
+
+          Open3.popen3(*podman_command)
+        rescue StandardError
+          @logger.trace { "Command aborted" }
+          raise
+        end
+
+        # Converts the JSON encoded STDOUT string from the podman cli into ruby objects
+        #
+        # @param stdout [String] The string to convert
+        # @return [Object] Ruby object representation of the JSON string
+        private def extract_json(stdout)
+          # Podman renders the output in pretty JSON, which results in a newline
+          # appearing in the output before the closing bracket.
+          # should we only get a single line with no newline at all, we also
+          # assume it is a single minified JSON object
+          stdout.strip!
+          newline = stdout.index("\n") || -1
+          bracket = stdout.index('}') || -1
+          JSON.parse(stdout) if bracket > newline
+        end
+      end
+    end
+  end
+end

--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -343,6 +343,17 @@ module Bolt
         Open3.capture3(env, 'docker', *cmd, { binmode: true })
       end
 
+      # Executes a Podman CLI command. This is useful for running commands as
+      # part of this class without having to go through the `execute`
+      # function and manage pipes.
+      #
+      # @param cmd [String] The podman command and arguments to run
+      #   e.g. 'cp <src> <dest>' for `podman cp <src> <dest>`
+      # @return [String, String, Process::Status] The output of the command: STDOUT, STDERR, Process Status
+      def exec_podman(cmd, env = {})
+        Open3.capture3(env, 'podman', *cmd, { binmode: true })
+      end
+
       # Formats a map of environment variables to be passed to a command that
       # accepts repeated `--env` flags
       #

--- a/rakelib/tests.rake
+++ b/rakelib/tests.rake
@@ -12,7 +12,7 @@ begin
     RSpec::Core::RakeTask.new(:unit) do |t|
       t.rspec_opts = '--tag ~ssh --tag ~docker --tag ~lxd_transport --tag ~bash --tag ~winrm ' \
                      '--tag ~windows_agents --tag ~puppetserver --tag ~puppetdb ' \
-                     '--tag ~omi --tag ~kerberos --tag ~lxd_remote'
+                     '--tag ~omi --tag ~kerberos --tag ~lxd_remote --tag ~podman'
     end
 
     desc 'Run tests that require a host System Under Test configured with WinRM'
@@ -40,6 +40,11 @@ begin
       t.rspec_opts = '--tag lxd_remote'
     end
 
+    desc 'Run tests that require a host System Under Test configured with Podman'
+    RSpec::Core::RakeTask.new(:podman) do |t|
+      t.rspec_opts = '--tag podman'
+    end
+
     desc 'Run tests that require Bash on the local host'
     RSpec::Core::RakeTask.new(:bash) do |t|
       t.rspec_opts = '--tag bash'
@@ -65,7 +70,7 @@ begin
       RSpec::Core::RakeTask.new(:fast) do |t|
         t.rspec_opts = '--tag ~winrm --tag ~lxd_transport --tag ~windows_agents --tag ~puppetserver ' \
                        '--tag ~puppetdb --tag ~omi --tag ~windows --tag ~kerberos --tag ~expensive ' \
-                       '--tag ~lxd_remote'
+                       '--tag ~lxd_remote --tag ~podman'
       end
 
       # Run RSpec tests that are slow or require slow to start containers for setup
@@ -81,7 +86,7 @@ begin
       RSpec::Core::RakeTask.new(:agentless) do |t|
         t.rspec_opts = '--tag ~ssh --tag ~docker --tag ~lxd_transport --tag ~bash --tag ~windows_agents ' \
                        '--tag ~orchestrator --tag ~puppetserver --tag ~puppetdb --tag ~omi ' \
-                       '--tag ~kerberos --tag ~lxd_remote'
+                       '--tag ~kerberos --tag ~lxd_remote --tag ~podman'
       end
 
       # Run RSpec tests that require Puppet Agents configured with Windows

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -100,6 +100,9 @@
         "pcp": {
           "$ref": "#/definitions/pcp"
         },
+        "podman": {
+          "$ref": "#/definitions/podman"
+        },
         "remote": {
           "$ref": "#/definitions/remote"
         },
@@ -347,13 +350,14 @@
         {
           "type": "string",
           "enum": [
-            "ssh",
-            "winrm",
-            "pcp",
+            "docker",
             "local",
             "lxd",
-            "docker",
-            "remote"
+            "pcp",
+            "podman",
+            "remote",
+            "ssh",
+            "winrm"
           ]
         },
         {
@@ -660,6 +664,79 @@
               "oneOf": [
                 {
                   "$ref": "#/transport_definitions/token-file"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "podman": {
+      "description": "A map of configuration options for the podman transport.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cleanup": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/cleanup"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
+            "host": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/host"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
+            "interpreters": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/interpreters"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
+            "shell-command": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/shell-command"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
+            "tmpdir": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/tmpdir"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
+            "tty": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/tty"
                 },
                 {
                   "$ref": "#/definitions/_plugin"

--- a/schemas/bolt-inventory.schema.json
+++ b/schemas/bolt-inventory.schema.json
@@ -41,13 +41,14 @@
                 {
                   "type": "string",
                   "enum": [
-                    "ssh",
-                    "winrm",
-                    "pcp",
+                    "docker",
                     "local",
                     "lxd",
-                    "docker",
-                    "remote"
+                    "pcp",
+                    "podman",
+                    "remote",
+                    "ssh",
+                    "winrm"
                   ]
                 },
                 {
@@ -393,6 +394,91 @@
                       "oneOf": [
                         {
                           "type": "string"
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
+            "podman": {
+              "description": "A map of configuration options for the podman transport.",
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "cleanup": {
+                      "description": "Whether to clean up temporary files created on targets. When running commands on a target, Bolt might create temporary files. After completing the command, these files are automatically deleted. This value can be set to 'false' if you wish to leave these temporary files on the target.",
+                      "oneOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
+                    "host": {
+                      "description": "The target's hostname.",
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
+                    "interpreters": {
+                      "description": "A map of an extension name to the absolute path of an executable,  enabling you to override the shebang defined in a task executable. The extension can optionally be specified with the `.` character (`.py` and `py` both map to a task executable `task.py`) and the extension is case sensitive. When a target's name is `localhost`, Ruby tasks run with the Bolt Ruby interpreter by default.",
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "propertyNames": {
+                            "pattern": "^.?[a-zA-Z0-9]+$"
+                          }
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
+                    "shell-command": {
+                      "description": "A shell command to wrap any Docker exec commands in, such as `bash -lc`.",
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
+                    "tmpdir": {
+                      "description": "The directory to upload and execute temporary files on the target.",
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
+                    "tty": {
+                      "description": "Whether to enable tty on exec commands.",
+                      "oneOf": [
+                        {
+                          "type": "boolean"
                         },
                         {
                           "$ref": "#/definitions/_plugin"

--- a/spec/bolt/config/transport/podman_spec.rb
+++ b/spec/bolt/config/transport/podman_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/config/transport/podman'
+require 'shared_examples/transport_config'
+
+describe Bolt::Config::Transport::Podman do
+  let(:transport) { Bolt::Config::Transport::Podman }
+  let(:data) { { 'host' => 'example.com' } }
+  let(:merge_data) { { 'tmpdir' => '/path/to/tmpdir' } }
+
+  include_examples 'transport config'
+  include_examples 'filters options'
+
+  context 'using plugins' do
+    let(:plugin_data)   { { 'host' => { '_plugin' => 'foo' } } }
+    let(:resolved_data) { { 'host' => 'foo' } }
+
+    include_examples 'plugins'
+  end
+
+  context 'validating' do
+    include_examples 'interpreters'
+
+    it 'tty errors with wrong type' do
+      data['tty'] = 'true'
+      expect { transport.new(data) }.to raise_error(Bolt::ValidationError)
+    end
+
+    %w[host shell-command tmpdir].each do |opt|
+      it "#{opt} errors with wrong type" do
+        data[opt] = 100
+        expect { transport.new(data) }.to raise_error(Bolt::ValidationError)
+      end
+    end
+  end
+end

--- a/spec/integration/transport/podman_spec.rb
+++ b/spec/integration/transport/podman_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/conn'
+require 'bolt_spec/transport'
+require 'bolt/transport/podman'
+require 'bolt/inventory'
+
+require 'shared_examples/transport'
+
+describe Bolt::Transport::Podman, podman: true do
+  include BoltSpec::Conn
+  include BoltSpec::Transport
+
+  let(:transport)        { 'podman' }
+  let(:hostname)         { conn_info('podman')[:host] }
+  let(:uri)              { "podman://#{hostname}" }
+  let(:podman)           { Bolt::Transport::Podman.new }
+  let(:inventory)        { Bolt::Inventory.empty }
+  let(:target)           { make_target }
+  let(:transport_config) { {} }
+
+  def make_target
+    inventory.get_target(uri)
+  end
+
+  context 'with podman' do
+    let(:transport)  { :podman }
+    let(:os_context) { posix_context }
+
+    it "can test whether the target is available" do
+      expect(runner.connected?(target)).to eq(true)
+    end
+
+    it "returns false if the target is not available" do
+      expect(runner.connected?(inventory.get_target('unknownfoo'))).to eq(false)
+    end
+
+    include_examples 'transport api'
+  end
+
+  context 'with_connection' do
+    it "fails with an unknown host" do
+      expect {
+        podman.with_connection(inventory.get_target('not_a_target')) {}
+      }.to raise_error(Bolt::Node::ConnectError, /Could not find a container with name or ID matching 'not_a_target'/)
+    end
+  end
+
+  context 'when there is no host in the target' do
+    # Directly create an inventory target, since Inventory#get_target doesn't allow
+    # for passing config and would set the host as the name passed to it
+    let(:target) { Bolt::Target.from_hash({ 'name' => 'hostless' }, inventory) }
+
+    it 'errors' do
+      expect { podman.run_command(target, 'whoami') }.to raise_error(/does not have a host/)
+    end
+  end
+
+  context 'with shell-command specified' do
+    let(:target_data) {
+      { 'uri' => uri,
+        'config' => {
+          'podman' => { 'shell-command' => '/bin/bash -c' }
+        } }
+    }
+    let(:target) { Bolt::Target.from_hash(target_data, inventory) }
+
+    it 'uses the specified shell' do
+      result = podman.run_command(target, 'echo $SHELL')
+      expect(result.value['stdout'].strip).to eq('/bin/bash')
+    end
+  end
+end

--- a/spec/integration/validator_spec.rb
+++ b/spec/integration/validator_spec.rb
@@ -356,7 +356,7 @@ describe 'validating config' do
           /Value at 'groups.0.facts' must be of type Hash/,
           /Value at 'groups.0.features' must be of type Array/,
           /Value at 'groups.1.groups' must be of type Array/,
-          /Value at 'config.transport' must be one of ssh, winrm, pcp, local, lxd, docker, remote/,
+          /Value at 'config.transport' must be one of/,
           /Value at 'config.ssh.host-key-check' must be of type Boolean/,
           /Value at 'config.winrm.password' must be of type String/
         )

--- a/spec/lib/bolt_spec/conn.rb
+++ b/spec/lib/bolt_spec/conn.rb
@@ -23,14 +23,14 @@ module BoltSpec
         default_port      = 25985
         additional_config = { ssl: false,
                               'connect-timeout': 30 }
-      when 'docker'
+      when 'docker', 'podman'
         default_user     = ''
         default_password = ''
         default_host     = 'ubuntu_node'
       when 'lxd'
         default_host     = 'testlxd'
       else
-        raise Error, "The transport must be either 'ssh', 'winrm', 'docker', or 'lxd'."
+        raise Error, "The transport must be either 'ssh', 'winrm', 'docker', 'podman', or 'lxd'."
       end
 
       additional_config.merge(

--- a/spec/shared_examples/transport.rb
+++ b/spec/shared_examples/transport.rb
@@ -16,7 +16,7 @@ def posix_context
   # The docker transport doesn't run commands in a shell by default so commands
   # that interpolate variables won't work. For other transports, on the other
   # hand, that's exactly the behavior we want to ensure.
-  env_command = if target.protocol == 'docker'
+  env_command = if target.protocol =~ /^(docker|podman)$/
                   "printenv BOLT_TEST_VAR"
                 else
                   'echo $BOLT_TEST_VAR'
@@ -122,7 +122,7 @@ shared_examples 'transport api' do
     end
 
     it "can return a non-zero exit status" do
-      command = if target.protocol == 'docker'
+      command = if target.protocol =~ /^(docker|podman)$/
                   # explicitly launch bash for Docker transport because Docker doesn't have
                   # a default shell when you perform: docker exec
                   "/bin/bash -c 'exit 2'"


### PR DESCRIPTION
This adds a new Podman transport to connect to local running Podman
containers. This is mostly useful for testing scenarios and debugging.
The Podman transport accepts many of the same configuration options as
the Docker transport. You can see the full list of supported
configuration options [on the transport reference
page](bolt_transports_reference.md). The Podman transport doesn't
support the `service-url` configuration options as the
transport doesn't support remote connections.

!feature

* **Add Podman transport** ([#2456](https://github.com/puppetlabs/bolt/issues/2456))

  The Podman transport connects to local running Podman containers,
  useful for testing scenarios or debugging.