### PR TITLE
(maint) allow people on Ruby 3 to install bolt

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = "~> 2.5"
+  spec.required_ruby_version = ">= 2.5"
 
   spec.add_dependency "addressable", '~> 2.5'
   spec.add_dependency "aws-sdk-ec2", '~> 1'


### PR DESCRIPTION
I also wanted to add Ruby 3 to any CI tests but I'm not sure if there are any ruby version specific tests. I didn't found anything in the github workflows directory.