### PR TITLE
add shell-command and tty support to the LXD transport

### DIFF
--- a/lib/bolt/config/transport/lxd.rb
+++ b/lib/bolt/config/transport/lxd.rb
@@ -11,7 +11,9 @@ module Bolt
           cleanup
           interpreters
           remote
+          shell-command
           tmpdir
+          tty
         ].concat(RUN_AS_OPTIONS).sort.freeze
 
         DEFAULTS = {

--- a/lib/bolt/config/transport/options.rb
+++ b/lib/bolt/config/transport/options.rb
@@ -332,7 +332,7 @@ module Bolt
           },
           "shell-command" => {
             type: String,
-            description: "A shell command to wrap any Docker exec commands in, such as `bash -lc`.",
+            description: "A shell command to wrap any exec commands in, such as `bash -lc`.",
             _plugin: true,
             _example: "bash -lc"
           },

--- a/schemas/bolt-defaults.schema.json
+++ b/schemas/bolt-defaults.schema.json
@@ -885,6 +885,16 @@
                 }
               ]
             },
+            "shell-command": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/shell-command"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
             "sudo-executable": {
               "oneOf": [
                 {
@@ -909,6 +919,16 @@
               "oneOf": [
                 {
                   "$ref": "#/transport_definitions/tmpdir"
+                },
+                {
+                  "$ref": "#/definitions/_plugin"
+                }
+              ]
+            },
+            "tty": {
+              "oneOf": [
+                {
+                  "$ref": "#/transport_definitions/tty"
                 },
                 {
                   "$ref": "#/definitions/_plugin"
@@ -2118,7 +2138,7 @@
       ]
     },
     "shell-command": {
-      "description": "A shell command to wrap any Docker exec commands in, such as `bash -lc`.",
+      "description": "A shell command to wrap any exec commands in, such as `bash -lc`.",
       "oneOf": [
         {
           "type": "string"

--- a/schemas/bolt-inventory.schema.json
+++ b/schemas/bolt-inventory.schema.json
@@ -150,7 +150,7 @@
                       ]
                     },
                     "shell-command": {
-                      "description": "A shell command to wrap any Docker exec commands in, such as `bash -lc`.",
+                      "description": "A shell command to wrap any exec commands in, such as `bash -lc`.",
                       "oneOf": [
                         {
                           "type": "string"
@@ -292,7 +292,7 @@
                       ]
                     },
                     "shell-command": {
-                      "description": "A shell command to wrap any Docker exec commands in, such as `bash -lc`.",
+                      "description": "A shell command to wrap any exec commands in, such as `bash -lc`.",
                       "oneOf": [
                         {
                           "type": "string"
@@ -561,6 +561,17 @@
                         }
                       ]
                     },
+                    "shell-command": {
+                      "description": "A shell command to wrap any exec commands in, such as `bash -lc`.",
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
                     "sudo-executable": {
                       "description": "The executable to use when escalating to the configured `run-as` user. This is useful when you want to escalate using the configured `sudo-password`, since `run-as-command` does not use `sudo-password` or support prompting. The command executed on the target is `<sudo-executable> -S -u <user> -p custom_bolt_prompt <command>`. **This option is experimental.**",
                       "oneOf": [
@@ -588,6 +599,17 @@
                       "oneOf": [
                         {
                           "type": "string"
+                        },
+                        {
+                          "$ref": "#/definitions/_plugin"
+                        }
+                      ]
+                    },
+                    "tty": {
+                      "description": "Whether to enable tty on exec commands.",
+                      "oneOf": [
+                        {
+                          "type": "boolean"
                         },
                         {
                           "$ref": "#/definitions/_plugin"
@@ -787,7 +809,7 @@
                       ]
                     },
                     "shell-command": {
-                      "description": "A shell command to wrap any Docker exec commands in, such as `bash -lc`.",
+                      "description": "A shell command to wrap any exec commands in, such as `bash -lc`.",
                       "oneOf": [
                         {
                           "type": "string"


### PR DESCRIPTION
!feature

* **add shell-command and tty support to the LXD transport** ([#3262](https://github.com/puppetlabs/bolt/pull/3262))

Previously the LXD transport would always execute commands on the target with `sh -c`. The shell-command and tty options are added to provide a more consistent experience between the docker, podman and lxd transports.