### PR TITLE
(GH-2771) Add puppetdb_command plan function

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/puppetdb_command.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/puppetdb_command.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'bolt/error'
+
+# Send a command with a payload to PuppetDB.
+#
+# The `pdb_command` function only supports version 5 of the `replace_facts`
+# command. Other commands might also work, but are not tested or supported
+# by Bolt.
+#
+# See the [commands endpoint](https://puppet.com/docs/puppetdb/latest/api/command/v1/commands.html)
+# documentation for more information about available commands and payload
+# format.
+#
+# _This function is experimental and subject to change._
+#
+# > **Note:** Not available in apply block
+#
+Puppet::Functions.create_function(:puppetdb_command) do
+  # @param command The command to invoke.
+  # @param version The version of the command to invoke.
+  # @param payload The payload to the command.
+  # @return The UUID identifying the response sent by PuppetDB.
+  # @example Replace facts for a target
+  #   $payload = {
+  #     'certname'           => 'localhost',
+  #     'environment'        => 'dev',
+  #     'producer'           => 'bolt',
+  #     'producer_timestamp' => '1970-01-01',
+  #     'values'             => { 'orchestrator' => 'bolt' }
+  #   }
+  #
+  #   puppetdb_command('replace_facts', 5, $payload)
+  dispatch :puppetdb_command do
+    param 'String[1]', :command
+    param 'Integer', :version
+    param 'Hash[Data, Data]', :payload
+    return_type 'String'
+  end
+
+  def puppetdb_command(command, version, payload)
+    # Disallow in apply blocks.
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING,
+        action: 'puppetdb_command'
+      )
+    end
+
+    # Send analytics report.
+    Puppet.lookup(:bolt_executor).report_function_call(self.class.name)
+
+    puppetdb_client = Puppet.lookup(:bolt_pdb_client)
+
+    # Error if the PDB client does not implement :send_command
+    unless puppetdb_client.respond_to?(:send_command)
+      raise Bolt::Error.new(
+        "PuppetDB client #{puppetdb_client.class} does not implement :send_command, "\
+        "unable to invoke command.",
+        'bolt/pdb-command'
+      )
+    end
+
+    puppetdb_client.send_command(command, version, payload)
+  end
+end

--- a/bolt-modules/boltlib/spec/functions/puppetdb_command_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/puppetdb_command_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/executor'
+
+describe 'puppetdb_command' do
+  include PuppetlabsSpec::Fixtures
+
+  let(:executor)   { Bolt::Executor.new }
+  let(:pdb_client) { mock('pdb_client') }
+  let(:tasks)      { true }
+
+  let(:command) { 'replace_facts' }
+  let(:payload) { {} }
+  let(:version) { 5 }
+
+  around(:each) do |example|
+    Puppet[:tasks] = tasks
+    Puppet.override(bolt_executor: executor, bolt_pdb_client: pdb_client) do
+      example.run
+    end
+  end
+
+  it 'calls Bolt::PuppetDB::Client.send_command' do
+    pdb_client.expects(:send_command).with(command, version, payload).returns('uuid')
+    is_expected.to run.with_params(command, version, payload)
+  end
+
+  it 'errors if client does not implement :send_command' do
+    is_expected.to run
+      .with_params(command, version, payload)
+      .and_raise_error(/PuppetDB client .* does not implement :send_command/)
+  end
+
+  it 'reports the call to analytics' do
+    pdb_client.expects(:send_command).returns('uuid')
+    executor.expects(:report_function_call).with('puppetdb_command')
+    is_expected.to run.with_params(command, version, payload)
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks) { false }
+
+    it 'errors' do
+      is_expected.to run
+        .with_params(command, version, payload)
+        .and_raise_error(/Plan language function 'puppetdb_command' cannot be used/)
+    end
+  end
+end

--- a/spec/integration/puppetdb_spec.rb
+++ b/spec/integration/puppetdb_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/puppetdb/client'
+require 'bolt_spec/puppetdb'
+require 'bolt_spec/bolt_server'
+
+describe Bolt::PuppetDB::Client, puppetdb: true do
+  include BoltSpec::PuppetDB
+  include BoltSpec::BoltServer
+
+  let(:client) { pdb_client }
+
+  # Don't run any tests until PDB and puppetserver are responsive
+  before(:all) do
+    wait_until_available(timeout: 30, interval: 1)
+  end
+
+  context '#send_command' do
+    let(:command) { 'replace_facts' }
+    let(:facts)   { { 'dog' => 'germanshepherd' } }
+    let(:target)  { 'target.example.com' }
+    let(:version) { 5 }
+
+    let(:payload) do
+      {
+        'certname'           => target,
+        'environment'        => 'dev',
+        'producer'           => 'bolt',
+        'producer_timestamp' => Time.now.strftime("%Y-%m-%d"),
+        'values'             => facts
+      }
+    end
+
+    it 'replaces facts' do
+      expect { client.send_command(command, version, payload) }.not_to raise_error
+      expect(client.facts_for_node([target])).to eq(target => facts)
+    end
+
+    it 'returns a UUID' do
+      expect(client.send_command(command, version, payload)).to be_kind_of(String)
+    end
+
+    it 'errors without a certname' do
+      payload.delete('certname')
+      expect { client.send_command(command, version, payload) }.to raise_error(
+        Bolt::Error,
+        /Payload must include 'certname'/
+      )
+    end
+  end
+end


### PR DESCRIPTION
This adds a new `puppetdb_command` plan function which can be used to
invoke commands in PuppetDB. The function accepts three parameters: the
command, the command version, and the payload. Bolt uses these values to
build a POST request to the command v1 endpoint for PuppetDB. If the
request is successful, the command returns the UUID for the command
invocation, which can be used to reference the command in logs.

Currently, this function only supports and tests the `replace_facts`
command, though other commands might still work.

!feature

* **`puppetdb_command` plan function**
  ([#2771](https://github.com/puppetlabs/bolt/issues/2771))

  The `puppetdb_command` plan function can be used to invoke commands in
  PuppetDB. Currently, only the `replace_facts` command is officially
  tested and supported, though other commands might work as well.

  _This feature is experimental and subject to change._

---

## Bolt acceptance criteria

- [x] Is able to replace facts for a target with an agent
- [x] Is able to add facts for an agentless target
- [x] Does not update facts with a malformed payload
- [x] Returns a UUID for the command on success
- [x] Tries additional server URLs if unable to connect to PDB
- [x] Errors with a helpful message if the PDB client does not implement `:send_message`
- [x] Errors with a helpful message if missing `certname` in the payload