### PR TITLE
Allow git acceptance tests to work for Ruby3

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -16,12 +16,12 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 4")
-gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.2")
-gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.0")
-gem 'beaker-pe', *location_for(ENV['BEAKER_PE_VERSION'] || '~> 2')
-gem 'beaker-puppet', *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 2.1')
-gem 'beaker-vmpooler', *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || '~> 1')
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 6")
+gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || ">= 0")
+gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || ">= 0")
+gem 'beaker-pe', *location_for(ENV['BEAKER_PE_VERSION'] || ">= 0")
+gem 'beaker-puppet', *location_for(ENV['BEAKER_PUPPET_VERSION'] || ">= 0")
+gem 'beaker-vmpooler', *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || ">= 0")
 gem 'rake', "~> 12.1"
 gem 'rototiller'
 

--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -15,9 +15,9 @@ extend Acceptance::BoltSetupHelper
 desc "Generate Beaker Host config"
 rototiller_task :host_config do |task|
   unless ENV['BEAKER_HOSTS']
-    task.add_env(name: 'BOLT_CONTROLLER', default: 'debian10-64')
+    task.add_env(name: 'BOLT_CONTROLLER', default: 'debian12-64')
     task.add_env(name: 'BOLT_NODES',
-                 default: 'centos7-64,osx1012-64,windows10ent-64')
+                 default: 'redhat9-64,fedora40-64,windows10ent-64')
     ns = [ENV['BOLT_CONTROLLER'], ENV['BOLT_NODES']].join(',')
     n  = ns.split(',')
     n_new = []
@@ -34,7 +34,7 @@ rototiller_task :host_config do |task|
       n_new << node
     end
     nodes_final = n_new.join('-')
-    generate = "bundle exec beaker-hostgenerator"
+    generate = "bundle exec beaker-hostgenerator --hypervisor abs"
     generate += " #{nodes_final}"
     generate += " > hosts.yaml"
     sh generate
@@ -141,7 +141,7 @@ def transform_floaty_to_beaker_abs(floaty_hash)
       arr << {
         'hostname' => hostname,
         'type' => host_type,
-        'engine' => 'vmpooler'
+        'engine' => 'abs'
       }
     end
   end

--- a/acceptance/setup/common/pre-suite/010_install_ruby.rb
+++ b/acceptance/setup/common/pre-suite/010_install_ruby.rb
@@ -24,40 +24,20 @@ PS
       on(bolt, powershell('ridk install 2 3'))
       # Add the msys bins to PATH
       bolt.add_env_var('PATH', "/cygdrive/c/tools/msys64:PATH")
-      # public_suffix for win requires Ruby version >= 2.6
-      # current Ruby 2.5.0 works with public_suffix version 4.0.7
-      on(bolt, powershell('gem install public_suffix -v 4.0.7'))
-      # current Ruby 2.5.0 works with puppet-strings 2.9.0
-      on(bolt, powershell('gem install puppet-strings -v 2.9.0'))
-      # net-ssh 7.x no longer supports ruby 2.5
-      on(bolt, powershell('gem install net-ssh -v 6.1.0'))
-      # semantic puppet no longer supports ruby < 2.7
-      on(bolt, powershell('gem install semantic_puppet -v 1.0.4'))
-      on(bolt, powershell('gem install puppet -v 7.24.0'))
-      on(bolt, powershell('gem install highline -v 2.1.0'))
     when /debian|ubuntu/
+      # TODO: allow for tests to work or ruby3 on ubuntu 
       # install system ruby packages
       install_package(bolt, 'ruby')
+      install_package(bolt, 'ruby-dev')
       install_package(bolt, 'ruby-ffi')
-      on(bolt, 'gem install fast_gettext -v 2.4.0')
-      # semantic puppet no longer supports ruby < 2.7
-      on(bolt, 'gem install semantic_puppet -v 1.0.4')
-      on(bolt, 'gem install puppet -v 7.24.0')
-      on(bolt, 'gem install highline -v 2.1.0')
-      on(bolt, 'gem install nori -v 2.6.0')
-      on(bolt, 'gem install CFPropertyList -v 3.0.6')
-      on(bolt, 'gem install winrm -v 2.3.6')
-      on(bolt, 'gem install public_suffix -v 5.1.1')
     when /el-|centos/
       # install system ruby packages
       install_package(bolt, 'ruby')
-      install_package(bolt, 'rubygem-json')
-      install_package(bolt, 'rubygem-ffi')
-      install_package(bolt, 'rubygem-bigdecimal')
-      install_package(bolt, 'rubygem-io-console')
-      on(bolt, 'gem install highline -v 2.1.0')
+      install_package(bolt, 'ruby-devel')
+      on(bolt, 'gem install ffi')
     when /fedora/
       # install system ruby packages
+      install_package(bolt, 'git')
       install_package(bolt, 'ruby')
       install_package(bolt, 'ruby-devel')
       install_package(bolt, 'libffi')
@@ -67,21 +47,8 @@ PS
       install_package(bolt, 'rubygem-json')
       install_package(bolt, 'rubygem-bigdecimal')
       install_package(bolt, 'rubygem-io-console')
-      on(bolt, 'gem install highline -v 2.1.0')
     when /osx/
-      # System ruby for osx is 2.3. winrm-fs and its dependencies require > 2.3.
-      on(bolt, 'gem install nori -v 2.6.0 --no-document')
-      on(bolt, 'gem install winrm -v 2.3.6 --no-document')
-      on(bolt, 'gem install winrm-fs -v 1.3.3 --no-document')
-      on(bolt, 'gem install public_suffix -v 5.1.1 --no-document')
-      on(bolt, 'gem install CFPropertyList -v 3.0.6 --no-document')
-      on(bolt, 'gem install fast_gettext -v 2.4.0')
-      # System ruby for osx12 is 2.6, which can only manage puppet-strings 2.9.0
-      on(bolt, 'gem install puppet-strings -v 2.9.0 --no-document')
-      # semantic puppet no longer supports ruby < 2.7
-      on(bolt, 'gem install semantic_puppet -v 1.0.4')
-      on(bolt, 'gem install puppet -v 7.24.0')
-      on(bolt, 'gem install highline -v 2.1.0')
+      # TODO: allow for tests to work or ruby3 on macOS 
     else
       fail_test("#{bolt['platform']} not currently a supported bolt controller")
     end

--- a/acceptance/setup/common/pre-suite/010_install_ruby.rb
+++ b/acceptance/setup/common/pre-suite/010_install_ruby.rb
@@ -25,7 +25,7 @@ PS
       # Add the msys bins to PATH
       bolt.add_env_var('PATH', "/cygdrive/c/tools/msys64:PATH")
     when /debian|ubuntu/
-      # TODO: allow for tests to work or ruby3 on ubuntu 
+      # TODO: allow for tests to work or ruby3 on ubuntu
       # install system ruby packages
       install_package(bolt, 'ruby')
       install_package(bolt, 'ruby-dev')
@@ -48,7 +48,7 @@ PS
       install_package(bolt, 'rubygem-bigdecimal')
       install_package(bolt, 'rubygem-io-console')
     when /osx/
-      # TODO: allow for tests to work on ruby3 on macOS 
+      # TODO: allow for tests to work on ruby3 on macOS
     else
       fail_test("#{bolt['platform']} not currently a supported bolt controller")
     end

--- a/acceptance/setup/common/pre-suite/010_install_ruby.rb
+++ b/acceptance/setup/common/pre-suite/010_install_ruby.rb
@@ -48,7 +48,7 @@ PS
       install_package(bolt, 'rubygem-bigdecimal')
       install_package(bolt, 'rubygem-io-console')
     when /osx/
-      # TODO: allow for tests to work or ruby3 on macOS 
+      # TODO: allow for tests to work on ruby3 on macOS 
     else
       fail_test("#{bolt['platform']} not currently a supported bolt controller")
     end


### PR DESCRIPTION
These changes updates the acceptance test pre-suite to unpin any ruby2 gems and to make sure ruby3 is installed on the machines tests are being run on

I have also added changes to the acceptance gemfile to allow for newer beaker versions 