### PR TITLE
(maint) Bump bundled modules to latest versions

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -10,15 +10,15 @@ mod 'puppetlabs-puppet_agent', '4.9.0'
 mod 'puppetlabs-facts', '1.4.0'
 
 # Core types and providers for Puppet 6
-mod 'puppetlabs-augeas_core', '1.1.2'
-mod 'puppetlabs-host_core', '1.0.3'
+mod 'puppetlabs-augeas_core', '1.2.0'
+mod 'puppetlabs-host_core', '1.1.0'
 mod 'puppetlabs-scheduled_task', '3.0.1'
-mod 'puppetlabs-sshkeys_core', '2.2.0'
-mod 'puppetlabs-zfs_core', '1.2.0'
-mod 'puppetlabs-cron_core', '1.0.5'
-mod 'puppetlabs-mount_core', '1.0.4'
-mod 'puppetlabs-selinux_core', '1.1.0'
-mod 'puppetlabs-yumrepo_core', '1.0.7'
+mod 'puppetlabs-sshkeys_core', '2.3.0'
+mod 'puppetlabs-zfs_core', '1.3.0'
+mod 'puppetlabs-cron_core', '1.1.0'
+mod 'puppetlabs-mount_core', '1.1.0'
+mod 'puppetlabs-selinux_core', '1.2.0'
+mod 'puppetlabs-yumrepo_core', '1.1.0'
 mod 'puppetlabs-zone_core', '1.0.3'
 
 # Useful additional modules
@@ -29,7 +29,7 @@ mod 'puppetlabs-python_task_helper', '0.5.0'
 mod 'puppetlabs-reboot', '4.1.0'
 mod 'puppetlabs-ruby_task_helper', '0.6.0'
 mod 'puppetlabs-ruby_plugin_helper', '0.2.0'
-mod 'puppetlabs-stdlib', '8.0.0'
+mod 'puppetlabs-stdlib', '8.1.0'
 
 # Plugin modules
 mod 'puppetlabs-aws_inventory', '0.7.0'


### PR DESCRIPTION
!feature

* **Update bundled modules to latest versions**

  The following bundled modules have been updated to their latest
  versions:

  - [augeas_core 1.2.0](https://forge.puppet.com/puppetlabs/augeas_core/1.2.0/changelog)
  - [cron_core 1.1.0](https://forge.puppet.com/puppetlabs/cron_core/1.1.0/changelog)
  - [host_core 1.1.0](https://forge.puppet.com/puppetlabs/host_core/1.1.0/changelog)
  - [mount_core 1.1.0](https://forge.puppet.com/puppetlabs/mount_core/1.1.0/changelog)
  - [selinux_core 1.2.0](https://forge.puppet.com/puppetlabs/selinux_core/1.2.0/changelog)
  - [sshkeys_core 2.3.0](https://forge.puppet.com/puppetlabs/sshkeys_core/2.3.0/changelog)
  - [stdlib 8.1.0](https://forge.puppet.com/puppetlabs/stdlib/8.1.0/changelog)
  - [yumrepo_core 1.1.0](https://forge.puppet.com/puppetlabs/yumrepo_core/1.1.0/changelog)
  - [zfs_core 1.3.0](https://forge.puppet.com/puppetlabs/zfs_core/1.3.0/changelog)