### PR TITLE
support using the target agent puppet config

### DIFF
--- a/documentation/applying_manifest_blocks.md
+++ b/documentation/applying_manifest_blocks.md
@@ -184,6 +184,11 @@ The `apply` function supports the following options:
   option is for transports that allow a user to run commands under a different
   username.)
 
+- `_agent => true` applies the manifest block with the targets default Puppet
+  confdir. Without this option, Bolt will use a temporary directory to prevent
+  Puppet from automatically reading any files from the targets local
+  configuration.
+
 ```puppet
 # Preview installing docker as root on $targets.
 apply($targets, _catch_errors => true, _noop => true, _run_as => root) {

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -264,7 +264,8 @@ module Bolt
 
         result_promises = targets.zip(futures).flat_map do |target, future|
           @executor.queue_execute([target]) do |transport, batch|
-            @executor.with_node_logging("Applying manifest block", batch) do
+            message = format("Applying manifest block%s", (" (with agent confdir)" if options[:agent]))
+            @executor.with_node_logging(message, batch) do
               catalog = future.value
               if future.rejected?
                 batch.map do |batch_target|
@@ -285,7 +286,8 @@ module Bolt
                   'plugins' => Puppet::Pops::Types::PSensitiveType::Sensitive.new(plugins),
                   'apply_settings' => @apply_settings,
                   '_task' => catalog_apply_task.name,
-                  '_noop' => options[:noop]
+                  '_noop' => options[:noop],
+                  '_agent' => options[:agent]
                 }
 
                 callback = proc do |event|

--- a/libexec/apply_catalog.rb
+++ b/libexec/apply_catalog.rb
@@ -17,7 +17,10 @@ args = JSON.parse(ARGV[0] ? File.read(ARGV[0]) : $stdin.read)
 puppet_root = Dir.mktmpdir
 moduledir = File.join(puppet_root, 'modules')
 Dir.mkdir(moduledir)
-cli = (Puppet::Settings::REQUIRED_APP_SETTINGS + [:rundir]).flat_map do |setting|
+settings = (Puppet::Settings::REQUIRED_APP_SETTINGS + [:rundir]).reject do |setting|
+  setting == :confdir && args['_agent']
+end
+cli = settings.flat_map do |setting|
   ["--#{setting}", File.join(puppet_root, setting.to_s.chomp('dir'))]
 end
 cli << '--modulepath' << moduledir


### PR DESCRIPTION
modules like puppetlabs-puppetdb which make use of Puppet.runtime[:http] require the agent ssl certificate and key. this change supports an optional flag which simply skips the confdir setting override when initializing the Puppet object.