### PR TITLE
(maint) Bump bundled modules

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,13 +6,13 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '2.0.0'
-mod 'puppetlabs-puppet_agent', '4.6.1'
+mod 'puppetlabs-puppet_agent', '4.7.0'
 mod 'puppetlabs-facts', '1.4.0'
 
 # Core types and providers for Puppet 6
 mod 'puppetlabs-augeas_core', '1.1.2'
 mod 'puppetlabs-host_core', '1.0.3'
-mod 'puppetlabs-scheduled_task', '3.0.0'
+mod 'puppetlabs-scheduled_task', '3.0.1'
 mod 'puppetlabs-sshkeys_core', '2.2.0'
 mod 'puppetlabs-zfs_core', '1.2.0'
 mod 'puppetlabs-cron_core', '1.0.5'
@@ -29,14 +29,14 @@ mod 'puppetlabs-python_task_helper', '0.5.0'
 mod 'puppetlabs-reboot', '4.0.2'
 mod 'puppetlabs-ruby_task_helper', '0.6.0'
 mod 'puppetlabs-ruby_plugin_helper', '0.2.0'
-mod 'puppetlabs-stdlib', '7.0.1'
+mod 'puppetlabs-stdlib', '7.1.0'
 
 # Plugin modules
 mod 'puppetlabs-aws_inventory', '0.7.0'
 mod 'puppetlabs-azure_inventory', '0.5.0'
 mod 'puppetlabs-gcloud_inventory', '0.3.0'
 mod 'puppetlabs-http_request', '0.2.2'
-mod 'puppetlabs-pkcs7', '0.1.1'
+mod 'puppetlabs-pkcs7', '0.1.2'
 mod 'puppetlabs-secure_env_vars', '0.2.0'
 mod 'puppetlabs-terraform', '0.6.1'
 mod 'puppetlabs-vault', '0.4.0'


### PR DESCRIPTION
This updates the following bundled modules to their latest versions:

- [pkcs7 0.1.2](https://forge.puppet.com/puppetlabs/pkcs7/0.1.2/changelog)
- [puppet_agent 4.7.0](https://forge.puppet.com/puppetlabs/puppet_agent/4.7.0/changelog)
- [scheduled_task 3.0.1](https://forge.puppet.com/puppetlabs/scheduled_task/3.0.1/changelog)
- [stdlib 7.1.0](https://forge.puppet.com/puppetlabs/stdlib/7.1.0/changelog)

!feature

* **Update bundled modules to latest versions**

  The following bundled modules have been updated to their latest
  versions:

  - [pkcs7 0.1.2](https://forge.puppet.com/puppetlabs/pkcs7/0.1.2/changelog)
  - [puppet_agent 4.7.0](https://forge.puppet.com/puppetlabs/puppet_agent/4.7.0/changelog)
    - The `puppet_agent::install` task now supports running in `noop` mode.
  - [scheduled_task 3.0.1](https://forge.puppet.com/puppetlabs/scheduled_task/3.0.1/changelog)
  - [stdlib 7.1.0](https://forge.puppet.com/puppetlabs/stdlib/7.1.0/changelog)