### PR TITLE
(bug) Use Pathname object when building plugin tar ball path

### DIFF
--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -307,10 +307,11 @@ module Bolt
         search_dirs = yield mod
 
         tar_dir = Pathname.new(mod.name) # goes great with fish
+        mod_dir = Pathname.new(mod.path)
         files = Find.find(*search_dirs).select { |file| File.file?(file) }
 
         files.each do |file|
-          tar_path = tar_dir + Pathname.new(file).relative_path_from(mod.path)
+          tar_path = tar_dir + Pathname.new(file).relative_path_from(mod_dir)
           @logger.trace("Packing plugin #{file} to #{tar_path}")
           stat = File.stat(file)
           content = File.binread(file)


### PR DESCRIPTION
This fixes a bug in `Bolt::Applicator.build_plugin_tarball` that was
causing Bolt to stacktrace when running an apply block on a Windows
controller. When Bolt builds the tar ball, it joins the module's name
with the path to the module file relative to the module directory (i.e.
`my_module` + `files/some_file.txt`). To get the relative path to the
module file, Bolt calls the Ruby function `Pathname.relative_path_from`.
Previously, the string representation of the file's full path was passed
to this function, which then errored as it called `Pathname.cleanpath`
internally, which is not valid for string objects. Bolt now passes a
`Pathname` object to this function, fixing the stacktrace issue.

!no-release-note