### PR TITLE
(maint) Fix bug in plan_spec integration test

### DIFF
--- a/spec/integration/plan_spec.rb
+++ b/spec/integration/plan_spec.rb
@@ -113,7 +113,7 @@ describe 'plans' do
 
       it "prints the spinner when running executor functions", ssh: true do
         expect_any_instance_of(Bolt::Outputter::Human).to receive(:start_spin).at_least(:once)
-        run_cli(%w[plan run sample::noop --targets #{target}] + config_flags, **opts)
+        run_cli(%W[plan run sample::noop --targets #{target}] + config_flags, **opts)
       end
 
       it "doesn't print the spinner when running non-executor functions", ssh: true do


### PR DESCRIPTION
Previously the `target` argument was not being properly resolved in the argument array resulting in the literal string `#{target}` being used instead of the resolved value.

!no-release-note