### PR TITLE
(bug) Do not set `env_vars` to an empty hash when none are provided

### DIFF
--- a/lib/bolt/application.rb
+++ b/lib/bolt/application.rb
@@ -89,7 +89,7 @@ module Bolt
     # @param env_vars [Hash] Environment variables to set on the target.
     # @return [Bolt::ResultSet]
     #
-    def run_command(command, targets, env_vars: {})
+    def run_command(command, targets, env_vars: nil)
       targets = inventory.get_targets(targets)
 
       with_benchmark do
@@ -448,7 +448,7 @@ module Bolt
     # @param env_vars [Hash] Environment variables to set on the target.
     # @return [Bolt::ResultSet]
     #
-    def run_script(script, targets, arguments: [], env_vars: {})
+    def run_script(script, targets, arguments: [], env_vars: nil)
       script = find_file(script)
 
       Bolt::Util.validate_file('script', script)


### PR DESCRIPTION
This fixes a bug introduced in the CLI refactor. Previously, if a user
did not provide any env vars to a command or script, Bolt would not set
the `env_vars` option for the command. When the CLI was refactored and
the `Bolt::Application` class was introduced, this option was set to
have a default value of an empty hash `{}`. This resulted in the
`Bolt::Shell::Bash` class wrapping all commands in `sh -c`, which caused
commands to fail on some targets (such as those using `native-ssh` to
connect to Windows targets that did not recognize the `sh` command).

!bug

* **Do not wrap commands in `sh -c` when not using environment variables
  or privilege escalation**

  Bolt no longer wraps commands in `sh -c` when environment variables
  are not specified and not using privilege escalation. Previously, Bolt
  would wrap all commands in `sh -c` when using the SSH transport, which
  caused commands to fail on targets that do not recognize `sh`, such as
  some Windows targets.