### PR TITLE
(maint) Disable rerunfile config in user and system config

### DIFF
--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -610,7 +610,6 @@ module Bolt
         plugin-hooks
         plugins
         puppetdb
-        rerunfile
         save-rerun
         spinner
         stream

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -43,9 +43,6 @@
     "puppetdb": {
       "$ref": "#/definitions/puppetdb"
     },
-    "rerunfile": {
-      "$ref": "#/definitions/rerunfile"
-    },
     "save-rerun": {
       "$ref": "#/definitions/save-rerun"
     },
@@ -345,17 +342,6 @@
               ]
             }
           }
-        },
-        {
-          "$ref": "#/definitions/_plugin"
-        }
-      ]
-    },
-    "rerunfile": {
-      "description": "The path to the project's rerun file. The rerun file is used to store information about targets from the most recent run. Expands relative to the project directory.",
-      "oneOf": [
-        {
-          "type": "string"
         },
         {
           "$ref": "#/definitions/_plugin"


### PR DESCRIPTION
This disables the `rerunfile` config option in the user and system
config files, as config for project files should only be configurable in
the project config file.

!no-release-note