### PR TITLE
(GH-2550) Document installing PuppetBolt PowerShell module

### DIFF
--- a/documentation/bolt_installing.md
+++ b/documentation/bolt_installing.md
@@ -203,6 +203,8 @@ manager](https://chocolatey.org/docs/installation) installed.
     refreshenv
     ```
 
+1. Install the [PuppetBolt PowerShell module](#puppetbolt-powershell-module).
+
 1. Run a [Bolt cmdlet](bolt_cmdlet_reference.md). If you see an error message
    instead of the expected output, you might need to [add the Bolt module to
    PowerShell](troubleshooting.md#powershell-does-not-recognize-bolt-cmdlets) or
@@ -236,6 +238,8 @@ Use the Windows installer (MSI) package to install Bolt on Windows:
 
 1.  Double-click the MSI file and run the installer.
 
+1. Install the [PuppetBolt PowerShell module](#puppetbolt-powershell-module).
+
 1.  Open a new PowerShell window and run a [Bolt cmdlet](bolt_cmdlet_reference.md).
     If you see an error message instead of the expected output, you might need to
     [add the Bolt module to
@@ -255,6 +259,41 @@ You can uninstall Bolt from Windows **Apps & Features**:
 1. Press **Windows** + **X** + **F** to open **Apps & Features**.
 
 1. Search for **Puppet Bolt**, select it, and click **Uninstall**.
+
+### PuppetBolt PowerShell module
+
+The PuppetBolt PowerShell module is available on the [PowerShell
+Gallery](https://www.powershellgallery.com/packages/PuppetBolt) and includes
+help documents and [PowerShell cmdlets](bolt_cmdlet_reference.md) for running
+each of Bolt's commands. New versions of the PuppetBolt module are shipped at the
+same time as a new Bolt release.
+
+**Install PuppetBolt**
+
+To install the PuppetBolt PowerShell module, run the following command in
+PowerShell:
+
+```powershell
+Install-Module PuppetBolt
+```
+
+**Update PuppetBolt**
+
+To update the PuppetBolt PowerShell module, run the following command in
+PowerShell:
+
+```powershell
+Update-Module PuppetBolt
+```
+
+**Uninstall PuppetBolt**
+
+To uninstall the PuppetBolt PowerShell module, run the following command in
+PowerShell:
+
+```powershell
+Remove-Module PuppetBolt
+```
 
 ## Install Bolt on RHEL
 

--- a/documentation/templates/bolt_cmdlet_reference.md.erb
+++ b/documentation/templates/bolt_cmdlet_reference.md.erb
@@ -1,5 +1,8 @@
 # PowerShell cmdlets
 
+To use the PuppetBolt PowerShell module, see the [installation
+documentation](bolt_installing.md#puppetbolt-powershell-module).
+
 ## Cmdlet syntax
 
 Bolt PowerShell cmdlets follow a verb-noun convention.

--- a/rakelib/pwsh.rake
+++ b/rakelib/pwsh.rake
@@ -87,7 +87,7 @@ namespace :pwsh do
       actions << nil if actions.empty?
       actions.each do |action|
         help_text = parser.get_help_text(subcommand, action)
-        matches = help_text[:banner].match(/Usage(?<usage>.+?)Description(?<desc>.+?)(Examples|\z)/m)
+        matches = help_text[:banner].match(/Usage(?<usage>.+?)Description(?<desc>.+?)(Documentation|Examples|\z)/m)
         action.chomp unless action.nil?
 
         if action.nil? && %w[apply lookup].include?(subcommand)


### PR DESCRIPTION
This documents installing the PuppetBolt PowerShell module through the
PowerShell Gallery, as the module no longer ships with Bolt.

!feature

* **Ship PuppetBolt PowerShell module to PowerShell Gallery**
  ([#2550](https://github.com/puppetlabs/bolt/issues/2550))

  The PuppetBolt PowerShell module is now shipped to the [PowerShell
  Gallery](https://www.powershellgallery.com/packages/PuppetBolt). For more information about
  installing the PuppetBolt PowerShell module, see the
  [documentation](bolt_installing.md#puppetbolt-powershell-module).