### PR TITLE
(maint) Trigger stale workflow manually, increase operations per run

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -3,6 +3,7 @@ name: 'Close stale issues and PRs'
 on:
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   stale:
@@ -10,6 +11,7 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
+          operations-per-run: 1000
           exempt-issue-labels: Ready for Engineering
           exempt-pr-labels: Blocked,Do Not Merge
           stale-issue-message: |


### PR DESCRIPTION
This updates the "Stale" workflow so it can be triggered manually and
also increases the number of operations allowed per run.