### PR TITLE
(hack) Improve 'group show' output

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -642,8 +642,12 @@ module Bolt
         options[:targets] = 'all'
       end
 
-      inventoryfile = config.inventoryfile || config.default_inventoryfile
-      outputter.print_targets(group_targets_by_source, inventoryfile, target_flag)
+      outputter.print_targets(
+        group_targets_by_source,
+        inventory.source,
+        config.default_inventoryfile,
+        target_flag
+      )
     end
 
     def show_targets
@@ -653,8 +657,12 @@ module Bolt
         options[:targets] = 'all'
       end
 
-      inventoryfile = config.inventoryfile || config.default_inventoryfile
-      outputter.print_target_info(group_targets_by_source, inventoryfile, target_flag)
+      outputter.print_target_info(
+        group_targets_by_source,
+        inventory.source,
+        config.default_inventoryfile,
+        target_flag
+      )
     end
 
     # Returns a hash of targets sorted by those that are found in the
@@ -675,8 +683,7 @@ module Bolt
     end
 
     def list_groups
-      groups = inventory.group_names
-      outputter.print_groups(groups)
+      outputter.print_groups(inventory.group_names.sort, inventory.source, config.default_inventoryfile)
     end
 
     def run_plan(plan_name, plan_arguments, nodes, options)

--- a/lib/bolt/inventory.rb
+++ b/lib/bolt/inventory.rb
@@ -86,6 +86,7 @@ module Bolt
         if config.default_inventoryfile.exist?
           logger.debug("Loaded inventory from #{config.default_inventoryfile}")
         else
+          source = nil
           logger.debug("Tried to load inventory from #{config.default_inventoryfile}, but the file does not exist")
         end
       end
@@ -100,17 +101,17 @@ module Bolt
         validator.warnings.each { |warning| Bolt::Logger.warn(warning[:id], warning[:msg]) }
       end
 
-      inventory = create_version(data, config.transport, config.transports, plugins)
+      inventory = create_version(data, config.transport, config.transports, plugins, source)
       inventory.validate
       inventory
     end
 
-    def self.create_version(data, transport, transports, plugins)
+    def self.create_version(data, transport, transports, plugins, source = nil)
       version = (data || {}).delete('version') { 2 }
 
       case version
       when 2
-        Bolt::Inventory::Inventory.new(data, transport, transports, plugins)
+        Bolt::Inventory::Inventory.new(data, transport, transports, plugins, source)
       else
         raise ValidationError.new("Unsupported version #{version} specified in inventory", nil)
       end
@@ -120,7 +121,7 @@ module Bolt
       config  = Bolt::Config.default
       plugins = Bolt::Plugin.setup(config, nil)
 
-      create_version({}, config.transport, config.transports, plugins)
+      create_version({}, config.transport, config.transports, plugins, nil)
     end
   end
 end

--- a/lib/bolt/inventory/inventory.rb
+++ b/lib/bolt/inventory/inventory.rb
@@ -6,7 +6,7 @@ require 'bolt/inventory/target'
 module Bolt
   class Inventory
     class Inventory
-      attr_reader :targets, :plugins, :config, :transport
+      attr_reader :config, :plugins, :source, :targets, :transport
 
       class WildcardError < Bolt::Error
         def initialize(target)
@@ -15,7 +15,7 @@ module Bolt
       end
 
       # TODO: Pass transport config instead of config object
-      def initialize(data, transport, transports, plugins)
+      def initialize(data, transport, transports, plugins, source = nil)
         @logger       = Bolt::Logger.logger(self)
         @data         = data || {}
         @transport    = transport
@@ -24,6 +24,7 @@ module Bolt
         @groups       = Group.new(@data, plugins, all_group: true)
         @group_lookup = {}
         @targets      = {}
+        @source       = source
 
         @groups.resolve_string_targets(@groups.target_aliases, @groups.all_targets)
 

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -100,12 +100,12 @@ module Bolt
                        moduledir: moduledir.to_s }.to_json)
       end
 
-      def print_targets(target_list, inventoryfile, _target_flag)
+      def print_targets(target_list, inventory_source, default_inventory, _target_flag)
         @stream.puts ::JSON.pretty_generate(
           inventory: {
             targets: target_list[:inventory].map(&:name),
             count: target_list[:inventory].count,
-            file: inventoryfile.to_s
+            file: (inventory_source || default_inventory).to_s
           },
           adhoc: {
             targets: target_list[:adhoc].map(&:name),
@@ -116,7 +116,7 @@ module Bolt
         )
       end
 
-      def print_target_info(target_list, _inventoryfile, _target_flag)
+      def print_target_info(target_list, _inventory_source, _default_inventory, _target_flag)
         targets = target_list.values.flatten
 
         @stream.puts ::JSON.pretty_generate(
@@ -125,7 +125,7 @@ module Bolt
         )
       end
 
-      def print_groups(groups)
+      def print_groups(groups, _inventory_source, _default_inventory)
         count = groups.count
         @stream.puts({ groups: groups,
                        count: count }.to_json)

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -2663,7 +2663,7 @@ describe "Bolt::CLI" do
 
     it 'defaults to showing all targets' do
       cli = Bolt::CLI.new(%w[inventory show])
-      inventory = double('inventory', target_names: [], get_targets: [])
+      inventory = double('inventory', target_names: [], get_targets: [], source: '')
       allow(cli).to receive(:inventory).and_return(inventory)
       expect(inventory).to receive(:get_targets).with('all')
       expect_any_instance_of(Bolt::Outputter::Human).to receive(:print_targets)

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -414,39 +414,37 @@ describe "Bolt::Outputter::Human" do
     end
 
     it 'prints adhoc targets' do
-      outputter.print_targets(target_list, inventoryfile, true)
+      outputter.print_targets(target_list, inventoryfile, nil, true)
       expect(output.string).to match(/target\s*\(Not found in inventory file\)/)
     end
 
-    it 'prints the inventory file path' do
-      expect(File).to receive(:exist?).with(inventoryfile).and_return(true)
-      outputter.print_targets(target_list, inventoryfile, true)
-      expect(output.string).to match(/Inventory file.*#{inventoryfile}/m)
+    it 'prints the inventory source' do
+      outputter.print_targets(target_list, inventoryfile, nil, true)
+      expect(output.string).to match(/Inventory source.*#{inventoryfile}/m)
     end
 
     it 'prints a message that the inventory file does not exist' do
-      expect(File).to receive(:exist?).with(inventoryfile).and_return(false)
-      outputter.print_targets(target_list, inventoryfile, true)
-      expect(output.string).to match(/Inventory file.*does not exist/m)
+      outputter.print_targets(target_list, nil, inventoryfile, true)
+      expect(output.string).to match(/Inventory source.*does not exist/m)
     end
 
     it 'prints target counts' do
-      outputter.print_targets(target_list, inventoryfile, true)
+      outputter.print_targets(target_list, inventoryfile, nil, true)
       expect(output.string).to match(/2 total, 1 from inventory, 1 adhoc/)
     end
 
     it 'prints suggestion to use a targetting option if one was not provided' do
-      outputter.print_targets(target_list, inventoryfile, false)
+      outputter.print_targets(target_list, inventoryfile, nil, false)
       expect(output.string).to match(/Use the .* option to view specific targets/)
     end
 
     it 'does not print suggestion to use a targetting option if one was provided' do
-      outputter.print_targets(target_list, inventoryfile, true)
+      outputter.print_targets(target_list, inventoryfile, nil, true)
       expect(output.string).not_to match(/Use the .* option to view specific targets/)
     end
 
     it 'prints suggestion to use detail option' do
-      outputter.print_targets(target_list, inventoryfile, true)
+      outputter.print_targets(target_list, inventoryfile, nil, true)
       expect(output.string).to match(/Use the .* option to view target configuration and data/)
     end
   end
@@ -462,18 +460,43 @@ describe "Bolt::Outputter::Human" do
     end
 
     it 'prints suggestion to use a targetting option if one was not provided' do
-      outputter.print_target_info(target_list, inventoryfile, false)
+      outputter.print_target_info(target_list, inventoryfile, nil, false)
       expect(output.string).to match(/Use the .* option to view specific targets/)
     end
 
     it 'does not print suggestion to use a targetting option if one was provided' do
-      outputter.print_target_info(target_list, inventoryfile, true)
+      outputter.print_target_info(target_list, inventoryfile, nil, true)
       expect(output.string).not_to match(/Use the .* option to view specific targets/)
     end
 
     it 'does not print suggestion to use detail option' do
-      outputter.print_target_info(target_list, inventoryfile, true)
+      outputter.print_target_info(target_list, inventoryfile, nil, true)
       expect(output.string).not_to match(/Use the .* option to view target configuration and data/)
+    end
+  end
+
+  context '#print_groups' do
+    let(:inventoryfile) { '/path/to/inventory' }
+    let(:groups)        { %w[apple banana carrot] }
+
+    it 'prints groups' do
+      outputter.print_groups(groups, inventoryfile, nil)
+      expect(output.string).to match(/Groups.*apple.*banana.*carrot/m)
+    end
+
+    it 'prints the inventory source' do
+      outputter.print_groups(groups, inventoryfile, nil)
+      expect(output.string).to match(/Inventory source.*#{inventoryfile}/m)
+    end
+
+    it 'prints that the inventory file does not exist' do
+      outputter.print_groups(groups, nil, inventoryfile)
+      expect(output.string).to match(/Inventory source.*but the file does not exist/m)
+    end
+
+    it 'prints the group count' do
+      outputter.print_groups(groups, inventoryfile, nil)
+      expect(output.string).to match(/Group count.*3 total/m)
     end
   end
 end

--- a/spec/bolt/outputter/json_spec.rb
+++ b/spec/bolt/outputter/json_spec.rb
@@ -177,7 +177,7 @@ describe "Bolt::Outputter::JSON" do
     end
 
     it 'outputs inventory targets with count and file' do
-      outputter.print_targets(target_list, inventoryfile, true)
+      outputter.print_targets(target_list, inventoryfile, inventoryfile, true)
       parsed = JSON.parse(output.string)
 
       expect(parsed['inventory']).to eq(
@@ -188,7 +188,7 @@ describe "Bolt::Outputter::JSON" do
     end
 
     it 'outputs adhoc targets with count' do
-      outputter.print_targets(target_list, inventoryfile, true)
+      outputter.print_targets(target_list, inventoryfile, inventoryfile, true)
       parsed = JSON.parse(output.string)
 
       expect(parsed['adhoc']).to eq(
@@ -198,11 +198,25 @@ describe "Bolt::Outputter::JSON" do
     end
 
     it 'outputs all targets with count' do
-      outputter.print_targets(target_list, inventoryfile, true)
+      outputter.print_targets(target_list, inventoryfile, inventoryfile, true)
       parsed = JSON.parse(output.string)
 
       expect(parsed['targets']).to match_array(%w[target target])
       expect(parsed['count']).to eq(2)
+    end
+  end
+
+  context '#print_groups' do
+    let(:inventoryfile) { '/path/to/inventory' }
+    let(:groups)        { %w[apple banana carrot] }
+
+    it 'outputs groups, count, and inventoryfile' do
+      outputter.print_groups(groups, inventoryfile, inventoryfile)
+
+      expect(JSON.parse(output.string)).to eq(
+        'groups' => groups,
+        'count' => groups.count
+      )
     end
   end
 end

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -662,6 +662,18 @@ describe 'running with an inventory file', reset_puppet_settings: true do
       expect { run_cli(%w[inventory show -t all], outputter: Bolt::Outputter::Human) }
         .not_to raise_error
     end
+
+    it 'shows inventory source' do
+      result = run_cli(%w[inventory show -t all], outputter: Bolt::Outputter::Human, project: @project)
+      expect(result).to match(/Inventory source.*#{@project.inventory_file}/m)
+    end
+  end
+
+  context 'when showing groups' do
+    it 'shows inventory source' do
+      result = run_cli(%w[group show -t all], outputter: Bolt::Outputter::Human, project: @project)
+      expect(result).to match(/Inventory source.*#{@project.inventory_file}/m)
+    end
   end
 
   context 'with plugin-hooks configured' do


### PR DESCRIPTION
This updates the output for the `bolt group show` / `Get-BoltGroup`
commands to better align with other `show` commands. The command now
lists information under colorized headers and also lists the source of
the inventory file if one was loaded.

!feature

* **Improved group information output**

  The `bolt group show` and `Get-BoltGroup` commands now display `human`
  output in a similar format to other `show` commands. The `json` output
  now includes the path to the inventory file that the groups are loaded
  from.