### PR TITLE
(GH-2794) Document encrypted keys with 'key-data' issue

### DIFF
--- a/documentation/troubleshooting.md
+++ b/documentation/troubleshooting.md
@@ -179,12 +179,6 @@ SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to
 Set the `SSL_CERT_DIR` and `SSL_CERT_FILE` environment variables to use a valid
 certificate and certificate directory.
 
-## I still need help
-
-Visit the **#bolt** channel in the [Puppet Community
-Slack](https://slack.puppet.com) to find a whole community of people waiting
-to help!
-
 ## PowerShell does not recognize Bolt cmdlets
 
 PowerShell 3.0 cannot automatically discover and load the Bolt module. If you're
@@ -251,3 +245,18 @@ To change your script execution policy:
     documentation about [execution
     policies](http://go.microsoft.com/fwlink/?LinkID=135170) and [how to set
     them](https://msdn.microsoft.com/en-us/powershell/reference/5.1/microsoft.powershell.security/set-executionpolicy).
+
+## 'Could not parse PKey: no start line' error message when using SSH private key
+
+Bolt does not support encrypted SSH private keys if the keys are provided using the
+`key-data` field in your transport configuration. If providing a decrypted key is feasible
+for your use case and security practices, you can manually decrypt the key by running
+`openssl rsa -in <KEY FILE>` and providing your passphrase. Alternatively, you can
+add the key to your SSH agent and *not* specify a `private-key` for Bolt to use. Bolt
+will use the agent to authenticate your connection.
+
+## I still need help
+
+Visit the **#bolt** channel in the [Puppet Community
+Slack](https://slack.puppet.com) to find a whole community of people waiting
+to help!

--- a/lib/bolt/config/transport/options.rb
+++ b/lib/bolt/config/transport/options.rb
@@ -235,7 +235,8 @@ module Bolt
           "private-key" => {
             type: [Hash, String],
             description: "Either the path to the private key file to use for authentication, or "\
-                         "a hash with the key `key-data` and the contents of the private key.",
+            "a hash with the key `key-data` and the contents of the private key. Note that "\
+            "the key cannot be encrypted if using the `key-data` hash.",
             required: ["key-data"],
             properties: {
               "key-data" => {

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -1597,7 +1597,7 @@
       ]
     },
     "private-key": {
-      "description": "Either the path to the private key file to use for authentication, or a hash with the key `key-data` and the contents of the private key.",
+      "description": "Either the path to the private key file to use for authentication, or a hash with the key `key-data` and the contents of the private key. Note that the key cannot be encrypted if using the `key-data` hash.",
       "oneOf": [
         {
           "type": [

--- a/schemas/bolt-inventory.schema.json
+++ b/schemas/bolt-inventory.schema.json
@@ -762,7 +762,7 @@
                       ]
                     },
                     "private-key": {
-                      "description": "Either the path to the private key file to use for authentication, or a hash with the key `key-data` and the contents of the private key.",
+                      "description": "Either the path to the private key file to use for authentication, or a hash with the key `key-data` and the contents of the private key. Note that the key cannot be encrypted if using the `key-data` hash.",
                       "oneOf": [
                         {
                           "type": [


### PR DESCRIPTION
This adds a note to the Transport configuration reference page and the
Troubleshooting page that providing an encrypted private SSH key with
`key-data` will not work, and includes instructions on the
Troubleshooting page with how to decrypt the key.

!no-release-note