### PR TITLE
(PE-35088) Relax net-scp gem dependency versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,3 +39,6 @@ local_gemfile = File.join(__dir__, 'Gemfile.local')
 if File.exist? local_gemfile
   eval_gemfile local_gemfile
 end
+
+# TODO: remove this pin once we solve PE-35920
+gem "puppet", '~> 7.24'

--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "jwt", "~> 2.2"
   spec.add_dependency "logging", "~> 2.2"
   spec.add_dependency "minitar", "~> 0.6"
-  spec.add_dependency "net-scp", "~> 1.2"
+  spec.add_dependency "net-scp", ">= 1.2", "< 5.0"
   spec.add_dependency "net-ssh", ">= 4.0", "< 8.0"
   spec.add_dependency "net-ssh-krb", "~> 0.5"
   spec.add_dependency "orchestrator_client", "~> 0.5"


### PR DESCRIPTION
As we prep for building bolt to work with puppet 8 we need to relax the net-scp version dependency while we come up with a way to support running against both the puppet 7 and 8 runtimes.