### PR TITLE
(GH-2926) Add YAML plan verbose step

### DIFF
--- a/documentation/writing_yaml_plans.md
+++ b/documentation/writing_yaml_plans.md
@@ -107,7 +107,7 @@ Message steps support the following keys:
 
 | Key | Type | Description | Required |
 | --- | --- | --- | --- |
-| `message` | `String` | The message to print. | ✓ |
+| `message` | `Any` | The message to print. | ✓ |
 
 For example:
 
@@ -123,6 +123,30 @@ prints the object as a string.
 
 For information on printing a step result with `message`, see [Debugging
 plans](#debugging-plans).
+
+### Verbose step
+
+Use a `verbose` step to print a message in verbose mode. The step prints a message to standard
+out (stdout) when using the `human` output format, and prints to standard error
+(stderr) when using the `json` output format. 
+
+Verbose steps support the following keys:
+
+| Key | Type | Description | Required |
+| --- | --- | --- | --- |
+| `verbose` | `Any` | The message to print. | ✓ |
+
+For example:
+
+```yaml
+steps:
+  - verbose: hello world
+```
+
+You can pass variables to the verbose step to print them to stdout. If the 
+variable is a [Bolt datatype](bolt_types_reference.md) it will be formatted 
+as a Hash. Once the object is formatted, if it's a Hash or Array it is printed
+as JSON, otherwise Bolt prints the object as a string.
 
 ### Command step
 

--- a/lib/bolt/pal/yaml_plan/step.rb
+++ b/lib/bolt/pal/yaml_plan/step.rb
@@ -13,6 +13,7 @@ module Bolt
           download
           eval
           message
+          verbose
           plan
           resources
           script
@@ -219,3 +220,4 @@ require 'bolt/pal/yaml_plan/step/task'
 require 'bolt/pal/yaml_plan/step/upload'
 require 'bolt/pal/yaml_plan/step/download'
 require 'bolt/pal/yaml_plan/step/message'
+require 'bolt/pal/yaml_plan/step/verbose'

--- a/lib/bolt/pal/yaml_plan/step/verbose.rb
+++ b/lib/bolt/pal/yaml_plan/step/verbose.rb
@@ -4,25 +4,25 @@ module Bolt
   class PAL
     class YamlPlan
       class Step
-        class Message < Step
+        class Verbose < Step
           def self.allowed_keys
-            super + Set['message']
+            super + Set['verbose']
           end
 
           def self.required_keys
-            Set['message']
+            Set['verbose']
           end
 
           # Returns an array of arguments to pass to the step's function call
           #
           private def format_args(body)
-            [body['message']]
+            [body['verbose']]
           end
 
           # Returns the function corresponding to the step
           #
           private def function
-            'out::message'
+            'out::verbose'
           end
         end
       end

--- a/schemas/bolt-yaml-plan.schema.json
+++ b/schemas/bolt-yaml-plan.schema.json
@@ -320,7 +320,24 @@
           "type": "string"
         }
       }
-    }
+    },
+    "verbose": {
+      "description": "Print a message only when run in verbose mode. This will print a message to standard out (stdout) when using the 'human' output format or standard error (stderr) when using the 'json' output format.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verbose"],
+      "properties": {
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "verbose": {
+          "description": "The message to print."
+        },
+        "name": {
+          "$ref": "#/definitions/name"
+        }
+      }
+    },
   },
   "definitions": {
     "catch_errors": {

--- a/spec/bolt/pal/yaml_plan/evaluator_spec.rb
+++ b/spec/bolt/pal/yaml_plan/evaluator_spec.rb
@@ -198,6 +198,19 @@ describe Bolt::PAL::YamlPlan::Evaluator do
     end
   end
 
+  describe "verbose step" do
+    let(:step_body) do
+      {
+        'verbose' => 'hello world'
+      }
+    end
+
+    it 'calls out::verbose' do
+      expect(scope).to receive(:call_function).with('out::verbose', ['hello world'])
+      step.evaluate(scope, subject)
+    end
+  end
+
   describe "task step" do
     let(:step_body) do
       { 'task' => 'package',

--- a/spec/bolt/pal/yaml_plan/step_spec.rb
+++ b/spec/bolt/pal/yaml_plan/step_spec.rb
@@ -46,6 +46,19 @@ describe Bolt::PAL::YamlPlan::Step do
       end
     end
 
+    context 'with verbose step' do
+      let(:step_body) do
+        {
+          "verbose" => make_string("hello world")
+        }
+      end
+      let(:output) { "  out::verbose('hello world')\n" }
+
+      it 'stringifies a message step' do
+        expect(step.transpile).to eq(output)
+      end
+    end
+
     context 'with command step' do
       let(:step_body) do
         { "command" => make_string("echo peanut butter"),

--- a/spec/fixtures/modules/yaml/plans/verbose.yaml
+++ b/spec/fixtures/modules/yaml/plans/verbose.yaml
@@ -1,0 +1,9 @@
+parameters:
+  message:
+    type: String
+    default: hershey
+
+steps:
+  - name: verbose
+    verbose: $message
+    description: 'This will call out::verbose(hershey)'

--- a/spec/integration/plan_spec.rb
+++ b/spec/integration/plan_spec.rb
@@ -77,24 +77,18 @@ describe 'plans' do
 
       let(:config_flags) { ['--no-host-key-check'] }
       let(:opts)         { { outputter: Bolt::Outputter::Human, project: @project } }
+      let(:project)      { @project }
 
-      context 'output' do
-        let(:output)    { StringIO.new }
-        let(:outputter) { Bolt::Outputter::Human.new(true, true, true, true, output) }
-
-        before(:each) do
-          allow(Bolt::Outputter::Human).to receive(:new).and_return(outputter)
+      context 'out::verbose' do
+        it 'outputs verbose messages in verbose mode' do
+          result = run_cli(%w[plan run output::verbose --verbose], outputter: Bolt::Outputter::Human,
+                                                                   project: project)
+          expect(result).to match(/Hi, I'm Dave/)
         end
 
-        it 'outputs message with verbose flag' do
-          run_cli(%W[plan run output::verbose --targets #{target} --verbose] + config_flags,
-                  outputter: Bolt::Outputter::Human, project: @project)
-          expect(output.string).to match(/Hi, I'm Dave/)
-        end
-
-        it 'doesnt output without verbose flag' do
-          result = run_cli(%W[plan run output::verbose --targets #{target}] + config_flags,
-                           outputter: Bolt::Outputter::Human, project: @project)
+        it 'does not output verbose messages when not in verbose mode' do
+          result = run_cli(%w[plan run output::verbose], outputter: Bolt::Outputter::Human,
+                                                         project: project)
           expect(result).not_to match(/Hi, I'm Dave/)
         end
       end

--- a/spec/lib/bolt_spec/integration.rb
+++ b/spec/lib/bolt_spec/integration.rb
@@ -17,8 +17,9 @@ module BoltSpec
       allow(cli).to receive(:puppetdb_client).and_return(pdb_client)
       allow(cli).to receive(:analytics).and_return(Bolt::Analytics::NoopClient.new)
 
+      verbose = arguments.include?('--verbose')
       output =  StringIO.new
-      outputter = outputter.new(false, false, false, false, output)
+      outputter = outputter.new(false, verbose, false, false, output)
       allow(cli).to receive(:outputter).and_return(outputter)
 
       # Don't allow tests to override the captured log config


### PR DESCRIPTION
This adds a YAML plan verbose step that prints a message when run in verbose mode.

!feature

* **YAML plan verbose step**
  ([#2926](https://github.com/puppetlabs/bolt/issues/2926))

  YAML plans now support a verbose step that prints a message when run in verbose mode.