### PR TITLE
(maint) Fix broken integration tests

### DIFF
--- a/spec/fixtures/parallel/wait/plans/no_future/basic.pp
+++ b/spec/fixtures/parallel/wait/plans/no_future/basic.pp
@@ -8,16 +8,16 @@ plan wait::no_future::basic(
   $msgs.each |$msg| {
     background($msg) || {
       if $msg =~ /Run immediately/ {
-          return $msg
+        return $msg
       } else {
         # Include a sleep to ensure that this does some "work" before returning
-        run_command("sleep 0.1", $targets)
+        ctrl::sleep(0.1)
         return $msg
       }
     }
   }
   # Give the first Future a chance to run
-  run_command('hostname', $targets)
+  ctrl::sleep(1)
   # Wait for messages
   return wait()
 }

--- a/spec/integration/shareable_task_spec.rb
+++ b/spec/integration/shareable_task_spec.rb
@@ -35,7 +35,8 @@ describe "Shareable tasks with files", bash: true do
   end
 
   it 'fails with an invalid path' do
-    msg = /Files must be saved in module directories that Puppet makes available via mount points: lib, files, tasks/
+    msg = Regexp.new('Files must be saved in module directories that Puppet makes '\
+                     'available via mount points: files, lib, scripts, tasks')
     expect {
       run_cli_json(%w[task run shareable::invalid_path] + config_flags)
     }.to raise_error(Bolt::PAL::PALError, msg)


### PR DESCRIPTION
This fixes a shareable task integration test that was caused by the release of
Puppet 7.10.0, which includes changes to an error message that the test
matches against.

This also fixes parallel integration tests on winrm that were failing
due to connection timeout errors. The connection timeout seemed to be
caused by running multiple `sleep` commands on the winrm target.

!no-release-note