### PR TITLE
(GH-3286) Add `file::delete()` function

### DIFF
--- a/bolt-modules/file/lib/puppet/functions/file/delete.rb
+++ b/bolt-modules/file/lib/puppet/functions/file/delete.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Delete a file on localhost using ruby's `File.delete`. This will only delete
+# files on the machine you run Bolt on.
+Puppet::Functions.create_function(:'file::delete') do
+  # @param filename Absolute path.
+  # @example Delete a file from disk
+  #   file::delete('C:/Users/me/report')
+  dispatch :delete do
+    required_param 'String[1]', :filename
+    return_type 'Undef'
+  end
+
+  def delete(filename)
+    # Send Analytics Report
+    Puppet.lookup(:bolt_executor) {}&.report_function_call(self.class.name)
+
+    File.delete(filename)
+    nil
+  end
+end

--- a/bolt-modules/file/spec/functions/file/delete_spec.rb
+++ b/bolt-modules/file/spec/functions/file/delete_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tempfile'
+
+describe 'file::delete' do
+  it {
+    Dir.mktmpdir do |dir|
+      file = File.join(dir, 'file_delete')
+      File.write(file, 'file_delete_contents')
+      is_expected.to run.with_params(file)
+      expect(File.exist?(file)).to eq(false)
+    end
+  }
+end


### PR DESCRIPTION
Closes #3286

!feature

* **Add `file::delete()` function** Delete a file on localhost using ruby's `File.delete`. This will only delete files on the machine you run Bolt on.