### PR TITLE
Remove puppet version pin from gemfile

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ruby: [2.7, 3.1]
+        ruby: [3.1]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/bolt_server.yaml
+++ b/.github/workflows/bolt_server.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ruby: [2.7, 3.1]
+        ruby: [3.1]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/bolt_spec.yaml
+++ b/.github/workflows/bolt_spec.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ruby: [2.7, 3.1]
+        ruby: [3.1]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/docker_transport.yaml
+++ b/.github/workflows/docker_transport.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.1]
+        ruby: [3.1]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.1]
+        ruby: [3.1]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/local_transport.yaml
+++ b/.github/workflows/local_transport.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ruby: [2.7, 3.1]
+        ruby: [3.1]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/modules.yaml
+++ b/.github/workflows/modules.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.1]
+        ruby: [3.1]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/modules.yaml
+++ b/.github/workflows/modules.yaml
@@ -39,7 +39,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.1]
+        ruby: [3.1]
     env:
       BOLT_WINDOWS: true
     steps:

--- a/.github/workflows/orch_transport.yaml
+++ b/.github/workflows/orch_transport.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ruby: [2.7, 3.1]
+        ruby: [3.1]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/ssh_transport.yaml
+++ b/.github/workflows/ssh_transport.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.1]
+        ruby: [3.1]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ruby: [2.7, 3.1]
+        ruby: [3.1]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.1]
+        ruby: [3.1]
     env:
       WINDOWS_AGENTS: true
     steps:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -58,7 +58,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.1]
+        ruby: [3.1]
     env:
       BOLT_WINDOWS: true
     steps:

--- a/.github/workflows/winrm_transport.yaml
+++ b/.github/workflows/winrm_transport.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.1]
+        ruby: [3.1]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,3 @@ local_gemfile = File.join(__dir__, 'Gemfile.local')
 if File.exist? local_gemfile
   eval_gemfile local_gemfile
 end
-
-# TODO: remove this pin once we solve PE-35920
-gem "puppet", '~> 7.24'

--- a/documentation/hiera.md
+++ b/documentation/hiera.md
@@ -162,13 +162,10 @@ Running the plan results in an error like this:
 ```shell
 $ bolt plan run my_project::request --targets server
 Starting: plan my_project::request
-Finished: plan my_project::example in 0.01 sec
-{
-  "kind": "bolt/pal-error",
-  "msg": "Interpolations are not supported in lookups outside of an apply block: Undefined variable 'trusted' (file: /Users/bolt/.puppetlabs/bolt/hiera.yaml)",
-  "details": {
-  }
-}
+Interpolation failed with 'application', but compilation continuing; 
+   (file & line not available)
+Finished: plan my_project::request in 0.01 sec
+Function lookup() did not find a value for the name 'api_key'
 ```
 
 The plan run fails because the lookup takes place outside of an apply block,
@@ -218,8 +215,9 @@ apply block.
 
 Interpolations are not well supported in the `plan_hierarchy` hierarchy.
 Target-level data such as facts are not available to lookups outside of apply blocks,
-so the normal hierarchy interpolation does not work. The `lookup()` function
-only interpolates based on the variables currently in scope.
+so the normal hierarchy interpolation does not work. 
+However, the `lookup()` function can perform lookups without error by using default 
+values provided by Puppet and Hiera when the necessary context is not available.
 
 The following example demonstrates interpolating the `$application` variable
 into a `plan_hierarchy` hierarchy:

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -9,7 +9,6 @@ require 'bolt_spec/puppet_agent'
 require 'bolt_spec/run'
 
 TEST_VERSIONS = [
-  [7, 'puppet7'],
   [8, 'puppet8']
 ].freeze
 

--- a/spec/integration/lookup_spec.rb
+++ b/spec/integration/lookup_spec.rb
@@ -94,9 +94,13 @@ describe 'lookup' do
 
     context 'with interpolations' do
       let(:hiera_config) { File.join(project, 'hiera_interpolations.yaml') }
-      it 'returns a value' do
+
+      it 'returns an error' do
         result = run_cli_json(cli_command + %w[key=test::interpolations])
-        expect(result).to eq('test::interpolations data/common.yaml')
+        expect(result).to include(
+          'kind' => 'bolt/pal-error',
+          'msg'  => /Interpolations are not supported in lookups/
+        )
       end
     end
 

--- a/spec/integration/lookup_spec.rb
+++ b/spec/integration/lookup_spec.rb
@@ -94,13 +94,9 @@ describe 'lookup' do
 
     context 'with interpolations' do
       let(:hiera_config) { File.join(project, 'hiera_interpolations.yaml') }
-
-      it 'returns an error' do
+      it 'returns a value' do
         result = run_cli_json(cli_command + %w[key=test::interpolations])
-        expect(result).to include(
-          'kind' => 'bolt/pal-error',
-          'msg'  => /Interpolations are not supported in lookups/
-        )
+        expect(result).to eq('test::interpolations data/common.yaml')
       end
     end
 

--- a/spec/integration/lookup_spec.rb
+++ b/spec/integration/lookup_spec.rb
@@ -92,15 +92,12 @@ describe 'lookup' do
       end
     end
 
-    context 'with interpolations' do
+    context 'when context is not available' do
       let(:hiera_config) { File.join(project, 'hiera_interpolations.yaml') }
 
-      it 'returns an error' do
+      it 'returns the default value' do
         result = run_cli_json(cli_command + %w[key=test::interpolations])
-        expect(result).to include(
-          'kind' => 'bolt/pal-error',
-          'msg'  => /Interpolations are not supported in lookups/
-        )
+        expect(result).to eq('test::interpolations data/common.yaml')
       end
     end
 
@@ -159,11 +156,11 @@ describe 'lookup' do
       let(:plan)         { 'test::plan_lookup' }
       let(:uri)          { 'localhost' }
 
-      it 'raises a validation error' do
+      it 'errors with a missing key' do
         result = run_cli_json(cli_command + %W[-t #{uri}])
         expect(result).to include(
           'kind' => 'bolt/pal-error',
-          'msg'  => /Interpolations are not supported in lookups/
+          'msg'  => "Function lookup() did not find a value for the name 'pop'"
         )
       end
     end
@@ -307,9 +304,9 @@ describe 'lookup' do
       context 'with invalid plan_hierarchy' do
         let(:hiera_config) { File.join(project, 'plan_hiera_facts.yaml') }
 
-        it 'raises a validation error' do
-          expect { run_cli_json(%w[lookup environment] + opts) }
-            .to raise_error(Bolt::PAL::PALError, /Interpolations are not supported in lookups/)
+        it 'returns the default value' do
+          result = run_cli_json(%w[lookup environment] + opts)
+          expect(result).to eq("environment data/common.yaml")
         end
       end
 


### PR DESCRIPTION
Since PE-35920 is resolved I have removed the puppet version pin in the gemfile
