### PR TITLE
(PE-32485) Allow plugin_hooks to be passed to bolt-server actions

### DIFF
--- a/lib/bolt_server/schemas/partials/target-ssh.json
+++ b/lib/bolt_server/schemas/partials/target-ssh.json
@@ -62,6 +62,10 @@
     "interpreters": {
       "type": "object",
       "description": "Map of file extensions to remote executable"
+    },
+    "plugin_hooks": {
+      "type": "object",
+      "description": "Configuration for plugins to use"
     }
   },
   "oneOf": [

--- a/lib/bolt_server/schemas/partials/target-winrm.json
+++ b/lib/bolt_server/schemas/partials/target-winrm.json
@@ -56,6 +56,10 @@
     "smb-port": {
       "type": "integer",
       "description": "Port for SMB protocol"
+    },
+    "plugin_hooks": {
+      "type": "object",
+      "description": "Configuration for plugins to use"
     }
   },
   "required": ["hostname", "user", "password"],

--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -441,7 +441,7 @@ module BoltServer
         'uri' => target_hash['hostname'],
         'config' => {
           'transport' => 'ssh',
-          'ssh' => opts
+          'ssh' => opts.slice(*Bolt::Config::Transport::SSH.options)
         }
       }
 
@@ -479,7 +479,7 @@ module BoltServer
         'uri' => target_hash['hostname'],
         'config' => {
           'transport' => 'winrm',
-          'winrm' => opts
+          'winrm' => opts.slice(*Bolt::Config::Transport::WinRM.options)
         }
       }
 


### PR DESCRIPTION
This adds the plugin_hooks key to the SSH and WinRM target schemas,
allowing it to be passed to the API. This will let the key be used
internally within orchestrator without worrying about whether it gets
passed to bolt-server.

This key, along with the existing special 'hostname' and
'private-key-content' keys, will automatically be ignored by Bolt's
transport config handling. However, for clarity we now explicitly filter
the options we pass to the config to include only those that are
accepted by the transport. While not strictly necessary, this makes it
more obvious why those keys don't cause a problem and it provides an
extra layer of certainty in case the underlying implementation shifts in
the future.