### PR TITLE
(GH-2785) Improve error message when provided git repo isn't available

### DIFF
--- a/lib/bolt/module_installer/specs/git_spec.rb
+++ b/lib/bolt/module_installer/specs/git_spec.rb
@@ -67,8 +67,7 @@ module Bolt
                  elsif git.start_with?('https://github.com')
                    git.split('https://github.com/').last.split('.git').first
                  else
-                   raise Bolt::ValidationError,
-                         "Invalid git source: #{git}. Only GitHub modules are supported."
+                   raise Bolt::ValidationError, invalid_git_msg(git)
                  end
 
           [git, repo]
@@ -87,6 +86,14 @@ module Bolt
             'git' => @git,
             'ref' => @ref
           }
+        end
+
+        # Returns an error message that the provided repo is not a git repo or
+        # is private.
+        #
+        private def invalid_git_msg(repo_name)
+          "#{repo_name} is not a public GitHub repository. See https://pup.pt/no-resolve "\
+            "for information on how to install this module."
         end
 
         # Returns a PuppetfileResolver::Model::GitModule object for resolving.
@@ -157,10 +164,7 @@ module Bolt
 
               raise Bolt::Error.new(message, 'bolt/github-api-rate-limit-error')
             when Net::HTTPNotFound
-              raise Bolt::Error.new(
-                "#{git} is not a git repository.",
-                "bolt/missing-git-repository-error"
-              )
+              raise Bolt::Error.new(invalid_git_msg(git), "bolt/missing-git-repository-error")
             else
               raise Bolt::Error.new(
                 "Ref #{ref} at #{git} is not a commit, tag, or branch.",

--- a/spec/bolt/module_installer/specs/git_spec_spec.rb
+++ b/spec/bolt/module_installer/specs/git_spec_spec.rb
@@ -41,7 +41,7 @@ describe Bolt::ModuleInstaller::Specs::GitSpec do
       init_hash['git'] = 'https://gitlab.com/puppetlabs/puppetlabs-yaml'
       expect { spec }.to raise_error(
         Bolt::ValidationError,
-        /Invalid git source/
+        /^.*is not a public GitHub repository/
       )
     end
 
@@ -173,7 +173,7 @@ describe Bolt::ModuleInstaller::Specs::GitSpec do
       it 'errors' do
         expect { spec.sha }.to raise_error(
           Bolt::Error,
-          /is not a git repository/
+          /is not a public GitHub repository/
         )
       end
     end

--- a/spec/integration/module_installer_spec.rb
+++ b/spec/integration/module_installer_spec.rb
@@ -172,7 +172,7 @@ describe 'installing modules' do
     it 'errors' do
       expect { run_cli(command, project: project) }.to raise_error(
         Bolt::Error,
-        %r{https://github.com/puppetlabs/puppetlabs-foobarbaz is not a git repository.}
+        %r{https://github.com/puppetlabs/puppetlabs-foobarbaz is not a public GitHub repository.}
       )
     end
   end


### PR DESCRIPTION
When specifying modules to install, when a user provides a git module if
the module cannot be retrieved we raise an error. Previously the error
simply stated that the provided repo was invalid, without specifying
that private repositories cannot have their dependencies resolved and
must follow a documented workflow. This updates the error message to
state that the repo is either not a Git repo or is private, and link to
documentation describing how to install modules that include a private
Git repo without installing dependencies.

!no-release-note