### PR TITLE
Allow latest version of puppet-strings

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -59,7 +59,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "puppet", ">= 6.18.0"
   spec.add_dependency "puppetfile-resolver", ">= 0.6.2", "< 1.0"
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
-  spec.add_dependency "puppet-strings", "~> 2.3"
+  spec.add_dependency "puppet-strings", ">= 2.3.0", "< 4.0"
   spec.add_dependency "r10k", "~> 3.10"
   spec.add_dependency "ruby_smb", "~> 1.0"
   spec.add_dependency "terminal-table", "~> 3.0"


### PR DESCRIPTION
[puppet-strings 3.0.0] was released on 2022-10-21.  It bumps some
minimal requirements which seems to be in-line with those of Bolt so
allow this version too.

[puppet-strings 3.0.0]:https://github.com/puppetlabs/puppet-strings/blob/main/CHANGELOG.md#v300---2022-10-21
