### PR TITLE
Include a backtrace on unexpected exceptions

### DIFF
--- a/libexec/bolt_catalog
+++ b/libexec/bolt_catalog
@@ -59,7 +59,7 @@ when "compile"
     puts({ message: message, backtrace: e.backtrace }.to_json)
     exit 1
   rescue StandardError => e
-    puts({ message: e.message }.to_json)
+    puts({ message: e.message, backtrace: e.backtrace }.to_json)
     exit 1
   end
 else


### PR DESCRIPTION
Especially when we haven't handled an exception well, and didn't expect
it, we should include a backtrace. It's really, really hard to debug
without this info.