### PR TITLE
support using the target puppet config

### DIFF
--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -123,6 +123,14 @@ module Bolt
                        "plan function or the `bolt apply` command.",
           type: Hash,
           properties: {
+            "confdir" => {
+              description: "This feature is experimental. Use the bolt created temporary path "\
+                           "or the Puppet default confdir on the target.",
+              type: String,
+              enum: %w[bolt target],
+              _example: "target",
+              _default: "bolt"
+            },
             "evaltrace" => {
               description: "Whether each resource should log when it is being evaluated. This allows "\
                            "you to interactively see exactly what is being done.",

--- a/schemas/bolt-project.schema.json
+++ b/schemas/bolt-project.schema.json
@@ -95,6 +95,14 @@
       "description": "A map of Puppet settings to use when applying Puppet code using the `apply` plan function or the `bolt apply` command.",
       "type": "object",
       "properties": {
+        "confdir": {
+          "description": "This feature is experimental. Use the bolt created temporary path or the Puppet default confdir on the target.",
+          "type": "string",
+          "enum": [
+            "bolt",
+            "target"
+          ]
+        },
         "evaltrace": {
           "description": "Whether each resource should log when it is being evaluated. This allows you to interactively see exactly what is being done.",
           "type": "boolean"


### PR DESCRIPTION
!feature !experimental

* **add new option to apply-settings** ([#3255](https://github.com/puppetlabs/bolt/pull/3255))

A new enum option 'confdir' supports overriding the default behavior of using a bolt temporary confdir for each Puppet apply. This feature is currently considered experimental.