### PR TITLE
(maint) Address puppetlabs_spec_helper deprecation warning

### DIFF
--- a/bolt-modules/boltlib/spec/spec_helper.rb
+++ b/bolt-modules/boltlib/spec/spec_helper.rb
@@ -7,4 +7,7 @@ require 'bolt/pal'
 # so we get task loaders.
 Puppet[:tasks] = true
 Bolt::PAL.load_puppet
+RSpec.configure do |c|
+  c.mock_with :mocha
+end
 require 'puppetlabs_spec_helper/module_spec_helper'

--- a/bolt-modules/ctrl/spec/spec_helper.rb
+++ b/bolt-modules/ctrl/spec/spec_helper.rb
@@ -5,4 +5,7 @@ require 'puppet_pal'
 # Ensure tasks are enabled when rspec-puppet sets up an environment
 # so we get task loaders.
 Puppet[:tasks] = true
+RSpec.configure do |c|
+  c.mock_with :mocha
+end
 require 'puppetlabs_spec_helper/module_spec_helper'

--- a/bolt-modules/dir/spec/spec_helper.rb
+++ b/bolt-modules/dir/spec/spec_helper.rb
@@ -5,4 +5,7 @@ require 'puppet_pal'
 # Ensure tasks are enabled when rspec-puppet sets up an environment
 # so we get task loaders.
 Puppet[:tasks] = true
+RSpec.configure do |c|
+  c.mock_with :mocha
+end
 require 'puppetlabs_spec_helper/module_spec_helper'

--- a/bolt-modules/file/spec/spec_helper.rb
+++ b/bolt-modules/file/spec/spec_helper.rb
@@ -5,4 +5,7 @@ require 'puppet_pal'
 # Ensure tasks are enabled when rspec-puppet sets up an environment
 # so we get task loaders.
 Puppet[:tasks] = true
+RSpec.configure do |c|
+  c.mock_with :mocha
+end
 require 'puppetlabs_spec_helper/module_spec_helper'

--- a/bolt-modules/out/spec/spec_helper.rb
+++ b/bolt-modules/out/spec/spec_helper.rb
@@ -7,4 +7,7 @@ require 'bolt/pal'
 # so we get task loaders.
 Puppet[:tasks] = true
 Bolt::PAL.load_puppet
+RSpec.configure do |c|
+  c.mock_with :mocha
+end
 require 'puppetlabs_spec_helper/module_spec_helper'

--- a/bolt-modules/prompt/spec/spec_helper.rb
+++ b/bolt-modules/prompt/spec/spec_helper.rb
@@ -7,4 +7,7 @@ require 'bolt/pal'
 # so we get task loaders.
 Puppet[:tasks] = true
 Bolt::PAL.load_puppet
+RSpec.configure do |c|
+  c.mock_with :mocha
+end
 require 'puppetlabs_spec_helper/module_spec_helper'

--- a/bolt-modules/system/spec/spec_helper.rb
+++ b/bolt-modules/system/spec/spec_helper.rb
@@ -5,4 +5,7 @@ require 'puppet_pal'
 # Ensure tasks are enabled when rspec-puppet sets up an environment
 # so we get task loaders.
 Puppet[:tasks] = true
+RSpec.configure do |c|
+  c.mock_with :mocha
+end
 require 'puppetlabs_spec_helper/module_spec_helper'

--- a/bolt_spec_spec/spec/functions/with_datatype_spec.rb
+++ b/bolt_spec_spec/spec/functions/with_datatype_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'puppetlabs_spec_helper/module_spec_helper'
 require 'spec_helper'
 require 'bolt_spec/bolt_context'
 

--- a/bolt_spec_spec/spec/spec_helper.rb
+++ b/bolt_spec_spec/spec/spec_helper.rb
@@ -1,3 +1,7 @@
 # frozen_string_literal: true
 
+RSpec.configure do |c|
+  c.mock_with :mocha
+end
 $LOAD_PATH.unshift File.join(__dir__, '..', '..', 'lib')
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/modules/aggregate/spec/spec_helper.rb
+++ b/modules/aggregate/spec/spec_helper.rb
@@ -5,4 +5,7 @@ require 'puppet_pal'
 # Ensure tasks are enabled when rspec-puppet sets up an environment
 # so we get task loaders.
 Puppet[:tasks] = true
+RSpec.configure do |c|
+  c.mock_with :mocha
+end
 require 'puppetlabs_spec_helper/module_spec_helper'

--- a/modules/canary/spec/spec_helper.rb
+++ b/modules/canary/spec/spec_helper.rb
@@ -5,4 +5,7 @@ require 'puppet_pal'
 # Ensure tasks are enabled when rspec-puppet sets up an environment
 # so we get task loaders.
 Puppet[:tasks] = true
+RSpec.configure do |c|
+  c.mock_with :mocha
+end
 require 'puppetlabs_spec_helper/module_spec_helper'

--- a/modules/puppet_connect/spec/spec_helper.rb
+++ b/modules/puppet_connect/spec/spec_helper.rb
@@ -5,4 +5,7 @@ require 'puppet_pal'
 # Ensure tasks are enabled when rspec-puppet sets up an environment
 # so we get task loaders.
 Puppet[:tasks] = true
+RSpec.configure do |c|
+  c.mock_with :mocha
+end
 require 'puppetlabs_spec_helper/module_spec_helper'

--- a/modules/puppetdb_fact/spec/spec_helper.rb
+++ b/modules/puppetdb_fact/spec/spec_helper.rb
@@ -5,4 +5,7 @@ require 'puppet_pal'
 # Ensure tasks are enabled when rspec-puppet sets up an environment
 # so we get task loaders.
 Puppet[:tasks] = true
+RSpec.configure do |c|
+  c.mock_with :mocha
+end
 require 'puppetlabs_spec_helper/module_spec_helper'


### PR DESCRIPTION
The `puppetlabs_spec_helper` ruby library we use as part of testing
embedded Bolt modules was raising a deprecation warning that the default
mocking framework was `mocha` but that to silence the warning the tests
themselves should specify which framework was being used. While I'd
honestly love to switch to `rspec` it's a lot of work to do so for
relatively little gain. For now setting the configuration to `mocha` to
silence the warning is easiest.

!no-release-note