### PR TITLE
(BOLT-1572) Warn when bolt-plugin.json is present

### DIFF
--- a/lib/bolt/module.rb
+++ b/lib/bolt/module.rb
@@ -42,6 +42,12 @@ module Bolt
     end
 
     def plugin?
+      if File.exist?(File.join(path, 'bolt-plugin.json'))
+        msg = "Found bolt-plugin.json in module #{name} at #{path}. Bolt looks for " \
+          "bolt_plugin.json to determine if the module contains plugins. " \
+          "Rename the file for Bolt to recognize it."
+        Bolt::Logger.warn_once('plugin_file_name', msg)
+      end
       File.exist?(plugin_data_file)
     end
   end


### PR DESCRIPTION
This adds a warning when `bolt-plugin.json` is found in a module when
Bolt is looking for module plugins. The warning is raised regardless of
whether `bolt_plugin.json` is present, and instructs the user to rename
the file if they want Bolt to load it. We're preferring to warn rather
than just load `bolt-plugin.json` or rename it ourselves because then we
have to determine behavior when `bolt_plugin.json` is present, and would
have to have a precedence if both were loaded, and it just seems less
confusing to have have one be supported and raise an error when we find
common typos.

Also not entirely sure this needs a release note...

!feature

* **Warn when `bolt-plugin.json` is found** ([BOLT-1572](https://tickets.puppetlabs.com/browse/BOLT-1572))

  Bolt will now warn if, while loading plugins, it finds a
  `bolt-plugin.json` file in a module. The correct filename is
  `bolt_plugin.json`, and Bolt will advise renaming the file in order for
  it to be loaded.