### PR TITLE
(PE-32490) Add project_plugin_tarball endpoint

### DIFF
--- a/developer-docs/bolt-server/api.md
+++ b/developer-docs/bolt-server/api.md
@@ -383,6 +383,20 @@ This endpoint returns the base64 encoded tar archive of plugin code that is need
 "H4sIAI7ot2AAA+2UywqDMBBFXfsVAfcm0RihPxOiRhtIY8gDSr++UbCrQtGF\nLSVnN7O5A5czRoVJ6pH33rHbPAQl4DqUAxR3L6zmii2L0l2zo6AIJeTtfqVC\nGSaoaVpa4xZnCDe4ohlAhxN3EJznNp5yRtYPUoCtZrDUnH/7nsS5mNX/TX0l\nO2iCMcLDMejey1k76OabYNtY2m53xkf/G/ryn9Qk+k9bXCf/z6AAo50fQjPn\nrdQTUzJ+A64uwNsg8gIs5YOt/PQdEolE4m94AocSIJ4ADAAA\n"
 ```
 
+## GET /project_plugin_tarball
+
+This endpoint returns the base64 encoded tar archive of _all_ plugin code for a project.
+
+### Query parameters
+
+- `versioned_project`: String, *required* - Reference to the bolt project (in the form [PROJECT NAME]\_[REF])
+
+### Response
+
+```
+"H4sIAI7ot2AAA+2UywqDMBBFXfsVAfcm0RihPxOiRhtIY8gDSr++UbCrQtGF\nLSVnN7O5A5czRoVJ6pH33rHbPAQl4DqUAxR3L6zmii2L0l2zo6AIJeTtfqVC\nGSaoaVpa4xZnCDe4ohlAhxN3EJznNp5yRtYPUoCtZrDUnH/7nsS5mNX/TX0l\nO2iCMcLDMejey1k76OabYNtY2m53xkf/G/ryn9Qk+k9bXCf/z6AAo50fQjPn\nrdQTUzJ+A64uwNsg8gIs5YOt/PQdEolE4m94AocSIJ4ADAAA\n"
+```
+
 ## GET /tasks
 - `environment`: String
 

--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -766,6 +766,26 @@ module BoltServer
       [200, plugins_tarball.to_json]
     end
 
+    # Returns the base64 encoded tar archive of _all_ plugin code for a project
+    #
+    # @param versioned_project [String] the versioned_project to build the plugin tarball from
+    get '/project_plugin_tarball' do
+      raise BoltServer::RequestError, "'versioned_project' is a required argument" if params['versioned_project'].nil?
+      content_type :json
+
+      plugins_tarball = build_project_plugins_tarball(params['versioned_project']) do |mod|
+        search_dirs = []
+        search_dirs << mod.plugins if mod.plugins?
+        search_dirs << mod.pluginfacts if mod.pluginfacts?
+        search_dirs << mod.files if mod.files?
+        type_files = "#{mod.path}/types"
+        search_dirs << type_files if File.exist?(type_files)
+        search_dirs
+      end
+
+      [200, plugins_tarball.to_json]
+    end
+
     error 404 do
       err = Bolt::Error.new("Could not find route #{request.path}",
                             'boltserver/not-found')

--- a/spec/fixtures/bolt_server/projects/bolt_server_test_project/modules/plugin_module/types/some_alias.pp
+++ b/spec/fixtures/bolt_server/projects/bolt_server_test_project/modules/plugin_module/types/some_alias.pp
@@ -1,0 +1,1 @@
+type Alias = Integer


### PR DESCRIPTION
This endpoint returns a tarball of _all_ plugin code for a project. It
might be worth reconciling project_facts_plugin_tarball and
project_plugin_tarball into a single endpoint in the future, but this is
good enough for now.

Signed-off-by: Enis Inan <enis.inan@puppet.com>