### PR TITLE
Allow Docker to connect with long IDs

### DIFF
--- a/lib/bolt/transport/docker/connection.rb
+++ b/lib/bolt/transport/docker/connection.rb
@@ -46,8 +46,8 @@ module Bolt
         def connect
           # We don't actually have a connection, but we do need to
           # check that the container exists and is running.
-          output = execute_local_json_command('ps')
-          index = output.find_index { |item| item["ID"] == target.host || item["Names"] == target.host }
+          output = execute_local_json_command('ps', ['--no-trunc'])
+          index = output.find_index { |item| item["ID"].start_with?(target.host) || item["Names"] == target.host }
           raise "Could not find a container with name or ID matching '#{target.host}'" if index.nil?
           # Now find the indepth container information
           output = execute_local_json_command('inspect', [output[index]["ID"]])

--- a/spec/integration/transport/docker_spec.rb
+++ b/spec/integration/transport/docker_spec.rb
@@ -46,6 +46,20 @@ describe Bolt::Transport::Docker, docker: true do
         docker.with_connection(inventory.get_target('not_a_target')) {}
       }.to raise_error(Bolt::Node::ConnectError, /Could not find a container with name or ID matching 'not_a_target'/)
     end
+
+    context "when connecting to containers by ID" do
+      let(:container_id) { docker.with_connection(target, &:container_id) }
+
+      it "succeeds when using full container IDs" do
+        expect(docker.connected?(inventory.get_target("docker://#{container_id}"))).to eq(true)
+      end
+
+      it "succeeds when using short container IDs" do
+        short_id = container_id[0..11]
+
+        expect(docker.connected?(inventory.get_target("docker://#{short_id}"))).to eq(true)
+      end
+    end
   end
 
   context 'when url is specified' do


### PR DESCRIPTION
Currently, Docker connections only succeed when the 12 character
"short ID" of a container is used. When a full container ID is
provided, connections fail despite the container being present
and running. This is because the Docker transport searches for the
container ID in the output of `docker ps` and `docker ps` only returns
short ID values unless the `--no-trunc` flag is used.

This commit updates the connection logic to pass the `--no-trunc` flag
and match container IDs using `start_with?` instead of an equality
check.

Fixes puppetlabs/bolt#2791.