### PR TITLE
(bug) Correctly print secret key paths when using rainbow format

### DIFF
--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -2,6 +2,7 @@
 
 require_relative '../../bolt/container_result'
 require_relative '../../bolt/pal'
+require_relative '../../bolt/util/format'
 
 module Bolt
   class Outputter
@@ -890,7 +891,7 @@ module Bolt
       end
 
       def print_message(message)
-        @stream.puts(message)
+        @stream.puts(Bolt::Util::Format.stringify(message))
       end
 
       def print_error(message)

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../../bolt/util/format'
+
 module Bolt
   class Outputter
     class JSON < Bolt::Outputter
@@ -190,7 +192,7 @@ module Bolt
       end
 
       def print_message(message)
-        $stderr.puts(message)
+        $stderr.puts(Bolt::Util::Format.stringify(message))
       end
       alias print_error print_message
 

--- a/lib/bolt/outputter/rainbow.rb
+++ b/lib/bolt/outputter/rainbow.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../bolt/pal'
+require_relative '../../bolt/util/format'
 
 module Bolt
   class Outputter
@@ -110,7 +111,7 @@ module Bolt
       end
 
       def print_message(message)
-        @stream.puts colorize(:rainbow, message)
+        @stream.puts colorize(:rainbow, Bolt::Util::Format.stringify(message))
       end
     end
   end

--- a/spec/integration/plugin/module_spec.rb
+++ b/spec/integration/plugin/module_spec.rb
@@ -233,14 +233,14 @@ describe 'using module based plugins' do
       result = run_cli(%w[secret encrypt secret_msg --plugin my_secret] + config_flags,
                        outputter: Bolt::Outputter::Human)
       # This is kind of brittle and we look for plaintext_value because this is really the identity task
-      expect(result).to match(/"plaintext_value"=>"secret_msg"/)
+      expect(result).to match(/"plaintext_value": "secret_msg"/)
     end
 
     it 'calls the decrypt task' do
       result = run_cli(%w[secret decrypt secret_msg --plugin my_secret] + config_flags,
                        outputter: Bolt::Outputter::Human)
       # This is kind of brittle and we look for "encrypted_value because this is really the identity task
-      expect(result).to match(/"encrypted_value"=>"secret_msg"/)
+      expect(result).to match(/"encrypted_value": "secret_msg"/)
     end
   end
 


### PR DESCRIPTION
This fixes a bug that caused bolt to error when running `bolt secret
createkeys --format rainbow`.

!bug

* **Correctly print secret key paths when using rainbow format**

  Bolt no longer errors when running `bolt secret createkeys --format
  rainbow` or `New-BoltSecretKey -Format rainbow`.