### PR TITLE
(maint) Update bundled Puppet modules

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,7 +6,7 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '2.0.0'
-mod 'puppetlabs-puppet_agent', '4.5.0'
+mod 'puppetlabs-puppet_agent', '4.6.1'
 mod 'puppetlabs-facts', '1.4.0'
 
 # Core types and providers for Puppet 6
@@ -17,7 +17,7 @@ mod 'puppetlabs-sshkeys_core', '2.2.0'
 mod 'puppetlabs-zfs_core', '1.2.0'
 mod 'puppetlabs-cron_core', '1.0.5'
 mod 'puppetlabs-mount_core', '1.0.4'
-mod 'puppetlabs-selinux_core', '1.0.4'
+mod 'puppetlabs-selinux_core', '1.1.0'
 mod 'puppetlabs-yumrepo_core', '1.0.7'
 mod 'puppetlabs-zone_core', '1.0.3'
 
@@ -29,7 +29,7 @@ mod 'puppetlabs-python_task_helper', '0.5.0'
 mod 'puppetlabs-reboot', '4.0.2'
 mod 'puppetlabs-ruby_task_helper', '0.6.0'
 mod 'puppetlabs-ruby_plugin_helper', '0.2.0'
-mod 'puppetlabs-stdlib', '7.0.0'
+mod 'puppetlabs-stdlib', '7.0.1'
 
 # Plugin modules
 mod 'puppetlabs-aws_inventory', '0.7.0'


### PR DESCRIPTION
This updates the following bundled Puppet modules:
- `puppetlabs-stdlib` from 7.0.0 to 7.0.1:
   - This just [fixes typo in validate_ipv6_address function](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/CHANGELOG.md#v701-2021-04-03)
- `puppetlabs-selinux_core` from 1.0.4 to 1.1.0:
   - [This change results in a substantial performance increase when checking current resource state, on the order of 50% or more.](https://github.com/puppetlabs/puppetlabs-selinux_core/blob/main/CHANGELOG.md#110-2021-03-31)
- `puppetlabs-puppet_agent` from 4.5.0 to 4.6.1:
   - Remove puppet5 collection from the puppet_agent install task
   - Fix SLES 11 PE upgrades and improve GPG key check
   - Add Fedora 32 support
   - Add exclude parameter to facts_diff task
   - New task to remove local filebucket

!removal

* **Puppet5 collection no longer available for puppet_agent::install
  task**

  Now that this collection is unavailable to download from, it's not a
  valid parameter to the `puppet_agent::install` task.

!feature

* **Facts diff task accepts 'exclude' parameter**

  The `puppet_agent::facts_diff` task now accepts an `exclude` parameter
  to filter output based on a provided regex.