### PR TITLE
(GH-2618) Add `catalog` to `ApplyResult` objects

### DIFF
--- a/bolt-modules/boltlib/lib/puppet/datatypes/applyresult.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/applyresult.rb
@@ -4,6 +4,13 @@
 # returns an `ApplyResult`. An `ApplyResult` is part of a `ResultSet` object and
 # contains information about the apply action.
 #
+# @param catalog
+#   The Puppet catalog used to configure the target. The catalog describes the desired state
+#   of the target. The catalog is masked with the `Sensitive` data type to protect any
+#   sensitive information in the catalog from being printed to the console or logs. To access
+#   the catalog, unwrap it using `$apply_result.catalog.unwrap`. For more information
+#   about catalogs and the catalog compilation process, see [Catalog
+#   compilation](https://puppet.com/docs/puppet/latest/subsystem_catalog_compilation.html).
 # @param report
 #   The Puppet report from the apply action. Equivalent to calling `ApplyResult.value['report']`.
 #   The report is a hash representation of the [`Puppet::Transaction::Report`
@@ -29,6 +36,7 @@
 Puppet::DataTypes.create_type('ApplyResult') do
   interface <<-PUPPET
     attributes => {
+      'catalog' => Sensitive[Hash[String[1], Data]],
       'report' => Hash[String[1], Data],
       'target' => Target
     },

--- a/bolt-modules/boltlib/lib/puppet/datatypes/applyresult.rb
+++ b/bolt-modules/boltlib/lib/puppet/datatypes/applyresult.rb
@@ -4,13 +4,6 @@
 # returns an `ApplyResult`. An `ApplyResult` is part of a `ResultSet` object and
 # contains information about the apply action.
 #
-# @param catalog
-#   The Puppet catalog used to configure the target. The catalog describes the desired state
-#   of the target. The catalog is masked with the `Sensitive` data type to protect any
-#   sensitive information in the catalog from being printed to the console or logs. To access
-#   the catalog, unwrap it using `$apply_result.catalog.unwrap`. For more information
-#   about catalogs and the catalog compilation process, see [Catalog
-#   compilation](https://puppet.com/docs/puppet/latest/subsystem_catalog_compilation.html).
 # @param report
 #   The Puppet report from the apply action. Equivalent to calling `ApplyResult.value['report']`.
 #   The report is a hash representation of the [`Puppet::Transaction::Report`
@@ -19,11 +12,20 @@
 #   keys](applying_manifest_blocks.md#result-keys).
 # @param target
 #   The target the result is from.
+# @param error
+#   An Error object constructed from the `_error` field of the result's value.
+# @param catalog
+#   The Puppet catalog used to configure the target. The catalog describes the
+#   desired state of the target. The catalog is masked with the `Sensitive` data
+#   type to protect any sensitive information in the catalog from being printed
+#   to the console or logs. Using this function automatically unwraps the
+#   catalog. For more information about catalogs and the catalog compilation
+#   process, see [Catalog
+#   compilation](https://puppet.com/docs/puppet/latest/subsystem_catalog_compilation.html).
+
 #
 # @!method action
 #   The action performed. `ApplyResult.action` always returns the string `apply`.
-# @!method error
-#   Returns an Error object constructed from the `_error` field of the result's value.
 # @!method message
 #   The `_output` field of the result's value.
 # @!method ok
@@ -36,12 +38,12 @@
 Puppet::DataTypes.create_type('ApplyResult') do
   interface <<-PUPPET
     attributes => {
-      'catalog' => Sensitive[Hash[String[1], Data]],
       'report' => Hash[String[1], Data],
-      'target' => Target
+      'target' => Target,
+      'error' => Optional[Error],
+      'catalog' => Optional[Hash]
     },
     functions => {
-      error => Callable[[], Optional[Error]],
       ok => Callable[[], Boolean],
       message => Callable[[], Optional[String]],
       action => Callable[[], String],

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -280,10 +280,8 @@ module Bolt
                   result
                 end
               else
-                sensitive_catalog = Puppet::Pops::Types::PSensitiveType::Sensitive.new(catalog)
-
                 arguments = {
-                  'catalog' => sensitive_catalog,
+                  'catalog' => Puppet::Pops::Types::PSensitiveType::Sensitive.new(catalog),
                   'plugins' => Puppet::Pops::Types::PSensitiveType::Sensitive.new(plugins),
                   'apply_settings' => @apply_settings,
                   '_task' => catalog_apply_task.name,
@@ -292,7 +290,7 @@ module Bolt
 
                 callback = proc do |event|
                   if event[:type] == :node_result
-                    event = event.merge(result: ApplyResult.from_task_result(event[:result], sensitive_catalog))
+                    event = event.merge(result: ApplyResult.from_task_result(event[:result], catalog))
                   end
                   @executor.publish_event(event)
                 end
@@ -300,7 +298,7 @@ module Bolt
                 options[:run_as] = @executor.run_as if @executor.run_as && !options.key?(:run_as)
 
                 results = transport.batch_task(batch, catalog_apply_task, arguments, options, &callback)
-                Array(results).map { |result| ApplyResult.from_task_result(result, sensitive_catalog) }
+                Array(results).map { |result| ApplyResult.from_task_result(result, catalog) }
               end
             end
           end

--- a/lib/bolt/apply_result.rb
+++ b/lib/bolt/apply_result.rb
@@ -96,17 +96,21 @@ module Bolt
     def _pcore_init_hash
       { 'target' => @target,
         'error' => value['_error'],
-        'report' => value['report'] }
+        'report' => value['report'],
+        'catalog' => catalog }
     end
 
     def initialize(target, error: nil, report: nil, catalog: nil)
       @target = target
       @value = {}
       @action = 'apply'
-      @value['catalog'] = catalog if catalog
       @value['report'] = report if report
       @value['_error'] = error if error
       @value['_output'] = metrics_message if metrics_message
+
+      if catalog
+        @value['_sensitive'] = Puppet::Pops::Types::PSensitiveType::Sensitive.new({ 'catalog' => catalog })
+      end
     end
 
     def event_metrics
@@ -140,7 +144,7 @@ module Bolt
     end
 
     def catalog
-      @value['catalog']
+      sensitive.unwrap['catalog'] if sensitive
     end
 
     def generic_value

--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -201,12 +201,10 @@ module Bolt
     def to_data
       serialized_value = safe_value
 
-      # if serialized_value.key?('_sensitive') &&
-      #    serialized_value['_sensitive'].is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive)
-      #   serialized_value['_sensitive'] = serialized_value['_sensitive'].to_s
-      # end
-
-      serialized_value.transform_values! { |v| v.is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive) ? v.to_s : v }
+      if serialized_value.key?('_sensitive') &&
+         serialized_value['_sensitive'].is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive)
+        serialized_value['_sensitive'] = serialized_value['_sensitive'].to_s
+      end
 
       {
         "target" => @target.name,

--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -200,16 +200,20 @@ module Bolt
 
     def to_data
       serialized_value = safe_value
-      if serialized_value.key?('_sensitive') &&
-         serialized_value['_sensitive'].is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive)
-        serialized_value['_sensitive'] = serialized_value['_sensitive'].to_s
-      end
+
+      # if serialized_value.key?('_sensitive') &&
+      #    serialized_value['_sensitive'].is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive)
+      #   serialized_value['_sensitive'] = serialized_value['_sensitive'].to_s
+      # end
+
+      serialized_value.transform_values! { |v| v.is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive) ? v.to_s : v }
+
       {
         "target" => @target.name,
         "action" => action,
         "object" => object,
         "status" => status,
-        "value" => serialized_value
+        "value"  => serialized_value
       }
     end
 

--- a/spec/unit/apply_result_spec.rb
+++ b/spec/unit/apply_result_spec.rb
@@ -12,8 +12,9 @@ describe Bolt::ApplyResult do
       "status" => "" }
   }
 
-  let(:task_result) { Bolt::Result.for_task(example_target, result_value.to_json, '', 0, 'catalog', []) }
-  let(:apply_result) { Bolt::ApplyResult.from_task_result(task_result) }
+  let(:catalog)      { Puppet::Pops::Types::PSensitiveType::Sensitive.new({}) }
+  let(:task_result)  { Bolt::Result.for_task(example_target, result_value.to_json, '', 0, 'catalog', []) }
+  let(:apply_result) { Bolt::ApplyResult.from_task_result(task_result, catalog) }
 
   describe '#puppet_missing_error' do
     it 'returns the nil if no identifiable errors are found' do
@@ -86,20 +87,24 @@ describe Bolt::ApplyResult do
   end
 
   describe 'exposes methods for examining data' do
-    let(:expected) {
+    let(:expected) do
       { "target" => "target",
         "action" => "apply",
         "object" => nil,
         "status" => "success",
-        "value" => { "report" => result_value } }
-    }
+        "value" => { "report" => result_value, "catalog" => catalog } }
+    end
+
+    let(:expected_data) do
+      expected.tap { |e| e['value']['catalog'] = e['value']['catalog'].to_s }
+    end
 
     it 'with to_json' do
-      expect(JSON.parse(apply_result.to_json)).to eq(expected)
+      expect(JSON.parse(apply_result.to_json)).to eq(expected_data)
     end
 
     it 'with to_data' do
-      expect(apply_result.to_data).to eq(expected)
+      expect(apply_result.to_data).to eq(expected_data)
     end
 
     it 'with value' do


### PR DESCRIPTION
This adds a `catalog` attribute to the `ApplyResult` object, which
includes the catalog used during an apply. The catalog is masked using
the `Sensitive` data type to prevent any sensitive information from
being printed to the console or logs.

!feature

* **Include catalog in `ApplyResult` objects**
  ([#2618](https://github.com/puppetlabs/bolt/issues/2618))

  The `ApplyResult` object now includes a `catalog` attribute that
  includes the catalog used during an apply. The catalog is masked using
  the `Sensitive` data type to prevent sensitive information in the
  catalog from being printed to the catalog or Bolt logs.