### PR TITLE
(maint) Test bolt against ruby 3.2

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ruby: [2.7, 3.1]
+        ruby: [2.7, 3.2]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/bolt_server.yaml
+++ b/.github/workflows/bolt_server.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ruby: [2.7, 3.1]
+        ruby: [2.7, 3.2]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/bolt_spec.yaml
+++ b/.github/workflows/bolt_spec.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ruby: [2.7, 3.1]
+        ruby: [2.7, 3.2]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/docker_transport.yaml
+++ b/.github/workflows/docker_transport.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.1]
+        ruby: [2.7, 3.2]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.1]
+        ruby: [2.7, 3.2]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/local_transport.yaml
+++ b/.github/workflows/local_transport.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ruby: [2.7, 3.1]
+        ruby: [2.7, 3.2]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/modules.yaml
+++ b/.github/workflows/modules.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.1]
+        ruby: [2.7, 3.2]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.1]
+        ruby: [2.7, 3.2]
     env:
       BOLT_WINDOWS: true
     steps:

--- a/.github/workflows/orch_transport.yaml
+++ b/.github/workflows/orch_transport.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ruby: [2.7, 3.1]
+        ruby: [2.7, 3.2]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/ssh_transport.yaml
+++ b/.github/workflows/ssh_transport.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.1]
+        ruby: [2.7, 3.2]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ruby: [2.7, 3.1]
+        ruby: [2.7, 3.2]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.1]
+        ruby: [2.7, 3.2]
     env:
       WINDOWS_AGENTS: true
     steps:
@@ -58,7 +58,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.1]
+        ruby: [2.7, 3.2]
     env:
       BOLT_WINDOWS: true
     steps:

--- a/.github/workflows/winrm_transport.yaml
+++ b/.github/workflows/winrm_transport.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.1]
+        ruby: [2.7, 3.2]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ end
 # Optional paint gem for rainbow outputter
 gem "paint", "~> 2.2"
 
+gem "orchestrator_client", :git => "https://github.com/donoghuc/orchestrator_client-ruby.git", :branch => "ruby-3.2"
+
 group(:test) do
   gem "beaker-hostgenerator"
   gem "mocha", '~> 1.4.0'

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "paint", "~> 2.2"
 
 gem "orchestrator_client", git: "https://github.com/donoghuc/orchestrator_client-ruby.git", branch: "ruby-3.2"
 gem "rubyntlm", git: "https://github.com/larskanis/rubyntlm.git", branch: "openssl-3-legacy"
+gem "puppet", git: "https://github.com/puppetlabs/puppet.git", branch: 'main'
 
 group(:test) do
   gem "beaker-hostgenerator"

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,8 @@ end
 # Optional paint gem for rainbow outputter
 gem "paint", "~> 2.2"
 
-gem "orchestrator_client", :git => "https://github.com/donoghuc/orchestrator_client-ruby.git", :branch => "ruby-3.2"
+gem "orchestrator_client", git: "https://github.com/donoghuc/orchestrator_client-ruby.git", branch: "ruby-3.2"
+gem "rubyntlm", git: "https://github.com/larskanis/rubyntlm.git", branch: "openssl-3-legacy"
 
 group(:test) do
   gem "beaker-hostgenerator"

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "jwt", "~> 2.2"
   spec.add_dependency "logging", "~> 2.2"
   spec.add_dependency "minitar", "~> 0.6"
-  spec.add_dependency "net-scp", "~> 1.2"
+  spec.add_dependency "net-scp", "~> 4.0"
   spec.add_dependency "net-ssh", ">= 4.0", "< 8.0"
   spec.add_dependency "net-ssh-krb", "~> 0.5"
   spec.add_dependency "orchestrator_client", "~> 0.5"

--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -91,7 +91,7 @@ module Bolt
           )
         rescue StandardError => e
           raise Bolt::Node::ConnectError.new(
-            "Failed to connect to #{endpoint}: #{e.message}",
+            "Failed to connect to #{endpoint}: #{e.message} #{e.backtrace}",
             'CONNECT_ERROR'
           )
         end


### PR DESCRIPTION
Assuming the github action runners can run ruby 3.2, try to use this version to test bolt against. This will likely be the version of ruby puppet 8 ships with so we want to make sure bolt is ready.