### PR TITLE
(bug) Do not error when using `--run-as` on Windows controller

### DIFF
--- a/lib/bolt/config/transport/docker.rb
+++ b/lib/bolt/config/transport/docker.rb
@@ -27,10 +27,6 @@ module Bolt
           if @config['interpreters']
             @config['interpreters'] = normalize_interpreters(@config['interpreters'])
           end
-
-          if Bolt::Util.windows? && @config['run-as']
-            raise Bolt::ValidationError, "run-as is not supported when using PowerShell"
-          end
         end
       end
     end

--- a/lib/bolt/config/transport/podman.rb
+++ b/lib/bolt/config/transport/podman.rb
@@ -26,10 +26,6 @@ module Bolt
           if @config['interpreters']
             @config['interpreters'] = normalize_interpreters(@config['interpreters'])
           end
-
-          if Bolt::Util.windows? && @config['run-as']
-            raise Bolt::ValidationError, "run-as is not supported when using PowerShell"
-          end
         end
       end
     end

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -884,24 +884,14 @@ describe "Bolt::CLI" do
     describe "sudo" do
       it "supports running as a user" do
         cli = Bolt::CLI.new(%w[command run --targets foo whoami --run-as root])
-        if Bolt::Util.windows?
-          expect { cli.parse }
-            .to raise_error(Bolt::ValidationError, "run-as is not supported when using PowerShell")
-        else
-          expect(cli.parse[:'run-as']).to eq('root')
-        end
+        expect(cli.parse[:'run-as']).to eq('root')
       end
     end
 
     describe "sudo-password" do
       it "accepts a password" do
         cli = Bolt::CLI.new(%w[command run uptime --sudo-password opensez --run-as alibaba --targets foo])
-        if Bolt::Util.windows?
-          expect { cli.parse }
-            .to raise_error(Bolt::ValidationError, "run-as is not supported when using PowerShell")
-        else
-          expect(cli.parse).to include('sudo-password': 'opensez')
-        end
+        expect(cli.parse).to include('sudo-password': 'opensez')
       end
     end
 

--- a/spec/integration/transport/podman_spec.rb
+++ b/spec/integration/transport/podman_spec.rb
@@ -81,7 +81,7 @@ describe Bolt::Transport::Podman, podman: true do
     }
     let(:target) { Bolt::Target.from_hash(target_data, inventory) }
 
-    it 'uses the specified shell' do
+    it 'uses the specified run-as user' do
       result = podman.run_command(target, 'whoami')
       expect(result.value['stdout'].strip).to eq('root')
     end


### PR DESCRIPTION
This fixes a bug introduced by #2806 that causes Bolt to error on a
Windows controller whenever the `--run-as` command-line option is used.
Previously, the `docker` and `podman` transport config classes included
validation that would raise an error whenever the `run-as` option was
set for the transport and the controller was running Windows. Because
Bolt automatically sets the `run-as` configuration for all transports
that support it when using the `--run-as` command-line option, this
resulted in any command using that option to raise this error, even if
there weren't any targets using that transport.

This removes the relevant validation in the transport config classes.
This will not result in any errors when running on targets using these
transports, as Bolt automatically sets the transport's shell to
`powershell`, which does not include logic for running as another user
and cannot be overridden by the user.

!bug

* **Do not error when using `--run-as` on a Windows controller**

  Bolt no longer raises an error when using the `--run-as` command-line
  option on a Windows controller.