### PR TITLE
(hack) Add --script to plan new

### DIFF
--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -1042,6 +1042,21 @@ module Bolt
       define('--pp', 'Create a new Puppet language plan.') do |_|
         @options[:puppet] = true
       end
+      define('--script SCRIPT', 'Create a new plan that wraps a script.') do |path|
+        # If the path is a relative, absolute, or not a scripts path, raise an
+        # error. This flag is intended to be used to create shareable plans.
+        #
+        # This also limits valid mounts to files and scripts, which we may want
+        # to expand in the future.
+        if File.exist?(path) || Pathname.new(path).absolute? ||
+           !%w[scripts files].include?(path.split(File::SEPARATOR)[1])
+          raise Bolt::CLIError, "The script must be a detailed Puppet file reference, " \
+            "for example 'mymodule/scripts/myscript.sh'. See http://pup.pt/bolt-scripts for " \
+            "more information on detailed Puppet file references."
+        end
+
+        @options[:plan_script] = path
+      end
 
       separator "\n#{self.class.colorize(:cyan, 'Display options')}"
       define('--filter FILTER', 'Filter tasks and plans by a matching substring.') do |filter|

--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -20,7 +20,6 @@ require 'bolt/logger'
 require 'bolt/module_installer'
 require 'bolt/outputter'
 require 'bolt/pal'
-require 'bolt/plan_creator'
 require 'bolt/plugin'
 require 'bolt/project_manager'
 require 'bolt/puppetdb'
@@ -611,7 +610,7 @@ module Bolt
           app.convert_plan(options[:object])
           SUCCESS
         when 'new'
-          result = app.new_plan(options[:object], **options.slice(:puppet))
+          result = app.new_plan(options[:object], **options.slice(:puppet, :plan_script))
           outputter.print_new_plan(**result)
           SUCCESS
         when 'run'

--- a/spec/bolt/application_spec.rb
+++ b/spec/bolt/application_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bolt/application'
+require 'bolt/plan_creator'
 
 require 'bolt_spec/files'
 
@@ -153,6 +154,16 @@ describe Bolt::Application do
     it 'defaults to showing all targets' do
       expect(inventory).to receive(:get_targets).with(['all']).and_return([target])
       application.show_inventory(nil)
+    end
+  end
+
+  describe "#new_plan" do
+    let(:config) { double(future: {}, project: nil) }
+
+    it 'errors if provided a script and future.file_paths is not set' do
+      allow(Bolt::PlanCreator).to receive(:validate_plan_name)
+      expect { application.new_plan('planplanplan', plan_script: 'scriptscriptscript') }
+        .to raise_error(Bolt::CLIError, /The --script flag can only be used if future.file_paths/)
     end
   end
 

--- a/spec/bolt/bolt_option_parser_spec.rb
+++ b/spec/bolt/bolt_option_parser_spec.rb
@@ -155,6 +155,31 @@ describe 'parser' do
       end
     end
 
+    describe '--script' do
+      it 'errors with a relative path' do
+        # This path is specifically structured so that it *won't* be caught by
+        # verifying `scripts` is the second segment of the path.
+        expect { parser.permute(%w[--script ./scripts/ci.ps1]) }
+          .to raise_error(Bolt::CLIError, /The script must be a detailed Puppet file ref/)
+      end
+
+      it 'errors with an absolute path' do
+        path = File.expand_path('./scripts/ci.ps1')
+        expect { parser.permute(%W[--script #{path}]) }
+          .to raise_error(Bolt::CLIError, /The script must be a detailed Puppet file ref/)
+      end
+
+      it 'errors with a nonspecific Puppet file reference' do
+        expect { parser.permute(%w[--script mymodule/myfile]) }
+          .to raise_error(Bolt::CLIError, /The script must be a detailed Puppet file ref/)
+      end
+
+      it 'accepts a Puppet file reference to the scripts directory' do
+        parser.permute(%w[--script mymodule/scripts/myscript.sh])
+        expect(options[:plan_script]).to eq('mymodule/scripts/myscript.sh')
+      end
+    end
+
     describe '--sudo-password-prompt' do
       it 'prompts for a password' do
         allow($stdin).to receive(:noecho).and_return('opensesame')

--- a/spec/bolt/plan_creator_spec.rb
+++ b/spec/bolt/plan_creator_spec.rb
@@ -17,10 +17,10 @@ describe Bolt::PlanCreator do
     end
   end
 
-  context "#validate_input" do
+  context "#validate_plan_name" do
     it 'errors without a named project' do
       allow(project).to receive(:name).and_return(nil)
-      expect { subject.validate_input(project, plan_name) }.to raise_error(
+      expect { subject.validate_plan_name(project, plan_name) }.to raise_error(
         Bolt::Error,
         /Project directory '.*' is not a named project/
       )
@@ -28,7 +28,7 @@ describe Bolt::PlanCreator do
 
     it 'errors when the plan name is invalid' do
       %w[Foo foo-bar foo:: foo::Bar foo::1bar ::foo].each do |plan_name|
-        expect { subject.validate_input(project, plan_name) }.to raise_error(
+        expect { subject.validate_plan_name(project, plan_name) }.to raise_error(
           Bolt::ValidationError,
           /Invalid plan name '#{plan_name}'/
         )
@@ -36,7 +36,7 @@ describe Bolt::PlanCreator do
     end
 
     it 'errors if the first name segment is not the project name' do
-      expect { subject.validate_input(project, 'plan') }.to raise_error(
+      expect { subject.validate_plan_name(project, 'plan') }.to raise_error(
         Bolt::ValidationError,
         /Incomplete plan name: A plan name must be prefixed with the name of the/
       )
@@ -48,7 +48,7 @@ describe Bolt::PlanCreator do
         FileUtils.mkdir(File.dirname(plan_path))
         FileUtils.touch(plan_path)
 
-        expect { subject.validate_input(project, plan_name) }.to raise_error(
+        expect { subject.validate_plan_name(project, plan_name) }.to raise_error(
           Bolt::Error,
           /A plan with the name '#{plan_name}' already exists/
         )
@@ -59,14 +59,14 @@ describe Bolt::PlanCreator do
   context "#create_plan" do
     it "creates a missing 'plans' directory" do
       expect(Dir.exist?(project.plans_path)).to eq(false)
-      subject.create_plan(project.plans_path, plan_name, nil)
+      subject.create_plan(project.plans_path, plan_name)
       expect(Dir.exist?(project.plans_path)).to eq(true)
     end
 
     it 'creates a missing directory structure' do
       plan_name = "#{project.name}::foo::bar"
       expect(Dir.exist?(project.plans_path + 'foo')).to eq(false)
-      subject.create_plan(project.plans_path, plan_name, nil)
+      subject.create_plan(project.plans_path, plan_name)
       expect(Dir.exist?(project.plans_path + 'foo')).to eq(true)
     end
 
@@ -75,33 +75,53 @@ describe Bolt::PlanCreator do
       FileUtils.mkdir(project.plans_path)
       FileUtils.touch(project.plans_path + 'foo')
 
-      expect { subject.create_plan(project.plans_path, plan_name, nil) }
+      expect { subject.create_plan(project.plans_path, plan_name) }
         .to raise_error(Bolt::Error, /unable to create plan directory/)
     end
 
     it "creates an 'init' plan when the plan name matches the project name" do
-      subject.create_plan(project.plans_path, plan_name, nil)
+      subject.create_plan(project.plans_path, plan_name)
       expect(File.exist?(project.plans_path + 'init.yaml')).to eq(true)
     end
 
     it 'creates a yaml plan by default' do
       plan_name = "#{project.name}::foo"
 
-      subject.create_plan(project.plans_path, plan_name, nil)
+      subject.create_plan(project.plans_path, plan_name)
       expect(File.read(project.plans_path + 'foo.yaml'))
-        .to eq(subject.yaml_plan(plan_name))
+        .to eq(subject.send(:yaml_plan, plan_name))
     end
 
     it 'creates a puppet plan when the flag is provided' do
       plan_name = "#{project.name}::foo"
 
-      subject.create_plan(project.plans_path, plan_name, true)
+      subject.create_plan(project.plans_path, plan_name, is_puppet: true)
       expect(File.read(project.plans_path + 'foo.pp'))
-        .to eq(subject.puppet_plan(plan_name))
+        .to eq(subject.send(:puppet_plan, plan_name))
+    end
+
+    context "with --script" do
+      let(:script) { 'mymodule/scripts/chillout.ps1' }
+
+      it 'creates a yaml plan that runs the provided script' do
+        plan_name = "#{project.name}::foo"
+
+        subject.create_plan(project.plans_path, plan_name, script: script)
+        expect(File.read(project.plans_path + 'foo.yaml'))
+          .to eq(subject.send(:yaml_script_plan, script))
+      end
+
+      it 'creates a puppet plan that runs the script' do
+        plan_name = "#{project.name}::foo"
+
+        subject.create_plan(project.plans_path, plan_name, is_puppet: true, script: script)
+        expect(File.read(project.plans_path + 'foo.pp'))
+          .to eq(subject.send(:puppet_script_plan, plan_name, script))
+      end
     end
 
     it 'returns the name and path to the plan' do
-      expect(subject.create_plan(project.plans_path, plan_name, nil)).to include(
+      expect(subject.create_plan(project.plans_path, plan_name)).to include(
         name: plan_name,
         path: project.plans_path + 'init.yaml'
       )

--- a/spec/integration/container_spec.rb
+++ b/spec/integration/container_spec.rb
@@ -6,7 +6,7 @@ require 'bolt_spec/files'
 require 'bolt_spec/integration'
 require 'bolt_spec/project'
 
-describe 'plans' do
+describe 'plans', bash: true do
   include BoltSpec::Conn
   include BoltSpec::Files
   include BoltSpec::Integration


### PR DESCRIPTION
This adds a new flag `--script` to the `bolt plan new` command that
accepts a detailed (new-style) Puppet file reference to a script. The 
flag can only be used if `future.file_paths` is configured, so that
detailed file references are loaded. Bolt will then validate the file
exists, and create a new plan that simply runs the script and returns
the result.

Many users migrate to using Bolt from running scripts, and find it
difficult to begin writing Bolt content that can orchestrate their
scripts. This makes it easy to create the boilerplate for running a
script, with future improvements to accept parameters for the script and 
integrate those into the generated plan.

!feature

* **Pass `--script` to `bolt plan new` to wrap a script in a plan** (hack)
  The `bolt plan new` command now accepts a `--script SCRIPT` parameter
  that will generate a plan that simply runs the script and returns the 
  result. The flag only supports detailed (new-style) Puppet file
  references. Learn more about file references at http://pup.pt/bolt-scripts