### PR TITLE
(maint) Pin net-ssh to < 7.0

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "logging", "~> 2.2"
   spec.add_dependency "minitar", "~> 0.6"
   spec.add_dependency "net-scp", "~> 1.2"
-  spec.add_dependency "net-ssh", ">= 4.0"
+  spec.add_dependency "net-ssh", ">= 4.0", "< 7.0"
   spec.add_dependency "net-ssh-krb", "~> 0.5"
   spec.add_dependency "orchestrator_client", "~> 0.5"
   spec.add_dependency "puppet", ">= 6.18.0"


### PR DESCRIPTION
This pins the max version of net-ssh to < 7.0. net-ssh >= 7.0
requires Ruby >= 2.6, which we cannot ship since Bolt needs to be
compatible with Ruby >= 2.5.

!no-release-note