### PR TITLE
(PE-32844) Deprecate `future.file_paths` config option

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/run_script.rb
@@ -108,11 +108,8 @@ Puppet::Functions.create_function(:run_script, Puppet::Functions::InternalFuncti
     # Send Analytics Report
     executor.report_function_call(self.class.name)
 
-    future = executor&.future || {}
-    fallback = future.fetch('file_paths', false)
-
     # Find the file path if it exists, otherwise return nil
-    found = Bolt::Util.find_file_from_scope(script, scope, fallback)
+    found = Bolt::Util.find_file_from_scope(script, scope)
     unless found && Puppet::FileSystem.exist?(found)
       raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
         Puppet::Pops::Issues::NO_SUCH_FILE_OR_DIRECTORY, file: script

--- a/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/upload_file.rb
@@ -70,11 +70,8 @@ Puppet::Functions.create_function(:upload_file, Puppet::Functions::InternalFunct
     # Send Analytics Report
     executor.report_function_call(self.class.name)
 
-    future = executor&.future || {}
-    fallback = future.fetch('file_paths', false)
-
     # Find the file path if it exists, otherwise return nil
-    found = Bolt::Util.find_file_from_scope(source, scope, fallback)
+    found = Bolt::Util.find_file_from_scope(source, scope)
     unless found && Puppet::FileSystem.exist?(found)
       raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
         Puppet::Pops::Issues::NO_SUCH_FILE_OR_DIRECTORY, file: source

--- a/bolt-modules/boltlib/spec/functions/run_script_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_script_spec.rb
@@ -43,11 +43,10 @@ describe 'run_script' do
         .and_return(result_set)
     end
 
-    context 'with future.file_paths enabled' do
+    context 'when locating files' do
       let(:module_root) { File.expand_path(fixtures('modules')) }
 
       before(:each) do
-        executor.expects(:future).returns({ 'file_paths' => true })
         inventory.stubs(:get_targets).with(hostname).returns([target])
       end
 
@@ -126,25 +125,6 @@ describe 'run_script' do
             .with_params('with_files/files/toplevel.sh', hostname)
             .and_return(result_set)
         end
-      end
-    end
-
-    context 'with future.file_paths explicitly disabled' do
-      before(:each) do
-        executor.expects(:future).returns({ 'file_paths' => false })
-      end
-
-      it 'does not load from scripts/' do
-        is_expected.to run
-          .with_params('with_scripts/scripts/hostname.sh', hostname)
-          .and_raise_error(/No such file or directory: .*with_scripts.*hostname\.sh/)
-      end
-
-      it 'does not load from files/ if files/files/script.sh is specified' do
-        # This file exists at the toplevel but not under files/, so should not get loaded
-        is_expected.to run
-          .with_params('with_files/files/toplevel.sh', hostname)
-          .and_raise_error(/No such file or directory: .*with_files.*toplevel\.sh/)
       end
     end
 

--- a/bolt-modules/boltlib/spec/functions/upload_file_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/upload_file_spec.rb
@@ -58,11 +58,10 @@ describe 'upload_file' do
         .and_return(result_set)
     end
 
-    context 'with future.file_paths enabled' do
+    context 'when locating files' do
       let(:module_root) { File.expand_path(fixtures('modules')) }
 
       before(:each) do
-        executor.expects(:future).returns({ 'file_paths' => true })
         inventory.stubs(:get_targets).with(hostname).returns([target])
       end
 
@@ -141,25 +140,6 @@ describe 'upload_file' do
             .with_params('with_files/files/toplevel.sh', destination, hostname)
             .and_return(result_set)
         end
-      end
-    end
-
-    context 'with future.file_paths explicitly disabled' do
-      before(:each) do
-        executor.expects(:future).returns({ 'file_paths' => false })
-      end
-
-      it 'does not load from scripts/' do
-        is_expected.to run
-          .with_params('with_scripts/scripts/hostname.sh', destination, hostname)
-          .and_raise_error(/No such file or directory: .*with_scripts.*hostname\.sh/)
-      end
-
-      it 'does not load from files/ if files/files/script.sh is specified' do
-        # This file exists at the toplevel but not under files/, so should not get loaded
-        is_expected.to run
-          .with_params('with_files/files/toplevel.sh', destination, hostname)
-          .and_raise_error(/No such file or directory: .*with_files.*toplevel\.sh/)
       end
     end
 

--- a/bolt-modules/file/lib/puppet/functions/file/exists.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/exists.rb
@@ -21,11 +21,8 @@ Puppet::Functions.create_function(:'file::exists', Puppet::Functions::InternalFu
     executor = Puppet.lookup(:bolt_executor) {}
     executor&.report_function_call(self.class.name)
 
-    future = executor&.future || Puppet.lookup(:future) { {} }
-    fallback = future.fetch('file_paths', false)
-
     # Find the file path if it exists, otherwise return nil
-    found = Bolt::Util.find_file_from_scope(filename, scope, fallback)
+    found = Bolt::Util.find_file_from_scope(filename, scope)
     found ? Puppet::FileSystem.exist?(found) : false
   end
 end

--- a/bolt-modules/file/lib/puppet/functions/file/read.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/read.rb
@@ -20,11 +20,8 @@ Puppet::Functions.create_function(:'file::read', Puppet::Functions::InternalFunc
     executor = Puppet.lookup(:bolt_executor) {}
     executor&.report_function_call(self.class.name)
 
-    future = executor&.future || Puppet.lookup(:future) { {} }
-    fallback = future.fetch('file_paths', false)
-
     # Find the file path if it exists, otherwise return nil
-    found = Bolt::Util.find_file_from_scope(filename, scope, fallback)
+    found = Bolt::Util.find_file_from_scope(filename, scope)
     unless found && Puppet::FileSystem.exist?(found)
       raise Puppet::ParseErrorWithIssue.from_issue_and_stack(
         Puppet::Pops::Issues::NO_SUCH_FILE_OR_DIRECTORY, file: filename

--- a/bolt-modules/file/lib/puppet/functions/file/readable.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/readable.rb
@@ -21,11 +21,8 @@ Puppet::Functions.create_function(:'file::readable', Puppet::Functions::Internal
     executor = Puppet.lookup(:bolt_executor) {}
     executor&.report_function_call(self.class.name)
 
-    future = executor&.future || Puppet.lookup(:future) { {} }
-    fallback = future.fetch('file_paths', false)
-
     # Find the file path if it exists, otherwise return nil
-    found = Bolt::Util.find_file_from_scope(filename, scope, fallback)
+    found = Bolt::Util.find_file_from_scope(filename, scope)
     found ? File.readable?(found) : false
   end
 end

--- a/bolt-modules/file/spec/functions/file/exists_spec.rb
+++ b/bolt-modules/file/spec/functions/file/exists_spec.rb
@@ -5,22 +5,17 @@ require 'spec_helper'
 
 describe 'file::exists' do
   around(:each) do |example|
-    Puppet.override({ bolt_executor: executor,
-                      future: future }) do
+    Puppet.override({ bolt_executor: executor }) do
       example.run
     end
   end
 
   shared_examples "file loading" do
-    let(:future) { {} }
-
     it 'returns whether a file exists' do
       is_expected.to run.with_params('with_files/toplevel.sh').and_return(true)
     end
 
-    context 'with future.file_paths enabled' do
-      let(:future)  { { 'file_paths' => true } }
-
+    context 'when locating files' do
       context 'with nonspecific module syntax' do
         it 'does not load from scripts/ subdir' do
           is_expected.to run
@@ -64,23 +59,6 @@ describe 'file::exists' do
         end
       end
     end
-
-    context 'with future.file_paths explicitly disabled' do
-      let(:future) { { 'file_paths' => false } }
-
-      it 'does not load from scripts/' do
-        is_expected.to run
-          .with_params('with_scripts/scripts/filepath.sh')
-          .and_return(false)
-      end
-
-      it 'does not load from files/ if files/files/script.sh is specified' do
-        # This file exists at the toplevel but not under files/, so should not get loaded
-        is_expected.to run
-          .with_params('with_files/files/toplevel.sh')
-          .and_return(false)
-      end
-    end
   end
 
   context "with an executor" do
@@ -89,8 +67,7 @@ describe 'file::exists' do
       Bolt::Executor.new(1,
                          Bolt::Analytics::NoopClient.new,
                          false,
-                         false,
-                         future)
+                         false)
     }
 
     include_examples 'file loading'

--- a/bolt-modules/file/spec/functions/file/read_spec.rb
+++ b/bolt-modules/file/spec/functions/file/read_spec.rb
@@ -5,23 +5,18 @@ require 'spec_helper'
 
 describe 'file::read' do
   around(:each) do |example|
-    Puppet.override({ bolt_executor: executor,
-                      future: future }) do
+    Puppet.override({ bolt_executor: executor }) do
       example.run
     end
   end
 
   shared_examples 'file loading' do
-    let(:future) { {} }
-
     it 'reads the contents of a file' do
       is_expected.to run.with_params('with_files/toplevel.sh')
                         .and_return("with_files/files/toplevel.sh\n")
     end
 
-    context 'with future.file_paths enabled' do
-      let(:future) { { 'file_paths' => true } }
-
+    context 'when locating files' do
       context 'with nonspecific module syntax' do
         it 'does not load from scripts/ subdir' do
           is_expected.to run
@@ -65,23 +60,6 @@ describe 'file::read' do
         end
       end
     end
-
-    context 'with future.file_paths explicitly disabled' do
-      let(:future) { { 'file_paths' => false } }
-
-      it 'does not load from scripts/' do
-        is_expected.to run
-          .with_params('with_scripts/scripts/filepath.sh')
-          .and_raise_error(/No such file or directory: .*with_scripts.*filepath\.sh/)
-      end
-
-      it 'does not load from files/ if files/files/script.sh is specified' do
-        # This file exists at the toplevel but not under files/, so should not get loaded
-        is_expected.to run
-          .with_params('with_files/files/toplevel.sh')
-          .and_raise_error(/No such file or directory: .*with_files.*toplevel\.sh/)
-      end
-    end
   end
 
   context "with an executor" do
@@ -89,8 +67,7 @@ describe 'file::read' do
       Bolt::Executor.new(1,
                          Bolt::Analytics::NoopClient.new,
                          false,
-                         false,
-                         future)
+                         false)
     }
 
     include_examples 'file loading'

--- a/bolt-modules/file/spec/functions/file/readable_spec.rb
+++ b/bolt-modules/file/spec/functions/file/readable_spec.rb
@@ -5,22 +5,17 @@ require 'spec_helper'
 
 describe 'file::readable' do
   around(:each) do |example|
-    Puppet.override({ bolt_executor: executor,
-                      future: future }) do
+    Puppet.override({ bolt_executor: executor }) do
       example.run
     end
   end
 
   shared_examples 'file loading' do
-    let(:future) { {} }
-
     it 'returns if a file is readable' do
       is_expected.to run.with_params('with_files/toplevel.sh').and_return(true)
     end
 
-    context 'with future.file_paths enabled' do
-      let(:future) { { 'file_paths' => true } }
-
+    context 'when locating files' do
       context 'with nonspecific module syntax' do
         it 'does not load from scripts/ subdir' do
           is_expected.to run
@@ -64,23 +59,6 @@ describe 'file::readable' do
         end
       end
     end
-
-    context 'with future.file_paths explicitly disabled' do
-      let(:future) { { 'file_paths' => false } }
-
-      it 'does not load from scripts/' do
-        is_expected.to run
-          .with_params('with_scripts/scripts/filepath.sh')
-          .and_return(false)
-      end
-
-      it 'does not load from files/ if files/files/script.sh is specified' do
-        # This file exists at the toplevel but not under files/, so should not get loaded
-        is_expected.to run
-          .with_params('with_files/files/toplevel.sh')
-          .and_return(false)
-      end
-    end
   end
 
   context "with an executor" do
@@ -88,8 +66,7 @@ describe 'file::readable' do
       Bolt::Executor.new(1,
                          Bolt::Analytics::NoopClient.new,
                          false,
-                         false,
-                         future)
+                         false)
     }
 
     include_examples 'file loading'

--- a/documentation/running_bolt_commands.md
+++ b/documentation/running_bolt_commands.md
@@ -401,6 +401,23 @@ _PowerShell cmdlet_
 Invoke-BoltScript -Script ./scripts/configure.ps1 -Targets servers
 ```
 
+You can also run scripts that are part of a project or module. Scripts that are
+part of a project or module are saved in the `scripts/` directory. To run the
+script, specify a Puppet file path with the form `<MODULE OR PROJECT
+NAME>/scripts/<FILE NAME>`:
+
+_\*nix shell command_
+
+```shell
+bolt script run my_module/scripts/configure.sh --targets servers
+```
+
+_PowerShell cmdlet_
+
+```powershell
+Invoke-BoltScript -Script my_module/scripts/configure.ps1 -Targets servers
+```
+
 ### Pass arguments to a script
 
 Argument values are passed literally and are not interpolated by the shell on

--- a/documentation/templates/bolt_defaults_reference.md.erb
+++ b/documentation/templates/bolt_defaults_reference.md.erb
@@ -9,7 +9,7 @@ which is supported in both the [system-wide and user-level configuration directo
 ### <% if data.key?(:_deprecation) %>⛔ <% end %>`<%= option %>`
 
 <% if data.key?(:_deprecation) -%>
-_This option is deprecated. <%= data[:_deprecation] %>_
+_This option is deprecated._
 <% end -%>
 
 <%= data[:description] %>
@@ -30,7 +30,11 @@ For a detailed description of each option, their default values, and any availab
 sub-options, see [Transport configuration reference](bolt_transports_reference.md).
 <% elsif data.key?(:properties) -%>
 <% data[:properties].each do |option, data| -%>
-#### `<%= option %>`
+#### <% if data.key?(:_deprecation) %>⛔ <% end %>`<%= option %>`
+
+<% if data.key?(:_deprecation) -%>
+_This option is deprecated._
+<% end -%>
 
 <%= data[:description] %>
 

--- a/documentation/templates/bolt_project_reference.md.erb
+++ b/documentation/templates/bolt_project_reference.md.erb
@@ -9,7 +9,7 @@ For more information, see [Configuring Bolt](configuring_bolt.md).
 ### <% if data.key?(:_deprecation) %>⛔ <% end %>`<%= option %>`
 
 <% if data.key?(:_deprecation) -%>
-_This option is deprecated. <%= data[:_deprecation] %>_
+_This option is deprecated._
 <% end -%>
 
 <%= data[:description] %>
@@ -27,7 +27,11 @@ _This option is deprecated. <%= data[:_deprecation] %>_
 
 <% if data.key?(:properties) -%>
 <% data[:properties].each do |option, data| -%>
-#### `<%= option %>`
+#### <% if data.key?(:_deprecation) %>⛔ <% end %>`<%= option %>`
+
+<% if data.key?(:_deprecation) -%>
+_This option is deprecated._
+<% end -%>
 
 <%= data[:description] %>
 

--- a/lib/bolt/application.rb
+++ b/lib/bolt/application.rb
@@ -333,12 +333,6 @@ module Bolt
     def new_plan(name, puppet: false, plan_script: nil)
       Bolt::PlanCreator.validate_plan_name(config.project, name)
 
-      if plan_script && !config.future&.fetch('file_paths', false)
-        raise Bolt::CLIError,
-              "The --script flag can only be used if future.file_paths is " \
-              "configured in bolt-project.yaml."
-      end
-
       if plan_script
         Bolt::Util.validate_file('script', find_file(plan_script))
       end
@@ -575,11 +569,10 @@ module Bolt
       modulepath = Bolt::Config::Modulepath.new(config.modulepath)
       modules    = Bolt::Module.discover(modulepath.full_modulepath, config.project)
       mod, file  = path.split(File::SEPARATOR, 2)
-      future     = executor.future&.fetch('file_paths', false)
 
       if modules[mod]
         logger.debug("Did not find file at #{File.expand_path(path)}, checking in module '#{mod}'")
-        found = Bolt::Util.find_file_in_module(modules[mod].path, file || "", future)
+        found = Bolt::Util.find_file_in_module(modules[mod].path, file || "")
         path  = found.nil? ? File.join(modules[mod].path, 'files', file) : found
       end
 

--- a/lib/bolt/catalog.rb
+++ b/lib/bolt/catalog.rb
@@ -65,8 +65,7 @@ module Bolt
       puppet_overrides = {
         bolt_pdb_client: pdb_client,
         bolt_inventory: inv,
-        bolt_project: bolt_project,
-        future: request['future']
+        bolt_project: bolt_project
       }
 
       # Facts will be set by the catalog compiler, so we need to ensure

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -150,7 +150,9 @@ module Bolt
               description: "Load scripts from the `scripts/` directory of a module.",
               type: [TrueClass, FalseClass],
               _example: true,
-              _default: false
+              _default: false,
+              _deprecation: "Bolt no longer honors this option and enables loading scripts from the scripts "\
+                            "directory by default."
             },
             "script_interpreter" => {
               description: "Use a target's [`interpreters` configuration](bolt_transports_reference.md#interpreters) "\
@@ -161,7 +163,7 @@ module Bolt
             }
           },
           _plugin: false,
-          _example: { 'file_paths' => true, 'script_interpreter' => true }
+          _example: { 'script_interpreter' => true }
         },
         "hiera-config" => {
           description: "The path to the Hiera configuration file.",

--- a/rakelib/docs.rake
+++ b/rakelib/docs.rake
@@ -201,10 +201,6 @@ begin
       # 'console' and filepath
       @opts['log'][:properties] = @opts['log'][:additionalProperties][:properties]
 
-      # Remove 'notice' log level. This is soft-deprecated and shouldn't appear
-      # in documentation.
-      @opts['log'][:properties]['level'][:enum].delete('notice')
-
       # Stringify data types
       @opts.transform_values! { |data| stringify_types(data) }
 
@@ -460,10 +456,6 @@ begin
       # Move sub-options for 'log' option up one level, as they're nested under
       # 'console' and filepath
       @opts['log'][:properties] = @opts['log'][:additionalProperties][:properties]
-
-      # Remove 'notice' log level. This is soft-deprecated and shouldn't appear
-      # in documentation.
-      @opts['log'][:properties]['level'][:enum].delete('notice')
 
       # Stringify data types
       @opts.transform_values! { |data| stringify_types(data) }

--- a/spec/integration/script_loading_spec.rb
+++ b/spec/integration/script_loading_spec.rb
@@ -12,10 +12,10 @@ describe "CLI parses input" do
   include BoltSpec::Integration
   include BoltSpec::Project
 
-  let(:modulepath)  { fixtures_path('modules') }
-  let(:target)      { 'localhost' }
-  let(:flags)       { %W[-t #{target} --project #{@project.path}] }
-  let(:config)      { { 'modulepath' => [modulepath] } }
+  let(:modulepath) { fixtures_path('modules') }
+  let(:target)     { 'localhost' }
+  let(:flags)      { %W[-t #{target} --project #{@project.path}] }
+  let(:config)     { { 'modulepath' => [modulepath] } }
 
   around :each do |example|
     with_project(config: config) do |project|
@@ -29,115 +29,77 @@ describe "CLI parses input" do
   end
 
   describe "running scripts from the commandline" do
-    context 'with future.file_paths enabled' do
-      let(:config) do
-        { 'modulepath' => [modulepath],
-          'future' => { 'file_paths' => true } }
+    context 'with nonspecific module syntax' do
+      it 'does not load from scripts/ subdir' do
+        expect { run_one_node(%w[script run with_scripts/filepath.rb] + flags) }
+          .to raise_error(/The script.*with_scripts.*filepath\.rb' does not exist/)
       end
 
-      context 'with nonspecific module syntax' do
-        it 'does not load from scripts/ subdir' do
-          expect { run_one_node(%w[script run with_scripts/filepath.rb] + flags) }
-            .to raise_error(/The script.*with_scripts.*filepath\.rb' does not exist/)
-        end
-
-        it 'loads from files/' do
-          result = run_one_node(%w[script run with_files/filepath.rb] + flags)
-          expect(result['stdout'].chomp).to eq("Loaded from with_files/files/")
-        end
-      end
-
-      context 'with scripts/ specified' do
-        it 'prefers loading from files/scripts/' do
-          result = run_one_node(%w[script run with_both/scripts/filepath.rb] + flags)
-          expect(result['stdout'].chomp).to eq("Loaded from with_both/files/scripts/")
-        end
-
-        it 'falls back to scripts/ if not found in files/' do
-          result = run_one_node(%w[script run with_scripts/scripts/filepath.rb] + flags)
-          expect(result['stdout'].chomp).to eq("Loaded from with_scripts/scripts/")
-        end
-      end
-
-      context 'with files/ specified' do
-        it 'prefers loading from files/files/' do
-          result = run_one_node(%w[script run with_files/files/filepath.rb] + flags)
-          expect(result['stdout'].chomp).to eq("Loaded from with_files/files/files/")
-        end
-
-        it 'falls back to files/ if enabled' do
-          result = run_one_node(%w[script run with_files/files/toplevel.rb] + flags)
-          expect(result['stdout'].chomp).to eq("Loaded from with_files/files/")
-        end
+      it 'loads from files/' do
+        result = run_one_node(%w[script run with_files/filepath.rb] + flags)
+        expect(result['stdout'].chomp).to eq("Loaded from with_files/files/")
       end
     end
 
-    context 'with future.file_paths explicitly disabled' do
-      it 'does not load from scripts/' do
-        expect { run_one_node(%w[script run with_scripts/scripts/filepath.rb] + flags) }
-          .to raise_error(%r{The script.*with_scripts/files/scripts/filepath\.rb' does not exist})
+    context 'with scripts/ specified' do
+      it 'prefers loading from files/scripts/' do
+        result = run_one_node(%w[script run with_both/scripts/filepath.rb] + flags)
+        expect(result['stdout'].chomp).to eq("Loaded from with_both/files/scripts/")
       end
 
-      it 'does not load from files/ if files/files/script.rb is specified' do
-        expect { run_one_node(%w[script run with_files/files/toplevel.rb] + flags) }
-          .to raise_error(%r{The script.*with_files/files/files/toplevel\.rb' does not exist})
+      it 'falls back to scripts/ if not found in files/' do
+        result = run_one_node(%w[script run with_scripts/scripts/filepath.rb] + flags)
+        expect(result['stdout'].chomp).to eq("Loaded from with_scripts/scripts/")
+      end
+    end
+
+    context 'with files/ specified' do
+      it 'prefers loading from files/files/' do
+        result = run_one_node(%w[script run with_files/files/filepath.rb] + flags)
+        expect(result['stdout'].chomp).to eq("Loaded from with_files/files/files/")
+      end
+
+      it 'falls back to files/ if enabled' do
+        result = run_one_node(%w[script run with_files/files/toplevel.rb] + flags)
+        expect(result['stdout'].chomp).to eq("Loaded from with_files/files/")
       end
     end
   end
 
   describe "running a plan with run_script()" do
-    context 'with future.file_paths enabled' do
-      let(:config) do
-        { 'modulepath' => [modulepath],
-          'future' => { 'file_paths' => true } }
+    context 'with nonspecific module syntax' do
+      it 'does not load from scripts/ subdir' do
+        result = run_cli_json(%w[plan run sample::run_script script=with_scripts/filepath.rb] + flags)
+        expect(result['msg'].chomp).to match(%r{No such file or directory: with_scripts/filepath.rb})
       end
 
-      context 'with nonspecific module syntax' do
-        it 'does not load from scripts/ subdir' do
-          result = run_cli_json(%w[plan run sample::run_script script=with_scripts/filepath.rb] + flags)
-          expect(result['msg'].chomp).to match(%r{No such file or directory: with_scripts/filepath.rb})
-        end
-
-        it 'loads from files/' do
-          result = run_cli_json(%w[plan run sample::run_script script=with_files/filepath.rb] + flags)
-          expect(get_stdout(result)).to eq("Loaded from with_files/files/")
-        end
-      end
-
-      context 'with scripts/ specified' do
-        it 'prefers loading from files/scripts/' do
-          result = run_cli_json(%w[plan run sample::run_script script=with_both/scripts/filepath.rb] + flags)
-          expect(get_stdout(result)).to eq("Loaded from with_both/files/scripts/")
-        end
-
-        it 'falls back to scripts/ if not found in files/' do
-          result = run_cli_json(%w[plan run sample::run_script script=with_scripts/scripts/filepath.rb] + flags)
-          expect(get_stdout(result)).to eq("Loaded from with_scripts/scripts/")
-        end
-      end
-
-      context 'with files/ specified' do
-        it 'prefers loading from files/files/' do
-          result = run_cli_json(%w[plan run sample::run_script script=with_files/files/filepath.rb] + flags)
-          expect(get_stdout(result)).to eq("Loaded from with_files/files/files/")
-        end
-
-        it 'falls back to files/ if enabled' do
-          result = run_cli_json(%w[plan run sample::run_script script=with_files/files/toplevel.rb] + flags)
-          expect(get_stdout(result)).to eq("Loaded from with_files/files/")
-        end
+      it 'loads from files/' do
+        result = run_cli_json(%w[plan run sample::run_script script=with_files/filepath.rb] + flags)
+        expect(get_stdout(result)).to eq("Loaded from with_files/files/")
       end
     end
 
-    context 'with future.file_paths explicitly disabled' do
-      it 'does not load from scripts/' do
-        result = run_cli_json(%w[plan run sample::run_script script=with_scripts/scripts/filepath.rb] + flags)
-        expect(result['msg'].chomp).to match(%r{No such file or directory: with_scripts/scripts/filepath\.rb})
+    context 'with scripts/ specified' do
+      it 'prefers loading from files/scripts/' do
+        result = run_cli_json(%w[plan run sample::run_script script=with_both/scripts/filepath.rb] + flags)
+        expect(get_stdout(result)).to eq("Loaded from with_both/files/scripts/")
       end
 
-      it 'does not load from files/ if files/files/script.rb is specified' do
+      it 'falls back to scripts/ if not found in files/' do
+        result = run_cli_json(%w[plan run sample::run_script script=with_scripts/scripts/filepath.rb] + flags)
+        expect(get_stdout(result)).to eq("Loaded from with_scripts/scripts/")
+      end
+    end
+
+    context 'with files/ specified' do
+      it 'prefers loading from files/files/' do
+        result = run_cli_json(%w[plan run sample::run_script script=with_files/files/filepath.rb] + flags)
+        expect(get_stdout(result)).to eq("Loaded from with_files/files/files/")
+      end
+
+      it 'falls back to files/ if enabled' do
         result = run_cli_json(%w[plan run sample::run_script script=with_files/files/toplevel.rb] + flags)
-        expect(result['msg'].chomp).to match(%r{No such file or directory: with_files/files/toplevel\.rb})
+        expect(get_stdout(result)).to eq("Loaded from with_files/files/")
       end
     end
   end

--- a/spec/integration/ssh_spec.rb
+++ b/spec/integration/ssh_spec.rb
@@ -92,11 +92,7 @@ describe "when runnning over the ssh transport", ssh: true do
       }
     end
 
-    let(:future_config) do
-      {
-        'file_paths' => true
-      }
-    end
+    let(:future_config) { {} }
 
     let(:default_inv) do
       {
@@ -170,7 +166,6 @@ describe "when runnning over the ssh transport", ssh: true do
       context 'with future.script_interpreter configured' do
         let(:future_config) do
           {
-            'file_paths'         => true,
             'script_interpreter' => true
           }
         end

--- a/spec/integration/winrm_spec.rb
+++ b/spec/integration/winrm_spec.rb
@@ -95,11 +95,7 @@ describe "when runnning over the winrm transport", winrm: true do
       }
     end
 
-    let(:future_config) do
-      {
-        'file_paths' => true
-      }
-    end
+    let(:future_config) { {} }
 
     let(:default_inv) do
       {
@@ -225,7 +221,6 @@ describe "when runnning over the winrm transport", winrm: true do
       context 'with future.script_interpreter configured' do
         let(:future_config) do
           {
-            'file_paths'         => true,
             'script_interpreter' => true
           }
         end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -157,16 +157,6 @@ describe Bolt::Application do
     end
   end
 
-  describe "#new_plan" do
-    let(:config) { double(future: {}, project: nil) }
-
-    it 'errors if provided a script and future.file_paths is not set' do
-      allow(Bolt::PlanCreator).to receive(:validate_plan_name)
-      expect { application.new_plan('planplanplan', plan_script: 'scriptscriptscript') }
-        .to raise_error(Bolt::CLIError, /The --script flag can only be used if future.file_paths/)
-    end
-  end
-
   describe '#plan_run' do
     let(:plan)        { 'plan' }
     let(:plan_info)   { { 'parameters' => plan_params } }


### PR DESCRIPTION
This deprecates the `future.file_paths` config option and enables
loading scripts from the `scripts` directory of a project or module by
default.

!deprecation

* **Deprecate `future.file_paths` configuration option**

  The `future.file_paths` configuration option has been deprecated.

!feature

* **Look for scripts in a `scripts` directory**

  Bolt now looks for scripts in a project's or module's `scripts`
  directory when provided a Puppet file path with the form
  `<module>/scripts/<file>`. Previously, this behavior was opt-in only
  by setting the `future.file_paths` configuration option.