### PR TITLE
(docs) Fix Typo Getting Started Guide

### DIFF
--- a/documentation/getting_started_with_bolt.md
+++ b/documentation/getting_started_with_bolt.md
@@ -428,7 +428,7 @@ steps:
   - name: start_apache
     script: apache/start_apache.sh
     targets: $targets
-    description: "Starting Apache service" 
+    description: "Starting Apache service"
 ```
 
 Run the plan again:

--- a/documentation/getting_started_with_bolt.md
+++ b/documentation/getting_started_with_bolt.md
@@ -428,7 +428,7 @@ steps:
   - name: start_apache
     script: apache/start_apache.sh
     targets: $targets
-    description: "Start the Apache service"
+    description: "Starting Apache service" 
 ```
 
 Run the plan again:


### PR DESCRIPTION
This fixes a typo in the Getting Started Guide.

!no-release-note