### PR TITLE
(docs) Fix ruby error in an example

### DIFF
--- a/documentation/writing_tasks.md
+++ b/documentation/writing_tasks.md
@@ -421,7 +421,7 @@ rescue ZeroDivisionError
   result[:_error] = { msg: "Cannot divide by zero",
                       # namespace the error to this module
                       kind: "puppetlabs-example_modules/dividebyzero",
-                      details: { divisor: divisor },
+                      details: { divisor: params['divisor'] },
                     }
 rescue Exception => e
   result[:_error] = { msg: e.message,


### PR DESCRIPTION
the divide-by-zero example uses `divisor` as bare word that's never
asigned. We fix the resulting:

```
div-by-zero.rb:14:in `rescue in <main>': undefined local variable or method `divisor' for main:Object (NameError)
```

and provide a sensible error should this case ever occur.

!no-release-note