### PR TITLE
(GH-3076) Update puppet_agent module

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,7 +6,7 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '2.1.0'
-mod 'puppetlabs-puppet_agent', '4.9.0'
+mod 'puppetlabs-puppet_agent', '4.10.0'
 mod 'puppetlabs-facts', '1.4.0'
 
 # Core types and providers for Puppet 6


### PR DESCRIPTION
Ship latest puppet_agent module.

!feature

* **Ship the latest puppet_agent module**
  ([#3076](#3076))

  Bolt now ships with puppet_agent the 4.10.0 module which supports AlmaLinux installation..