### PR TITLE
(bug) Fix `BoltSpec::Plans::MockExecutor#wait` method signature

### DIFF
--- a/lib/bolt_spec/plans/mock_executor.rb
+++ b/lib/bolt_spec/plans/mock_executor.rb
@@ -286,7 +286,7 @@ module BoltSpec
         future
       end
 
-      def wait(results, _timeout, **_kwargs)
+      def wait(results, **_kwargs)
         results
       end
 


### PR DESCRIPTION
This removes the `timeout` argument from
`BoltSpec::Plans::MockExecutor#wait`'s method signature so it matches
the same method signature on `Bolt::Executor`, which sets `timeout` as a
keyword argument.

!bug

* **Test plans that use `parallelize()` plan function in BoltSpec**

  BoltSpec no longer fails when testing plans that include the
  `parallelize()` plan function. Previously, testing plans that used
  this function would cause the plan to fail with an argument mismatch
  error.