### PR TITLE
(GH-2922) Attempt to restore Ruby environment on local

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -9,7 +9,7 @@ extend Acceptance::BoltSetupHelper
 
 desc "Generate Beaker Host config"
 rototiller_task :host_config do |task|
-  unless ENV['BEAKER_HOSTS']
+  unless ENV['BEAKER_HOSTS_FILE']
     task.add_env(name: 'BOLT_CONTROLLER', default: 'debian10-64')
     task.add_env(name: 'BOLT_NODES',
                  default: 'centos7-64,osx1012-64,windows10ent-64')

--- a/acceptance/tests/task_local.rb
+++ b/acceptance/tests/task_local.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bolt_command_helper'
+require 'bolt_setup_helper'
 
 test_name "bolt task run should execute tasks on localhost via local transport" do
   extend Acceptance::BoltCommandHelper
@@ -32,7 +33,7 @@ test_name "bolt task run should execute tasks on localhost via local transport" 
       assert_equal(profile_pre.stdout, profile_post.stdout, 'Profile was loaded')
     end
   else
-    step "create task on bolt controller" do
+    step "create whoami task on bolt controller" do
       on(bolt, "mkdir -p #{dir}/modules/test/tasks")
       create_remote_file(bolt, "#{dir}/modules/test/tasks/whoami_nix", <<-FILE)
       #!/bin/sh
@@ -40,7 +41,16 @@ test_name "bolt task run should execute tasks on localhost via local transport" 
       FILE
     end
 
-    step "execute `bolt task run` on localhost via local transport" do
+    step "create ruby_env task on bolt controller" do
+      # Still -p; can never be too careful
+      on(bolt, "mkdir -p #{dir}/modules/test/tasks")
+      create_remote_file(bolt, "#{dir}/modules/test/tasks/ruby_env.sh", <<-FILE)
+      #!/bin/sh
+      echo $GEM_PATH
+      FILE
+    end
+
+    step "execute `bolt task run test::whoami_nix` on localhost via local transport" do
       bolt_command = "bolt task run test::whoami_nix greetings=hello"
       flags = {
         '--targets' => 'localhost',
@@ -51,6 +61,18 @@ test_name "bolt task run should execute tasks on localhost via local transport" 
       message = "Unexpected output from the command:\n#{result.cmd}"
       regex = /hello from root/
       assert_match(regex, result.stdout, message)
+    end
+
+    step "execute `bolt task run test::ruby_env` on localhost via local transport" do
+      bolt_command = "GEM_PATH=$(gem env GEM_PATHS) bolt task run test::ruby_env"
+      flags = {
+        '--targets' => 'localhost',
+        '--modulepath' => "#{dir}/modules"
+      }
+
+      result = bolt_command_on(bolt, bolt_command, flags)
+      message = "Unexpected output from the command:\n#{result.cmd}"
+      assert_match(on(bolt, 'gem env GEM_PATHS').stdout, result.stdout, message)
     end
 
     step "execute `bolt task run` on localhost via local transport with run-as" do

--- a/lib/bolt/transport/local/connection.rb
+++ b/lib/bolt/transport/local/connection.rb
@@ -10,6 +10,8 @@ module Bolt
   module Transport
     class Local < Simple
       class Connection
+        RUBY_ENV_VARS = %w[GEM_PATH GEM_HOME RUBYLIB RUBYLIB_PREFIX RUBYOPT RUBYPATH RUBYSHELL].freeze
+
         attr_accessor :user, :logger, :target
 
         def initialize(target)
@@ -68,7 +70,21 @@ module Bolt
             end
           end
 
-          Open3.popen3(*command)
+          # Only do this if bundled-ruby is set to false, not nil
+          ruby_env_vars = if target.transport_config['bundled-ruby'] == false
+                            RUBY_ENV_VARS.each_with_object({}) do |e, acc|
+                              acc[e] = ENV["BOLT_ORIG_#{e}"] if ENV["BOLT_ORIG_#{e}"]
+                            end
+                          end
+
+          if target.transport_config['bundled-ruby'] == false &&
+             Gem.loaded_specs.keys.include?('bundler')
+            Bundler.with_unbundled_env do
+              Open3.popen3(ruby_env_vars || {}, *command)
+            end
+          else
+            Open3.popen3(ruby_env_vars || {}, *command)
+          end
         end
 
         # This is used by the Bash shell to decide whether to `cd` before

--- a/spec/bolt/transport/local_spec.rb
+++ b/spec/bolt/transport/local_spec.rb
@@ -148,5 +148,12 @@ describe Bolt::Transport::Local do
         .with(anything, /The local transport will default/)
       subject.with_connection(get_target(inventory, uri)) do |conn|; end
     end
+
+    it 'unbundles the env' do
+      expect(Bundler).to receive(:with_unbundled_env)
+      subject.with_connection(get_target(inventory, uri)) do |conn|
+        conn.execute('ls')
+      end
+    end
   end
 end

--- a/spec/fixtures/modules/env_var/tasks/ruby_env.json
+++ b/spec/fixtures/modules/env_var/tasks/ruby_env.json
@@ -1,0 +1,6 @@
+{
+  "implementations": [
+    {"name": "ruby_env.sh", "requirements": ["shell"]},
+    {"name": "ruby_env.ps1", "requirements": ["powershell"]}
+  ]
+}

--- a/spec/fixtures/modules/env_var/tasks/ruby_env.ps1
+++ b/spec/fixtures/modules/env_var/tasks/ruby_env.ps1
@@ -1,0 +1,1 @@
+Write-Output $env:GEM_HOME

--- a/spec/fixtures/modules/env_var/tasks/ruby_env.sh
+++ b/spec/fixtures/modules/env_var/tasks/ruby_env.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo $GEM_HOME


### PR DESCRIPTION
When running over the `local` transport with `bundled-ruby` set to
false, Bolt will attempt to restore the original Ruby environment
variables, specifically:
* GEM_PATH
* GEM_HOME
* RUBYLIB
* RUBYLIB_PREFIX
* RUBYOPT
* RUBYPATH
* RUBYSHELL

The Bolt binary wrapper explicitly unsets these variables to provide a
clean environment for the Bolt process to run in, which affects running
Bolt from a system package, and Bundler can also modify these
environment variables, saving their original values to
`BUNDLER_ORIG_<env_var>`. Changes to the Ruby environment that Bolt runs
in are incidentally picked up by Ruby tasks and plans running over the
local transport, which opens a new subprocess to execute. The binary
wrapper now stores those environment variables in `BOLT_ORIG_<env_var>`
environment variables, and when executing with `bundled-ruby` explicitly set
to false (not unconfigured), Bolt will attempt to restore the
environment variables first from `BOLT_ORIG_<env_var>`, then from
`BUNDLER_ORIG_<env_var>`.

!bug

* **Attempt to restore Ruby environment on local with bundled-ruby false** ([#2922](https://github.com/puppetlabs/bolt/issues/2922))
  When executing, Bolt will unset several Ruby environment variables in
  it's own environment to avoid unexpected behavior. This can interfere
  with running Ruby on the local transport with Bolt though. Bolt will now
  attempt to restore Ruby environment variables like `GEM_HOME` and
  `GEM_PATH` when running over the local transport with `bundled-ruby` set
  to false.