### PR TITLE
(GH-2755) Add support for running plans in noop mode

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,7 +6,7 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '2.0.0'
-mod 'puppetlabs-puppet_agent', '4.6.1'
+mod 'puppetlabs-puppet_agent', '4.7.0'
 mod 'puppetlabs-facts', '1.4.0'
 
 # Core types and providers for Puppet 6

--- a/bolt-modules/boltlib/lib/puppet/functions/download_file.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/download_file.rb
@@ -81,6 +81,11 @@ Puppet::Functions.create_function(:download_file, Puppet::Functions::InternalFun
     executor = Puppet.lookup(:bolt_executor)
     inventory = Puppet.lookup(:bolt_inventory)
 
+    # executor.noop is set when using 'plan run --noop' from the CLI
+    if executor.noop
+      raise Bolt::Error.new('download_file is not supported in noop mode', 'bolt/noop-error')
+    end
+
     if (destination = destination.strip).empty?
       raise Bolt::ValidationError, "Destination cannot be an empty string"
     end

--- a/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_command.rb
@@ -77,6 +77,11 @@ Puppet::Functions.create_function(:run_command) do
     executor = Puppet.lookup(:bolt_executor)
     inventory = Puppet.lookup(:bolt_inventory)
 
+    # executor.noop is set when using 'plan run --noop' from the CLI
+    if executor.noop
+      raise Bolt::Error.new('run_command is not supported in noop mode', 'bolt/noop-error')
+    end
+
     # Send Analytics Report
     executor.report_function_call(self.class.name)
 

--- a/bolt-modules/boltlib/lib/puppet/functions/run_container.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_container.rb
@@ -38,6 +38,12 @@ Puppet::Functions.create_function(:run_container) do
 
     # Send Analytics Report
     executor = Puppet.lookup(:bolt_executor)
+
+    # executor.noop is set when using 'plan run --noop' from the CLI
+    if executor.noop
+      raise Bolt::Error.new('run_container is not supported in noop mode', 'bolt/noop-error')
+    end
+
     executor.report_function_call(self.class.name)
 
     options = options.transform_keys { |k| k.sub(/^_/, '').to_sym }

--- a/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
@@ -105,6 +105,11 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
     executor = Puppet.lookup(:bolt_executor)
     inventory = Puppet.lookup(:bolt_inventory)
 
+    # executor.noop is set when using 'plan run --noop' from the CLI
+    if executor.noop
+      raise Bolt::Error.new('run_script is not supported in noop mode', 'bolt/noop-error')
+    end
+
     # Send Analytics Report
     executor.report_function_call(self.class.name)
 

--- a/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
@@ -126,7 +126,7 @@ Puppet::Functions.create_function(:run_task) do
       if task.supports_noop
         params['_noop'] = true
       else
-        raise with_stack(:TASK_NO_NOOP, 'Task does not support noop')
+        raise with_stack(:TASK_NO_NOOP, "Task '#{task.name}' does not support noop")
       end
     end
 

--- a/bolt-modules/boltlib/lib/puppet/functions/run_task_with.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task_with.rb
@@ -167,11 +167,11 @@ Puppet::Functions.create_function(:run_task_with) do
     end
 
     # Add a noop parameter if the function was called with the noop metaparameter.
-    if options[:noop]
+    if executor.noop || options[:noop]
       if task.supports_noop
         target_mapping.each_value { |params| params['_noop'] = true }
       else
-        raise with_stack(:TASK_NO_NOOP, 'Task does not support noop')
+        raise with_stack(:TASK_NO_NOOP, "Task '#{task.name}' does not support noop")
       end
     end
 

--- a/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
@@ -67,6 +67,11 @@ Puppet::Functions.create_function(:upload_file, Puppet::Functions::InternalFunct
     executor = Puppet.lookup(:bolt_executor)
     inventory = Puppet.lookup(:bolt_inventory)
 
+    # executor.noop is set when using 'plan run --noop' from the CLI
+    if executor.noop
+      raise Bolt::Error.new('upload_file is not supported in noop mode', 'bolt/noop-error')
+    end
+
     # Send Analytics Report
     executor.report_function_call(self.class.name)
 

--- a/bolt-modules/boltlib/lib/puppet/functions/write_file.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/write_file.rb
@@ -32,6 +32,12 @@ Puppet::Functions.create_function(:write_file) do
     end
 
     executor = Puppet.lookup(:bolt_executor)
+
+    # executor.noop is set when using 'plan run --noop' from the CLI
+    if executor.noop
+      raise Bolt::Error.new('write_file is not supported in noop mode', 'bolt/noop-error')
+    end
+
     # Send Analytics Report
     executor.report_function_call(self.class.name)
 

--- a/bolt-modules/boltlib/spec/functions/download_file_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/download_file_spec.rb
@@ -197,6 +197,14 @@ describe 'download_file' do
         .and_return(result_set)
     end
 
+    it 'errors in noop mode' do
+      executor.expects(:noop).returns(true)
+
+      is_expected.to run
+        .with_params(source, destination, hostname)
+        .and_raise_error(Bolt::Error, /download_file is not supported in noop mode/)
+    end
+
     context 'with description' do
       let(:message) { 'test message' }
 

--- a/bolt-modules/boltlib/spec/functions/run_command_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_command_spec.rb
@@ -26,6 +26,7 @@ describe 'run_command' do
     let(:command) { 'hostname' }
     let(:result) { Bolt::Result.new(target, value: { 'stdout' => hostname }) }
     let(:result_set) { Bolt::ResultSet.new([result]) }
+
     before(:each) do
       Puppet.features.stubs(:bolt?).returns(true)
     end
@@ -73,6 +74,14 @@ describe 'run_command' do
       is_expected.to run
         .with_params(command, hostname)
         .and_return(result_set)
+    end
+
+    it 'errors in noop mode' do
+      executor.expects(:noop).returns(true)
+
+      is_expected.to run
+        .with_params(command, hostname)
+        .and_raise_error(Bolt::Error, /run_command is not supported in noop mode/)
     end
 
     context 'with description' do

--- a/bolt-modules/boltlib/spec/functions/run_container_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_container_spec.rb
@@ -62,6 +62,14 @@ describe 'run_container' do
         .and_return(result)
     end
 
+    it 'errors in noop mode' do
+      executor.expects(:noop).returns(true)
+
+      is_expected.to run
+        .with_params(image, { 'cmd' => 'whoami', 'rm' => true })
+        .and_raise_error(Bolt::Error, /run_container is not supported in noop mode/)
+    end
+
     context 'with errors' do
       before :each do
         mock_status.stubs(:exitstatus).returns(127)

--- a/bolt-modules/boltlib/spec/functions/run_script_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_script_spec.rb
@@ -219,6 +219,14 @@ describe 'run_script' do
         .and_return(result_set)
     end
 
+    it 'errors in noop mode' do
+      executor.expects(:noop).returns(true)
+
+      is_expected.to run
+        .with_params('test/uploads/hostname.sh', hostname)
+        .and_raise_error(Bolt::Error, /run_script is not supported in noop mode/)
+    end
+
     context 'with description' do
       let(:message) { 'test message' }
 

--- a/bolt-modules/boltlib/spec/functions/upload_file_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/upload_file_spec.rb
@@ -197,6 +197,14 @@ describe 'upload_file' do
         .and_return(result_set)
     end
 
+    it 'errors in noop mode' do
+      executor.expects(:noop).returns(true)
+
+      is_expected.to run
+        .with_params('test/uploads/index.html', destination, hostname)
+        .and_raise_error(Bolt::Error, /upload_file is not supported in noop mode/)
+    end
+
     context 'with description' do
       let(:message) { 'test message' }
 

--- a/bolt-modules/boltlib/spec/functions/write_file_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/write_file_spec.rb
@@ -16,6 +16,14 @@ describe 'write_file' do
     end
   end
 
+  it 'errors in noop mode' do
+    executor.expects(:noop).returns(true)
+
+    is_expected.to run
+      .with_params('example.com', 'Hello, world!', 'hello.txt')
+      .and_raise_error(Bolt::Error, /write_file is not supported in noop mode/)
+  end
+
   context 'without tasks enabled' do
     let(:tasks_enabled) { false }
 

--- a/bolt-modules/file/lib/puppet/functions/file/write.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/write.rb
@@ -15,8 +15,15 @@ Puppet::Functions.create_function(:'file::write') do
   end
 
   def write(filename, content)
+    executor = Puppet.lookup(:bolt_executor) {}
+
+    # executor.noop is set when using 'plan run --noop' from the CLI
+    if executor&.noop
+      raise Bolt::Error.new('file::write is not supported in noop mode', 'bolt/noop-error')
+    end
+
     # Send Analytics Report
-    Puppet.lookup(:bolt_executor) {}&.report_function_call(self.class.name)
+    executor&.report_function_call(self.class.name)
 
     File.write(filename, content)
     nil

--- a/bolt-modules/file/spec/functions/file/write_spec.rb
+++ b/bolt-modules/file/spec/functions/file/write_spec.rb
@@ -2,13 +2,34 @@
 
 require 'spec_helper'
 require 'tempfile'
+require 'bolt/executor'
 
 describe 'file::write' do
-  it {
+  let(:executor) { Bolt::Executor.new }
+
+  around(:each) do |example|
+    Puppet.override(bolt_executor: executor) do
+      example.run
+    end
+  end
+
+  it 'writes a file' do
     Dir.mktmpdir do |dir|
       file = File.join(dir, 'file_write')
       is_expected.to run.with_params(file, 'some content')
       expect(File.read(file)).to eq('some content')
     end
-  }
+  end
+
+  it 'errors in noop mode' do
+    executor.expects(:noop).returns(true)
+
+    Dir.mktmpdir do |dir|
+      file = File.join(dir, 'file_write')
+
+      is_expected.to run
+        .with_params(file, 'some content')
+        .and_raise_error(Bolt::Error, /file::write is not supported in noop mode/)
+    end
+  end
 end

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -165,6 +165,8 @@ module Bolt
         options = args[1].transform_keys { |k| k.sub(/^_/, '').to_sym }
       end
 
+      options[:noop] = @executor.noop
+
       plan_vars = scope.to_hash(true, true)
 
       targets = @inventory.get_targets(args[0])

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -96,7 +96,7 @@ module Bolt
           { flags: OPTIONS[:global] + PROJECT_PATHS + %w[pp],
             banner: PLAN_NEW_HELP }
         when 'run'
-          { flags: ACTION_OPTS + %w[params compile-concurrency tmpdir hiera-config],
+          { flags: ACTION_OPTS + %w[params compile-concurrency tmpdir hiera-config noop],
             banner: PLAN_RUN_HELP }
         when 'show'
           { flags: OPTIONS[:global] + OPTIONS[:global_config_setters] + %w[filter format],
@@ -847,9 +847,6 @@ module Bolt
              "Available filters are 'all', 'failure', and 'success'.") do |rerun|
         @options[:rerun] = rerun
       end
-      define('--noop', 'See what changes Bolt will make without actually executing the changes.') do |_|
-        @options[:noop] = true
-      end
       define('--params PARAMETERS',
              "Parameters to a task or plan as json, a json file '@<file>', or on stdin '-'.") do |params|
         @options[:task_options] = parse_params(params)
@@ -925,6 +922,9 @@ module Bolt
         @options[:modulepath] = modulepath.split(File::PATH_SEPARATOR).map do |moduledir|
           File.expand_path(moduledir)
         end
+      end
+      define('--noop', 'See what changes Bolt will make without actually executing the changes.') do |_|
+        @options[:noop] = true
       end
       define('--project PATH',
              'Path to load the Bolt project from (default: autodiscovered from current dir).') do |path|

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -361,9 +361,10 @@ module Bolt
       end
 
       if options[:noop] &&
-         !(options[:subcommand] == 'task' && options[:action] == 'run') && options[:subcommand] != 'apply'
+         !(%w[plan task].include?(options[:subcommand]) && options[:action] == 'run') &&
+         options[:subcommand] != 'apply'
         raise Bolt::CLIError,
-              "Option '--noop' can only be specified when running a task or applying manifest code"
+              "Option '--noop' can only be specified when running a plan, running a task, or applying manifest code"
       end
 
       if options[:env_vars]

--- a/lib/bolt/plugin.rb
+++ b/lib/bolt/plugin.rb
@@ -44,6 +44,12 @@ module Bolt
           super(msg, 'bolt/plugin-loading-disabled', { 'plugin_name' => plugin_name })
         end
       end
+
+      class NoopError < PluginError
+        def initialize(msg)
+          super(msg, 'bolt/noop-error')
+        end
+      end
     end
 
     class PluginContext

--- a/lib/bolt/plugin/module.rb
+++ b/lib/bolt/plugin/module.rb
@@ -267,6 +267,14 @@ module Bolt
         options = {}
         options[:run_as] = meta_params['_run_as'] if meta_params['_run_as']
 
+        if meta_params['_noop']
+          if task.supports_noop
+            params['_noop'] = true
+          else
+            raise Bolt::Plugin::PluginError::NoopError, "puppet_library plugin '#{task.name}' does not support noop"
+          end
+        end
+
         proc do
           apply_prep.run_task([target], task, params, options).first
         end

--- a/lib/bolt/plugin/task.rb
+++ b/lib/bolt/plugin/task.rb
@@ -50,11 +50,21 @@ module Bolt
         params = opts['parameters'] || {}
         run_opts = {}
         run_opts[:run_as] = opts['_run_as'] if opts['_run_as']
+
         begin
           task = apply_prep.get_task(opts['task'], params)
         rescue Bolt::Error => e
           raise Bolt::Plugin::PluginError::ExecutionError.new(e.message, name, 'puppet_library')
         end
+
+        if opts['_noop']
+          if task.supports_noop
+            params['_noop'] = true
+          else
+            raise Bolt::Plugin::PluginError::NoopError, "puppet_library plugin '#{task.name}' does not support noop"
+          end
+        end
+
         proc do
           apply_prep.run_task([target], task, params, run_opts).first
         end

--- a/lib/bolt_spec/plans.rb
+++ b/lib/bolt_spec/plans.rb
@@ -114,7 +114,7 @@ module BoltSpec
       @puppetdb_client ||= MockPuppetDBClient.new(Bolt::PuppetDB::Config.new({}))
     end
 
-    def run_plan(name, params)
+    def run_plan(name, params, noop: false)
       pal = Bolt::PAL.new(
         Bolt::Config::Modulepath.new(config.modulepath),
         config.hiera_config,
@@ -125,8 +125,10 @@ module BoltSpec
         config.project
       )
 
-      result = executor.with_plan_allowed_exec(name, params) do
-        pal.run_plan(name, params, executor, inventory, puppetdb_client)
+      result = executor.with_settings(noop: noop) do
+        executor.with_plan_allowed_exec(name, params) do
+          pal.run_plan(name, params, executor, inventory, puppetdb_client)
+        end
       end
 
       if executor.error_message

--- a/lib/bolt_spec/plans/mock_executor.rb
+++ b/lib/bolt_spec/plans/mock_executor.rb
@@ -21,7 +21,6 @@ module BoltSpec
       attr_accessor :run_as, :transport_features, :execute_any_plan
 
       def initialize(modulepath)
-        @noop = false
         @run_as = nil
         @in_parallel = false
         @future = {}
@@ -38,6 +37,13 @@ module BoltSpec
         @execute_any_plan = true
         # plans that are allowed to be executed by the @executor_real
         @allowed_exec_plans = {}
+      end
+
+      def with_settings(noop: false)
+        @noop = noop
+        yield
+      ensure
+        @noop = false
       end
 
       def module_file_id(file)

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1176,7 +1176,8 @@ describe "Bolt::CLI" do
       end
 
       it "fails show with --noop" do
-        expected = "Option '--noop' can only be specified when running a task or applying manifest code"
+        expected = "Option '--noop' can only be specified when running a plan, running "\
+                   "a task, or applying manifest code"
         expect {
           cli = Bolt::CLI.new(%w[task show foo --targets bar --noop])
           cli.parse
@@ -1215,14 +1216,6 @@ describe "Bolt::CLI" do
           cli = Bolt::CLI.new(%w[plan run foo --query nodes{} --targets bar])
           cli.update_targets(cli.parse)
         }.to raise_error(Bolt::CLIError, /Only one targeting option/)
-      end
-
-      it "fails with --noop" do
-        expected = "Option '--noop' can only be specified when running a task or applying manifest code"
-        expect {
-          cli = Bolt::CLI.new(%w[plan run foo --targets bar --noop])
-          cli.parse
-        }.to raise_error(Bolt::CLIError, expected)
       end
     end
 
@@ -2358,7 +2351,7 @@ describe "Bolt::CLI" do
 
           expect(executor).not_to receive(:run_task)
 
-          expect { cli.execute(options) }.to raise_error('Task does not support noop')
+          expect { cli.execute(options) }.to raise_error("Task 'sample::no_noop' does not support noop")
         end
 
         it "errors on a task without metadata" do
@@ -2366,7 +2359,7 @@ describe "Bolt::CLI" do
 
           expect(executor).not_to receive(:run_task)
 
-          expect { cli.execute(options) }.to raise_error('Task does not support noop')
+          expect { cli.execute(options) }.to raise_error("Task 'sample::echo' does not support noop")
         end
       end
     end

--- a/spec/bolt_spec/plan_spec.rb
+++ b/spec/bolt_spec/plan_spec.rb
@@ -64,6 +64,21 @@ describe "BoltSpec::Plans" do
     expect { run_plan('plans::yaml', {}) }.not_to raise_error
   end
 
+  context 'with noop mode' do
+    it 'runs plans' do
+      expect_task('plans::noop').always_return({ 'noop' => true })
+      result = run_plan('plans::noop', {}, noop: true)
+      expect(result.ok?).to be(true)
+    end
+
+    it 'errors with unsupported plan functions' do
+      expect_command('whoami').not_be_called
+      result = run_plan('plans::noop_unsupported', {}, noop: true)
+      expect(result.ok?).to be(false)
+      expect(result.value.msg).to match(/run_command is not supported in noop mode/)
+    end
+  end
+
   context 'with commands' do
     let(:plan_name) { 'plans::command' }
     let(:return_expects) { { command: 'echo hello', params: {} } }

--- a/spec/fixtures/bolt_spec/plans/plans/noop.pp
+++ b/spec/fixtures/bolt_spec/plans/plans/noop.pp
@@ -1,0 +1,6 @@
+plan plans::noop (
+  TargetSpec $targets = 'localhost'
+) {
+  $result = run_task('plans::noop', $targets)
+  return $result
+}

--- a/spec/fixtures/bolt_spec/plans/plans/noop_unsupported.pp
+++ b/spec/fixtures/bolt_spec/plans/plans/noop_unsupported.pp
@@ -1,0 +1,6 @@
+plan plans::noop_unsupported (
+  TargetSpec $targets = 'localhost'
+) {
+  $result = run_command('whoami', $targets)
+  return $result
+}

--- a/spec/fixtures/bolt_spec/plans/tasks/noop.json
+++ b/spec/fixtures/bolt_spec/plans/tasks/noop.json
@@ -1,0 +1,3 @@
+{
+  "supports_noop": true
+}

--- a/spec/fixtures/modules/noop/plans/init.pp
+++ b/spec/fixtures/modules/noop/plans/init.pp
@@ -1,0 +1,6 @@
+plan noop (
+  TargetSpec $targets = 'localhost'
+) {
+  $result = run_task('noop', $targets)
+  return $result
+}

--- a/spec/fixtures/modules/noop/plans/metaparameter.pp
+++ b/spec/fixtures/modules/noop/plans/metaparameter.pp
@@ -1,0 +1,6 @@
+plan noop::metaparameter (
+  TargetSpec $targets = 'localhost'
+) {
+  $result = run_task('noop', $targets, '_noop' => false)
+  return $result
+}

--- a/spec/fixtures/modules/noop/plans/subplans.pp
+++ b/spec/fixtures/modules/noop/plans/subplans.pp
@@ -1,0 +1,6 @@
+plan noop::subplans (
+  TargetSpec $targets = 'localhost'
+) {
+  $result = run_plan('noop', $targets)
+  return $result
+}

--- a/spec/fixtures/modules/noop/plans/unsupported.pp
+++ b/spec/fixtures/modules/noop/plans/unsupported.pp
@@ -1,0 +1,5 @@
+plan noop::unsupported (
+  TargetSpec $targets = 'localhost'
+) {
+  run_command('whoami', $targets)
+}

--- a/spec/fixtures/modules/noop/tasks/init.json
+++ b/spec/fixtures/modules/noop/tasks/init.json
@@ -1,0 +1,13 @@
+{
+  "implementations": [
+    {
+      "name": "init_linux.sh",
+      "requirements": ["shell"]
+    },
+    {
+      "name": "init_windows.ps1",
+      "requirements": ["powershell"]
+    }
+  ],
+  "supports_noop": true
+}

--- a/spec/fixtures/modules/noop/tasks/init_linux.sh
+++ b/spec/fixtures/modules/noop/tasks/init_linux.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [[ $PT__noop == true ]]; then
+  echo '{"noop":true}'
+else
+  echo '{"noop":false}'
+fi

--- a/spec/fixtures/modules/noop/tasks/init_windows.ps1
+++ b/spec/fixtures/modules/noop/tasks/init_windows.ps1
@@ -1,0 +1,10 @@
+[CmdletBinding()]
+Param(
+  [Bool]$_noop = $False
+)
+
+if($_noop -eq 'true') {
+  Write-Output '{"noop":true}'
+} else {
+  Write-Output '{"noop":false}'
+}


### PR DESCRIPTION
This adds basic support for running plans in noop mode. When running
`plan run --noop` or `Invoke-BoltPlan -Noop`, Bolt sets the executor
into noop mode. This automatically runs all tasks and apply blocks in a
plan in noop mode.

When running in noop mode, only a subset of plan functions are
supported. The plan functions that are not supported in noop mode are
`run_command`, `run_container`, `run_script`, `download_file`,
`upload_file`, `write_file`, and `file::write`, as they make changes to
either the controller or the specified targets and do not have a defined
noop mode. When any of these functions are encountered, the plan
immediately fails.

This also updates the `apply_prep` function to run the `puppet_library`
plugin in noop mode, which affects both the `apply --noop` command as
well as the `apply_prep` plan function. Because running this plugin in
noop mode might result in a target not having the puppet-agent package
installed, this also disables running the custom facts task in noop
mode, as the custom facts task depends on both the puppet-agent package
and Puppet's Ruby interpreter being available to the target.

!feature

* **Support running plans in noop mode**
  ([#2755](https://github.com/puppetlabs/bolt/issues/2755))

  Plans can now be run in no-operation mode from the command line using
  the `--noop` command-line option. Running in no-operation mode will
  automatically run all tasks and apply blocks in no-operation mode.
  Plans that use other plan functions to make changes to targets, such
  as `run_script`, will fail in no-operation mode, as these plan
  functions are not supported in this mode.