### PR TITLE
(GH-2966) Fix stacktrace for conflicting `module add` and `Puppetfile`

### DIFF
--- a/lib/bolt/module_installer/puppetfile.rb
+++ b/lib/bolt/module_installer/puppetfile.rb
@@ -97,20 +97,34 @@ module Bolt
           end
         end
 
-        return if unsatisfied_specs.empty?
-
+        versionless_mods = @modules.select { |mod| mod.is_a?(ForgeModule) && mod.version.nil? }
         command = Bolt::Util.windows? ? 'Install-BoltModule -Force' : 'bolt module install --force'
 
-        message = <<~MESSAGE.chomp
-          Puppetfile does not include modules that satisfy the following specifications:
+        if unsatisfied_specs.any?
+          message = <<~MESSAGE.chomp
+            Puppetfile does not include modules that satisfy the following specifications:
 
-          #{unsatisfied_specs.map(&:to_hash).to_yaml.lines.drop(1).join.chomp}
-          
-          This Puppetfile might not be managed by Bolt. To forcibly overwrite the
-          Puppetfile, run '#{command}'.
-        MESSAGE
+            #{unsatisfied_specs.map(&:to_hash).to_yaml.lines.drop(1).join.chomp}
+            
+            This Puppetfile might not be managed by Bolt. To forcibly overwrite the
+            Puppetfile, run '#{command}'.
+          MESSAGE
 
-        raise Bolt::Error.new(message, 'bolt/missing-module-specs')
+          raise Bolt::Error.new(message, 'bolt/missing-module-specs')
+        end
+
+        if versionless_mods.any?
+          message = <<~MESSAGE.chomp
+            Puppetfile includes Forge modules without a version requirement:
+            
+            #{versionless_mods.map(&:to_spec).join.chomp}
+            
+            This Puppetfile might not be managed by Bolt. To forcibly overwrite the
+            Puppetfile, run '#{command}'.
+          MESSAGE
+
+          raise Bolt::Error.new(message, 'bolt/missing-module-version-specs')
+        end
       end
     end
   end

--- a/spec/bolt/module_installer/puppetfile_spec.rb
+++ b/spec/bolt/module_installer/puppetfile_spec.rb
@@ -112,5 +112,21 @@ describe Bolt::ModuleInstaller::Puppetfile do
         )
       end
     end
+
+    context 'with missing module version' do
+      let(:spec)    { double('spec', satisfied_by?: true) }
+      let(:version) { nil }
+
+      let(:mod) do
+        [double('mod', name: name, version: version, is_a?: true, to_spec: "mod '#{name}'")]
+      end
+
+      it "errors" do
+        expect { puppetfile.assert_satisfies(specs) }.to raise_error(
+          Bolt::Error,
+          /Puppetfile includes Forge modules without a version/
+        )
+      end
+    end
   end
 end

--- a/spec/bolt/module_installer_spec.rb
+++ b/spec/bolt/module_installer_spec.rb
@@ -54,6 +54,16 @@ describe Bolt::ModuleInstaller do
       )
     end
 
+    it 'errors if module is already in puppetfile without version' do
+      File.write(puppetfile, "mod '#{new_module}'")
+      expect {
+        installer.add(new_module, [], puppetfile, moduledir, project_file, install_config)
+      }.to raise_error(
+        Bolt::Error,
+        /Puppetfile includes Forge modules without a version/
+      )
+    end
+
     it 'updates files and installs modules' do
       expect(installer).to receive(:install_puppetfile)
       installer.add(new_module, specs, puppetfile, moduledir, project_file, install_config)


### PR DESCRIPTION
When a project's `Puppetfile` has a forge module without a version specified, Bolt now offers a more helpful error when attempting to do a `module install/add` of the same module.

!bug

* **Fix stacktrace for conflicting module add and Puppetfile**
[(#2966)](https://github.com/puppetlabs/bolt/issues/2966)

  When a project's `Puppetfile` has a forge module without a version specified,
  Bolt now offers a more helpful error when attempting to do a `module install/add` of 
  the same module.