### PR TITLE
(bug) Do not lookup `:future` in Puppet for `file::*` functions

### DIFF
--- a/bolt-modules/file/lib/puppet/functions/file/exists.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/exists.rb
@@ -21,7 +21,7 @@ Puppet::Functions.create_function(:'file::exists', Puppet::Functions::InternalFu
     executor = Puppet.lookup(:bolt_executor) {}
     executor&.report_function_call(self.class.name)
 
-    future = executor&.future || Puppet.lookup(:future) || {}
+    future = executor&.future || {}
     fallback = future.fetch('file_paths', false)
 
     # Find the file path if it exists, otherwise return nil

--- a/bolt-modules/file/lib/puppet/functions/file/read.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/read.rb
@@ -20,7 +20,7 @@ Puppet::Functions.create_function(:'file::read', Puppet::Functions::InternalFunc
     executor = Puppet.lookup(:bolt_executor) {}
     executor&.report_function_call(self.class.name)
 
-    future = executor&.future || Puppet.lookup(:future) || {}
+    future = executor&.future || {}
     fallback = future.fetch('file_paths', false)
 
     # Find the file path if it exists, otherwise return nil

--- a/bolt-modules/file/lib/puppet/functions/file/readable.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/readable.rb
@@ -21,7 +21,7 @@ Puppet::Functions.create_function(:'file::readable', Puppet::Functions::Internal
     executor = Puppet.lookup(:bolt_executor) {}
     executor&.report_function_call(self.class.name)
 
-    future = executor&.future || Puppet.lookup(:future) || {}
+    future = executor&.future || {}
     fallback = future.fetch('file_paths', false)
 
     # Find the file path if it exists, otherwise return nil

--- a/bolt-modules/file/spec/functions/file/exists_spec.rb
+++ b/bolt-modules/file/spec/functions/file/exists_spec.rb
@@ -17,6 +17,19 @@ describe 'file::exists' do
     it 'returns whether a file exists' do
       is_expected.to run.with_params('with_files/toplevel.sh').and_return(true)
     end
+  end
+
+  context "with an executor" do
+    # *Why* didn't we use kwargs
+    let(:executor) {
+      Bolt::Executor.new(1,
+                         Bolt::Analytics::NoopClient.new,
+                         false,
+                         false,
+                         future)
+    }
+
+    include_examples 'file loading'
 
     context 'with future.file_paths enabled' do
       let(:future)  { { 'file_paths' => true } }
@@ -81,19 +94,6 @@ describe 'file::exists' do
           .and_return(false)
       end
     end
-  end
-
-  context "with an executor" do
-    # *Why* didn't we use kwargs
-    let(:executor) {
-      Bolt::Executor.new(1,
-                         Bolt::Analytics::NoopClient.new,
-                         false,
-                         false,
-                         future)
-    }
-
-    include_examples 'file loading'
   end
 
   context "without an executor" do

--- a/bolt-modules/file/spec/functions/file/read_spec.rb
+++ b/bolt-modules/file/spec/functions/file/read_spec.rb
@@ -5,8 +5,7 @@ require 'spec_helper'
 
 describe 'file::read' do
   around(:each) do |example|
-    Puppet.override({ bolt_executor: executor,
-                      future: future }) do
+    Puppet.override({ bolt_executor: executor }) do
       example.run
     end
   end
@@ -18,6 +17,18 @@ describe 'file::read' do
       is_expected.to run.with_params('with_files/toplevel.sh')
                         .and_return("with_files/files/toplevel.sh\n")
     end
+  end
+
+  context "with an executor" do
+    let(:executor) {
+      Bolt::Executor.new(1,
+                         Bolt::Analytics::NoopClient.new,
+                         false,
+                         false,
+                         future)
+    }
+
+    include_examples 'file loading'
 
     context 'with future.file_paths enabled' do
       let(:future) { { 'file_paths' => true } }
@@ -82,18 +93,6 @@ describe 'file::read' do
           .and_raise_error(/No such file or directory: .*with_files.*toplevel\.sh/)
       end
     end
-  end
-
-  context "with an executor" do
-    let(:executor) {
-      Bolt::Executor.new(1,
-                         Bolt::Analytics::NoopClient.new,
-                         false,
-                         false,
-                         future)
-    }
-
-    include_examples 'file loading'
   end
 
   context "without an executor" do

--- a/bolt-modules/file/spec/functions/file/readable_spec.rb
+++ b/bolt-modules/file/spec/functions/file/readable_spec.rb
@@ -17,6 +17,18 @@ describe 'file::readable' do
     it 'returns if a file is readable' do
       is_expected.to run.with_params('with_files/toplevel.sh').and_return(true)
     end
+  end
+
+  context "with an executor" do
+    let(:executor) {
+      Bolt::Executor.new(1,
+                         Bolt::Analytics::NoopClient.new,
+                         false,
+                         false,
+                         future)
+    }
+
+    include_examples 'file loading'
 
     context 'with future.file_paths enabled' do
       let(:future) { { 'file_paths' => true } }
@@ -81,18 +93,6 @@ describe 'file::readable' do
           .and_return(false)
       end
     end
-  end
-
-  context "with an executor" do
-    let(:executor) {
-      Bolt::Executor.new(1,
-                         Bolt::Analytics::NoopClient.new,
-                         false,
-                         false,
-                         future)
-    }
-
-    include_examples 'file loading'
   end
 
   context "without an executor" do

--- a/spec/Dockerfile.puppetdb
+++ b/spec/Dockerfile.puppetdb
@@ -1,4 +1,4 @@
-FROM puppet/puppetdb
+FROM puppet/puppetdb:7.2.0
 
 # Use our own certs so this doesn't have to wait for puppetserver startup
 COPY fixtures/ssl/ca.pem /opt/puppetlabs/server/data/puppetdb/certs/certs/ca.pem


### PR DESCRIPTION
This fixes a bug in the `file::*` plan functions that was introduced
in #2731. Previously, these functions would look for future
configuration with a Puppet lookup (i.e. `Puppet.lookup(:future)`).
However, Bolt does not set this value in Puppet, causing the functions
to error. This updates the functions to only check the Bolt executor for
future configuration.

!bug

* **Do not error when looking up future configuration in `file::*` plan
  functions**

  The `file::read`, `file::readable`, and `file::exists` plan functions
  no longer error when checking for `future` configuration in Bolt.