### PR TITLE
(docs) update /puppet/ links to point to latest

### DIFF
--- a/documentation/applying_manifest_blocks.md
+++ b/documentation/applying_manifest_blocks.md
@@ -227,7 +227,7 @@ $results.each |$result| {
 
 The [`ApplyResult` object](bolt_types_reference.md#applyresult) includes a
 `report` method that returns a hash representation of the
-[`Puppet::Transaction::Report`](https://puppet.com/docs/puppet/7.3/format_report.html)
+[`Puppet::Transaction::Report`](https://puppet.com/docs/puppet/latest/format_report.html)
 object. Each property on the object corresponds to a key with the same name in
 the report hash. However, not every property is presented in the hash for every
 result. Only properties that have a value from the apply are present in the

--- a/documentation/json_output_reference.md
+++ b/documentation/json_output_reference.md
@@ -30,7 +30,7 @@ This command outputs an array of objects. Each object uses the following keys:
   - `report` (object):
     A report from the reply. This is a serialized representation of the
     [`Puppet::Transaction::Report`
-    object](https://puppet.com/docs/puppet/7.6/format_report.html#format_report-puppet-transaction-report).
+    object](https://puppet.com/docs/puppet/latest/format_report.html#format_report-puppet-transaction-report).
 
 For example:
 

--- a/documentation/writing_yaml_plans.md
+++ b/documentation/writing_yaml_plans.md
@@ -69,7 +69,7 @@ Each plan name segment must begin with a lowercase letter and:
 -   Can include digits.
 -   Can include underscores.
 -   Must not be a [reserved
-    word](https://docs.puppet.com/puppet/5.3/lang_reserved.html).
+    word](https://docs.puppet.com/puppet/latest/lang_reserved.html).
 -   Must not have the same name as any Puppet data types.
 -   Namespace segments must match the following regular expression
     `\A[a-z][a-z0-9_]*\Z`


### PR DESCRIPTION
some links were still using a specific version, rather than the
`/latest/` meta-version.
In most cases that did redirect to `/7/` but let's just make sure this
always works.

!no-release-note