### PR TITLE
(GH-2698) Support `interpreters` configuration when running scripts

### DIFF
--- a/documentation/analytics.md
+++ b/documentation/analytics.md
@@ -61,6 +61,7 @@ with a randomly generated, non-identifiable user UUID:
 - Whether the source file for `upload_file`, `run_script`, or `file::read` plan
   functions uses an absolute path or a module path.
 - Whether a task is run in no-operation mode.
+- Whether `future.script_interpreter` is enabled.
 
 ## Viewing collected data
 

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -147,14 +147,21 @@ module Bolt
           type: Hash,
           properties: {
             "file_paths" => {
-              description: "Load scripts from the `scripts/` directory of a module",
+              description: "Load scripts from the `scripts/` directory of a module.",
+              type: [TrueClass, FalseClass],
+              _example: true,
+              _default: false
+            },
+            "script_interpreter" => {
+              description: "Use a target's [`interpreters` configuration](bolt_transports_reference.md#interpreters) "\
+                           "when running a script.",
               type: [TrueClass, FalseClass],
               _example: true,
               _default: false
             }
           },
           _plugin: false,
-          _example: { 'file_paths' => true }
+          _example: { 'file_paths' => true, 'script_interpreter' => true }
         },
         "hiera-config" => {
           description: "The path to the Hiera configuration file.",

--- a/lib/bolt/executor.rb
+++ b/lib/bolt/executor.rb
@@ -300,6 +300,9 @@ module Bolt
       description = options.fetch(:description, "script #{script}")
       log_action(description, targets) do
         options[:run_as] = run_as if run_as && !options.key?(:run_as)
+        options[:script_interpreter] = (future || {}).fetch('script_interpreter', false)
+
+        @analytics&.event('Future', 'script_interpreter', label: options[:script_interpreter].to_s)
 
         batch_execute(targets) do |transport, batch|
           with_node_logging("Running script #{script} with '#{arguments.to_json}'", batch) do

--- a/lib/bolt/shell/bash.rb
+++ b/lib/bolt/shell/bash.rb
@@ -94,7 +94,17 @@ module Bolt
           with_tmpdir do |dir|
             path = write_executable(dir.to_s, script)
             dir.chown(run_as)
-            output = execute([path, *arguments], environment: options[:env_vars], sudoable: true)
+
+            exec_args   = [path, *arguments]
+            interpreter = select_interpreter(script, target.options['interpreters'])
+
+            # Only use interpreter if script_interpreter config is enabled
+            if options[:script_interpreter] && interpreter
+              exec_args.unshift(interpreter)
+              logger.trace("Running '#{script}' using '#{interpreter}' interpreter")
+            end
+
+            output = execute(exec_args, environment: options[:env_vars], sudoable: true)
             Bolt::Result.for_command(target,
                                      output.to_h,
                                      'script',

--- a/lib/bolt/shell/powershell.rb
+++ b/lib/bolt/shell/powershell.rb
@@ -212,7 +212,14 @@ module Bolt
                     elsif powershell_file?(script_path)
                       Snippets.run_script(arguments, script_path)
                     else
-                      path, args = *process_from_extension(script_path)
+                      interpreter = select_interpreter(script_path, target.options['interpreters'])
+                      if options[:script_interpreter] && interpreter
+                        path = interpreter
+                        args = escape_arguments([script_path])
+                        logger.trace("Running '#{script_path}' using '#{interpreter}' interpreter")
+                      else
+                        path, args = *process_from_extension(script_path)
+                      end
                       args += escape_arguments(arguments)
                       execute_process(path, args)
                     end

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -149,7 +149,11 @@
       "type": "object",
       "properties": {
         "file_paths": {
-          "description": "Load scripts from the `scripts/` directory of a module",
+          "description": "Load scripts from the `scripts/` directory of a module.",
+          "type": "boolean"
+        },
+        "script_interpreter": {
+          "description": "Use a target's [`interpreters` configuration](bolt_transports_reference.md#interpreters) when running a script.",
           "type": "boolean"
         }
       }

--- a/spec/fixtures/modules/sample/scripts/script.py
+++ b/spec/fixtures/modules/sample/scripts/script.py
@@ -1,0 +1,1 @@
+print('Hello, world!')

--- a/spec/fixtures/modules/sample/scripts/script.rb
+++ b/spec/fixtures/modules/sample/scripts/script.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+puts "Hello, world!"

--- a/spec/integration/ssh_spec.rb
+++ b/spec/integration/ssh_spec.rb
@@ -85,51 +85,102 @@ describe "when runnning over the ssh transport", ssh: true do
 
   context 'when using a project', :reset_puppet_settings do
     let(:config) do
-      { 'format' => 'json',
-        'modulepath' => modulepath }
+      {
+        'format'     => 'json',
+        'future'     => future_config,
+        'modulepath' => modulepath
+      }
     end
+
+    let(:future_config) do
+      {
+        'file_paths' => true
+      }
+    end
+
     let(:default_inv) do
-      { 'config' =>
-      { 'ssh' => {
-        'user' => user,
-        'password' => password,
-        'host-key-check' => false
-      } } }
+      {
+        'config' => {
+          'ssh' => {
+            'user' => user,
+            'password' => password,
+            'host-key-check' => false
+          }
+        }
+      }
     end
-    let(:inv)                 { default_inv }
-    let(:uri)                 { (1..2).map { |i| "#{conn_uri('ssh')}?id=#{i}" }.join(',') }
-    let(:project)             { @project }
-    let(:config_flags)        { %W[--targets #{uri} --project #{project.path}] }
-    let(:single_target_conf)  { %W[--targets #{conn_uri('ssh')} --project #{project.path}] }
-    let(:interpreter_task)    { 'sample::interpreter' }
+
+    let(:inv)                { default_inv }
+    let(:uri)                { (1..2).map { |i| "#{conn_uri('ssh')}?id=#{i}" }.join(',') }
+    let(:project)            { @project }
+    let(:config_flags)       { %W[--targets #{uri} --project #{project.path}] }
+    let(:single_target_conf) { %W[--targets #{conn_uri('ssh')} --project #{project.path}] }
+    let(:interpreter_task)   { 'sample::interpreter' }
+    let(:interpreter_script) { 'sample/scripts/script.py' }
+
     let(:run_as_conf) do
-      { 'config' => {
-        'ssh' => { 'run-as' => user }
-      } }
+      {
+        'config' => {
+          'ssh' => {
+            'run-as' => user
+          }
+        }
+      }
     end
+
     let(:interpreter_ext) do
-      { 'config' => {
-        'ssh' => {
-          'interpreters' => {
-            '.py' => '/usr/bin/python3'
+      {
+        'config' => {
+          'ssh' => {
+            'interpreters' => {
+              '.py' => '/usr/bin/python3'
+            }
           }
         }
-      } }
+      }
     end
+
     let(:interpreter_no_ext) do
-      { 'config' => {
-        'ssh' => {
-          'interpreters' => {
-            'py' => '/usr/bin/python3'
+      {
+        'config' => {
+          'ssh' => {
+            'interpreters' => {
+              'py' => '/usr/bin/python3'
+            }
           }
         }
-      } }
+      }
     end
 
     around :each do |example|
       with_project(config: config, inventory: inv) do |project|
         @project = project
         example.run
+      end
+    end
+
+    shared_examples 'script interpreter' do
+      it 'does not run script with specified interpreter' do
+        result = run_cli_json(%W[script run #{interpreter_script}] + config_flags)['items'][0]
+        expect(result['status']).to eq('failure')
+        expect(result['value']['exit_code']).to eq(2)
+        expect(result['value']['stderr']).to match(/word unexpected/)
+      end
+
+      context 'with future.script_interpreter configured' do
+        let(:future_config) do
+          {
+            'file_paths'         => true,
+            'script_interpreter' => true
+          }
+        end
+
+        it 'runs script with specified interpreter' do
+          result = run_cli_json(%W[script run #{interpreter_script}] + config_flags)['items'][0]
+          expect(result['status']).to eq('success')
+          expect(result['value']['exit_code']).to eq(0)
+          expect(result['value']['stdout']).to match(/Hello, world!/)
+        end
       end
     end
 
@@ -155,6 +206,8 @@ describe "when runnning over the ssh transport", ssh: true do
     context 'with interpreters without dots configured' do
       let(:inv) { Bolt::Util.deep_merge(default_inv, interpreter_no_ext) }
 
+      include_examples 'script interpreter'
+
       it 'runs task with specified interpreter key py' do
         result = run_nodes(%W[task run #{interpreter_task} message=short] + config_flags)
         expect(result.map { |r| r['env'].strip }).to eq(%w[short short])
@@ -171,6 +224,8 @@ describe "when runnning over the ssh transport", ssh: true do
 
     context 'with interpreters with dots configured' do
       let(:inv) { Bolt::Util.deep_merge(default_inv, interpreter_ext) }
+
+      include_examples 'script interpreter'
 
       it 'runs task with interpreter key .py' do
         result = run_nodes(%W[task run #{interpreter_task} message=short] + config_flags)

--- a/spec/integration/winrm_spec.rb
+++ b/spec/integration/winrm_spec.rb
@@ -89,6 +89,18 @@ describe "when runnning over the winrm transport", winrm: true do
   end
 
   context 'when using an inventoryfile', :reset_puppet_settings do
+    let(:config) do
+      {
+        'future' => future_config
+      }
+    end
+
+    let(:future_config) do
+      {
+        'file_paths' => true
+      }
+    end
+
     let(:default_inv) do
       {
         'config' => {
@@ -101,43 +113,54 @@ describe "when runnning over the winrm transport", winrm: true do
         }
       }
     end
-    let(:inv)               { default_inv }
-    let(:uri)               { (1..2).map { |i| "#{conn_uri('winrm')}?id=#{i}" }.join(',') }
-    let(:project)           { @project }
-    let(:common_flags)      { %W[--format json --modulepath #{modulepath} --project #{project.path}] }
-    let(:config_flags)      { %W[--targets #{uri}] + common_flags }
-    let(:single_target)     { %W[--targets #{conn_uri('winrm')}] + common_flags }
-    let(:interpreter_task)  { 'sample::bolt_ruby' }
+
+    let(:inv)                { default_inv }
+    let(:uri)                { (1..2).map { |i| "#{conn_uri('winrm')}?id=#{i}" }.join(',') }
+    let(:project)            { @project }
+    let(:common_flags)       { %W[--format json --modulepath #{modulepath} --project #{project.path}] }
+    let(:config_flags)       { %W[--targets #{uri}] + common_flags }
+    let(:single_target)      { %W[--targets #{conn_uri('winrm')}] + common_flags }
+    let(:interpreter_task)   { 'sample::bolt_ruby' }
+    let(:interpreter_script) { 'sample/scripts/script.rb' }
+
     let(:interpreter_ext) do
-      { 'config' => {
-        'winrm' => {
-          'interpreters' => {
-            '.rb' => RbConfig.ruby
+      {
+        'config' => {
+          'winrm' => {
+            'interpreters' => {
+              '.rb' => RbConfig.ruby
+            }
           }
         }
-      } }
+      }
     end
+
     let(:interpreter_no_ext) do
-      { 'config' => {
-        'winrm' => {
-          'interpreters' => {
-            'rb' => RbConfig.ruby
+      {
+        'config' => {
+          'winrm' => {
+            'interpreters' => {
+              'rb' => RbConfig.ruby
+            }
           }
         }
-      } }
+      }
     end
+
     let(:bad_interpreter) do
-      { 'config' => {
-        'winrm' => {
-          'interpreters' => {
-            'rb' => 'C:\dev\null'
+      {
+        'config' => {
+          'winrm' => {
+            'interpreters' => {
+              'rb' => 'C:\dev\null'
+            }
           }
         }
-      } }
+      }
     end
 
     around :each do |example|
-      with_project(inventory: inv) do |project|
+      with_project(config: config, inventory: inv) do |project|
         @project = project
         example.run
       end
@@ -181,6 +204,37 @@ describe "when runnning over the winrm transport", winrm: true do
       it 'task fails with bad interpreter', windows: true do
         result = run_failed_node(%W[task run #{interpreter_task} message=short] + single_target)
         expect(result['_error']['msg']).to match(/'C:\\dev\\null' is not recognized/)
+      end
+    end
+
+    context 'script interpreter' do
+      # Windows automatically searches for an interpreter if one is not
+      # specified. We use a bad interpreter here to check that the interpreter
+      # is being set correctly, otherwise Windows would just find the Ruby
+      # interpreter on its own.
+      let(:inv) { Bolt::Util.deep_merge(default_inv, bad_interpreter) }
+
+      context 'without future.script_interpreter configured' do
+        it 'does not run script with specified interpreter' do
+          result = run_cli_json(%W[script run #{interpreter_script}] + config_flags)['items'][0]
+          expect(result['status']).to eq('success')
+          expect(result['value']['stdout']).to match(/Hello, world!/)
+        end
+      end
+
+      context 'with future.script_interpreter configured' do
+        let(:future_config) do
+          {
+            'file_paths'         => true,
+            'script_interpreter' => true
+          }
+        end
+
+        it 'runs script with specified interpreter' do
+          result = run_cli_json(%W[script run #{interpreter_script}] + config_flags)['items'][0]
+          expect(result['status']).to eq('failure')
+          expect(result['value']['stdout']).not_to match(/Hello, world!/)
+        end
       end
     end
   end

--- a/spec/unit/executor_spec.rb
+++ b/spec/unit/executor_spec.rb
@@ -105,7 +105,7 @@ describe "Bolt::Executor" do
   context 'executes running a script' do
     it "on all nodes" do
       node_results.each do |target, result|
-        expect(ssh).to receive(:run_script).with(target, script, [], {}, []).and_return(result)
+        expect(ssh).to receive(:run_script).with(target, script, [], anything, []).and_return(result)
       end
 
       results = executor.run_script(targets, script, [], {})
@@ -117,7 +117,7 @@ describe "Bolt::Executor" do
     it 'passes run_as' do
       executor.run_as = 'foo'
       node_results.each do |target, result|
-        expect(ssh).to receive(:run_script).with(target, script, [], { run_as: 'foo' }, [])
+        expect(ssh).to receive(:run_script).with(target, script, [], include(run_as: 'foo'), [])
                                            .and_return(result)
       end
 
@@ -129,7 +129,7 @@ describe "Bolt::Executor" do
 
     it "yields each result" do
       node_results.each do |target, result|
-        expect(ssh).to receive(:run_script).with(target, script, [], {}, []).and_return(result)
+        expect(ssh).to receive(:run_script).with(target, script, [], anything, []).and_return(result)
       end
 
       executor.run_script(targets, script, [])
@@ -145,7 +145,7 @@ describe "Bolt::Executor" do
       node_results.each_key do |target|
         expect(ssh)
           .to receive(:run_script)
-          .with(target, script, [], {}, position)
+          .with(target, script, [], anything, position)
           .and_raise(Bolt::Error.new('failed', 'my-exception', file_lineno))
       end
 
@@ -823,7 +823,7 @@ describe "Bolt::Executor" do
       node_results.each do |target, result|
         expect(ssh)
           .to receive(:run_script)
-          .with(target, script, [], {}, [])
+          .with(target, script, [], anything, [])
           .and_return(result)
       end
 


### PR DESCRIPTION
This adds support for running scripts using the `interpreters` transport
configuration. This feature is gated by the `script_interpreter` future
flag.

!feature

* **Support `interpreters` configuration when running scripts**
  ([#2698](https://github.com/puppetlabs/bolt/issues/2698))

  Bolt now supports the `interpreters` transport configuration when
  running scripts. To enable this feature, set the
  `future.script_interpreter` configuration to `true`.