### PR TITLE
(GH-2832) Use module name for plugin tar directory

### DIFF
--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -306,11 +306,11 @@ module Bolt
       Puppet.lookup(:current_environment).override_with(modulepath: @plugin_dirs).modules.each do |mod|
         search_dirs = yield mod
 
-        parent = Pathname.new(mod.path).parent
+        tar_dir = Pathname.new(mod.name) # goes great with fish
         files = Find.find(*search_dirs).select { |file| File.file?(file) }
 
         files.each do |file|
-          tar_path = Pathname.new(file).relative_path_from(parent)
+          tar_path = tar_dir + Pathname.new(file).relative_path_from(mod.path)
           @logger.trace("Packing plugin #{file} to #{tar_path}")
           stat = File.stat(file)
           content = File.binread(file)

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -23,8 +23,9 @@ describe 'apply', expensive: true do
 
   let(:apply_settings) { {} }
   let(:project)        { @project }
+  let(:project_config) { base_config }
 
-  let(:project_config) do
+  let(:base_config) do
     {
       'apply-settings' => apply_settings,
       'hiera-config'   => fixtures_path('hiera', 'empty.yaml'),
@@ -138,6 +139,20 @@ describe 'apply', expensive: true do
                                 project: project)
 
           expect(result.first).to include('status' => 'success')
+        end
+
+        context 'in a project with a name different than the directory' do
+          let(:project_config) { base_config.merge('name' => 'example') }
+
+          it 'can reference project files with Puppet file syntax' do
+            FileUtils.mkdir_p(project.path + 'files')
+            FileUtils.touch(project.path + 'files' + 'testfile')
+
+            result = run_cli_json(%W[plan run basic::project_files -t nix_agents project_name=#{project.name}],
+                                  project: project)
+
+            expect(result.first).to include('status' => 'success')
+          end
         end
 
         context 'with show_diff configured' do

--- a/spec/lib/bolt_spec/integration.rb
+++ b/spec/lib/bolt_spec/integration.rb
@@ -40,7 +40,7 @@ module BoltSpec
     end
 
     def run_cli_json(arguments, **opts)
-      output = run_cli(arguments + ['--format', 'json'], opts)
+      output = run_cli(arguments + ['--format', 'json'], **opts)
 
       begin
         result = JSON.parse(output, quirks_mode: true)

--- a/spec/lib/bolt_spec/project.rb
+++ b/spec/lib/bolt_spec/project.rb
@@ -32,7 +32,7 @@ module BoltSpec
     # instance.
     #
     def with_project(name = 'project', **kwargs)
-      with_project_directory(name, kwargs) do |project_path|
+      with_project_directory(name, **kwargs) do |project_path|
         project = Bolt::Project.create_project(project_path)
         yield(project)
       end


### PR DESCRIPTION
This updates the applicator to use the name of a module as the name of
the directory that plugin files are saved in when building the plugin
tarball. Previously, the applicator would use name of the module
directory as name of the directory that plugin files were saved to. This
caused issues when referencing a file in a project that had a configured
name that is different than the project directory's name.

For example, in a project named `foo` that uses a `Boltdir`, a file
might be located at `foo/Boltdir/files/somefile.txt`. When building the
plugin tarball, the applicator would set the path of this file to
`Boltdir/files/somefile.txt` instead of the correct path
`foo/files/somefile.txt`. This would cause any plan that referenced that
file using the correct syntax `puppet:///modules/foo/somefile.txt` to
error.

!feature

* **Upload project plugin files to correct directory when running an
  apply**
  ([#2832](https://github.com/puppetlabs/bolt/issues/2832))

  Project plugin files are now uploaded to the correct directory when
  running an apply. Previously, if a project used a `Boltdir` or had a
  directory name that did not match the project's configured name, apply
  blocks could not correctly reference files in the project using Puppet
  file syntax (`puppet:///modules/<project name>/<file name>`).