### PR TITLE
(GH-2877) `wait()` with no arguments waits on all Futures from the plan

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/background.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/background.rb
@@ -31,7 +31,8 @@ Puppet::Functions.create_function(:background, Puppet::Functions::InternalFuncti
     executor = Puppet.lookup(:bolt_executor)
     executor.report_function_call(self.class.name)
 
-    executor.create_future(scope: scope, name: name) do |newscope|
+    plan_id = executor.get_current_plan_id(fiber: Fiber.current)
+    executor.create_future(scope: scope, name: name, plan_id: plan_id) do |newscope|
       # Catch 'return' calls inside the block
       result = catch(:return) do
         # Execute the block. Individual plan steps in the block will yield

--- a/bolt-modules/boltlib/lib/puppet/functions/parallelize.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/parallelize.rb
@@ -34,7 +34,11 @@ Puppet::Functions.create_function(:parallelize, Puppet::Functions::InternalFunct
     executor.report_function_call(self.class.name)
 
     futures = data.map do |object|
-      executor.create_future(scope: scope) do |newscope|
+      # We're going to immediately wait for these futures, *and* don't want
+      # their results to be returned as part of `wait()`, so use a 'dummy'
+      # value as the plan_id. This could also be nil, though in general we want
+      # to require Futures to have a plan stack so that they don't get lost.
+      executor.create_future(scope: scope, plan_id: 'parallel') do |newscope|
         # Catch 'return' calls inside the block
         result = catch(:return) do
           # Add the object to the block parameters

--- a/bolt-modules/boltlib/lib/puppet/functions/wait.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/wait.rb
@@ -1,14 +1,13 @@
 # frozen_string_literal: true
 
 require 'bolt/logger'
-require 'bolt/target'
 
 # Wait for a Future or array of Futures to finish and return results,
 # optionally with a timeout.
 #
 # > **Note:** Not available in apply block
 Puppet::Functions.create_function(:wait, Puppet::Functions::InternalFunction) do
-  # Wait for Future(s) to finish
+  # Wait for Futures to finish.
   # @param futures A Bolt Future object or array of Bolt Futures to wait on.
   # @param options A hash of additional options.
   # @option options [Boolean] _catch_errors Whether to catch raised errors.
@@ -27,7 +26,37 @@ Puppet::Functions.create_function(:wait, Puppet::Functions::InternalFunction) do
     return_type 'Array[Boltlib::PlanResult]'
   end
 
-  # Wait for Future(s) to finish with timeout
+  # Wait for all Futures in the current plan to finish.
+  # @param options A hash of additional options.
+  # @option options [Boolean] _catch_errors Whether to catch raised errors.
+  # @return A Result or Results from the Futures
+  # @example Perform multiple tasks in the background, then wait for all of them to finish
+  #   background() || { upload_file("./large_file", "/opt/jfrog/...", $targets) }
+  #   background() || { run_task("db::migrate", $targets) }
+  #   # Wait for all futures in the plan to finish and return all results
+  #   $results = wait()
+  dispatch :wait_for_all do
+    optional_param 'Hash[String[1], Any]', :options
+    return_type 'Array[Boltlib::PlanResult]'
+  end
+
+  # Wait for all Futures in the current plan to finish with a timeout.
+  # @param timeout How long to wait for Futures to finish before raising a Timeout error.
+  # @param options A hash of additional options.
+  # @option options [Boolean] _catch_errors Whether to catch raised errors.
+  # @return A Result or Results from the Futures
+  # @example Perform multiple tasks in the background, then wait for all of them to finish with a timeout
+  #   background() || { upload_file("./large_file", "/opt/jfrog/...", $targets) }
+  #   background() || { run_task("db::migrate", $targets) }
+  #   # Wait for all futures in the plan to finish and return all results
+  #   $results = wait(30)
+  dispatch :wait_for_all_with_timeout do
+    param 'Variant[Integer[0], Float[0.0]]', :timeout
+    optional_param 'Hash[String[1], Any]', :options
+    return_type 'Array[Boltlib::PlanResult]'
+  end
+
+  # Wait for Futures to finish with timeout.
   # @param futures A Bolt Future object or array of Bolt Futures to wait on.
   # @param timeout How long to wait for Futures to finish before raising a Timeout error.
   # @param options A hash of additional options.
@@ -58,14 +87,22 @@ Puppet::Functions.create_function(:wait, Puppet::Functions::InternalFunction) do
   end
 
   def wait(futures, options = {})
-    inner_wait(futures, nil, options)
+    inner_wait(futures: futures, options: options)
+  end
+
+  def wait_for_all(options = {})
+    inner_wait(options: options)
+  end
+
+  def wait_for_all_with_timeout(timeout, options = {})
+    inner_wait(timeout: timeout, options: options)
   end
 
   def wait_with_timeout(futures, timeout, options = {})
-    inner_wait(futures, timeout, options)
+    inner_wait(futures: futures, timeout: timeout, options: options)
   end
 
-  def inner_wait(futures, timeout = nil, options = {})
+  def inner_wait(futures: nil, timeout: nil, options: {})
     unless Puppet[:tasks]
       raise Puppet::ParseErrorWithIssue
         .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'wait')
@@ -85,7 +122,10 @@ Puppet::Functions.create_function(:wait, Puppet::Functions::InternalFunction) do
     executor = Puppet.lookup(:bolt_executor)
     executor.report_function_call(self.class.name)
 
-    futures = Array(futures)
+    # If we get a single Future, make sure it's an array. If we didn't get any
+    # futures pass that on to wait so we can continue collecting any futures
+    # that are created while waiting on existing futures.
+    futures = Array(futures) unless futures.nil?
     executor.wait(futures, **valid)
   end
 end

--- a/bolt-modules/boltlib/spec/functions/background_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/background_spec.rb
@@ -9,10 +9,11 @@ describe 'background' do
   include PuppetlabsSpec::Fixtures
   let(:name)      { "Pluralize" }
   let(:object)    { "noodle" }
-  let(:future)    { Bolt::PlanFuture.new('foo', name) }
+  let(:future)    { Bolt::PlanFuture.new('foo', name, plan_id: 1234) }
   let(:executor)  { Bolt::Executor.new }
 
   around(:each) do |example|
+    executor.expects(:get_current_plan_id).returns(1234)
     Puppet[:tasks] = true
     Puppet.override(bolt_executor: executor) do
       example.run

--- a/bolt-modules/boltlib/spec/functions/parallelize_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/parallelize_spec.rb
@@ -9,14 +9,14 @@ require 'bolt/plan_result'
 describe 'parallelize' do
   include PuppetlabsSpec::Fixtures
   let(:array) { %w[a b c d a b a] }
-  let(:future) { Bolt::PlanFuture.new(nil, 1, 'name') }
+  let(:future) { Bolt::PlanFuture.new(nil, 1, name: 'name', plan_id: 1234) }
   let(:executor) { Bolt::Executor.new }
   let(:result_array) { %w[ea eb ec ed ea eb ea] }
   let(:tasks_enabled) { true }
 
   around(:each) do |example|
     Puppet[:tasks] = tasks_enabled
-    Puppet.override(bolt_executor: executor) do
+    Puppet.override(bolt_executor: executor, plan_stack: []) do
       example.run
     end
   end

--- a/bolt-modules/boltlib/spec/functions/wait_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/wait_spec.rb
@@ -8,7 +8,7 @@ require 'bolt/plan_future'
 describe 'wait' do
   include PuppetlabsSpec::Fixtures
   let(:name)      { "Pluralize" }
-  let(:future)    { Bolt::PlanFuture.new('foo', name) }
+  let(:future)    { Bolt::PlanFuture.new('foo', name, plan_id: 1234) }
   let(:executor)  { Bolt::Executor.new }
   let(:result)    { ['return'] }
   let(:timeout)   { 2 }
@@ -28,6 +28,42 @@ describe 'wait' do
 
     is_expected.to(run
       .with_params(future))
+  end
+
+  context 'with no futures' do
+    it "passes 'nil' to the executor" do
+      executor.expects(:wait).with(nil).returns(result)
+
+      is_expected.to(run
+        .and_return(result))
+    end
+
+    it 'accepts just a timeout' do
+      executor.expects(:wait)
+              .with(nil, timeout: 2).returns(result)
+
+      is_expected.to(run
+        .with_params(2)
+        .and_return(result))
+    end
+
+    it 'accepts just options' do
+      executor.expects(:wait)
+              .with(nil, catch_errors: true).returns(result)
+
+      is_expected.to(run
+        .with_params('_catch_errors' => true)
+        .and_return(result))
+    end
+
+    it 'accepts a timeout and options' do
+      executor.expects(:wait)
+              .with(nil, timeout: 2, catch_errors: true).returns(result)
+
+      is_expected.to(run
+        .with_params(2, '_catch_errors' => true)
+        .and_return(result))
+    end
   end
 
   it 'turns a single object into an array' do

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -381,8 +381,16 @@ module Bolt
     # overloaded while also minimizing the Puppet lookups needed from plan
     # functions
     #
-    def create_future(scope: nil, name: nil, &block)
-      @fiber_executor.create_future(scope: scope, name: name, &block)
+    def create_future(plan_id:, scope: nil, name: nil, &block)
+      @fiber_executor.create_future(scope: scope, name: name, plan_id: plan_id, &block)
+    end
+
+    def get_current_future(fiber:)
+      @fiber_executor.get_current_future(fiber: fiber)
+    end
+
+    def get_current_plan_id(fiber:)
+      @fiber_executor.get_current_plan_id(fiber: fiber)
     end
 
     def plan_complete?
@@ -401,8 +409,8 @@ module Bolt
       @fiber_executor.wait(futures, **opts)
     end
 
-    def plan_futures
-      @fiber_executor.plan_futures
+    def get_futures_for_plan(plan_id:)
+      @fiber_executor.get_futures_for_plan(plan_id: plan_id)
     end
 
     # Execute a plan function concurrently. This function accepts the executor

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -683,7 +683,10 @@ module Bolt
         # Create a Fiber for the main plan. This will be run along with any
         # other Fibers created during the plan run in the round_robin, with the
         # main plan always taking precedence in being resumed.
-        future = executor.create_future(name: plan_name) do |_scope|
+        #
+        # Every future except for the main plan needs to have a plan id in
+        # order to be tracked for the `wait()` function with no arguments.
+        future = executor.create_future(name: plan_name, plan_id: 1) do |_scope|
           r = compiler.call_function('run_plan', plan_name, params.merge('_bolt_api_call' => true))
           Bolt::PlanResult.from_pcore(r, 'success')
         rescue Bolt::Error => e

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -1311,6 +1311,7 @@ describe "Bolt::CLI" do
                shutdown: nil,
                in_parallel?: false,
                plan_complete?: true,
+               get_current_future: nil,
                future: {})
       }
       let(:cli)         { Bolt::CLI.new({}) }

--- a/spec/bolt/fiber_executor_spec.rb
+++ b/spec/bolt/fiber_executor_spec.rb
@@ -5,6 +5,7 @@ require 'bolt/fiber_executor'
 
 describe "Bolt::FiberExecutor" do
   let(:fiber_executor)  { Bolt::FiberExecutor.new }
+  let(:plan_id)         { 1234 }
   let(:mock_scope)      { double('scope', compiler: nil, to_hash: {}) }
   let(:mock_newscope)   { double('newscope', push_ephemerals: nil) }
 
@@ -15,34 +16,34 @@ describe "Bolt::FiberExecutor" do
       expect(Puppet::Parser::Scope::LocalScope)
         .to receive(:new).and_return({})
 
-      fiber_executor.create_future(scope: mock_scope) { |_| return 0 }
+      fiber_executor.create_future(scope: mock_scope, plan_id: plan_id) { |_| return 0 }
     end
 
     it "does not create a new scope if an existing scope is not passed" do
       expect(Puppet::Parser::Scope)
         .not_to receive(:new)
 
-      fiber_executor.create_future { |_| return 0 }
+      fiber_executor.create_future(plan_id: plan_id) { |_| return 0 }
     end
 
     it "creates a new PlanFuture object with a name" do
       expect(Bolt::PlanFuture).to receive(:new)
-        .with(instance_of(Fiber), instance_of(Integer), 'name')
+        .with(instance_of(Fiber), instance_of(Integer), name: 'name', plan_id: plan_id)
         .and_call_original
-      fiber_executor.create_future(name: 'name') { |_| return 0 }
+      fiber_executor.create_future(name: 'name', plan_id: plan_id) { |_| return 0 }
     end
 
     it "adds the PlanFuture to the list of futures" do
-      fiber_executor.create_future { |_| return 0 }
-      expect(fiber_executor.plan_futures.length).to eq(1)
-      expect(fiber_executor.plan_futures[0].class).to eq(Bolt::PlanFuture)
+      fiber_executor.create_future(plan_id: plan_id) { |_| return 0 }
+      expect(fiber_executor.active_futures.length).to eq(1)
+      expect(fiber_executor.active_futures[0].class).to eq(Bolt::PlanFuture)
     end
   end
 
   describe "#round_robin" do
     before :each do
       @futures = %w[lion tiger bear].map do |val|
-        fiber_executor.create_future do
+        fiber_executor.create_future(plan_id: plan_id) do
           sleep(rand(0.01..0.1))
           val + 's'
         end
@@ -73,12 +74,12 @@ describe "Bolt::FiberExecutor" do
       @futures.each do |future|
         # Return true once, then return false as many times as it's called
         allow(future).to receive(:alive?).and_return(true, false)
-        expect(fiber_executor.plan_futures).to receive(:delete)
+        expect(fiber_executor.active_futures).to receive(:delete)
           .with(future).and_call_original
       end
 
       fiber_executor.round_robin until fiber_executor.plan_complete?
-      expect(fiber_executor.plan_futures).to eq([])
+      expect(fiber_executor.active_futures).to eq([])
     end
 
     it "sleeps if all futures returned immediately" do
@@ -90,6 +91,92 @@ describe "Bolt::FiberExecutor" do
 
       expect(fiber_executor).to receive(:sleep)
       fiber_executor.round_robin until fiber_executor.plan_complete?
+    end
+  end
+
+  describe "#wait" do
+    context "when passed 'nil' futures" do
+      before :each do
+        h = { 'lion' => 2, 'tiger' => 2, 'bear' => 3 }
+        @futures = h.map do |val, p_id|
+          dbl = double("future_#{val}", value: val + 's', original_plan: p_id, fiber: nil)
+          allow(dbl).to receive(:alive?).and_return(true, false)
+          dbl
+        end
+        allow(fiber_executor).to receive(:all_futures).and_return(@futures)
+        allow(fiber_executor).to receive(:wait).and_call_original
+      end
+
+      it "waits for all futures from the current plan invocation" do
+        # Mock the plan ID
+        expect(fiber_executor).to receive(:get_current_plan_id).and_return(2)
+
+        # The actual thing we're testing - mock return to avoid yielding from
+        # the root Fiber.
+        expect(fiber_executor).to receive(:wait)
+          .with(@futures[0..1], timeout: nil, catch_errors: false)
+
+        fiber_executor.wait(nil)
+      end
+
+      it "returns results from all futures" do
+        expect(fiber_executor).to receive(:get_current_plan_id).and_return(2)
+        expect(fiber_executor.wait(nil)).to eq(%w[lions tigers])
+      end
+
+      it "continues getting futures until all futures have finished" do
+        # Mock the plan ID
+        expect(fiber_executor).to receive(:get_current_plan_id).and_return(2)
+
+        # Assert that this loops
+        expect(fiber_executor).to receive(:get_futures_for_plan)
+          .with(plan_id: 2).twice
+          .and_call_original
+
+        fiber_executor.wait(nil)
+      end
+    end
+
+    context "when passed a timeout" do
+      before :each do
+        @futures = %w[lion tiger bear].map do |val|
+          name = "future_#{val}"
+          error = Bolt::FutureTimeoutError.new(name, timeout)
+          double(name, alive?: true, value: error, name: name)
+        end
+        allow(Fiber).to receive(:yield)
+      end
+      let(:timeout) { 0.1 }
+
+      it "raises an error if any Futures exceed the timeout without catch_errors" do
+        @futures.each do |f|
+          # This is a little backwards since calling 'raise' should set the
+          # value, not vice-versa, but it doesn't particularly matter for unit
+          # testing.
+          expect(f).to receive(:raise).with(f.value)
+        end
+
+        expect { fiber_executor.wait(@futures, timeout: timeout) }
+          .to raise_error(Bolt::ParallelFailure, /parallel block failed on 3 targets/)
+      end
+    end
+
+    context "when futures error" do
+      before :each do
+        @futures = %w[lion tiger bear].map do |val|
+          name = "future_#{val}"
+          error = Bolt::Error.new("Error", 'bolt/test-error')
+          # Don't bother loading Puppet datatypes
+          allow(error).to receive(:to_puppet_error).and_return(error)
+          double(name, alive?: false, value: error, name: name)
+        end
+      end
+
+      it "returns the result set if catch_errors is true" do
+        expect { fiber_executor.wait(@futures, catch_errors: true) }.not_to raise_error
+        expect(fiber_executor.wait(@futures, catch_errors: true))
+          .to eq(@futures.map(&:value))
+      end
     end
   end
 end

--- a/spec/bolt/plan_future_spec.rb
+++ b/spec/bolt/plan_future_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'bolt/plan_future'
 
 describe Bolt::PlanFuture do
-  let(:future) { Bolt::PlanFuture.new(fiber, 'Test future') }
+  let(:future) { Bolt::PlanFuture.new(fiber, 'Test future', plan_id: 1234) }
   let(:fiber) { double('fiber', alive?: true) }
 
   describe :resume do

--- a/spec/fixtures/parallel/wait/plans/no_future/basic.pp
+++ b/spec/fixtures/parallel/wait/plans/no_future/basic.pp
@@ -1,0 +1,23 @@
+# @summary
+#   Test plan to verify the wait() function behavior when not passed Futures
+plan wait::no_future::basic(
+  TargetSpec $targets
+) {
+  # Create futures
+  $msgs = ["Run immediately", "Who's on first", "What's on second", "I don't know's on third"]
+  $msgs.each |$msg| {
+    background($msg) || {
+      if $msg =~ /Run immediately/ {
+          return $msg
+      } else {
+        # Include a sleep to ensure that this does some "work" before returning
+        run_command("sleep 0.1", $targets)
+        return $msg
+      }
+    }
+  }
+  # Give the first Future a chance to run
+  run_command('hostname', $targets)
+  # Wait for messages
+  return wait()
+}

--- a/spec/fixtures/parallel/wait/plans/no_future/infinite_loop.pp
+++ b/spec/fixtures/parallel/wait/plans/no_future/infinite_loop.pp
@@ -1,0 +1,5 @@
+plan wait::no_future::infinite_loop() {
+  background("infinite loop") || {
+    wait()
+  }
+}

--- a/spec/fixtures/parallel/wait/plans/no_future/inner_bg.pp
+++ b/spec/fixtures/parallel/wait/plans/no_future/inner_bg.pp
@@ -1,0 +1,9 @@
+plan wait::no_future::inner_bg() {
+  background() || {
+    background() || {
+      return "Thing 2"
+    }
+    return "Thing 1"
+  }
+  return wait()
+}

--- a/spec/fixtures/parallel/wait/plans/no_future/multiple_calls.pp
+++ b/spec/fixtures/parallel/wait/plans/no_future/multiple_calls.pp
@@ -1,0 +1,6 @@
+plan wait::no_future::multiple_calls (
+  TargetSpec $targets
+) {
+  $first = run_plan('wait::no_future::subplan', $targets)
+  $second = run_plan('wait::no_future::subplan', $target)
+}

--- a/spec/fixtures/parallel/wait/plans/no_future/subplan.pp
+++ b/spec/fixtures/parallel/wait/plans/no_future/subplan.pp
@@ -1,0 +1,10 @@
+plan wait::no_future::subplan(
+  TargetSpec $targets
+) {
+  background("subplan background") || {
+    run_plan("wait::no_future::basic", $targets)
+    return "Just a subplan, hold the mustard"
+  }
+  run_plan("wait::no_future::basic", $targets)
+  return wait()
+}

--- a/spec/integration/private_plan_spec.rb
+++ b/spec/integration/private_plan_spec.rb
@@ -54,54 +54,6 @@ describe "with private plans" do
         run_cli(%w[plan show] + config_flags)
         expect(original_mtime).to eq(File.mtime(project.plan_cache_file))
       end
-
-      context 'with a local plan' do
-        let(:plan_path) { File.join(project.plans_path, 'yaml.yaml') }
-
-        before :each do
-          FileUtils.mkdir_p(project.plans_path)
-          FileUtils.touch(plan_path)
-        end
-
-        it 'updates the cache for local plans if modified' do
-          File.write(plan_path, yaml_plan.to_yaml)
-          run_cli(%w[module generate-types] + config_flags)
-          original_mtime = File.mtime(project.plan_cache_file)
-
-          yaml_plan['private'] = false
-          File.write(plan_path, yaml_plan.to_yaml)
-          run_cli(%w[plan show] + config_flags)
-          expect(original_mtime).not_to eq(File.mtime(project.plan_cache_file))
-        end
-      end
-
-      context 'with a downloaded plan' do
-        let(:config_flags) { %W[--project #{@root}] }
-        let(:plan_path) { File.join(@plans_dir, 'yaml.yaml') }
-        let(:cache_file) { File.join(@root, '.plan_cache.json') }
-
-        around :each do |example|
-          Dir.mktmpdir(nil, Dir.pwd) do |root|
-            @root = root
-            @plans_dir = File.join(root, 'modules', 'mymodule', 'plans')
-            FileUtils.mkdir_p(@plans_dir)
-            example.run
-          end
-        end
-
-        it 'does not update the cache if downloaded plans are modified' do
-          FileUtils.touch(plan_path)
-          File.write(plan_path, yaml_plan.to_yaml)
-          run_cli(%w[module generate-types] + config_flags)
-          original_mtime = File.mtime(cache_file)
-
-          yaml_plan['private'] = false
-          File.write(plan_path, yaml_plan.to_yaml)
-
-          run_cli(%w[plan show] + config_flags)
-          expect(original_mtime).not_to eq(File.mtime(cache_file))
-        end
-      end
     end
   end
 


### PR DESCRIPTION
This amends the `wait()` plan function to wait on all the Futures that
were spawned from the same plan as the `wait()` call if the function is
not provided a list of futures. The function still accepts a `timeout`
or `options` parameter if it is not passed any futures. To support this,
Bolt's `PlanFuture` object now has a `plan_id` attribute, which
determines which **invocation** of a plan the Future was created from
(since the same plan can be invoked multiple times in parallel). When
`wait()` is called without Futures, it selects the Futures from the
FiberExecutor with a matching `plan_id` to itself, and waits on those.

    
This also removes a flaky test around whether the cache file is updated
when plans in modules are modified. The test doesn't seem to be failing
legitimately based on local testing.

- [ ] puppetlabs/orchestrator#1738
- [ ] puppetlabs/pe-bolt-modules#20

!feature

* **`wait()` without arguments waits on all Futures from plan** ([#2877](https://github.com/puppetlabs/bolt/issues/2877))

  Calling the `wait()` plan function without a list of Futures will now
  wait on all Futures created so far in the plan.