### PR TITLE
(GH-2840) Report whether tasks are run in noop mode

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task.rb
@@ -130,6 +130,9 @@ Puppet::Functions.create_function(:run_task) do
       end
     end
 
+    # Report whether the task was run in noop mode.
+    executor.report_noop_mode(executor.noop || options[:noop])
+
     if targets.empty?
       Bolt::ResultSet.new([])
     else

--- a/bolt-modules/boltlib/lib/puppet/functions/run_task_with.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_task_with.rb
@@ -175,6 +175,9 @@ Puppet::Functions.create_function(:run_task_with) do
       end
     end
 
+    # Report whether the task was run in noop mode.
+    executor.report_noop_mode(executor.noop || options[:noop])
+
     if targets.empty?
       Bolt::ResultSet.new([])
     else

--- a/documentation/analytics.md
+++ b/documentation/analytics.md
@@ -60,6 +60,7 @@ with a randomly generated, non-identifiable user UUID:
 - IDs of any deprecation warnings
 - Whether the source file for `upload_file`, `run_script`, or `file::read` plan
   functions uses an absolute path or a module path.
+- Whether a task is run in no-operation mode.
 
 ## Viewing collected data
 

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -242,6 +242,10 @@ module Bolt
       @analytics&.event('Plan', plan_function, label: label)
     end
 
+    def report_noop_mode(noop)
+      @analytics&.event('Task', 'noop', label: (!!noop).to_s)
+    end
+
     def report_apply(statement_count, resource_counts)
       data = { statement_count: statement_count }
 

--- a/lib/bolt_spec/plans/mock_executor.rb
+++ b/lib/bolt_spec/plans/mock_executor.rb
@@ -325,6 +325,8 @@ module BoltSpec
 
       def report_yaml_plan(_plan); end
 
+      def report_noop_mode(_mode); end
+
       def shutdown; end
 
       def start_plan(_plan_context); end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1325,6 +1325,7 @@ describe "Bolt::CLI" do
         allow(cli).to receive(:config).and_return(Bolt::Config.default)
         allow(executor).to receive(:report_function_call)
         allow(executor).to receive(:report_bundled_content)
+        allow(executor).to receive(:report_noop_mode)
         allow(Bolt::Executor).to receive(:new).and_return(executor)
         allow(executor).to receive(:log_plan) { |_plan_name, &block| block.call }
         allow(executor).to receive(:run_plan) do |scope, plan, params|
@@ -2323,6 +2324,7 @@ describe "Bolt::CLI" do
         outputter = Bolt::Outputter::JSON.new(false, false, false, false, output)
         allow(cli).to receive(:outputter).and_return(outputter)
         allow(executor).to receive(:report_bundled_content)
+        allow(executor).to receive(:report_noop_mode)
         allow(cli).to receive(:config).and_return(Bolt::Config.default)
       end
 


### PR DESCRIPTION
This adds a new analytics event that reports whether or not a task is
run in no-operation mode.

!feature

* **Report whether tasks are run in no-operation mode**
  ([#2840](https://github.com/puppetlabs/bolt/issues/2840))

  Bolt now reports whether or not a task is run in no-operation mode
  when it collects analytics.