### PR TITLE
Set `DOCKER_HOST` in the args to `popen3()` instead of using `--env`

### DIFF
--- a/lib/bolt/transport/docker/connection.rb
+++ b/lib/bolt/transport/docker/connection.rb
@@ -74,7 +74,6 @@ module Bolt
           # CODEREVIEW: Is it always safe to pass --interactive?
           args += %w[--interactive]
           args += %w[--tty] if target.options['tty']
-          args += %W[--env DOCKER_HOST=#{@docker_host}] if @docker_host
           args += @env_vars if @env_vars
 
           if target.options['shell-command'] && !target.options['shell-command'].empty?
@@ -86,7 +85,7 @@ module Bolt
           docker_command = %w[docker exec] + args + [container_id] + Shellwords.split(command)
           @logger.trace { "Executing: #{docker_command.join(' ')}" }
 
-          Open3.popen3(*docker_command)
+          Open3.popen3(env_hash, *docker_command)
         rescue StandardError
           @logger.trace { "Command aborted" }
           raise


### PR DESCRIPTION
We use `service-url` in `inventory.yaml` to specify an alternate Docker server address. For example:

```
   config:
     transport: docker
     docker:
       host: containername
       service-url: unix:///var/run/docker2.sock
```

This transport configuration has worked in the past with versions of Bolt 2. When we recently upgraded to Bolt 3, we found that the same configuration fails with a connection error. The error incorrectly refers to the default Docker socket, `/var/run/docker.sock`, instead of the Docker server specified by the inventory.

```
# bolt command run -t containername whoami
Started on containername...
Failed on containername:
  The command failed with exit code 1
  Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
Failed on 1 target: containername
Ran on 1 target in 0.3 sec
```

## Expected Behavior

The `command run` invocation should succeed:

```
# bolt command run -t containername whoami
Started on containername...
Finished on containername:
  root
Successful on 1 target: containername
Ran on 1 target in 0.62 sec

```

## Steps to Reproduce

This procedure assumes that you have the Docker CLI client installed and are using an alternate socket or remote Docker host to access a container.


* Confirm CLI access to the alternate Docker server
```
# DOCKER_HOST=unix:///var/run/docker2.sock docker exec containername whoami
root
```
* Create a Bolt project with `inventory.yaml` as follows:

```
version: 2
groups:
 - name: example
   targets:
     - containername
   config:
     transport: docker
     docker:
       host: containername
       service-url: unix:///var/run/docker2.sock
```

* Attempt `bolt command run` using the alternate Docker host:
```
# bolt command run -t containername whoami
```

* Success == output is `root` as expected

* Failure == Bolt issues the connection error referring to the default Docker socket


## Environment
 - Version: 3.7.1
 - Platform: CentOS 7

## Additional Context

The `execute()` method inside `lib/bolt/transport/docker/connection.rb` uses `--env` to pass the `DOCKER_HOST` variable to the `docker exec` command.

	        args += %W[--env DOCKER_HOST=#{@docker_host}] if @docker_host


Although it's not clear in the [Docker exec](https://docs.docker.com/engine/reference/commandline/exec/) documentation, a direct test shows that `--env` sets variables *inside* the container. It does not change the process environment of the `docker exec` command itself. And that's where `DOCKER_HOST` is needed in this case.

The suggested patch sets `DOCKER_HOST` by passing `env_hash` to the optional `env` argument of `popen3()`. This seems consistent with the other methods in `connection.rb`.

With this change, the `bolt command run` invocation succeeds as expected with Bolt 3.7.1.
