### PR TITLE
(GH-3296) Prefer cert auth to token auth for puppetdb client

### DIFF
--- a/lib/bolt/puppetdb/config.rb
+++ b/lib/bolt/puppetdb/config.rb
@@ -60,7 +60,7 @@ module Bolt
       end
 
       def token
-        return @token if @token
+        return @token if @token_computed
         # Allow nil in config to skip loading a token
         if @settings.include?('token')
           if @settings['token']
@@ -69,6 +69,12 @@ module Bolt
         elsif File.exist?(DEFAULT_TOKEN)
           @token = File.read(DEFAULT_TOKEN)
         end
+        # Only use cert based auth in the case token and cert are both configured
+        if @token && cert
+          Bolt::Logger.logger(self).debug("Both cert and token based auth configured, using cert only")
+          @token = nil
+        end
+        @token_computed = true
         @token = @token.strip if @token
       end
 

--- a/spec/unit/puppetdb/config_spec.rb
+++ b/spec/unit/puppetdb/config_spec.rb
@@ -72,6 +72,8 @@ describe Bolt::PuppetDB::Config do
     context "token" do
       context "token is valid" do
         before :each do
+          options.delete('cert')
+          options.delete('key')
           allow(File).to receive(:read).with(token).and_return 'footoken'
           allow(File).to receive(:read).with(Bolt::PuppetDB::Config::DEFAULT_TOKEN).and_return 'bartoken'
         end
@@ -97,6 +99,8 @@ describe Bolt::PuppetDB::Config do
 
       context "token is invalid" do
         before :each do
+          options.delete('cert')
+          options.delete('key')
           allow(File).to receive(:read).with(token).and_return "footoken\n"
           allow(File).to receive(:read).with(Bolt::PuppetDB::Config::DEFAULT_TOKEN).and_return "bartoken\n"
         end
@@ -110,6 +114,14 @@ describe Bolt::PuppetDB::Config do
           options.delete('token')
 
           expect(config.token).to eq('bartoken')
+        end
+      end
+
+      context "both token and cert" do
+        it "returns nil for token when cert is configured" do
+          allow(config).to receive(:validate_file_exists).with('cert').and_return true
+          allow(File).to receive(:read).with(token).and_return 'footoken'
+          expect(config.token).to be_nil
         end
       end
     end


### PR DESCRIPTION
Previously regardless of using certs any puppetdb token (either read from default location OR configured in settings) would be sent in x-authentication header for puppetdb requests. In the case a cert is configured, do not include this as the puppetdb endpoint will 401 in the case a valid cert but revoked token is presented.