### PR TITLE
(GH-3106) Retrieve fact values using named PDB instance

### DIFF
--- a/lib/bolt/plugin/puppetdb.rb
+++ b/lib/bolt/plugin/puppetdb.rb
@@ -88,7 +88,7 @@ module Bolt
 
         facts.uniq!
         # Returns {'mycertname' => [{'path' => ['nested', 'fact'], 'value' => val'}], ... }
-        fact_values = @puppetdb_client.fact_values(targets, facts)
+        fact_values = @puppetdb_client.fact_values(targets, facts, opts['instance'])
 
         targets.map do |certname|
           target_data = fact_values[certname]


### PR DESCRIPTION
This fixes a bug where the `puppetdb` was correctly querying certnames
from a named PuppetDB instance, but was not collecting fact values from
the named PuppetDB instance. The `puppetdb` plugin now correctly
connects to the named instance when querying certnames and collecting
fact values.

!bug

* **Collect fact values from a named PuppetDB instance using `puppetdb`
  plugin**
  ([#3106](https://github.com/puppetlabs/bolt/issues/3106))

  The `puppetdb` plugin now correctly connects to a named PuppetDB
  instance when collecting fact values. Previously, the plugin only
  connected to the named PuppetDB instance when querying certnames.