### PR TITLE
Improve add_facts performance

### DIFF
--- a/lib/bolt/inventory/target.rb
+++ b/lib/bolt/inventory/target.rb
@@ -98,7 +98,7 @@ module Bolt
 
       def add_facts(new_facts = {})
         validate_fact_names(new_facts)
-        @facts = Bolt::Util.deep_merge(@facts, new_facts)
+        Bolt::Util.deep_merge!(@facts, new_facts)
       end
 
       def features

--- a/lib/bolt/util.rb
+++ b/lib/bolt/util.rb
@@ -212,6 +212,17 @@ module Bolt
         hash1.merge(hash2, &recursive_merge)
       end
 
+      def deep_merge!(hash1, hash2)
+        recursive_merge = proc do |_key, h1, h2|
+          if h1.is_a?(Hash) && h2.is_a?(Hash)
+            h1.merge!(h2, &recursive_merge)
+          else
+            h2
+          end
+        end
+        hash1.merge!(hash2, &recursive_merge)
+      end
+
       # Accepts a Data object and returns a copy with all hash keys
       # modified by block. use &:to_s to stringify keys or &:to_sym to symbolize them
       def walk_keys(data, &block)


### PR DESCRIPTION
When making multiple add_facts calls to add facts to an already present and large set of target facts performance declines as more are added due to the initialization and copying of the large hashes each time.

This change merges the added facts in place to the existing facts, which slightly improves performance.