### PR TITLE
Work around PuppetDB bug involving large array queries

### DIFF
--- a/lib/bolt/plugin/puppetdb.rb
+++ b/lib/bolt/plugin/puppetdb.rb
@@ -79,8 +79,9 @@ module Bolt
 
         Bolt::Util.walk_vals(template) do |value|
           # This is done in parts instead of in place so that we only need to
-          # make one puppetDB query
-          if value.is_a?(String)
+          # make one puppetDB query. Don't gather certname since we already
+          # have that and it's not a fact.
+          if value.is_a?(String) && value != 'certname'
             facts << fact_path(value)
           end
           value

--- a/lib/bolt/puppetdb/client.rb
+++ b/lib/bolt/puppetdb/client.rb
@@ -110,11 +110,11 @@ module Bolt
         return {} if certnames.empty? || facts.empty?
 
         certnames.uniq!
-        name_query = certnames.map { |c| ["=", "certname", c] }
-        name_query.insert(0, "or")
+        name_query = certnames.each_slice(100).map { |slice| ["in", "certname", ["array", slice]] }
+        name_query.unshift("or")
 
         facts_query = facts.map { |f| ["=", "path", f] }
-        facts_query.insert(0, "or")
+        facts_query.unshift("or")
 
         query = ['and', name_query, facts_query]
 


### PR DESCRIPTION
PuppetDB has degenerate performance when parsing a query that contains a 
long array. When querying facts for a list of certnames, we generate a 
query that enumerates all the certnames to consider. This triggers the 
degenerate performance when querying for a large number (on the order of 
tens of thousands) of nodes. We now follow a common pattern of breaking 
this single array into many nested arrays, capping the length of any 
individual array at 100 elements.

We also now use an `in` query instead of an `or` query, which doesn't have
a performance impact but is cleaner to generate.

This also fixes a bug where we would always query PuppetDB for facts even if we
were only referencing "certname", which is not a fact, in the target_mapping
section.