### PR TITLE
(maint) Stop installing docker-compose

### DIFF
--- a/.github/actions/docker_setup/action.yaml
+++ b/.github/actions/docker_setup/action.yaml
@@ -6,6 +6,5 @@ runs:
     - name: Bring up containers
       shell: bash
       run: |
-        sudo apt install docker-compose
-        docker-compose -f spec/docker-compose.yml build --parallel
-        docker-compose -f spec/docker-compose.yml up -d
+        docker compose -f spec/docker-compose.yml build --parallel
+        docker compose -f spec/docker-compose.yml up -d

--- a/.github/actions/sudo_setup/action.yaml
+++ b/.github/actions/sudo_setup/action.yaml
@@ -6,9 +6,8 @@ runs:
     - name: Bring up containers
       shell: bash
       run: |
-        sudo apt install docker-compose
-        docker-compose -f spec/docker-compose.yml build --parallel
-        docker-compose -f spec/docker-compose.yml up -d
+        docker compose -f spec/docker-compose.yml build --parallel
+        docker compose -f spec/docker-compose.yml up -d
     - name: Create non-sudo user
       shell: bash
       run: |


### PR DESCRIPTION
Docker now ships a `docker compose` CLI, no need to install `docker-compose` on test runners.

!no-release-notes