### PR TITLE
(GH-2875) Add `batch-mode` config option for `native-ssh`

### DIFF
--- a/documentation/troubleshooting.md
+++ b/documentation/troubleshooting.md
@@ -92,6 +92,42 @@ By default, Bolt tries to connect over the standard SSH port 22. If you need to
 connect over a different port, either include the port in the name of the target
 (`hostname.example.com:2345`) or set it in your Bolt config or inventory.
 
+### Providing a password non-interactively using `native-ssh`
+
+By default, the `native-ssh` transport enables `BatchMode` when establishing
+connections to targets. When `BatchMode` is enabled, SSH does not fall back to
+querying for a password, which might make it impossible to connect to a target
+if you are unable to authenticate using keys.
+
+You can disable `BatchMode` in your transport configuration using the
+`batch-mode` setting, which allows SSH to fall back to querying for a password
+when key authentication fails. However, `native-ssh` uses the `ssh` client by
+default, which prompts for passwords interactively and causes Bolt to hang. 
+
+To avoid hanging when `BatchMode` is disabled, you must configure `ssh-command`
+to use an SSH utility like `sshpass` to provide a password to the SSH client
+non-interactively. Additionally, ensure the `user` is configured and
+`host-key-check` is disabled.
+
+The following configuration shows how to disable `BatchMode` and provide a
+password to the SSH client using sshpass and the `prompt` plugin.
+
+```yaml
+# inventory.yaml
+config:
+  ssh:
+    native-ssh: true
+    host-key-check: false
+    batch-mode: false
+    user: root
+    ssh-command:
+      - sshpass
+      - -p
+      - _plugin: prompt
+        message: Enter your SSH password
+      - ssh
+```
+
 ## Bolt can't connect to my Windows hosts
 
 ### Timeout or connection refused

--- a/lib/bolt/config/transport/options.rb
+++ b/lib/bolt/config/transport/options.rb
@@ -16,6 +16,18 @@ module Bolt
             _default: false,
             _example: true
           },
+          "batch-mode" => {
+            type: [TrueClass, FalseClass],
+            description: "Whether to disable password querying. When set to `false`, SSH will fall back to "\
+                         "prompting for a password if key authentication fails. This might cause Bolt to hang. "\
+                         "To prevent Bolt from hanging, you can configure `ssh-command` to use an SSH utility "\
+                         "such as sshpass that supports providing a password non-interactively. For more "\
+                         "information, see [Providing a password non-interactively using "\
+                         "`native-ssh`](troubleshooting.md#providing-a-password-non-interactively-using-native-ssh).",
+            _plugin: true,
+            _default: true,
+            _example: false
+          },
           "bundled-ruby" => {
             description: "Whether to use the Ruby bundled with Bolt packages for local targets.",
             type: [TrueClass, FalseClass],

--- a/lib/bolt/config/transport/ssh.rb
+++ b/lib/bolt/config/transport/ssh.rb
@@ -34,6 +34,7 @@ module Bolt
 
         # Options available when using the native ssh transport
         NATIVE_OPTIONS = %w[
+          batch-mode
           cleanup
           copy-command
           host
@@ -49,6 +50,7 @@ module Bolt
         ].concat(RUN_AS_OPTIONS).sort.freeze
 
         DEFAULTS = {
+          "batch-mode"         => true,
           "cleanup"            => true,
           "connect-timeout"    => 10,
           "disconnect-timeout" => 5,
@@ -123,6 +125,11 @@ module Bolt
           if @config['native-ssh'] && !@config['load-config']
             msg = 'Cannot use native SSH transport with load-config set to false'
             raise Bolt::ValidationError, msg
+          end
+
+          if !@config['batch-mode'] && !@config['ssh-command']
+            raise Bolt::ValidationError,
+                  'Must set ssh-command when batch-mode is set to false'
           end
         end
       end

--- a/lib/bolt/transport/ssh/exec_connection.rb
+++ b/lib/bolt/transport/ssh/exec_connection.rb
@@ -47,7 +47,9 @@ module Bolt
           cmd = []
           # BatchMode is SSH's noninteractive option: if key authentication
           # fails it will error out instead of falling back to password prompt
-          cmd += %w[-o BatchMode=yes]
+          batch_mode = @target.transport_config['batch-mode'] ? 'yes' : 'no'
+          cmd += %W[-o BatchMode=#{batch_mode}]
+
           cmd += %W[-o Port=#{@target.port}] if @target.port
 
           if @target.transport_config.key?('host-key-check')

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -1395,6 +1395,17 @@
         }
       ]
     },
+    "batch-mode": {
+      "description": "Whether to disable password querying. When set to `false`, SSH will fall back to prompting for a password if key authentication fails. This might cause Bolt to hang. To prevent Bolt from hanging, you can configure `ssh-command` to use an SSH utility such as sshpass that supports providing a password non-interactively. For more information, see [Providing a password non-interactively using `native-ssh`](troubleshooting.md#providing-a-password-non-interactively-using-native-ssh).",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
     "bundled-ruby": {
       "description": "Whether to use the Ruby bundled with Bolt packages for local targets.",
       "type": "boolean"

--- a/schemas/bolt-inventory.schema.json
+++ b/schemas/bolt-inventory.schema.json
@@ -1063,6 +1063,17 @@
                         }
                       ]
                     },
+                    "batch-mode": {
+                      "description": "Whether to disable password querying. When set to `false`, SSH will fall back to prompting for a password if key authentication fails. This might cause Bolt to hang. To prevent Bolt from hanging, you can configure `ssh-command` to use an SSH utility such as sshpass that supports providing a password non-interactively. For more information, see [Providing a password non-interactively using `native-ssh`](troubleshooting.md#providing-a-password-non-interactively-using-native-ssh).",
+                      "oneOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
                     "copy-command": {
                       "description": "The command to use when copying files using native SSH. Bolt runs `<copy-command> <src> <dest>`. This option is used when you need support for features or algorithms that are not supported by the net-ssh Ruby library. **This option is experimental.** You can read more about this option in [Native SSH transport](experimental_features.md#native-ssh-transport).",
                       "oneOf": [

--- a/spec/bolt/config/transport/ssh_spec.rb
+++ b/spec/bolt/config/transport/ssh_spec.rb
@@ -75,6 +75,19 @@ describe Bolt::Config::Transport::SSH do
       end
     end
 
+    context 'batch-mode' do
+      let(:data) do
+        {
+          'batch-mode' => false,
+          'native-ssh' => true
+        }
+      end
+
+      it 'errors without ssh-command set' do
+        expect { transport.new(data) }.to raise_error(Bolt::ValidationError)
+      end
+    end
+
     context "when using powershell" do
       before :each do
         data['login-shell'] = 'powershell'

--- a/spec/bolt/inventory/inventory_spec.rb
+++ b/spec/bolt/inventory/inventory_spec.rb
@@ -1053,7 +1053,8 @@ describe Bolt::Inventory::Inventory do
       }
       let(:inventory) { Bolt::Inventory::Inventory.new(data, transport, transports, plugins) }
       let(:expected_options) {
-        { "connect-timeout" => 10,
+        { "batch-mode" => true,
+          "connect-timeout" => 10,
           "tty" => false,
           "load-config" => true,
           "disconnect-timeout" => 11,
@@ -1267,6 +1268,7 @@ describe Bolt::Inventory::Inventory do
         'config' => {
           'transport' => 'ssh',
           'ssh' => {
+            'batch-mode' => true,
             'connect-timeout' => 10,
             'tty' => false,
             'load-config' => true,


### PR DESCRIPTION
This adds a new `batch-mode` configuration option for the `native-ssh`
transport. When set to `false`, `BatchMode` is disabled, which allows
SSH to fall back to querying for a password when key authentication
fails. This config option can be set in conjunction with the
`ssh-command` option to allow users to provide a password
non-interactively to SSH when using `native-ssh`.

!feature

* **Add `batch-mode` configuration option for `native-ssh` transport**
  ([#2875](https://github.com/puppetlabs/bolt/issues/2875))

  The `native-ssh` transport has a new `batch-mode` configuration option
  that can be used to enable or disable `BatchMode`. For more
  information, see [the
  documentation](https://puppet.com/docs/bolt/latest/troubleshooting.html#providing-a-password-non-interactively-using-native-ssh).