### PR TITLE
(BOLT-1586) Remove ssh role from bolt controller in acceptance tests

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,7 +6,7 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '2.2.0'
-mod 'puppetlabs-puppet_agent', '4.9.0'
+mod 'puppetlabs-puppet_agent', '4.11.0'
 mod 'puppetlabs-facts', '1.4.0'
 
 # Core types and providers for Puppet 6

--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -23,8 +23,9 @@ rototiller_task :host_config do |task|
     n_new = []
     n.each_with_index do |node, i|
       roles = []
-      roles << 'bolt' if i.zero?
-      roles << if /win/ =~ node
+      roles << if i.zero?
+                 'bolt'
+               elsif /win/ =~ node
                  'winrm'
                else
                  'ssh'
@@ -93,7 +94,7 @@ beaker_env = [
 
 def test_targets
   # TODO: make this compatable with BOLT_CONTROLER and BOLT_NODES
-  ENV['LAYOUT'] || 'fedora32-64bolt,ssh.{type=aio}-ubuntu2004-64ssh.{type=aio}-windows10ent-64winrm.{type=aio}'
+  ENV['LAYOUT'] || 'fedora32-64bolt.{type=aio}-ubuntu2004-64ssh.{type=aio}-windows10ent-64winrm.{type=aio}'
 end
 
 # Use beaker-hostgenerator to get a list of platform names used by ABS based on


### PR DESCRIPTION
This updates the acceptance test Rakefile to not add the `ssh` role to
the Bolt controller. Previously, the `ssh` role was added to the Bolt
controller, which caused some tests run on the controller to connect
over SSH. This caused problems when installing the puppet-agent package
on the controller during acceptance tests, as the
`puppet_agent::install` task added logic to not install the puppet-agent
package when a gem install of the agent is detected in
`puppet_agent >= 4.10.0`. Removing the `ssh` role results in Bolt using
the puppet gem instead of the puppet-agent package.

---

Run the following command from the `acceptance/` directory to see the failing tests:

```shell
bundle exec rake test:preserve
```

Then run the following command to see the tests passing with this change:

```shell
GIT_FORK='beechtom/bolt' GIT_BRANCH='1586/acceptance' bundle exec rake test:preserve
```