### PR TITLE
(PUP-11722) Restrict concurrent ruby to 1.1.x

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "addressable", '~> 2.5'
   spec.add_dependency "aws-sdk-ec2", '~> 1'
   spec.add_dependency "CFPropertyList", "~> 2.2"
-  spec.add_dependency "concurrent-ruby", "~> 1.0"
+  spec.add_dependency "concurrent-ruby", "~> 1.0", "< 1.2.0"
   spec.add_dependency "ffi", ">= 1.9.25", "< 2.0.0"
   spec.add_dependency "hiera-eyaml", "~> 3"
   spec.add_dependency "jwt", "~> 2.2"


### PR DESCRIPTION
The 1.2.x series of concurrent ruby is incompatable with existing puppet 7.x. This commit restricts concurrent ruby while we figure out how to take up 1.2.