### PR TITLE
(GH-3217) Only log compiled catalogs at trace level

### DIFF
--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -256,7 +256,7 @@ module Bolt
         futures = targets.map do |target|
           Concurrent::Future.execute(executor: @pool) do
             Thread.current[:name] ||= Thread.current.name
-            @executor.with_node_logging("Compiling manifest block", [target]) do
+            @executor.with_node_logging("Compiling manifest block", [target], :trace) do
               compile(target, scope)
             end
           end


### PR DESCRIPTION
Previously compiled catalogs would be logged per target at INFO level. This clogs up logs and can expose Sensitive data in catalogs. This commit moves logging of compiled catalogs to the TRACE log level only.

!bug

* **Only log compiled catalogs at trace level** ([#3217](#3217))

  Previously compiled catalogs would be logged per target at INFO level. This clogs up logs and can expose Sensitive data in catalogs. This commit moves logging of compiled catalogs to the TRACE log level only.