### PR TITLE
(bug-fix) Package bolt gem with `guides` directory

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
                        Dir['modules/*/types/**/*'] +
                        Dir['Puppetfile'] +
                        Dir['resources/bolt_bash_completion.sh'] +
-                       Dir['guides/*.txt']
+                       Dir['guides/*.yaml']
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
When we updated the `guides/` to be YAML instead of text, we missed
updating the list of files to include in the Bolt gem to include the new
file extension for guides, so 3.14.1 shipped without any guides. This
updates the gemspec to include yaml files in `guides/` in the Bolt gem.

!bug

* **Ship with Bolt guides**

  Bolt 3.14.1 neglected to updated the `bolt.gemspec` to include new
  guide files. This updates the gemspec to include the new guide files.