### PR TITLE
(maint) Pin cfpropertylist on for component acceptance

### DIFF
--- a/acceptance/setup/common/pre-suite/010_install_ruby.rb
+++ b/acceptance/setup/common/pre-suite/010_install_ruby.rb
@@ -44,6 +44,7 @@ PS
       on(bolt, 'gem install puppet -v 7.24.0')
       on(bolt, 'gem install highline -v 2.1.0')
       on(bolt, 'gem install nori -v 2.6.0')
+      on(bolt, 'gem install CFPropertyList -v 3.0.6')
     when /el-|centos/
       # install system ruby packages
       install_package(bolt, 'ruby')
@@ -68,6 +69,7 @@ PS
       # System ruby for osx is 2.3. winrm-fs and its dependencies require > 2.3.
       on(bolt, 'gem install winrm-fs -v 1.3.3 --no-document')
       on(bolt, 'gem install nori -v 2.6.0 --no-document')
+      on(bolt, 'gem install CFPropertyList -v 3.0.6 --no-document')
       # System ruby for osx12 is 2.6, which can only manage puppet-strings 2.9.0
       on(bolt, 'gem install puppet-strings -v 2.9.0 --no-document')
       # semantic puppet no longer supports ruby < 2.7


### PR DESCRIPTION
cfpropertylist 3.0.7 adds a new nfk dependency which native extensions cannot be built on older ruby envs on component bolt runners. Pin back to 3.0.6.

!no-release-note