### PR TITLE
(GH-2889) Temporarily override scope when resuming future

### DIFF
--- a/lib/bolt/plan_future.rb
+++ b/lib/bolt/plan_future.rb
@@ -4,14 +4,19 @@ require 'fiber'
 
 module Bolt
   class PlanFuture
-    attr_reader :fiber, :id
+    attr_reader :fiber, :id, :scope
     attr_accessor :value, :plan_stack
 
-    def initialize(fiber, id, plan_id:, name: nil)
-      @fiber   = fiber
-      @id      = id
-      @name    = name
-      @value   = nil
+    def initialize(fiber, id, plan_id:, name: nil, scope: nil)
+      @fiber = fiber
+      @id    = id
+      @name  = name
+      @value = nil
+
+      # Default to Puppet's current global_scope, otherwise things will
+      # blow up when the Fiber Executor tries to override the global_scope.
+      @scope = scope || Puppet.lookup(:global_scope) { nil }
+
       # The plan invocation ID when the Future is created may be
       # different from the plan ID of the Future when we switch to it if a new
       # plan was run inside the Future, so keep track of the plans that a

--- a/spec/bolt/fiber_executor_spec.rb
+++ b/spec/bolt/fiber_executor_spec.rb
@@ -28,7 +28,7 @@ describe "Bolt::FiberExecutor" do
 
     it "creates a new PlanFuture object with a name" do
       expect(Bolt::PlanFuture).to receive(:new)
-        .with(instance_of(Fiber), instance_of(Integer), name: 'name', plan_id: plan_id)
+        .with(instance_of(Fiber), instance_of(Integer), name: 'name', plan_id: plan_id, scope: anything)
         .and_call_original
       fiber_executor.create_future(name: 'name', plan_id: plan_id) { |_| return 0 }
     end

--- a/spec/fixtures/parallel/parallel/functions/custom_function.pp
+++ b/spec/fixtures/parallel/parallel/functions/custom_function.pp
@@ -1,0 +1,5 @@
+function parallel::custom_function (
+  TargetSpec $target
+) {
+  run_command('whoami', $target)
+}

--- a/spec/fixtures/parallel/parallel/plans/custom_function.pp
+++ b/spec/fixtures/parallel/parallel/plans/custom_function.pp
@@ -1,0 +1,12 @@
+# Invoke a custom Puppet language function that invokes an executor function
+# within a parallelize block. The $target variable should not be removed from
+# the scope after the custom function is invoked.
+plan parallel::custom_function () {
+  $target = 'localhost'
+
+  parallelize([1, 2]) |$i| {
+    parallel::custom_function($target)
+  }
+
+  return $target
+}

--- a/spec/integration/parallel_spec.rb
+++ b/spec/integration/parallel_spec.rb
@@ -66,6 +66,11 @@ describe 'plans' do
 
     it "runs when provided an array with duplicate objects" do
     end
+
+    it "does not lose scope when calling an executor function from a custom Puppet language function" do
+      result = run_cli_json(%W[plan run parallel::custom_function -m #{modulepath}])
+      expect(result).to eq('localhost')
+    end
   end
 
   shared_examples "#background()" do


### PR DESCRIPTION
This updates `PlanFuture` instances to keep track of their own scope
object. When a `PlanFuture` is resumed by the `FiberExecutor`, the
`global_scope` in Puppet is temporarily overridden with the `PlanFuture`
scope. This prevents ephemerals from being popped off in the wrong order
due to race conditions that arise from invoking custom Puppet language
functions that invoke Bolt executor functions.

!bug

* **Do not remove variables from scope when using `parallelize()`**
  ([#2889](https://github.com/puppetlabs/bolt/issues/2889))

  Bolt no longer removes variables from a plan's scope when invoking
  a custom Puppet language function that invokes a `run_*` function from
  a `parallelize()` block. Previously, a race condition would result in
  the current plan's variables to be removed from the plan's scope.