### PR TITLE
(GH-2855) Document installing Bolt for macOS 11

### DIFF
--- a/documentation/bolt_installing.md
+++ b/documentation/bolt_installing.md
@@ -11,7 +11,7 @@ and Microsoft Windows.
 | ------------------------- | ------------------- |
 | Debian                    | 9, 10               |
 | Fedora                    | 30, 31, 32          |
-| macOS                     | 10.14, 10.15        |
+| macOS                     | 10.14, 10.15, 11    |
 | Microsoft Windows*        | 10 Enterprise       |
 | Microsoft Windows Server* | 2012R2, 2019        |
 | RHEL                      | 6, 7, 8             |
@@ -157,6 +157,7 @@ Use the Apple Disk Image (DMG) to install Bolt on macOS:
 
    - [10.14 (Mojave)](https://downloads.puppet.com/mac/puppet-tools/10.14/x86_64/puppet-bolt-latest.dmg)
    - [10.15 (Catalina)](https://downloads.puppet.com/mac/puppet-tools/10.15/x86_64/puppet-bolt-latest.dmg)
+   - [11 (Big Sur)](https://downloads.puppet.com/mac/puppet-tools/11/x86_64/puppet-bolt-latest.dmg)
 
 1. Double-click the `puppet-bolt-latest.dmg` file to mount the installer and
    then double-click `puppet-bolt-[version]-installer.pkg` to run the installer.


### PR DESCRIPTION
This adds documentation for installing Bolt on macOS 11.

!feature

* **macOS 11 packages**
  ([#2855](https://github.com/puppetlabs/bolt/issues/2855))

  Bolt now ships packages for macOS 11 (Big Sur).