### PR TITLE
(hack) Add `bolt script show` and `Get-BoltScript` commands

### DIFF
--- a/lib/bolt/application.rb
+++ b/lib/bolt/application.rb
@@ -631,6 +631,42 @@ module Bolt
       end
     end
 
+    # Show scripts available to the project.
+    #
+    # @param filter [String] A substring to filter scripts by.
+    # @return [Hash]
+    #
+    def list_scripts(filter: nil)
+      {
+        scripts:    filter_content(pal.list_scripts, filter),
+        modulepath: pal.user_modulepath
+      }
+    end
+
+    # Show a script.
+    #
+    # @param script [String] The name of the script.
+    # @return [Hash]
+    #
+    def show_script(script)
+      path = find_file(script)
+
+      unless File.readable?(path)
+        raise Bolt::Error.new(
+          "The script #{script} does not exist or is not readable.",
+          'bolt/unknown-script-error'
+        )
+      end
+
+      content = File.read(path)
+
+      {
+        filepath: path,
+        name:     script,
+        script:   content
+      }
+    end
+
     # Generate a keypair using the configured secret plugin.
     #
     # @param force [Boolean] Forcibly create a keypair.

--- a/lib/bolt/application.rb
+++ b/lib/bolt/application.rb
@@ -638,7 +638,7 @@ module Bolt
     #
     def list_scripts(filter: nil)
       {
-        scripts:    filter_content(pal.list_scripts, filter),
+        scripts:    filter_content(pal.list_scripts(filter_content: true), filter),
         modulepath: pal.user_modulepath
       }
     end

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -146,6 +146,9 @@ module Bolt
         when 'run'
           { flags: ACTION_OPTS + %w[tmpdir env-var],
             banner: SCRIPT_RUN_HELP }
+        when 'show'
+          { flags: OPTIONS[:global] + OPTIONS[:global_config_setters] + %w[filter format],
+            banner: SCRIPT_SHOW_HELP }
         else
           { flags: OPTIONS[:global],
             banner: SCRIPT_HELP }
@@ -219,7 +222,7 @@ module Bolt
           plugin            Show available plugins
           policy            Apply, create, and show policies
           project           Create and migrate Bolt projects
-          script            Upload a local script and run it remotely
+          script            Show and run scripts
           secret            Create encryption keys and encrypt and decrypt values
           task              Show and run Bolt tasks
 
@@ -783,13 +786,14 @@ module Bolt
           bolt script <action> [options]
 
       #{colorize(:cyan, 'Description')}
-          Run a script on the specified targets.
+          Show and run scripts.
 
       #{colorize(:cyan, 'Documentation')}
           Learn more about running scripts at https://pup.pt/bolt-commands.
 
       #{colorize(:cyan, 'Actions')}
-          run         Run a script on the specified targets.
+          run         Run a script on the specified targets
+          show        Show available scripts
     HELP
 
     SCRIPT_RUN_HELP = <<~HELP
@@ -812,6 +816,33 @@ module Bolt
 
       #{colorize(:cyan, 'Examples')}
           bolt script run myscript.sh 'echo hello' --targets target1,target2
+    HELP
+
+    SCRIPT_SHOW_HELP = <<~HELP
+      #{colorize(:cyan, 'Name')}
+          script show
+
+      #{colorize(:cyan, 'Usage')}
+          bolt script show [script] [options]
+            [options]
+
+      #{colorize(:cyan, 'Description')}
+          Show available scripts.
+
+          This command only shows scripts that are saved to a module or project's
+          'scripts/' and 'files/scripts/' directories. If you have scripts saved to
+          a module or project's 'files/' directory, they will not appear in the
+          output for this command.
+
+          Script names follow the convention 'MODULE/scripts/SCRIPT'
+          and 'MODULE/files/scripts/SCRIPT'.
+
+          When showing a specific script, Bolt will print the script's contents
+          to the console.
+
+      #{colorize(:cyan, 'Examples')}
+          bolt script show
+          bolt script show my_module/scripts/my_script.py
     HELP
 
     SECRET_HELP = <<~HELP

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -491,6 +491,19 @@ module Bolt
           _example: false,
           _default: true
         },
+        "scripts" => {
+          description: "A list of scripts and glob patterns to filter the project's scripts by. This option is used "\
+                       "to limit the visibility of scripts for users of the project. For example, project authors "\
+                       "might want to limit the visibility of scripts that should only be run as part of a larger "\
+                       "workflow. When this option is not configured, all scripts are visible. This option does "\
+                       "not prevent users from running scripts that are not part of this list.",
+          type: Array,
+          items: {
+            type: String
+          },
+          _plugin: false,
+          _example: ["myproject/scripts/*", "myproject/files/scripts/myscript.py"]
+        },
         "spinner" => {
           description: "Whether to print a spinner to the console for long-running Bolt operations.",
           type: [TrueClass, FalseClass],
@@ -655,6 +668,7 @@ module Bolt
         puppetdb-instances
         rerunfile
         save-rerun
+        scripts
         spinner
         stream
         tasks

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -707,6 +707,52 @@ module Bolt
         @stream.puts info.chomp
       end
 
+      # Prints a script.
+      #
+      # @param filepath [String] The path to the script.
+      # @param name [String] The script's name.
+      # @param script [String] The script content.
+      #
+      def print_script_info(filepath:, name:, script:)
+        command = if Bolt::Util.powershell?
+                    'Invoke-BoltScript -Name <SCRIPT NAME> -Targets <TARGETS> [ARGS]'
+                  else
+                    'bolt script run <SCRIPT NAME> --targets <TARGETS> [ARGS]'
+                  end
+
+        @stream.puts colorize(:cyan, name)
+        @stream.puts indent(2, script)
+        @stream.puts
+
+        @stream.puts colorize(:cyan, 'Usage')
+        @stream.puts indent(2, command)
+        @stream.puts
+
+        @stream.puts colorize(:cyan, 'Path')
+        @stream.puts indent(2, filepath)
+      end
+
+      # Prints scripts available to the project.
+      #
+      # @param modulepath [Array] The project's modulepath.
+      # @param scripts [Array] The available scripts.
+      #
+      def print_scripts(modulepath:, scripts:)
+        command = Bolt::Util.powershell? ? 'Get-BoltScript -Name <SCRIPT NAME>' : 'bolt script show <SCRIPT NAME>'
+        scripts = scripts.map { |script| indent(2, script) }
+
+        @stream.puts colorize(:cyan, 'Scripts')
+        @stream.puts scripts.any? ? scripts : indent(2, 'No available scripts')
+        @stream.puts
+
+        @stream.puts colorize(:cyan, 'Modulepath')
+        @stream.puts indent(2, modulepath.join(File::PATH_SEPARATOR))
+        @stream.puts
+
+        @stream.puts colorize(:cyan, 'Additional information')
+        @stream.puts indent(2, "Use '#{command}' to view a script.")
+      end
+
       # Print target names and where they came from.
       #
       # @param adhoc [Hash] Adhoc targets provided on the command line.

--- a/lib/bolt/outputter/json.rb
+++ b/lib/bolt/outputter/json.rb
@@ -105,6 +105,14 @@ module Bolt
         print_table(**kwargs)
       end
 
+      def print_scripts(**kwargs)
+        print_table(**kwargs)
+      end
+
+      def print_script_info(**kwargs)
+        print_table(**kwargs)
+      end
+
       def print_apply_result(apply_result)
         @stream.puts apply_result.to_json
       end

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -478,14 +478,16 @@ module Bolt
 
     # List the scripts available to a project. This includes any scripts in a
     # project's or module's 'files/scripts/' and 'scripts/' directories.
-    def list_scripts
+    def list_scripts(filter_content: false)
       in_bolt_compiler do
-        Puppet.lookup(:current_environment).modules.collect do |mod|
+        scripts = Puppet.lookup(:current_environment).modules.collect do |mod|
           files_dir   = Pathname.new(mod.files) + 'scripts'
           scripts_dir = Pathname.new(mod.scripts)
-          scripts     = Bolt::Util.collect_files(files_dir) + Bolt::Util.collect_files(scripts_dir)
-          scripts.map { |path| File.join(mod.name, path.relative_path_from(mod.path)) }
+          paths       = Bolt::Util.collect_files(files_dir) + Bolt::Util.collect_files(scripts_dir)
+          paths.map { |path| File.join(mod.name, path.relative_path_from(mod.path)) }
         end.flatten.sort
+
+        filter_content ? filter_content(scripts, @project&.scripts) : scripts
       end
     end
 

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -476,6 +476,19 @@ module Bolt
       end
     end
 
+    # List the scripts available to a project. This includes any scripts in a
+    # project's or module's 'files/scripts/' and 'scripts/' directories.
+    def list_scripts
+      in_bolt_compiler do
+        Puppet.lookup(:current_environment).modules.collect do |mod|
+          files_dir   = Pathname.new(mod.files) + 'scripts'
+          scripts_dir = Pathname.new(mod.scripts)
+          scripts     = Bolt::Util.collect_files(files_dir) + Bolt::Util.collect_files(scripts_dir)
+          scripts.map { |path| File.join(mod.name, path.relative_path_from(mod.path)) }
+        end.flatten.sort
+      end
+    end
+
     def get_plan_info(plan_name, with_mtime: false)
       plan_sig = in_bolt_compiler do |compiler|
         compiler.plan_signature(plan_name)

--- a/lib/bolt/project.rb
+++ b/lib/bolt/project.rb
@@ -164,6 +164,10 @@ module Bolt
       @data['name']
     end
 
+    def scripts
+      @data['scripts']
+    end
+
     def tasks
       @data['tasks']
     end

--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -449,6 +449,23 @@ module Bolt
           end
         end
       end
+
+      # Recursively collects paths to all files in a directory.
+      #
+      # @param path [PathName]
+      #
+      def collect_files(path)
+        return [] unless path.directory?
+
+        path.children.collect do |child|
+          if child.file?
+            child
+          else
+            child.directory?
+            collect_files(child)
+          end
+        end.flatten
+      end
     end
   end
 end

--- a/pwsh_module/command.tests.ps1
+++ b/pwsh_module/command.tests.ps1
@@ -34,7 +34,7 @@ Describe "test bolt module" {
 
     it "has the correct number of exported functions" {
       # should count of pwsh functions
-      @($commands).Count | Should -Be 28
+      @($commands).Count | Should -Be 29
     }
   }
 }
@@ -279,6 +279,16 @@ Describe "test all bolt command examples" {
     It "bolt script run myscript.sh foo bar --targets target1,target2" {
       $result = Invoke-BoltScript -script 'myscript.sh' -arguments 'foo','bar' -targets 'target1,target2'
       $result | Should -Be "bolt script run myscript.sh foo bar --targets target1,target2"
+    }
+
+    It "bolt script show" {
+      $result = Get-BoltScript
+      $result | Should -Be "bolt script show"
+    }
+
+    It "bolt script show script" {
+      $result = Get-BoltScript -Script "script"
+      $result | Should -Be "bolt script show script"
     }
   }
 

--- a/rakelib/pwsh.rake
+++ b/rakelib/pwsh.rake
@@ -166,28 +166,31 @@ namespace :pwsh do
           }
         when 'script'
           # bolt command run <script> [options]
+          script_param_mandatory = (@pwsh_command[:verb] != 'Get')
           @pwsh_command[:options] << {
             name:                       'Script',
             ruby_short:                 's',
-            help_msg:                   'The script to execute',
+            help_msg:                   "The script to #{action}",
             type:                       'string',
             switch:                     false,
-            mandatory:                  true,
+            mandatory:                  script_param_mandatory,
             position:                   0,
             ruby_arg:                   'bare',
             validate_not_null_or_empty: true
           }
-          @pwsh_command[:options] << {
-            name:                           'Arguments',
-            ruby_short:                     'a',
-            help_msg:                       'The arguments to the script',
-            type:                           'string[]',
-            switch:                         false,
-            mandatory:                      false,
-            position:                       1,
-            ruby_arg:                       'bare',
-            value_from_remaining_arguments: true
-          }
+          unless @pwsh_command[:verb] == 'Get'
+            @pwsh_command[:options] << {
+              name:                           'Arguments',
+              ruby_short:                     'a',
+              help_msg:                       'The arguments to the script',
+              type:                           'string[]',
+              switch:                         false,
+              mandatory:                      false,
+              position:                       1,
+              ruby_arg:                       'bare',
+              value_from_remaining_arguments: true
+            }
+          end
         when 'task'
           # bolt task show|run <task> [parameters] [options]
           task_param_mandatory = (@pwsh_command[:verb] != 'Get')

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -635,6 +635,16 @@
                 }
               ]
             },
+            "extensions": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/extensions"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
             "interpreters": {
               "oneOf": [
                 {
@@ -712,6 +722,16 @@
               "oneOf": [
                 {
                   "$ref": "#/transport_definitions/cleanup"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
+            "interpreters": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/interpreters"
                 },
                 {
                   "$ref": "#/definitions/_plugin"

--- a/schemas/bolt-inventory.schema.json
+++ b/schemas/bolt-inventory.schema.json
@@ -231,6 +231,28 @@
                         }
                       ]
                     },
+                    "extensions": {
+                      "description": "A list of file extensions that are accepted for scripts or tasks on Windows. Scripts with these file extensions rely on the target's file type association to run. For example, if Python is installed on the system, a `.py` script runs with `python.exe`. The extensions `.ps1`, `.rb`, and `.pp` are always allowed and run via hard-coded executables.",
+                      "oneOf": [
+                        {
+                          "type": "array",
+                          "uniqueItems": true,
+                          "items": {
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/_plugin"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
                     "interpreters": {
                       "description": "A map of an extension name to the absolute path of an executable,  enabling you to override the shebang defined in a task executable. The extension can optionally be specified with the `.` character (`.py` and `py` both map to a task executable `task.py`) and the extension is case sensitive. When a target's name is `localhost`, Ruby tasks run with the Bolt Ruby interpreter by default.",
                       "oneOf": [
@@ -334,6 +356,26 @@
                       "oneOf": [
                         {
                           "type": "boolean"
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
+                    "interpreters": {
+                      "description": "A map of an extension name to the absolute path of an executable,  enabling you to override the shebang defined in a task executable. The extension can optionally be specified with the `.` character (`.py` and `py` both map to a task executable `task.py`) and the extension is case sensitive. When a target's name is `localhost`, Ruby tasks run with the Bolt Ruby interpreter by default.",
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": [
+                              "string",
+                              "array"
+                            ]
+                          },
+                          "propertyNames": {
+                            "pattern": "^.?[a-zA-Z0-9]+$"
+                          }
                         },
                         {
                           "$ref": "#/definitions/_plugin"

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -73,6 +73,9 @@
     "save-rerun": {
       "$ref": "#/definitions/save-rerun"
     },
+    "scripts": {
+      "$ref": "#/definitions/scripts"
+    },
     "spinner": {
       "$ref": "#/definitions/spinner"
     },
@@ -597,6 +600,13 @@
     "save-rerun": {
       "description": "Whether to update `.rerun.json` in the Bolt project directory. If your target names include passwords, set this value to `false` to avoid writing passwords to disk.",
       "type": "boolean"
+    },
+    "scripts": {
+      "description": "A list of scripts and glob patterns to filter the project's scripts by. This option is used to limit the visibility of scripts for users of the project. For example, project authors might want to limit the visibility of scripts that should only be run as part of a larger workflow. When this option is not configured, all scripts are visible. This option does not prevent users from running scripts that are not part of this list.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "spinner": {
       "description": "Whether to print a spinner to the console for long-running Bolt operations.",

--- a/spec/fixtures/modules/sample/scripts/nested/script.sh
+++ b/spec/fixtures/modules/sample/scripts/nested/script.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "Nested script"

--- a/spec/integration/cli/cli_spec.rb
+++ b/spec/integration/cli/cli_spec.rb
@@ -368,6 +368,18 @@ describe 'commands' do
       result = run_cli_json(%w[script show --filter nested], project: project)
       expect(result['scripts']).to eq(["sample/scripts/nested/script.sh"])
     end
+
+    context 'with an allowlist' do
+      let(:config) { base_config.merge('scripts' => ['with_both*']) }
+
+      it 'filters scripts' do
+        result = run_cli_json(%w[script show], project: project)
+        expect(result['scripts']).to eq([
+                                          "with_both/files/scripts/filepath.rb",
+                                          "with_both/scripts/filepath.rb"
+                                        ])
+      end
+    end
   end
 
   describe 'task show' do

--- a/spec/integration/cli/cli_spec.rb
+++ b/spec/integration/cli/cli_spec.rb
@@ -331,6 +331,45 @@ describe 'commands' do
     end
   end
 
+  describe 'script show' do
+    it 'shows available scripts' do
+      result = run_cli_json(%w[script show], project: project)
+      expect(result['scripts']).to include(
+        "sample/scripts/nested/script.sh",
+        "sample/scripts/script.py",
+        "sample/scripts/script.rb",
+        "with_both/scripts/filepath.rb",
+        "with_scripts/scripts/filepath.rb",
+        "with_both/files/scripts/filepath.rb"
+      )
+    end
+
+    it 'shows the modulepath' do
+      result = run_cli_json(%w[script show], project: project)
+      expect(result['modulepath']).to include(modulepath)
+    end
+
+    it 'shows individual script data' do
+      result = run_cli_json(%w[script show sample/scripts/script.py], project: project)
+      expect(result).to include(
+        'name'     => 'sample/scripts/script.py',
+        'script'   => "print('Hello, world!')\n",
+        'filepath' => fixtures_path('modules', 'sample', 'scripts', 'script.py')
+      )
+    end
+
+    it 'errors with an unknown script' do
+      expect { run_cli_json(%w[script show foo/bar/baz.sh], project: project) }.to raise_error(
+        %r{The script foo/bar/baz.sh does not exist or is not readable}
+      )
+    end
+
+    it 'filters scripts with a substring' do
+      result = run_cli_json(%w[script show --filter nested], project: project)
+      expect(result['scripts']).to eq(["sample/scripts/nested/script.sh"])
+    end
+  end
+
   describe 'task show' do
     it 'shows available tasks with descriptions' do
       result = run_cli_json(%w[task show], project: project)


### PR DESCRIPTION
This adds new `bolt script show` and `Get-BoltScript` commands.
When used without a script specified, they list all scripts available to
the project. When a script is specified, they print the script to the
console.

These commands load scripts from the `scripts/` and `files/scripts/`
directories in a project and modules on the modulepath, similar to the
`bolt script run` and `Invoke-BoltScript` commands. It does not load
scripts that are in the `files/` directory, as Bolt does not know
whether a file in that directory is a script or a file used elsewhere in
a module.

!feature

* **Add `bolt script show` and `Get-BoltScript` commands**

  You can now view scripts available to a project using the new `bolt
  script show` and `Get-BoltScript` commands. These commands show
  scripts in the `scripts/` and `files/scripts/` directories for
  projects and modules.

---

This adds a new `scripts` project configuration option that allows users
to create an allowlist of scripts that are available to the project.
This option supports globbing. Any scripts that are not present in the
allowlist will not appear in `bolt script show` or `Get-BoltScript`
output, though they can still be run by users directly.

!feature

* **Add `scripts` project configuration option**

  This new configuration option allows users to create an allowlist of
  scripts that are available to the project. Glob patterns are
  supported. Any scripts not in the allowlist are hidden from `bolt
  script show` and `Get-BoltScript` output, but can still be run
  directly by users.