### PR TITLE
(maint) Pin public_suffix for component acceptance

### DIFF
--- a/acceptance/setup/common/pre-suite/010_install_ruby.rb
+++ b/acceptance/setup/common/pre-suite/010_install_ruby.rb
@@ -47,6 +47,7 @@ PS
       on(bolt, 'gem install nori -v 2.6.0')
       on(bolt, 'gem install CFPropertyList -v 3.0.6')
       on(bolt, 'gem install winrm -v 2.3.6')
+      on(bolt, 'gem install public_suffix -v 5.1.1')
     when /el-|centos/
       # install system ruby packages
       install_package(bolt, 'ruby')
@@ -70,8 +71,9 @@ PS
     when /osx/
       # System ruby for osx is 2.3. winrm-fs and its dependencies require > 2.3.
       on(bolt, 'gem install nori -v 2.6.0 --no-document')
-      on(bolt, 'gem install winrm-fs -v 1.3.3 --no-document')
       on(bolt, 'gem install winrm -v 2.3.6 --no-document')
+      on(bolt, 'gem install winrm-fs -v 1.3.3 --no-document')
+      on(bolt, 'gem install public_suffix -v 5.1.1 --no-document')
       on(bolt, 'gem install CFPropertyList -v 3.0.6 --no-document')
       on(bolt, 'gem install fast_gettext -v 2.4.0')
       # System ruby for osx12 is 2.6, which can only manage puppet-strings 2.9.0


### PR DESCRIPTION
Pin pack public_suffix gem in old ruby envs for component acceptance to maintain compatability with older rubies.

!no-release-note