### PR TITLE
(GH-2756) Do not stack trace when missing project config file

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -822,15 +822,10 @@ module Bolt
     #
     def assert_project_file(project)
       unless project.project_file?
-        msg = if project.config_file.exist?
-                command = Bolt::Util.powershell? ? 'Update-BoltProject' : 'bolt project migrate'
-                "Detected Bolt configuration file #{project.config_file}, unable to install "\
-                "modules. To update to a project configuration file, run '#{command}'."
-              else
-                command = Bolt::Util.powershell? ? 'New-BoltProject' : 'bolt project init'
-                "Could not find project configuration file #{project.project_file}, unable "\
-                "to install modules. To create a Bolt project, run '#{command}'."
-              end
+        command = Bolt::Util.powershell? ? 'New-BoltProject' : 'bolt project init'
+
+        msg = "Could not find project configuration file #{project.project_file}, unable "\
+              "to install modules. To create a Bolt project, run '#{command}'."
 
         raise Bolt::Error.new(msg, 'bolt/missing-project-config-error')
       end


### PR DESCRIPTION
This fixes a bug that arises from running the `bolt module add|install`
command when a project does not have a `bolt-project.yaml` file.
Previously, Bolt would call the undefined method
`Bolt::Project.config_file`, result in a stacktrace. Since this method
was removed in Bolt 3.0, the condition that called this method has been
removed.

!bug

* **Do not stack trace when missing project configuration file**
  ([#2756](https://github.com/puppetlabs/bolt/issues/2756))

  Bolt no longer stack traces when installing modules if the project
  does not have a `bolt-project.yaml` configuration file.