### PR TITLE
(GH-2550) Add deprecation warning to PuppetBolt module import

### DIFF
--- a/.github/workflows/publish-powershell-module.yaml
+++ b/.github/workflows/publish-powershell-module.yaml
@@ -18,6 +18,9 @@ jobs:
       run:
         shell: powershell
 
+    env:
+      BOLT_DISABLE_PWSH_WARNING: 'true'
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/pwsh_module/pwsh_bolt.psm1.erb
+++ b/pwsh_module/pwsh_bolt.psm1.erb
@@ -90,3 +90,20 @@ end
 
 }
 <% end %>
+
+<% unless ENV['BOLT_DISABLE_PWSH_WARNING'] -%>
+function Write-DeprecationWarning
+{
+  $FirstRunFile = "$HOME/.puppetlabs/etc/bolt/.first_runs_free"
+
+  if (-not(Test-Path -Path $FirstRunFile)) {
+    New-Item -ItemType File -Path $FirstRunFile -Force -ErrorAction SilentlyContinue
+
+    $Warning =  "The PuppetBolt PowerShell module will no longer ship with Bolt packages in a future release. ";
+    $Warning += "Install the PuppetBolt PowerShell module from PowerShell Gallery instead using 'Import-Module PuppetBolt'."
+    Write-Warning $Warning
+  }
+}
+
+Write-DeprecationWarning
+<% end -%>


### PR DESCRIPTION
This adds a warning to the PuppetBolt module that the module will no
longer ship with Bolt packages in a future Bolt release. It also
provides information for installing the module through PowerShell
Gallery. The warning is only displayed the first time the module is
used, after which a 'first run' file is created in the module to
indicate that the message should not be printed.

This also adds an environment variable to the module publishing workflow
to not add this warning to the module that is published to PowerShell
Gallery.

!deprecation

* **PuppetBolt PowerShell module will not ship with Bolt packages in a
  future release**
  ([#2550](https://github.com/puppetlabs/bolt/issues/2550))

  The PuppetBolt PowerShell module will no longer ship with Bolt
  packages on Windows in a future release. The PuppetBolt PowerShell
  module should instead be installed from PowerShell Gallery.