### PR TITLE
(bugfix) Ensure all messages are streamed and saved to merged_output

### DIFF
--- a/spec/integration/local_spec.rb
+++ b/spec/integration/local_spec.rb
@@ -123,6 +123,11 @@ describe "when running over the local transport" do
       expect(result.map { |r| r['stdout'].strip }).to eq(%w[root root])
     end
 
+    it 'returns merged output', :reset_puppet_settings do
+      result = run_nodes(["command", "run", ">&2 echo Hello $USER && whoami"] + config_flags)
+      expect(result.map { |r| r['merged_output'].strip }).to eq(["Hello root\nroot", "Hello root\nroot"])
+    end
+
     it 'with script with parameters', :reset_puppet_settings do
       with_tempfile_containing('script', "#!/usr/bin/env bash \n echo $1", '.sh') do |script|
         results = run_cli_json(%W[script run #{script.path} hello] + config_flags)

--- a/spec/integration/logging_spec.rb
+++ b/spec/integration/logging_spec.rb
@@ -155,8 +155,10 @@ shared_examples 'streaming output' do
   include BoltSpec::Integration
   include BoltSpec::Project
 
-  let(:lines)       { @log_output.readlines }
-  let(:logger)      { Bolt::Logger.logger(:stream) }
+  let(:lines)         { @log_output.readlines }
+  let(:logger)        { Bolt::Logger.logger(:stream) }
+  let(:rootuser)      { 'root' }
+  let(:run_as_flags)  { config_flags + %W[--run-as #{rootuser} --sudo-password #{pw}] }
 
   around :each do |example|
     with_project(config: config) do |project|
@@ -186,6 +188,11 @@ shared_examples 'streaming output' do
     it 'streams stderr to the console' do
       expect(logger).to receive(:warn).with(/\[#{uri}\] err: error/)
       run_cli(%W[command run #{err_cmd} -t #{uri}] + config_flags, project: @project)
+    end
+
+    it 'streams when using run-as', ssh: true do
+      expect(logger).to receive(:warn).with(/\[#{uri}\] out: #{rootuser}/)
+      run_cli(%W[command run #{whoami} -t #{uri}] + run_as_flags, project: @project)
     end
 
     it 'formats multi-line messages correctly' do


### PR DESCRIPTION
In the Bash shell class we collect messages from stdout and stderr in a
few places: when using `run-as` after checking for a prompt, during the
read-loop as the command is executing, and then reading anything that's
unread after the thread exits. When we added streaming and merged_output
features we did this for the main read-loop, but not for the initial
sudo-prompt check or the cleanup loop that executes once the thread has
finished. This resulted in some scripts and commands not having their
results printed since we now print merged_output, which was missing
messages from the final stream reading.

Now, any messages read during the initial sudo-prompt check or once the
thread has finished will be read and logged to the stream output and
saved to `merged_output` so that it can be printed.

!bug

* **Ensure all messages printed, even after thread finishes**

  Bolt now ensures that all messages from a command or script are
  printed back to the user. Previously, some messages would be lost
  if they were read after the thread finished executing or when Bolt had
  been prompted for a sudo password.