### PR TITLE
(GH-3310) Ensure plugin code for core types is available on local transport

### DIFF
--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -284,6 +284,9 @@ module Bolt
                   'catalog' => Puppet::Pops::Types::PSensitiveType::Sensitive.new(catalog),
                   'plugins' => Puppet::Pops::Types::PSensitiveType::Sensitive.new(plugins),
                   'apply_settings' => @apply_settings,
+                  # This should just be boltlib and modules dirs shipped with bolt packages
+                  # The apply_catalog task uses them to load core types if they exist
+                  'bolt_builtin_content' => @modulepath - @plugin_dirs,
                   '_task' => catalog_apply_task.name,
                   '_noop' => options[:noop]
                 }

--- a/libexec/apply_catalog.rb
+++ b/libexec/apply_catalog.rb
@@ -52,6 +52,19 @@ begin
     $LOAD_PATH << dir unless $LOAD_PATH.include?(dir)
   end
 
+  # In the case we are applying on a bolt runner and using bundled-ruby over local transport
+  # we will want to load code shipped with bolt. This is last on the load path and therefore
+  # explicitly packaged plugins should take precedence
+  args['bolt_builtin_content'].each do |builtin_dir|
+    next unless Dir.exist?(builtin_dir)
+    Dir.foreach(builtin_dir) do |dir|
+      unless ['.', '..'].include? dir
+        full_path = File.join(builtin_dir, dir, 'lib')
+        $LOAD_PATH << full_path unless $LOAD_PATH.include?(full_path)
+      end
+    end
+  end
+
   if (conn_info = args['_target'])
     unless (type = conn_info['remote-transport'])
       puts "Cannot execute a catalog for a remote target without knowing it's the remote-transport type."


### PR DESCRIPTION
When using the local transport defaulting to `bundled-ruby: true` it is assumed an agent is on the target. Generally when a `puppet-agent` feature is applied to a target this is assumed to be the case. This provides the core types and providers when an catalog is applied. We explicitly do not want to pluginsync all the core types and providers when we do not have to. This commit updates the apply_catalog task to take advantage of the fact that bolt packages have the core types in them. This works by sending as a task parameter the install location of bundled module content in bolt packages. After unpacking the plugins sent to the apply_catalog task, if the task finds any modules shipped with bolt, it will add those to the `LOAD_PATH`. This allows us to continue to avoid excessive pluginsync and also support the bundled-ruby config over the local transport.