### PR TITLE
Update actions workflows to use ubuntu-22.04

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -26,7 +26,7 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-22.04, windows-latest]
         ruby: [3.1]
     runs-on: ${{ matrix.os }}
     steps:
@@ -48,11 +48,11 @@ jobs:
       - name: Install modules
         if: steps.modules.outputs.cache-hit != 'true'
         run: bundle exec r10k puppetfile install
-      - if: matrix.os == 'ubuntu-latest'
+      - if: matrix.os == 'ubuntu-22.04'
         uses: ./.github/actions/sudo_setup
       - if: matrix.os == 'windows-latest'
         uses: ./.github/actions/windows_agent_setup
-      - if: matrix.os == 'ubuntu-latest'
+      - if: matrix.os == 'ubuntu-22.04'
         name: Run tests
         run: bundle exec rake ci:apply:linux
       - if: matrix.os == 'windows-latest'

--- a/.github/workflows/bolt_server.yaml
+++ b/.github/workflows/bolt_server.yaml
@@ -27,7 +27,7 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-22.04, windows-latest]
         ruby: [3.1]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/bolt_spec.yaml
+++ b/.github/workflows/bolt_spec.yaml
@@ -27,7 +27,7 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-22.04, windows-latest]
         ruby: [3.1]
     runs-on: ${{ matrix.os }}
     steps:
@@ -49,7 +49,7 @@ jobs:
       - name: Install modules
         if: steps.modules.outputs.cache-hit != 'true'
         run: bundle exec r10k puppetfile install
-      - if: matrix.os == 'ubuntu-latest'
+      - if: matrix.os == 'ubuntu-22.04'
         uses: ./.github/actions/docker_setup
       - if: matrix.os == 'windows-latest'
         uses: ./.github/actions/windows_agentless_setup
@@ -57,5 +57,5 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: bundle exec rake ci:boltspec:windows
       - name: Run tests
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         run: bundle exec rake ci:boltspec:linux

--- a/.github/workflows/docker_transport.yaml
+++ b/.github/workflows/docker_transport.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   docker_transport:
     name: Docker Transport
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         ruby: [3.1]

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -19,7 +19,7 @@ jobs:
 
   docs:
     name: Docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,7 @@ jobs:
 
   rubocop:
     name: Rubocop
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   integration:
     name: Integration
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         ruby: [3.1]

--- a/.github/workflows/local_transport.yaml
+++ b/.github/workflows/local_transport.yaml
@@ -26,7 +26,7 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-22.04, windows-latest]
         ruby: [3.1]
     runs-on: ${{ matrix.os }}
     steps:
@@ -48,11 +48,11 @@ jobs:
       - name: Install modules
         if: steps.modules.outputs.cache-hit != 'true'
         run: bundle exec r10k puppetfile install
-      - if: matrix.os == 'ubuntu-latest'
+      - if: matrix.os == 'ubuntu-22.04'
         uses: ./.github/actions/sudo_setup
       - if: matrix.os == 'windows-latest'
         uses: ./.github/actions/windows_agent_setup
-      - if: matrix.os == 'ubuntu-latest'
+      - if: matrix.os == 'ubuntu-22.04'
         name: Run tests
         run: bundle exec rake ci:local_transport:linux
       - if: matrix.os == 'windows-latest'

--- a/.github/workflows/mend.yml
+++ b/.github/workflows/mend.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   scan:
     name: Mend Scanning
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: checkout repo content
       uses: actions/checkout@v3

--- a/.github/workflows/modules.yaml
+++ b/.github/workflows/modules.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   linux:
     name: Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         ruby: [3.1]

--- a/.github/workflows/orch_transport.yaml
+++ b/.github/workflows/orch_transport.yaml
@@ -26,7 +26,7 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-22.04, windows-latest]
         ruby: [3.1]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -13,7 +13,7 @@ jobs:
 
   release-notes:
     name: Release Notes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/schemas.yaml
+++ b/.github/workflows/schemas.yaml
@@ -14,7 +14,7 @@ jobs:
 
   generate:
     name: Generate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/ssh_transport.yaml
+++ b/.github/workflows/ssh_transport.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   ssh_transport:
     name: SSH Transport
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         ruby: [3.1]

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Unit
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-22.04, windows-latest]
         ruby: [3.1]
     runs-on: ${{ matrix.os }}
     steps:

--- a/spec/integration/cli/cli_spec.rb
+++ b/spec/integration/cli/cli_spec.rb
@@ -457,7 +457,6 @@ describe "when loading bolt for CLI invocation" do
       # orchestrator client + dependencies
       'orchestrator_client',
       'faraday',
-      'multipart-post',
       # httpclient + dependencies
       'httpclient',
       # locale + dependencies

--- a/spec/unit/outputter/human_spec.rb
+++ b/spec/unit/outputter/human_spec.rb
@@ -273,7 +273,7 @@ describe "Bolt::Outputter::Human" do
 
   it "prints empty results from a plan" do
     outputter.print_plan_result(Bolt::PlanResult.new([], 'success'))
-    expect(output.string).to eq("[\n\n]\n")
+    expect(output.string).to eq("[]\n")
   end
 
   it "formats unwrapped ExecutionResult from a plan" do


### PR DESCRIPTION
Updated github actions workflows to use ubuntu-22.04 instead of ubuntu-latest, ubuntu-22.04 being the latest stable version of ubuntu for Bolt