### PR TITLE
(GH-3034) Resolve puppetdb plugins only when needed

### DIFF
--- a/lib/bolt/cli.rb
+++ b/lib/bolt/cli.rb
@@ -446,7 +446,7 @@ module Bolt
           check_gem_install
           warn_inventory_overrides_cli(config, options)
           submit_screen_view(analytics, config, inventory, options)
-          options[:targets] = process_target_list(plugins.puppetdb_client, @rerun, options)
+          options[:targets] = process_target_list(plugins, @rerun, options)
 
           # TODO: Fix casing issue in Windows.
           config.check_path_case('modulepath', config.modulepath)
@@ -689,14 +689,14 @@ module Bolt
     # Process the target list by turning a PuppetDB query or rerun mode into a
     # list of target names.
     #
-    # @param pdb_client [Bolt::PuppetDB::Client] The PuppetDB client.
+    # @param plugins [Bolt::Plugin] The Plugin instance.
     # @param rerun [Bolt::Rerun] The Rerun instance.
     # @param options [Hash] The CLI options.
     # @return [Hash] The target list.
     #
-    private def process_target_list(pdb_client, rerun, options)
+    private def process_target_list(plugins, rerun, options)
       if options[:query]
-        pdb_client.query_certnames(options[:query])
+        plugins.puppetdb_client.query_certnames(options[:query])
       elsif options[:rerun]
         rerun.get_targets(options[:rerun])
       elsif options[:targets]


### PR DESCRIPTION
This updates the CLI class to only load the puppetdb client and resolve
plugins for the client as needed. Previously, the puppetdb client was
loaded for every command, which would cause Bolt to error when the
config for the client used plugins that were not available to the
project (such as when installing a project's modules for the first
time).

!bug

* **Resolve puppetdb client configuration plugins as needed**
  ([#3034](https://github.com/puppetlabs/bolt/issues/3034))

  Bolt now only resolves plugins for the puppetdb client when needed.
  Previously, Bolt would attempt to resolve plugins for the puppetdb
  client for every command, which would cause Bolt to error if the
  plugin module was not available (such as when installing a project's
  modules for the first time).