### PR TITLE
(Docs) Add documentation for `allow_any_plan` and `allow_any_task`

### DIFF
--- a/documentation/boltspec_reference.md
+++ b/documentation/boltspec_reference.md
@@ -7,8 +7,8 @@ how to use these functions, see [Testing plans](testing_plans.md).
 ## Execution modes
 
 Plans often execute sub-plans with the `run_plan` function to build complex
-workflows. When testing these plans, it might be helpful to execute any
-sub-plans as well without needing to stub or mock the plan. To support this,
+workflows. When testing a plan with sub-plans, it might be helpful to execute the
+sub-plans without needing to separately stub or mock each one. To support this,
 `BoltSpec` offers two different execution modes:
 
 ### `execute_any_plan`
@@ -227,7 +227,8 @@ The `expect_download` function accepts the following modifiers:
 
 ### `expect_out_message`
 
-The `expect_out_message` function mocks the [`out::message` function](plan_functions.md#out::message). It does not accept any parameters.
+The `expect_out_message` function mocks the [`out::message` function](plan_functions.md#outmessage).
+It does not accept parameters.
 
 ```ruby
 expect_out_message
@@ -262,7 +263,7 @@ The `expect_out_message` function accepts the following modifiers:
 
 ### `expect_out_verbose`
 
-The `expect_out_verbose` function mocks the [`out::verbose` function](plan_functions.md#outverbose). It does not accept any parameters.
+The `expect_out_verbose` function mocks the [`out::verbose` function](plan_functions.md#outverbose). It does not accept parameters.
 
 ```ruby
 expect_out_verbose
@@ -294,7 +295,6 @@ The `expect_out_verbose` function accepts the following modifiers:
   ```ruby
   expect_out_verbose.with_params('This is not the example you are looking for.')
   ```
-
 
 ### `expect_plan`
 
@@ -638,14 +638,14 @@ function to be invoked any number of times during a test.
 ### `allow_apply`
 
 The `allow_apply` function stubs the [`apply`
-function](plan_functions.md#apply). It does not accept any parameters or
+function](plan_functions.md#apply). It does not accept parameters or
 modifiers. Using the `allow_apply` stub only allows you to invoke the `apply`
 function in a plan.
 
 ### `allow_apply_prep`
 
 The `allow_apply_prep` function stubs the [`apply_prep`
-function](plan_functions.md#apply-prep). It does not accept any parameters or
+function](plan_functions.md#apply-prep). It does not accept parameters or
 modifiers. Using the `allow_apply_prep` stub only allows you to invoke the
 `apply_prep` function in a plan.
 
@@ -825,7 +825,8 @@ The `allow_download` function accepts the following modifiers:
 
 ### `allow_out_message`
 
-The `allow_out_message` function stubs the [`out::message` function](plan_functions.md#out::message). It does not accept any parameters.
+The `allow_out_message` function stubs the [`out::message` function](plan_functions.md#outmessage). 
+It does not accept parameters.
 
 ```ruby
 allow_out_message
@@ -860,7 +861,8 @@ The `allow_out_message` function accepts the following stub modifiers:
 
 ### `allow_out_verbose`
 
-The `allow_out_verbose` function stubs the [`out::verbose` function](plan_functions.md#outverbose). It does not accept any parameters.
+The `allow_out_verbose` function stubs the [`out::verbose` function](plan_functions.md#outverbose). 
+It does not accept parameters.
 
 ```ruby
 allow_out_verbose
@@ -1224,6 +1226,579 @@ The `allow_upload` function accepts the following modifiers:
 
   ```ruby
   allow_upload('sshd_config').error_with('msg' => 'Not authorized')
+  ```
+  
+## Global stubs
+
+Global stubs allow you to stub all related function invocations. This can be useful in
+larger plans. For example, `allow_any_task` can be used in place of invoking `allow_task` 
+for each individual task. All global stub functions follow the `allow_any_*` naming
+scheme.
+
+### `allow_any_command`
+
+The `allow_any_command` function stubs all invocations of the [`run_command`
+function](plan_functions.md#run-command). It does not accept parameters.
+
+```ruby
+allow_any_command
+```
+
+The `allow_any_command` function accepts the following modifiers:
+
+- `be_called_times(number)`
+
+  The test fails if any one command is run more than _number_ of times.
+
+  ```ruby
+  allow_any_command.be_called_times(3)
+  ```
+
+- `not_be_called`
+
+  The test fails if any command is run.
+
+  ```ruby
+  allow_any_command.not_be_called
+  ```
+
+- `with_targets(targets)`
+
+  The target or list of targets that a command can be run on. The test fails
+  if any command is run on a different list of targets.
+
+  ```ruby
+  allow_any_command.with_targets(['target1', 'target2', 'target3'])
+  ```
+
+- `with_params(parameters)`
+
+  The [options](plan_functions.md#run-command) that can be passed to the
+  `run_command` function. The test fails if any command is run with a different
+  set of options.
+
+  ```ruby
+  allow_any_command.with_params({ '_run_as' => 'root' })
+  ```
+
+- `always_return(value)`
+
+  Sets the value for each target's `Result` when any command is run. Returns a
+  `Bolt::ResultSet` object. Only accepts `stderr` and `stdout` keys.
+
+  ```ruby
+  allow_any_command.always_return({ 'stdout' => 'BoltyMcBoltface' })
+  ```
+
+- `return_for_targets(targets_to_values)`
+
+  Sets the value for each target's `Result` when any command is run. Accepts a
+  hash of key-value pairs where each key is a target and the value is the value
+  for that target's `Result`. Values can only have `stderr` and `stdout` keys.
+
+  ```ruby
+  allow_any_command.return_for_targets(
+    'target1' => { 'stdout' => 'BoltyMcBoltFace' },
+    'target2' => { 'stdout' => 'Robert' },
+    'target3' => { 'stdout' => 'Bobert' }
+  )
+  ```
+
+- `return(&block) { |targets, command, params| ... }`
+
+  Invokes a block to construct the `ResultSet` returned by the `run_command`
+  function.
+
+  ```ruby
+  allow_any_command.return do |targets, command, params|
+    results = targets.map do |target|
+      Bolt::Result.new(target, value: { 'stdout' => 'BoltyMcBoltface' })
+    end
+
+    Bolt::ResultSet.new(results)
+  end
+  ```
+
+- `error_with(error)`
+
+  Sets the error hash for each target's `Result` for any command that is run. 
+  Returns a `Bolt::ResultSet` object.
+
+  ```ruby
+  allow_any_command.error_with('msg' => 'sh: command not found: whoami')
+  ```
+
+### `allow_any_download`
+
+The `allow_any_download` function stubs all invocations of the [`download_file`
+function](plan_functions.md#download-file). It does not accept parameters.
+
+```ruby
+allow_any_download
+```
+
+The `allow_any_download` function accepts the following modifiers:
+
+- `be_called_times(number)`
+
+  The test fails if any one file is downloaded more than _number_ times.
+
+  ```ruby
+  allow_any_download.be_called_times(1)
+  ```
+
+- `not_be_called`
+
+  The test fails if any file is downloaded.
+
+  ```ruby
+  allow_any_download.not_be_called
+  ```
+
+- `with_targets(targets)`
+
+  The target or list of targets that the file can be downloaded from. The test
+  fails if any file is downloaded from a different list of targets.
+
+  ```ruby
+  allow_any_download.with_targets(['target1', 'target2', 'target3'])
+  ```
+
+- `with_params(parameters)`
+
+  The [options](plan_functions.md#download-file) that can be passed to the
+  `download_file` function. The test fails if any file is downloaded with a
+  different set of options.
+
+  ```ruby
+  allow_any_download.with_params({ '_run_as' => 'root' })
+  ```
+
+- `with_destination(destination)`
+
+  The destination path that the file is downloaded to. The test fails if any
+  file is downloaded to a different location.
+
+  ```ruby
+  allow_any_download.with_destination('kernel')
+  ```
+
+- `return(&block) { |targets, source, destination, params| ... }`
+
+  Invokes a block to construct the `ResultSet` returned by the `download_file`
+  function.
+
+  ```ruby
+  allow_any_download.return do |targets, source, destination, params|
+    results = targets.map do |target|
+      Bolt::Result.new(target, value: { 'path' => File.join(destination, source) })
+    end
+
+    Bolt::ResultSet.new(results)
+  end
+  ```
+
+- `error_with(error)`
+
+  Sets the error hash for each target's `Result` when the file is downloaded.
+  Returns a `Bolt::ResultSet` object.
+
+  ```ruby
+  allow_any_download.error_with('msg' => 'File not found')
+  ```
+
+### `allow_any_out_message`
+
+The `allow_any_out_message` function stubs all invocations of the [`out::message`
+function](plan_functions.md#outmessage). It does not accept parameters.
+
+```ruby
+allow_any_out_message
+```
+
+The `allow_any_out_message` function accepts the following modifiers:
+
+- `be_called_times(number)`
+
+  The test fails if `out::message` is run more than _number_ times. 
+
+  ```ruby
+  allow_any_out_message.be_called_times(3)
+  ```
+
+- `not_be_called`
+
+  The test fails if `out::message` is called.
+
+  ```ruby
+  allow_any_out_message.not_be_called
+  ```
+
+- `with_params(parameters)`
+
+  The parameters that can be passed to the `out::message` function. 
+  The test fails if `out::mesage` is called with a different
+  set of parameters.
+
+  ```ruby
+  allow_any_out_message.with_params("hello world")
+  ```
+
+### `allow_any_out_verbose`
+
+The `allow_any_out_verbose` function stubs all invocations of the [`out::verbose`
+function](plan_functions.md#outverbose). It does not accept parameters.
+
+```ruby
+allow_any_out_verbose
+```
+
+The `allow_any_out_verbose` function accepts the following modifiers:
+
+- `be_called_times(number)`
+
+  The test fails if `out::verbose` is run more than _number_ times. 
+
+  ```ruby
+  allow_any_out_verbose.be_called_times(3)
+  ```
+
+- `not_be_called`
+
+  The test fails if `out::verbose` is called.
+
+  ```ruby
+  allow_any_out_verbose.not_be_called
+  ```
+
+- `with_params(parameters)`
+
+  The parameters that can be passed to the `out::verbose` function. 
+  The test fails if `out::verbose` is called with a different
+  set of parameters.
+
+  ```ruby
+  allow_any_out_verbose.with_params("hello world")
+  ```
+
+### `allow_any_plan`
+
+The `allow_any_plan` function stubs all invocations of the [`run_plan`
+function](plan_functions.md#run-plan). It does not accept parameters.
+
+```ruby
+allow_any_plan
+```
+
+The `allow_any_plan` function accepts the following modifiers:
+
+- `be_called_times(number)`
+
+  The test fails if any plan is run more than _number_ times. 
+
+  ```ruby
+  allow_any_plan.be_called_times(3)
+  ```
+
+- `not_be_called`
+
+  The test fails if any plan is run.
+
+  ```ruby
+  allow_any_plan.not_be_called
+  ```
+
+- `with_params(parameters)`
+
+  The parameters and [options](plan_functions.md#run-plan) that can be passed to
+  the `run_plan` function. The test fails if any plan is run with a different
+  set of parameters and options.
+
+  ```ruby
+  allow_any_plan.with_params({ 'fruit' => 'apple', '_run_as' => 'root' })
+  ```
+
+- `always_return(value)`
+
+  Sets the value for the `PlanResult` object returned by every plan. The
+  `PlanResult` object returned by this modifier always has a `success` status.
+
+  ```ruby
+  allow_any_plan.always_return(318)
+  ```
+
+- `return(&block) { |plan, params| ... }`
+
+  Invokes a block to construct the `PlanResult` returned by the `run_plan`
+  function.
+
+  ```ruby
+  allow_any_plan.return do |plan, params|
+    Bolt::PlanResult.new(100, 'success')
+  end
+  ```
+
+- `error_with(error)`
+
+  Sets the value for the `PlanResult` object returned by each plan. The
+  `PlanResult` object returned by this modifier always has a `failure` status.
+
+  ```ruby
+  allow_any_plan.error_with('Too many apples, buffer overflow!')
+  ```
+
+### `allow_any_script`
+
+The `allow_script` function stubs all invocations of the [`run_script`
+function](plan_functions.md#run-script). It does not accept parameters.
+
+```ruby
+allow_any_script
+```
+
+The `allow_any_script` function accepts the following modifiers:
+
+- `be_called_times(number)`
+
+  The test fails if any one script is run more than _number_ times.
+
+  ```ruby
+  allow_any_script.be_called_times(3)
+  ```
+
+- `not_be_called`
+
+  The test fails if any script is run.
+
+  ```ruby
+  allow_any_script.not_be_called
+  ```
+
+- `with_targets(targets)`
+
+  The target or list of targets that a script can be run on. The test fails if
+  any script is run on a different list of targets.
+
+  ```ruby
+  allow_any_script.with_targets(['target1', 'target2', 'target3'])
+  ```
+
+- `with_params(parameters)`
+
+  The [options](plan_functions.md#run-script) that can be passed to the
+  `run_script` function. The test fails if any script is run with a different
+  set of options.
+
+  ```ruby
+  allow_any_script.with_params({ 'arguments' => ['/u', 'Administrator'] })
+  ```
+
+- `always_return(value)`
+
+  Sets the value for each target's `Result` when any script is run. Returns a
+  `Bolt::ResultSet` object. Values only accept `stderr` and `stdout` keys.
+
+  ```ruby
+  allow_any_script.always_return({ 'stdout' => 'success' })
+  ```
+
+- `return_for_targets(targets_to_values)`
+
+  Sets the value for each target's `Result` when any script is run. Accepts a
+  hash of key-value pairs where each key is a target and the value is the value
+  for that target's `Result`. Values only accept `stderr` and `stdout` keys.
+
+  ```ruby
+  allow_any_script.return_for_targets(
+    'target1' => { 'stdout' => 'success' },
+    'target2' => { 'stdout' => 'failure' }
+  )
+  ```
+
+- `return(&block) { |targets, script, params| ... }`
+
+  Invokes a block to construct the `ResultSet` returned by the `run_script`
+  function.
+
+  ```ruby
+  allow_any_script.return do |targets, script, params|
+    results = targets.map do |target|
+      Bolt::Result.new(target, value: { 'stdout' => 'success' })
+    end
+
+    Bolt::ResultSet.new(results)
+  end
+  ```
+
+- `error_with(error)`
+
+  Sets the error hash for each target's `Result` when any script is run. Returns a
+  `Bolt::ResultSet` object.
+
+  ```ruby
+  allow_any_script.error_with('msg' => 'sh: command not found: apt-get')
+  ```
+
+### `allow_any_task`
+
+The `allow_any_task` function stubs the [`run_task`
+function](plan_functions.md#run-task). It does not accept parameters.
+
+```ruby
+allow_any_task
+```
+
+The `allow_any_task` function accepts the following modifiers:
+
+- `be_called_times(number)`
+
+  The test fails if the any one task is run more than _number_ times.
+
+  ```ruby
+  allow_any_task.be_called_times(3)
+  ```
+
+- `not_be_called`
+
+  The test fails if any task is run.
+
+  ```ruby
+  allow_any_task.not_be_called
+  ```
+
+- `with_targets(targets)`
+
+  The target or list of targets that a task can be run on. The test fails if
+  any task is run on a different list of targets.
+
+  ```ruby
+  allow_any_task.with_targets(['target1', 'target2', 'target3'])
+  ```
+
+- `with_params(parameters)`
+
+  The parameters and [options](plan_functions.md#run-script) that can be passed to the
+  `run_task` function. The test fails if any task is run with a different
+  set of parameters and options.
+
+  ```ruby
+  allow_any_task.with_params({ 'breed' => 'german shepherd' })
+  ```
+
+- `always_return(value)`
+
+  Sets the value for each target's `Result` for any task that is run. Returns a
+  `Bolt::ResultSet` object.
+
+  ```ruby
+  allow_any_task.always_return({ 'happy' => true })
+  ```
+
+- `return_for_targets(targets_to_values)`
+
+  Sets the value for each target's `Result` when any task is run. Accepts a
+  hash of key-value pairs where each key is a target and the value is the value
+  for that target's `Result`.
+
+  ```ruby
+  allow_any_task('pet_dog').return_for_targets(
+    'target1' => { 'happy' => true },
+    'target2' => { 'happy' => false }
+  )
+  ```
+
+- `return(&block) { |targets, task, params| ... }`
+
+  Invokes a block to construct the `ResultSet` returned by the `run_task`
+  function.
+
+  ```ruby
+  allow_any_task.return do |targets, task, params|
+    results = targets.map do |target|
+      Bolt::Result.new(target, value: { 'happy' => true })
+    end
+
+    Bolt::ResultSet.new(results)
+  end
+  ```
+
+### `allow_any_upload`
+
+The `allow_any_upload` function stubs any invocation of the [`upload_file`
+function](plan_functions.md#upload-file). It does not accept parameters.
+
+```ruby
+allow_any_upload
+```
+
+The `allow_any_upload` function accepts the following modifiers:
+
+- `be_called_times(number)`
+
+  The test fails if any one file is uploaded more than _number_ times.
+
+  ```ruby
+  allow_any_upload.be_called_times(1)
+  ```
+
+- `not_be_called`
+
+  The test fails if any file is uploaded.
+
+  ```ruby
+  allow_any_upload.not_be_called
+  ```
+
+- `with_targets(targets)`
+
+  The target or list of targets that a file can be uploaded to. The test
+  fails if any file is uploaded to a different list of targets.
+
+  ```ruby
+  allow_any_upload.with_targets(['target1', 'target2', 'target3'])
+  ```
+
+- `with_params(parameters)`
+
+  The [options](plan_functions.md#upload-file) that can be passed to the
+  `upload_file` function. The test fails if any file is uploaded with a
+  different set of  options.
+
+  ```ruby
+  allow_any_upload.with_params({ '_run_as' => 'root' })
+  ```
+
+- `with_destination(destination)`
+
+  The destination path that a file is uploaded to. The test fails if any
+  file is uploaded to a different location.
+
+  ```ruby
+  allow_any_upload.with_destination('/etc/ssh/sshd_config')
+  ```
+
+- `return(&block) { |targets, source, destination, params| ... }`
+
+  Invokes a block to construct the `ResultSet` returned by the `upload_file`
+  function.
+
+  ```ruby
+  allow_any_upload.return do |targets, source, destination, params|
+    results = targets.map do |target|
+      Bolt::Result.new(target, value: { 'path' => File.join(destination, source) })
+    end
+
+    Bolt::ResultSet.new(results)
+  end
+  ```
+
+- `error_with(error)`
+
+  Sets the error hash for each target's `Result` when any file is uploaded.
+  Returns a `Bolt::ResultSet` object.
+
+  ```ruby
+  allow_any_upload.error_with('msg' => 'Not authorized')
   ```
 
 📖 **Related information**

--- a/documentation/testing_plans.md
+++ b/documentation/testing_plans.md
@@ -266,18 +266,18 @@ is a stub or a mock.
 You can stub or mock the following functions. Click on each function to view its
 documentation.
 
-| plan function | Stub function | Mock function |
-| --- | --- | --- |
-| [`apply`](plan_functions.md#apply) | [`allow_apply`](boltspec_reference.md#allow-apply) | - |
-| [`apply_prep`](plan_functions.md#apply-prep) | [`allow_apply_prep`](boltspec_reference.md#allow-apply-prep) | - |
-| [`download_file`](plan_functions.md#download-file) | [`allow_download`](boltspec_reference.md#allow-download) | [`expect_download`](boltspec_reference.md#expect_download) |
-| [`out::message`](plan_functions.md#outmessage) | [`allow_out_message`](boltspec_reference.md#allow-out-message) | [`expect_out_message`](boltspec_reference.md#expect-out-message) |
-| [`out::verbose`](plan_functions.md#outverbose) | [`allow_out_verbose`](boltspec_reference.md#allow-out-verbose) | [`expect_out_verbose`](boltspec_reference.md#expect-out-verbose) |
-| [`run_command`](plan_functions.md#run-command) | [`allow_command`](boltspec_reference.md#allow-command) | [`expect_command`](boltspec_reference.md#expect-command) |
-| [`run_plan`](plan_functions.md#run-plan) | [`allow_plan`](boltspec_reference.md#allow-plan) | [`expect_plan`](boltspec_reference.md#expect-plan) |
-| [`run_script`](plan_functions.md#run-script) | [`allow_script`](boltspec_reference.md#allow-script) | [`expect_script`](boltspec_reference.md#expect-script) |
-| [`run_task`](plan_functions.md#run-task) | [`allow_task`](boltspec_reference.md#allow-task) | [`expect_task`](boltspec_reference.md#expect-task) |
-| [`upload_file`](plan_functions.md#upload-file) | [`allow_upload`](boltspec_reference.md#allow-upload) | [`expect_upload`](boltspec_reference.md#expect-upload) |
+| plan function | Stub function | Global stub function | Mock function
+| --- | --- | --- | --- |
+| [`apply`](plan_functions.md#apply) | [`allow_apply`](boltspec_reference.md#allow-apply) | - | - |
+| [`apply_prep`](plan_functions.md#apply-prep) | [`allow_apply_prep`](boltspec_reference.md#allow-apply-prep) | - | - |
+| [`download_file`](plan_functions.md#download-file) | [`allow_download`](boltspec_reference.md#allow-download) | [`allow_any_download`](boltspec_reference.md#allow-any-download) | [`expect_download`](boltspec_reference.md#expect_download) |
+| [`out::message`](plan_functions.md#outmessage) | [`allow_out_message`](boltspec_reference.md#allow-out-message) | [`allow_any_out_message`](boltspec_reference.md#allow-any-out-message) | [`expect_out_message`](boltspec_reference.md#expect-out-message) |
+| [`out::verbose`](plan_functions.md#outverbose) | [`allow_out_verbose`](boltspec_reference.md#allow-out-verbose) | [`allow_any_out_verbose`](boltspec_reference.md#allow-any-out-verbose) | [`expect_out_verbose`](boltspec_reference.md#expect-out-verbose) |
+| [`run_command`](plan_functions.md#run-command) | [`allow_command`](boltspec_reference.md#allow-command) | [`allow_any_command`](boltspec_reference.md#allow-any-command) | [`expect_command`](boltspec_reference.md#expect-command) |
+| [`run_plan`](plan_functions.md#run-plan) | [`allow_plan`](boltspec_reference.md#allow-plan) | [`allow_any_plan`](boltspec_reference.md#allow-any-plan) | [`expect_plan`](boltspec_reference.md#expect-plan) |
+| [`run_script`](plan_functions.md#run-script) | [`allow_script`](boltspec_reference.md#allow-script) | [`allow_any_script`](boltspec_reference.md#allow-any-script) |[`expect_script`](boltspec_reference.md#expect-script) |
+| [`run_task`](plan_functions.md#run-task) | [`allow_task`](boltspec_reference.md#allow-task) | [`allow_any_task`](boltspec_reference.md#allow-any-task) | [`expect_task`](boltspec_reference.md#expect-task) |
+| [`upload_file`](plan_functions.md#upload-file) | [`allow_upload`](boltspec_reference.md#allow-upload) | [`allow_any_upload`](boltspec_reference.md#allow-any-upload) | [`expect_upload`](boltspec_reference.md#expect-upload) |
 
 ### Modifiers
 


### PR DESCRIPTION
Here we update `boltspec_reference` and `testing_plans` to include documentation for `allow_any_plan` and `allow_any_task`

!no-release-note