### PR TITLE
(GH-3309) Ensure bundled-ruby defaults are applied at target init

### DIFF
--- a/lib/bolt/inventory/target.rb
+++ b/lib/bolt/inventory/target.rb
@@ -34,7 +34,7 @@ module Bolt
           @name = @uri
           @safe_name = @uri_obj.omit(:password).to_str.sub(%r{^//}, '')
         end
-
+        # handle special localhost target
         if @name == 'localhost'
           default = { 'config' => { 'transport' => 'local' } }
           target_data = Bolt::Util.deep_merge(default, target_data)
@@ -53,6 +53,8 @@ module Bolt
         @inventory = inventory
 
         validate
+        # after setting config, apply local defaults when using bundled ruby
+        set_local_defaults if transport_config['bundled-ruby']
       end
 
       def set_local_defaults

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -80,10 +80,6 @@ module Bolt
       inventory_target.resources
     end
 
-    def set_local_defaults
-      inventory_target.set_local_defaults
-    end
-
     # rubocop:disable Naming/AccessorMethodName
     def set_resource(resource)
       inventory_target.set_resource(resource)

--- a/lib/bolt/transport/local.rb
+++ b/lib/bolt/transport/local.rb
@@ -11,10 +11,6 @@ module Bolt
       end
 
       def with_connection(target)
-        if target.transport_config['bundled-ruby']
-          target.set_local_defaults
-        end
-
         yield Connection.new(target)
       end
     end

--- a/spec/unit/transport/local_spec.rb
+++ b/spec/unit/transport/local_spec.rb
@@ -94,6 +94,16 @@ describe Bolt::Transport::Local do
       end
     end
 
+    context 'without with_connection' do
+      let(:data) { { 'targets' => [] } }
+      it 'applies bundled-ruby config' do
+        target = get_target(inventory, 'local://foo')
+        expect(target.transport).to eq('local')
+        expect(target.options['interpreters']).to include('.rb' => RbConfig.ruby)
+        expect(target.features).to include('puppet-agent')
+      end
+    end
+
     context 'with group-level config' do
       let(:data) {
         { 'targets' => [uri],


### PR DESCRIPTION
Previously defaults were not applied until an action was actually requested on a target. This made inventory resolution confusing and non-determanistic behavior with apply_prep. This commit moves application of defaults for a target to the init method for creating a target object.

!bug

* **Apply bundled-ruby defaults at target creation** ([#3309](3309))

  Ensure defaults associated with `bundled-ruby` transport config are applied at target initialization.