### PR TITLE
(GH-2866) Include undef variables in parallelize blocks

### DIFF
--- a/lib/bolt/fiber_executor.rb
+++ b/lib/bolt/fiber_executor.rb
@@ -34,7 +34,7 @@ module Bolt
         local = Puppet::Parser::Scope::LocalScope.new
 
         # Compress the current scopes into a single vars hash to add to the new scope
-        scope.to_hash.each_pair { |k, v| local[k] = v }
+        scope.to_hash(true, true).each_pair { |k, v| local[k] = v }
         newscope.push_ephemerals([local])
       end
 

--- a/lib/bolt_spec/plans/mock_executor.rb
+++ b/lib/bolt_spec/plans/mock_executor.rb
@@ -274,7 +274,7 @@ module BoltSpec
           local = Puppet::Parser::Scope::LocalScope.new
 
           # Compress the current scopes into a single vars hash to add to the new scope
-          scope.to_hash.each_pair { |k, v| local[k] = v }
+          scope.to_hash(true, true).each_pair { |k, v| local[k] = v }
           newscope.push_ephemerals([local])
         end
 

--- a/spec/fixtures/parallel/background/plans/variables.pp
+++ b/spec/fixtures/parallel/background/plans/variables.pp
@@ -1,10 +1,11 @@
 plan background::variables(
-  TargetSpec $targets
+  TargetSpec $targets,
+  Optional[String] $undef = undef
 ) {
   $var = 'Before background'
   $future = background() || {
     out::message("Inside background: $var")
-    out::message("Targets: ${$targets}")
+    out::message("Undef: $undef")
     out::message("Foo: $foo")
   }
   $foo = 'After background'

--- a/spec/integration/parallel_spec.rb
+++ b/spec/integration/parallel_spec.rb
@@ -83,16 +83,17 @@ Plan completed successfully}
       expect(output).to match(regex)
     end
 
-    it "includes variables from the plan in scope" do
+    it "includes variables, including undef vars, from the plan in scope" do
       regex = %r{Starting: plan background::variables
 In main plan: After background
 Finished: plan background::variables.*
 Inside background: Before background
-Targets}
+Undef:}
       output = run_cli(%w[plan run background::variables] + config_flags,
                        outputter: Bolt::Outputter::Human)
       expect(output).to match(regex)
       expect(output).to match(/Unknown variable: 'foo'/)
+      expect(output).not_to match(/Unknown variable: 'undef'/)
     end
 
     it "returns from a 'return' statement'" do


### PR DESCRIPTION
When creating a new Future block, Bolt must copy any variables that
should be in scope for the block into a new scope for the block, so that
if variables redefined inside the block they don't affect other blocks
running in parallel. Gathering variables in scope uses the
`Puppet::Parser::Scope#to_hash` method, which accepts 2 positional
parameters:
- The first parameter tells the function whether to recursively get
  variables from parent (aka enclosing) scopes. This defaults to true
  and we want it to be true.
- The second parameter tells the function whether to include variables
  set to 'undef', which defaults to false and which we want to be true.

Previously we had not enabled including undef variables in the new
scope, which resulted in defined variables not being passed to the new
block as users expect. This changes how we call `to_hash` to correctly
include variables that are `undef`.

!bug

* **Undef variables are now included in Future block scopes** ([#2866](https://github.com/puppetlabs/bolt/issues/2866))
  Previously, Bolt would not include variables with a value `undef` in
  Future block scopes, leading them to be undefined. Bolt now includes
  those variables when creating the new scope for Future blocks.