### PR TITLE
(maint) Fix keyword parameters warning in logger

### DIFF
--- a/lib/bolt/logger.rb
+++ b/lib/bolt/logger.rb
@@ -203,7 +203,7 @@ module Bolt
     def self.flush_queue
       @mutex.synchronize do
         @message_queue.each do |message|
-          log_message(message)
+          log_message(**message)
         end
 
         @message_queue.clear


### PR DESCRIPTION
```
lib/bolt/logger.rb:206: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

This line was invoking a method by passing a hash and expecting it to be
implicitly interpreted as the the **kwargs argument. This behavior is
deprecated and the hash needs to be explicitly passed as **kwargs.

!no-release-note