### PR TITLE
(GH-3065) Support looking up pdb facts in arrays puppetdb plugin

### DIFF
--- a/lib/bolt/plugin/puppetdb.rb
+++ b/lib/bolt/plugin/puppetdb.rb
@@ -42,6 +42,13 @@ module Bolt
 
       def fact_path(raw_fact)
         fact_path = raw_fact.split(".")
+        fact_path = fact_path.map do |segment|
+          # Turn it into an integer if we can
+          Integer(segment)
+        rescue ArgumentError
+          # Otherwise return the value
+          segment
+        end
         if fact_path[0] == 'facts'
           fact_path.drop(1)
         elsif fact_path == ['certname']

--- a/spec/unit/plugin/puppetdb_spec.rb
+++ b/spec/unit/plugin/puppetdb_spec.rb
@@ -17,6 +17,10 @@ describe Bolt::Plugin::Puppetdb do
       expect(plugin.fact_path("facts.straw.berries")).to eq(%w[straw berries])
     end
 
+    it "converts array indexes to integers" do
+      expect(plugin.fact_path("facts.0.berries")).to eq([0, 'berries'])
+    end
+
     it "errors when fact is not prepended with 'facts'" do
       expect { plugin.fact_path("strawberries") }
         .to raise_error(Bolt::Plugin::Puppetdb::FactLookupError,


### PR DESCRIPTION
This commit fixes a bug where the puppetdb plugin could not index in to arrays when resolving target_mappings.

!bug

* **Support resolving facts from nested arrays with puppetdb plugin**
  ([puppetlabs#3065](puppetlabs#3065))

  Previously indexing into arrays when resolving values from puppetdb
  facts using the target_mapping for the puppetdb plugin did not work.
  This is now possible by specifying the index of the array, for example:
  `facts.my_fact_array.0.nested_value`.