### PR TITLE
Dockerfile: dont use legacy bundler syntax

### DIFF
--- a/Dockerfile.bolt-server
+++ b/Dockerfile.bolt-server
@@ -10,7 +10,8 @@ RUN mkdir /bolt-server
 # Gemfile requires gemspec which requires bolt/version which requires bolt
 ADD . /bolt-server
 WORKDIR /bolt-server
-RUN bundle install --no-cache --path vendor/bundle --jobs=$(nproc)
+RUN bundle config set path 'vendor/bundle' \
+  && bundle install --no-cache --jobs=$(nproc)
 
 # Final image
 FROM alpine:3.14


### PR DESCRIPTION
the old --path option throws a warning.