### PR TITLE
(PE-34483) Ensure plan execution is halted when sleep is interrupted

### DIFF
--- a/bolt-modules/ctrl/lib/puppet/functions/ctrl/do_until.rb
+++ b/bolt-modules/ctrl/lib/puppet/functions/ctrl/do_until.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative '../../../shared/sleep_signal'
 # Repeat the block until it returns a truthy value. Returns the value.
 Puppet::Functions.create_function(:'ctrl::do_until') do
   # @param options A hash of additional options.
@@ -35,7 +36,7 @@ Puppet::Functions.create_function(:'ctrl::do_until') do
     until (x = yield)
       i += 1
       break if limit != 0 && i >= limit
-      Kernel.sleep(interval) if interval
+      SleepSignal.sleep_with_signal_handler(interval) if interval
     end
     x
   end

--- a/bolt-modules/ctrl/lib/puppet/functions/ctrl/sleep.rb
+++ b/bolt-modules/ctrl/lib/puppet/functions/ctrl/sleep.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../../../shared/sleep_signal'
+
 # Sleeps for specified number of seconds.
 Puppet::Functions.create_function(:'ctrl::sleep') do
   # @param period Time to sleep (in seconds)
@@ -13,8 +15,7 @@ Puppet::Functions.create_function(:'ctrl::sleep') do
   def sleeper(period)
     # Send Analytics Report
     Puppet.lookup(:bolt_executor) {}&.report_function_call(self.class.name)
-
-    sleep(period)
+    SleepSignal.sleep_with_signal_handler(period)
     nil
   end
 end

--- a/bolt-modules/ctrl/lib/shared/sleep_signal.rb
+++ b/bolt-modules/ctrl/lib/shared/sleep_signal.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module SleepSignal
+  def self.sleep_with_signal_handler(period)
+    # When running with a jruby interpreter sleep will handle an iterrupt and allow the plan to keep
+    # running. In order to have consistent behavior between plans in bolt and PE and to ensure plans
+    # are able to be reliably stopped we add a signal handler to raise an exception on interrupt.
+    handler = Signal.trap(:INT) { raise Puppet::Error, "interrupt signal received during sleep" }
+    Kernel.sleep(period)
+  ensure
+    Signal.trap :INT, handler if handler
+  end
+end


### PR DESCRIPTION
The ruby sleep function will handle an interrup signal and allow plan execution to continue when run in PE (using jruby interpreter). This commit updates the `ctrl` functions (which use sleep) to handle an interrupt signal by raising an error when interrupted so that plan execution is stopped.