### PR TITLE
(maint) unpin spec helper

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -66,10 +66,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "winrm", "~> 2.0"
   spec.add_dependency "winrm-fs", "~> 1.3"
 
-  # there is a bug in puppetlabs_spec_helper for modules without fixtures
   spec.add_development_dependency "bundler", ">= 1.14"
   spec.add_development_dependency "octokit", "~> 4.0"
-  spec.add_development_dependency "puppetlabs_spec_helper", "<= 2.15.0"
+  spec.add_development_dependency "puppetlabs_spec_helper", "~> 5.0"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
We were previously pinning to an old version. The bug we were pinning the dependency for has been fixed and we now need the updated code. This commit bumps the development dependency to the 5.x series of pupetlabs-spec-helper.

!no-release-note