### PR TITLE
(maint) Bump minimum version for packaging gem to 0.105

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ group(:test) do
 end
 
 group(:packaging) do
-  gem 'packaging', '~> 0.99.35'
+  gem 'packaging', '~> 0.105'
 end
 
 local_gemfile = File.join(__dir__, 'Gemfile.local')


### PR DESCRIPTION
This bumps the minimum version for the `packaging` gem to 0.105.0, as
Bolt packages are now available for el-9 and this is the earliest
version of the packaging gem that can build packages for that platform.

!no-release-note

---

Support for el-9 added to the packaging gem [here](https://github.com/puppetlabs/packaging/commit/225fef5456f15b797ba839c2be4685d658d4f5b4)