### PR TITLE
(maint) Stop pinning concurrent-ruby

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "addressable", '~> 2.5'
   spec.add_dependency "aws-sdk-ec2", '~> 1'
   spec.add_dependency "CFPropertyList", ">= 2.2"
-  spec.add_dependency "concurrent-ruby", "~> 1.0", "< 1.2.0"
+  spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "ffi", ">= 1.9.25", "< 2.0.0"
   spec.add_dependency "hiera-eyaml", "~> 3"
   spec.add_dependency "jwt", "~> 2.2"


### PR DESCRIPTION
Previously we needed to pin back concurrent-ruby due to an issue in puppet, we have since resolved that issue and no longer need to pin back concurrent-ruby.

!no-release-note