### PR TITLE
(GH-2291) Enable Bootsnap

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "addressable", '~> 2.5'
   spec.add_dependency "aws-sdk-ec2", '~> 1'
+  spec.add_dependency "bootsnap", '~> 1.7'
   spec.add_dependency "CFPropertyList", "~> 2.2"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "ffi", ">= 1.9.25", "< 2.0.0"

--- a/exe/bolt
+++ b/exe/bolt
@@ -1,6 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
+  require 'bootsnap'
+  Bootsnap.setup(
+    cache_dir:       File.join(ENV['ProgramData'], 'PuppetLabs', 'bolt'),
+    load_path_cache: false
+  )
+end
 require 'bolt'
 require 'bolt/cli'
 


### PR DESCRIPTION
This enables Bootsnap's compile cache for Bolt when running on Windows, which caches the compiled Ruby bytecode and YAML Messagepack format results for faster loading. When using Bootsnap we disable the load path cache, since Bolt modifies the load path from the user's environment which results in the cache being recomputed and rewritten every Bolt run, which negates any performance improvements from compilation caching.

!no-release-note