### PR TITLE
Fix with latest version of yard

### DIFF
--- a/acceptance/setup/common/pre-suite/010_install_ruby.rb
+++ b/acceptance/setup/common/pre-suite/010_install_ruby.rb
@@ -27,7 +27,6 @@ PS
       # public_suffix for win requires Ruby version >= 2.6
       # current Ruby 2.5.0 works with public_suffix version 4.0.7
       on(bolt, powershell('gem install public_suffix -v 4.0.7'))
-      on(bolt, powershell('gem install yard -v 0.9.36'))
       # current Ruby 2.5.0 works with puppet-strings 2.9.0
       on(bolt, powershell('gem install puppet-strings -v 2.9.0'))
       # net-ssh 7.x no longer supports ruby 2.5
@@ -77,7 +76,6 @@ PS
       on(bolt, 'gem install public_suffix -v 5.1.1 --no-document')
       on(bolt, 'gem install CFPropertyList -v 3.0.6 --no-document')
       on(bolt, 'gem install fast_gettext -v 2.4.0')
-      on(bolt, 'gem install yard -v 0.9.36 --no-document')
       # System ruby for osx12 is 2.6, which can only manage puppet-strings 2.9.0
       on(bolt, 'gem install puppet-strings -v 2.9.0 --no-document')
       # semantic puppet no longer supports ruby < 2.7

--- a/lib/bolt/pal.rb
+++ b/lib/bolt/pal.rb
@@ -498,7 +498,12 @@ module Bolt
         require 'puppet-strings'
         require 'puppet-strings/yard'
         PuppetStrings::Yard.setup!
-        YARD::Logger.instance.level = :error
+        YARD::Logger.instance.level = if YARD::Logger.const_defined?(:Severity)
+                                        YARD::Logger::Severity::ERROR
+                                      else
+                                        # Backward compatility for YARD < 0.9.37
+                                        YARD::Logger.instance.level = :error
+                                      end
         YARD.parse(pp_path)
 
         plan = YARD::Registry.at("puppet_plans::#{plan_name}")


### PR DESCRIPTION
Monkey patching libraries is a bad idea. Latest version of yard changed
some internal details, which broke bolt.

A workaround was proposed in #3349 but the root cause was not addressed.

Detect if the version of YARD we are using provide the
`YARD::Logger::Severity` class (part of the new interal API) and if so
use its constants to set the log level, otherwise fallback to the
previous way of setting the log level using a Symbol.

While here, revert the workaround that was committed in #3349 and #3350.
