### PR TITLE
Stop submitting sensitive param values to plan_start command

### DIFF
--- a/lib/bolt/transport/orch/connection.rb
+++ b/lib/bolt/transport/orch/connection.rb
@@ -6,7 +6,7 @@ module Bolt
       class Connection
         attr_reader :logger, :key
 
-        CONTEXT_KEYS = Set.new(%i[plan_name description params]).freeze
+        CONTEXT_KEYS = Set.new(%i[plan_name description params sensitive]).freeze
 
         def self.get_key(opts)
           [
@@ -46,6 +46,7 @@ module Bolt
           if plan_context
             begin
               opts = plan_context.select { |k, _| CONTEXT_KEYS.include? k }
+              opts[:params] = opts[:params].reject { |k, _| plan_context[:sensitive].include?(k) }
               @client.command.plan_start(opts)['name']
             rescue OrchestratorClient::ApiError => e
               if e.code == '404'

--- a/spec/integration/parallel_spec.rb
+++ b/spec/integration/parallel_spec.rb
@@ -55,8 +55,8 @@ describe 'plans' do
     end
 
     it "fails immediately when a Puppet error is raised" do
-      expect { run_cli_json(%w[plan run parallel::hard_fail] + config_flags) }
-        .to raise_error(Bolt::PAL::PALError, /This Name has no effect./)
+      result = run_cli_json(%w[plan run parallel::hard_fail] + config_flags)
+      expect(result['msg']).to match(/This Name has no effect./)
     end
 
     it "runs normally when no steps are parallelizable" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,6 +76,7 @@ RSpec.configure do |config|
   config.after :each do
     Bolt::Logger.stream    = nil
     Bolt::Logger.analytics = nil
+    YARD::Registry.clear if defined?(YARD::Registry)
   end
 
   # This will be default in future rspec, leave it on

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -254,10 +254,8 @@ describe Bolt::Application do
     it 'errors if targets are specified twice' do
       params = { 'targets' => targets }
 
-      expect { application.run_plan(plan, targets, params: params) }.to raise_error(
-        Bolt::CLIError,
-        /A plan's 'targets' parameter can be specified using the --targets option/
-      )
+      result = application.run_plan(plan, targets, params: params)
+      expect(result.value.msg).to match(/A plan's 'targets' parameter can be specified using the --targets option/)
     end
   end
 


### PR DESCRIPTION
Previously, we sent all supplied parameter values to the plan_start
command, which meant Orchestrator stored and returned sensitive values.
We now use the plan metadata to remove sensitive values and send them in
a separate `sensitive` array. This allows the names to be stored and
returned without the values, so we can indicate *which* parameters were
used without exposing sensitive data.

When run against versions of PE that don't support the `sensitive`
array, it will just look like those params were never supplied.