### PR TITLE
(GH-2816) Document how inventory is loaded

### DIFF
--- a/guides/inventory.txt
+++ b/guides/inventory.txt
@@ -14,6 +14,11 @@ DESCRIPTION
     project configuration file named 'bolt-project.yaml' alongside the inventory
     file.
 
+    When Bolt loads inventory, it loads the entire inventory, not just the
+    groups and targets specified on the command line. If you've defined a
+    target in multiple groups, this might result in target configuration that
+    is different than expected.
+
 DOCUMENTATION
     https://pup.pt/bolt-inventory
     https://pup.pt/bolt-inventory-reference


### PR DESCRIPTION
This adds documentation describing how inventory is loaded and how it
might lead to different target configuration than expected. It also
includes examples for switching between default transports.

!no-release-note