### PR TITLE
(PE-32839) Support r10k authorization_token setting

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -60,7 +60,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "puppetfile-resolver", "~> 0.5"
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "puppet-strings", "~> 2.3"
-  spec.add_dependency "r10k", "~> 3.1"
+  spec.add_dependency "r10k", "~> 3.10"
   spec.add_dependency "ruby_smb", "~> 1.0"
   spec.add_dependency "terminal-table", "~> 1.8"
   spec.add_dependency "winrm", "~> 2.0"

--- a/documentation/bolt_installing_modules.md
+++ b/documentation/bolt_installing_modules.md
@@ -329,6 +329,27 @@ module-install:
     proxy: https://forge-proxy.com:8080
 ```
 
+## Install modules using an authorization token
+
+If you need to install modules that require an authorization token to download,
+you can configure Bolt to pass a token as part of the request it makes to the
+Forge host. To configure Bolt to use an authorization token, set the
+`module-install` configuration option in either your project configuration file,
+`bolt-project.yaml`, or the default configuration file, `bolt-defaults.yaml`.
+
+To set an authorization token that is used when installing Forge modules,
+set the `authorization_token` key under the `forge` section of the
+`module-install` option. When you set the `authorization_token` key, you
+must also set the `baseurl` key.
+
+```yaml
+# bolt-project.yaml
+module-install:
+  forge:
+    authorization_token: Bearer eyJhbGciOiJIUzI1NiIsInR5c...
+    baseurl: https://forge.example.com
+```
+
 📖 **Related information**
 
 - [bolt-project.yaml options](bolt_project_reference.md#module-install)

--- a/lib/bolt/application.rb
+++ b/lib/bolt/application.rb
@@ -258,7 +258,7 @@ module Bolt
                     config.project.puppetfile,
                     config.project.managed_moduledir,
                     config.project.project_file,
-                    config.module_install)
+                    @plugins.resolve_references(config.module_install))
     end
 
     # Generate Puppet data types from project modules.
@@ -292,7 +292,7 @@ module Bolt
       installer.install(config.project.modules,
                         config.project.puppetfile,
                         config.project.managed_moduledir,
-                        config.module_install,
+                        @plugins.resolve_references(config.module_install),
                         force: force,
                         resolve: resolve)
     end

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -255,10 +255,16 @@ module Bolt
           type: Hash,
           properties: {
             "forge" => {
-              description: "A subsection that can have its own `proxy` setting to set an HTTP proxy for Forge "\
-                           "operations only, and a `baseurl` setting to specify a different Forge host.",
+              description: "A subsection for configuring connections to a Forge host.",
               type: Hash,
               properties: {
+                "authorization_token" => {
+                  description: "The token used to authorize requests to the Forge host. Must also specify "\
+                               "`baseurl` when using this option.",
+                  type: String,
+                  _example: "Bearer eyJhbGciOiJIUzI1NiIsInR5c...",
+                  _plugin: true
+                },
                 "baseurl" => {
                   description: "The URL to the Forge host.",
                   type: String,
@@ -272,7 +278,11 @@ module Bolt
                   _example: "https://my-forge-proxy.com:8080"
                 }
               },
-              _example: { "baseurl" => "https://forge.example.com", "proxy" => "https://my-forge-proxy.com:8080" }
+              _example: {
+                "authorization_token" => "Bearer eyJhbGciOiJIUzI1NiIsInR5c...",
+                "baseurl" => "https://forge.example.com",
+                "proxy" => "https://my-forge-proxy.com:8080"
+              }
             },
             "proxy" => {
               description: "The HTTP proxy to use for Git and Forge operations.",

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -184,9 +184,20 @@
       "type": "object",
       "properties": {
         "forge": {
-          "description": "A subsection that can have its own `proxy` setting to set an HTTP proxy for Forge operations only, and a `baseurl` setting to specify a different Forge host.",
+          "description": "A subsection for configuring connections to a Forge host.",
           "type": "object",
           "properties": {
+            "authorization_token": {
+              "description": "The token used to authorize requests to the Forge host. Must also specify `baseurl` when using this option.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
             "baseurl": {
               "description": "The URL to the Forge host.",
               "type": "string",

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -235,9 +235,20 @@
       "type": "object",
       "properties": {
         "forge": {
-          "description": "A subsection that can have its own `proxy` setting to set an HTTP proxy for Forge operations only, and a `baseurl` setting to specify a different Forge host.",
+          "description": "A subsection for configuring connections to a Forge host.",
           "type": "object",
           "properties": {
+            "authorization_token": {
+              "description": "The token used to authorize requests to the Forge host. Must also specify `baseurl` when using this option.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
             "baseurl": {
               "description": "The URL to the Forge host.",
               "type": "string",


### PR DESCRIPTION
This adds a new `module-install.forge.authorization_token` setting which
can be used to configure r10k to use a token for authorizing requests to
the Forge when installing modules.

!feature

* **Support Forge authorization token when installing modules**

  Bolt now supports using a token to authorizing requests to the Forge
  when installing modules using the
  `module-install.forge.authorization_token` setting.