### PR TITLE
(bug-fix) Error if the project doesn't have a name

### DIFF
--- a/lib/bolt/application.rb
+++ b/lib/bolt/application.rb
@@ -490,6 +490,16 @@ module Bolt
         raise Bolt::ValidationError, message
       end
 
+      # Validate that we're not running with the default project
+      if @config.project.name.nil?
+        command = Bolt::Util.powershell? ? 'New-BoltProject -Name <NAME>' : 'bolt project init <NAME>'
+        message = <<~MESSAGE.chomp
+          Can't create a policy for the default Bolt project because it doesn't
+          have a name. Run '#{command}' to create a new project.
+        MESSAGE
+        raise Bolt::ValidationError, message
+      end
+
       prefix, *name_segments, basename = name.split('::')
 
       # Error if name is not namespaced to project


### PR DESCRIPTION
This was just a small thing I noticed, when using the default Bolt
project the project doesn't have a name, and so there's no way for `bolt
policy new` to succeed, but the error doesn't say as much. This raises
an error instructing the user to create a project with a name before
creating policies.

!no-release-note