### PR TITLE
(PT-317) Add project_facts_plugin_tarball endpoint to bolt-server

### DIFF
--- a/developer-docs/bolt-server/api.md
+++ b/developer-docs/bolt-server/api.md
@@ -369,8 +369,20 @@ Returns a list of targets parsed from project inventory
   }
 ]
 
+## GET /project_facts_plugin_tarball
+
+This endpoint returns the base64 encoded tar archive of plugin code that is needed to calculate custom facts.
+
+### Query parameters
+
+- `versioned_project`: String, *required* - Reference to the bolt project (in the form [PROJECT NAME]\_[REF])
+
+### Response
 
 ```
+"H4sIAI7ot2AAA+2UywqDMBBFXfsVAfcm0RihPxOiRhtIY8gDSr++UbCrQtGF\nLSVnN7O5A5czRoVJ6pH33rHbPAQl4DqUAxR3L6zmii2L0l2zo6AIJeTtfqVC\nGSaoaVpa4xZnCDe4ohlAhxN3EJznNp5yRtYPUoCtZrDUnH/7nsS5mNX/TX0l\nO2iCMcLDMejey1k76OabYNtY2m53xkf/G/ryn9Qk+k9bXCf/z6AAo50fQjPn\nrdQTUzJ+A64uwNsg8gIs5YOt/PQdEolE4m94AocSIJ4ADAAA\n"
+```
+
 ## GET /tasks
 - `environment`: String
 

--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -21,6 +21,10 @@ require 'puppet'
 # Needed by the `/project_file_metadatas` endpoint
 require 'puppet/file_serving/fileset'
 
+# Needed by the 'project_facts_plugin_tarball' endpoint
+require 'minitar'
+require 'zlib'
+
 module BoltServer
   class TransportApp < Sinatra::Base
     # This disables Sinatra's error page generation
@@ -70,6 +74,8 @@ module BoltServer
 
       # This is needed until the PAL is threadsafe.
       @pal_mutex = Mutex.new
+
+      @logger = Bolt::Logger.logger(self)
 
       super(nil)
     end
@@ -673,6 +679,70 @@ module BoltServer
 
         [200, target_list.to_json]
       end
+    end
+
+    # Returns the base64 encoded tar archive of plugin code that is needed to calculate
+    # custom facts
+    #
+    # @param versioned_project [String] the versioned_project to build the plugin tarball from
+    get '/project_facts_plugin_tarball' do
+      raise BoltServer::RequestError, "'versioned_project' is a required argument" if params['versioned_project'].nil?
+      content_type :json
+
+      # Inspired by Bolt::Applicator.build_plugin_tarball
+      start_time = Time.now
+
+      # Fetch the plugin files
+      plugin_files = in_bolt_project(params['versioned_project']) do |context|
+        files = {}
+
+        # Bolt also sets plugin_modulepath to user modulepath so do it here too for
+        # consistency
+        plugin_modulepath = context[:pal].user_modulepath
+        Puppet.lookup(:current_environment).override_with(modulepath: plugin_modulepath).modules.each do |mod|
+          search_dirs = []
+          search_dirs << mod.plugins if mod.plugins?
+          search_dirs << mod.pluginfacts if mod.pluginfacts?
+
+          files[mod] ||= []
+          Find.find(*search_dirs).each do |file|
+            files[mod] << file if File.file?(file)
+          end
+        end
+
+        files
+      end
+
+      # Pack the plugin files
+      sio = StringIO.new
+      begin
+        output = Minitar::Output.new(Zlib::GzipWriter.new(sio))
+
+        plugin_files.each do |mod, files|
+          tar_dir = Pathname.new(mod.name)
+          mod_dir = Pathname.new(mod.path)
+
+          files.each do |file|
+            tar_path = tar_dir + Pathname.new(file).relative_path_from(mod_dir)
+            stat = File.stat(file)
+            content = File.binread(file)
+            output.tar.add_file_simple(
+              tar_path.to_s,
+              data: content,
+              size: content.size,
+              mode: stat.mode & 0o777,
+              mtime: stat.mtime
+            )
+          end
+        end
+
+        duration = Time.now - start_time
+        @logger.trace("Packed plugins in #{duration * 1000} ms")
+      ensure
+        output.close
+      end
+
+      [200, Base64.encode64(sio.string).to_json]
     end
 
     error 404 do

--- a/spec/fixtures/bolt_server/projects/bolt_server_test_project/modules/plugin_module/lib/puppet/functions/some_function.rb
+++ b/spec/fixtures/bolt_server/projects/bolt_server_test_project/modules/plugin_module/lib/puppet/functions/some_function.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+# some function

--- a/spec/fixtures/bolt_server/projects/bolt_server_test_project/modules/pluginfacts_module/facts.d/external_fact.sh
+++ b/spec/fixtures/bolt_server/projects/bolt_server_test_project/modules/pluginfacts_module/facts.d/external_fact.sh
@@ -1,0 +1,1 @@
+# external fact


### PR DESCRIPTION
This returns the base64 encoded tar archive of plugin code that is needed to
calculate custom facts.

Signed-off-by: Enis Inan <enis.inan@puppet.com>