### PR TITLE
(bug-fix) Use Plugin.new instead of Plugin.setup

### DIFF
--- a/scripts/server_client.rb
+++ b/scripts/server_client.rb
@@ -29,7 +29,7 @@ class Client
 
   def initialize
     config = Bolt::Config.default
-    plugins = Bolt::Plugin.setup(config, nil)
+    plugins = Bolt::Plugin.new(config, nil)
     @inventory = Bolt::Inventory::Inventory.new(
       conn_inventory.merge(easy_config),
       config.transport,


### PR DESCRIPTION
The bolt_server client setup script still calls the removed
`Plugin.setup`, which was removed. Since this uses the default Config
object, changing to `new` shouldn't pose any risk or result in any
changes.

!no-release-note