### PR TITLE
(PT-789) Add documentation for config policies and `policy` subcommands

### DIFF
--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -23,8 +23,9 @@ Policies can be managed through the `policy` command, with `apply`, `new` and
 Bolt project using `bolt policy new <POLICY NAME>`, which will add `POLICY NAME`
 to the `policies` key in `bolt-project.yaml` and create an empty class at
 `<PROJECT DIRECTORY>/manifests/<POLICY NAME>.pp` that you can then populate.
-`<Bolt project directory>/manifests/<policyname>.pp`. Bolt creates an empty
-class to fill in with the desired configuration.
+This is only the default creation directory, policies can be loaded from
+anywhere on the modulepath. Policies can also manually added to the `policies`
+key in `bolt-project.yaml`.
 
 You can list available policies using `bolt policy show`, and apply them to
 targets using `bolt policy apply`. apply` and available policies can be listed

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -28,8 +28,8 @@ configured then no policies will be available for Bolt to apply.
 
 Policies may be manually added to the `policies` key in `bolt-project.yaml` or
 managed via Bolt commands. This key supports glob pattern for easily listing
-multiple policies, i.e. boltproject::* includes boltproject::admin and
-boltproject::sshkeys policies.
+multiple policies. For example, `bolt::project::*` includes `bolt::project::admin` and
+`bolt::project::sshkeys` policies.
 
 The following configuration file makes the `bolt::project::admin` and
 `bolt::project::sshkeys` policies available to the project:
@@ -54,7 +54,7 @@ project-level policy named `bolt::project::user`, run:
 
 * _PowerShell cmdlet_
   ```
-  New-BoltPolicy bolt::project::user
+  New-BoltPolicy -Name bolt::project::user
   ```
 
 An empty class is created in the project's `manifests/` directory that you can
@@ -64,7 +64,7 @@ Example output:
 ```
 Created policy 'bolt::project::user' at '/Users/puppet.user/bolt/manifests/project/user.pp'
 ```
-> Policy names must follow [class naming
+Policy names must follow [class naming
 conventions](https://puppet.com/docs/puppet/7/lang_reserved.html#classes-and-defined-resource-type-names).
 
 Policies can also be created manually by:
@@ -75,7 +75,7 @@ Policies can also be created manually by:
 
 ### Listing available policies
 
-You can list available policies using `bolt policy show`.
+You can list available policies for the project:
 
 * _*nix shell command_ 
   ```
@@ -116,7 +116,7 @@ policies to a target:
 
 * _PowerShell cmdlet_
   ```
-  Invoke-BoltPolicy bolt::project::admin,bolt::project::sshkeys -t mytarget
+  Invoke-BoltPolicy -Name bolt::project::admin,bolt::project::sshkeys -Targets mytarget
   ```
 
 Example output:

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -49,6 +49,7 @@ subcommands for more detail or `Get-Help` followed by any Powershell cmdlet
 name.
 
 #### Creating new policies 
+> Policy names must follow [class naming conventions](https://puppet.com/docs/puppet/7/lang_reserved.html#classes-and-defined-resource-type-names).
 
 You can create a new policy with `bolt policy new <POLICY NAME>`, which performs
 two actions for you:
@@ -62,7 +63,6 @@ two actions for you:
 ```
 % bolt policy new boltproject::user
 Created policy 'boltproject::user' at '/Users/puppet.user/bolt/manifests/user.pp'
-
 ```
 
 Policies can also be created manually by:

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -13,7 +13,7 @@ around breaking behavior where possible.
 This feature was introduced in [Bolt 3.21.0](). 
 
 Configuration policies are public classes that can be assigned directly to one
-or more nodes via the Bolt command line. Policies are Puppet code stored in .pp
+or more nodes. Policies are Puppet code stored in the `manifests/` directory of modules on the modulepath.
 files.
 
 Policies can be accessed through the `policy` subcommand, with `apply`, `new`

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -57,9 +57,6 @@ project-level policy named `bolt::project::user`, run:
   New-BoltPolicy bolt::project::user
   ```
 
-> Policy names must follow [class naming
-conventions](https://puppet.com/docs/puppet/7/lang_reserved.html#classes-and-defined-resource-type-names).
-
 An empty class is created in the project's `manifests/` directory that you can
 then populate.
 
@@ -67,6 +64,8 @@ Example output:
 ```
 Created policy 'bolt::project::user' at '/Users/puppet.user/bolt/manifests/project/user.pp'
 ```
+> Policy names must follow [class naming
+conventions](https://puppet.com/docs/puppet/7/lang_reserved.html#classes-and-defined-resource-type-names).
 
 Policies can also be created manually by:
 
@@ -103,7 +102,12 @@ Modulepath
 Applying policies is very similar to [applying Puppet
 code](https://puppet.com/docs/bolt/latest/applying_manifest_blocks.html) with
 `bolt apply`, with the addition that `bolt policy apply` allows you to apply one
-or more policies at a time.
+or more policies at a time. `bolt policy apply` accepts a comma-separated list
+of policy names to apply, or a single policy name to apply to a list of one or
+more targets. 
+
+For example, to apply both `bolt::project::admin` and `bolt::project::sshkeys`
+policies to a target:
 
 * _*nix shell command_
   ```
@@ -114,13 +118,6 @@ or more policies at a time.
   ```
   Invoke-BoltPolicy bolt::project::admin,bolt::project::sshkeys -t mytarget
   ```
-
-Before applying policies, Bolt will install the puppet-agent package and collect
-facts from each target. `bolt policy apply` accepts a comma-separated list of
-policy names to apply, or a single policy name to apply to a list of one or more
-targets. Under the hood, Bolt creates a single line of Puppet code `include
-<POLICIES>` that will be compiled and applied to the provided targets, and will
-log that code at the debug level.
 
 Example output:
 ```
@@ -134,6 +131,11 @@ Finished: apply catalog with 0 failures in 8.59 sec
 Successful on 1 target: mytarget
 Ran on 1 target in 15.2 sec
 ```
+
+Before applying policies, Bolt will install the puppet-agent package and collect
+facts from each target. Under the hood, Bolt creates a single line of Puppet
+code `include <POLICIES>` that will be compiled and applied to the provided
+targets, and will log that code at the debug level.
 
 ## `run_container` plan step
 

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -14,29 +14,31 @@ This feature was introduced in [Bolt 3.21.0]().
 
 Configuration policies, or policies for short, are public classes that can be
 applied directly to one or more nodes. Policies are Puppet code stored in the
-`manifests/` directory of modules on the modulepath. A class becomes a policy
-when it's listed under the `policies` key in `bolt-project.yaml`, and if the
-`policies` key is empty then no policies will be available for Bolt to apply.
+`manifests/` directory of modules on the modulepath. A Bolt project's
+configuration file `bolt-project.yaml` also has a new `policies` setting which
+lists the policies available to a project. When not configured, no policies will
+be available to Bolt to be applied. A class becomes a policy when it's listed
+under the `policies` key, and if the `policies` key is empty then no policies
+will be available for Bolt to apply.
 
 Policies can be managed through the `policy` command, with `apply`, `new` and
-`show` subcommands. A common workflow is to create a new policy in your current
-Bolt project using `bolt policy new <POLICY NAME>`, which will add `POLICY NAME`
-to the `policies` key in `bolt-project.yaml` and create an empty class at
-`<PROJECT DIRECTORY>/manifests/<POLICY NAME>.pp` that you can then populate.
-This is only the default creation directory, policies can be loaded from
-anywhere on the modulepath. Policies can also manually added to the `policies`
-key in `bolt-project.yaml`.
+`show` subcommands or the corresponding Powershell cmdlets `Invoke-BoltPolicy`,
+`Get-BoltPolicy`, and `New-BoltPolicy`. A common workflow is to create a new
+policy in your current Bolt project using `bolt policy new <POLICY NAME>`, which
+will add `POLICY NAME` to the `policies` key in `bolt-project.yaml` and create
+an empty class at `<PROJECT DIRECTORY>/manifests/<POLICY NAME>.pp` that you can
+then populate. Under the hood, Bolt creates a single line of Puppet code
+"include #{policies.join(,)}" that will be compiled and applied to the provided
+targets, and will log that code at the debug level. Policies are also not
+limited to the project directory; they can be loaded from anywhere on the
+modulepath. Policies can also be manually added to the `policies` key in
+`bolt-project.yaml`.
 
 You can list available policies using `bolt policy show`, and apply them to
-targets using `bolt policy apply`. apply` and available policies can be listed
-via `bolt policy show`.`bolt policy apply` accepts a comma-separated list of
-policy names to apply, or a single policy name to apply to a list of one or more
-targets. Use '-h' with any of the policy subcommand options for more detail.
-
-A Bolt project's configuration file `bolt-project.yaml` also has a new
-`policies` setting which lists the configuration policies available to a
-project. When not configured, no policies will be available to Bolt to be
-applied. disabled.
+targets using `bolt policy apply`. `bolt policy apply` accepts a comma-separated
+list of policy names to apply, or a single policy name to apply to a list of one
+or more targets. Use '-h' with any of the policy subcommands for more detail or
+`Get-Help` with any Powershell cmdlet.
 
 ## `run_container` plan step
 

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -12,7 +12,7 @@ around breaking behavior where possible.
 
 This feature was introduced in [Bolt 3.21.0](). 
 
-Configuration policies are public classes that can be assigned directly to one
+Configuration policies, or policies for short, are public classes that can be applied directly to one
 or more nodes. Policies are Puppet code stored in the `manifests/` directory of modules on the modulepath.
 
 Policies can be accessed through the `policy` subcommand, with `apply`, `new`

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -131,9 +131,9 @@ Successful on 1 target: mytarget
 Ran on 1 target in 15.2 sec
 ```
 
-Before applying policies, Bolt uses the apply_prep function to collect facts and
+Before applying policies, Bolt uses the `apply_prep` function to collect facts and
 ensure that the puppet-agent package is available on each target. For more
-information on how Bolt uses apply_prep, see [Applying manifest
+information on how Bolt uses `apply_prep`, see [Applying manifest
 blocks](applying_manifest_blocks.md#applying-manifest-blocks-from-a-puppet-plan).
 Bolt creates a single line of Puppet code to compile and apply to the provided
 targets. This line of code includes the syntax `include <POLICIES>` and Bolt

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -20,7 +20,7 @@ and `show` subcommands. A common workflow is to create a new policy in your curr
 `<Bolt project directory>/manifests/<policyname>.pp`. Bolt creates an empty
 class to fill in with the desired configuration.
 
-Once a policy is created it can be applied to target nodes via `bolt policy
+You can list available policies using `bolt policy show`, and apply them to targets using `bolt policy apply`.
 apply` and available policies can be listed via `bolt policy show`.`bolt policy
 apply` accepts a comma-separated list of policy names to apply, or a single
 policy name to apply to a list of one or more targets. Use '-h' with any of the

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -8,6 +8,16 @@ API might change, requiring the user to update their code or configuration. The
 Bolt team attempts to make these changes painless by providing useful warnings
 around breaking behavior where possible. 
 
+## Configuration policies and `bolt policy` subcommand
+
+This feature was introduced in [Bolt 3.21.0](https://github.com/puppetlabs/bolt/blob/main/CHANGELOG.md#bolt-321-2021-some-date). 
+
+Configuration policies are public classes that can be assigned directly to one or more nodes via the Bolt command line. Policies are Puppet code (.pp files).
+
+Policies can be accessed through the `policy` subcommand, with `apply`, `new` and `show` options. The default location for a policy created through Bolt is `<Bolt project directory>/manifests/<policyname>.pp`. Bolt creates an empty class to fill in with the desired configuration.
+
+Once a policy is created it can be applied to targets via `bolt policy apply` and available policies can be listed via `bolt policy show`.`bolt policy apply` accepts a comma-separated list of policy names to apply, or a single policy name to apply to a list of one or more targets.
+
 ## `run_container` plan step
 
 This feature was introduced in [Bolt 3.5.0](https://github.com/puppetlabs/bolt/blob/main/CHANGELOG.md#bolt-350-2021-3-29).

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -16,7 +16,7 @@ Configuration policies, or policies for short, are public classes that can be ap
 or more nodes. Policies are Puppet code stored in the `manifests/` directory of modules on the modulepath.
 
 Policies can be accessed through the `policy` subcommand, with `apply`, `new`
-and `show` options. The default location for a policy created through Bolt is
+and `show` subcommands. A common workflow is to create a new policy in your current Bolt project using `bolt policy new <POLICY NAME>`, which will add `POLICY NAME` to the `policies` key in `bolt-project.yaml` and create an empty class at `<PROJECT DIRECTORY>/manifests/<POLICY NAME>.pp` that you can then populate.
 `<Bolt project directory>/manifests/<policyname>.pp`. Bolt creates an empty
 class to fill in with the desired configuration.
 

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -31,43 +31,41 @@ managed via Bolt commands. This key supports glob pattern for easily listing
 multiple policies, i.e. boltproject::* includes boltproject::admin and
 boltproject::sshkeys policies.
 
-The following configuration file makes the `boltproject::admin` and
-`boltproject::sshkeys` policies available to the project:
-
+The following configuration file makes the `bolt::project::admin` and
+`bolt::project::sshkeys` policies available to the project:
 ```
 ---
-name: boltproject
+name: bolt
 policies:
-- boltproject::admin
-- boltproject::sshkeys
+- bolt::project::admin
+- bolt::project::sshkeys
 ```
 
-### Policy management overview
+### Creating new policies 
 
-Policies can be managed through the `policy` command, with `apply`, `new` and
-`show` subcommands or the corresponding Powershell cmdlets `Invoke-BoltPolicy`,
-`Get-BoltPolicy`, and `New-BoltPolicy`. Use '-h' with any of the policy
-subcommands for more detail or `Get-Help` followed by any Powershell cmdlet
-name.
+You can use Bolt to create a new policy in your project and add it to the
+`policies` key in your project configuration. For example, to create a new
+project-level policy named `bolt::project::user`, run:
 
-#### Creating new policies 
-> Policy names must be in the form `<PROJECT NAME>::<POLICY NAME>`. This is
-> referred to as `<POLICY NAME>` below. Policy names must also follow [class
-> naming
-> conventions](https://puppet.com/docs/puppet/7/lang_reserved.html#classes-and-defined-resource-type-names).
+* _*nix shell command_
+  ```
+  bolt policy new bolt::project::user
+  ```
 
-You can create a new policy with `bolt policy new <POLICY NAME>`, which performs
-two actions for you:
+* _PowerShell cmdlet_
+  ```
+  New-BoltPolicy bolt::project::user
+  ```
 
-1. `<POLICY NAME>` is added to the `policies` key in `bolt-project.yaml`.
-2.  An empty class is created at `<PROJECT DIRECTORY>/manifests/<POLICY
-    NAME>.pp` that you can then populate. Under the hood, Bolt creates a single
-    line of Puppet code "include #{policies.join(,)}" that will be compiled and
-    applied to the provided targets, and will log that code at the debug level.
+> Policy names must follow [class naming
+conventions](https://puppet.com/docs/puppet/7/lang_reserved.html#classes-and-defined-resource-type-names).
 
+An empty class is created in the project's `manifests/` directory that you can
+then populate.
+
+Example output:
 ```
-$ bolt policy new boltproject::user
-Created policy 'boltproject::user' at '/Users/puppet.user/bolt/manifests/user.pp'
+Created policy 'bolt::project::user' at '/Users/puppet.user/bolt/manifests/project/user.pp'
 ```
 
 Policies can also be created manually by:
@@ -76,36 +74,56 @@ Policies can also be created manually by:
 2. Modifying the project's `bolt-project.yaml` to include the policy in the
    `policies` key.
 
-#### Listing available policies
+### Listing available policies
 
 You can list available policies using `bolt policy show`.
-* This command supports glob pattern for easily listing multiple policies, i.e.
-  boltproject::* includes boltproject::admin and boltproject::sshkeys policies.
 
+* _*nix shell command_ 
+  ```
+  bolt policy show 
+  ```
+
+* _PowerShell cmdlet_ 
+  ``` 
+  Get-BoltPolicy 
+  ```
+
+Example output:
 ```
-$ bolt policy show
 Policies
-  boltproject::admin
-  boltproject::sshkeys
+  bolt::project::admin
+  bolt::project::sshkeys
 
 Modulepath
   /Users/puppet.user/bolt/modules:/Users/puppet.user/bolt/.modules
 ```
 
-#### Applying policies to targets
+### Applying policies to targets
 
 Applying policies is very similar to [applying Puppet
 code](https://puppet.com/docs/bolt/latest/applying_manifest_blocks.html) with
 `bolt apply`, with the addition that `bolt policy apply` allows you to apply one
-or more policies at a time. Before applying policies, Bolt will install the
-puppet-agent package and collect facts from each target.
+or more policies at a time.
 
-`bolt policy apply` accepts a comma-separated list of policy names to apply, or
-a single policy name to apply to a list of one or more targets.
+* _*nix shell command_
+  ```
+  bolt policy apply bolt::project::admin,bolt::project::sshkeys -t mytarget                                
+  ```
 
+* _PowerShell cmdlet_
+  ```
+  Invoke-BoltPolicy bolt::project::admin,bolt::project::sshkeys -t mytarget
+  ```
+
+Before applying policies, Bolt will install the puppet-agent package and collect
+facts from each target. `bolt policy apply` accepts a comma-separated list of
+policy names to apply, or a single policy name to apply to a list of one or more
+targets. Under the hood, Bolt creates a single line of Puppet code `include
+<POLICIES>` that will be compiled and applied to the provided targets, and will
+log that code at the debug level.
+
+Example output:
 ```
-$ bolt policy apply boltproject::admin -t mytarget                                                                                                  
-
 Starting: install puppet and gather facts on mytarget
 Finished: install puppet and gather facts with 0 failures in 6.51 sec
 Starting: apply catalog on mytarget

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -15,13 +15,13 @@ This feature was introduced in [Bolt 3.21.0]().
 ### What are policies?
 
 Configuration policies, or policies for short, are public classes that can be
-applied directly to one or more nodes. Policies are Puppet code stored in the
+applied directly to one or more targets. Policies are Puppet code stored in the
 `manifests/` directory of modules on the modulepath. They can be applied
 directly to targets just like other Puppet code.
 
 ### Policies in Bolt project yaml
 
-A Bolt project's configuration file `bolt-project.yaml` has a `policies` key
+The project configuration file, `bolt-project.yaml`, supports a `policies` key
 which lists the policies available to a project. A Puppet class becomes a policy
 when it's listed under the `policies` key, and if the `policies` key is empty
 then no policies will be available for Bolt to apply.
@@ -29,11 +29,12 @@ then no policies will be available for Bolt to apply.
 Policies may be manually added to the `policies` key in `bolt-project.yaml` or
 managed via Bolt commands.
 
-Example bolt-project.yaml
+The following configuration file makes the `boltproject::admin` and `boltproject::sshkeys`
+policies available to the project:
+
 ```
 ---
 name: boltproject
-modules: []
 policies:
 - boltproject::admin
 - boltproject::sshkeys

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -12,24 +12,30 @@ around breaking behavior where possible.
 
 This feature was introduced in [Bolt 3.21.0](). 
 
-Configuration policies, or policies for short, are public classes that can be applied directly to one
-or more nodes. Policies are Puppet code stored in the `manifests/` directory of modules on the modulepath.
+Configuration policies, or policies for short, are public classes that can be
+applied directly to one or more nodes. Policies are Puppet code stored in the
+`manifests/` directory of modules on the modulepath. A class becomes a policy
+when it's listed under the `policies` key in `bolt-project.yaml`, and if the
+`policies` key is empty then no policies will be available for Bolt to apply.
 
-Policies can be managed through the `policy` command, with `apply`, `new`
-and `show` subcommands. A common workflow is to create a new policy in your current Bolt project using `bolt policy new <POLICY NAME>`, which will add `POLICY NAME` to the `policies` key in `bolt-project.yaml` and create an empty class at `<PROJECT DIRECTORY>/manifests/<POLICY NAME>.pp` that you can then populate.
+Policies can be managed through the `policy` command, with `apply`, `new` and
+`show` subcommands. A common workflow is to create a new policy in your current
+Bolt project using `bolt policy new <POLICY NAME>`, which will add `POLICY NAME`
+to the `policies` key in `bolt-project.yaml` and create an empty class at
+`<PROJECT DIRECTORY>/manifests/<POLICY NAME>.pp` that you can then populate.
 `<Bolt project directory>/manifests/<policyname>.pp`. Bolt creates an empty
 class to fill in with the desired configuration.
 
-You can list available policies using `bolt policy show`, and apply them to targets using `bolt policy apply`.
-apply` and available policies can be listed via `bolt policy show`.`bolt policy
-apply` accepts a comma-separated list of policy names to apply, or a single
-policy name to apply to a list of one or more targets. Use '-h' with any of the
-policy subcommand options for more detail.
+You can list available policies using `bolt policy show`, and apply them to
+targets using `bolt policy apply`. apply` and available policies can be listed
+via `bolt policy show`.`bolt policy apply` accepts a comma-separated list of
+policy names to apply, or a single policy name to apply to a list of one or more
+targets. Use '-h' with any of the policy subcommand options for more detail.
 
 A Bolt project's configuration file `bolt-project.yaml` also has a new
 `policies` setting which lists the configuration policies available to a
-project. When not configured, no policies will be available to Bolt to be applied.
-disabled.
+project. When not configured, no policies will be available to Bolt to be
+applied. disabled.
 
 ## `run_container` plan step
 

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -15,7 +15,7 @@ This feature was introduced in [Bolt 3.21.0]().
 Configuration policies, or policies for short, are public classes that can be applied directly to one
 or more nodes. Policies are Puppet code stored in the `manifests/` directory of modules on the modulepath.
 
-Policies can be accessed through the `policy` subcommand, with `apply`, `new`
+Policies can be managed through the `policy` command, with `apply`, `new`
 and `show` subcommands. A common workflow is to create a new policy in your current Bolt project using `bolt policy new <POLICY NAME>`, which will add `POLICY NAME` to the `policies` key in `bolt-project.yaml` and create an empty class at `<PROJECT DIRECTORY>/manifests/<POLICY NAME>.pp` that you can then populate.
 `<Bolt project directory>/manifests/<policyname>.pp`. Bolt creates an empty
 class to fill in with the desired configuration.

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -6,7 +6,7 @@ while iterating on new functionality. Almost all experimental features are
 eventually stabilized in future releases. While a feature is experimental, its
 API might change, requiring the user to update their code or configuration. The
 Bolt team attempts to make these changes painless by providing useful warnings
-around breaking behavior where possible. 
+around breaking behavior where possible.
 
 ## Configuration policies and the policy command
 
@@ -50,7 +50,6 @@ name.
 #### Creating new policies 
 > Policy names must follow [class naming
 > conventions](https://puppet.com/docs/puppet/7/lang_reserved.html#classes-and-defined-resource-type-names).
-
 > Policy names must also be in the form `<PROJECT NAME>::<POLICY NAME>`. This is
 > referred to as `<POLICY NAME>` below.
 

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -131,10 +131,13 @@ Successful on 1 target: mytarget
 Ran on 1 target in 15.2 sec
 ```
 
-Before applying policies, Bolt installs the `puppet-agent` package and collects
-facts from each target. Bolt creates a single line of Puppet code to compile and
-apply to the provided targets. This line of code includes the syntax `include
-<POLICIES>` and Bolt logs the line at the debug level.
+Before applying policies, Bolt uses the apply_prep function to collect facts and
+ensure that the puppet-agent package is available on each target. For more
+information on how Bolt uses apply_prep, see [Applying manifest
+blocks](applying_manifest_blocks.md#applying-manifest-blocks-from-a-puppet-plan).
+Bolt creates a single line of Puppet code to compile and apply to the provided
+targets. This line of code includes the syntax `include <POLICIES>` and Bolt
+logs the line at the debug level.
 
 ## `run_container` plan step
 

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -28,8 +28,8 @@ configured then no policies will be available for Bolt to apply.
 
 Policies may be manually added to the `policies` key in `bolt-project.yaml` or
 managed via Bolt commands. This key supports glob pattern for easily listing
-multiple policies. For example, `bolt::project::*` includes `bolt::project::admin` and
-`bolt::project::sshkeys` policies.
+multiple policies. For example, `bolt::project::*` includes
+`bolt::project::admin` and `bolt::project::sshkeys` policies.
 
 The following configuration file makes the `bolt::project::admin` and
 `bolt::project::sshkeys` policies available to the project:
@@ -57,6 +57,8 @@ project-level policy named `bolt::project::user`, run:
   New-BoltPolicy -Name bolt::project::user
   ```
 
+Policy names must follow [class naming
+conventions](https://puppet.com/docs/puppet/7/lang_reserved.html#classes-and-defined-resource-type-names).
 An empty class is created in the project's `manifests/` directory that you can
 then populate.
 
@@ -64,8 +66,6 @@ Example output:
 ```
 Created policy 'bolt::project::user' at '/Users/puppet.user/bolt/manifests/project/user.pp'
 ```
-Policy names must follow [class naming
-conventions](https://puppet.com/docs/puppet/7/lang_reserved.html#classes-and-defined-resource-type-names).
 
 Policies can also be created manually by:
 
@@ -136,6 +136,7 @@ Before applying policies, Bolt will install the puppet-agent package and collect
 facts from each target. Under the hood, Bolt creates a single line of Puppet
 code `include <POLICIES>` that will be compiled and applied to the provided
 targets, and will log that code at the debug level.
+
 
 ## `run_container` plan step
 

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -14,47 +14,47 @@ This feature was introduced in [Bolt 3.21.0]().
 
 ### What are policies?
 
-Configuration policies are public Puppet classes stored in the `manifests/` 
-directory of modules on the modulepath. Just like other Puppet code, you 
-can apply policies directly to one or more targets.
+Configuration policies are public Puppet classes stored in the `manifests/`
+directory of modules on the modulepath. Just like other Puppet code, you can
+apply policies directly to one or more targets.
 
 ### Policies in a Bolt project's configuration file
 
 The project configuration file, `bolt-project.yaml`, supports a `policies` key
 which lists the policies available to a project. A Puppet class becomes a policy
-when you list it under the `policies` key. If you do not configure 
-the `policies` key, no policies will be available for Bolt to apply.
+when you list it under the `policies` key. If you do not configure the
+`policies` key, no policies will be available for Bolt to apply.
 
 You can manually add policies to the `policies` key in `bolt-project.yaml`, or
-manage policies using the Bolt command line. The `policies` key supports
-glob patterns for easily listing multiple policies. For example, `bolt::project::*` 
-includes both the `bolt::project::admin` and `bolt::project::sshkeys` policies.
+manage policies using the Bolt command line. The `policies` key supports glob
+patterns for easily listing multiple policies. For example, `myproject::*`
+includes both the `myproject::admin` and `myproject::sshkeys` policies.
 
-The following configuration file makes the `bolt::project::admin` and
-`bolt::project::sshkeys` policies available to the project:
+The following configuration file makes the `myproject::admin` and
+`myproject::sshkeys` policies available to the project:
 ```
 ---
 # bolt-project.yaml
 name: myproject
 policies:
-- bolt::project::admin
-- bolt::project::sshkeys
+- myproject::admin
+- myproject::sshkeys
 ```
 
 ### Creating new policies 
 
 You can use Bolt to create a new policy in your project and add it to the
 `policies` key in your project configuration. For example, to create a new
-project-level policy named `bolt::project::user`, run:
+project-level policy named `myproject::user`, run:
 
 * _*nix shell command_
   ```
-  bolt policy new bolt::project::user
+  bolt policy new myproject::user
   ```
 
 * _PowerShell cmdlet_
   ```
-  New-BoltPolicy -Name bolt::project::user
+  New-BoltPolicy -Name myproject::user
   ```
 
 Bolt creates an empty class in the project's `manifests/` directory that you can
@@ -64,7 +64,7 @@ conventions](https://puppet.com/docs/puppet/7/lang_reserved.html#classes-and-def
 
 Example output:
 ```
-Created policy 'bolt::project::user' at '/Users/puppet.user/bolt/manifests/project/user.pp'
+Created policy 'myproject::user' at '/Users/puppet.user/myproject/manifests/project/user.pp'
 ```
 
 Create policies manually by:
@@ -90,32 +90,32 @@ You can list available policies for the project:
 Example output:
 ```
 Policies
-  bolt::project::admin
-  bolt::project::sshkeys
+  myproject::admin
+  myproject::sshkeys
 
 Modulepath
-  /Users/puppet.user/bolt/modules:/Users/puppet.user/bolt/.modules
+  /Users/puppet.user/myproject/modules:/Users/puppet.user/myproject/.modules
 ```
 
 ### Applying policies to targets
 
 Applying policies is similar to [applying Puppet
-code](https://puppet.com/docs/bolt/latest/applying_manifest_blocks.html), 
-with the addition that you can apply one or more policies at a time. The Bolt 
-commands for applying policies accept a single policy name or a 
-comma-separated list of policy names to apply to a list of one or more targets. 
+code](https://puppet.com/docs/bolt/latest/applying_manifest_blocks.html), with
+the addition that you can apply one or more policies at a time. The Bolt
+commands for applying policies accept a single policy name or a comma-separated
+list of policy names to apply to a list of one or more targets. 
 
-For example, to apply both `bolt::project::admin` and `bolt::project::sshkeys`
-policies to a target:
+For example, to apply both `myproject::admin` and `myproject::sshkeys` policies
+to a target:
 
 * _*nix shell command_
   ```
-  bolt policy apply bolt::project::admin,bolt::project::sshkeys -t mytarget                                
+  bolt policy apply myproject::admin,myproject::sshkeys -t mytarget                                
   ```
 
 * _PowerShell cmdlet_
   ```
-  Invoke-BoltPolicy -Name bolt::project::admin,bolt::project::sshkeys -Targets mytarget
+  Invoke-BoltPolicy -Name myproject::admin,myproject::sshkeys -Targets mytarget
   ```
 
 Example output:
@@ -132,10 +132,9 @@ Ran on 1 target in 15.2 sec
 ```
 
 Before applying policies, Bolt installs the `puppet-agent` package and collects
-facts from each target. Bolt creates a single line of Puppet code to compile 
-and apply to the provided targets. This line of code includes the syntax
-`include <POLICIES>` and Bolt logs the line at the debug level.
-
+facts from each target. Bolt creates a single line of Puppet code to compile and
+apply to the provided targets. This line of code includes the syntax `include
+<POLICIES>` and Bolt logs the line at the debug level.
 
 ## `run_container` plan step
 

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -12,11 +12,13 @@ around breaking behavior where possible.
 
 This feature was introduced in [Bolt 3.21.0](). 
 
-Configuration policies are public classes that can be assigned directly to one or more nodes via the Bolt command line. Policies are Puppet code (.pp files).
+Configuration policies are public classes that can be assigned directly to one or more nodes via the Bolt command line. Policies are Puppet code stored in .pp files.
 
 Policies can be accessed through the `policy` subcommand, with `apply`, `new` and `show` options. The default location for a policy created through Bolt is `<Bolt project directory>/manifests/<policyname>.pp`. Bolt creates an empty class to fill in with the desired configuration.
 
-Once a policy is created it can be applied to targets via `bolt policy apply` and available policies can be listed via `bolt policy show`.`bolt policy apply` accepts a comma-separated list of policy names to apply, or a single policy name to apply to a list of one or more targets.
+Once a policy is created it can be applied to target nodes via `bolt policy apply` and available policies can be listed via `bolt policy show`.`bolt policy apply` accepts a comma-separated list of policy names to apply, or a single policy name to apply to a list of one or more targets. Use '-h' with any of the policy subcommand options for more detail.
+
+A Bolt project's configuration file `bolt-project.yaml` also has a new `policies` setting which lists the configuration policies available to a project. When not configured, the policies feature for a given project is disabled.
 
 ## `run_container` plan step
 

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -10,7 +10,7 @@ around breaking behavior where possible.
 
 ## Configuration policies and `bolt policy` subcommand
 
-This feature was introduced in [Bolt 3.21.0](https://github.com/puppetlabs/bolt/blob/main/CHANGELOG.md#bolt-321-2021-some-date). 
+This feature was introduced in [Bolt 3.21.0](). 
 
 Configuration policies are public classes that can be assigned directly to one or more nodes via the Bolt command line. Policies are Puppet code (.pp files).
 

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -28,7 +28,7 @@ policy subcommand options for more detail.
 
 A Bolt project's configuration file `bolt-project.yaml` also has a new
 `policies` setting which lists the configuration policies available to a
-project. When not configured, the policies feature for a given project is
+project. When not configured, no policies will be available to Bolt to be applied.
 disabled.
 
 ## `run_container` plan step

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -19,13 +19,12 @@ applied directly to one or more nodes. Policies are Puppet code stored in the
 `manifests/` directory of modules on the modulepath. They can be applied
 directly to targets just like other Puppet code.
 
-### Policies in a Bolt project's yaml
+### Policies in Bolt project yaml
 
 A Bolt project's configuration file `bolt-project.yaml` has a `policies` key
-which lists the policies available to a project. When not configured, no
-policies will be available to Bolt to be applied. A Puppet class becomes a
-policy when it's listed under the `policies` key, and if the `policies` key is
-empty then no policies will be available for Bolt to apply.
+which lists the policies available to a project. A Puppet class becomes a policy
+when it's listed under the `policies` key, and if the `policies` key is empty
+then no policies will be available for Bolt to apply.
 
 Policies may be manually added to the `policies` key in `bolt-project.yaml` or
 managed via Bolt commands.
@@ -49,19 +48,23 @@ subcommands for more detail or `Get-Help` followed by any Powershell cmdlet
 name.
 
 #### Creating new policies 
-> Policy names must follow [class naming conventions](https://puppet.com/docs/puppet/7/lang_reserved.html#classes-and-defined-resource-type-names).
+> Policy names must follow [class naming
+> conventions](https://puppet.com/docs/puppet/7/lang_reserved.html#classes-and-defined-resource-type-names).
+
+> Policy names must also be in the form `<PROJECT NAME>::<POLICY NAME>`. This is
+> referred to as `<POLICY NAME>` below.
 
 You can create a new policy with `bolt policy new <POLICY NAME>`, which performs
 two actions for you:
 
-1. `<PROJECT NAME>::<POLICY NAME>` is added to the `policies` key in `bolt-project.yaml`.
+1. `<POLICY NAME>` is added to the `policies` key in `bolt-project.yaml`.
 2.  An empty class is created at `<PROJECT DIRECTORY>/manifests/<POLICY
     NAME>.pp` that you can then populate. Under the hood, Bolt creates a single
     line of Puppet code "include #{policies.join(,)}" that will be compiled and
     applied to the provided targets, and will log that code at the debug level.
 
 ```
-% bolt policy new boltproject::user
+$ bolt policy new boltproject::user
 Created policy 'boltproject::user' at '/Users/puppet.user/bolt/manifests/user.pp'
 ```
 
@@ -69,8 +72,7 @@ Policies can also be created manually by:
 
 1. Adding the file to a module's or project's `manifests/` directory.
 2. Modifying the project's `bolt-project.yaml` to include the policy in the
-   `policies` key. Policies are listed in the form `<PROJECT NAME>::<POLICY
-   NAME>`.
+   `policies` key.
 
 #### Listing available policies
 
@@ -79,7 +81,7 @@ You can list available policies using `bolt policy show`.
   boltproject::* includes boltproject::admin and boltproject::sshkeys policies.
 
 ```
-% bolt policy show
+$ bolt policy show
 Policies
   boltproject::admin
   boltproject::sshkeys
@@ -90,8 +92,28 @@ Modulepath
 
 #### Applying policies to targets
 
+Applying policies is very similar to [applying Puppet
+code](https://puppet.com/docs/bolt/latest/applying_manifest_blocks.html) with
+`bolt apply`, with the addition that `bolt policy apply` allows you to apply one
+or more policies at a time. Before applying policies, Bolt will install the
+puppet-agent package and collect facts from each target.
+
 `bolt policy apply` accepts a comma-separated list of policy names to apply, or
-a single policy name to apply to a list of one or more targets. 
+a single policy name to apply to a list of one or more targets.
+
+```
+$ bolt policy apply boltproject::admin -t mytarget                                                                                                  
+
+Starting: install puppet and gather facts on mytarget
+Finished: install puppet and gather facts with 0 failures in 6.51 sec
+Starting: apply catalog on mytarget
+Started on mytarget...
+Finished on mytarget:
+  changed: 1, failed: 0, unchanged: 0 skipped: 0, noop: 0
+Finished: apply catalog with 0 failures in 8.59 sec
+Successful on 1 target: mytarget
+Ran on 1 target in 15.2 sec
+```
 
 ## `run_container` plan step
 

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -34,7 +34,8 @@ The following configuration file makes the `bolt::project::admin` and
 `bolt::project::sshkeys` policies available to the project:
 ```
 ---
-name: bolt
+# bolt-project.yaml
+name: myproject
 policies:
 - bolt::project::admin
 - bolt::project::sshkeys

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -52,13 +52,12 @@ name.
 
 You can create a new policy with `bolt policy new <POLICY NAME>`, which performs
 two actions for you:
-1. `POLICY NAME` is added to the `policies` key in `bolt-project.yaml`.
+
+1. `<PROJECT NAME>::<POLICY NAME>` is added to the `policies` key in `bolt-project.yaml`.
 2.  An empty class is created at `<PROJECT DIRECTORY>/manifests/<POLICY
-    NAME>.pp`[^1] that you can then populate. Under the hood, Bolt creates a single
+    NAME>.pp` that you can then populate. Under the hood, Bolt creates a single
     line of Puppet code "include #{policies.join(,)}" that will be compiled and
     applied to the provided targets, and will log that code at the debug level.
-
-    [^1]:Policy files are not limited to the project directory; they can be loaded from anywhere on the modulepath.
 
 ```
 % bolt policy new boltproject::user
@@ -67,6 +66,7 @@ Created policy 'boltproject::user' at '/Users/puppet.user/bolt/manifests/user.pp
 ```
 
 Policies can also be created manually by:
+
 1. Adding the file to a module's or project's `manifests/` directory.
 2. Modifying the project's `bolt-project.yaml` to include the policy in the
    `policies` key. Policies are listed in the form `<PROJECT NAME>::<POLICY

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -48,10 +48,10 @@ subcommands for more detail or `Get-Help` followed by any Powershell cmdlet
 name.
 
 #### Creating new policies 
-> Policy names must follow [class naming
+> Policy names must be in the form `<PROJECT NAME>::<POLICY NAME>`. This is
+> referred to as `<POLICY NAME>` below. Policy names must also follow [class
+> naming
 > conventions](https://puppet.com/docs/puppet/7/lang_reserved.html#classes-and-defined-resource-type-names).
-> Policy names must also be in the form `<PROJECT NAME>::<POLICY NAME>`. This is
-> referred to as `<POLICY NAME>` below.
 
 You can create a new policy with `bolt policy new <POLICY NAME>`, which performs
 two actions for you:

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -12,13 +12,25 @@ around breaking behavior where possible.
 
 This feature was introduced in [Bolt 3.21.0](). 
 
-Configuration policies are public classes that can be assigned directly to one or more nodes via the Bolt command line. Policies are Puppet code stored in .pp files.
+Configuration policies are public classes that can be assigned directly to one
+or more nodes via the Bolt command line. Policies are Puppet code stored in .pp
+files.
 
-Policies can be accessed through the `policy` subcommand, with `apply`, `new` and `show` options. The default location for a policy created through Bolt is `<Bolt project directory>/manifests/<policyname>.pp`. Bolt creates an empty class to fill in with the desired configuration.
+Policies can be accessed through the `policy` subcommand, with `apply`, `new`
+and `show` options. The default location for a policy created through Bolt is
+`<Bolt project directory>/manifests/<policyname>.pp`. Bolt creates an empty
+class to fill in with the desired configuration.
 
-Once a policy is created it can be applied to target nodes via `bolt policy apply` and available policies can be listed via `bolt policy show`.`bolt policy apply` accepts a comma-separated list of policy names to apply, or a single policy name to apply to a list of one or more targets. Use '-h' with any of the policy subcommand options for more detail.
+Once a policy is created it can be applied to target nodes via `bolt policy
+apply` and available policies can be listed via `bolt policy show`.`bolt policy
+apply` accepts a comma-separated list of policy names to apply, or a single
+policy name to apply to a list of one or more targets. Use '-h' with any of the
+policy subcommand options for more detail.
 
-A Bolt project's configuration file `bolt-project.yaml` also has a new `policies` setting which lists the configuration policies available to a project. When not configured, the policies feature for a given project is disabled.
+A Bolt project's configuration file `bolt-project.yaml` also has a new
+`policies` setting which lists the configuration policies available to a
+project. When not configured, the policies feature for a given project is
+disabled.
 
 ## `run_container` plan step
 

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -8,7 +8,7 @@ API might change, requiring the user to update their code or configuration. The
 Bolt team attempts to make these changes painless by providing useful warnings
 around breaking behavior where possible. 
 
-## Configuration policies and `bolt policy` subcommand
+## Configuration policies and the policy command
 
 This feature was introduced in [Bolt 3.21.0](). 
 

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -19,18 +19,20 @@ applied directly to one or more targets. Policies are Puppet code stored in the
 `manifests/` directory of modules on the modulepath. They can be applied
 directly to targets just like other Puppet code.
 
-### Policies in Bolt project yaml
+### Policies in a Bolt project's configuration file
 
 The project configuration file, `bolt-project.yaml`, supports a `policies` key
 which lists the policies available to a project. A Puppet class becomes a policy
-when it's listed under the `policies` key, and if the `policies` key is empty
-then no policies will be available for Bolt to apply.
+when it's listed under the `policies` key, and if the `policies` key is not
+configured then no policies will be available for Bolt to apply.
 
 Policies may be manually added to the `policies` key in `bolt-project.yaml` or
-managed via Bolt commands.
+managed via Bolt commands. This key supports glob pattern for easily listing
+multiple policies, i.e. boltproject::* includes boltproject::admin and
+boltproject::sshkeys policies.
 
-The following configuration file makes the `boltproject::admin` and `boltproject::sshkeys`
-policies available to the project:
+The following configuration file makes the `boltproject::admin` and
+`boltproject::sshkeys` policies available to the project:
 
 ```
 ---

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -8,28 +8,27 @@ API might change, requiring the user to update their code or configuration. The
 Bolt team attempts to make these changes painless by providing useful warnings
 around breaking behavior where possible.
 
-## Configuration policies and the policy command
+## Configuration policies and the `policy` command
 
 This feature was introduced in [Bolt 3.21.0](). 
 
 ### What are policies?
 
-Configuration policies, or policies for short, are public classes that can be
-applied directly to one or more targets. Policies are Puppet code stored in the
-`manifests/` directory of modules on the modulepath. They can be applied
-directly to targets just like other Puppet code.
+Configuration policies are public Puppet classes stored in the `manifests/` 
+directory of modules on the modulepath. Just like other Puppet code, you 
+can apply policies directly to one or more targets.
 
 ### Policies in a Bolt project's configuration file
 
 The project configuration file, `bolt-project.yaml`, supports a `policies` key
 which lists the policies available to a project. A Puppet class becomes a policy
-when it's listed under the `policies` key, and if the `policies` key is not
-configured then no policies will be available for Bolt to apply.
+when you list it under the `policies` key. If you do not configure 
+the `policies` key, no policies will be available for Bolt to apply.
 
-Policies may be manually added to the `policies` key in `bolt-project.yaml` or
-managed via Bolt commands. This key supports glob pattern for easily listing
-multiple policies. For example, `bolt::project::*` includes
-`bolt::project::admin` and `bolt::project::sshkeys` policies.
+You can manually add policies to the `policies` key in `bolt-project.yaml`, or
+manage policies using the Bolt command line. The `policies` key supports
+glob patterns for easily listing multiple policies. For example, `bolt::project::*` 
+includes both the `bolt::project::admin` and `bolt::project::sshkeys` policies.
 
 The following configuration file makes the `bolt::project::admin` and
 `bolt::project::sshkeys` policies available to the project:
@@ -57,17 +56,17 @@ project-level policy named `bolt::project::user`, run:
   New-BoltPolicy -Name bolt::project::user
   ```
 
-Policy names must follow [class naming
+Bolt creates an empty class in the project's `manifests/` directory that you can
+populate with code. Policy names must follow [class naming
 conventions](https://puppet.com/docs/puppet/7/lang_reserved.html#classes-and-defined-resource-type-names).
-An empty class is created in the project's `manifests/` directory that you can
-then populate.
+
 
 Example output:
 ```
 Created policy 'bolt::project::user' at '/Users/puppet.user/bolt/manifests/project/user.pp'
 ```
 
-Policies can also be created manually by:
+Create policies manually by:
 
 1. Adding the file to a module's or project's `manifests/` directory.
 2. Modifying the project's `bolt-project.yaml` to include the policy in the
@@ -99,12 +98,11 @@ Modulepath
 
 ### Applying policies to targets
 
-Applying policies is very similar to [applying Puppet
-code](https://puppet.com/docs/bolt/latest/applying_manifest_blocks.html) with
-`bolt apply`, with the addition that `bolt policy apply` allows you to apply one
-or more policies at a time. `bolt policy apply` accepts a comma-separated list
-of policy names to apply, or a single policy name to apply to a list of one or
-more targets. 
+Applying policies is similar to [applying Puppet
+code](https://puppet.com/docs/bolt/latest/applying_manifest_blocks.html), 
+with the addition that you can apply one or more policies at a time. The Bolt 
+commands for applying policies accept a single policy name or a 
+comma-separated list of policy names to apply to a list of one or more targets. 
 
 For example, to apply both `bolt::project::admin` and `bolt::project::sshkeys`
 policies to a target:
@@ -132,10 +130,10 @@ Successful on 1 target: mytarget
 Ran on 1 target in 15.2 sec
 ```
 
-Before applying policies, Bolt will install the puppet-agent package and collect
-facts from each target. Under the hood, Bolt creates a single line of Puppet
-code `include <POLICIES>` that will be compiled and applied to the provided
-targets, and will log that code at the debug level.
+Before applying policies, Bolt installs the `puppet-agent` package and collects
+facts from each target. Bolt creates a single line of Puppet code to compile 
+and apply to the provided targets. This line of code includes the syntax
+`include <POLICIES>` and Bolt logs the line at the debug level.
 
 
 ## `run_container` plan step

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -64,7 +64,7 @@ conventions](https://puppet.com/docs/puppet/7/lang_reserved.html#classes-and-def
 
 Example output:
 ```
-Created policy 'myproject::user' at '/Users/puppet.user/myproject/manifests/project/user.pp'
+Created policy 'myproject::user' at '/Users/puppet.user/myproject/manifests/user.pp'
 ```
 
 Create policies manually by:

--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -14,7 +14,6 @@ This feature was introduced in [Bolt 3.21.0]().
 
 Configuration policies are public classes that can be assigned directly to one
 or more nodes. Policies are Puppet code stored in the `manifests/` directory of modules on the modulepath.
-files.
 
 Policies can be accessed through the `policy` subcommand, with `apply`, `new`
 and `show` options. The default location for a policy created through Bolt is


### PR DESCRIPTION
Added documentation on policies and a guide on what has been added to Bolt vis-à-vis policies.