### PR TITLE
(maint) Update codeowners to skeletor team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,5 @@
-# Default to Bolt team
-* @puppetlabs/bolt
+# Default to Skeletor team
+* @puppetlabs/skeletor
 
-/documentation @hestonhoffman @puppetlabs/bolt
-/guides @hestonhoffman @puppetlabs/bolt
-/lib/bolt_server @puppetlabs/skeletor
-/spec/bolt_server @puppetlabs/skeletor
+/documentation @hestonhoffman @puppetlabs/skeletor
+/guides @hestonhoffman @puppetlabs/skeletor


### PR DESCRIPTION
This updates the codeowners file to notify the skeletor team, as the
bolt team is now defunct.