### PR TITLE
(GH-2915) `--clear-cache` clears plan/task metadata cache

### DIFF
--- a/documentation/troubleshooting.md
+++ b/documentation/troubleshooting.md
@@ -40,6 +40,19 @@ You can resolve this by [configuring an alternate tmpdir](bolt_transports_refere
 transport you're using, or by talking to your administrator about updating permissions for the
 directory.
 
+## My `plan/task show` output is not correct
+
+Bolt caches task and plan metadata when listing plans and tasks, and only
+updates the cache when modules in the `<PROJECT DIRECTORY>/modules/` directory
+are modified. Try rerunning the command with `--clear-cache` to refresh the
+cache and update task and plan metadata.
+The task or plan may also be present at a higher precedence on the modulepath.
+To verify that the specific task or plan is being loaded from the place you
+expect, run `bolt task show [task name]`, `bolt plan show [plan name]`,
+`Get-BoltTask -Name <TASK NAME>`, or `Get-BoltPlan -Name <PLAN NAME>`to see
+the path the task or plan is loaded from.
+
+
 ## My task fails mysteriously
 
 Try running Bolt with `--log-level debug` to see the exact output from your task.

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -1095,7 +1095,7 @@ module Bolt
         @options[:log] = { 'console' => { 'level' => level } }
       end
       define('--clear-cache',
-             "Clear plugin cache before executing.") do |_|
+             "Clear plugin, plan, and task caches before executing.") do |_|
         @options[:clear_cache] = true
       end
       define('--plugin PLUGIN', 'Select the plugin to use.') do |plug|

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -238,8 +238,10 @@ module Bolt
       config.check_path_case('modulepath', config.modulepath)
       config.project.check_deprecated_file
 
-      if options[:clear_cache] && File.exist?(config.project.plugin_cache_file)
-        FileUtils.rm(config.project.plugin_cache_file)
+      if options[:clear_cache]
+        FileUtils.rm(config.project.plugin_cache_file) if File.exist?(config.project.plugin_cache_file)
+        FileUtils.rm(config.project.task_cache_file) if File.exist?(config.project.task_cache_file)
+        FileUtils.rm(config.project.plan_cache_file) if File.exist?(config.project.plan_cache_file)
       end
 
       warn_inventory_overrides_cli(options)

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -2695,6 +2695,28 @@ describe "Bolt::CLI" do
         cli.parse
       }.to raise_error(Bolt::FileError, /Could not parse/)
     end
+
+    context '--clear-cache' do
+      around(:each) do |example|
+        in_project(config: project_config) do |project|
+          @project = project
+          FileUtils.touch(@project.plugin_cache_file)
+          FileUtils.touch(@project.plan_cache_file)
+          FileUtils.touch(@project.task_cache_file)
+
+          example.run
+        end
+      end
+
+      it 'clears cache for plug-in, plan, and task cache' do
+        cli = Bolt::CLI.new(%w[plan show --clear-cache] + config_flags)
+        allow(FileUtils).to receive(:rm)
+        expect(FileUtils).to receive(:rm).with(@project.plugin_cache_file)
+        expect(FileUtils).to receive(:rm).with(@project.plan_cache_file)
+        expect(FileUtils).to receive(:rm).with(@project.task_cache_file)
+        cli.parse
+      end
+    end
   end
 
   describe 'inventoryfile' do


### PR DESCRIPTION
`--clear-cache` now clears plan/task metadata cache.

!feature

* **`--clear-cache` clears plan/task metadata cache.**
	([#2915](https://github.com/puppetlabs/bolt/issues/2915))


`--clear-cache` flag now clears plan/task metadata cache.