### PR TITLE
(maint) Pin public_suffix in Windows component acceptance test

### DIFF
--- a/acceptance/setup/common/pre-suite/010_install_ruby.rb
+++ b/acceptance/setup/common/pre-suite/010_install_ruby.rb
@@ -18,6 +18,9 @@ PS
         version = /ruby (2\.[0-9])/.match(output.stdout)[1].delete('.')
         bolt.add_env_var('PATH', "/cygdrive/c/tools/ruby#{version}/bin:PATH")
       end
+      # public_suffix for win requires Ruby version >= 2.6
+      # current Ruby 2.5.0 works with public_suffix version 4.0.7
+      on(bolt, powershell('gem install public_suffix -v 4.0.7'))
     when /debian|ubuntu/
       # install system ruby packages
       install_package(bolt, 'ruby')


### PR DESCRIPTION
The public_suffix gem beyond version `4.0.7` does not support our RubyGems.
This commit pre-installs that gem version on windows.