### PR TITLE
(maint) Fix broken Windows acceptance tests

### DIFF
--- a/acceptance/lib/acceptance/bolt_command_helper.rb
+++ b/acceptance/lib/acceptance/bolt_command_helper.rb
@@ -18,7 +18,16 @@ module Acceptance
 
       case host['platform']
       when /windows/
-        execute_powershell_script_on(host, bolt_command, opts)
+        # Set the PATH environment variable before running the Bolt command. Ideally this
+        # would be set during the setup process, but the PATH is not preserved between
+        # sessions on the SUT.
+        script = <<~PS
+          $boltpath = [IO.Path]::Combine($env:ProgramFiles, 'Puppet Labs', 'Bolt', 'bin')
+          $env:Path = $boltpath + ";" + $env:Path
+          #{bolt_command}
+        PS
+
+        execute_powershell_script_on(host, script, opts)
       when /osx/
         # Ensure Bolt runs with UTF-8 under macOS. Otherwise we get issues with
         # UTF-8 content in task results.

--- a/acceptance/setup/common/pre-suite/032_configure_windows_profile.rb
+++ b/acceptance/setup/common/pre-suite/032_configure_windows_profile.rb
@@ -5,36 +5,35 @@ require 'bolt_setup_helper'
 test_name "Configure Windows Profile" do
   extend Acceptance::BoltSetupHelper
 
+  # TODO: The PATH environment variable is not preserved between sessions on the SUT.
+  #       To work around this, Acceptance::BoltCommandHelper.bolt_command_on
+  #       modifies the PATH prior to executing the Bolt command.
   step "Configure PATH environment variable" do
     if bolt['platform'] =~ /windows/
-      execute_powershell_script_on(bolt, <<-PS)
-$boltpath = Join-Path $env:ProgramFiles "Puppet Labs" "Bolt" "bin"
-$envpath = $boltpath + ";" + $env:Path
-[System.Environment]::SetEnvironmentVariable(
-  'PATH',
-  $envpath,
-  [System.EnvironmentVariableTarget]::Machine
-)
-PS
+      execute_powershell_script_on(bolt, <<~PS)
+        $boltpath = [IO.Path]::Combine($env:ProgramFiles, 'Puppet Labs', 'Bolt', 'bin')
+        $envpath = $boltpath + ";" + $env:Path
+        [System.Environment]::SetEnvironmentVariable('PATH', $envpath, [System.EnvironmentVariableTarget]::Machine)
+      PS
     end
   end
 
   step "Configure a Windows Profile that contains will write to a file every time it is loaded" do
     if bolt['platform'] =~ /windows/
-      execute_powershell_script_on(bolt, <<-PS)
-$profileTracker = #{profile_tracker.inspect}
-$BaseDir = Split-Path $profileTracker
-if (!(Test-Path -Path $BaseDir ))
-{ New-Item -Type Directory -Path $BaseDir -Force }
-if (!(Test-Path -Path $PROFILE.AllUsersAllHosts))
-{ New-Item -Type File -Path $PROFILE.AllUsersAllHosts -Force }
-$ProfileCode = [string]::Format('"Profile Loaded" | Out-File {0} -Append', $profileTracker)
-Set-Content -Path $PROFILE.AllUsersAllHosts -value $ProfileCode
-PS
+      execute_powershell_script_on(bolt, <<~PS)
+        $profileTracker = #{profile_tracker.inspect}
+        $BaseDir = Split-Path $profileTracker
+        if (!(Test-Path -Path $BaseDir ))
+        { New-Item -Type Directory -Path $BaseDir -Force }
+        if (!(Test-Path -Path $PROFILE.AllUsersAllHosts))
+        { New-Item -Type File -Path $PROFILE.AllUsersAllHosts -Force }
+        $ProfileCode = [string]::Format('"Profile Loaded" | Out-File {0} -Append', $profileTracker)
+        Set-Content -Path $PROFILE.AllUsersAllHosts -value $ProfileCode
+      PS
 
-      result = execute_powershell_script_on(bolt, <<-PS)
-Type $PROFILE.AllUsersAllHosts
-PS
+      result = execute_powershell_script_on(bolt, <<~PS)
+        Type $PROFILE.AllUsersAllHosts
+      PS
       assert_match(result.stdout.strip, "\"Profile Loaded\" | Out-File #{profile_tracker} -Append")
     end
   end


### PR DESCRIPTION
Starting with Bolt 3.0, we no longer include the `bolt` function in the
PuppetBolt PowerShell module and instead shipped with a batch file for
Windows packages that would run the Bolt executable. When this change
was made acceptance tests were broken as the `PATH` did not include the
path to Bolt's `bin/` directory and the test would error with a "bolt is
not a recognized command" message.

During the beaker setup process (specifically step 032), beaker
updates the `PATH` to include Bolt's `bin/` directory. Previously, the
script responsible for this used the `Join-Path` cmdlet with multiple
positional arguments, which is not supported in PowerShell < 6.0,
resulting in the `PATH` not getting updated. Updating this line to not
error correctly sets the `PATH` for the step that sets it, but the
`PATH` is not preserved between PowerShell sessions. This resulted in
the tests continuing to fail since `bolt` was not recognized as a
command.

This change updates the `bolt_command_on` helper method to set the
`PATH` prior to invoking `bolt`, ensuring that the `PATH` is correctly
configured every time Bolt is run.

!no-release-note