### PR TITLE
(GH-3032) Fix JSON typo in writing_tasks

### DIFF
--- a/documentation/writing_tasks.md
+++ b/documentation/writing_tasks.md
@@ -400,6 +400,7 @@ included in the message.
     "msg": "Task exited 1:\nSomething on stderr",
     "kind": "puppetlabs.tasks/task-error",
     "details": { "exitcode": 1 }
+  }
 }
 ```
 


### PR DESCRIPTION
Fixes a typo with a missing curly bracket in the example JSON
documenting returning errors from tasks.

!no-release-note