### PR TITLE
Improve inventory target name resolution

### DIFF
--- a/lib/bolt/inventory/inventory.rb
+++ b/lib/bolt/inventory/inventory.rb
@@ -119,8 +119,7 @@ module Bolt
         if ext_glob
           File.fnmatch(wildcard, target_name, File::FNM_CASEFOLD | File::FNM_EXTGLOB)
         else
-          regexp = Regexp.new("^#{Regexp.escape(wildcard).gsub('\*', '.*?')}$", Regexp::IGNORECASE)
-          target_name =~ regexp
+          File.fnmatch(wildcard, target_name, File::FNM_CASEFOLD)
         end
       end
 


### PR DESCRIPTION
Update the target string name resolution behavior with two significant improvements:
- Do not perform wildcard lookups unless a wildcard character is present in the string, instead only performing exact-name matches.
- When performing a wildcard lookup, use fnmatch for improved speed and functionality.