### PR TITLE
(maint) Fix docs reference to PlanResult data type

### DIFF
--- a/documentation/templates/bolt_types_reference.md.erb
+++ b/documentation/templates/bolt_types_reference.md.erb
@@ -83,7 +83,7 @@ Plans can return just about any Puppet type, so the `PlanResult` can be any of t
 * `ResultSet`
 * `Target`
 * `ResourceInstance`
-* `Array[PlanResults]`
+* `Array[PlanResult]`
 * `Hash{String => PlanResult}`. In other words, a `Hash` where each key is a `String` and each
   corresponding value is a `PlanResult`, which could be any of the above types, including another
   Hash.


### PR DESCRIPTION
The docs indicated there was a type called `PlanResults` but I couldn't find any such reference so it appears to be a typo of `PlanResult`.

!no-release-note