### PR TITLE
(maint) Update workflow triggers

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -1,12 +1,18 @@
 name: Apply
 
 on:
-  push:
-    branches: [main]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
     types: [opened, reopened, edited, synchronize]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
+    paths:
+      - .github/workflows/apply.yaml
+      - bolt.gemspec
+      - Gemfile
+      - Puppetfile
+      - bolt-modules/**
+      - lib/bolt/**
+      - libexec/**
+      - rakelib/tests.rake
+      - spec/**
 
 env:
   BOLT_WINRM_USER: roddypiper

--- a/.github/workflows/bolt_server.yaml
+++ b/.github/workflows/bolt_server.yaml
@@ -1,12 +1,19 @@
 name: Bolt Server
 
 on:
-  push:
-    branches: [main]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
     types: [opened, reopened, edited, synchronize]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
+    paths:
+      - .github/workflows/bolt_server.yaml
+      - bolt.gemspec
+      - Gemfile
+      - Puppetfile
+      - bolt-modules/**
+      - lib/bolt/**
+      - lib/bolt_server/**
+      - libexec/**
+      - rakelib/tests.rake
+      - spec/**
 
 env:
   BOLT_WINRM_USER: roddypiper

--- a/.github/workflows/bolt_spec.yaml
+++ b/.github/workflows/bolt_spec.yaml
@@ -1,12 +1,19 @@
 name: BoltSpec
 
 on:
-  push:
-    branches: [main]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
     types: [opened, reopened, edited, synchronize]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
+    paths:
+      - .github/workflows/bolt_spec.yaml
+      - bolt.gemspec
+      - Gemfile
+      - Puppetfile
+      - bolt-modules/**
+      - lib/bolt/**
+      - lib/bolt_spec/**
+      - libexec/**
+      - rakelib/tests.rake
+      - spec/**
 
 env:
   BOLT_WINRM_USER: roddypiper

--- a/.github/workflows/docker_transport.yaml
+++ b/.github/workflows/docker_transport.yaml
@@ -1,12 +1,18 @@
 name: Docker transport
 
 on:
-  push:
-    branches: [main]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
     types: [opened, reopened, edited, synchronize]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
+    paths:
+      - .github/workflows/docker_transport.yaml
+      - bolt.gemspec
+      - Gemfile
+      - Puppetfile
+      - bolt-modules/**
+      - lib/bolt/**
+      - libexec/**
+      - rakelib/tests.rake
+      - spec/**
 
 jobs:
   docker_transport:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,12 +1,19 @@
 name: Docs
 
 on:
-  push:
-    branches: [main]
-    paths-ignore: ['schemas/*']
   pull_request:
     types: [opened, reopened, edited, synchronize]
-    paths-ignore: ['schemas/*']
+    paths:
+      - .github/workflows/docs.yaml
+      - bolt.gemspec
+      - Gemfile
+      - Puppetfile
+      - bolt-modules/**
+      - documentation/**
+      - lib/bolt/**
+      - modules/**
+      - pwsh_module/**
+      - rakelib/docs.rake
 
 jobs:
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,12 +1,11 @@
 name: Linting
 
 on:
-  push:
-    branches: [main]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
     types: [opened, reopened, edited, synchronize]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
+    paths:
+      - .github/workflows/lint.yaml
+      - '**.rb'
 
 jobs:
 

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -1,12 +1,18 @@
 name: Linux
 
 on:
-  push:
-    branches: [main]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
     types: [opened, reopened, edited, synchronize]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
+    paths:
+      - .github/workflows/linux.yaml
+      - bolt.gemspec
+      - Gemfile
+      - Puppetfile
+      - bolt-modules/**
+      - lib/bolt/**
+      - libexec/**
+      - rakelib/tests.rake
+      - spec/**
 
 jobs:
   integration:

--- a/.github/workflows/local_transport.yaml
+++ b/.github/workflows/local_transport.yaml
@@ -1,12 +1,18 @@
 name: Local Transport
 
 on:
-  push:
-    branches: [main]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
     types: [opened, reopened, edited, synchronize]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
+    paths:
+      - .github/workflows/local_transport.yaml
+      - bolt.gemspec
+      - Gemfile
+      - Puppetfile
+      - bolt-modules/**
+      - lib/bolt/**
+      - libexec/**
+      - rakelib/tests.rake
+      - spec/**
 
 env:
   BOLT_WINRM_USER: roddypiper

--- a/.github/workflows/modules.yaml
+++ b/.github/workflows/modules.yaml
@@ -1,12 +1,18 @@
 name: Modules
 
 on:
-  push:
-    branches: [main]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
     types: [opened, reopened, edited, synchronize]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
+    paths:
+      - .github/workflows/modules.yaml
+      - bolt.gemspec
+      - Gemfile
+      - Puppetfile
+      - bolt-modules/**
+      - bolt_spec_spec/**
+      - lib/bolt/**
+      - modules/**
+      - rakelib/tests.rake
 
 jobs:
   linux:

--- a/.github/workflows/orch_transport.yaml
+++ b/.github/workflows/orch_transport.yaml
@@ -1,12 +1,18 @@
 name: Orch Transport
 
 on:
-  push:
-    branches: [main]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
     types: [opened, reopened, edited, synchronize]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
+    paths:
+      - .github/workflows/orch_transport.yaml
+      - bolt.gemspec
+      - Gemfile
+      - Puppetfile
+      - bolt-modules/**
+      - lib/bolt/**
+      - libexec/**
+      - rakelib/tests.rake
+      - spec/**
 
 env:
   BOLT_WINRM_USER: roddypiper

--- a/.github/workflows/pwsh.yaml
+++ b/.github/workflows/pwsh.yaml
@@ -1,12 +1,13 @@
 name: pwsh
 
 on:
-  push:
-    branches: [master]
-    paths: ['pwsh_module/*']
   pull_request:
     types: [opened, reopened, edited, synchronize]
-    paths: ['pwsh_module/*', 'lib/bolt/bolt_option_parser.rb', 'rakelib/pwsh.rake']
+    paths:
+      - .github/workflows/pwsh.yaml
+      - pwsh_module/*
+      - lib/bolt/bolt_option_parser.rb
+      - rakelib/pwsh.rake
 
 jobs:
 

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -3,18 +3,11 @@ name: Release Notes
 on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
-    paths-ignore: 
-      - '*.md'
-      - '**.md'
-      - '**.erb'
-      - 'lib/bolt_server/**'
-      - 'spec/**'
-      - 'acceptance/**'
-      - 'bolt_spec_spec/**'
-      - 'config/**'
-      - '.github/**'
-      - 'rakelib/**'
-      - 'Dockerfile.bolt-server'
+    paths:
+      - Puppetfile
+      - bolt-modules/**
+      - lib/bolt/**
+      - modules/**
 
 jobs:
 

--- a/.github/workflows/schemas.yaml
+++ b/.github/workflows/schemas.yaml
@@ -1,20 +1,14 @@
 name: Schemas
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'rakelib/schemas.rake'
-      - 'schemas/*.json'
-      - 'lib/bolt/config/options.rb'
-      - 'lib/bolt/config/transport/*'
   pull_request:
     types: [opened, reopened, edited, synchronize]
     paths:
-      - 'rakelib/schemas.rake'
-      - 'schemas/*.json'
-      - 'lib/bolt/config/options.rb'
-      - 'lib/bolt/config/transport/options.rb'
+      - lib/bolt/config/options.rb
+      - lib/bolt/config/transport/**
+      - lib/bolt/inventory/options.rb
+      - rakelib/schemas.rake
+      - schemas/*.json
 
 jobs:
 

--- a/.github/workflows/ssh_transport.yaml
+++ b/.github/workflows/ssh_transport.yaml
@@ -1,12 +1,18 @@
 name: SSH Transport
 
 on:
-  push:
-    branches: [main]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
     types: [opened, reopened, edited, synchronize]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
+    paths:
+      - .github/workflows/ssh_transport.yaml
+      - bolt.gemspec
+      - Gemfile
+      - Puppetfile
+      - bolt-modules/**
+      - lib/bolt/**
+      - libexec/**
+      - rakelib/tests.rake
+      - spec/**
 
 jobs:
   ssh_transport:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,12 +1,18 @@
 name: Unit tests
 
 on:
-  push:
-    branches: [main]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
     types: [opened, reopened, edited, synchronize]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
+    paths:
+      - .github/workflows/unit.yaml
+      - bolt.gemspec
+      - Gemfile
+      - Puppetfile
+      - bolt-modules/**
+      - lib/bolt/**
+      - libexec/**
+      - rakelib/tests.rake
+      - spec/**
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,12 +1,18 @@
 name: Windows
 
 on:
-  push:
-    branches: [main]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
     types: [opened, reopened, edited, synchronize]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
+    paths:
+      - .github/workflows/windows.yaml
+      - bolt.gemspec
+      - Gemfile
+      - Puppetfile
+      - bolt-modules/**
+      - lib/bolt/**
+      - libexec/**
+      - rakelib/tests.rake
+      - spec/**
 
 env:
   BOLT_WINRM_USER: roddypiper

--- a/.github/workflows/winrm_transport.yaml
+++ b/.github/workflows/winrm_transport.yaml
@@ -1,12 +1,18 @@
 name: WinRM Transport
 
 on:
-  push:
-    branches: [main]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
   pull_request:
     types: [opened, reopened, edited, synchronize]
-    paths-ignore: ['**.md', '**.erb', 'schemas/*']
+    paths-ignore:
+      - .github/workflows/winrm_transport.yaml
+      - bolt.gemspec
+      - Gemfile
+      - Puppetfile
+      - bolt-modules/**
+      - lib/bolt/**
+      - libexec/**
+      - rakelib/tests.rake
+      - spec/**
 
 env:
   BOLT_WINRM_USER: roddypiper


### PR DESCRIPTION
This does two things:

1. Removes `push` as a trigger for workflows in CI.

   Because puppetlabs repositories no longer allow for pushing to the
   main branch, and because workflows are already triggered for all pull
   requests, there is no longer a need to run workflows for pushes to
   main.

2. Update paths that trigger workflows in CI.

   Paths that trigger workflows have been updated. This limits the tests
   that will run when certain files are modified in a pull request. For
   example, spec tests will no longer run when files in the
   `acceptance/` directory are modified.

!no-release-note