### PR TITLE
(maint) Pin back winrm gem for component acceptance

### DIFF
--- a/acceptance/setup/common/pre-suite/010_install_ruby.rb
+++ b/acceptance/setup/common/pre-suite/010_install_ruby.rb
@@ -46,6 +46,7 @@ PS
       on(bolt, 'gem install highline -v 2.1.0')
       on(bolt, 'gem install nori -v 2.6.0')
       on(bolt, 'gem install CFPropertyList -v 3.0.6')
+      on(bolt, 'gem install winrm -v 2.3.6')
     when /el-|centos/
       # install system ruby packages
       install_package(bolt, 'ruby')
@@ -70,6 +71,7 @@ PS
       # System ruby for osx is 2.3. winrm-fs and its dependencies require > 2.3.
       on(bolt, 'gem install nori -v 2.6.0 --no-document')
       on(bolt, 'gem install winrm-fs -v 1.3.3 --no-document')
+      on(bolt, 'gem install winrm -v 2.3.6 --no-document')
       on(bolt, 'gem install CFPropertyList -v 3.0.6 --no-document')
       on(bolt, 'gem install fast_gettext -v 2.4.0')
       # System ruby for osx12 is 2.6, which can only manage puppet-strings 2.9.0


### PR DESCRIPTION
The component platforms in internal jenkins CI uses system ruby on older VMs that require old rubies. This commit pins winrm to the last version compatible with the system rubies on test hosts.

!no-release-note