### PR TITLE
(GH-3069) Make native-ssh more portable

### DIFF
--- a/documentation/experimental_features.md
+++ b/documentation/experimental_features.md
@@ -843,7 +843,7 @@ For example:
 ```
 ssh:
   ssh-command: 'ssh'
-  copy-command: 'scp -r -F ~/ssh-config/myconf'
+  copy-command: ['scp', '-r', '-F', '~/ssh-config/myconf']
 ```
 
 ### Connecting with SSH configuration not supported by net-ssh

--- a/lib/bolt/transport/ssh/exec_connection.rb
+++ b/lib/bolt/transport/ssh/exec_connection.rb
@@ -44,11 +44,12 @@ module Bolt
         end
 
         def ssh_opts
+          # NOTE: not all commands we might use here support various `-o` options,
+          # always provide a way to run without them.
           cmd = []
           # BatchMode is SSH's noninteractive option: if key authentication
           # fails it will error out instead of falling back to password prompt
-          batch_mode = @target.transport_config['batch-mode'] ? 'yes' : 'no'
-          cmd += %W[-o BatchMode=#{batch_mode}]
+          cmd += %w[-o BatchMode=yes] if @target.transport_config['batch-mode']
 
           cmd += %W[-o Port=#{@target.port}] if @target.port
 
@@ -68,6 +69,8 @@ module Bolt
           ssh_cmd = Array(ssh_conf)
           ssh_cmd += ssh_opts
           ssh_cmd << userhost
+          # Add option separator before command for wrappers around SSH
+          ssh_cmd << '--'
           ssh_cmd << command
         end
 


### PR DESCRIPTION
Updates `native-ssh` so there's always a way to configure it to omit all SSH options (since you can also include them in `ssh-command` and `copy-command`) and puts the command to execute after a `--` to separate out positional arguments.

!bug

* **Make native-ssh more portable**([https://github.com/puppetlabs/bolt/issues/3069](https://github.com/puppetlabs/bolt/issues/3069))

  Updates `native-ssh` so setting `batch-mode: false` omits `-o
  BatchMode=` and adds a double-dash separater `--` before commands to
  execute.