### PR TITLE
(hack) Format PlanResult if it's a Bolt datatype

### DIFF
--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -665,6 +665,12 @@ module Bolt
           print_container_result(value.result)
         when Bolt::ResultSet
           print_result_set(value)
+        when Bolt::Result
+          print_result(value)
+        when Bolt::ApplyResult
+          print_apply_result(value)
+        when Bolt::Error
+          print_bolt_error(**value.to_h.transform_keys(&:to_sym))
         else
           @stream.puts(::JSON.pretty_generate(plan_result, quirks_mode: true))
         end
@@ -702,6 +708,17 @@ module Bolt
 
       def print_error(message)
         @stream.puts(colorize(:red, message))
+      end
+
+      def print_bolt_error(msg:, details:, **_kwargs)
+        err = msg
+        if (f = details[:file])
+          err += "\n  (file: #{f}"
+          err += ", line: #{details[:line]}" if details[:line]
+          err += ", column: #{details[:column]}" if details[:column]
+          err += ")"
+        end
+        @stream.puts(colorize(:red, err))
       end
 
       def print_prompt(prompt)

--- a/spec/integration/parallel_spec.rb
+++ b/spec/integration/parallel_spec.rb
@@ -149,7 +149,7 @@ Undef:}
         output = run_cli(%w[plan run wait::error] + config_flags,
                          outputter: Bolt::Outputter::Human)
         expect(output).to include("Who's on first\nI don't know's on third")
-        expect(output).to include("\"msg\": \"parallel block failed on 1 target")
+        expect(output).to include("parallel block failed on 1 target")
         expect(output).not_to include("Finished main plan.")
       end
 


### PR DESCRIPTION
Bolt will format a PlanResult as JSON when we don't have a handler for
the class of the result. Despite having functions for printing
`Bolt::Result`, `Bolt::ApplyResult`, and `Bolt::Error` types, the plan
result printer in the human outputter would not use these functions and
would format the types as JSON, which often makes them difficult to
read. Bolt will now correctly format the result types if returned from a
plan.

!feature

* **Format PlanResults if they are Bolt datatypes** (hack)

  Bolt will now print a more human readable message for plan results
  that are Bolt datatypes when using the human output format, rather than
  printing JSON.