### PR TITLE
(bug) Provide project for BoltSpec::Run::Runner#pal

### DIFF
--- a/lib/bolt_spec/run.rb
+++ b/lib/bolt_spec/run.rb
@@ -182,7 +182,10 @@ module BoltSpec
         @pal ||= Bolt::PAL.new(Bolt::Config::Modulepath.new(config.modulepath),
                                config.hiera_config,
                                config.project.resource_types,
-                               config.compile_concurrency)
+                               config.compile_concurrency,
+                               config.trusted_external,
+                               config.apply_settings,
+                               config.project)
       end
 
       def resolve_targets(target_spec)

--- a/spec/bolt_spec/run_spec.rb
+++ b/spec/bolt_spec/run_spec.rb
@@ -96,6 +96,13 @@ describe "BoltSpec::Run", ssh: true do
       expect(result['status']).to eq('failure')
       expect(result['value']['kind']).to eq('bolt/run-failure')
     end
+
+    it 'runs a plan that downloads a file' do
+      result = run_plan('sample::download_file', 'nodes' => 'ssh')
+      expect(result['status']).to eq('success')
+      data = result['value'][0]
+      expect(data['value']['path']).to match(%r{^/tmp/})
+    end
   end
 
   context 'with a target that has a puppet-agent installed' do

--- a/spec/fixtures/modules/sample/plans/download_file.pp
+++ b/spec/fixtures/modules/sample/plans/download_file.pp
@@ -1,0 +1,5 @@
+plan sample::download_file(
+  TargetSpec $nodes,
+) {
+  return download_file('/etc/hosts', 'subdir', $nodes)
+}


### PR DESCRIPTION
Ran into a case where using BoltSpec::Run.run_plan with a plan
containing a download_file() call would fail here:

https://github.com/puppetlabs/bolt/blob/3.9.0/bolt-modules/boltlib/lib/puppet/functions/download_file.rb#L99

because Puppet.lookup(:bolt_project) would otherwise be null at this
point.

Providing the config.project to the Bolt::PAL instance created by
BoltSpec::Run::Runner#pal fixes this.