### PR TITLE
(bug-fix) Return resolved config object to inventory

### DIFF
--- a/lib/bolt/inventory/inventory.rb
+++ b/lib/bolt/inventory/inventory.rb
@@ -71,7 +71,7 @@ module Bolt
           @config
         else
           @config_resolved = true
-          @config.transform_values! { |t| t.resolved? ? t : t.resolve(@plugins) }
+          @config.each_value { |t| t.resolve(@plugins) unless t.resolved? }
         end
       end
 

--- a/spec/unit/inventory/inventory_spec.rb
+++ b/spec/unit/inventory/inventory_spec.rb
@@ -1320,6 +1320,38 @@ describe Bolt::Inventory::Inventory do
     end
   end
 
+  context 'resolving transport config' do
+    let(:config_data) do
+      {
+        'ssh' => {
+          'user' => {
+            '_plugin' => 'mock_plugin'
+          }
+        }
+      }
+    end
+    let(:config)    { make_config(config_data) }
+    let(:inventory) do
+      Bolt::Inventory::Inventory.new({ 'config' => config_data },
+                                     config.transport,
+                                     config.transports,
+                                     plugins)
+    end
+
+    before(:each) do
+      mock_plugin = double('mock_plugin')
+      allow(mock_plugin).to receive(:name).and_return('mock_plugin')
+      allow(mock_plugin).to receive(:hooks).and_return([:resolve_reference])
+      allow(mock_plugin).to receive(:resolve_reference).and_return("test_user")
+      plugins.add_plugin(mock_plugin)
+    end
+
+    it 'sets the resolved config on the inventory config object' do
+      config = inventory.config
+      expect(config['ssh'].to_h['user']).to eq("test_user")
+    end
+  end
+
   context 'when the transport config contains keys that resolved to nil' do
     let(:transport_config) do
       {


### PR DESCRIPTION
When resolving inventory plugins for transport configuration the
inventory would call `resolve()` on each transport object in it's config
map (which maps the transport name "ssh" to the class
Bolt::Transport::SSH object). Previously the `resolve()` function
returned `nil` since it's last method is to call `validate`, which
caused the inventory value for the config key to be nil instead of the
class itself. This amends the `resolve()` function to return the
modified transport class so that the inventory config map is correctly
updated.

!bug

* **Correctly set inventory config when resolving plugins**

  Previously, Bolt would resolve plugins then set the config in the
  Inventory to `nil`, causing errors like `undefined method 'merge' for
  nil:NilClass`. Bolt now correctly returns the resolved config to the
  inventory.