### PR TITLE
(PE-33643) Update bolt-server to read from versioned envs

### DIFF
--- a/lib/bolt_server/transport_app.rb
+++ b/lib/bolt_server/transport_app.rb
@@ -326,6 +326,7 @@ module BoltServer
         cli << "--basemodulepath" << basemodulepath
         Puppet.settings.send(:clear_everything_for_tests)
         Puppet.initialize_settings(cli)
+        Puppet[:versioned_environment_dirs] = true
         yield
       end
     end


### PR DESCRIPTION
This commit updates the configuration of puppet in bolt-server's environment
loading code to allow for reading of versioned environments. The
:versioned_environment_dirs setting in puppet configures it to read from
versioned environments when it finds them, so this change enables that
behavior during environment operations in bolt-server.

Note that enabling the setting does not affect any code loading operations if
environments are _not_ versioned, so to make things easier the setting is
always true.