### PR TITLE
(maint) Increase timeouts for spec tests

### DIFF
--- a/spec/bolt_server/app_integration_spec.rb
+++ b/spec/bolt_server/app_integration_spec.rb
@@ -20,7 +20,7 @@ describe "BoltServer::TransportApp", puppetserver: true do
   end
 
   before(:all) do
-    wait_until_available(timeout: 30, interval: 1)
+    wait_until_available(timeout: 120, interval: 1)
   end
 
   after(:all) do

--- a/spec/bolt_server/file_cache_spec.rb
+++ b/spec/bolt_server/file_cache_spec.rb
@@ -13,7 +13,7 @@ describe BoltServer::FileCache, puppetserver: true do
   include BoltSpec::BoltServer
 
   before(:all) do
-    wait_until_available(timeout: 30, interval: 1)
+    wait_until_available(timeout: 120, interval: 1)
   end
 
   before(:each) do

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -24,7 +24,7 @@ describe 'running with an inventory file', reset_puppet_settings: true do
           conn[:protocol] => {
             user: conn[:user],
             port: conn[:port],
-            'connect-timeout': conn[:'connect-timeout'] || 10
+            'connect-timeout': conn[:'connect-timeout'] || 120
           }
         } },
       { name: 'uriless',

--- a/spec/integration/logging_spec.rb
+++ b/spec/integration/logging_spec.rb
@@ -242,7 +242,7 @@ describe 'streaming output over WinRM', winrm: true do
   let(:user)          { conn_info('winrm')[:user] }
   let(:whoami)        { '$env:UserName' }
   let(:err_cmd)       { '$host.ui.WriteErrorLine("error")' }
-  let(:config_flags)  { %W[--no-ssl --no-ssl-verify --connect-timeout 45 --password #{pw}] }
+  let(:config_flags)  { %W[--no-ssl --no-ssl-verify --connect-timeout 120 --password #{pw}] }
 
   include_examples 'streaming output'
 end

--- a/spec/integration/puppetdb/client_spec.rb
+++ b/spec/integration/puppetdb/client_spec.rb
@@ -161,7 +161,7 @@ describe Bolt::PuppetDB::Client do
     end
 
     before(:all) do
-      wait_until_available(timeout: 30, interval: 1)
+      wait_until_available(timeout: 120, interval: 1)
       push_facts(facts_hash)
     end
 

--- a/spec/integration/puppetdb/puppetdb_spec.rb
+++ b/spec/integration/puppetdb/puppetdb_spec.rb
@@ -13,7 +13,7 @@ describe Bolt::PuppetDB::Client, puppetdb: true do
 
   # Don't run any tests until PDB and puppetserver are responsive
   before(:all) do
-    wait_until_available(timeout: 30, interval: 1)
+    wait_until_available(timeout: 120, interval: 1)
   end
 
   context '#send_command' do

--- a/spec/integration/transport/winrm_spec.rb
+++ b/spec/integration/transport/winrm_spec.rb
@@ -44,7 +44,7 @@ describe Bolt::Transport::WinRM, winrm_transport: true do
 
   def mk_config(conf)
     conf = Bolt::Util.walk_keys(conf, &:to_s)
-    conf['connect-timeout'] ||= 45
+    conf['connect-timeout'] ||= 120
     conf
   end
 

--- a/spec/integration/winrm_spec.rb
+++ b/spec/integration/winrm_spec.rb
@@ -20,7 +20,7 @@ describe "when runnning over the winrm transport", winrm: true do
   context 'when using CLI options' do
     let(:config_flags) {
       %W[--targets #{uri} --no-ssl --no-ssl-verify --format json --modulepath #{modulepath}
-         --password #{password} --connect-timeout 45]
+         --password #{password} --connect-timeout 120]
     }
 
     it 'runs a command' do
@@ -107,7 +107,7 @@ describe "when runnning over the winrm transport", winrm: true do
             'password' => password,
             'ssl' => false,
             'ssl-verify' => false,
-            'connect-timeout' => 45
+            'connect-timeout' => 120
           }
         }
       }

--- a/spec/lib/bolt_spec/conn.rb
+++ b/spec/lib/bolt_spec/conn.rb
@@ -22,7 +22,7 @@ module BoltSpec
       when 'winrm'
         default_port      = 25985
         additional_config = { ssl: false,
-                              'connect-timeout': 45 }
+                              'connect-timeout': 120 }
       when 'docker', 'podman'
         default_user     = ''
         default_password = ''


### PR DESCRIPTION
This increases the timeouts for spec tests to 120. This should help
prevent tests from failing when PuppetDB/PuppetServer are slow to start
or connections to the WinRM runner are slow.

!no-release-note