### PR TITLE
(GH-2777) Do not error when using metaparameters in YAML plans

### DIFF
--- a/lib/bolt/pal/yaml_plan/step.rb
+++ b/lib/bolt/pal/yaml_plan/step.rb
@@ -122,9 +122,11 @@ module Bolt
               raise StepError.new("Parameters key must be a hash", body['name'], step_number)
             end
 
-            metaparams = option_keys.map { |key| "_#{key}" }
+            metaparams = body['parameters'].keys
+                                           .select { |key| key.start_with?('_') }
+                                           .map { |key| key.sub(/^_/, '') }
 
-            if (dups = body['parameters'].keys & metaparams).any?
+            if (dups = body.keys & metaparams).any?
               raise StepError.new(
                 "Cannot specify metaparameters when using top-level keys with same name: #{dups.join(', ')}",
                 body['name'],


### PR DESCRIPTION
This fixes a bug that was causing YAML plan plan and task steps that
specified a metaparameter under the `parameters` key to error. The
correct behavior for Bolt is to only error when the metaparameter is
present as both a top-level key _and_ under the `parameters` key. For
example, specifying the `catch_errors` key and the
`parameters._catch_errors` key.

!bug

* **Do not error when using metaparameters in YAML plans**
  ([#2777](https://github.com/puppetlabs/bolt/issues/2777))

  Bolt no longer errors for YAML plans that include a plan or task step
  that includes an additional option (e.g. `_catch_errors`) under the
  `parameters` key.