### PR TITLE
(maint) Fix usage string in `bolt task show` output

### DIFF
--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -363,7 +363,7 @@ module Bolt
                  end
         usage << (Bolt::Util.powershell? ? ' [-Noop]' : ' [--noop]') if task.supports_noop
         params.each do |name, data|
-          usage << if data['type']&.start_with?('Optional')
+          usage << if data['type']&.start_with?('Optional') || data.key?('default')
                      " [#{name}=<value>]"
                    else
                      " #{name}=<value>"


### PR DESCRIPTION
This fixes the usage string in `bolt task show` output so parameters
that define a default value are shown as optional.

!no-release-note