### PR TITLE
(GH-2820) Update link to module spec documentation

### DIFF
--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -279,7 +279,8 @@ module Bolt
         "modules" => {
           description: "A list of module dependencies for the project. Each dependency is a map of data specifying "\
                        "the module to install. To install the project's module dependencies, run the `bolt module "\
-                       "install` command.",
+                       "install` command. For more information about specifying modules, see [the "\
+                       "documentation](https://pup.pt/bolt-module-specs).",
           type: Array,
           items: {
             type: [Hash, String],

--- a/lib/bolt/module_installer/specs.rb
+++ b/lib/bolt/module_installer/specs.rb
@@ -55,7 +55,7 @@ module Bolt
           Invalid module specification:
           #{hash.to_yaml.lines.drop(1).join.chomp}
 
-          To read more about specifying modules, see https://pup.pt/bolt-modules
+          To read more about specifying modules, see https://pup.pt/bolt-module-specs
         MESSAGE
       end
 

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -256,7 +256,7 @@
       }
     },
     "modules": {
-      "description": "A list of module dependencies for the project. Each dependency is a map of data specifying the module to install. To install the project's module dependencies, run the `bolt module install` command.",
+      "description": "A list of module dependencies for the project. Each dependency is a map of data specifying the module to install. To install the project's module dependencies, run the `bolt module install` command. For more information about specifying modules, see [the documentation](https://pup.pt/bolt-module-specs).",
       "type": "array",
       "items": {
         "type": [


### PR DESCRIPTION
This updates the link to the documentation for module specs in the
project configuration file. Previously, if a project included an invalid
spec, the raised error message would direct the user to the 'Modules
overview' page. Now, the message directs the user to the docs that
explicitly define valid specs.

!no-release-note