### PR TITLE
FIXES #3229 Require bundler 2.3.4+ to fix deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ ENV['BOLT_DISABLE_ANALYTICS'] = 'true'
 # Disable warning that Bolt may be installed as a gem
 ENV['BOLT_GEM'] = 'true'
 
-ruby '2.7.7', :bundler => ">= 2.3.4"
+ruby '>= 2.7.7', :bundler => ">= 2.3.4"
 
 gemspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,8 @@ ENV['BOLT_DISABLE_ANALYTICS'] = 'true'
 # Disable warning that Bolt may be installed as a gem
 ENV['BOLT_GEM'] = 'true'
 
+ruby '2.7.7', :bundler => ">= 2.3.4"
+
 gemspec
 
 group(:bolt_server) do


### PR DESCRIPTION
Upgrading to bundler 2.3.4 or above fixes the 

```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
```

error. In order to apply this change with a locally built bolt:

1. delete Gemfile.lock
2. delete `modules/**/*`
3. upgrade bundler `gem install bundler -v '2.3.4'`
4. confirm that `bundle -v` returns the correct version
5. if 4 is confirmed, then 
    5a. `bundle install`
    5b. `bundle exec r10k puppetfile install Puppetfile` 