### PR TITLE
(GH-2985) Create .gitignore during bolt project init

### DIFF
--- a/lib/bolt/project_manager.rb
+++ b/lib/bolt/project_manager.rb
@@ -36,6 +36,16 @@ module Bolt
       #     ssl: false
     INVENTORY
 
+    GITIGNORE_CONTENT = <<~GITIGNORE
+      .modules/
+      .resource_types/
+      bolt-debug.log
+      .plan_cache.json
+      .plugin_cache.json
+      .task_cache.json
+      .rerun.json
+    GITIGNORE
+
     def initialize(config, outputter, pal)
       @config    = config
       @outputter = outputter
@@ -53,6 +63,7 @@ module Bolt
       puppetfile    = project + 'Puppetfile'
       moduledir     = project + '.modules'
       inventoryfile = project + 'inventory.yaml'
+      gitignore     = project + '.gitignore'
       project_name  = name || File.basename(project)
 
       if config.exist?
@@ -122,6 +133,14 @@ module Bolt
           File.write(inventoryfile.to_path, INVENTORY_TEMPLATE)
         rescue StandardError => e
           raise Bolt::FileError.new("Could not create inventory.yaml at #{project}: #{e.message}", nil)
+        end
+      end
+
+      unless gitignore.exist?
+        begin
+          File.write(gitignore.to_path, GITIGNORE_CONTENT)
+        rescue StandardError => e
+          raise Bolt::FileError.new("Could not create .gitignore at #{project}: #{e.message}", nil)
         end
       end
 

--- a/spec/unit/project_manager_spec.rb
+++ b/spec/unit/project_manager_spec.rb
@@ -27,6 +27,7 @@ describe Bolt::ProjectManager do
   let(:config_migrator)    { double('config_migrator',    migrate: true) }
   let(:inventory_migrator) { double('inventory_migrator', migrate: true) }
   let(:module_migrator)    { double('module_migrator',    migrate: true) }
+  let(:gitignore_path)     { Pathname.new(File.join(@project.path, ".gitignore")) }
 
   around :each do |example|
     with_project do |project|
@@ -65,6 +66,17 @@ describe Bolt::ProjectManager do
     it 'does not create an inventory.yaml if one already exists' do
       FileUtils.touch(project.inventory_file)
       expect(File).not_to receive(:write).with(project.inventory_file.to_path, anything)
+      manager.create(project.path, 'myproject', nil)
+    end
+
+    it 'creates a .gitignore' do
+      manager.create(project.path, 'myproject', nil)
+      expect(gitignore_path.exist?).to be
+    end
+
+    it 'does not create a .gitignore if one already exists' do
+      FileUtils.touch(gitignore_path)
+      expect(File).not_to receive(:write).with(gitignore_path.to_path, anything)
       manager.create(project.path, 'myproject', nil)
     end
 


### PR DESCRIPTION
This lays down a `.gitignore` file with the following content as part of
`bolt project init` if the file does not already exist:
* .modules/
* .resource_types/
* bolt-debug.log
* .plan_cache.json
* .plugin_cache.json
* .task_cache.json
* .rerun.json

!feature

* **Create .gitignore with local Bolt files** ([#2985](https://github.com/puppetlabs/bolt))

  The `bolt project init` subcommand now lays down a `.gitignore` file
  to ignore local files that Bolt creates while executing.