### PR TITLE
(GH-2899) Add built-in log module

### DIFF
--- a/bolt-modules/log/Rakefile
+++ b/bolt-modules/log/Rakefile
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'puppetlabs_spec_helper/rake_tasks'

--- a/bolt-modules/log/lib/puppet/functions/log/debug.rb
+++ b/bolt-modules/log/lib/puppet/functions/log/debug.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Log a debugging message.
+#
+# Messages logged at this level typically include detailed information about
+# what a plan is doing. For example, you might log a message at the `debug`
+# level that shows what value is returned from a function invocation.
+#
+# See [Logs](logs.md) for more information about Bolt's log levels.
+#
+# > **Note:** Not available in apply block
+Puppet::Functions.create_function(:'log::debug') do
+  # Log a debugging message.
+  # @param message The message to log.
+  # @example Log a debugging message
+  #   log::trace("Function frogsay returned: ${result}")
+  dispatch :log_debug do
+    param 'Any', :message
+    return_type 'Undef'
+  end
+
+  def log_debug(message)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING,
+        action: 'log::debug'
+      )
+    end
+
+    Puppet.lookup(:bolt_executor).tap do |executor|
+      executor.report_function_call(self.class.name)
+      executor.publish_event(type: :log, level: :debug, message: message)
+    end
+
+    nil
+  end
+end

--- a/bolt-modules/log/lib/puppet/functions/log/debug.rb
+++ b/bolt-modules/log/lib/puppet/functions/log/debug.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bolt/util/format'
+
 # Log a debugging message.
 #
 # Messages logged at this level typically include detailed information about
@@ -13,7 +15,7 @@ Puppet::Functions.create_function(:'log::debug') do
   # Log a debugging message.
   # @param message The message to log.
   # @example Log a debugging message
-  #   log::trace("Function frogsay returned: ${result}")
+  #   log::debug("Function frogsay returned: ${result}")
   dispatch :log_debug do
     param 'Any', :message
     return_type 'Undef'
@@ -29,7 +31,7 @@ Puppet::Functions.create_function(:'log::debug') do
 
     Puppet.lookup(:bolt_executor).tap do |executor|
       executor.report_function_call(self.class.name)
-      executor.publish_event(type: :log, level: :debug, message: message)
+      executor.publish_event(type: :log, level: :debug, message: Bolt::Util::Format.stringify(message))
     end
 
     nil

--- a/bolt-modules/log/lib/puppet/functions/log/error.rb
+++ b/bolt-modules/log/lib/puppet/functions/log/error.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bolt/util/format'
+
 # Log an error message.
 #
 # Messages logged at this level typically indicate that the plan encountered an
@@ -30,7 +32,7 @@ Puppet::Functions.create_function(:'log::error') do
 
     Puppet.lookup(:bolt_executor).tap do |executor|
       executor.report_function_call(self.class.name)
-      executor.publish_event(type: :log, level: :error, message: message)
+      executor.publish_event(type: :log, level: :error, message: Bolt::Util::Format.stringify(message))
     end
 
     nil

--- a/bolt-modules/log/lib/puppet/functions/log/error.rb
+++ b/bolt-modules/log/lib/puppet/functions/log/error.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Log an error message.
+#
+# Messages logged at this level typically indicate that the plan encountered an
+# error that can be recovered from. For example, you might log a message at the
+# `error` level if you want to inform the user an action running on a target
+# failed but that the plan will continue running.
+#
+# See [Logs](logs.md) for more information about Bolt's log levels.
+#
+# > **Note:** Not available in apply block
+Puppet::Functions.create_function(:'log::error') do
+  # Log an error message.
+  # @param message The message to log.
+  # @example Log an error message
+  #   log::error("The HTTP request returned an error, continuing the plan: ${result}")
+  dispatch :log_error do
+    param 'Any', :message
+    return_type 'Undef'
+  end
+
+  def log_error(message)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING,
+        action: 'log::error'
+      )
+    end
+
+    Puppet.lookup(:bolt_executor).tap do |executor|
+      executor.report_function_call(self.class.name)
+      executor.publish_event(type: :log, level: :error, message: message)
+    end
+
+    nil
+  end
+end

--- a/bolt-modules/log/lib/puppet/functions/log/fatal.rb
+++ b/bolt-modules/log/lib/puppet/functions/log/fatal.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bolt/util/format'
+
 # Log a fatal message.
 #
 # Messages logged at this level indicate that the plan encountered an error that
@@ -30,7 +32,7 @@ Puppet::Functions.create_function(:'log::fatal') do
 
     Puppet.lookup(:bolt_executor).tap do |executor|
       executor.report_function_call(self.class.name)
-      executor.publish_event(type: :log, level: :fatal, message: message)
+      executor.publish_event(type: :log, level: :fatal, message: Bolt::Util::Format.stringify(message))
     end
 
     nil

--- a/bolt-modules/log/lib/puppet/functions/log/fatal.rb
+++ b/bolt-modules/log/lib/puppet/functions/log/fatal.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Log a fatal message.
+#
+# Messages logged at this level indicate that the plan encountered an error that
+# could not be recovered from. For example, you might log a message at the
+# `fatal` level if a service is unavailable and the plan cannot continue running
+# without it.
+#
+# See [Logs](logs.md) for more information about Bolt's log levels.
+#
+# > **Note:** Not available in apply block
+Puppet::Functions.create_function(:'log::fatal') do
+  # Log a fatal message.
+  # @param message The message to log.
+  # @example Log a fatal message
+  #   log::fatal("The service is unavailable, unable to continue running: ${result}")
+  dispatch :log_fatal do
+    param 'Any', :message
+    return_type 'Undef'
+  end
+
+  def log_fatal(message)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING,
+        action: 'log::fatal'
+      )
+    end
+
+    Puppet.lookup(:bolt_executor).tap do |executor|
+      executor.report_function_call(self.class.name)
+      executor.publish_event(type: :log, level: :fatal, message: message)
+    end
+
+    nil
+  end
+end

--- a/bolt-modules/log/lib/puppet/functions/log/info.rb
+++ b/bolt-modules/log/lib/puppet/functions/log/info.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bolt/util/format'
+
 # Log an info message.
 #
 # Messages logged at this level typically include high-level information about
@@ -29,7 +31,7 @@ Puppet::Functions.create_function(:'log::info') do
 
     Puppet.lookup(:bolt_executor).tap do |executor|
       executor.report_function_call(self.class.name)
-      executor.publish_event(type: :log, level: :info, message: message)
+      executor.publish_event(type: :log, level: :info, message: Bolt::Util::Format.stringify(message))
     end
 
     nil

--- a/bolt-modules/log/lib/puppet/functions/log/info.rb
+++ b/bolt-modules/log/lib/puppet/functions/log/info.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Log an info message.
+#
+# Messages logged at this level typically include high-level information about
+# what a plan is doing. For example, you might log a message at the `info` level
+# that informs users that the plan is reading a file on disk.
+#
+# See [Logs](logs.md) for more information about Bolt's log levels.
+#
+# > **Note:** Not available in apply block
+Puppet::Functions.create_function(:'log::info') do
+  # Log an info message.
+  # @param message The message to log.
+  # @example Log an info message
+  #   log::info("Reading network device command file ${file}.")
+  dispatch :log_info do
+    param 'Any', :message
+    return_type 'Undef'
+  end
+
+  def log_info(message)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING,
+        action: 'log::info'
+      )
+    end
+
+    Puppet.lookup(:bolt_executor).tap do |executor|
+      executor.report_function_call(self.class.name)
+      executor.publish_event(type: :log, level: :info, message: message)
+    end
+
+    nil
+  end
+end

--- a/bolt-modules/log/lib/puppet/functions/log/trace.rb
+++ b/bolt-modules/log/lib/puppet/functions/log/trace.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Log a trace message.
+#
+# Messages logged at this level typically include the most detailed information
+# about what a plan is doing. For example, you might log a message at the `trace`
+# level that describes how a plan is manipulating data.
+#
+# See [Logs](logs.md) for more information about Bolt's log levels.
+#
+# > **Note:** Not available in apply block
+Puppet::Functions.create_function(:'log::trace') do
+  # Log a trace message.
+  # @param message The message to log.
+  # @example Log a trace message
+  #   log::trace("Creating Target object with data ${data} from file ${file}")
+  dispatch :log_trace do
+    param 'Any', :message
+    return_type 'Undef'
+  end
+
+  def log_trace(message)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING,
+        action: 'log::trace'
+      )
+    end
+
+    Puppet.lookup(:bolt_executor).tap do |executor|
+      executor.report_function_call(self.class.name)
+      executor.publish_event(type: :log, level: :trace, message: message)
+    end
+
+    nil
+  end
+end

--- a/bolt-modules/log/lib/puppet/functions/log/trace.rb
+++ b/bolt-modules/log/lib/puppet/functions/log/trace.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bolt/util/format'
+
 # Log a trace message.
 #
 # Messages logged at this level typically include the most detailed information
@@ -29,7 +31,7 @@ Puppet::Functions.create_function(:'log::trace') do
 
     Puppet.lookup(:bolt_executor).tap do |executor|
       executor.report_function_call(self.class.name)
-      executor.publish_event(type: :log, level: :trace, message: message)
+      executor.publish_event(type: :log, level: :trace, message: Bolt::Util::Format.stringify(message))
     end
 
     nil

--- a/bolt-modules/log/lib/puppet/functions/log/warn.rb
+++ b/bolt-modules/log/lib/puppet/functions/log/warn.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bolt/util/format'
+
 # Log a warning message.
 #
 # Messages logged at this level typically include messages about deprecated
@@ -31,7 +33,7 @@ Puppet::Functions.create_function(:'log::warn') do
 
     Puppet.lookup(:bolt_executor).tap do |executor|
       executor.report_function_call(self.class.name)
-      executor.publish_event(type: :log, level: :warn, message: message)
+      executor.publish_event(type: :log, level: :warn, message: Bolt::Util::Format.stringify(message))
     end
 
     nil

--- a/bolt-modules/log/lib/puppet/functions/log/warn.rb
+++ b/bolt-modules/log/lib/puppet/functions/log/warn.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Log a warning message.
+#
+# Messages logged at this level typically include messages about deprecated
+# behavior or potentially harmful situations that might affect the plan run.
+# For example, you might log a message at the `warn` level if you are
+# planning to make a breaking change to your plan in a future release and
+# want to notify users.
+#
+# See [Logs](logs.md) for more information about Bolt's log levels.
+#
+# > **Note:** Not available in apply block
+Puppet::Functions.create_function(:'log::warn') do
+  # Log a warning message.
+  # @param message The message to log.
+  # @example Log a warning message
+  #   log::warn('This plan will no longer install the package in a future release.')
+  dispatch :log_warn do
+    param 'Any', :message
+    return_type 'Undef'
+  end
+
+  def log_warn(message)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
+        Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING,
+        action: 'log::warn'
+      )
+    end
+
+    Puppet.lookup(:bolt_executor).tap do |executor|
+      executor.report_function_call(self.class.name)
+      executor.publish_event(type: :log, level: :warn, message: message)
+    end
+
+    nil
+  end
+end

--- a/bolt-modules/log/spec/functions/log/debug_spec.rb
+++ b/bolt-modules/log/spec/functions/log/debug_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'log::debug' do
+  let(:executor)      { stub('executor', report_function_call: nil, publish_event: nil) }
+  let(:tasks_enabled) { true }
+
+  around(:each) do |example|
+    Puppet[:tasks] = tasks_enabled
+
+    Puppet.override(bolt_executor: executor) do
+      example.run
+    end
+  end
+
+  it 'sends a log event to the executor' do
+    executor.expects(:publish_event).with(
+      type:    :log,
+      level:   :debug,
+      message: 'This is a debug message'
+    )
+
+    is_expected.to run.with_params('This is a debug message')
+  end
+
+  it 'reports function call to analytics' do
+    executor.expects(:report_function_call).with('log::debug')
+    is_expected.to run.with_params('This is a debug message')
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+
+    it 'fails and reports that log::debug is not available' do
+      is_expected.to run.with_params('This is a debug message')
+                        .and_raise_error(/Plan language function 'log::debug' cannot be used/)
+    end
+  end
+end

--- a/bolt-modules/log/spec/functions/log/error_spec.rb
+++ b/bolt-modules/log/spec/functions/log/error_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'log::error' do
+  let(:executor)      { stub('executor', report_function_call: nil, publish_event: nil) }
+  let(:tasks_enabled) { true }
+
+  around(:each) do |example|
+    Puppet[:tasks] = tasks_enabled
+
+    Puppet.override(bolt_executor: executor) do
+      example.run
+    end
+  end
+
+  it 'sends a log event to the executor' do
+    executor.expects(:publish_event).with(
+      type:    :log,
+      level:   :error,
+      message: 'This is an error message'
+    )
+
+    is_expected.to run.with_params('This is an error message')
+  end
+
+  it 'reports function call to analytics' do
+    executor.expects(:report_function_call).with('log::error')
+    is_expected.to run.with_params('This is an error message')
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+
+    it 'fails and reports that log::error is not available' do
+      is_expected.to run.with_params('This is an error message')
+                        .and_raise_error(/Plan language function 'log::error' cannot be used/)
+    end
+  end
+end

--- a/bolt-modules/log/spec/functions/log/fatal_spec.rb
+++ b/bolt-modules/log/spec/functions/log/fatal_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'log::fatal' do
+  let(:executor)      { stub('executor', report_function_call: nil, publish_event: nil) }
+  let(:tasks_enabled) { true }
+
+  around(:each) do |example|
+    Puppet[:tasks] = tasks_enabled
+
+    Puppet.override(bolt_executor: executor) do
+      example.run
+    end
+  end
+
+  it 'sends a log event to the executor' do
+    executor.expects(:publish_event).with(
+      type:    :log,
+      level:   :fatal,
+      message: 'This is a fatal message'
+    )
+
+    is_expected.to run.with_params('This is a fatal message')
+  end
+
+  it 'reports function call to analytics' do
+    executor.expects(:report_function_call).with('log::fatal')
+    is_expected.to run.with_params('This is a fatal message')
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+
+    it 'fails and reports that log::fatal is not available' do
+      is_expected.to run.with_params('This is a fatal message')
+                        .and_raise_error(/Plan language function 'log::fatal' cannot be used/)
+    end
+  end
+end

--- a/bolt-modules/log/spec/functions/log/info_spec.rb
+++ b/bolt-modules/log/spec/functions/log/info_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'log::info' do
+  let(:executor)      { stub('executor', report_function_call: nil, publish_event: nil) }
+  let(:tasks_enabled) { true }
+
+  around(:each) do |example|
+    Puppet[:tasks] = tasks_enabled
+
+    Puppet.override(bolt_executor: executor) do
+      example.run
+    end
+  end
+
+  it 'sends a log event to the executor' do
+    executor.expects(:publish_event).with(
+      type:    :log,
+      level:   :info,
+      message: 'This is an info message'
+    )
+
+    is_expected.to run.with_params('This is an info message')
+  end
+
+  it 'reports function call to analytics' do
+    executor.expects(:report_function_call).with('log::info')
+    is_expected.to run.with_params('This is an info message')
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+
+    it 'fails and reports that log::info is not available' do
+      is_expected.to run.with_params('This is an info message')
+                        .and_raise_error(/Plan language function 'log::info' cannot be used/)
+    end
+  end
+end

--- a/bolt-modules/log/spec/functions/log/trace_spec.rb
+++ b/bolt-modules/log/spec/functions/log/trace_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'log::trace' do
+  let(:executor)      { stub('executor', report_function_call: nil, publish_event: nil) }
+  let(:tasks_enabled) { true }
+
+  around(:each) do |example|
+    Puppet[:tasks] = tasks_enabled
+
+    Puppet.override(bolt_executor: executor) do
+      example.run
+    end
+  end
+
+  it 'sends a log event to the executor' do
+    executor.expects(:publish_event).with(
+      type:    :log,
+      level:   :trace,
+      message: 'This is a trace message'
+    )
+
+    is_expected.to run.with_params('This is a trace message')
+  end
+
+  it 'reports function call to analytics' do
+    executor.expects(:report_function_call).with('log::trace')
+    is_expected.to run.with_params('This is a trace message')
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+
+    it 'fails and reports that log::trace is not available' do
+      is_expected.to run.with_params('This is a trace message')
+                        .and_raise_error(/Plan language function 'log::trace' cannot be used/)
+    end
+  end
+end

--- a/bolt-modules/log/spec/functions/log/warn_spec.rb
+++ b/bolt-modules/log/spec/functions/log/warn_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'log::warn' do
+  let(:executor)      { stub('executor', report_function_call: nil, publish_event: nil) }
+  let(:tasks_enabled) { true }
+
+  around(:each) do |example|
+    Puppet[:tasks] = tasks_enabled
+
+    Puppet.override(bolt_executor: executor) do
+      example.run
+    end
+  end
+
+  it 'sends a log event to the executor' do
+    executor.expects(:publish_event).with(
+      type:    :log,
+      level:   :warn,
+      message: 'This is a warn message'
+    )
+
+    is_expected.to run.with_params('This is a warn message')
+  end
+
+  it 'reports function call to analytics' do
+    executor.expects(:report_function_call).with('log::warn')
+    is_expected.to run.with_params('This is a warn message')
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+
+    it 'fails and reports that log::warn is not available' do
+      is_expected.to run.with_params('This is a warn message')
+                        .and_raise_error(/Plan language function 'log::warn' cannot be used/)
+    end
+  end
+end

--- a/bolt-modules/log/spec/spec_helper.rb
+++ b/bolt-modules/log/spec/spec_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'puppet_pal'
+require 'bolt/pal'
+
+# Ensure tasks are enabled when rspec-puppet sets up an environment
+# so we get task loaders.
+Puppet[:tasks] = true
+Bolt::PAL.load_puppet
+RSpec.configure do |c|
+  c.mock_with :mocha
+end
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/bolt-modules/out/lib/puppet/functions/out/message.rb
+++ b/bolt-modules/out/lib/puppet/functions/out/message.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bolt/util/format'
+
 # Output a message for the user.
 #
 # This will print a message to stdout when using the human output format,
@@ -22,55 +24,11 @@ Puppet::Functions.create_function(:'out::message') do
         .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'out::message')
     end
 
-    executor = Puppet.lookup(:bolt_executor)
-    # Send Analytics Report
-    executor.report_function_call(self.class.name)
-
-    executor.publish_event(type: :message, message: stringify(message))
+    Puppet.lookup(:bolt_executor).tap do |executor|
+      executor.report_function_call(self.class.name)
+      executor.publish_event(type: :message, message: Bolt::Util::Format.stringify(message))
+    end
 
     nil
-  end
-
-  def stringify(message)
-    formatted = format_message(message)
-    if formatted.is_a?(Hash) || formatted.is_a?(Array)
-      ::JSON.pretty_generate(formatted)
-    else
-      formatted
-    end
-  end
-
-  def format_message(message)
-    case message
-    when Array
-      message.map { |item| format_message(item) }
-    when Bolt::ApplyResult
-      format_apply_result(message)
-    when Bolt::Result, Bolt::ResultSet
-      # This is equivalent to to_s, but formattable
-      message.to_data
-    when Bolt::RunFailure
-      formatted_resultset = message.result_set.to_data
-      message.to_h.merge('result_set' => formatted_resultset)
-    when Hash
-      message.each_with_object({}) do |(k, v), h|
-        h[format_message(k)] = format_message(v)
-      end
-    when Integer, Float, NilClass
-      message
-    else
-      message.to_s
-    end
-  end
-
-  def format_apply_result(result)
-    logs = result.resource_logs&.map do |log|
-      # Omit low-level info/debug messages
-      next if %w[info debug].include?(log['level'])
-      indent(2, format_log(log))
-    end
-    hash = result.to_data
-    hash['logs'] = logs unless logs.empty?
-    hash
   end
 end

--- a/bolt-modules/out/spec/functions/out/message_spec.rb
+++ b/bolt-modules/out/spec/functions/out/message_spec.rb
@@ -1,194 +1,39 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt/executor'
-require 'bolt/inventory'
 
 describe 'out::message' do
-  let(:executor)  { Bolt::Executor.new }
-  let(:outputter) { stub('outputter', handle_event: nil) }
-
-  let(:inventory) { Bolt::Inventory.empty }
-  let(:target)    { inventory.get_target('target1') }
-  let(:target2)   { inventory.get_target('target2') }
-
-  let(:result)       { Bolt::Result.new(target, message: "ok", action: 'action') }
-  let(:err_result)   { Bolt::Result.new(target2, error: { 'msg' => 'oops' }, action: 'action') }
-  let(:result_set)   { Bolt::ResultSet.new([result, err_result]) }
-  let(:apply_result) { Bolt::ApplyResult.new(target, report: { 'status' => 'changed' }) }
-
-  let(:error)        { Bolt::Error.new("Task 'watermelon' could not be found", 'bolt/apply-prep') }
-  let(:puppet_error) { Puppet::DataTypes::Error.new('Something went terribly, terribly wrong!') }
-
-  let(:resource) { Bolt::ResourceInstance.new(resource_data) }
-  let(:resource_data) do
-    {
-      'target'        => target,
-      'type'          => 'File',
-      'title'         => '/etc/puppetlabs/',
-      'state'         => { 'ensure' => 'present' },
-      'desired_state' => { 'ensure' => 'absent' },
-      'events'        => [{ 'audited' => false }]
-    }
-  end
+  let(:executor)      { stub('executor', report_function_call: nil, publish_event: nil) }
+  let(:tasks_enabled) { true }
 
   around(:each) do |example|
-    executor.subscribe(outputter)
+    Puppet[:tasks] = tasks_enabled
 
-    Puppet[:tasks] = true
     Puppet.override(bolt_executor: executor) do
       example.run
     end
   end
 
-  it "sends a message event to the executor" do
-    executor.expects(:publish_event).with(type: :message, message: 'hello world')
-    is_expected.to run.with_params('hello world')
-  end
-
-  it "formats result sets" do
-    executor.expects(:publish_event).with(type: :message, message: <<~RESULT_SET.chomp)
-      [
-        {
-          "target": "target1",
-          "action": "action",
-          "object": null,
-          "status": "success",
-          "value": {
-            "_output": "ok"
-          }
-        },
-        {
-          "target": "target2",
-          "action": "action",
-          "object": null,
-          "status": "failure",
-          "value": {
-            "_error": {
-              "msg": "oops"
-            }
-          }
-        }
-      ]
-    RESULT_SET
-
-    is_expected.to run.with_params(result_set)
-  end
-
-  it "formats a result" do
-    executor.expects(:publish_event).with(type: :message, message: <<~RESULT.chomp)
-      {
-        "target": "target1",
-        "action": "action",
-        "object": null,
-        "status": "success",
-        "value": {
-          "_output": "ok"
-        }
-      }
-    RESULT
-
-    is_expected.to run.with_params(result)
-  end
-
-  it "formats an apply result" do
-    executor.expects(:publish_event).with(type: :message, message: <<~APPLY_RESULT.chomp)
-    {
-      "target": "target1",
-      "action": "apply",
-      "object": null,
-      "status": "success",
-      "value": {
-        "report": {
-          "status": "changed"
-        }
-      }
-    }
-    APPLY_RESULT
-
-    is_expected.to run.with_params(apply_result)
-  end
-
-  it "formats resource instances" do
-    executor.expects(:publish_event).with(type: :message, message: "File[/etc/puppetlabs/]")
-    is_expected.to run.with_params(resource)
-  end
-
-  it "formats errors" do
-    executor.expects(:publish_event).with(type: :message, message: "Task 'watermelon' could not be found")
-    is_expected.to run.with_params(error)
-  end
-
-  it "formats targets" do
-    executor.expects(:publish_event).with(type: :message, message: "target1")
-    is_expected.to run.with_params(target)
-  end
-
-  it "formats arrays of complex objects" do
-    executor.expects(:publish_event).with(type: :message, message: <<~ARRAY.chomp)
-      [
-        "target1",
-        [
-          {
-            "target": "target1",
-            "action": "action",
-            "object": null,
-            "status": "success",
-            "value": {
-              "_output": "ok"
-            }
-          },
-          {
-            "target": "target2",
-            "action": "action",
-            "object": null,
-            "status": "failure",
-            "value": {
-              "_error": {
-                "msg": "oops"
-              }
-            }
-          }
-        ],
-        [
-          "subarray"
-        ]
-      ]
-   ARRAY
-
-    is_expected.to run.with_params([target, result_set, ['subarray']])
-  end
-
-  it "formats hashes of complex objects" do
-    executor.expects(:publish_event).with(type: :message, message: <<~HASH.chomp)
-      {
-        "target1": "(?-mix:regex)",
-        "hello": {
-          "target": "target1",
-          "action": "action",
-          "object": null,
-          "status": "success",
-          "value": {
-            "_output": "ok"
-          }
-        }
-      }
-    HASH
-
-    is_expected.to run.with_params({ target => /regex/, 'hello' => result })
-  end
-
-  it "formats preformatted Puppet errors" do
+  it 'sends a log event to the executor' do
     executor.expects(:publish_event).with(
-      type: :message,
-      message: "Error({'msg' => 'Something went terribly, terribly wrong!'})"
+      type:    :message,
+      message: 'This is a message'
     )
 
-    is_expected.to run.with_params(puppet_error)
+    is_expected.to run.with_params('This is a message')
   end
 
-  it "formats unhandled objects as strings" do
-    executor.expects(:publish_event).with(type: :message, message: "(?-mix:regexp)")
-    is_expected.to run.with_params(/regexp/)
+  it 'reports function call to analytics' do
+    executor.expects(:report_function_call).with('out::message')
+    is_expected.to run.with_params('This is a message')
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+
+    it 'fails and reports that out::message is not available' do
+      is_expected.to run.with_params('This is a message')
+                        .and_raise_error(/Plan language function 'out::message' cannot be used/)
+    end
   end
 end

--- a/documentation/troubleshooting.md
+++ b/documentation/troubleshooting.md
@@ -128,23 +128,30 @@ the following ways:
 
 ## Puppet log functions are not logging to the console
 
-The default log level for the console is `warn`. If you use a `notice` function
-in a plan, Bolt does not print it to the console. When you have messages
-you want to be printed to the console regardless of log level you should use the
-`out::message` plan function. The
-[`out::message`](plan_functions.md#outmessage) function is not
-available for use in an apply block and only accepts string values.
+Puppet logs might not be printing to the console because they are logged at a
+lower level than Bolt is configured to print at. By default, Bolt prints all
+logs at the `warn` level or higher to the console.
 
-If you need to send a message that is not a string value or is in an apply
-block, you can use the `warning` Puppet log function. 
+Additionally, Puppet logs are printed at a different level in Bolt than they
+would be in Puppet. For example, Puppet `notice` level logs are equivalent to
+the `info` level in Bolt. As a result, if you use the `notice()` Puppet log
+function, Bolt does not print the contents of `notice` to the console by
+default. You can see which Bolt log level each Puppet log level maps to in
+[Puppet log functions in Bolt](writing_plans.md#puppet-log-functions-in-bolt).
 
-If you only wish to see the output in the console when executing your plan with
-the `--log-level debug` command-line option, use the `notice` Puppet log
-function. The `notice` function sets the console log level to `debug` for that
-run.
+To print logs and messages in Bolt to the console you can do one or more of the
+following:
 
-For more information, see the docs for configuring [Bolt's log
-level](https://puppet.com/docs/bolt/latest/bolt_configuration_options.html#log-file-configuration-options).
+- When you want to view all logs at a specific level on the console, [set the
+  log level](logs.md#setting-log-level) from the command line or in your
+  configuration file.
+
+- When you have messages you want to log directly from Bolt, use Bolt's [log
+  plan functions](writing_plans.md#log-functions).
+
+- When you have messages you want printed to the console regardless of log
+  level, you should use the [`out::message` plan
+  function](plan_functions.md#outmessage).
 
 ## 'Extensions are not built' error message
 If you see a `gem` related error similar to the following: 

--- a/documentation/writing_plans.md
+++ b/documentation/writing_plans.md
@@ -866,7 +866,7 @@ run_task('my_task', $targets, 'Better description', 'param1' => 'val')
 ```
 
 If your plan contains many small actions, you might want to suppress these
-messages and use explicit calls to the Puppet log functions instead. This can be
+messages and use explicit calls to the log functions instead. This can be
 accomplished by wrapping actions in a `without_default_logging` block, which
 causes the action messages to be logged at info level instead of notice. For
 example to loop over a series of targets without logging each action:
@@ -896,11 +896,25 @@ without_default_logging { run_command('echo hi', $targets) }
 
 For information on configuring log levels, see [Logs](logs.md).
 
+### Log functions
+
+Bolt ships with built-in functions for logging at each of Bolt's log levels.
+
+| Log level | Plan function |
+| --- | --- |
+| `trace` | [`log::trace`](plan_functions.md#logtrace) |
+| `debug` | [`log::debug`](plan_functions.md#logdebug) |
+| `info` | [`log::info`](plan_functions.md#loginfo) |
+| `warn` | [`log::warn`](plan_functions.md#logwarn) |
+| `error` | [`log::error`](plan_functions.md#logtrace) |
+| `fatal` | [`log::fatal`](plan_functions.md#logfatal) |
+
 ### Puppet log functions in Bolt
 
 You can use Puppet log functions in Bolt plans, but Bolt log levels do not map
 directly to Puppet log levels. For example, a `notice` function in a plan logs
-at the `info` level in Bolt. Log levels map as follows:
+at the `info` level in Bolt. Whenever possible, use Bolt log functions instead
+of Puppet log functions. Log levels map as follows:
 
 | Puppet log level | Bolt log level |
 | --- | --- |
@@ -909,6 +923,9 @@ at the `info` level in Bolt. Log levels map as follows:
 | `notice` | `info` |
 | `warning` | `warn` |
 | `err` | `error` |
+| `alert` | `error` |
+| `emerg` | `fatal` |
+| `crit` | `fatal` |
 
 ## Documenting plans
 

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -1088,7 +1088,7 @@ module Bolt
       end
       define('--log-level LEVEL',
              "Set the log level for the console. Available options are",
-             "trace, debug, info, warn, error, fatal, any.") do |level|
+             "trace, debug, info, warn, error, fatal.") do |level|
         @options[:log] = { 'console' => { 'level' => level } }
       end
       define('--clear-cache',

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -202,7 +202,7 @@ module Bolt
                 "level" => {
                   description: "The type of information to log.",
                   type: String,
-                  enum: %w[trace debug error info warn fatal any],
+                  enum: %w[trace debug error info warn fatal],
                   _default: "warn"
                 }
               }
@@ -221,7 +221,7 @@ module Bolt
               "level" => {
                 description: "The type of information to log.",
                 type: String,
-                enum: %w[trace debug error info warn fatal any],
+                enum: %w[trace debug error info warn fatal],
                 _default: "warn"
               }
             }

--- a/lib/bolt/outputter/logger.rb
+++ b/lib/bolt/outputter/logger.rb
@@ -24,6 +24,8 @@ module Bolt
           log_container_start(event)
         when :container_finish
           log_container_finish(event)
+        when :log
+          log_message(**event)
         end
       end
 
@@ -64,6 +66,10 @@ module Bolt
         else
           @logger.info("Finished: run container '#{result.object}' failed.")
         end
+      end
+
+      def log_message(level:, message:, **_kwargs)
+        @logger.send(level, message)
       end
     end
   end

--- a/lib/bolt/util/format.rb
+++ b/lib/bolt/util/format.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Bolt
+  module Util
+    module Format
+      class << self
+        # Stringifies an object, formatted as valid JSON.
+        #
+        # @param message [Object] The object to stringify.
+        # @return [String] The JSON string.
+        #
+        def stringify(message)
+          formatted = format_message(message)
+          if formatted.is_a?(Hash) || formatted.is_a?(Array)
+            ::JSON.pretty_generate(formatted)
+          else
+            formatted
+          end
+        end
+
+        # Recursively formats an object into a format that can be represented by
+        # JSON.
+        #
+        # @param message [Object] The object to stringify.
+        # @return [Array, Hash, String]
+        #
+        private def format_message(message)
+          case message
+          when Array
+            message.map { |item| format_message(item) }
+          when Bolt::ApplyResult
+            format_apply_result(message)
+          when Bolt::Result, Bolt::ResultSet
+            # This is equivalent to to_s, but formattable
+            message.to_data
+          when Bolt::RunFailure
+            formatted_resultset = message.result_set.to_data
+            message.to_h.merge('result_set' => formatted_resultset)
+          when Hash
+            message.each_with_object({}) do |(k, v), h|
+              h[format_message(k)] = format_message(v)
+            end
+          when Integer, Float, NilClass
+            message
+          else
+            message.to_s
+          end
+        end
+
+        # Formats a Bolt::ApplyResult object.
+        #
+        # @param result [Bolt::ApplyResult] The apply result.
+        # @return [Hash]
+        #
+        private def format_apply_result(result)
+          logs = result.resource_logs&.map do |log|
+            # Omit low-level info/debug messages
+            next if %w[info debug].include?(log['level'])
+            indent(2, format_log(log))
+          end
+          hash = result.to_data
+          hash['logs'] = logs unless logs.empty?
+          hash
+        end
+      end
+    end
+  end
+end

--- a/lib/bolt_spec/plans.rb
+++ b/lib/bolt_spec/plans.rb
@@ -98,7 +98,7 @@ module BoltSpec
       Puppet[:tasks] = true
 
       # Ensure logger is initialized with Puppet levels so 'notice' works when running plan specs.
-      Logging.init :trace, :debug, :info, :notice, :warn, :error, :fatal, :any
+      Logging.init :trace, :debug, :info, :notice, :warn, :error, :fatal
     end
 
     # Provided as a class so expectations can be placed on it.

--- a/rakelib/docs.rake
+++ b/rakelib/docs.rake
@@ -71,6 +71,8 @@ begin
     # list.
     desc ''
     task :generate_strings do
+      modules = Dir.children("#{__dir__}/../bolt-modules").map { |dir| dir.prepend('bolt-modules/') }
+
       @puppet_strings ||= begin
         FileUtils.mkdir_p('tmp')
         tmpfile = 'tmp/boltlib.json'
@@ -80,13 +82,7 @@ begin
           markup: 'markdown',
           json: true,
           path: tmpfile,
-          yard_args: ['bolt-modules/boltlib',
-                      'bolt-modules/ctrl',
-                      'bolt-modules/dir',
-                      'bolt-modules/file',
-                      'bolt-modules/out',
-                      'bolt-modules/prompt',
-                      'bolt-modules/system']
+          yard_args: modules
         )
 
         JSON.parse(File.read(tmpfile))

--- a/rakelib/pwsh.rake
+++ b/rakelib/pwsh.rake
@@ -335,7 +335,7 @@ namespace :pwsh do
           when 'transport'
             pwsh_param[:validate_set] = Bolt::Config::Options::TRANSPORT_CONFIG.keys
           when 'loglevel'
-            pwsh_param[:validate_set] = %w[trace debug info notice warn error fatal any]
+            pwsh_param[:validate_set] = %w[trace debug info notice warn error fatal]
           when 'filter'
             pwsh_param[:validate_pattern] = '^[a-z0-9_:]+$'
           when 'rerun'

--- a/rakelib/tests.rake
+++ b/rakelib/tests.rake
@@ -100,8 +100,8 @@ begin
     task :modules do
       success = true
       # Test core modules
-      %w[boltlib ctrl file dir out prompt system].each do |mod|
-        Dir.chdir("#{__dir__}/../bolt-modules/#{mod}") do
+      Pathname.new("#{__dir__}/../bolt-modules").each_child do |mod|
+        Dir.chdir(mod) do
           sh 'rake spec' do |ok, _|
             success = false unless ok
           end

--- a/resources/bolt_bash_completion.sh
+++ b/resources/bolt_bash_completion.sh
@@ -47,7 +47,7 @@ _bolt_complete() {
     next=$(compgen -f -d "" -- $cur)
   # Handle tab completing enumerable CLI options
   elif [ "$prev" == "--log-level" ]; then
-    next="trace debug info warn error fatal any"
+    next="trace debug info warn error fatal"
   elif [ "$prev" == "--transport" ]; then
     next="docker local lxd pcp podman remote ssh winrm"
   elif [ "$prev" == "--format" ]; then

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -144,8 +144,7 @@
                 "error",
                 "info",
                 "warn",
-                "fatal",
-                "any"
+                "fatal"
               ]
             }
           }
@@ -174,8 +173,7 @@
               "error",
               "info",
               "warn",
-              "fatal",
-              "any"
+              "fatal"
             ]
           }
         }

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -181,8 +181,7 @@
                 "error",
                 "info",
                 "warn",
-                "fatal",
-                "any"
+                "fatal"
               ]
             }
           }
@@ -211,8 +210,7 @@
               "error",
               "info",
               "warn",
-              "fatal",
-              "any"
+              "fatal"
             ]
           }
         }

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -2459,7 +2459,7 @@ describe "Bolt::CLI" do
         cli.parse
         modules = cli.list_modules
         expect(modules.keys.first).to match(/bolt-modules/)
-        expect(modules.values.first.map { |h| h[:name] }).to eq(%w[boltlib ctrl dir file out prompt system])
+        expect(modules.values.first.map { |h| h[:name] }).to match_array(Dir.children("#{__dir__}/../../bolt-modules"))
         expect(modules.values[1].map { |h| h[:name] })
           .to include("aggregate", "canary", "puppetdb_fact", "puppetlabs/yaml")
       end

--- a/spec/bolt/util/format_spec.rb
+++ b/spec/bolt/util/format_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt/util/format'
+
+require 'bolt/apply_result'
+require 'bolt/error'
+require 'bolt/inventory'
+require 'bolt/resource_instance'
+require 'bolt/result'
+require 'bolt/result_set'
+
+describe Bolt::Util::Format do
+  describe '#stringify' do
+    let(:inventory) { Bolt::Inventory.empty }
+    let(:target1)   { inventory.get_target('target1') }
+    let(:target2)   { inventory.get_target('target2') }
+
+    let(:result)       { Bolt::Result.new(target1, message: "ok", action: 'action') }
+    let(:err_result)   { Bolt::Result.new(target2, error: { 'msg' => 'oops' }, action: 'action') }
+    let(:result_set)   { Bolt::ResultSet.new([result, err_result]) }
+    let(:apply_result) { Bolt::ApplyResult.new(target1, report: { 'status' => 'changed' }) }
+
+    let(:error)        { Bolt::Error.new("Task 'watermelon' could not be found", 'bolt/apply-prep') }
+
+    let(:resource) { Bolt::ResourceInstance.new(resource_data) }
+    let(:resource_data) do
+      {
+        'target'        => target1,
+        'type'          => 'File',
+        'title'         => '/etc/puppetlabs/',
+        'state'         => { 'ensure' => 'present' },
+        'desired_state' => { 'ensure' => 'absent' },
+        'events'        => [{ 'audited' => false }]
+      }
+    end
+
+    it 'formats result sets' do
+      expect(Bolt::Util::Format.stringify(result_set)).to eq(<<~RESULT_SET.chomp)
+        [
+          {
+            "target": "target1",
+            "action": "action",
+            "object": null,
+            "status": "success",
+            "value": {
+              "_output": "ok"
+            }
+          },
+          {
+            "target": "target2",
+            "action": "action",
+            "object": null,
+            "status": "failure",
+            "value": {
+              "_error": {
+                "msg": "oops"
+              }
+            }
+          }
+        ]
+      RESULT_SET
+    end
+
+    it 'formats a result' do
+      expect(Bolt::Util::Format.stringify(result)).to eq(<<~RESULT.chomp)
+        {
+          "target": "target1",
+          "action": "action",
+          "object": null,
+          "status": "success",
+          "value": {
+            "_output": "ok"
+          }
+        }
+      RESULT
+    end
+
+    it 'formats an apply result' do
+      expect(Bolt::Util::Format.stringify(apply_result)).to eq(<<~APPLY_RESULT.chomp)
+      {
+        "target": "target1",
+        "action": "apply",
+        "object": null,
+        "status": "success",
+        "value": {
+          "report": {
+            "status": "changed"
+          }
+        }
+      }
+      APPLY_RESULT
+    end
+
+    it "formats resource instances" do
+      expect(Bolt::Util::Format.stringify(resource)).to eq('File[/etc/puppetlabs/]')
+    end
+
+    it "formats errors" do
+      expect(Bolt::Util::Format.stringify(error)).to eq("Task 'watermelon' could not be found")
+    end
+
+    it "formats targets" do
+      expect(Bolt::Util::Format.stringify(target1)).to eq('target1')
+    end
+
+    it "formats arrays of complex objects" do
+      expect(Bolt::Util::Format.stringify([target1, result_set, ['subarray']])).to eq(<<~ARRAY.chomp)
+        [
+          "target1",
+          [
+            {
+              "target": "target1",
+              "action": "action",
+              "object": null,
+              "status": "success",
+              "value": {
+                "_output": "ok"
+              }
+            },
+            {
+              "target": "target2",
+              "action": "action",
+              "object": null,
+              "status": "failure",
+              "value": {
+                "_error": {
+                  "msg": "oops"
+                }
+              }
+            }
+          ],
+          [
+            "subarray"
+          ]
+        ]
+     ARRAY
+    end
+
+    it "formats hashes of complex objects" do
+      expect(Bolt::Util::Format.stringify({ target1 => /regex/, 'hello' => result })).to eq(<<~HASH.chomp)
+        {
+          "target1": "(?-mix:regex)",
+          "hello": {
+            "target": "target1",
+            "action": "action",
+            "object": null,
+            "status": "success",
+            "value": {
+              "_output": "ok"
+            }
+          }
+        }
+      HASH
+    end
+
+    it "formats unhandled objects as strings" do
+      expect(Bolt::Util::Format.stringify(/regexp/)).to eq("(?-mix:regexp)")
+    end
+  end
+end

--- a/spec/fixtures/modules/logs/plans/init.pp
+++ b/spec/fixtures/modules/logs/plans/init.pp
@@ -1,0 +1,8 @@
+plan logs () {
+  log::trace('This is a trace message')
+  log::debug('This is a debug message')
+  log::warn('This is a warn message')
+  log::info('This is an info message')
+  log::error('This is an error message')
+  log::fatal('This is a fatal message')
+}

--- a/spec/fixtures/modules/output/plans/error.pp
+++ b/spec/fixtures/modules/output/plans/error.pp
@@ -1,0 +1,3 @@
+plan output::error () {
+  out::message(Error.new('Something went horribly, horribly wrong'))
+}

--- a/spec/integration/plan_spec.rb
+++ b/spec/integration/plan_spec.rb
@@ -68,34 +68,45 @@ describe 'plans' do
     end
 
     context "using the human outputter" do
-      let(:config_flags) {
-        ['--project', fixtures_path('configs', 'empty'),
-         '--modulepath', modulepath,
-         '--no-host-key-check']
-      }
+      around(:each) do |example|
+        with_project(config: { 'modulepath' => [modulepath] }) do |project|
+          @project = project
+          example.run
+        end
+      end
+
+      let(:config_flags) { ['--no-host-key-check'] }
+      let(:opts)         { { outputter: Bolt::Outputter::Human, project: @project } }
 
       it "prints the spinner when running executor functions", ssh: true do
         expect_any_instance_of(Bolt::Outputter::Human).to receive(:start_spin).at_least(:once)
-        run_cli(%w[plan run sample::noop --targets #{target}] + config_flags, outputter: Bolt::Outputter::Human)
+        run_cli(%w[plan run sample::noop --targets #{target}] + config_flags, **opts)
       end
 
       it "doesn't print the spinner when running non-executor functions", ssh: true do
         expect_any_instance_of(Bolt::Outputter::Human).not_to receive(:start_spin)
-        run_cli(%w[plan run output] + config_flags, outputter: Bolt::Outputter::Human)
+        run_cli(%w[plan run output] + config_flags, **opts)
+      end
+
+      it 'prints formatted Puppet errors' do
+        output = run_cli(%w[plan run output::error] + config_flags, **opts)
+        expect(output).to match(Regexp.escape("Error({'msg' => 'Something went horribly, horribly wrong'})"))
       end
     end
 
-    it 'logs messages' do
-      with_project do |project|
-        run_cli_json(%W[plan run logs -m #{modulepath}], project: project)
-        expect(@log_output.readlines).to include(
-          /TRACE.*This is a trace message/,
-          /DEBUG.*This is a debug message/,
-          /WARN.*This is a warn message/,
-          /INFO.*This is an info message/,
-          /ERROR.*This is an error message/,
-          /FATAL.*This is a fatal message/
-        )
+    context 'using the logger outputter' do
+      it 'logs messages' do
+        with_project do |project|
+          run_cli_json(%W[plan run logs -m #{modulepath}], project: project)
+          expect(@log_output.readlines).to include(
+            /TRACE.*This is a trace message/,
+            /DEBUG.*This is a debug message/,
+            /WARN.*This is a warn message/,
+            /INFO.*This is an info message/,
+            /ERROR.*This is an error message/,
+            /FATAL.*This is a fatal message/
+          )
+        end
       end
     end
 

--- a/spec/integration/plan_spec.rb
+++ b/spec/integration/plan_spec.rb
@@ -85,6 +85,20 @@ describe 'plans' do
       end
     end
 
+    it 'logs messages' do
+      with_project do |project|
+        run_cli_json(%W[plan run logs -m #{modulepath}], project: project)
+        expect(@log_output.readlines).to include(
+          /TRACE.*This is a trace message/,
+          /DEBUG.*This is a debug message/,
+          /WARN.*This is a warn message/,
+          /INFO.*This is an info message/,
+          /ERROR.*This is an error message/,
+          /FATAL.*This is a fatal message/
+        )
+      end
+    end
+
     it 'runs a yaml plan', ssh: true do
       result = run_cli(['plan', 'run', 'sample::yaml', '--targets', target] + config_flags)
       expect(JSON.parse(result)).to eq(


### PR DESCRIPTION
This adds a new built-in `log` module that includes plan functions for
logging messages at each of Bolt's log levels. Functions include
`log::trace`, `log::debug`, `log::warn`, `log::debug`, `log::error`, and
`log::fatal`. Each of the functions publishes a `:log` event to the
executor. The logger outputter has been udpated to handle this event
type and passes the message directly to the configured logger instance.

!feature

* **Add built-in `log` module**
  ([#2899](#2899))

  Bolt now ships with a new built-in `log` module that includes plan
  functions for logging messages at each of Bolt's log levels. The new
  plan functions include `log::trace`, `log::debug`, `log::warn`,
  `log::info`, `log::error`, and `log::fatal`.

---

This adds a new `Bolt::Util::Format` module that includes utility
methods for formatting. Specifically, this moves the `stringify()`
method that used to live on the `out::message` function to a reusable
module, as the `log::*` functions need this functionality as well.

Note: These methods cannot live on `Bolt::Outputter`, as they must be
able to format Puppet object types in plans. Attempting to stringify a
Puppet object type outside the scope of a plan results in a "stack trace
too deep" error.

!no-release-note