### PR TITLE
Ensure bash shell executions close file descriptors

### DIFF
--- a/lib/bolt/shell/bash.rb
+++ b/lib/bolt/shell/bash.rb
@@ -470,7 +470,10 @@ module Bolt
             result_output.merged_output << to_print
           }
         rescue Errno::EAGAIN, EOFError
+        ensure
+          stream.close
         end
+        inp.close
         result_output.stdout << read_streams[out]
         result_output.stderr << read_streams[err]
         result_output.exit_code = t.value.respond_to?(:exitstatus) ? t.value.exitstatus : t.value
@@ -490,7 +493,7 @@ module Bolt
         result_output
       rescue StandardError
         # Ensure we close stdin and kill the child process
-        inp&.close
+        inp.close unless inp.nil? || inp.closed?
         t&.terminate if t&.alive?
         @logger.trace { "Command aborted" }
         raise


### PR DESCRIPTION
Currently Bolt::Shell::Bash will leaves open file descriptors at the conclusion of execute(). The file descriptions do fall out of scope at the conclusion of the execute() method and the Ruby GC eventually closes them. However, on a very busy Bolt invocation with lots of short-lived Tasks or a number of Tasks running in parallel (e.g. via background()) the number of open FDs before garbage collection can get moderately high, hitting problems on systems with low file descriptor limits.

In some simple testing in my environment this reduced the number of consistently open FDs from around 90-110 to somewhere in the 50s for a given test scenario.
