### PR TITLE
(maint) Pin puppetdb container to 7.2.0

### DIFF
--- a/spec/Dockerfile.puppetdb
+++ b/spec/Dockerfile.puppetdb
@@ -1,4 +1,4 @@
-FROM puppet/puppetdb
+FROM puppet/puppetdb:7.2.0
 
 # Use our own certs so this doesn't have to wait for puppetserver startup
 COPY fixtures/ssl/ca.pem /opt/puppetlabs/server/data/puppetdb/certs/certs/ca.pem


### PR DESCRIPTION
This pins the puppetdb container used in spec tests to 7.2.0, as 7.3.1
introduced changes that are causing connection errors.

!no-release-note