### PR TITLE
(maint) stop restricting bundler and ruby in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,6 @@ ENV['BOLT_DISABLE_ANALYTICS'] = 'true'
 # Disable warning that Bolt may be installed as a gem
 ENV['BOLT_GEM'] = 'true'
 
-ruby '>= 2.7.7', bundler: ">= 2.3.4"
-
 gemspec
 
 group(:bolt_server) do


### PR DESCRIPTION
Bolt's gemspec allows ruby 2.5 and up. This is the source of truth for ruby compatability. This commit removes the versions in the Gemfile. The restriction was added to try to get rid of a warning message when using a bundler version that is too old. This is something bundler users can manage themselves if the warning is annoying them.

!bug

* **Stop restricting ruby version in Gemfile**

  The source of truth for minimum ruby version is in the gemspec. Stop duplicating that and risking conflicts in the Gemfile.