### PR TITLE
Communicate clearly that aliases are not supported in yaml files

### DIFF
--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -65,6 +65,9 @@ module Bolt
         raise Bolt::FileError.new("Could not parse #{file_name} file at #{path}, line #{e.line}, "\
                                   "column #{e.column}\n#{e.problem}",
                                   path)
+      rescue Psych::BadAlias => e
+        raise Bolt::FileError.new('Bolt does not support the use of aliases in YAML files. Alias '\
+                                  "detected in #{file_name} file at #{path}\n#{e.message}", path)
       rescue Psych::Exception => e
         raise Bolt::FileError.new("Could not parse #{file_name} file at #{path}\n#{e.message}",
                                   path)

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -117,6 +117,19 @@ describe Bolt::Util do
         }.to raise_error(Bolt::FileError, /should be a Hash or empty, not String/)
       end
     end
+
+    it "communicates that aliases are not supported" do
+      contents = <<~YAML
+      ---
+      foo: &flag value
+      bar: *flag
+      YAML
+      with_tempfile_containing('config_file_test', contents) do |file|
+        expect {
+          Bolt::Util.read_yaml_hash(file, 'inventory')
+        }.to raise_error(Bolt::FileError, /does not support.*aliases/)
+      end
+    end
   end
 
   context "when parsing a yaml file with read_optional_yaml_hash" do


### PR DESCRIPTION
Update: this PR informs users attempting to use Yaml anchor/alias features that Bolt does not support them.

-------------------
Original description:

Ruby's YAML::safe_load method is used to load yaml files. By default,
::safe_load will error on yaml files that contain references and
aliases.

This commit passes `aliases: true` to ::safe_load so that users can use
yaml files which contain aliases.

This is specifically useful when hand-writing complex inventory files
using plugins, to avoid huge amounts of copy-pasta of plugin boilerplate
content in similar targets/groups.