### PR TITLE
(bugfix) Ensure all messages are streamed and saved to merged_output

### DIFF
--- a/spec/integration/logging_spec.rb
+++ b/spec/integration/logging_spec.rb
@@ -155,8 +155,10 @@ shared_examples 'streaming output' do
   include BoltSpec::Integration
   include BoltSpec::Project
 
-  let(:lines)       { @log_output.readlines }
-  let(:logger)      { Bolt::Logger.logger(:stream) }
+  let(:lines)         { @log_output.readlines }
+  let(:logger)        { Bolt::Logger.logger(:stream) }
+  let(:rootuser)      { 'root' }
+  let(:run_as_flags)  { config_flags + %W[--run-as #{rootuser} --sudo-password #{pw}] }
 
   around :each do |example|
     with_project(config: config) do |project|
@@ -186,6 +188,11 @@ shared_examples 'streaming output' do
     it 'streams stderr to the console' do
       expect(logger).to receive(:warn).with(/\[#{uri}\] err: error/)
       run_cli(%W[command run #{err_cmd} -t #{uri}] + config_flags, project: @project)
+    end
+
+    it 'streams when using run-as', ssh: true do
+      expect(logger).to receive(:warn).with(/\[#{uri}\] out: #{rootuser}/)
+      run_cli(%W[command run #{whoami} -t #{uri}] + run_as_flags, project: @project)
     end
 
     it 'formats multi-line messages correctly' do


### PR DESCRIPTION
Previously, in the Bash shell class when a command had finished we
collected any leftover messages in a read-loop and saved them to the
appropriate stream to be printed. When we added streaming and
merged_output features we did this for the main read-loop, but not for
the cleanup loop that executes once the thread has finished. This
resulted in some scripts and commands not having their results printed
since we now print merged_output, which was missing messages from the
final stream reading.

Now, any messages read once the thread has finished will be read and
logged to the stream output and saved to `merged_output` so that it can
be printed.

As a note, automated tests to verify that running a script with `run-as` prints pass without the changes here, which is concerning. It seems like it's hard to get the automated tests to a state where the thread has finished but not all messages have been read, and I'm not sure how to force that. Putting this up now since it's time sensitive and we can figure out automated testing later.

!bug

* **Ensure all messages printed, even after thread finishes**

  Bolt now ensures that all messages from a command or script are
  printed back to the user. Previously, some final messages would be lost
  if they were read after the thread finished executing.