### PR TITLE
(GH-2873) Disable 'exported resources' warning from Puppet

### DIFF
--- a/spec/fixtures/apply/basic/manifests/exported_resources.pp
+++ b/spec/fixtures/apply/basic/manifests/exported_resources.pp
@@ -1,0 +1,7 @@
+class basic::exported_resources() {
+  @@file { 'helloworld.txt':
+    content => 'hello world',
+  }
+
+  File <<| |>>
+}

--- a/spec/fixtures/apply/basic/plans/exported_resources.pp
+++ b/spec/fixtures/apply/basic/plans/exported_resources.pp
@@ -1,0 +1,7 @@
+plan basic::exported_resources (
+  TargetSpec $targets
+) {
+  apply($targets) {
+    include 'basic::exported_resources'
+  }
+}

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -61,6 +61,14 @@ describe 'apply', expensive: true do
         expect(result.dig('value', 'report', 'resource_statuses')).to include(/Notify\[Hello .*\]/)
       end
     end
+
+    it 'warns about exported resources with an ID' do
+      allow(Bolt::Logger).to receive(:warn)
+      expect(Bolt::Logger).to receive(:warn).with('exported_resources', /the export is ignored/).at_least(:once)
+      expect(Bolt::Logger).to receive(:warn).with('exported_resources',
+                                                  /the collection will be ignored/).at_least(:once)
+      run_cli_json(%W[plan run basic::exported_resources -t #{targets}], project: project)
+    end
   end
 
   describe 'over ssh', ssh: true do


### PR DESCRIPTION
This adds an ID to 'exported resources' warnings that come from Puppet
when applying a manifest that creates an exported resource or collects
exported resources. This allows these warnings to be disabled by listing
the ID under the `disable-warnings` config option.

!feature

* **Disable 'exported resources' warnings from Puppet**
  ([#2889](https://github.com/puppetlabs/bolt/issues/2889))

  Warnings logged by Puppet when declaring or collecting exported
  resources in a manifest can now be disabled. To disable these warnings
  add the `exported_resources` ID under the `disable-warnings`
  configuration option.