### PR TITLE
(maint) Turn off analytics submissions

### DIFF
--- a/.github/actions/docker_setup/action.yaml
+++ b/.github/actions/docker_setup/action.yaml
@@ -6,5 +6,6 @@ runs:
     - name: Bring up containers
       shell: bash
       run: |
+        sudo apt install docker-compose
         docker-compose -f spec/docker-compose.yml build --parallel
         docker-compose -f spec/docker-compose.yml up -d

--- a/.github/actions/sudo_setup/action.yaml
+++ b/.github/actions/sudo_setup/action.yaml
@@ -6,6 +6,7 @@ runs:
     - name: Bring up containers
       shell: bash
       run: |
+        sudo apt install docker-compose
         docker-compose -f spec/docker-compose.yml build --parallel
         docker-compose -f spec/docker-compose.yml up -d
     - name: Create non-sudo user

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,4 +35,5 @@ jobs:
       - name: Run DITA
         uses: dita-ot/dita-ot-action@master
         with:
+          dita-ot-version: 4.1.2
           build: dita -i documentation/bolt.ditamap -o out -f html5 --processing-mode=strict

--- a/documentation/analytics.md
+++ b/documentation/analytics.md
@@ -1,7 +1,8 @@
 # Analytics
 
 Bolt collects data about how you use it to help the Bolt team make decisions
-about how to improve it. You can opt out of providing this data.
+about how to improve it. You can opt out of providing this data. Analytics is
+disabled by default.
 
 ## Opt out of data collection
 
@@ -12,7 +13,7 @@ or by setting an environment variable.
 
 To disable data collection, set `analytics: false` in your [configuration
 file](configuring_bolt.md). This option is supported in the system-wide,
-user-level, and project configuration files.
+user-level, and project configuration files. `false` is the default value.
 
 ```yaml
 # bolt-defaults.yaml

--- a/documentation/bolt_installing.md
+++ b/documentation/bolt_installing.md
@@ -1,9 +1,5 @@
 # Installing Bolt
 
-> Bolt automatically collects data about how you use it. If you want to opt
-> out of providing this data, you can do so. For more information, see
-> [Opt out of data collection](analytics.md#opt-out-of-data-collection).
-
 Packaged versions of Bolt are available for several Linux distributions, macOS,
 and Microsoft Windows.
 

--- a/lib/bolt/config.rb
+++ b/lib/bolt/config.rb
@@ -169,7 +169,7 @@ module Bolt
       @config_files = []
 
       default_data = {
-        'analytics'           => true,
+        'analytics'           => false,
         'apply-settings'      => {},
         'color'               => true,
         'compile-concurrency' => Etc.nprocessors,

--- a/lib/bolt/shell/powershell/snippets.rb
+++ b/lib/bolt/shell/powershell/snippets.rb
@@ -55,21 +55,25 @@ module Bolt
             }
             #{build_arg_list}
 
-            switch -regex ( Get-ExecutionPolicy )
+            try
             {
-              '^AllSigned'
+              switch -regex ( Get-ExecutionPolicy )
               {
-                if ((Get-AuthenticodeSignature -File "#{script_path}").Status -ne 'Valid') {
-                  $Host.UI.WriteErrorLine("Error: Target host Powershell ExecutionPolicy is set to ${_} and script '#{script_path}' does not contain a valid signature.")
+                '^AllSigned'
+                {
+                  if ((Get-AuthenticodeSignature -File "#{script_path}").Status -ne 'Valid') {
+                    $Host.UI.WriteErrorLine("Error: Target host Powershell ExecutionPolicy is set to ${_} and script '#{script_path}' does not contain a valid signature.")
+                    exit 1;
+                  }
+                }
+                '^Restricted'
+                {
+                  $Host.UI.WriteErrorLine("Error: Target host Powershell ExecutionPolicy is set to ${_} which denies running any scripts on the target.")
                   exit 1;
                 }
               }
-              '^Restricted'
-              {
-                $Host.UI.WriteErrorLine("Error: Target host Powershell ExecutionPolicy is set to ${_} which denies running any scripts on the target.")
-                exit 1;
-              }
             }
+            catch {}
 
             if([string]::IsNullOrEmpty($invokeArgs.ScriptBlock)){
               $Host.UI.WriteErrorLine("Error: Failed to obtain scriptblock from '#{script_path}'. Running scripts might be disabled on this system. For more information, see about_Execution_Policies at https:/go.microsoft.com/fwlink/?LinkID=135170");

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -377,8 +377,8 @@ describe Bolt::Config do
     end
 
     context 'analytics' do
-      it 'defaults to enabled' do
-        expect(config.analytics).to eq(true)
+      it 'defaults to disabled' do
+        expect(config.analytics).to eq(false)
       end
 
       it 'overrides a true value with false' do


### PR DESCRIPTION
Collecting analytics is now turned off by default.

!removal

* **Stop collecting bolt analytics** ([#3293](#3293))

  Bolt no longer collects analytics by default.