### PR TITLE
(GH-2977) Set main plan ID correctly

### DIFF
--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -736,7 +736,7 @@ module Bolt
         #
         # Every future except for the main plan needs to have a plan id in
         # order to be tracked for the `wait()` function with no arguments.
-        future = executor.create_future(name: plan_name, plan_id: 1) do |_scope|
+        future = executor.create_future(name: plan_name, plan_id: 0) do |_scope|
           r = compiler.call_function('run_plan', plan_name, params.merge('_bolt_api_call' => true))
           Bolt::PlanResult.from_pcore(r, 'success')
         rescue Bolt::Error => e


### PR DESCRIPTION
This fixes a small bug where the main plan ID was being set incorrectly.
Previously, the main plan ID was set to 1, while the fiber executor
expected the main plan ID to be 0. The main plan ID is now correctly set
to 0 as expected by the fiber executor.

This also adds documentation for running plans in verbose mode to view
error results from a parallel block.

!bug

* **Correctly set main plan ID**
  ([#2977](https://github.com/puppetlabs/bolt/issues/2977))

  Bolt now sets the main plan's ID to the correct value. Previously, the
  main plan ID was set incorrectly, causing Bolt to issue warnings
  during plan runs when it should not have.