### PR TITLE
(GH-2998) Exit with code 1 when Bolt errors

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -53,8 +53,7 @@ module Bolt
     TARGETING_OPTIONS = %i[query rerun targets].freeze
 
     SUCCESS = 0
-    ERROR   = 1
-    FAILURE = 2
+    FAILURE = 1
 
     def initialize(argv)
       Bolt::Logger.initialize_logging


### PR DESCRIPTION
Previously, Bolt would exit with code 1 for any CLI parsing errors and
code 2 for any other errors raised while executing Bolt, which is
[backwards from industry
standards](https://tldp.org/LDP/abs/html/exitcodes.html). This modifies
Bolt to exit with 1 whenever it is not successful. It'd be great to
eventually exit with 2 whenever we raise `Bolt::CLIError`, but Ruby
doesn't seem to have a way to set the exit code when raising errors and
any larger changes seem like more work than they're worth.

!bug

* **Return exit code 1 instead of 2 when Bolt errors** ([#2998](https://github.com/puppetlabs/bolt/issues/2998))

  Bolt will now exit with code 1 instead of 2 whenever a Bolt operation
  fails.