### PR TITLE
(maint) Update acceptance config of OSX/Win for puppet-strings 2.9

### DIFF
--- a/acceptance/setup/common/pre-suite/010_install_ruby.rb
+++ b/acceptance/setup/common/pre-suite/010_install_ruby.rb
@@ -21,6 +21,8 @@ PS
       # public_suffix for win requires Ruby version >= 2.6
       # current Ruby 2.5.0 works with public_suffix version 4.0.7
       on(bolt, powershell('gem install public_suffix -v 4.0.7'))
+      # current Ruby 2.5.0 works with puppet-strings 2.9.0
+      on(bolt, powershell('gem install puppet-strings -v 2.9.0'))
     when /debian|ubuntu/
       # install system ruby packages
       install_package(bolt, 'ruby')
@@ -46,6 +48,8 @@ PS
     when /osx/
       # System ruby for osx is 2.3. winrm-fs and its dependencies require > 2.3.
       on(bolt, 'gem install winrm-fs -v 1.3.3 --no-document')
+      # System ruby for osx12 is 2.6, which can only manage puppet-strings 2.9.0
+      on(bolt, 'gem install puppet-strings -v 2.9.0 --no-document')
     else
       fail_test("#{bolt['platform']} not currently a supported bolt controller")
     end


### PR DESCRIPTION
Following up on 806852ae, two of our internal acceptance test platforms, osx12 and windows19 have older Rubies and Rubygems (2.6, 2.5) that are neither compatible with puppet-strings 3, nor capable of recognizing that they need to downshift to 2.x. So this commit updates the presuite to force installation of puppet-strings 2.9.0 ahead of installing the test bolt gem on those platforms.