### PR TITLE
(maint) Update bundled modules

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -5,14 +5,14 @@ forge "http://forge.puppetlabs.com"
 moduledir File.join(File.dirname(__FILE__), 'modules')
 
 # Core modules used by 'apply'
-mod 'puppetlabs-service', '2.1.0'
+mod 'puppetlabs-service', '2.2.0'
 mod 'puppetlabs-puppet_agent', '4.9.0'
 mod 'puppetlabs-facts', '1.4.0'
 
 # Core types and providers for Puppet 6
 mod 'puppetlabs-augeas_core', '1.2.0'
 mod 'puppetlabs-host_core', '1.1.0'
-mod 'puppetlabs-scheduled_task', '3.0.1'
+mod 'puppetlabs-scheduled_task', '3.1.0'
 mod 'puppetlabs-sshkeys_core', '2.3.0'
 mod 'puppetlabs-zfs_core', '1.3.0'
 mod 'puppetlabs-cron_core', '1.1.0'
@@ -22,14 +22,14 @@ mod 'puppetlabs-yumrepo_core', '1.1.0'
 mod 'puppetlabs-zone_core', '1.0.3'
 
 # Useful additional modules
-mod 'puppetlabs-package', '2.1.0'
+mod 'puppetlabs-package', '2.2.0'
 mod 'puppetlabs-powershell_task_helper', '0.1.0'
-mod 'puppetlabs-puppet_conf', '1.2.0'
+mod 'puppetlabs-puppet_conf', '1.3.0'
 mod 'puppetlabs-python_task_helper', '0.5.0'
 mod 'puppetlabs-reboot', '4.1.0'
 mod 'puppetlabs-ruby_task_helper', '0.6.1'
 mod 'puppetlabs-ruby_plugin_helper', '0.2.0'
-mod 'puppetlabs-stdlib', '8.1.0'
+mod 'puppetlabs-stdlib', '8.2.0'
 
 # Plugin modules
 mod 'puppetlabs-aws_inventory', '0.7.0'


### PR DESCRIPTION
This updates Bolt's bundled modules to their latest versions.

!feature

* **Update bundled modules to latest versions**

  The following bundled modules have been updated to their latest versions:

  - [package 2.2.0](https://forge.puppet.com/puppetlabs/package/2.2.0/changelog)
  - [puppet_conf 1.3.0](https://forge.puppet.com/puppetlabs/puppet_conf/1.3.0/changelog)
  - [scheduled_task 3.1.0](https://forge.puppet.com/puppetlabs/scheduled_task/3.1.0/changelog)
  - [service 2.2.0](https://forge.puppet.com/puppetlabs/service/2.2.0/changelog)
  - [stdlib 8.2.0](https://forge.puppet.com/puppetlabs/stdlib/8.2.0/changelog)