### PR TITLE
(GH-2788) Pass multiple arguments to PowerShell `-Arguments` parameter

### DIFF
--- a/documentation/running_bolt_commands.md
+++ b/documentation/running_bolt_commands.md
@@ -416,10 +416,17 @@ bolt script run ./scripts/configure.sh --targets servers arg1 arg2
 
 _PowerShell cmdlet_
 
-To pass arguments to a script, use the `-Arguments` parameter:
+To pass arguments to a script, specify them after the command:
 
 ```powershell
-Invoke-BoltScript -Script ./scripts/configure.sh -Targets servers -Arguments arg1 arg2
+Invoke-BoltScript -Script ./scripts/configure.sh -Targets servers arg1 arg2
+```
+
+You can also use the `-Arguments` parameter and provide a comma-separated
+list of arguments:
+
+```powershell
+Invoke-BoltScript -Script ./scripts/configure.sh -Targets servers -Arguments arg1,arg2
 ```
 
 > 🔩 **Tip:** If an argument contains spaces or special characters, wrap them

--- a/pwsh_module/command.tests.ps1
+++ b/pwsh_module/command.tests.ps1
@@ -266,6 +266,16 @@ Describe "test all bolt command examples" {
       # This does work without quotes being explicitly added here
       $result | Should -Be "bolt script run myscript.sh echo hello --targets target1,target2"
     }
+
+    It "bolt script run myscript.sh foo bar --targets target1,target2" {
+      $result = Invoke-BoltScript -script 'myscript.sh' 'foo' 'bar' -targets 'target1,target2'
+      $result | Should -Be "bolt script run myscript.sh --targets target1,target2 foo bar"
+    }
+
+    It "bolt script run myscript.sh foo bar --targets target1,target2" {
+      $result = Invoke-BoltScript -script 'myscript.sh' -arguments 'foo','bar' -targets 'target1,target2'
+      $result | Should -Be "bolt script run myscript.sh foo bar --targets target1,target2"
+    }
   }
 
   Context "bolt secret" {

--- a/rakelib/pwsh.rake
+++ b/rakelib/pwsh.rake
@@ -161,14 +161,15 @@ namespace :pwsh do
             validate_not_null_or_empty: true
           }
           @pwsh_command[:options] << {
-            name:       'Arguments',
-            ruby_short: 'a',
-            help_msg:   'The arguments to the script',
-            type:       'string',
-            switch:     false,
-            mandatory:  false,
-            position:   1,
-            ruby_arg:   'bare'
+            name:                           'Arguments',
+            ruby_short:                     'a',
+            help_msg:                       'The arguments to the script',
+            type:                           'string[]',
+            switch:                         false,
+            mandatory:                      false,
+            position:                       1,
+            ruby_arg:                       'bare',
+            value_from_remaining_arguments: true
           }
         when 'task'
           # bolt task show|run <task> [parameters] [options]


### PR DESCRIPTION
This fixes a bug in the PuppetBolt PowerShell module that was preventing
multiple arguments from being passed to the `-Arguments` parameter. This
updates the parameter's `ValueFromRemainingArguments` parameter to
`true`, so any arguments not bound to another parameter are passed to
`-Arguments`. This supports the following cmdlet invocations:

- `Invoke-BoltScript -Script script.sh -Arguments foo,bar -Targets all`
- `Invoke-BoltScript -Script script.sh foo bar -Targets all`

!bug

* **Pass remaining arguments to PowerShell `-Arguments` parameter**
  ([#2788](https://github.com/puppetlabs/bolt/issues/2788))

  The PuppetBolt PowerShell module now correctly supports passing
  multiple arguments to the `-Arguments` parameter. Previously, any
  unbound arguments were not passed to this parameter, causing the
  PowerShell parser to error.