### PR TITLE
(GH-2879) Add out::verbose Puppet plan function

### DIFF
--- a/bolt-modules/out/lib/puppet/functions/out/verbose.rb
+++ b/bolt-modules/out/lib/puppet/functions/out/verbose.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'bolt/util/format'
+
+# Output a message for the user when running in verbose mode.
+#
+# This will print a message to stdout when using the human output format,
+# and print to stderr when using the json output format.
+#
+# > **Note:** Not available in apply block
+Puppet::Functions.create_function(:'out::verbose') do
+  # @param message The message to output.
+  # @example Print a message
+  #   out::verbose('Something went wrong')
+  dispatch :output_verbose do
+    param 'Any', :message
+    return_type 'Undef'
+  end
+
+  def output_verbose(message)
+    unless Puppet[:tasks]
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'out::verbose')
+    end
+
+    Puppet.lookup(:bolt_executor).tap do |executor|
+      executor.report_function_call(self.class.name)
+      executor.publish_event(type: :verbose, message: Bolt::Util::Format.stringify(message))
+    end
+
+    nil
+  end
+end

--- a/bolt-modules/out/spec/functions/out/verbose_spec.rb
+++ b/bolt-modules/out/spec/functions/out/verbose_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'out::verbose' do
+  let(:executor)      { stub('executor', report_function_call: nil, publish_event: nil) }
+  let(:tasks_enabled) { true }
+
+  around(:each) do |example|
+    Puppet[:tasks] = tasks_enabled
+
+    Puppet.override(bolt_executor: executor) do
+      example.run
+    end
+  end
+
+  it 'sends a verbose event to the executor' do
+    executor.expects(:publish_event).with(
+      type:    :verbose,
+      message: 'This is a message'
+    )
+
+    is_expected.to run.with_params('This is a message')
+  end
+
+  it 'reports function call to analytics' do
+    executor.expects(:report_function_call).with('out::verbose')
+    is_expected.to run.with_params('This is a message')
+  end
+
+  context 'without tasks enabled' do
+    let(:tasks_enabled) { false }
+    it 'fails and reports that out::verbose is not available' do
+      is_expected.to run.with_params('This is a message')
+                        .and_raise_error(/Plan language function 'out::verbose' cannot be used/)
+    end
+  end
+end

--- a/documentation/boltspec_reference.md
+++ b/documentation/boltspec_reference.md
@@ -260,6 +260,42 @@ The `expect_out_message` function accepts the following modifiers:
   expect_out_message.with_params('This is not the example you are looking for.')
   ```
 
+### `expect_out_verbose`
+
+The `expect_out_verbose` function mocks the [`out::verbose` function](plan_functions.md#outverbose). It does not accept any parameters.
+
+```ruby
+expect_out_verbose
+```
+
+The `expect_out_verbose` function accepts the following modifiers:
+
+- `be_called_times(number)`
+
+  The test fails if `out::verbose` is not invoked exactly _number_ times.
+
+  ```ruby
+  expect_out_verbose.be_called_times(3)
+  ```
+
+- `not_be_called`
+
+  The test fails if `out::verbose` is invoked.
+
+  ```ruby
+  expect_out_verbose.not_be_called
+  ```
+
+- `with_params(params)`
+
+  The message that must be passed to the `out::verbose` function. The test fails if
+  the function is not invoked with the message.
+
+  ```ruby
+  expect_out_verbose.with_params('This is not the example you are looking for.')
+  ```
+
+
 ### `expect_plan`
 
 The `expect_plan` function mocks the [`run_plan` function](plan_functions.md#run-plan).
@@ -820,6 +856,41 @@ The `allow_out_message` function accepts the following stub modifiers:
 
   ```ruby
   allow_out_message.with_params('This is not the example you are looking for.')
+  ```
+
+### `allow_out_verbose`
+
+The `allow_out_verbose` function stubs the [`out::verbose` function](plan_functions.md#outverbose). It does not accept any parameters.
+
+```ruby
+allow_out_verbose
+```
+
+The `allow_out_verbose` function accepts the following stub modifiers:
+
+- `be_called_times(number)`
+
+  The test fails if `out::verbose` is invoked more than _number_ times.
+
+  ```ruby
+  allow_out_verbose.be_called_times(3)
+  ```
+
+- `not_be_called`
+
+  The test fails if `out::verbose` is invoked.
+
+  ```ruby
+  allow_out_verbose.not_be_called
+  ```
+
+- `with_params(params)`
+
+  The message that can be passed to the `out::verbose` function. The test fails if
+  the function is invoked with a different message.
+
+  ```ruby
+  allow_out_verbose.with_params('This is not the example you are looking for.')
   ```
 
 ### `allow_plan`

--- a/documentation/logs.md
+++ b/documentation/logs.md
@@ -154,6 +154,10 @@ Puppet code.
 
 ## Using `verbose` output
 
+Verbose output is useful when you want to see the results for Bolt actions on your targets that are
+usually not printed to standard out (stdout). Verbose isn't a log level, but is a way of telling
+Bolt to output additional information in a human-readable format.
+
 The following Bolt commands include the `--verbose` CLI option: 
 - `bolt command run`
 - `bolt task run`
@@ -172,11 +176,17 @@ The following PowerShell cmdlets include the `-Verbose` argument:
 - `Receive-BoltFile`
 - `Invoke-BoltApply`
 
-Verbose output is useful when you want to see the results for Bolt actions on your targets that are
-usually not printed to standard out (stdout). Verbose isn't a log level, but is a way of telling
-Bolt to output additional information in a human-readable format. Verbose output is particularly
-useful for debugging your tasks and plans - if you're not sure why something is failing, try running
-it with `--verbose` to get more information.
+Verbose output is particularly useful for debugging your tasks and plans. If
+you're not sure why something is failing, try running it with `--verbose` to get
+more information. You can also use `out::verbose` in plans to print messages to
+stdout in verbose mode. For example, to print "Hello world" to stdout in verbose
+mode:
+
+ ```shell
+plan mymodule::myplan {
+  out::verbose('Hello world')
+}
+  ```
 
 ## Suppress warnings
 

--- a/documentation/testing_plans.md
+++ b/documentation/testing_plans.md
@@ -271,7 +271,8 @@ documentation.
 | [`apply`](plan_functions.md#apply) | [`allow_apply`](boltspec_reference.md#allow-apply) | - |
 | [`apply_prep`](plan_functions.md#apply-prep) | [`allow_apply_prep`](boltspec_reference.md#allow-apply-prep) | - |
 | [`download_file`](plan_functions.md#download-file) | [`allow_download`](boltspec_reference.md#allow-download) | [`expect_download`](boltspec_reference.md#expect_download) |
-| [`out::message`](plan_functions.md#out::message) | [`allow_out_message`](boltspec_reference.md#allow-out-message) | [`expect_out_message`](boltspec_reference.md#expect-out-message) |
+| [`out::message`](plan_functions.md#outmessage) | [`allow_out_message`](boltspec_reference.md#allow-out-message) | [`expect_out_message`](boltspec_reference.md#expect-out-message) |
+| [`out::verbose`](plan_functions.md#outverbose) | [`allow_out_verbose`](boltspec_reference.md#allow-out-verbose) | [`expect_out_verbose`](boltspec_reference.md#expect-out-verbose) |
 | [`run_command`](plan_functions.md#run-command) | [`allow_command`](boltspec_reference.md#allow-command) | [`expect_command`](boltspec_reference.md#expect-command) |
 | [`run_plan`](plan_functions.md#run-plan) | [`allow_plan`](boltspec_reference.md#allow-plan) | [`expect_plan`](boltspec_reference.md#expect-plan) |
 | [`run_script`](plan_functions.md#run-script) | [`allow_script`](boltspec_reference.md#allow-script) | [`expect_script`](boltspec_reference.md#expect-script) |

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -787,8 +787,8 @@ module Bolt
       if %w[human rainbow].include?(options.fetch(:format, 'human'))
         executor.subscribe(outputter)
       else
-        # Only subscribe to out::message events for JSON outputter
-        executor.subscribe(outputter, [:message])
+        # Only subscribe to out module events for JSON outputter
+        executor.subscribe(outputter, %i[message verbose])
       end
 
       executor.subscribe(log_outputter)

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -78,6 +78,8 @@ module Bolt
           @disable_depth += 1
         when :message
           print_message(event[:message])
+        when :verbose
+          print_message(event[:message]) if @verbose
         end
 
         if enabled?

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -23,6 +23,8 @@ module Bolt
           print_result(event[:result])
         when :message
           print_message(event[:message])
+        when :verbose
+          print_message(event[:message]) if @verbose
         end
       end
 

--- a/lib/bolt_spec/bolt_context.rb
+++ b/lib/bolt_spec/bolt_context.rb
@@ -191,6 +191,15 @@ module BoltSpec
       allow_out_message.expect_call
     end
 
+    def allow_out_verbose
+      executor.stub_out_verbose.add_stub
+    end
+    alias allow_any_out_verbose allow_out_verbose
+
+    def expect_out_verbose
+      allow_out_verbose.expect_call
+    end
+
     # Example helpers to mock other run functions
     # The with_targets method makes sense for all stubs
     # with_params could be reused for options

--- a/lib/bolt_spec/plans/publish_stub.rb
+++ b/lib/bolt_spec/plans/publish_stub.rb
@@ -7,19 +7,19 @@ module BoltSpec
   module Plans
     class PublishStub < ActionStub
       def return
-        raise "return is not implemented for out_message"
+        raise "return is not implemented for out module functions"
       end
 
       def return_for_targets(_data)
-        raise "return_for_targets is not implemented for out_message"
+        raise "return_for_targets is not implemented for out module functions"
       end
 
       def always_return(_data)
-        raise "always_return is not implemented for out_message"
+        raise "always_return is not implemented for out module functions"
       end
 
       def error_with(_data)
-        raise "error_with is not implemented for out_message"
+        raise "error_with is not implemented for out module functions"
       end
 
       def matches(message)

--- a/spec/bolt_spec/plan_spec.rb
+++ b/spec/bolt_spec/plan_spec.rb
@@ -315,6 +315,59 @@ describe "BoltSpec::Plans" do
     end
   end
 
+  context 'with out::verbose' do
+    let(:plan_name) { 'plans::out_verbose' }
+    let(:message) { 'foo' }
+    let(:other_message) { 'bar' }
+
+    it 'allows with params' do
+      allow_out_verbose.with_params(message)
+      result = run_plan(plan_name, 'messages' => [message])
+      expect(result).to be_ok
+    end
+
+    it 'allows any out message' do
+      allow_any_out_verbose
+      result = run_plan(plan_name, 'messages' => [message])
+      expect(result).to be_ok
+    end
+
+    it 'errors when not allowed' do
+      expect { run_plan(plan_name, 'messages' => [message]) }.to raise_error(RuntimeError, /Unexpected call to/)
+    end
+
+    it 'expects with params' do
+      expect_out_verbose.with_params(message)
+      result = run_plan(plan_name, 'messages' => [message])
+      expect(result).to be_ok
+    end
+
+    it 'expects multiple times with params' do
+      expect_out_verbose.be_called_times(2).with_params(message)
+      result = run_plan(plan_name, 'messages' => [message, message])
+      expect(result).to be_ok
+    end
+
+    it 'expects with different params' do
+      expect_out_verbose.with_params(message)
+      expect_out_verbose.with_params(other_message)
+      result = run_plan(plan_name, 'messages' => [message, other_message])
+      expect(result).to be_ok
+    end
+
+    it 'errors when not expected' do
+      expect_out_verbose.not_be_called
+      expect { run_plan(plan_name, 'messages' => [message]) }
+        .to raise_error(RuntimeError, /Expected out::verbose to be called 0 times/)
+    end
+
+    it 'errors with wrong params' do
+      expect_out_verbose.with_params(other_message)
+      expect { run_plan(plan_name, 'messages' => [message]) }
+        .to raise_error(RuntimeError, /Expected out::verbose to be called 1 times with parameters #{other_message}/)
+    end
+  end
+
   context 'with plan calling sub-plan' do
     let(:plan_name) { 'plans::plan_calling_plan' }
     let(:sub_plan_name) { 'plans::command' }

--- a/spec/fixtures/bolt_spec/plans/plans/out_verbose.pp
+++ b/spec/fixtures/bolt_spec/plans/plans/out_verbose.pp
@@ -1,0 +1,5 @@
+plan plans::out_verbose(Array[String] $messages) {
+  $messages.each |$message| {
+    out::verbose($message)
+  }
+}

--- a/spec/fixtures/modules/output/plans/verbose.pp
+++ b/spec/fixtures/modules/output/plans/verbose.pp
@@ -1,0 +1,3 @@
+plan output::verbose(){
+  out::verbose("Hi, I'm Dave")
+}

--- a/spec/integration/plan_spec.rb
+++ b/spec/integration/plan_spec.rb
@@ -78,6 +78,27 @@ describe 'plans' do
       let(:config_flags) { ['--no-host-key-check'] }
       let(:opts)         { { outputter: Bolt::Outputter::Human, project: @project } }
 
+      context 'output' do
+        let(:output)    { StringIO.new }
+        let(:outputter) { Bolt::Outputter::Human.new(true, true, true, true, output) }
+
+        before(:each) do
+          allow(Bolt::Outputter::Human).to receive(:new).and_return(outputter)
+        end
+
+        it 'outputs message with verbose flag' do
+          run_cli(%W[plan run output::verbose --targets #{target} --verbose] + config_flags,
+                  outputter: Bolt::Outputter::Human, project: @project)
+          expect(output.string).to match(/Hi, I'm Dave/)
+        end
+
+        it 'doesnt output without verbose flag' do
+          result = run_cli(%W[plan run output::verbose --targets #{target}] + config_flags,
+                           outputter: Bolt::Outputter::Human, project: @project)
+          expect(result).not_to match(/Hi, I'm Dave/)
+        end
+      end
+
       it "prints the spinner when running executor functions", ssh: true do
         expect_any_instance_of(Bolt::Outputter::Human).to receive(:start_spin).at_least(:once)
         run_cli(%w[plan run sample::noop --targets #{target}] + config_flags, **opts)


### PR DESCRIPTION
Add `out::verbose` to Bolt, which allows for similar functionality as `out::message`, but only prints when run with `--verbose` flag. We also update relevant documentation and testing. This also adds `allow_out_verbose` and `expect_out_verbose` to BoltSpec.

!feature

* **Add `out::verbose` plan function** ([#2879](#2879))

  Bolt now has `out::verbose` plan function, which allows for printing output when run in verbose mode.