### PR TITLE
(maint) Fix rubocop failure from recent PR

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ ENV['BOLT_DISABLE_ANALYTICS'] = 'true'
 # Disable warning that Bolt may be installed as a gem
 ENV['BOLT_GEM'] = 'true'
 
-ruby '>= 2.7.7', :bundler => ">= 2.3.4"
+ruby '>= 2.7.7', bundler: ">= 2.3.4"
 
 gemspec
 


### PR DESCRIPTION
We recently added a required bundler version to the ruby version in the Gemspec. Rubocop doesn't like the syntax we used.