### PR TITLE
(GH-2903) Document installing Bolt for Fedora 34

### DIFF
--- a/documentation/bolt_installing.md
+++ b/documentation/bolt_installing.md
@@ -10,7 +10,7 @@ and Microsoft Windows.
 | Operating system          | Versions            |
 | ------------------------- | ------------------- |
 | Debian                    | 9, 10               |
-| Fedora                    | 30, 31, 32          |
+| Fedora                    | 30, 31, 32, 34      |
 | macOS                     | 10.14, 10.15, 11    |
 | Microsoft Windows*        | 10 Enterprise       |
 | Microsoft Windows Server* | 2012R2, 2019        |
@@ -88,6 +88,13 @@ have installed:
 
   ```shell
   sudo rpm -Uvh https://yum.puppet.com/puppet-tools-release-fedora-32.noarch.rpm
+  sudo dnf install puppet-bolt
+  ```
+
+- _Fedora 34_
+
+  ```shell
+  sudo rpm -Uvh https://yum.puppet.com/puppet-tools-release-fedora-34.noarch.rpm
   sudo dnf install puppet-bolt
   ```
 


### PR DESCRIPTION
This adds documentation for installing Bolt on Fedora 34.

!feature

* **Fedora 34 packages**
  ([#2903](https://github.com/puppetlabs/bolt/issues/2903))

  Bolt now ships packages for Fedora 34.

---

- [x] **DO NOT MERGE** until puppet-tools-release package is available for Fedora 34.