### PR TITLE
Update beaker-puppet 2.1

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -20,7 +20,7 @@ gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 4")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.2")
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.0")
 gem 'beaker-pe', *location_for(ENV['BEAKER_PE_VERSION'] || '~> 2')
-gem 'beaker-puppet', *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1')
+gem 'beaker-puppet', *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 2.1')
 gem 'beaker-vmpooler', *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || '~> 1')
 gem 'rake', "~> 12.1"
 gem 'rototiller'


### PR DESCRIPTION
Versions prior to 2.1 resulted in errors like the following:

    No repository installation step for amazon yet...

We can't use beaker-puppet 3, because that depends on beaker 5.