### PR TITLE
(maint) Update trigger for WinRM transport workflow

### DIFF
--- a/.github/workflows/winrm_transport.yaml
+++ b/.github/workflows/winrm_transport.yaml
@@ -3,7 +3,7 @@ name: WinRM Transport
 on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
-    paths-ignore:
+    paths:
       - .github/workflows/winrm_transport.yaml
       - bolt.gemspec
       - Gemfile


### PR DESCRIPTION
This fixes the trigger for the WinRM transport workflow to `paths`
instead of `paths-ignore`. Previously, the workflow only ran when files
that do not affect the transport were modified, which is backwards.

!no-release-note