### PR TITLE
(GH-2747) Default to showing all targets with 'inventory show'

### DIFF
--- a/guides/targets.txt
+++ b/guides/targets.txt
@@ -1,0 +1,31 @@
+TOPIC
+    targets
+
+DESCRIPTION
+    A target is a device that Bolt connects to and runs actions on. Targets can
+    be physical, such as servers, or virtual, such as containers or virtual
+    machines.
+
+    Several of Bolt's commands connect to targets and run actions on them. When
+    you run these commands, Bolt requires a list of targets to run the action
+    on. For example, the `bolt script run` command and `Invoke-BoltScript`
+    PowerShell cmdlet require you to provide a list of targets to run your
+    script on. You can provide a list of targets to a command using one of the
+    following command-line options:
+
+    Shell commands
+        -t, --targets TARGETS
+        -q, --query   QUERY
+            --rerun   FILTER
+
+    PowerShell cmdlets
+        -T, -Targets TARGETS
+        -Q, -Query   QUERY
+            -Rerun   FILTER
+
+    Typically, targets and their configuration and data are listed in a
+    project's inventory file. For more information about inventory files,
+    see 'bolt guide inventory'.
+
+DOCUMENTATION
+    https://pup.pt/bolt-commands

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -190,7 +190,8 @@ module Bolt
           apply
 
       USAGE
-          bolt apply [manifest.pp] [options]
+          bolt apply [manifest] {--targets TARGETS | --query QUERY | --rerun FILTER}
+            [options]
 
       DESCRIPTION
           Apply Puppet manifest code on the specified targets.
@@ -219,7 +220,8 @@ module Bolt
           run
 
       USAGE
-          bolt command run <command> [options]
+          bolt command run <command> {--targets TARGETS | --query QUERY | --rerun FILTER}
+            [options]
 
       DESCRIPTION
           Run a command on the specified targets.
@@ -248,7 +250,8 @@ module Bolt
           download
 
       USAGE
-          bolt file download <src> <dest> [options]
+          bolt file download <source> <destination> {--targets TARGETS | --query QUERY | --rerun FILTER}
+            [options]
 
       DESCRIPTION
           Download a file or directory from one or more targets.
@@ -267,7 +270,8 @@ module Bolt
           upload
 
       USAGE
-          bolt file upload <src> <dest> [options]
+          bolt file upload <source> <destination> {--targets TARGETS | --query QUERY | --rerun FILTER}
+            [options]
 
       DESCRIPTION
           Upload a local file or directory.
@@ -343,7 +347,12 @@ module Bolt
           bolt inventory show [options]
 
       DESCRIPTION
-          Show the list of targets an action would run on.
+          Show the list of targets an action would run on. This command will list
+          all targets in the project's inventory by default.
+
+          To filter the targets in the list, use the --targets, --query, or --rerun
+          options. To view detailed configuration and data for targets, use the
+          --detail option.
     HELP
 
     MODULE_HELP = <<~HELP
@@ -432,7 +441,7 @@ module Bolt
           plan
 
       USAGE
-          bolt plan <action> [parameters] [options]
+          bolt plan <action> [options]
 
       DESCRIPTION
           Convert, create, show, and run Bolt plans.
@@ -449,16 +458,18 @@ module Bolt
           convert
 
       USAGE
-          bolt plan convert <path> [options]
+          bolt plan convert <plan name> [options]
 
       DESCRIPTION
-          Convert a YAML plan to a Puppet language plan and print the converted plan to stdout.
+          Convert a YAML plan to a Puppet language plan and print the converted
+          plan to stdout.
 
           Converting a YAML plan might result in a plan that is syntactically
           correct but has different behavior. Always verify a converted plan's
           functionality. Note that the converted plan is not written to a file.
 
       EXAMPLES
+          bolt plan convert myproject::myplan
           bolt plan convert path/to/plan/myplan.yaml
     HELP
 
@@ -467,7 +478,7 @@ module Bolt
           new
       
       USAGE
-          bolt plan new <plan> [options]
+          bolt plan new <plan name> [options]
       
       DESCRIPTION
           Create a new plan in the current project.
@@ -481,7 +492,7 @@ module Bolt
           run
 
       USAGE
-          bolt plan run <plan> [parameters] [options]
+          bolt plan run <plan name> [parameters] [options]
 
       DESCRIPTION
           Run a plan on the specified targets.
@@ -495,7 +506,7 @@ module Bolt
           show
 
       USAGE
-          bolt plan show [plan] [options]
+          bolt plan show [plan name] [options]
 
       DESCRIPTION
           Show available plans and plan documentation.
@@ -557,7 +568,8 @@ module Bolt
           bolt project migrate [options]
 
       DESCRIPTION
-          Migrate a Bolt project to use current best practices and the latest version of configuration files.
+          Migrate a Bolt project to use current best practices and the latest version of
+          configuration files.
     HELP
 
     SCRIPT_HELP = <<~HELP
@@ -579,7 +591,8 @@ module Bolt
           run
 
       USAGE
-          bolt script run <script> [arguments] [options]
+          bolt script run <script> [arguments] {--targets TARGETS | --query QUERY | --rerun FILTER}
+            [options]
 
       DESCRIPTION
           Run a script on the specified targets.
@@ -661,7 +674,8 @@ module Bolt
           run
 
       USAGE
-          bolt task run <task> [parameters] [options]
+          bolt task run <task name> [parameters] {--targets TARGETS | --query QUERY | --rerun FILTER}
+            [options]
 
       DESCRIPTION
           Run a task on the specified targets.
@@ -677,7 +691,7 @@ module Bolt
           show
 
       USAGE
-          bolt task show [task] [options]
+          bolt task show [task name] [options]
 
       DESCRIPTION
           Show available tasks and task documentation.
@@ -710,7 +724,8 @@ module Bolt
              "SSH is the default protocol; can be #{TRANSPORTS.keys.join(', ')}",
              'For Windows targets, specify the winrm:// protocol if it has not be configured',
              'For SSH, port defaults to `22`',
-             'For WinRM, port defaults to `5985` or `5986` based on the --[no-]ssl setting') do |targets|
+             'For WinRM, port defaults to `5985` or `5986` based on the --[no-]ssl setting',
+             "For more information, see 'bolt guide targets'.") do |targets|
         @options[:targets] ||= []
         @options[:targets] << Bolt::Util.get_arg_input(targets)
       end

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -47,6 +47,8 @@ module Bolt
       'guide' => %w[]
     }.freeze
 
+    TARGETING_OPTIONS = %i[query rerun targets].freeze
+
     attr_reader :config, :options
 
     def initialize(argv)
@@ -262,7 +264,7 @@ module Bolt
     end
 
     def update_targets(options)
-      target_opts = options.keys.select { |opt| %i[query rerun targets].include?(opt) }
+      target_opts = options.keys.select { |opt| TARGETING_OPTIONS.include?(opt) }
       target_string = "'--targets', '--rerun', or '--query'"
       if target_opts.length > 1
         raise Bolt::CLIError, "Only one targeting option #{target_string} can be specified"
@@ -634,13 +636,25 @@ module Bolt
     end
 
     def list_targets
+      if options.keys.any? { |key| TARGETING_OPTIONS.include?(key) }
+        target_flag = true
+      else
+        options[:targets] = 'all'
+      end
+
       inventoryfile = config.inventoryfile || config.default_inventoryfile
-      outputter.print_targets(group_targets_by_source, inventoryfile)
+      outputter.print_targets(group_targets_by_source, inventoryfile, target_flag)
     end
 
     def show_targets
+      if options.keys.any? { |key| TARGETING_OPTIONS.include?(key) }
+        target_flag = true
+      else
+        options[:targets] = 'all'
+      end
+
       inventoryfile = config.inventoryfile || config.default_inventoryfile
-      outputter.print_target_info(group_targets_by_source, inventoryfile)
+      outputter.print_target_info(group_targets_by_source, inventoryfile, target_flag)
     end
 
     # Returns a hash of targets sorted by those that are found in the

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -483,7 +483,7 @@ module Bolt
         end
       end
 
-      def print_targets(target_list, inventoryfile)
+      def print_targets(target_list, inventoryfile, target_flag)
         adhoc = colorize(:yellow, "(Not found in inventory file)")
 
         targets  = []
@@ -506,11 +506,13 @@ module Bolt
         print_inventory_summary(
           target_list[:inventory].count,
           target_list[:adhoc].count,
-          inventoryfile
+          inventoryfile,
+          target_flag,
+          false
         )
       end
 
-      def print_target_info(target_list, inventoryfile)
+      def print_target_info(target_list, inventoryfile, target_flag)
         adhoc_targets     = target_list[:adhoc].map(&:name).to_set
         inventory_targets = target_list[:inventory].map(&:name).to_set
         targets           = target_list.values.flatten.sort_by(&:name)
@@ -537,11 +539,13 @@ module Bolt
         print_inventory_summary(
           inventory_targets.count,
           adhoc_targets.count,
-          inventoryfile
+          inventoryfile,
+          target_flag,
+          true
         )
       end
 
-      private def print_inventory_summary(inventory_count, adhoc_count, inventoryfile)
+      private def print_inventory_summary(inventory_count, adhoc_count, inventoryfile, target_flag, detail_flag)
         info = +''
 
         # Add inventory file source
@@ -559,6 +563,21 @@ module Bolt
                 "#{adhoc_count} adhoc"
         info << colorize(:cyan, "Target count\n")
         info << indent(2, count)
+
+        # Add filtering information
+        unless target_flag && detail_flag
+          info << colorize(:cyan, "\n\nAdditional information\n")
+
+          unless target_flag
+            opt = Bolt::Util.windows? ? "'-Targets', '-Query', or '-Rerun'" : "'--targets', '--query', or '--rerun'"
+            info << indent(2, "Use the #{opt} option to view specific targets\n")
+          end
+
+          unless detail_flag
+            opt = Bolt::Util.windows? ? '-Detail' : '--detail'
+            info << indent(2, "Use the '#{opt}' option to view target configuration and data")
+          end
+        end
 
         @stream.puts info
       end

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -100,7 +100,7 @@ module Bolt
                        moduledir: moduledir.to_s }.to_json)
       end
 
-      def print_targets(target_list, inventoryfile)
+      def print_targets(target_list, inventoryfile, _target_flag)
         @stream.puts ::JSON.pretty_generate(
           inventory: {
             targets: target_list[:inventory].map(&:name),
@@ -116,7 +116,7 @@ module Bolt
         )
       end
 
-      def print_target_info(target_list, _inventoryfile)
+      def print_target_info(target_list, _inventoryfile, _target_flag)
         targets = target_list.values.flatten
 
         @stream.puts ::JSON.pretty_generate(

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -2661,6 +2661,15 @@ describe "Bolt::CLI" do
       cli.execute(cli.parse)
     end
 
+    it 'defaults to showing all targets' do
+      cli = Bolt::CLI.new(%w[inventory show])
+      inventory = double('inventory', target_names: [], get_targets: [])
+      allow(cli).to receive(:inventory).and_return(inventory)
+      expect(inventory).to receive(:get_targets).with('all')
+      expect_any_instance_of(Bolt::Outputter::Human).to receive(:print_targets)
+      cli.execute(cli.parse)
+    end
+
     it 'lists groups in the inventory file' do
       cli = Bolt::CLI.new(%w[group show])
       expect_any_instance_of(Bolt::Outputter::Human).to receive(:print_groups)

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -491,7 +491,7 @@ describe "Bolt::CLI" do
             expect {
               cli.parse
             }.to raise_error(Bolt::CLIExit)
-          }.to output(/USAGE.*bolt apply \[manifest.pp\]/m).to_stdout
+          }.to output(/USAGE.*bolt apply \[manifest\]/m).to_stdout
         end
       end
     end

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -414,25 +414,66 @@ describe "Bolt::Outputter::Human" do
     end
 
     it 'prints adhoc targets' do
-      outputter.print_targets(target_list, inventoryfile)
+      outputter.print_targets(target_list, inventoryfile, true)
       expect(output.string).to match(/target\s*\(Not found in inventory file\)/)
     end
 
     it 'prints the inventory file path' do
       expect(File).to receive(:exist?).with(inventoryfile).and_return(true)
-      outputter.print_targets(target_list, inventoryfile)
+      outputter.print_targets(target_list, inventoryfile, true)
       expect(output.string).to match(/Inventory file.*#{inventoryfile}/m)
     end
 
     it 'prints a message that the inventory file does not exist' do
       expect(File).to receive(:exist?).with(inventoryfile).and_return(false)
-      outputter.print_targets(target_list, inventoryfile)
+      outputter.print_targets(target_list, inventoryfile, true)
       expect(output.string).to match(/Inventory file.*does not exist/m)
     end
 
     it 'prints target counts' do
-      outputter.print_targets(target_list, inventoryfile)
+      outputter.print_targets(target_list, inventoryfile, true)
       expect(output.string).to match(/2 total, 1 from inventory, 1 adhoc/)
+    end
+
+    it 'prints suggestion to use a targetting option if one was not provided' do
+      outputter.print_targets(target_list, inventoryfile, false)
+      expect(output.string).to match(/Use the .* option to view specific targets/)
+    end
+
+    it 'does not print suggestion to use a targetting option if one was provided' do
+      outputter.print_targets(target_list, inventoryfile, true)
+      expect(output.string).not_to match(/Use the .* option to view specific targets/)
+    end
+
+    it 'prints suggestion to use detail option' do
+      outputter.print_targets(target_list, inventoryfile, true)
+      expect(output.string).to match(/Use the .* option to view target configuration and data/)
+    end
+  end
+
+  context '#print_target_info' do
+    let(:inventoryfile) { '/path/to/inventory' }
+
+    let(:target_list) do
+      {
+        inventory: [double('target', name: 'target', detail: {})],
+        adhoc:     [double('target', name: 'target', detail: {})]
+      }
+    end
+
+    it 'prints suggestion to use a targetting option if one was not provided' do
+      outputter.print_target_info(target_list, inventoryfile, false)
+      expect(output.string).to match(/Use the .* option to view specific targets/)
+    end
+
+    it 'does not print suggestion to use a targetting option if one was provided' do
+      outputter.print_target_info(target_list, inventoryfile, true)
+      expect(output.string).not_to match(/Use the .* option to view specific targets/)
+    end
+
+    it 'does not print suggestion to use detail option' do
+      outputter.print_target_info(target_list, inventoryfile, true)
+      expect(output.string).not_to match(/Use the .* option to view target configuration and data/)
     end
   end
 end

--- a/spec/bolt/outputter/json_spec.rb
+++ b/spec/bolt/outputter/json_spec.rb
@@ -177,7 +177,7 @@ describe "Bolt::Outputter::JSON" do
     end
 
     it 'outputs inventory targets with count and file' do
-      outputter.print_targets(target_list, inventoryfile)
+      outputter.print_targets(target_list, inventoryfile, true)
       parsed = JSON.parse(output.string)
 
       expect(parsed['inventory']).to eq(
@@ -188,7 +188,7 @@ describe "Bolt::Outputter::JSON" do
     end
 
     it 'outputs adhoc targets with count' do
-      outputter.print_targets(target_list, inventoryfile)
+      outputter.print_targets(target_list, inventoryfile, true)
       parsed = JSON.parse(output.string)
 
       expect(parsed['adhoc']).to eq(
@@ -198,7 +198,7 @@ describe "Bolt::Outputter::JSON" do
     end
 
     it 'outputs all targets with count' do
-      outputter.print_targets(target_list, inventoryfile)
+      outputter.print_targets(target_list, inventoryfile, true)
       parsed = JSON.parse(output.string)
 
       expect(parsed['targets']).to match_array(%w[target target])


### PR DESCRIPTION
(GH-2747) Default to showing all targets with 'inventory show'

This updates the `bolt inventory show` and `Get-BoltInventory` commands
to display the 'all' group if a targetting option is not provided to the
command. Additionally, the human outputter now displays additional
information to the user, indicating that they can view specific targets
using a targetting option or view target config and data with
`--detail`, assuming the options are not provided by the user.

!feature

* **Default to showing all targets with `bolt inventory show`**
  ([#2747](#2747))

  The `bolt inventory show` and `Get-BoltInventory` commands now default
  ot showing all targets in the inventory if a targetting option
  (`--targets`, `--query`, `--rerun`) are not provided.

---

(GH-2747) Show required options in help text

This updates the help text to show required options for each command.

!no-release-note

---

(GH-2747) Add 'targets' guide

This adds a new 'targets' guide to the `bolt guide` feature.

!no-release-note