### PR TITLE
(maint) Remove `Bolt::Inventory::Inventory#validate` now that it's un…

### DIFF
--- a/lib/bolt/inventory/inventory.rb
+++ b/lib/bolt/inventory/inventory.rb
@@ -75,12 +75,6 @@ module Bolt
         end
       end
 
-      # Validates the inventory.
-      #
-      def validate
-        groups.validate
-      end
-
       def group_names_for(target_name)
         group_data_for(target_name).fetch('groups', [])
       end

--- a/spec/unit/inventory/inventory_spec.rb
+++ b/spec/unit/inventory/inventory_spec.rb
@@ -162,38 +162,6 @@ describe Bolt::Inventory::Inventory do
       }
     }
 
-    describe :validate do
-      it 'accepts empty inventory' do
-        expect(Bolt::Inventory::Inventory.new({}, transport, transports, plugins).validate).to be_nil
-      end
-
-      it 'accepts non-empty inventory' do
-        expect(Bolt::Inventory::Inventory.new(data, transport, transports, plugins).validate).to be_nil
-      end
-
-      it 'fails with unnamed groups' do
-        data = { 'groups' => [{}] }
-        expect {
-          Bolt::Inventory::Inventory.new(data, transport, transports, plugins).validate
-        }.to raise_error(Bolt::Inventory::ValidationError, /Group does not have a name/)
-      end
-
-      it 'fails with unamed targets' do
-        data = { 'targets' => [{ 'name' => '' }] }
-
-        expect {
-          Bolt::Inventory::Inventory.new(data, transport, transports, plugins).validate
-        }.to raise_error(Bolt::Inventory::ValidationError, /No name or uri for target/)
-      end
-
-      it 'fails with duplicate groups' do
-        data = { 'groups' => [{ 'name' => 'group1' }, { 'name' => 'group1' }] }
-        expect {
-          Bolt::Inventory::Inventory.new(data, transport, transports, plugins).validate
-        }.to raise_error(Bolt::Inventory::ValidationError, /Tried to redefine group group1/)
-      end
-    end
-
     describe :collect_groups do
       it 'finds the all group with an empty inventory' do
         inventory = Bolt::Inventory::Inventory.new({}, transport, transports, plugins)


### PR DESCRIPTION
…used

As part of #2993, Bolt now resolves plugins and validates the resolved
inventory when the inventory is needed, instead of when instantiating
the Inventory class required to bring up the Bolt application. As part
of this, inventory groups will validate themselves when loaded, which
makes `Bolt::Inventory::Inventory#validate` not useful, and should mean
it's no longer called. This removes the function and it's tests.

!no-release-note