### PR TITLE
(GH-2925) Support `_catch_errors` in `apply_prep`

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
@@ -8,62 +8,23 @@ require 'bolt/task'
 # installed using either the configured plugin or the `task` plugin with the
 # `puppet_agent::install` task.
 #
-# Agent installation will be skipped if the target includes the `puppet-agent` feature, either as a
-# property of its transport (PCP) or by explicitly setting it as a feature in Bolt's inventory.
+# Agent installation will be skipped if the target includes the `puppet-agent`
+# feature, either as a property of its transport (PCP) or by explicitly setting
+# it as a feature in Bolt's inventory.
 #
 # > **Note:** Not available in apply block
 Puppet::Functions.create_function(:apply_prep) do
   # @param targets A pattern or array of patterns identifying a set of targets.
   # @param options Options hash.
+  # @option options [Boolean] _catch_errors Whether to catch raised errors.
   # @option options [Array] _required_modules An array of modules to sync to the target.
   # @option options [String] _run_as User to run as using privilege escalation.
-  # @return [nil]
+  # @return [Bolt::ResultSet]
   # @example Prepare targets by name.
   #   apply_prep('target1,target2')
   dispatch :apply_prep do
     param 'Boltlib::TargetSpec', :targets
     optional_param 'Hash[String, Data]', :options
-  end
-
-  def script_compiler
-    @script_compiler ||= Puppet::Pal::ScriptCompiler.new(closure_scope.compiler)
-  end
-
-  def inventory
-    @inventory ||= Puppet.lookup(:bolt_inventory)
-  end
-
-  def get_task(name, params = {})
-    tasksig = script_compiler.task_signature(name)
-    raise Bolt::Error.new("Task '#{name}' could not be found", 'bolt/apply-prep') unless tasksig
-
-    errors = []
-    unless tasksig.runnable_with?(params) { |msg| errors << msg }
-      # This relies on runnable with printing a partial message before the first real error
-      raise Bolt::ValidationError, "Invalid parameters for #{errors.join("\n")}"
-    end
-
-    Bolt::Task.from_task_signature(tasksig)
-  end
-
-  # rubocop:disable Naming/AccessorMethodName
-  def set_agent_feature(target)
-    inventory.set_feature(target, 'puppet-agent')
-  end
-  # rubocop:enable Naming/AccessorMethodName
-
-  def run_task(targets, task, args = {}, options = {})
-    executor.run_task(targets, task, args, options)
-  end
-
-  # Returns true if the target has the puppet-agent feature defined, either from inventory or transport.
-  def agent?(target, executor, inventory)
-    inventory.features(target).include?('puppet-agent') ||
-      executor.transport(target.transport).provided_features.include?('puppet-agent') || target.remote?
-  end
-
-  def executor
-    @executor ||= Puppet.lookup(:bolt_executor)
   end
 
   def apply_prep(target_spec, options = {})
@@ -72,22 +33,56 @@ Puppet::Functions.create_function(:apply_prep) do
         .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'apply_prep')
     end
 
-    # Unfreeze this
-    options = options.slice(*%w[_run_as _required_modules])
-
-    applicator = Puppet.lookup(:apply_executor)
+    options = options.slice(*%w[_catch_errors _required_modules _run_as])
+    targets = inventory.get_targets(target_spec)
 
     executor.report_function_call(self.class.name)
 
-    targets = inventory.get_targets(target_spec)
+    executor.log_action('install puppet and gather facts', targets) do
+      executor.without_default_logging do
+        install_results = install_agents(targets, options)
+        facts_results   = get_facts(install_results.ok_set.targets, options)
 
-    required_modules = options.delete('_required_modules').to_a
+        Bolt::ResultSet.new(install_results.error_set.results + facts_results.results)
+      end
+    end
+  end
+
+  def applicator
+    @applicator ||= Puppet.lookup(:apply_executor)
+  end
+
+  def executor
+    @executor ||= Puppet.lookup(:bolt_executor)
+  end
+
+  def inventory
+    @inventory ||= Puppet.lookup(:bolt_inventory)
+  end
+
+  # Runs a task. This method is called by the puppet_library hook.
+  #
+  def run_task(targets, task, args = {}, options = {})
+    executor.run_task(targets, task, args, options)
+  end
+
+  # Returns true if the target has the puppet-agent feature defined, either from
+  # inventory or transport.
+  #
+  private def agent?(target)
+    inventory.features(target).include?('puppet-agent') ||
+    executor.transport(target.transport).provided_features.include?('puppet-agent') ||
+    target.remote?
+  end
+
+  # Generate the plugin tarball.
+  #
+  private def build_plugin_tarball(required_modules)
     if required_modules.any?
       Puppet.debug("Syncing only required modules: #{required_modules.join(',')}.")
     end
 
-    # Gather facts, including custom facts
-    plugins = applicator.build_plugin_tarball do |mod|
+    tarball = applicator.build_plugin_tarball do |mod|
       next unless required_modules.empty? || required_modules.include?(mod.name)
       search_dirs = []
       search_dirs << mod.plugins if mod.plugins?
@@ -95,68 +90,106 @@ Puppet::Functions.create_function(:apply_prep) do
       search_dirs
     end
 
-    executor.log_action('install puppet and gather facts', targets) do
-      executor.without_default_logging do
-        # Skip targets that include the puppet-agent feature, as we know an agent will be available.
-        agent_targets, need_install_targets = targets.partition { |target| agent?(target, executor, inventory) }
-        agent_targets.each { |target| Puppet.debug "Puppet Agent feature declared for #{target.name}" }
-        unless need_install_targets.empty?
-          # lazy-load expensive gem code
-          require 'concurrent'
-          pool = Concurrent::ThreadPoolExecutor.new
+    Puppet::Pops::Types::PSensitiveType::Sensitive.new(tarball)
+  end
 
-          hooks = need_install_targets.map do |t|
-            opts = t.plugin_hooks&.fetch('puppet_library').dup
-            plugin_name = opts.delete('plugin')
-            hook = inventory.plugins.get_hook(plugin_name, :puppet_library)
-            # Give plan function options precedence over inventory options
-            { 'target' => t,
-              'hook_proc' => hook.call(opts.merge(options), t, self) }
-          rescue StandardError => e
-            Bolt::Result.from_exception(t, e)
-          end
+  # Install the puppet-agent package on targets that need it.
+  #
+  private def install_agents(targets, options)
+    results = []
 
-          hook_errors, ok_hooks = hooks.partition { |h| h.is_a?(Bolt::Result) }
+    agent_targets, agentless_targets = targets.partition { |target| agent?(target) }
 
-          futures = ok_hooks.map do |hash|
-            Concurrent::Future.execute(executor: pool) do
-              hash['hook_proc'].call
-            end
-          end
+    agent_targets.each do |target|
+      Puppet.debug("Puppet Agent feature declared for #{target}")
+      results << Bolt::Result.new(target)
+    end
 
-          results = futures.zip(ok_hooks).map do |f, hash|
-            f.value || Bolt::Result.from_exception(hash['target'], f.reason)
-          end
-          set = Bolt::ResultSet.new(results + hook_errors)
-          raise Bolt::RunFailure.new(set.error_set, 'apply_prep') unless set.ok
+    unless agentless_targets.empty?
+      hooks, errors = get_hooks(agentless_targets, options)
+      hook_results  = run_hooks(hooks)
 
-          need_install_targets.each { |target| set_agent_feature(target) }
-        end
+      hook_results.each do |result|
+        next unless result.ok?
+        inventory.set_feature(result.target, 'puppet-agent')
+      end
 
-        task = applicator.custom_facts_task
-        arguments = { 'plugins' => Puppet::Pops::Types::PSensitiveType::Sensitive.new(plugins) }
-        results = run_task(targets, task, arguments, options)
+      results.concat(hook_results).concat(errors)
+    end
 
-        # TODO: Standardize RunFailure type with error above
-        raise Bolt::RunFailure.new(results, 'run_task', task.name) unless results.ok?
+    Bolt::ResultSet.new(results).tap do |resultset|
+      unless resultset.ok? || options['_catch_errors']
+        raise Bolt::RunFailure.new(resultset.error_set, 'apply_prep')
+      end
+    end
+  end
 
-        results.each do |result|
-          # Log a warning if the client version is < 6
-          if unsupported_puppet?(result['clientversion'])
-            Bolt::Logger.deprecate(
-              "unsupported_puppet",
-              "Detected unsupported Puppet agent version #{result['clientversion']} on target "\
-              "#{result.target}. Bolt supports Puppet agent 6.0.0 and higher."
-            )
-          end
+  # Retrieve facts from each target and add them to inventory.
+  #
+  private def get_facts(targets, options)
+    return Bolt::ResultSet.new([]) unless targets.any?
 
-          inventory.add_facts(result.target, result.value)
-        end
+    task    = applicator.custom_facts_task
+    args    = { 'plugins' => build_plugin_tarball(options.delete('_required_modules').to_a) }
+    results = run_task(targets, task, args, options)
+
+    unless results.ok? || options['_catch_errors']
+      raise Bolt::RunFailure.new(results, 'run_task', task.name)
+    end
+
+    results.each do |result|
+      next unless result.ok?
+
+      if unsupported_puppet?(result['clientversion'])
+        Bolt::Logger.deprecate(
+          "unsupported_puppet",
+          "Detected unsupported Puppet agent version #{result['clientversion']} on target "\
+          "#{result.target}. Bolt supports Puppet agent 6.0.0 and higher."
+        )
+      end
+
+      inventory.add_facts(result.target, result.value)
+    end
+
+    results
+  end
+
+  # Return a list of targets and their puppet_library hooks.
+  #
+  private def get_hooks(targets, options)
+    hooks  = []
+    errors = []
+
+    targets.each do |target|
+      plugin_opts = target.plugin_hooks.fetch('puppet_library').dup
+      plugin_name = plugin_opts.delete('plugin')
+      hook        = inventory.plugins.get_hook(plugin_name, :puppet_library)
+
+      hooks << { 'target' => target,
+                 'proc'   => hook.call(plugin_opts.merge(options), target, self) }
+    rescue StandardError => e
+      errors << Bolt::Result.from_exception(target, e)
+    end
+
+    [hooks, errors]
+  end
+
+  # Runs the puppet_library hook for each target, returning the result
+  # of each.
+  #
+  private def run_hooks(hooks)
+    require 'concurrent'
+    pool = Concurrent::ThreadPoolExecutor.new
+
+    futures = hooks.map do |hook|
+      Concurrent::Future.execute(executor: pool) do
+        hook['proc'].call
       end
     end
 
-    # Return nothing
-    nil
+    futures.zip(hooks).map do |future, hook|
+      future.value || Bolt::Result.from_exception(hook['target'], future.reason)
+    end
   end
 
   # Returns true if the client's major version is < 6.

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -836,13 +836,16 @@ module Bolt
 
       results = nil
       elapsed_time = Benchmark.realtime do
-        pal.in_plan_compiler(executor, inventory, puppetdb_client) do |compiler|
-          compiler.call_function('apply_prep', targets)
+        apply_prep_results = pal.in_plan_compiler(executor, inventory, puppetdb_client) do |compiler|
+          compiler.call_function('apply_prep', targets, '_catch_errors' => true)
         end
 
-        results = pal.with_bolt_executor(executor, inventory, puppetdb_client) do
-          Puppet.lookup(:apply_executor).apply_ast(ast, targets, catch_errors: true, noop: noop)
+        apply_results = pal.with_bolt_executor(executor, inventory, puppetdb_client) do
+          Puppet.lookup(:apply_executor)
+                .apply_ast(ast, apply_prep_results.ok_set.targets, catch_errors: true, noop: noop)
         end
+
+        results = Bolt::ResultSet.new(apply_prep_results.error_set.results + apply_results.results)
       end
 
       executor.shutdown

--- a/lib/bolt/plugin/task.rb
+++ b/lib/bolt/plugin/task.rb
@@ -59,7 +59,7 @@ module Bolt
         run_opts = {}
         run_opts[:run_as] = opts['_run_as'] if opts['_run_as']
         begin
-          task = apply_prep.get_task(opts['task'], params)
+          task = @context.get_validated_task(opts['task'], params)
         rescue Bolt::Error => e
           raise Bolt::Plugin::PluginError::ExecutionError.new(e.message, name, 'puppet_library')
         end

--- a/spec/bolt/rerun_spec.rb
+++ b/spec/bolt/rerun_spec.rb
@@ -186,6 +186,7 @@ describe 'rerun' do
 
     it 'updates the file when apply fails' do
       allow(pal).to receive(:in_plan_compiler)
+        .and_return(Bolt::ResultSet.new([Bolt::Result.new(targets[0])]))
       allow(pal).to receive(:with_bolt_executor)
         .and_return(Bolt::ResultSet.new([Bolt::ApplyResult.new(targets[0], error: { 'kind' => 'oops' })]))
       run_cli(['apply', '--targets', 'node1', '-e', 'include foo'])
@@ -194,6 +195,7 @@ describe 'rerun' do
 
     it 'updates the file when apply succeeds' do
       allow(pal).to receive(:in_plan_compiler)
+        .and_return(Bolt::ResultSet.new([Bolt::Result.new(targets[0])]))
       allow(pal).to receive(:with_bolt_executor)
         .and_return(Bolt::ResultSet.new([Bolt::ApplyResult.new(targets[0], report: {})]))
       run_cli(['apply', '--targets', 'node1', '-e', 'include foo'])

--- a/spec/integration/plugin/task_spec.rb
+++ b/spec/integration/plugin/task_spec.rb
@@ -229,7 +229,7 @@ describe 'using the task plugin' do
         expect(result).to include('kind' => "bolt/run-failure")
         expect(result['msg']).to match(/apply_prep failed on 1 target/)
         expect(result['details']['result_set'][0]['value']['_error']['msg']).to match(
-          /Invalid parameters for Task sample::params/
+          /Error executing plugin task from puppet_library.*expects a value for parameter/m
         )
       end
     end
@@ -243,7 +243,7 @@ describe 'using the task plugin' do
         expect(result).to include('kind' => "bolt/run-failure")
         expect(result['msg']).to match(/apply_prep failed on 1 target/)
         expect(result['details']['result_set'][0]['value']['_error']['msg']).to match(
-          /Task 'non_existent_task' could not be found/
+          /Could not find a task named 'non_existent_task'/
         )
       end
     end


### PR DESCRIPTION
This adds support for using the `_catch_errors` metaparameter in the
`apply_prep` plan function. When set, the function will return a result
set that includes results for all targets that successfully installed
targets and retrieved custom facts, and any errors for targets that were
not able to do both.

This also updates the `bolt apply` and `Invoke-BoltApply` commands to
set `_catch_errors` when running the `apply_prep` function. This allows
the command to complete the apply on as many targets as possible instead
of erroring if even one target fails the `apply_prep` step.

!feature

* **Support `_catch_errors` in `apply_prep`**
  ([#2925](https://github.com/puppetlabs/bolt/issues/2925))

  The `apply_prep` function now accepts the `_catch_errors` parameter.
  Additionally, the `bolt apply` and `Invoke-BoltApply` commands set
  `_catch_errors` to `true`, allowing an apply action to complete on as
  many targets as possible instead of erroring if even one target fails
  the `apply_prep` portion of the command.