### PR TITLE
(GH-2905) Update BoltSpec functions to allow absolute paths

### DIFF
--- a/lib/bolt_spec/bolt_context.rb
+++ b/lib/bolt_spec/bolt_context.rb
@@ -39,12 +39,14 @@ require 'bolt/plugin'
 #
 # Stubs:
 # - allow_command(cmd), expect_command(cmd): expect the exact command
-# - allow_script(script), expect_script(script): expect the script as <module>/path/to/file
+# - allow_script(script), expect_script(script): expect the script as <module>/path/to/file or an absolute path
 # - allow_task(task), expect_task(task): expect the named task
 # - allow_download(file), expect_download(file): expect the identified source file
-# - allow_upload(file), expect_upload(file): expect the identified source file
+# - allow_upload(file), expect_upload(file): expect the source file as <module>/path/to/file or an absolute path
 # - allow_out_message, expect_out_message: expect a message to be passed to out::message (only modifiers are
 #   be_called_times(n), with_params(params), and not_be_called)
+#
+# Files with absolute path (for upload and script) must exist or those functions will fail.
 #
 # Stub modifiers:
 # - be_called_times(n): if allowed, fail if the action is called more than 'n' times
@@ -211,8 +213,8 @@ module BoltSpec
     # def allow_script(script_name)
     #
     # file uploads and downloads have a single destination and no arguments
-    # def allow_file_upload(source_name)
-    # def allow_file_download(source_name)
+    # def allow_upload(source_name)
+    # def allow_download(source_name)
     #
     # Most of the information in commands is in the command string itself
     # we may need more flexible allows than just the name/command string

--- a/lib/bolt_spec/plans/mock_executor.rb
+++ b/lib/bolt_spec/plans/mock_executor.rb
@@ -44,7 +44,7 @@ module BoltSpec
 
       def module_file_id(file)
         modpath = @modulepath.select { |path| file =~ /^#{path}/ }
-        raise "Could not identify modulepath containing #{file}: #{modpath}" unless modpath.size == 1
+        return nil unless modpath.size == 1
 
         path = Pathname.new(file)
         relative = path.relative_path_from(Pathname.new(modpath.first))
@@ -66,7 +66,7 @@ module BoltSpec
       end
 
       def run_script(targets, script_path, arguments, options = {}, _position = [])
-        script = module_file_id(script_path)
+        script = module_file_id(script_path) || script_path
         result = nil
         if (doub = @script_doubles[script] || @script_doubles[:default])
           result = doub.process(targets, script, arguments, options)
@@ -116,7 +116,7 @@ module BoltSpec
       end
 
       def upload_file(targets, source_path, destination, options = {}, _position = [])
-        source = module_file_id(source_path)
+        source = module_file_id(source_path) || source_path
         result = nil
         if (doub = @upload_doubles[source] || @upload_doubles[:default])
           result = doub.process(targets, source, destination, options)

--- a/spec/fixtures/bolt_spec/plans/plans/script.pp
+++ b/spec/fixtures/bolt_spec/plans/plans/script.pp
@@ -1,4 +1,4 @@
-plan plans::script(TargetSpec $nodes) {
-  run_script('plans/dir/prep', $nodes)
+plan plans::script(TargetSpec $nodes, String $source) {
+  run_script($source, $nodes)
   return run_script('plans/script', $nodes, 'arguments' => ['arg'])
 }

--- a/spec/fixtures/bolt_spec/plans/plans/upload.pp
+++ b/spec/fixtures/bolt_spec/plans/plans/upload.pp
@@ -1,4 +1,4 @@
-plan plans::upload(TargetSpec $nodes) {
-  upload_file('plans/dir/prep', '/b', $nodes)
+plan plans::upload(TargetSpec $nodes, String $source) {
+  upload_file($source, '/b', $nodes)
   return upload_file('plans/script', '/d', $nodes)
 }


### PR DESCRIPTION
Updates BoltSpec `allow/expect_upload` and `allow/expect_script` functions to accept an absolute path. The path referred to must still exist, but that's relatively easy to mock with temporary files.

----

!bug

* **Update BoltSpec functions to allow absolute paths** ([puppetlabs#2905](puppetlabs#2905))

  BoltSpec's `allow_upload`, `expect_upload`, `allow_script`, and `expect_script` functions now support passing absolute paths that rather than a module reference. The referenced path must refer to a real file or upload and script functions will still error.