### PR TITLE
(maint) Fix logic for detecting suitable Psych.parse invocation

### DIFF
--- a/lib/bolt/pal/yaml_plan/loader.rb
+++ b/lib/bolt/pal/yaml_plan/loader.rb
@@ -50,7 +50,7 @@ module Bolt
         def self.parse_plan(yaml_string, source_ref)
           # This passes the filename as the second arg for compatibility with Psych used with ruby < 2.6
           # This can be removed when we remove support for ruby 2.5
-          parse_tree = if Psych.method(:parse).parameters.rassoc(:filename)
+          parse_tree = if Psych.method(:parse).parameters.rassoc(:filename) == %i[key filename]
                          Psych.parse(yaml_string, filename: source_ref)
                        else
                          Psych.parse(yaml_string, source_ref)


### PR DESCRIPTION
In order to support the Psych module that ships with ruby >= 2.5 it is necessary to determine if
the `filename` argument should be positional or a keyword. Previosly this logic just checked if
a parameter called `filename` existed (which it does in the supported version range), the important
check is whether or not the argument should be positional or keyword. This commit updates the logic
to explicitly check if the argument is a keyword before invoking the parse method.

!no-release-note