### PR TITLE
(maint) Properly configure bundler in bolt-server build

### DIFF
--- a/Dockerfile.bolt-server
+++ b/Dockerfile.bolt-server
@@ -2,15 +2,15 @@
 FROM alpine:3.14 as build
 
 RUN \
-apk --no-cache add build-base ruby-dev ruby-bundler ruby-json ruby-bigdecimal git openssl-dev linux-headers && \
-echo 'gem: --no-document' > /etc/gemrc && \
-bundle config --global silence_root_warning 1
+  apk --no-cache add build-base ruby-dev ruby-bundler ruby-json ruby-bigdecimal git openssl-dev linux-headers \
+  && echo 'gem: --no-document' > /etc/gemrc \
+  && mkdir /bolt-server
 
-RUN mkdir /bolt-server
 # Gemfile requires gemspec which requires bolt/version which requires bolt
 ADD . /bolt-server
 WORKDIR /bolt-server
-RUN bundle config set path 'vendor/bundle' \
+RUN bundle config --local silence_root_warning 1 \
+  && bundle config --local path 'vendor/bundle' \
   && bundle install --no-cache --jobs=$(nproc)
 
 # Final image

--- a/config/docker.conf
+++ b/config/docker.conf
@@ -3,6 +3,7 @@ bolt-server: {
     ssl-key: "spec/fixtures/ssl/key.pem"
     ssl-ca-cert: "spec/fixtures/ssl/ca.pem"
     file-server-uri: "https://spec_puppetserver_1:8140"
+    projects-dir: "/opt/puppetlabs/server/data/orchestration-services/projects"
     loglevel: debug
     host: "0.0.0.0"
 }


### PR DESCRIPTION
Previously we were setting bundler config options at the user level in
the build container, which meant they didn't get copied over to the
runtime container. That caused gems not to be found at runtime. We now
set them in the local .bundle/config file so they get copied over to the
final build.