### PR TITLE
SOLARCH-278 updating bundle instructions to pdk

### DIFF
--- a/documentation/testing_plans.md
+++ b/documentation/testing_plans.md
@@ -31,17 +31,11 @@ Before you can write and run tests, you need to set up the test environment.
 1. Ensure your module has `Gemfile`, `Rakefile`, and `spec/spec_helper.rb`
    files.
 
-1. Install the `bundler` gem with Ruby:
-
-    ```shell
-    gem install bundler
-    ```
-
 1. Install the module's gem dependencies, which include Bolt and other testing
    tools:
 
     ```shell
-    bundle install
+    pdk bundle install
     ```
 
 ## Directory and file structure
@@ -133,7 +127,7 @@ To run tests for your modules, including tests that you write for plans, run the
 following command:
 
 ```shell
-bundle exec rake spec
+pdk bundle exec rake spec
 ```
 
 This command runs a rake task that is defined in the `Rakefile` created by PDK,
@@ -144,9 +138,9 @@ console together with each test's pass or fail status.
 To run tests for a single plan, run the following:
 
 ```shell
-bundle exec rake spec_prep
-bundle exec rspec spec/plans/<TEST FILE>
-bundle exec rake spec_clean
+pdk bundle exec rake spec_prep
+pdk bundle exec rspec spec/plans/<TEST FILE>
+pdk bundle exec rake spec_clean
 ```
 
 ## Configuration
@@ -620,7 +614,7 @@ end
 Run the tests:
 
 ```shell
-bundle exec rake spec
+pdk bundle exec rake spec
 ```
 
 ### Testing a plan with sub-plans
@@ -831,7 +825,7 @@ end
 Run the tests:
 
 ```shell
-bundle exec rake spec
+pdk bundle exec rake spec
 ```
 
 ### Testing a plan that uses `run_task_with`
@@ -979,7 +973,7 @@ end
 Run the tests:
 
 ```shell
-bundle exec rake spec
+pdk bundle exec rake spec
 ```
 
 📖 **Related information**


### PR DESCRIPTION
Since the setup uses pdk it would reduce complexity to use bundle via pdk for running and testing plans.