### PR TITLE
(docs) Use `map` in `background` example

### DIFF
--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -344,7 +344,7 @@ out::message($result)
 Similarly, using `wait()`:
 ```
 $ts = get_targets($targets)
-$futures = $ts.each |$target| {
+$futures = $ts.map |$target| {
   background() || {
     if $target.name == 'target1' {
       return "Don't run the task on this target"


### PR DESCRIPTION
This updates an example for the `background` function in the
"Experimental features" doc to use the `map` function instead of `each`.

!no-release-note