### PR TITLE
(GH-2886) Update `bolt guide` human output

### DIFF
--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -462,9 +462,11 @@ module Bolt
       end
 
       def print_topics(topics)
-        print_message("Available topics are:")
-        print_message(topics.join("\n"))
-        print_message("\nUse 'bolt guide <TOPIC>' to view a specific guide.")
+        info = +"#{colorize(:cyan, 'Topics')}\n"
+        info << indent(2, topics.join("\n"))
+        info << "\n\n#{colorize(:cyan, 'Additional information')}\n"
+        info << indent(2, "Use 'bolt guide <TOPIC>' to view a specific guide.")
+        @stream.puts info
       end
 
       def print_guide(guide, _topic)

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -372,12 +372,13 @@ describe "Bolt::Outputter::Human" do
   it 'prints a list of guide topics' do
     outputter.print_topics(%w[apple banana carrot])
     expect(output.string).to eq(<<~OUTPUT)
-      Available topics are:
-      apple
-      banana
-      carrot
+      Topics
+        apple
+        banana
+        carrot
 
-      Use 'bolt guide <TOPIC>' to view a specific guide.
+      Additional information
+        Use 'bolt guide <TOPIC>' to view a specific guide.
     OUTPUT
   end
 


### PR DESCRIPTION
This updates the human output for the `bolt guide` command to use a
similar format to the `show` commands.

!no-release-note