### PR TITLE
(maint) Update illegal characters message to list legal characters

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -996,8 +996,8 @@ module Bolt
       separator "\n#{self.class.colorize(:cyan, 'Display options')}"
       define('--filter FILTER', 'Filter tasks and plans by a matching substring.') do |filter|
         unless /^[a-z0-9_:]+$/.match(filter)
-          msg = "Illegal characters in filter string '#{filter}'. Filters must match a legal "\
-                "task or plan name."
+          msg = "Illegal characters in filter string '#{filter}'. Filters can "\
+          "only include lowercase letters, numbers, underscores, and colons."
           raise Bolt::CLIError, msg
         end
         @options[:filter] = filter


### PR DESCRIPTION
When provided a filter that includes characters that aren't allowed in
task or plan names, Bolt raises an error stating that the provided
filter includes characters that cannot be used in task or plan names.
This updates the message to include a list of valid characters in the
message so that users can better understand why the error was raised.

!no-release-note