### PR TITLE
(PE-32176) Use versioned_project from body for /project_inventory_targets

### DIFF
--- a/lib/bolt_server/schemas/connect-data.json
+++ b/lib/bolt_server/schemas/connect-data.json
@@ -16,7 +16,10 @@
         }
       },
       "additionalProperties": false
+    },
+    "versioned_project": {
+      "type": "string"
     }
   },
-  "required": ["puppet_connect_data"]
+  "required": ["puppet_connect_data", "versioned_project"]
 }

--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -637,11 +637,10 @@ module BoltServer
     #
     # @param versioned_project [String] the versioned_project to compute the inventory from
     post '/project_inventory_targets' do
-      raise BoltServer::RequestError, "'versioned_project' is a required argument" if params['versioned_project'].nil?
       content_type :json
       body = JSON.parse(request.body.read)
       validate_schema(@schemas["connect-data"], body)
-      in_bolt_project(params['versioned_project']) do |context|
+      in_bolt_project(body['versioned_project']) do |context|
         if context[:config].inventoryfile &&
            context[:config].project.inventory_file.to_s !=
            context[:config].inventoryfile


### PR DESCRIPTION
At one time, this endpoint used a GET request and therefore expected
versioned_project as a query param. It was later changed to a POST
request with puppet_connect_data included in the request body, but the
versioned_project query param remained. For consistency, we now expect
both pieces of data to be supplied in the request body.