### PR TITLE
(hack) Add `bolt module show <module>` command

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -507,10 +507,13 @@ module Bolt
           show
 
       #{colorize(:cyan, 'Usage')}
-          bolt module show [options]
+          bolt module show [module name] [options]
 
       #{colorize(:cyan, 'Description')}
           List modules available to the Bolt project.
+
+          Providing the name of a module will display detailed documentation for
+          the module.
 
       #{colorize(:cyan, 'Documentation')}
           To learn more about Bolt modules, run 'bolt guide module'.

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -494,7 +494,11 @@ module Bolt
         when 'group'
           list_groups
         when 'module'
-          list_modules
+          if options[:object]
+            show_module(options[:object])
+          else
+            list_modules
+          end
         when 'plugin'
           list_plugins
         end
@@ -850,6 +854,10 @@ module Bolt
 
     def list_modules
       outputter.print_module_list(pal.list_modules)
+    end
+
+    def show_module(name)
+      outputter.print_module_info(**pal.show_module(name))
     end
 
     def list_plugins

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -47,6 +47,7 @@ module Bolt
         @stream.puts results.to_json
       end
       alias print_module_list print_table
+      alias print_module_info print_table
 
       def print_task_info(task)
         path = task.files.first['path'].chomp("/tasks/#{task.files.first['name']}")

--- a/pwsh_module/command.tests.ps1
+++ b/pwsh_module/command.tests.ps1
@@ -256,6 +256,10 @@ Describe "test all bolt command examples" {
       $result = Get-BoltModule
       $result | Should -Be 'bolt module show'
     }
+    It "bolt module show puppet_agent" {
+      $result = Get-BoltModule -Name 'puppet_agent'
+      $result | Should -Be 'bolt module show puppet_agent'
+    }
   }
 
 

--- a/rakelib/pwsh.rake
+++ b/rakelib/pwsh.rake
@@ -263,7 +263,8 @@ namespace :pwsh do
         when 'module'
           # bolt module install
           # bolt module add [module]
-          if @pwsh_command[:verb] == 'Add'
+          case @pwsh_command[:verb]
+          when 'Add'
             @pwsh_command[:options] << {
               name:                       'Module',
               ruby_short:                 'md',
@@ -271,6 +272,19 @@ namespace :pwsh do
               mandatory:                  true,
               type:                       'string',
               switch:                     false,
+              position:                   0,
+              ruby_arg:                   'bare',
+              validate_not_null_or_empty: true
+            }
+          # bolt module show
+          when 'Get'
+            @pwsh_command[:options] << {
+              name:                       'Name',
+              ruby_short:                 'n',
+              help_msg:                   "The module to show",
+              type:                       'string',
+              switch:                     false,
+              mandatory:                  false,
               position:                   0,
               ruby_arg:                   'bare',
               validate_not_null_or_empty: true

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -2457,11 +2457,8 @@ describe "Bolt::CLI" do
         allow(cli).to receive(:outputter)
           .and_return(Bolt::Outputter::Human.new(false, false, false, false, output))
         cli.parse
-        modules = cli.list_modules
-        expect(modules.keys.first).to match(/bolt-modules/)
-        expect(modules.values.first.map { |h| h[:name] }).to match_array(Dir.children("#{__dir__}/../../bolt-modules"))
-        expect(modules.values[1].map { |h| h[:name] })
-          .to include("aggregate", "canary", "puppetdb_fact", "puppetlabs/yaml")
+        cli.list_modules
+        expect(output.string).to match(/boltlib.*aggregate.*canary/m)
       end
     end
 

--- a/spec/bolt/pal_spec.rb
+++ b/spec/bolt/pal_spec.rb
@@ -153,4 +153,59 @@ describe Bolt::PAL do
       end
     end
   end
+
+  describe :show_module do
+    let(:metadata)   { JSON.parse(File.read(fixtures_path('modules', 'sample', 'metadata.json'))) }
+    let(:modulepath) { Bolt::Config::Modulepath.new([fixtures_path('modules')]) }
+    let(:pal)        { Bolt::PAL.new(modulepath, nil, nil) }
+
+    it 'accepts short name' do
+      allow(pal).to receive_messages(list_plans_with_cache: [], list_tasks_with_cache: [])
+      expect { pal.show_module('sample') }.not_to raise_error
+    end
+
+    it 'accepts forge name with /' do
+      allow(pal).to receive_messages(list_plans_with_cache: [], list_tasks_with_cache: [])
+      expect { pal.show_module('bolt/sample') }.not_to raise_error
+    end
+
+    it 'accepts forge name with -' do
+      allow(pal).to receive_messages(list_plans_with_cache: [], list_tasks_with_cache: [])
+      expect { pal.show_module('bolt-sample') }.not_to raise_error
+    end
+
+    it 'errors with unknown module' do
+      expect { pal.show_module('abcdefg') }.to raise_error(
+        Bolt::Error,
+        /Could not find module 'abcdefg' on the modulepath/
+      )
+    end
+
+    it 'returns expected data' do
+      result = pal.show_module('bolt/sample')
+
+      expect(result.keys).to match_array(%i[metadata name path plans tasks]),
+                             'Does not return expected keys'
+
+      expect(result[:name]).to eq('bolt/sample'),
+                               'Does not return Forge name'
+
+      expect(result[:path]).to eq(fixtures_path('modules', 'sample')),
+                               'Does not return path to module'
+
+      expect(result[:plans]).to include(
+        ['sample::single_task', 'one line plan to show we can run a task by name'],
+        ['sample::yaml', nil]
+      ),
+                                'Does not return plan list'
+
+      expect(result[:tasks]).to include(
+        ['sample::multiline', 'Write a multiline string to the console']
+      ),
+                                'Does not return task list'
+
+      expect(result[:metadata]).to match(metadata),
+                                   'Does not return metadata'
+    end
+  end
 end

--- a/spec/fixtures/modules/sample/metadata.json
+++ b/spec/fixtures/modules/sample/metadata.json
@@ -1,0 +1,27 @@
+{
+  "name": "bolt-sample",
+  "author": "bolt",
+  "license": "Apache-2.0",
+  "source": "https://github.com/puppetlabs/bolt",
+  "version": "1.0.0",
+  "summary": "A sample module",
+  "dependencies": [
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 4.0.0 < 8.0.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS"
+    }
+  ]
+}

--- a/spec/integration/pal_spec.rb
+++ b/spec/integration/pal_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'bolt_spec/files'
+require 'bolt_spec/integration'
+require 'bolt_spec/project'
+
+describe Bolt::PAL do
+  include BoltSpec::Files
+  include BoltSpec::Integration
+  include BoltSpec::Project
+
+  describe :show_module do
+    around(:each) do |example|
+      with_project(config: config) do |project|
+        @project = project
+        example.run
+      end
+    end
+
+    let(:config)     { { 'modulepath' => [modulepath] } }
+    let(:modulepath) { fixtures_path('modules') }
+    let(:outputter)  { Bolt::Outputter::Human }
+    let(:project)    { @project }
+
+    it 'prints module information' do
+      result = run_cli(%w[module show sample], outputter: outputter, project: project)
+      expect(result).to match(%r{bolt/sample \[1.0.0\]}m)
+    end
+  end
+end


### PR DESCRIPTION
This adds a new `bolt module show <module>` command that shows detailed
information for a module. It lists the module's name, version, summary,
available plans and tasks, operating system support, and dependencies.

!feature

* **Show detailed module information**

  Bolt now supports showing detailed information about a module using
  the `bolt module show <module>` command and `Get-BoltModule -Name
  <module>` PowerShell cmdlet.