### PR TITLE
Add missing Puppetfile dependencies

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -8,6 +8,8 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 mod 'puppetlabs-service', '3.0.0'
 mod 'puppetlabs-puppet_agent', '4.21.0'
 mod 'puppetlabs-facts', '1.6.0'
+mod 'puppetlabs-apt', '9.4.0'
+mod 'puppetlabs-inifile', '6.1.1'
 
 # Core types and providers for Puppet 6
 mod 'puppetlabs-augeas_core', '1.5.0'


### PR DESCRIPTION
This PR introduces the following change to the `Puppetfile` to fix UNMET DEPENDENCY in the Puppetfile specification are occurring.  

Before the fix using `r10k` to install all the modules and then running `puppet module list --tree` shows:

```
➜  r10k_test git:(development) ✗ bundle exec r10k puppetfile install --verbose     
INFO     -> Using Puppetfile '/Users/gavin.didrichsen/@REFERENCES/github/app/development/tools/puppet/@products/bolt/bolt_release_management/dump/r10k_test/Puppetfile'
...
...
/Users/gavin.didrichsen/@REFERENCES/github/app/development/tools/puppet/@products/bolt/bolt_release_management/dump/r10k_test/modules/yaml
➜  r10k_test git:(development) ✗

➜  r10k_test git:(development) ✗ puppet module list --tree --modulepath=modules
Warning: Missing dependency 'puppetlabs-apt':
  'puppetlabs-puppet_agent' (v4.21.0) requires 'puppetlabs-apt' (>= 9.2.0 < 10.0.0)
Warning: Missing dependency 'puppetlabs-inifile':
  'puppetlabs-puppet_agent' (v4.21.0) requires 'puppetlabs-inifile' (>= 6.1.0 < 7.0.0)
/Users/gavin.didrichsen/@REFERENCES/github/app/development/tools/puppet/@products/bolt/bolt_release_management/dump/r10k_test/modules
├─┬ puppetlabs-zone_core (v1.2.0)
│ └── puppetlabs-zfs_core (v1.6.1)
├─┬ puppetlabs-aws_inventory (v0.7.0)
│ ├── puppetlabs-ruby_plugin_helper (v0.2.0)
│ └── puppetlabs-ruby_task_helper (v0.6.1)
├── puppetlabs-azure_inventory (v0.5.0)
├── puppetlabs-bash_task_helper (v2.1.1)
├── puppetlabs-cron_core (v1.3.0)
├── puppetlabs-terraform (v0.7.1)
├── puppetlabs-vault (v0.4.0)
├── puppetlabs-yaml (v0.2.0)
├── puppetlabs-yumrepo_core (v2.1.0)
├── puppetlabs-augeas_core (v1.5.0)
├── puppetlabs-gcloud_inventory (v0.3.0)
├── puppetlabs-host_core (v1.3.0)
├── puppetlabs-http_request (v0.3.1)
├── puppetlabs-mount_core (v1.3.0)
├── puppetlabs-package (v3.0.1)
├── puppetlabs-pkcs7 (v0.1.2)
├── puppetlabs-powershell_task_helper (v0.1.0)
├─┬ puppetlabs-puppet_agent (v4.21.0)
│ ├── UNMET DEPENDENCY puppetlabs-inifile (>= 6.1.0 < 7.0.0)
│ ├── UNMET DEPENDENCY puppetlabs-apt (>= 9.2.0 < 10.0.0)
│ ├── puppetlabs-stdlib (v9.6.0)
│ └── puppetlabs-facts (v1.6.0)
├── puppetlabs-puppet_conf (v2.0.0)
├── puppetlabs-python_task_helper (v0.5.0)
├── puppetlabs-reboot (v5.0.0)
├── puppetlabs-scheduled_task (v4.0.0)
├── puppetlabs-secure_env_vars (v0.2.0)
├── puppetlabs-selinux_core (v1.4.0)
├── puppetlabs-service (v3.0.0)
└── puppetlabs-sshkeys_core (v2.5.0)
➜  r10k_test git:(development) ✗
```

After the fix the module list runs clean

```bash
➜  r10k_test git:(development) ✗ puppet module list --tree --modulepath=modules
/Users/gavin.didrichsen/@REFERENCES/github/app/development/tools/puppet/@products/bolt/bolt_release_management/dump/r10k_test/modules
├─┬ puppetlabs-zone_core (v1.2.0)
│ └── puppetlabs-zfs_core (v1.6.1)
├── puppetlabs-augeas_core (v1.5.0)
├─┬ puppetlabs-aws_inventory (v0.7.0)
│ ├── puppetlabs-ruby_plugin_helper (v0.2.0)
│ └── puppetlabs-ruby_task_helper (v0.6.1)
├── puppetlabs-azure_inventory (v0.5.0)
├── puppetlabs-bash_task_helper (v2.1.1)
├── puppetlabs-cron_core (v1.3.0)
├── puppetlabs-selinux_core (v1.4.0)
├── puppetlabs-service (v3.0.0)
├── puppetlabs-sshkeys_core (v2.5.0)
├── puppetlabs-terraform (v0.7.1)
├── puppetlabs-vault (v0.4.0)
├── puppetlabs-yaml (v0.2.0)
├── puppetlabs-yumrepo_core (v2.1.0)
├── puppetlabs-gcloud_inventory (v0.3.0)
├── puppetlabs-host_core (v1.3.0)
├── puppetlabs-http_request (v0.3.1)
├── puppetlabs-mount_core (v1.3.0)
├── puppetlabs-package (v3.0.1)
├── puppetlabs-pkcs7 (v0.1.2)
├── puppetlabs-powershell_task_helper (v0.1.0)
├─┬ puppetlabs-puppet_agent (v4.21.0)
│ ├── puppetlabs-stdlib (v9.6.0)
│ ├── puppetlabs-inifile (v6.1.1)
│ ├── puppetlabs-apt (v9.4.0)
│ └── puppetlabs-facts (v1.6.0)
├── puppetlabs-puppet_conf (v2.0.0)
├── puppetlabs-python_task_helper (v0.5.0)
├── puppetlabs-reboot (v5.0.0)
├── puppetlabs-scheduled_task (v4.0.0)
└── puppetlabs-secure_env_vars (v0.2.0)
➜  r10k_test git:(development) ✗ 
```