### PR TITLE
(bug-fix) Support passing '_run_as' to 'apply_prep' plan function

### DIFF
--- a/spec/fixtures/apply/prep/plans/run_as.pp
+++ b/spec/fixtures/apply/prep/plans/run_as.pp
@@ -1,0 +1,8 @@
+plan prep::run_as(TargetSpec $targets) {
+  apply_prep($targets, '_run_as' => 'root')
+
+  return apply($targets) {
+    notify { "Hello ${$trusted['certname']}": }
+    notify { 'agent facts': message => "${clientcert}\n${fqdn}\n${clientversion}\n${puppetversion}\n${clientnoop}"}
+  }
+}

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -316,6 +316,27 @@ describe 'apply', expensive: true do
         uninstall(uri, inventory: inventory)
       end
 
+      context 'with _run_as passed to apply_prep' do
+        let(:config) do
+          {
+            'ssh' => {
+              'host-key-check' => false,
+              'password' => password
+            }
+          }
+        end
+
+        it 'installs puppet' do
+          result = run_cli_json(%W[plan run prep::run_as -t #{uri}], project: project)
+
+          expect(result).not_to include('kind')
+          expect(result.count).to eq(1)
+          expect(result[0]['status']).to eq('success')
+          report = result[0]['value']['report']
+          expect(report['resource_statuses']).to include("Notify[Hello #{conn_uri('ssh')}]")
+        end
+      end
+
       it 'installs puppet' do
         result = run_cli_json(%W[plan run prep -t #{uri}], project: project)
 


### PR DESCRIPTION
Previously, Bolt would not pass the `_run_as` option through to the
executor when the option was supplied to `apply_prep()`. The `run_as`
configuration would get successfully picked up through other methods,
like passing on the CLI or inventory, or included in the
`puppet_library` plugin configuration. This merges any supported options
passed to `apply_prep` with options passed to the `puppet_library`
plugin hook, giving the plan function configuration precedence. For now
the only supported metaparameter is `_run_as` since that is the only
option supported by the `puppet_library` plugin.

!bug

* **Support _run_as passed to apply_prep()**
  Bolt now respects the `_run_as` metaparameter when passed to the
  `apply_prep()` plan function. This is the only supported metaparameter,
  and takes highest precedence per the [Bolt configuration
  precedence](https://puppet.com/docs/bolt/latest/configuring_bolt.html#configuration-precedence)