### PR TITLE
(bug) Do not warn about analytics when analytics is disabled

### DIFF
--- a/lib/bolt/analytics.rb
+++ b/lib/bolt/analytics.rb
@@ -33,7 +33,7 @@ module Bolt
       logger = Bolt::Logger.logger(self)
       begin
         config_file = config_path
-        config = load_config(config_file)
+        config = enabled ? load_config(config_file) : {}
       rescue ArgumentError
         config = { 'disabled' => true }
       end

--- a/spec/bolt/analytics_spec.rb
+++ b/spec/bolt/analytics_spec.rb
@@ -59,6 +59,32 @@ describe Bolt::Analytics do
     expect(subject.build_client.user_id).to eq(uuid)
   end
 
+  context 'without analytics.yaml' do
+    before(:each) do
+      allow(subject).to receive(:load_config).and_call_original
+      allow(File).to receive(:exist?).and_return(false)
+      allow(subject).to receive(:write_config)
+    end
+
+    it 'warns when running with analytics enabled for the first time' do
+      expect(Bolt::Logger).to receive(:warn_once) do |id, message|
+        expect(id).to eq('analytics_opt_out')
+        expect(message).to match(/Bolt collects data about how you use it/)
+      end
+
+      subject.build_client(true)
+    end
+
+    it 'does not warn when running with analytics disabled' do
+      expect(Bolt::Logger).not_to receive(:warn_once) do |id, message|
+        expect(id).to eq('analytics_opt_out')
+        expect(message).to match(/Bolt collects data about how you use it/)
+      end
+
+      subject.build_client(false)
+    end
+  end
+
   context 'config file' do
     let(:path)     { File.expand_path(File.join('~', '.puppetlabs', 'etc', 'bolt', 'analytics.yaml')) }
     let(:old_path) { File.expand_path(File.join('~', '.puppetlabs', 'bolt', 'analytics.yaml')) }


### PR DESCRIPTION
This fixes a bug that was causing Bolt to warn about analytics
collection when analytics is disabled in a config file and the
`analytics.yaml` file does not exist.

!bug

* **Do not warn about analytics when analytics is disabled**

  Bolt no longer displays a warning about analytics collection when
  analytics is disabled and the `analytics.yaml` file does not exist.