### PR TITLE
(GH-2806) Support run_as for container transports using Bash

### DIFF
--- a/.github/workflows/schemas.yaml
+++ b/.github/workflows/schemas.yaml
@@ -7,7 +7,7 @@ on:
       - 'rakelib/schemas.rake'
       - 'schemas/*.json'
       - 'lib/bolt/config/options.rb'
-      - 'lib/bolt/config/transport/options.rb'
+      - 'lib/bolt/config/transport/*'
   pull_request:
     types: [opened, reopened, edited, synchronize]
     paths:

--- a/lib/bolt/config/transport/docker.rb
+++ b/lib/bolt/config/transport/docker.rb
@@ -15,7 +15,7 @@ module Bolt
           shell-command
           tmpdir
           tty
-        ].freeze
+        ].concat(RUN_AS_OPTIONS).sort.freeze
 
         DEFAULTS = {
           'cleanup' => true
@@ -26,6 +26,10 @@ module Bolt
 
           if @config['interpreters']
             @config['interpreters'] = normalize_interpreters(@config['interpreters'])
+          end
+
+          if Bolt::Util.windows? && @config['run-as']
+            raise Bolt::ValidationError, "run-as is not supported when using PowerShell"
           end
         end
       end

--- a/lib/bolt/config/transport/lxd.rb
+++ b/lib/bolt/config/transport/lxd.rb
@@ -11,7 +11,7 @@ module Bolt
           cleanup
           remote
           tmpdir
-        ].freeze
+        ].concat(RUN_AS_OPTIONS).sort.freeze
 
         DEFAULTS = {
           'cleanup' => true,

--- a/lib/bolt/config/transport/podman.rb
+++ b/lib/bolt/config/transport/podman.rb
@@ -14,7 +14,7 @@ module Bolt
           shell-command
           tmpdir
           tty
-        ].freeze
+        ].concat(RUN_AS_OPTIONS).sort.freeze
 
         DEFAULTS = {
           'cleanup' => true
@@ -25,6 +25,10 @@ module Bolt
 
           if @config['interpreters']
             @config['interpreters'] = normalize_interpreters(@config['interpreters'])
+          end
+
+          if Bolt::Util.windows? && @config['run-as']
+            raise Bolt::ValidationError, "run-as is not supported when using PowerShell"
           end
         end
       end

--- a/lib/bolt/transport/docker/connection.rb
+++ b/lib/bolt/transport/docker/connection.rb
@@ -27,6 +27,10 @@ module Bolt
                      end
         end
 
+        def reset_cwd?
+          true
+        end
+
         # The full ID of the target container
         #
         # @return [String] The full ID of the target container

--- a/lib/bolt/transport/lxd/connection.rb
+++ b/lib/bolt/transport/lxd/connection.rb
@@ -23,6 +23,10 @@ module Bolt
           Bolt::Shell::Bash.new(target, self)
         end
 
+        def reset_cwd?
+          true
+        end
+
         def container_id
           "#{@target.transport_config['remote']}:#{@target.host}"
         end

--- a/lib/bolt/transport/podman/connection.rb
+++ b/lib/bolt/transport/podman/connection.rb
@@ -30,6 +30,10 @@ module Bolt
                      end
         end
 
+        def reset_cwd?
+          true
+        end
+
         def connect
           # We don't actually have a connection, but we do need to
           # check that the container exists and is running.

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -408,6 +408,26 @@
                 }
               ]
             },
+            "run-as": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/run-as"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
+            "run-as-command": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/run-as-command"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
             "service-url": {
               "oneOf": [
                 {
@@ -422,6 +442,26 @@
               "oneOf": [
                 {
                   "$ref": "#/transport_definitions/shell-command"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
+            "sudo-executable": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/sudo-executable"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
+            "sudo-password": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/sudo-password"
                 },
                 {
                   "$ref": "#/definitions/_plugin"
@@ -574,6 +614,46 @@
                 }
               ]
             },
+            "run-as": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/run-as"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
+            "run-as-command": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/run-as-command"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
+            "sudo-executable": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/sudo-executable"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
+            "sudo-password": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/sudo-password"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
             "tmpdir": {
               "oneOf": [
                 {
@@ -720,10 +800,50 @@
                 }
               ]
             },
+            "run-as": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/run-as"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
+            "run-as-command": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/run-as-command"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
             "shell-command": {
               "oneOf": [
                 {
                   "$ref": "#/transport_definitions/shell-command"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
+            "sudo-executable": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/sudo-executable"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
+            "sudo-password": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/sudo-password"
                 },
                 {
                   "$ref": "#/definitions/_plugin"

--- a/schemas/bolt-inventory.schema.json
+++ b/schemas/bolt-inventory.schema.json
@@ -101,6 +101,38 @@
                         }
                       ]
                     },
+                    "run-as": {
+                      "description": "The user to run commands as after login. The run-as user must be different than the login user.",
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
+                    "run-as-command": {
+                      "description": "The command to elevate permissions. Bolt appends the user and command strings to the configured `run-as-command` before running it on the target. This command must not require  aninteractive password prompt, and the `sudo-password` option is ignored when `run-as-command` is specified. The `run-as-command` must be specified as an array.",
+                      "oneOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/_plugin"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
                     "service-url": {
                       "description": "The URL of the host used for API requests.",
                       "oneOf": [
@@ -115,6 +147,28 @@
                     },
                     "shell-command": {
                       "description": "A shell command to wrap any Docker exec commands in, such as `bash -lc`.",
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
+                    "sudo-executable": {
+                      "description": "The executable to use when escalating to the configured `run-as` user. This is useful when you want to escalate using the configured `sudo-password`, since `run-as-command` does not use `sudo-password` or support prompting. The command executed on the target is `<sudo-executable> -S -u <user> -p custom_bolt_prompt <command>`. **This option is experimental.**",
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
+                    "sudo-password": {
+                      "description": "The password to use when changing users via `run-as`.",
                       "oneOf": [
                         {
                           "type": "string"
@@ -284,6 +338,60 @@
                       "type": "string",
                       "description": "The LXD remote host to use."
                     },
+                    "run-as": {
+                      "description": "The user to run commands as after login. The run-as user must be different than the login user.",
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
+                    "run-as-command": {
+                      "description": "The command to elevate permissions. Bolt appends the user and command strings to the configured `run-as-command` before running it on the target. This command must not require  aninteractive password prompt, and the `sudo-password` option is ignored when `run-as-command` is specified. The `run-as-command` must be specified as an array.",
+                      "oneOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/_plugin"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
+                    "sudo-executable": {
+                      "description": "The executable to use when escalating to the configured `run-as` user. This is useful when you want to escalate using the configured `sudo-password`, since `run-as-command` does not use `sudo-password` or support prompting. The command executed on the target is `<sudo-executable> -S -u <user> -p custom_bolt_prompt <command>`. **This option is experimental.**",
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
+                    "sudo-password": {
+                      "description": "The password to use when changing users via `run-as`.",
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
                     "tmpdir": {
                       "description": "The directory to upload and execute temporary files on the target.",
                       "oneOf": [
@@ -452,8 +560,62 @@
                         }
                       ]
                     },
+                    "run-as": {
+                      "description": "The user to run commands as after login. The run-as user must be different than the login user.",
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
+                    "run-as-command": {
+                      "description": "The command to elevate permissions. Bolt appends the user and command strings to the configured `run-as-command` before running it on the target. This command must not require  aninteractive password prompt, and the `sudo-password` option is ignored when `run-as-command` is specified. The `run-as-command` must be specified as an array.",
+                      "oneOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/_plugin"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
                     "shell-command": {
                       "description": "A shell command to wrap any Docker exec commands in, such as `bash -lc`.",
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
+                    "sudo-executable": {
+                      "description": "The executable to use when escalating to the configured `run-as` user. This is useful when you want to escalate using the configured `sudo-password`, since `run-as-command` does not use `sudo-password` or support prompting. The command executed on the target is `<sudo-executable> -S -u <user> -p custom_bolt_prompt <command>`. **This option is experimental.**",
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
+                    "sudo-password": {
+                      "description": "The password to use when changing users via `run-as`.",
                       "oneOf": [
                         {
                           "type": "string"

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -884,14 +884,24 @@ describe "Bolt::CLI" do
     describe "sudo" do
       it "supports running as a user" do
         cli = Bolt::CLI.new(%w[command run --targets foo whoami --run-as root])
-        expect(cli.parse[:'run-as']).to eq('root')
+        if Bolt::Util.windows?
+          expect { cli.parse }
+            .to raise_error(Bolt::ValidationError, "run-as is not supported when using PowerShell")
+        else
+          expect(cli.parse[:'run-as']).to eq('root')
+        end
       end
     end
 
     describe "sudo-password" do
       it "accepts a password" do
         cli = Bolt::CLI.new(%w[command run uptime --sudo-password opensez --run-as alibaba --targets foo])
-        expect(cli.parse).to include('sudo-password': 'opensez')
+        if Bolt::Util.windows?
+          expect { cli.parse }
+            .to raise_error(Bolt::ValidationError, "run-as is not supported when using PowerShell")
+        else
+          expect(cli.parse).to include('sudo-password': 'opensez')
+        end
       end
     end
 

--- a/spec/integration/transport/docker_spec.rb
+++ b/spec/integration/transport/docker_spec.rb
@@ -95,4 +95,19 @@ describe Bolt::Transport::Docker, docker: true do
       expect(result.value['stdout'].strip).to eq('/bin/bash')
     end
   end
+
+  context 'with run_as specified' do
+    let(:target_data) {
+      { 'uri' => uri,
+        'config' => {
+          'docker' => { 'run-as' => 'root' }
+        } }
+    }
+    let(:target) { Bolt::Target.from_hash(target_data, inventory) }
+
+    it 'runs as the specified user' do
+      result = docker.run_command(target, 'whoami')
+      expect(result.value['stdout'].strip).to eq('root')
+    end
+  end
 end

--- a/spec/integration/transport/lxd_spec.rb
+++ b/spec/integration/transport/lxd_spec.rb
@@ -36,6 +36,23 @@ describe Bolt::Transport::LXD do
       expect(runner.connected?(inventory.get_target('unknownfoo'))).to eq(false)
     end
 
+    context "with run-as configured" do
+      let(:transport_config) {
+        {
+          'uri' => uri,
+          'config' => {
+            'lxd' => { 'run-as' => 'root' }
+          }
+        }
+      }
+      let(:target) { Bolt::Target.from_hash(transport_config, inventory) }
+
+      it "uses run-as user" do
+        result = lxd.run_command(target, 'whoami')
+        expect(result.value['stdout'].strip).to eq('root')
+      end
+    end
+
     include_examples 'transport api'
 
     context 'with_connection' do
@@ -77,6 +94,19 @@ describe Bolt::Transport::LXD do
 
     it "returns false if the target is not available" do
       expect(runner.connected?(inventory.get_target('unknownfoo'))).to eq(false)
+    end
+
+    context "with run-as configured" do
+      let(:run_as_config) do
+        run_as = { 'config' => { 'lxd' => { 'run-as' => 'root' } } }
+        Bolt::Util.deep_merge(transport_config, run_as)
+      end
+      let(:target) { Bolt::Target.from_hash(transport_config, inventory) }
+
+      it "uses run-as user" do
+        result = lxd.run_command(target, 'whoami')
+        expect(result.value['stdout'].strip).to eq('root')
+      end
     end
 
     include_examples 'transport api'

--- a/spec/integration/transport/podman_spec.rb
+++ b/spec/integration/transport/podman_spec.rb
@@ -71,4 +71,19 @@ describe Bolt::Transport::Podman, podman: true do
       expect(result.value['stdout'].strip).to eq('/bin/bash')
     end
   end
+
+  context 'with run-as specified' do
+    let(:target_data) {
+      { 'uri' => uri,
+        'config' => {
+          'podman' => { 'run-as' => 'root' }
+        } }
+    }
+    let(:target) { Bolt::Target.from_hash(target_data, inventory) }
+
+    it 'uses the specified shell' do
+      result = podman.run_command(target, 'whoami')
+      expect(result.value['stdout'].strip).to eq('root')
+    end
+  end
 end


### PR DESCRIPTION
This adds support for using `run-as` and associated configuration
options to the Docker, Podman, and LXD transports when running on *nix
systems. Originally, 'run-as' was not supported for the Docker transport
because it could be running on either Windows or *nix, and run-as is not
supported when running on Windows systems. At the time it seemed
confusing for the option to only be supported sometimes, but now that
this is the case for the SSH transport when using the PowerShell
`login-shell` there's more of a precedent for users understanding when
it is and isn't supported. This was intended to be
addressed after the great [shell-transport split of 2020](https://github.com/puppetlabs/bolt/pull/1702),
and just fell through the cracks.

In addition to adding support for `run-as` to Docker when running on
*nix, this adds support for the option on the related LXD and Podman
transports under the same circumstances, since those transports are
largely based on the Docker transport and operate in the same way. LXD
specifically does not support PowerShell, so `run-as` support requires
no caveats there.

This also fixes a bug where Bolt would stacktrace if `run-as` was set
for any of the above transports, because the Bash shell would try to
call `reset_cwd?` on the transport which was not defined.

!feature

* **Support run-as for container transports when running on \*nix** ([#2806](https://github.com/puppetlabs/bolt/issues/2806))
  The Docker, LXD, and Podman transports now support `run-as`
  configuration and related configuration options when running on *nix
  systems. `run-as` is not supported for any Windows systems or the
  PowerShell shell over SSH.