### PR TITLE
(maint) Standardize persisting scope for current plan

### DIFF
--- a/lib/bolt_spec/plans/mock_executor.rb
+++ b/lib/bolt_spec/plans/mock_executor.rb
@@ -274,11 +274,7 @@ module BoltSpec
           local = Puppet::Parser::Scope::LocalScope.new
 
           # Compress the current scopes into a single vars hash to add to the new scope
-          current_scope = scope.effective_symtable(true)
-          until current_scope.nil?
-            current_scope.instance_variable_get(:@symbols)&.each_pair { |k, v| local[k] = v }
-            current_scope = current_scope.parent
-          end
+          scope.to_hash.each_pair { |k, v| local[k] = v }
           newscope.push_ephemerals([local])
         end
 


### PR DESCRIPTION
THis commit updates the mock executor to match the fiber executor when persisting current plan scope.