### PR TITLE
(GH-2757) Update error message when 'plan new' receives incomplete name

### DIFF
--- a/lib/bolt/plan_creator.rb
+++ b/lib/bolt/plan_creator.rb
@@ -36,8 +36,8 @@ module Bolt
       prefix, _, basename = segment_plan_name(plan_name)
 
       unless prefix == project.name
-        message = "First segment of plan name '#{plan_name}' must match project name '#{project.name}'. "\
-                  "Did you mean '#{project.name}::#{plan_name}'?"
+        message = "Incomplete plan name: A plan name must be prefixed with the name of the "\
+          "project or module. Did you mean '#{project.name}::#{plan_name}'?"
 
         raise Bolt::ValidationError, message
       end

--- a/spec/bolt/plan_creator_spec.rb
+++ b/spec/bolt/plan_creator_spec.rb
@@ -39,7 +39,7 @@ describe Bolt::PlanCreator do
     it 'errors if the first name segment is not the project name' do
       expect { subject.validate_input(project, 'plan') }.to raise_error(
         Bolt::ValidationError,
-        /First segment of plan name 'plan' must match project name/
+        /Incomplete plan name: A plan name must be prefixed with the name of the/
       )
     end
 


### PR DESCRIPTION
This updates the error message when `bolt plan new` is run and receives
an invalid plan name to clarify that plan names include the project or
module that the plan is loaded from, so that users understand that plan
names must always include the module namespace in other contexts of Bolt
(for example `plan run` or `plan show`).

!no-release-note