### PR TITLE
(maint) Fix broken acceptance tests

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -9,7 +9,7 @@ extend Acceptance::BoltSetupHelper
 
 desc "Generate Beaker Host config"
 rototiller_task :host_config do |task|
-  unless ENV['BEAKER_HOSTS_FILE']
+  unless ENV['BEAKER_HOSTS']
     task.add_env(name: 'BOLT_CONTROLLER', default: 'debian10-64')
     task.add_env(name: 'BOLT_NODES',
                  default: 'centos7-64,osx1012-64,windows10ent-64')
@@ -28,7 +28,7 @@ rototiller_task :host_config do |task|
       n_new << node
     end
     nodes_final = n_new.join('-')
-    generate = "beaker-hostgenerator"
+    generate = "bundle exec beaker-hostgenerator"
     generate += " #{nodes_final}"
     generate += " > hosts.yaml"
     sh generate
@@ -49,7 +49,7 @@ beaker_options = [
     add_argument: {
       name: 'hosts.yaml',
       add_env: {
-        name: 'BEAKER_HOSTS_FILE',
+        name: 'BEAKER_HOSTS',
         message: 'Beaker hosts file'
       }
     } },


### PR DESCRIPTION
The environment variable for setting the beaker hosts file was changed
from `BEAKER_HOSTS` to `BEAKER_HOSTS_FILE` in #2956, which caused Bolt's
acceptance tests to begin failing. Tests began failing because the
vanagon integration job in Jenkins generates the hosts file and sets the
path to the file in `BEAKER_HOSTS`. This results in Bolt's acceptance
tests generating a new hosts file, since `BEAKER_HOSTS_FILE` is unset.
Generating the hosts file fails since the rake task runs
`beaker-hostgenerator` instead of the correct `bundle exec
beaker-hostgenerator`.

This resets the environment variable to `BEAKER_HOSTS` as expected by
the Jenkins job and beaker itself, and updates the shell command
executed by the acceptance test rake task.

!no-release-note