### PR TITLE
(maint) Do not fail fast for unit tests

### DIFF
--- a/rakelib/tests.rake
+++ b/rakelib/tests.rake
@@ -16,7 +16,6 @@ begin
     desc "Run RSpec tests that do not require VM fixtures or a particular shell"
     RSpec::Core::RakeTask.new(:unit) do |t|
       t.pattern = "spec/unit/**/*_spec.rb"
-      t.rspec_opts = "--fail-fast"
     end
 
     desc 'Run tests that require a host System Under Test configured with WinRM'


### PR DESCRIPTION
This removes the `--fail-fast` flag when running RSpec unit tests.
Previously, the unit test suite would fail as soon as a single test case
failed, which prevented us from seeing all tests that would have failed
in a run. Removing this flag will now let RSpec run all tests and show
all failures in the test suite, allowing for faster development.

!no-release-note