### PR TITLE
(maint) Make hostname_nix task more specific

### DIFF
--- a/acceptance/tests/plan_ssh.rb
+++ b/acceptance/tests/plan_ssh.rb
@@ -18,7 +18,7 @@ test_name "C100553: \
     on(bolt, "mkdir -p #{dir}/modules/test/{tasks,plans}")
     create_remote_file(bolt, "#{dir}/modules/test/tasks/hostname_nix.sh", <<-FILE)
 #!/bin/bash
-if [ ! -f /tmp/retry.txt ] && [ "$HOSTNAME" = '#{first_node}' ]; then
+if [ ! -f /tmp/retry.txt ] && [ "$(hostname -s)" = '#{first_node}' ]; then
   touch /tmp/retry.txt;
   exit 1
 elif [ -f /tmp/retry.txt ]; then


### PR DESCRIPTION
Some new platforms (namely fedora 36) will resolve `$HOSTNAME` as a fqdn. Instead of relying on this environment variable use the `hostname -s` command to compute the hostname. This will work on all of the unix systems we test ssh against in our acceptance test matrix.