### PR TITLE
(GH-3049) Configure path to rerun file

### DIFF
--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -461,6 +461,13 @@ module Bolt
           },
           _plugin: true
         },
+        "rerunfile" => {
+          description: "The path to the project's rerun file. The rerun file is used to store information "\
+                       "about targets from the most recent run. Expands relative to the project directory.",
+          type: String,
+          _example: "/Users/bolt/project/rerun.json",
+          _plugin: true
+        },
         "save-rerun" => {
           description: "Whether to update `.rerun.json` in the Bolt project directory. If "\
                        "your target names include passwords, set this value to `false` to avoid "\
@@ -603,6 +610,7 @@ module Bolt
         plugin-hooks
         plugins
         puppetdb
+        rerunfile
         save-rerun
         spinner
         stream
@@ -630,6 +638,7 @@ module Bolt
         plugins
         policies
         puppetdb
+        rerunfile
         save-rerun
         spinner
         stream

--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -128,6 +128,10 @@ module Bolt
 
       @data = data.slice(*Bolt::Config::PROJECT_OPTIONS)
 
+      if @data['rerunfile']
+        @rerunfile = File.expand_path(@data['rerunfile'], @path)
+      end
+
       validate if project_file?
     end
 

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -43,6 +43,9 @@
     "puppetdb": {
       "$ref": "#/definitions/puppetdb"
     },
+    "rerunfile": {
+      "$ref": "#/definitions/rerunfile"
+    },
     "save-rerun": {
       "$ref": "#/definitions/save-rerun"
     },
@@ -342,6 +345,17 @@
               ]
             }
           }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "rerunfile": {
+      "description": "The path to the project's rerun file. The rerun file is used to store information about targets from the most recent run. Expands relative to the project directory.",
+      "oneOf": [
+        {
+          "type": "string"
         },
         {
           "$ref": "#/definitions/_plugin"

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -64,6 +64,9 @@
     "puppetdb": {
       "$ref": "#/definitions/puppetdb"
     },
+    "rerunfile": {
+      "$ref": "#/definitions/rerunfile"
+    },
     "save-rerun": {
       "$ref": "#/definitions/save-rerun"
     },
@@ -469,6 +472,17 @@
               ]
             }
           }
+        },
+        {
+          "$ref": "#/definitions/_plugin"
+        }
+      ]
+    },
+    "rerunfile": {
+      "description": "The path to the project's rerun file. The rerun file is used to store information about targets from the most recent run. Expands relative to the project directory.",
+      "oneOf": [
+        {
+          "type": "string"
         },
         {
           "$ref": "#/definitions/_plugin"


### PR DESCRIPTION
This adds a new `rerunfile` configuration option that allows users to
configure the path to Bolt's rerun file.

!feature

* **Configure path to the rerun file**
  ([#3049](https://github.com/puppetlabs/bolt/issues/3049))

  You can now configure the path to Bolt's rerun file at the project,
  user, and system-wide levels with the new `rerunfile` config option.

Supersedes #3052
Closes #3049 