### PR TITLE
(maint) Pass required param to r10k Puppetfile installer

### DIFF
--- a/lib/bolt/module_installer/installer.rb
+++ b/lib/bolt/module_installer/installer.rb
@@ -30,7 +30,7 @@ module Bolt
 
         settings = R10K::Settings.global_settings.evaluate(@config)
         R10K::Initializers::GlobalInitializer.new(settings).call
-        install_action = R10K::Action::Puppetfile::Install.new(r10k_opts, nil)
+        install_action = R10K::Action::Puppetfile::Install.new(r10k_opts, nil, {})
 
         # Override the r10k logger with a proxy to our own logger
         R10K::Logging.instance_variable_set(:@outputter, Bolt::R10KLogProxy.new)

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -2416,7 +2416,7 @@ describe "Bolt::CLI" do
         expect(R10K::Action::Puppetfile::Install).to receive(:new)
           .with({ root: File.dirname(puppetfile),
                   puppetfile: puppetfile.to_s,
-                  moduledir: project.managed_moduledir.to_s }, nil)
+                  moduledir: project.managed_moduledir.to_s }, nil, {})
 
         allow(action_stub).to receive(:call).and_return(true)
 


### PR DESCRIPTION
Starting in r10k 3.9.1, the `R10K::Action::Puppetfile::Install` class
requires a third parameter. Previously, this third parameter was
optional and Bolt did not pass it, which caused tests to start failing
once it was required.

!no-release-note