### PR TITLE
(PE-32492, PE32496) Support for apply/apply_prep for plans sourced from projects

### DIFF
--- a/lib/bolt_server/file_cache.rb
+++ b/lib/bolt_server/file_cache.rb
@@ -183,16 +183,16 @@ module BoltServer
       end
     end
 
-    def get_cached_plugin_tarball(versioned_project, tarball_type)
+    def get_cached_project_file(versioned_project, file_name)
       file_dir = create_cache_dir(versioned_project)
-      file_path = File.join(file_dir, tarball_type)
-      File.read(file_path) if File.exist?(file_path)
+      file_path = File.join(file_dir, file_name)
+      serial_execute { File.read(file_path) if File.exist?(file_path) }
     end
 
-    def cache_plugin_tarball(versioned_project, tarball_type, tarball)
+    def cache_project_file(versioned_project, file_name, data)
       file_dir = create_cache_dir(versioned_project)
-      file_path = File.join(file_dir, tarball_type)
-      File.open(file_path, 'w') { |f| f.write(tarball) }
+      file_path = File.join(file_dir, file_name)
+      serial_execute { File.open(file_path, 'w') { |f| f.write(data) } }
     end
   end
 end

--- a/lib/bolt_server/file_cache.rb
+++ b/lib/bolt_server/file_cache.rb
@@ -182,5 +182,17 @@ module BoltServer
         end
       end
     end
+
+    def get_cached_plugin_tarball(versioned_project, tarball_type)
+      file_dir = create_cache_dir(versioned_project)
+      file_path = File.join(file_dir, tarball_type)
+      File.read(file_path) if File.exist?(file_path)
+    end
+
+    def cache_plugin_tarball(versioned_project, tarball_type, tarball)
+      file_dir = create_cache_dir(versioned_project)
+      file_path = File.join(file_dir, tarball_type)
+      File.open(file_path, 'w') { |f| f.write(tarball) }
+    end
   end
 end

--- a/lib/bolt_server/schemas/action-apply.json
+++ b/lib/bolt_server/schemas/action-apply.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "apply request",
+  "description": "POST <transport>/apply request schema",
+  "type": "object",
+  "properties": {
+    "versioned_project": {
+      "type": "String",
+      "description": "Project from which to load code"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "catalog": {
+          "type": "object",
+          "description": "Compiled catalog to apply"
+        },
+        "apply_options": {
+          "type": "object",
+          "description": "Options for application of a catalog"
+        }
+      }
+    },
+    "target": { "$ref": "partial:target-any" }
+  },
+  "required": ["target", "versioned_project", "parameters"],
+  "additionalProperties": false
+}

--- a/lib/bolt_server/schemas/action-apply.json
+++ b/lib/bolt_server/schemas/action-apply.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "versioned_project": {
-      "type": "String",
+      "type": "string",
       "description": "Project from which to load code"
     },
     "parameters": {
@@ -21,8 +21,12 @@
         }
       }
     },
+    "job_id": {
+      "type": "integer",
+      "description": "job-id associated with request"
+    },
     "target": { "$ref": "partial:target-any" }
   },
-  "required": ["target", "versioned_project", "parameters"],
+  "required": ["target", "versioned_project", "parameters", "job_id"],
   "additionalProperties": false
 }

--- a/lib/bolt_server/schemas/action-apply_prep.json
+++ b/lib/bolt_server/schemas/action-apply_prep.json
@@ -8,8 +8,12 @@
       "type": "String",
       "description": "Project from which to load code"
     },
-    "target": { "$ref": "partial:target-any" }
+    "target": { "$ref": "partial:target-any" },
+    "job_id": {
+      "type": "integer",
+      "description": "job-id associated with request"
+    }
   },
-  "required": ["target", "versioned_project"],
+  "required": ["target", "versioned_project", "job_id"],
   "additionalProperties": false
 }

--- a/lib/bolt_server/schemas/action-apply_prep.json
+++ b/lib/bolt_server/schemas/action-apply_prep.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "apply_prep request",
+  "description": "POST <transport>/apply_prep request schema",
+  "type": "object",
+  "properties": {
+    "versioned_project": {
+      "type": "String",
+      "description": "Project from which to load code"
+    },
+    "target": { "$ref": "partial:target-any" }
+  },
+  "required": ["target", "versioned_project"],
+  "additionalProperties": false
+}

--- a/spec/Dockerfile.puppetserver
+++ b/spec/Dockerfile.puppetserver
@@ -1,4 +1,4 @@
-FROM puppet/puppetserver
+FROM puppet/puppetserver:edge
 
 ARG hostname="boltserver"
 ENV PUPPETSERVER_HOSTNAME "$hostname"

--- a/spec/bolt_server/app_integration_spec.rb
+++ b/spec/bolt_server/app_integration_spec.rb
@@ -23,6 +23,10 @@ describe "BoltServer::TransportApp", puppetserver: true do
     wait_until_available(timeout: 30, interval: 1)
   end
 
+  after(:all) do
+    FileUtils.rm_rf(config_data['cache-dir'])
+  end
+
   context 'with ssh target', ssh: true do
     describe "run_task" do
       let(:path) { '/ssh/run_task' }
@@ -189,7 +193,8 @@ describe "BoltServer::TransportApp", puppetserver: true do
         }
         body = {
           versioned_project: 'bolt_server_test_project',
-          target: target
+          target: target,
+          job_id: 1
         }
         post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
         expect(last_response).to be_ok
@@ -213,7 +218,8 @@ describe "BoltServer::TransportApp", puppetserver: true do
         }
         body = {
           versioned_project: 'bolt_server_test_project',
-          target: target
+          target: target,
+          job_id: 1
         }
         post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
         expect(last_response).to be_ok
@@ -235,7 +241,8 @@ describe "BoltServer::TransportApp", puppetserver: true do
         }
         body = {
           versioned_project: 'bolt_server_test_project',
-          target: target
+          target: target,
+          job_id: 1
         }
         post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
         expect(last_response.status).to eq(400)
@@ -342,7 +349,8 @@ describe "BoltServer::TransportApp", puppetserver: true do
           parameters: {
             catalog: cross_platform_catalog(target[:hostname])['catalog'],
             apply_settings: {}
-          }
+          },
+          job_id: 1
         }
         post(path, JSON.generate(body), 'CONTENT_TYPE' => 'text/json')
         expect(last_response).to be_ok

--- a/spec/docker-compose.yml
+++ b/spec/docker-compose.yml
@@ -55,3 +55,4 @@ services:
       - "8140:8140"
     volumes:
       - ./fixtures/modules:/etc/puppetlabs/code/modules
+      - ./fixtures/bolt_server/projects:/etc/puppetlabs/code/projects

--- a/spec/fixtures/bolt_server/projects/bolt_server_test_project/modules/apply_helpers/tasks/apply_catalog.json
+++ b/spec/fixtures/bolt_server/projects/bolt_server_test_project/modules/apply_helpers/tasks/apply_catalog.json
@@ -1,0 +1,27 @@
+{
+  "description": "Helper to apply a catalog from Bolt (for internal use only)",
+  "input_method": "stdin",
+  "private": true,
+  "supports_noop": true,
+  "implementations": [
+    { "name": "apply_catalog.rb" },
+    { "name": "apply_catalog.rb", "remote": true}
+  ],
+  "parameters": {
+    "catalog": {
+      "description": "Catalog to be applied",
+      "type": "Data",
+      "sensitive": true
+    },
+    "plugins": {
+      "description": "Plugin bundle to use when applying resources",
+      "type": "String",
+      "sensitive": true
+    },
+    "apply_settings": {
+      "description": "Puppet Settings to use during catalog application for example `show_diff`",
+      "type": "Optional[Hash]",
+      "sensitive": true
+    }
+  }
+}

--- a/spec/fixtures/bolt_server/projects/bolt_server_test_project/modules/apply_helpers/tasks/apply_catalog.rb
+++ b/spec/fixtures/bolt_server/projects/bolt_server_test_project/modules/apply_helpers/tasks/apply_catalog.rb
@@ -1,0 +1,117 @@
+#! /opt/puppetlabs/puppet/bin/ruby
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'json'
+require 'puppet'
+require 'puppet/configurer'
+require 'puppet/module_tool/tar'
+require 'securerandom'
+require 'tempfile'
+
+args = JSON.parse(ARGV[0] ? File.read(ARGV[0]) : $stdin.read)
+
+# Create temporary directories for all core Puppet settings so we don't clobber
+# existing state or read from puppet.conf. Also create a temporary modulepath.
+# Additionally include rundir, which gets its own initialization.
+puppet_root = Dir.mktmpdir
+moduledir = File.join(puppet_root, 'modules')
+Dir.mkdir(moduledir)
+cli = (Puppet::Settings::REQUIRED_APP_SETTINGS + [:rundir]).flat_map do |setting|
+  ["--#{setting}", File.join(puppet_root, setting.to_s.chomp('dir'))]
+end
+cli << '--modulepath' << moduledir
+Puppet.initialize_settings(cli)
+
+# Avoid extraneous output
+Puppet[:report] = false
+
+# Make sure to apply the catalog
+Puppet[:noop] = args['_noop'] || false
+args['apply_settings'].each do |setting, value|
+  Puppet[setting.to_sym] = value
+end
+
+Puppet[:default_file_terminus] = :file_server
+
+exit_code = 0
+begin
+  # This happens implicitly when running the Configurer, but we make it explicit here. It creates the
+  # directories we configured earlier.
+  Puppet.settings.use(:main)
+
+  Tempfile.open('plugins.tar.gz') do |plugins|
+    File.binwrite(plugins, Base64.decode64(args['plugins']))
+    user = Etc.getpwuid.nil? ? Etc.getlogin : Etc.getpwuid.name
+    Puppet::ModuleTool::Tar.instance.unpack(plugins, moduledir, user)
+  end
+
+  env = Puppet.lookup(:environments).get('production')
+  # Needed to ensure features are loaded
+  env.each_plugin_directory do |dir|
+    $LOAD_PATH << dir unless $LOAD_PATH.include?(dir)
+  end
+
+  if (conn_info = args['_target'])
+    unless (type = conn_info['remote-transport'])
+      puts "Cannot execute a catalog for a remote target without knowing it's the remote-transport type."
+      exit 1
+    end
+
+    begin
+      require 'puppet/resource_api/transport'
+    rescue LoadError
+      msg = "Could not load 'puppet/resource_api/transport', puppet-resource_api "\
+            "gem version 1.8.0 or greater is required on the proxy target"
+      puts msg
+      exit 1
+    end
+
+    # Transport.connect will modify this hash!
+    transport_conn_info = conn_info.transform_keys(&:to_sym)
+
+    transport = Puppet::ResourceApi::Transport.connect(type, transport_conn_info)
+    Puppet::ResourceApi::Transport.inject_device(type, transport)
+
+    Puppet[:facts_terminus] = :network_device
+    Puppet[:certname] = conn_info['name']
+  end
+
+  # Ensure custom facts are available for provider suitability tests
+  facts = Puppet::Node::Facts.indirection.find(SecureRandom.uuid, environment: env)
+
+  report = if Puppet::Util::Package.versioncmp(Puppet.version, '5.0.0') > 0
+             Puppet::Transaction::Report.new
+           else
+             Puppet::Transaction::Report.new('apply')
+           end
+
+  overrides = { current_environment: env,
+                loaders: Puppet::Pops::Loaders.new(env) }
+  overrides[:network_device] = true if args['_target']
+
+  Puppet.override(overrides) do
+    catalog = Puppet::Resource::Catalog.from_data_hash(args['catalog'])
+    catalog.environment = env.name.to_s
+    catalog.environment_instance = env
+    if defined?(Puppet::Pops::Evaluator::DeferredResolver)
+      # Only available in Puppet 6
+      Puppet::Pops::Evaluator::DeferredResolver.resolve_and_replace(facts, catalog)
+    end
+    catalog = catalog.to_ral
+
+    configurer = Puppet::Configurer.new
+    configurer.run(catalog: catalog, report: report, pluginsync: false)
+  end
+
+  puts JSON.pretty_generate(report.to_data_hash)
+  exit_code = report.exit_status != 1
+ensure
+  begin
+    FileUtils.remove_dir(puppet_root)
+  rescue Errno::ENOTEMPTY => e
+    $stderr.puts("Could not cleanup temporary directory: #{e}")
+  end
+end
+
+exit exit_code

--- a/spec/fixtures/bolt_server/projects/bolt_server_test_project/modules/apply_helpers/tasks/custom_facts.json
+++ b/spec/fixtures/bolt_server/projects/bolt_server_test_project/modules/apply_helpers/tasks/custom_facts.json
@@ -1,0 +1,14 @@
+{
+  "description": "Helper to retrieve custom facts from Bolt (for internal use only)",
+  "input_method": "stdin",
+  "private": true,
+  "supports_noop": true,
+  "parameters": {
+    "plugins": {
+      "description": "Custom facts bundle to use when applying resources",
+      "type": "String",
+      "sensitive": true
+    }
+  }
+}
+

--- a/spec/fixtures/bolt_server/projects/bolt_server_test_project/modules/apply_helpers/tasks/custom_facts.rb
+++ b/spec/fixtures/bolt_server/projects/bolt_server_test_project/modules/apply_helpers/tasks/custom_facts.rb
@@ -1,0 +1,63 @@
+#! /opt/puppetlabs/puppet/bin/ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'puppet'
+require 'puppet/module_tool/tar'
+require 'tempfile'
+
+args = JSON.parse($stdin.read)
+
+Dir.mktmpdir do |puppet_root|
+  # Create temporary directories for all core Puppet settings so we don't clobber
+  # existing state or read from puppet.conf. Also create a temporary modulepath.
+  moduledir = File.join(puppet_root, 'modules')
+  Dir.mkdir(moduledir)
+  cli = Puppet::Settings::REQUIRED_APP_SETTINGS.flat_map do |setting|
+    ["--#{setting}", File.join(puppet_root, setting.to_s.chomp('dir'))]
+  end
+  cli << '--modulepath' << moduledir
+  Puppet.initialize_settings(cli)
+
+  Tempfile.open('plugins.tar.gz') do |plugins|
+    File.binwrite(plugins, Base64.decode64(args['plugins']))
+    user = Etc.getpwuid.nil? ? Etc.getlogin : Etc.getpwuid.name
+    Puppet::ModuleTool::Tar.instance.unpack(plugins, moduledir, user)
+  end
+
+  env = Puppet.lookup(:environments).get('production')
+  env.each_plugin_directory do |dir|
+    $LOAD_PATH << dir unless $LOAD_PATH.include?(dir)
+  end
+
+  if (conn_info = args['_target'])
+    unless (type = conn_info['remote-transport'])
+      puts "Cannot collect facts for a remote target without knowing the remote-transport type."
+      exit 1
+    end
+
+    begin
+      require 'puppet/resource_api/transport'
+    rescue LoadError
+      msg = "Could not load 'puppet/resource_api/transport', puppet-resource_api "\
+            "gem version 1.8.0 or greater is required on the proxy target"
+      puts msg
+      exit 1
+    end
+
+    # Transport.connect will modify this hash!
+    transport_conn_info = conn_info.transform_keys(&:to_sym)
+    transport = Puppet::ResourceApi::Transport.connect(type, transport_conn_info)
+    Puppet::ResourceApi::Transport.inject_device(type, transport)
+
+    Puppet[:facts_terminus] = :network_device
+    Puppet[:certname] = conn_info['name']
+  end
+
+  facts = Puppet::Node::Facts.indirection.find(SecureRandom.uuid, environment: env)
+
+  facts.name = facts.values['clientcert']
+  puts(facts.values.to_json)
+end
+
+exit 0

--- a/spec/fixtures/bolt_server/projects/bolt_server_test_project/modules/fake_puppet_agent/tasks/install.rb
+++ b/spec/fixtures/bolt_server/projects/bolt_server_test_project/modules/fake_puppet_agent/tasks/install.rb
@@ -1,0 +1,13 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+# frozen_string_literal: true
+
+require 'json'
+
+params = JSON.parse($stdin.read)
+
+if params['fail']
+  exit 1
+else
+  output = { 'installed' => 'agent' }
+  puts output.to_json
+end

--- a/spec/lib/bolt_spec/bolt_server.rb
+++ b/spec/lib/bolt_spec/bolt_server.rb
@@ -29,13 +29,14 @@ module BoltSpec
     def default_config
       spec_dir = File.join(__dir__, '..', '..')
       ssl_dir = File.join(spec_dir, 'fixtures', 'ssl')
+      basedir = File.join(__dir__, '..', '..', 'fixtures', 'bolt_server')
       {
         'ssl-cert' => File.join(ssl_dir, "cert.pem"),
         'ssl-key' => File.join(ssl_dir, "key.pem"),
         'ssl-ca-cert' => File.join(ssl_dir, "ca.pem"),
         'cache-dir' => File.join(spec_dir, "tmp", "cache"),
         'file-server-uri' => 'https://localhost:8140',
-        'projects-dir' => '/tmp/foo'
+        'projects-dir' => File.join(basedir, 'projects')
       }
     end
 

--- a/spec/lib/bolt_spec/file_cache.rb
+++ b/spec/lib/bolt_spec/file_cache.rb
@@ -22,6 +22,12 @@ module BoltSpec
           File.join(@moduledir, *parts)
         end
       end
+
+      def get_cached_project_file(_versioned_project, _file_name); end
+
+      def cache_project_file(_versioned_project, _file_name, data)
+        data
+      end
     end
 
     # TODO: support more than just the sample module


### PR DESCRIPTION
This commit adds two new actions to bolt-server. The apply_prep action runs a configurable task to install an agent and the `apply_helpers::custom_facts` task. The apply action runs the `apply_helpers::apply_catalog` task. These actions support apply/apply_prep from project plans run via orchestrator. Given a plugin tarbal is calculated for every invocation, this commit adds caching for plugin tarbals. The caching is "easy" here because a versioned project is unique and will not change over time.