### PR TITLE
(GH-3236) Only set ruby env vars on local transport when they exist

### DIFF
--- a/lib/bolt/transport/local/connection.rb
+++ b/lib/bolt/transport/local/connection.rb
@@ -73,7 +73,9 @@ module Bolt
           # Only do this if bundled-ruby is set to false, not nil
           ruby_env_vars = if target.transport_config['bundled-ruby'] == false
                             RUBY_ENV_VARS.each_with_object({}) do |e, acc|
-                              acc[e] = ENV["BOLT_ORIG_#{e}"] if ENV["BOLT_ORIG_#{e}"]
+                              if ENV["BOLT_ORIG_#{e}"] && !ENV["BOLT_ORIG_#{e}"].empty?
+                                acc[e] = ENV["BOLT_ORIG_#{e}"]
+                              end
                             end
                           end
 


### PR DESCRIPTION
Previously we would attempt to use any prior environment variables captured when bolt was invoked by simply looking for those existing. This works when those exist but in the case they did not exist the environment variables were set to empty strings. This makes it impossible to load ruby code (for example to do an apply on local transport). This commit updates the local transport to only set those environment variables if they are explicitly set to something other than an empty string.

!bug

* **Only set ruby env vars for local transport when non empty strings** ([#3236](#3236))

  Previously when using bundled-ruby=false for the local transport and not expliclty setting ruby environment variables internal apply tasks did not work due to ruby code not being able to be loaded. Now the local transport only preserves ruby environment variables when they are set to something other than an empty string.