### PR TITLE
(GH-2759) Add 'analytics' config option to disable analytics

### DIFF
--- a/documentation/analytics.md
+++ b/documentation/analytics.md
@@ -5,13 +5,33 @@ about how to improve it. You can opt out of providing this data.
 
 ## Opt out of data collection
 
-You can opt out of data collection by modifying Bolt's analytics configuration
-file. This file is located in the user's home directory at `<HOME
-DIRECTORY>/.puppetlabs/etc/bolt/analytics.yaml`. To opt out of data collection,
-add the following line to the file:
+You can opt out of data collection by setting an option in Bolt's configuration
+or by setting an environment variable.
+
+### Bolt configuration
+
+To disable data collection, set `analytics: false` in your [configuration
+file](configuring_bolt.md). This option is supported in the system-wide,
+user-level, and project configuration files.
 
 ```yaml
-disabled: true
+# bolt-defaults.yaml
+analytics: false
+```
+
+Setting the `analytics: false` option in a configuration file disables data
+collection universally. You cannot override the option by setting it to `true`
+in another configuration file. For example, setting `analytics: true` in a
+project configuration file does not enable data collection if you've set
+`analytics: false` in the system-wide or user-level configuration file.
+
+### Environment variable
+
+To disable data collection, set the `BOLT_DISABLE_ANALYTICS` environment
+variable to any value.
+
+```
+export BOLT_DISABLE_ANALYTICS=true
 ```
 
 ## Data collected

--- a/lib/bolt/analytics.rb
+++ b/lib/bolt/analytics.rb
@@ -29,7 +29,7 @@ module Bolt
       yaml_plan_count: :cd13
     }.freeze
 
-    def self.build_client
+    def self.build_client(enabled = true)
       logger = Bolt::Logger.logger(self)
       begin
         config_file = config_path
@@ -38,7 +38,7 @@ module Bolt
         config = { 'disabled' => true }
       end
 
-      if config['disabled'] || ENV['BOLT_DISABLE_ANALYTICS']
+      if !enabled || config['disabled'] || ENV['BOLT_DISABLE_ANALYTICS']
         logger.debug "Analytics opt-out is set, analytics will be disabled"
         NoopClient.new
       else
@@ -80,12 +80,8 @@ module Bolt
         unless ENV['BOLT_DISABLE_ANALYTICS']
           msg = <<~ANALYTICS
             Bolt collects data about how you use it. You can opt out of providing this data.
-
-            To disable analytics data collection, add this line to ~/.puppetlabs/etc/bolt/analytics.yaml :
-              disabled: true
-
-            Read more about what data Bolt collects and why here:
-              https://puppet.com/docs/bolt/latest/bolt_installing.html#analytics-data-collection
+            To learn how to disable data collection, or see what data Bolt collects and why,
+            see http://pup.pt/bolt-analytics
           ANALYTICS
           Bolt::Logger.warn_once('analytics_opt_out', msg)
         end

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -943,7 +943,7 @@ module Bolt
 
     def analytics
       @analytics ||= begin
-        client = Bolt::Analytics.build_client
+        client = Bolt::Analytics.build_client(config.analytics)
         client.bundled_content = bundled_content
         client
       end

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -169,6 +169,7 @@ module Bolt
       @config_files = []
 
       default_data = {
+        'analytics'           => true,
         'apply-settings'      => {},
         'color'               => true,
         'compile-concurrency' => Etc.nprocessors,
@@ -263,6 +264,8 @@ module Bolt
           # Disabled warnings are concatenated
           when 'disable-warnings'
             val1.concat(val2)
+          when 'analytics'
+            val1 && val2
           # All other values are overwritten
           else
             val2
@@ -454,6 +457,10 @@ module Bolt
 
     def disable_warnings
       Set.new(@project.disable_warnings + @data['disable-warnings'])
+    end
+
+    def analytics
+      @data['analytics']
     end
 
     # Check if there is a case-insensitive match to the path

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -57,6 +57,13 @@ module Bolt
       # Definitions used to validate config options.
       # https://github.com/puppetlabs/bolt/blob/main/schemas/README.md
       OPTIONS = {
+        "analytics" => {
+          description: "Whether to disable analytics. Setting this option to 'false' in the system-wide "\
+                       "or user-level configuration will disable analytics for all projects, even if this "\
+                       "option is set to 'true' at the project level.",
+          type: [TrueClass, FalseClass],
+          _example: false
+        },
         "apply-settings" => {
           description: "A map of Puppet settings to use when applying Puppet code using the `apply` "\
                        "plan function or the `bolt apply` command.",
@@ -554,6 +561,7 @@ module Bolt
 
       # Options that are available in a bolt-defaults.yaml file
       DEFAULTS_OPTIONS = %w[
+        analytics
         color
         compile-concurrency
         concurrency
@@ -573,6 +581,7 @@ module Bolt
 
       # Options that are available in a bolt-project.yaml file
       PROJECT_OPTIONS = %w[
+        analytics
         apply-settings
         color
         compile-concurrency

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -4,6 +4,9 @@
   "description": "Bolt Defaults bolt-defaults.yaml Schema",
   "type": "object",
   "properties": {
+    "analytics": {
+      "$ref": "#/definitions/analytics"
+    },
     "color": {
       "$ref": "#/definitions/color"
     },
@@ -51,6 +54,10 @@
     }
   },
   "definitions": {
+    "analytics": {
+      "description": "Whether to disable analytics. Setting this option to 'false' in the system-wide or user-level configuration will disable analytics for all projects, even if this option is set to 'true' at the project level.",
+      "type": "boolean"
+    },
     "color": {
       "description": "Whether to use colored output when printing messages to the console.",
       "type": "boolean"

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -4,6 +4,9 @@
   "description": "Bolt Project bolt-project.yaml Schema",
   "type": "object",
   "properties": {
+    "analytics": {
+      "$ref": "#/definitions/analytics"
+    },
     "apply-settings": {
       "$ref": "#/definitions/apply-settings"
     },
@@ -75,6 +78,10 @@
     }
   },
   "definitions": {
+    "analytics": {
+      "description": "Whether to disable analytics. Setting this option to 'false' in the system-wide or user-level configuration will disable analytics for all projects, even if this option is set to 'true' at the project level.",
+      "type": "boolean"
+    },
     "apply-settings": {
       "description": "A map of Puppet settings to use when applying Puppet code using the `apply` plan function or the `bolt apply` command.",
       "type": "object",

--- a/spec/bolt/analytics_spec.rb
+++ b/spec/bolt/analytics_spec.rb
@@ -16,11 +16,16 @@ describe Bolt::Analytics do
     allow(subject).to receive(:write_config)
   end
 
-  it 'creates a NoopClient if analytics is disabled' do
+  it 'creates a NoopClient if analytics is disabled in analytics file' do
     default_config.replace('disabled' => true)
     expect(subject).not_to receive(:write_config)
 
     expect(subject.build_client).to be_instance_of(Bolt::Analytics::NoopClient)
+  end
+
+  it 'creates a NoopClient if analytics is disabled in config' do
+    expect(subject).not_to receive(:write_config)
+    expect(subject.build_client(false)).to be_instance_of(Bolt::Analytics::NoopClient)
   end
 
   it 'creates a NoopClient if reading config fails' do

--- a/spec/bolt/config_spec.rb
+++ b/spec/bolt/config_spec.rb
@@ -329,6 +329,24 @@ describe Bolt::Config do
       project_config['log'] = { '~/.puppetlabs/debug.log' => 'disable' }
       expect(config.log).not_to include('~/.puppetlabs/debug.log')
     end
+
+    context 'analytics' do
+      it 'defaults to enabled' do
+        expect(config.analytics).to eq(true)
+      end
+
+      it 'overrides a true value with false' do
+        system_config['analytics']  = true
+        project_config['analytics'] = false
+        expect(config.analytics).to eq(false)
+      end
+
+      it 'does not override a false value' do
+        system_config['analytics']  = false
+        project_config['analytics'] = true
+        expect(config.analytics).to eq(false)
+      end
+    end
   end
 
   describe '#modulepath' do


### PR DESCRIPTION
This adds a new configuration option called `analytics` that disables
data collection in Bolt when set to `false`. The option is supported in
both `bolt-defaults.yaml` and `bolt-project.yaml`. If this option is set
to `false`, it cannot be overriden in another configuration file. For
example, setting `analytics: true` in `bolt-project.yaml` will not
enable data collection if `analytics: false` is set in
`bolt-defaults.yaml`.

!feature

* **Disable analytics in system, user, and project config files**
  ([#2759](https://github.com/puppetlabs/bolt/issues/2759))

  The new `analytics` configuration option can be used to disable data
  collection in Bolt and is supported in both `bolt-defaults.yaml` and
  `bolt-project.yaml`. Disabling data collection cannot be overridden by
  enabling it in another configuration file.