### PR TITLE
(GH-2892) Document sensitive task output limitations

### DIFF
--- a/documentation/troubleshooting.md
+++ b/documentation/troubleshooting.md
@@ -371,6 +371,12 @@ inventory-config:
     shell-command: /bin/sh -c
 ```
 
+## I can't access sensitive output from a task using the `pcp` transport
+
+Sensitive output is not supported when running tasks using the `pcp` transport.
+For more information, see the [`bolt_shim`
+documentation](https://github.com/puppetlabs/puppetlabs-bolt_shim/blob/main/docs/sensitive_task_output.md).
+
 ## I still need help
 
 Visit the **#bolt** channel in the [Puppet Community


### PR DESCRIPTION
This adds a section to the 'Troubleshooting' page that documents
limitations around running tasks with sensitive output using the `pcp`
transport.

!no-release-note

Closes #2892 