### PR TITLE
(GH-2863) Stacktrace when plan throws error

### DIFF
--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -174,11 +174,22 @@ module Bolt
           if result.message?
             @stream.puts(remove_trail(indent(2, result.message)))
           end
-
           case result.action
           when 'command', 'script'
             safe_value = result.safe_value
-            @stream.puts(indent(2, safe_value['merged_output'])) unless safe_value['merged_output'].strip.empty?
+            if safe_value["merged_output"]
+              @stream.puts(indent(2, safe_value['merged_output'])) unless safe_value['merged_output'].strip.empty?
+
+            else # output stdout or stderr
+              unless safe_value['stdout'].nil? || safe_value['stdout'].strip.empty?
+                @stream.puts(indent(2, "STDOUT:"))
+                @stream.puts(indent(4, safe_value['stdout']))
+              end
+              unless safe_value['stderr'].nil? || safe_value['stderr'].strip.empty?
+                @stream.puts(indent(2, "STDERR:"))
+                @stream.puts(indent(4, safe_value['stderr']))
+              end
+            end
           when 'lookup'
             @stream.puts(indent(2, result['value']))
           else

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -255,6 +255,19 @@ describe "Bolt::Outputter::Human" do
     expect(output.string).to match(/Finished on #{target}.*value/m)
   end
 
+  it "doesn't stacktrace when merged_output is nil" do
+    value = {
+      'stdout'        => 'stdout',
+      'stderr'        => 'stderr',
+      'merged_output' => nil,
+      'exit_code'     => 2
+    }
+    expect {
+      outputter.print_result(Bolt::Result.for_command(target, value, 'command', "executed", []))
+    }.not_to raise_error
+    expect(output.string).to match(/stdout.*stderr/m)
+  end
+
   it "prints empty results from a plan" do
     outputter.print_plan_result(Bolt::PlanResult.new([], 'success'))
     expect(output.string).to eq("[\n\n]\n")


### PR DESCRIPTION
This resolves a bug where previously, Bolt raised a stack trace when merged_output is nil due to the command or script having raised an error.

!bug

* Bolt no longer raises stack trace with plan error (#2863)