### PR TITLE
Add interpreters config option to LXD transport

### DIFF
--- a/lib/bolt/config/transport/lxd.rb
+++ b/lib/bolt/config/transport/lxd.rb
@@ -9,6 +9,7 @@ module Bolt
       class LXD < Base
         OPTIONS = %w[
           cleanup
+          interpreters
           remote
           tmpdir
         ].concat(RUN_AS_OPTIONS).sort.freeze
@@ -17,6 +18,14 @@ module Bolt
           'cleanup' => true,
           'remote'  => 'local'
         }.freeze
+
+        private def validate
+          super
+
+          if @config['interpreters']
+            @config['interpreters'] = normalize_interpreters(@config['interpreters'])
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This allows setting a custom Ruby path, which may come in handy when
using Puppet and Ruby packages provided by the distro itself (e.g. Arch
Linux) instead of the official Puppetlabs packages.

This change, together with setting `features: ['puppet-agent']`, allows
`bolt apply` to run against LXD containers with non-default Puppet and
Ruby paths.

!feature

* **Support interpreters in LXD transport configuration** ([#3013](https://github.com/puppetlabs/bolt/issues/3013))

Bolt now also supports setting the interpreters configuration option on LXD
transports.