### PR TITLE
(maint) Escape "[--noop]" in outputter test

### DIFF
--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -170,7 +170,7 @@ describe "Bolt::Outputter::Human" do
     option = (Bolt::Util.powershell? ? '[-Noop]' : '[--noop]')
 
     outputter.print_task_info(Bolt::Task.new(name, metadata, files))
-    expect(output.string).to match(/#{option}/)
+    expect(output.string).to match(Regexp.escape(option))
   end
 
   it 'prints modulepath as builtin for builtin modules' do


### PR DESCRIPTION
This escapes the "[--noop]" string when matching output in a test for
`bolt task show`. Previously, the string was unescaped and resulted in
Ruby printing a warning.

!no-release-note