### PR TITLE
(maint) Remove broken bundled-ruby acceptance test

### DIFF
--- a/acceptance/tests/task_local.rb
+++ b/acceptance/tests/task_local.rb
@@ -41,15 +41,6 @@ test_name "bolt task run should execute tasks on localhost via local transport" 
       FILE
     end
 
-    step "create ruby_env task on bolt controller" do
-      # Still -p; can never be too careful
-      on(bolt, "mkdir -p #{dir}/modules/test/tasks")
-      create_remote_file(bolt, "#{dir}/modules/test/tasks/ruby_env.sh", <<-FILE)
-      #!/bin/sh
-      echo $GEM_PATH
-      FILE
-    end
-
     step "execute `bolt task run test::whoami_nix` on localhost via local transport" do
       bolt_command = "bolt task run test::whoami_nix greetings=hello"
       flags = {
@@ -61,18 +52,6 @@ test_name "bolt task run should execute tasks on localhost via local transport" 
       message = "Unexpected output from the command:\n#{result.cmd}"
       regex = /hello from root/
       assert_match(regex, result.stdout, message)
-    end
-
-    step "execute `bolt task run test::ruby_env` on localhost via local transport" do
-      bolt_command = "GEM_PATH=$(gem env GEM_PATHS) bolt task run test::ruby_env"
-      flags = {
-        '--targets' => 'localhost',
-        '--modulepath' => "#{dir}/modules"
-      }
-
-      result = bolt_command_on(bolt, bolt_command, flags)
-      message = "Unexpected output from the command:\n#{result.cmd}"
-      assert_match(on(bolt, 'gem env GEM_PATHS').stdout, result.stdout, message)
     end
 
     step "execute `bolt task run` on localhost via local transport with run-as" do


### PR DESCRIPTION
This removes a broken acceptance test that checks that Ruby environment
variables are restored when the `bundled-ruby` is disabled.

This test currently fails for two reasons:

- The `gem` executable is not available on all *nix VMs when running
  tests on Jenkins. This causes the task to fail when attempting to set
  `GEM_PATH` with `gem env GEM_PATH`. This issue can be solved by
  setting `GEM_PATH` to a dummy value when running the command on the
  SUT.

- The `bundled-ruby` config is not disabled. This causes the test to run
  using Bolt's bundled Ruby, which is not what is being tested. This
  issue can be solved by setting `bundled-ruby: false` in the SUT's
  inventory file. However, doing so breaks other `local` transport tasks
  that rely on Bolt's bundled Ruby.

Since this feature has been reliably manually tested, and has a
sufficient integration test, we should remove this broken acceptance
test until we can find a suitable alternative.

!no-release-note