### PR TITLE
(maint) Pin nori in component acceptance

### DIFF
--- a/acceptance/setup/common/pre-suite/010_install_ruby.rb
+++ b/acceptance/setup/common/pre-suite/010_install_ruby.rb
@@ -43,6 +43,7 @@ PS
       on(bolt, 'gem install semantic_puppet -v 1.0.4')
       on(bolt, 'gem install puppet -v 7.24.0')
       on(bolt, 'gem install highline -v 2.1.0')
+      on(bolt, 'gem install nori -v 2.6.0')
     when /el-|centos/
       # install system ruby packages
       install_package(bolt, 'ruby')
@@ -66,6 +67,7 @@ PS
     when /osx/
       # System ruby for osx is 2.3. winrm-fs and its dependencies require > 2.3.
       on(bolt, 'gem install winrm-fs -v 1.3.3 --no-document')
+      on(bolt, 'gem install nori -v 2.6.0 --no-document')
       # System ruby for osx12 is 2.6, which can only manage puppet-strings 2.9.0
       on(bolt, 'gem install puppet-strings -v 2.9.0 --no-document')
       # semantic puppet no longer supports ruby < 2.7


### PR DESCRIPTION
Again the issue where rubygems wont consider min ruby version. latest nori gem drops old ruby support, this commit pins to last nori version supported on bolt controllers for component acceptance.

!no-release-note