### PR TITLE
dev dependencies: allow latest versions

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -67,8 +67,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "winrm-fs", "~> 1.3"
 
   spec.add_development_dependency "bundler", ">= 1.14"
-  spec.add_development_dependency "octokit", "~> 4.0"
-  spec.add_development_dependency "puppetlabs_spec_helper", "~> 5.0"
-  spec.add_development_dependency "rake", "~> 12.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "octokit", ">= 4.0", "< 9"
+  spec.add_development_dependency "puppetlabs_spec_helper", ">= 5.0", "< 8"
+  spec.add_development_dependency "rake", ">= 12.0", "< 14"
+  spec.add_development_dependency "rspec", ">= 3.0", "< 4"
 end


### PR DESCRIPTION
This updates all version constraints for development dependencies in gemspec to allow their latest major versions.

Followup for https://github.com/puppetlabs/bolt/pull/3249