### PR TITLE
Fixed Get-BoltTask 'Additional Information' param

### DIFF
--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -293,7 +293,7 @@ module Bolt
       end
 
       def print_tasks(tasks, modulepath)
-        command = Bolt::Util.powershell? ? 'Get-BoltTask -Task <TASK NAME>' : 'bolt task show <TASK NAME>'
+        command = Bolt::Util.powershell? ? 'Get-BoltTask -Name <TASK NAME>' : 'bolt task show <TASK NAME>'
 
         tasks = tasks.map do |name, description|
           description = truncate(description, 72)


### PR DESCRIPTION
Fixed the 'Additional Information' section of the help text for the Get-BoltTask cmdlet having an incorrect parameter for the task name

Fixes #2795