### PR TITLE
(maint) Bump bundled modules to latest versions

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -5,8 +5,8 @@ forge "http://forge.puppetlabs.com"
 moduledir File.join(File.dirname(__FILE__), 'modules')
 
 # Core modules used by 'apply'
-mod 'puppetlabs-service', '2.0.0'
-mod 'puppetlabs-puppet_agent', '4.8.0'
+mod 'puppetlabs-service', '2.1.0'
+mod 'puppetlabs-puppet_agent', '4.9.0'
 mod 'puppetlabs-facts', '1.4.0'
 
 # Core types and providers for Puppet 6
@@ -22,14 +22,14 @@ mod 'puppetlabs-yumrepo_core', '1.0.7'
 mod 'puppetlabs-zone_core', '1.0.3'
 
 # Useful additional modules
-mod 'puppetlabs-package', '2.0.0'
+mod 'puppetlabs-package', '2.1.0'
 mod 'puppetlabs-powershell_task_helper', '0.1.0'
-mod 'puppetlabs-puppet_conf', '1.1.0'
+mod 'puppetlabs-puppet_conf', '1.2.0'
 mod 'puppetlabs-python_task_helper', '0.5.0'
-mod 'puppetlabs-reboot', '4.0.2'
+mod 'puppetlabs-reboot', '4.1.0'
 mod 'puppetlabs-ruby_task_helper', '0.6.0'
 mod 'puppetlabs-ruby_plugin_helper', '0.2.0'
-mod 'puppetlabs-stdlib', '7.1.0'
+mod 'puppetlabs-stdlib', '8.0.0'
 
 # Plugin modules
 mod 'puppetlabs-aws_inventory', '0.7.0'


### PR DESCRIPTION
!feature

* **Update bundled modules to latest versions**

  The following bundled modules have been updated to their latest
  versions:

  - [package 2.1.0](https://forge.puppet.com/puppetlabs/package/2.1.0/changelog)

  - [puppet_agent 4.9.0](https://forge.puppet.com/puppetlabs/puppet_agent/4.9.0/changelog)

  - [puppet_conf 1.2.0](https://forge.puppet.com/puppetlabs/puppet_conf/1.2.0/changelog)

  - [reboot 4.1.0](https://forge.puppet.com/puppetlabs/reboot/4.1.0/changelog)

  - [service 2.1.0](https://forge.puppet.com/puppetlabs/service/2.1.0/changelog)

  - [stdlib 8.0.0](https://forge.puppet.com/puppetlabs/stdlib/8.0.0/changelog)

    The `stdlib 8.0.0` module includes breaking changes to the
    `ensure_packages` function. If you need to use an older version of
    the module, you can [install the module](http://pup.pt/bolt-modules)
    in your project configuration.