### PR TITLE
(maint) Increase winrm connection timeouts for windows-latest

### DIFF
--- a/bolt-modules/boltlib/spec/functions/run_container_spec.rb
+++ b/bolt-modules/boltlib/spec/functions/run_container_spec.rb
@@ -12,7 +12,7 @@ describe 'run_container' do
   # So that this can be called in the before block
   def image
     @image ||= if Bolt::Util.windows?
-                 'mcr.microsoft.com/windows/servercore:ltsc2019'
+                 'mcr.microsoft.com/windows/servercore:ltsc2022'
                else
                  'ubuntu:20.04'
                end

--- a/spec/bolt_server/transport_app_spec.rb
+++ b/spec/bolt_server/transport_app_spec.rb
@@ -727,6 +727,7 @@ describe "BoltServer::TransportApp" do
         password: target_data[:password],
         port: target_data[:port]
       }
+      target[:'connect-timeout'] = target_data[:'connect-timeout'] if target_data[:'connect-timeout']
 
       body = if multiple
                body_content.merge(targets: [target])

--- a/spec/fixtures/modules/error/plans/winrm_disconnect.pp
+++ b/spec/fixtures/modules/error/plans/winrm_disconnect.pp
@@ -2,6 +2,7 @@ plan error::winrm_disconnect(
   TargetSpec $targets
 ) {
   $result = run_command('restart-service winrm', $targets, _catch_errors => true)
+  wait_until_available($targets, _catch_errors => true)
   return run_command('get-service |? name -like winrm', $targets)
 }
 

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -23,7 +23,8 @@ describe 'running with an inventory file', reset_puppet_settings: true do
           transport: conn[:protocol],
           conn[:protocol] => {
             user: conn[:user],
-            port: conn[:port]
+            port: conn[:port],
+            'connect-timeout': conn[:'connect-timeout'] || 10
           }
         } },
       { name: 'uriless',

--- a/spec/integration/logging_spec.rb
+++ b/spec/integration/logging_spec.rb
@@ -242,7 +242,7 @@ describe 'streaming output over WinRM', winrm: true do
   let(:user)          { conn_info('winrm')[:user] }
   let(:whoami)        { '$env:UserName' }
   let(:err_cmd)       { '$host.ui.WriteErrorLine("error")' }
-  let(:config_flags)  { %W[--no-ssl --no-ssl-verify --password #{pw}] }
+  let(:config_flags)  { %W[--no-ssl --no-ssl-verify --connect-timeout 45 --password #{pw}] }
 
   include_examples 'streaming output'
 end

--- a/spec/integration/transport/winrm_spec.rb
+++ b/spec/integration/transport/winrm_spec.rb
@@ -44,7 +44,7 @@ describe Bolt::Transport::WinRM, winrm_transport: true do
 
   def mk_config(conf)
     conf = Bolt::Util.walk_keys(conf, &:to_s)
-    conf['connect-timeout'] ||= 30
+    conf['connect-timeout'] ||= 45
     conf
   end
 
@@ -78,7 +78,7 @@ describe Bolt::Transport::WinRM, winrm_transport: true do
 
       # The connection should fail immediately; this timeout helps ensure that
       # and avoids a hang
-      Timeout.timeout(3) do
+      Timeout.timeout(45) do
         expect_node_error(Bolt::Node::ConnectError,
                           'CONNECT_ERROR',
                           /Failed to connect to/) do
@@ -103,7 +103,7 @@ describe Bolt::Transport::WinRM, winrm_transport: true do
         port = socket.addr[1]
         conf = config.merge('connect-timeout' => 2)
 
-        Timeout.timeout(3) do
+        Timeout.timeout(45) do
           expect_node_error(Bolt::Node::ConnectError,
                             'CONNECT_ERROR',
                             /Timeout after \d+ seconds connecting to/) do

--- a/spec/integration/winrm_spec.rb
+++ b/spec/integration/winrm_spec.rb
@@ -20,7 +20,7 @@ describe "when runnning over the winrm transport", winrm: true do
   context 'when using CLI options' do
     let(:config_flags) {
       %W[--targets #{uri} --no-ssl --no-ssl-verify --format json --modulepath #{modulepath}
-         --password #{password}]
+         --password #{password} --connect-timeout 45]
     }
 
     it 'runs a command' do
@@ -83,7 +83,9 @@ describe "when runnning over the winrm transport", winrm: true do
     end
 
     it 'handles disconnects gracefully', :reset_puppet_settings do
-      result = run_cli_json(%w[plan run error::winrm_disconnect] + config_flags)
+      longer_timeout = %W[--targets #{uri} --no-ssl --no-ssl-verify --format json --modulepath #{modulepath}
+                          --password #{password} --connect-timeout 120]
+      result = run_cli_json(%w[plan run error::winrm_disconnect] + longer_timeout)
       expect(result.first['status']).to eq("success")
     end
   end
@@ -104,7 +106,8 @@ describe "when runnning over the winrm transport", winrm: true do
             'user' => user,
             'password' => password,
             'ssl' => false,
-            'ssl-verify' => false
+            'ssl-verify' => false,
+            'connect-timeout' => 45
           }
         }
       }

--- a/spec/lib/bolt_spec/conn.rb
+++ b/spec/lib/bolt_spec/conn.rb
@@ -22,7 +22,7 @@ module BoltSpec
       when 'winrm'
         default_port      = 25985
         additional_config = { ssl: false,
-                              'connect-timeout': 30 }
+                              'connect-timeout': 45 }
       when 'docker', 'podman'
         default_user     = ''
         default_password = ''


### PR DESCRIPTION
For any integration test that runs against a live winrm connection, increase the timeout as the new GH runner is slower to connect.