### PR TITLE
(maint) Add option to parse env_var values as json

### DIFF
--- a/documentation/supported_plugins.md
+++ b/documentation/supported_plugins.md
@@ -60,6 +60,7 @@ The following parameters are available to the `env_var` plugin:
 | `var` | **Required.** The name of the environment variable to read from. | `String` | None |
 | `default` | A value to use if the environment variable `var` isn't set. | `String` | None |
 | `optional` | Unless `true`, `env_var` raises an error when the environment variable `var` does not exist.  When `optional` is `true` and `var` does not exist, env_var returns `nil`. | `Boolean` | `false` |
+| `json` | The environment variable value is encoded in a json string, parse it and use the resolved data. | `Boolean` | `false` |
 
 #### Example usage
 


### PR DESCRIPTION
I want to use json encoded data fron ENV with the env_var plugin. This adds and option to the plugin to parse values looked up from environment as JSON.

!feature
* **Option to parse data as JSON looked up with `env_var` plugin**

  The env_var plugin now accepts a `parse-as-json` option to allow
  the plugin to use data encoded as JSON stored in environment
  variables.