### PR TITLE
(maint) Bump puppet_agent module to 4.8.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,7 +6,7 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '2.0.0'
-mod 'puppetlabs-puppet_agent', '4.7.0'
+mod 'puppetlabs-puppet_agent', '4.8.0'
 mod 'puppetlabs-facts', '1.4.0'
 
 # Core types and providers for Puppet 6


### PR DESCRIPTION
This bumps the `puppet_agent` module to 4.8.0.

!feature

* **Support macOS 11 in `puppet_agent::install task**

  The `puppet_agent::install` task now supports installing the
  puppet-agent package on macOS 11.