### PR TITLE
(maint) net-ssh 6.x in component acceptance tests

### DIFF
--- a/acceptance/setup/common/pre-suite/010_install_ruby.rb
+++ b/acceptance/setup/common/pre-suite/010_install_ruby.rb
@@ -23,6 +23,8 @@ PS
       on(bolt, powershell('gem install public_suffix -v 4.0.7'))
       # current Ruby 2.5.0 works with puppet-strings 2.9.0
       on(bolt, powershell('gem install puppet-strings -v 2.9.0'))
+      # net-ssh 7.x no longer supports ruby 2.5
+      on(bolt, powershell('gem install net-ssh -v 6.1.0'))
     when /debian|ubuntu/
       # install system ruby packages
       install_package(bolt, 'ruby')


### PR DESCRIPTION
This commit updates the bolt runner test host setup to ensure net-ssh 6.x is installed which is compatable with ruby 2.5.

!no-release-note