### PR TITLE
(GH-3122) Update character restrictions on target, group, and alias names

### DIFF
--- a/lib/bolt/inventory/target.rb
+++ b/lib/bolt/inventory/target.rb
@@ -8,6 +8,11 @@ module Bolt
     class Target
       attr_reader :name, :uri, :safe_name, :target_alias, :resources
 
+      # Illegal characters that are not permitted in target names.
+      # These characters are delimiters for target and group names and allowing
+      # them would cause unexpected behavior.
+      ILLEGAL_CHARS = /[\s,]/.freeze
+
       def initialize(target_data, inventory)
         unless target_data['name'] || target_data['uri']
           raise Bolt::Inventory::ValidationError.new("Target must have either a name or uri", nil)
@@ -148,6 +153,10 @@ module Bolt
       def validate
         unless name.ascii_only?
           raise Bolt::Inventory::ValidationError.new("Target name must be ASCII characters: #{@name}", nil)
+        end
+
+        if (illegal_char = @name.match(ILLEGAL_CHARS))
+          raise ValidationError.new("Illegal character '#{illegal_char}' in target name '#{@name}'", nil)
         end
 
         unless transport.nil? || Bolt::TRANSPORTS.include?(transport.to_sym)

--- a/spec/unit/inventory/group_spec.rb
+++ b/spec/unit/inventory/group_spec.rb
@@ -579,19 +579,6 @@ describe Bolt::Inventory::Group do
       it { expect { group }.to raise_error(/Alias entry on target1 must be a String or Array/) }
     end
 
-    context 'invalid alias name' do
-      let(:data) do
-        {
-          'name' => 'root',
-          'targets' => [
-            { 'name' => 'target1', 'alias' => 'not a valid alias' }
-          ]
-        }
-      end
-
-      it { expect { group }.to raise_error(/Invalid alias not a valid alias/) }
-    end
-
     context 'validating alias names' do
       let(:data) do
         {
@@ -602,17 +589,17 @@ describe Bolt::Inventory::Group do
         }
       end
 
-      %w[alias1 _alias1 1alias 1_alias_ alias-1 a 1].each do |alias_name|
+      %w[alias1 _alias1 1alias 1_alias_ alias-1 a 1 alias.1].each do |alias_name|
         it "accepts '#{alias_name}'" do
           @alias = alias_name
           expect(group.target_aliases).to eq(alias_name => 'target1')
         end
       end
 
-      %w[-alias1 alias/1 alias.1 - Alias1 ALIAS_1].each do |alias_name|
+      ['foo bar', 'foo,bar'].each do |alias_name|
         it "rejects '#{alias_name}'" do
           @alias = alias_name
-          expect { group }.to raise_error(/Invalid alias/)
+          expect { group }.to raise_error(/Illegal character/)
         end
       end
     end

--- a/spec/unit/inventory/target_spec.rb
+++ b/spec/unit/inventory/target_spec.rb
@@ -54,4 +54,12 @@ describe Bolt::Inventory::Target do
       )
     end
   end
+
+  context 'validating target name' do
+    ['foo bar', 'foo,bar'].each do |name|
+      it "rejects #{name}" do
+        expect { described_class.new({ 'name' => name }, inventory) }.to raise_error(/Illegal character/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This updates the regex used to validate group and alias names to be more
permissive with the characters that can be included in the name.
Previously, group and alias names were restricted to letters, digits,
underscores, and hyphens. This updates the regex to allow any character
other than whitespace or commas (as these are used as delimiters for
target and group names when retrieving targets from inventory).

!feature

* **Allow larger set of characters in group and alias names**
  ([#3122](https://github.com/puppetlabs/bolt/issues/3122))

  Group and alias names can now include any character other than
  whitespace characters and commas.

---

This updates target validation to raise an error if a target name
includes a whitespace character or comma. These characters are used as
delimiters for target and group names when retrieving targets from
inventory, and allowing them in target names causes problems.

!bug

* **Restrict whitespace characters and commas in target names**

  Bolt now raises a validation error when a target name includes a
  whitespace character or comma. Previously, these characters were
  allowed, but Bolt would not be able to retrieve the target from the
  inventory by name.