### PR TITLE
(bug) Do not error in `file::*` functions when future not configured

### DIFF
--- a/bolt-modules/file/lib/puppet/functions/file/exists.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/exists.rb
@@ -21,7 +21,7 @@ Puppet::Functions.create_function(:'file::exists', Puppet::Functions::InternalFu
     executor = Puppet.lookup(:bolt_executor) {}
     executor&.report_function_call(self.class.name)
 
-    future = executor&.future || Puppet.lookup(:future) || {}
+    future = executor&.future || Puppet.lookup(:future) { {} }
     fallback = future.fetch('file_paths', false)
 
     # Find the file path if it exists, otherwise return nil

--- a/bolt-modules/file/lib/puppet/functions/file/read.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/read.rb
@@ -20,7 +20,7 @@ Puppet::Functions.create_function(:'file::read', Puppet::Functions::InternalFunc
     executor = Puppet.lookup(:bolt_executor) {}
     executor&.report_function_call(self.class.name)
 
-    future = executor&.future || Puppet.lookup(:future) || {}
+    future = executor&.future || Puppet.lookup(:future) { {} }
     fallback = future.fetch('file_paths', false)
 
     # Find the file path if it exists, otherwise return nil

--- a/bolt-modules/file/lib/puppet/functions/file/readable.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/readable.rb
@@ -21,7 +21,7 @@ Puppet::Functions.create_function(:'file::readable', Puppet::Functions::Internal
     executor = Puppet.lookup(:bolt_executor) {}
     executor&.report_function_call(self.class.name)
 
-    future = executor&.future || Puppet.lookup(:future) || {}
+    future = executor&.future || Puppet.lookup(:future) { {} }
     fallback = future.fetch('file_paths', false)
 
     # Find the file path if it exists, otherwise return nil


### PR DESCRIPTION
This fixes a bug where the `file::exists`, `file::read`, and
`file::readable` plan functions would error outside of an apply block if
the `future` configuration was not set.

!bug

* **Do not error in `file::*` plan functions when `future` is not
  configured**

  The `file::exists`, `file::read`, and `file::readable` plan functions
  no longer error when invoked outside of an apply block when `future`
  is not configured.