### PR TITLE
(GH-2818) Support globbing group names

### DIFF
--- a/spec/unit/inventory/inventory_spec.rb
+++ b/spec/unit/inventory/inventory_spec.rb
@@ -307,6 +307,11 @@ describe Bolt::Inventory::Inventory do
                                                     target9])
         end
 
+        it 'globs against group names' do
+          targets = inventory.get_targets('group*')
+          expect(targets.map(&:name).sort).to eq(%w[ssh://target8 target4 target5 target6 target7 target9])
+        end
+
         it 'should fail if wildcard selector matches nothing' do
           expect {
             inventory.get_targets('*target')


### PR DESCRIPTION
This updates the inventory to support globbing group names in addition
to target names and aliases.

!feature

* **Support globbing group names**
  ([#2818](https://github.com/puppetlabs/bolt/issues/2818))

  Bolt now supports selecting group names with glob patterns when
  selecting targets.