### PR TITLE
(GH-2740) Use fiddle instead of Win32API

### DIFF
--- a/lib/bolt/transport/ssh/connection.rb
+++ b/lib/bolt/transport/ssh/connection.rb
@@ -39,8 +39,6 @@ module Bolt
           end
         end
 
-        PAGEANT_NAME = "Pageant\0".encode(Encoding::UTF_16LE)
-
         def connect
           options = {
             logger: @transport_logger,
@@ -115,10 +113,7 @@ module Bolt
                 options[:use_agent] = false
               end
             elsif Bolt::Util.windows?
-              require 'Win32API' # case matters in this require!
-              # https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-findwindoww
-              @find_window ||= Win32API.new('user32', 'FindWindowW', %w[P P], 'L')
-              if @find_window.call(nil, PAGEANT_NAME).to_i == 0
+              unless pageant_running?
                 @logger.debug { "Disabling use_agent in net-ssh: pageant process not running" }
                 options[:use_agent] = false
               end
@@ -316,6 +311,45 @@ module Bolt
           match = remote_version.match(/OpenSSH_for_Windows_(\d+\.\d+)/)
           if match && match[1].to_f < 7.9
             raise "Powershell over SSH requires OpenSSH server >= 7.9, target is running #{match[1]}"
+          end
+        end
+
+        # Returns true if the Pageant process is running. Used to determine if
+        # the 'use_agent' setting for net-ssh should be disabled.
+        #
+        def pageant_running?
+          @pageant_running ||= begin
+            require 'fiddle'
+
+            # Create a handler and open the 'user32' library, which includes the
+            # 'FindWindowW' function used to determine if the Pageant process
+            # is running.
+            user32 = Fiddle.dlopen('user32')
+
+            # Wrap the 'FindWindowW' function:
+            # https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-findwindoww
+            # This function accepts two parameters: the class name and the
+            # window name. Both parameters are pointers to strings. If the
+            # function locates the window, it returns a handle to the window.
+            # Otherwise, it returns NULL (0).
+            find_window = Fiddle::Function.new(
+              user32['FindWindowW'],                    # Function name
+              [Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP], # Parameter types
+              Fiddle::TYPE_LONG                         # Return type
+            )
+
+            # Pack the name of the window into a pointer, and then decode that
+            # pointer as a native-endian signed long.
+            # https://apidock.com/ruby/Array/pack
+            # https://apidock.com/ruby/String/unpack
+            pageant, = ["Pageant\0".encode(Encoding::UTF_16LE)].pack("p").unpack("l!*")
+
+            # Find the 'Pageant' process using the 'FindWindowW' function.
+            status = find_window.call(0, pageant)
+
+            # If the function does not return NULL (0), then the process was
+            # found running.
+            status.to_i != 0
           end
         end
       end


### PR DESCRIPTION
This replaces the use of the deprecated `Win32API` gem in SSH
connections on Windows with the use of `fiddle` instead.

!no-release-note

---

### Testing

Testing this PR requires running Bolt on a Windows machine and connecting to a target with the SSH transport.

**On main branch**

- Confirm that connecting to a target using the SSH transport results in the following warning:
   ```
   C:/Users/Administrator/bolt/lib/bolt/transport/ssh/connection.rb:118: warning: Win32API is deprecated after Ruby 1.9.1; use fiddle directly instead
   ```

**On feature branch**

- Connect to a target using the SSH transport while Pageant is not running. Check the debug logs to confirm that `use_agent = false` is passed to net-ssh.
- Install PuTTY and then start the Pageant process (you should see an icon of a computer with a hat in the system tray). Connect to a target using the SSH transport. Check the debug logs to confirm that `use_agent` was not disabled.

### Acceptance criteria

- [x] Does not warn that Win32API is deprecated
- [x] Passes `use_agent = false` to net-ssh if Pageant process is not running
- [x] Does not print a warning from net-ssh that Pageant process is not running
- [x] Does not pass `use_agent = false` to net-ssh if Pageant process is running
- [x] Picks up SSH configuration from Pageant