### PR TITLE
(BOLT-1527) Execute commands over winrm in separate shell instances

### DIFF
--- a/spec/integration/parallel_spec.rb
+++ b/spec/integration/parallel_spec.rb
@@ -276,7 +276,8 @@ Undef:}
        '--verbose',
        '--password', conn_info('winrm')[:password],
        '--no-ssl',
-       '--no-ssl-verify']
+       '--no-ssl-verify',
+       '--connect-timeout', '120']
     }
 
     include_examples 'parallelize plan function'

--- a/spec/integration/transport/winrm_spec.rb
+++ b/spec/integration/transport/winrm_spec.rb
@@ -67,7 +67,7 @@ describe Bolt::Transport::WinRM, winrm_transport: true do
   def stub_winrm_to_raise(klass, message)
     shell = double('powershell')
     allow_any_instance_of(WinRM::Connection)
-      .to receive(:shell).and_return(shell)
+      .to receive(:shell).and_yield(shell)
     allow(shell).to receive(:run).and_raise(klass, message)
     allow(shell).to receive(:close)
   end


### PR DESCRIPTION
This updates the `winrm` transport to execute each command from Bolt in
a separate shell instance. Previously, the `winrm` transport opened a
single shell instance and ran all commands through it. This prevented
tasks and scripts that load DLLs from executing Bolt's cleanup command,
as DLLs cannot be unloaded when the shell instance that loaded them is
still running. Now, any task or script executed over `winrm` is executed
in a separate shell instance from the cleanup command, allowing DLLs to
be unloaded and removed from the temp directory when they are no longer
needed.

!bug

* **Execute commands over `winrm` in separate shell instances**

  Bolt now opens a new shell instance each time it runs a command over
  `winrm`. Previously, Bolt used a single shell instance to run all
  commands, preventing Bolt from properly cleaning up temporary files in
  some instances.