### PR TITLE
Ubuntu 24.04 Support for BOLT

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -26,7 +26,7 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-latest]
+        os: [ubuntu-24.04, windows-latest]
         ruby: [3.1]
     runs-on: ${{ matrix.os }}
     steps:
@@ -48,11 +48,11 @@ jobs:
       - name: Install modules
         if: steps.modules.outputs.cache-hit != 'true'
         run: bundle exec r10k puppetfile install
-      - if: matrix.os == 'ubuntu-22.04'
+      - if: matrix.os == 'ubuntu-24.04'
         uses: ./.github/actions/sudo_setup
       - if: matrix.os == 'windows-latest'
         uses: ./.github/actions/windows_agent_setup
-      - if: matrix.os == 'ubuntu-22.04'
+      - if: matrix.os == 'ubuntu-24.04'
         name: Run tests
         run: bundle exec rake ci:apply:linux
       - if: matrix.os == 'windows-latest'

--- a/.github/workflows/bolt_server.yaml
+++ b/.github/workflows/bolt_server.yaml
@@ -27,7 +27,7 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-latest]
+        os: [ubuntu-24.04, windows-latest]
         ruby: [3.1]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/bolt_spec.yaml
+++ b/.github/workflows/bolt_spec.yaml
@@ -27,7 +27,7 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-latest]
+        os: [ubuntu-24.04, windows-latest]
         ruby: [3.1]
     runs-on: ${{ matrix.os }}
     steps:
@@ -49,7 +49,7 @@ jobs:
       - name: Install modules
         if: steps.modules.outputs.cache-hit != 'true'
         run: bundle exec r10k puppetfile install
-      - if: matrix.os == 'ubuntu-22.04'
+      - if: matrix.os == 'ubuntu-24.04'
         uses: ./.github/actions/docker_setup
       - if: matrix.os == 'windows-latest'
         uses: ./.github/actions/windows_agentless_setup
@@ -57,5 +57,5 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: bundle exec rake ci:boltspec:windows
       - name: Run tests
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu-24.04'
         run: bundle exec rake ci:boltspec:linux

--- a/.github/workflows/docker_transport.yaml
+++ b/.github/workflows/docker_transport.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   docker_transport:
     name: Docker Transport
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         ruby: [3.1]

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -19,7 +19,7 @@ jobs:
 
   docs:
     name: Docs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,7 @@ jobs:
 
   rubocop:
     name: Rubocop
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   integration:
     name: Integration
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         ruby: [3.1]

--- a/.github/workflows/local_transport.yaml
+++ b/.github/workflows/local_transport.yaml
@@ -26,7 +26,7 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-latest]
+        os: [ubuntu-24.04, windows-latest]
         ruby: [3.1]
     runs-on: ${{ matrix.os }}
     steps:
@@ -48,11 +48,11 @@ jobs:
       - name: Install modules
         if: steps.modules.outputs.cache-hit != 'true'
         run: bundle exec r10k puppetfile install
-      - if: matrix.os == 'ubuntu-22.04'
+      - if: matrix.os == 'ubuntu-24.04'
         uses: ./.github/actions/sudo_setup
       - if: matrix.os == 'windows-latest'
         uses: ./.github/actions/windows_agent_setup
-      - if: matrix.os == 'ubuntu-22.04'
+      - if: matrix.os == 'ubuntu-24.04'
         name: Run tests
         run: bundle exec rake ci:local_transport:linux
       - if: matrix.os == 'windows-latest'

--- a/.github/workflows/mend.yml
+++ b/.github/workflows/mend.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   scan:
     name: Mend Scanning
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: checkout repo content
       uses: actions/checkout@v3

--- a/.github/workflows/modules.yaml
+++ b/.github/workflows/modules.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   linux:
     name: Linux
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         ruby: [3.1]

--- a/.github/workflows/orch_transport.yaml
+++ b/.github/workflows/orch_transport.yaml
@@ -26,7 +26,7 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-latest]
+        os: [ubuntu-24.04, windows-latest]
         ruby: [3.1]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -13,7 +13,7 @@ jobs:
 
   release-notes:
     name: Release Notes
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/schemas.yaml
+++ b/.github/workflows/schemas.yaml
@@ -14,7 +14,7 @@ jobs:
 
   generate:
     name: Generate
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/ssh_transport.yaml
+++ b/.github/workflows/ssh_transport.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   ssh_transport:
     name: SSH Transport
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         ruby: [3.1]

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Unit
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-latest]
+        os: [ubuntu-24.04, windows-latest]
         ruby: [3.1]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Puppetfile
+++ b/Puppetfile
@@ -6,8 +6,8 @@ moduledir File.join(File.dirname(__FILE__), 'modules')
 
 # Core modules used by 'apply'
 mod 'puppetlabs-service', '3.0.0'
-mod 'puppetlabs-puppet_agent', '4.21.0'
-mod 'puppetlabs-facts', '1.6.0'
+mod 'puppetlabs-puppet_agent', '4.22.0'
+mod 'puppetlabs-facts', '1.7.0'
 
 # Core types and providers for Puppet 6
 mod 'puppetlabs-augeas_core', '1.5.0'
@@ -25,12 +25,12 @@ mod 'puppetlabs-zone_core', '1.2.0'
 mod 'puppetlabs-package', '3.0.1'
 mod 'puppetlabs-puppet_conf', '2.0.0'
 mod 'puppetlabs-reboot', '5.0.0'
-mod 'puppetlabs-stdlib', '9.6.0'
+mod 'puppetlabs-stdlib', '9.7.0'
 
 # Task helpers
 mod 'puppetlabs-powershell_task_helper', '0.1.0'
 mod 'puppetlabs-ruby_task_helper', '0.6.1'
-mod 'puppetlabs-ruby_plugin_helper', '0.2.0'
+mod 'puppetlabs-ruby_plugin_helper', '0.3.0'
 mod 'puppetlabs-python_task_helper', '0.5.0'
 mod 'puppetlabs-bash_task_helper', '2.1.1'
 

--- a/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb
@@ -2,6 +2,7 @@
 
 require 'bolt/logger'
 require 'bolt/task'
+require 'puppet/version'
 
 # Installs the `puppet-agent` package on targets if needed, then collects facts,
 # including any custom facts found in Bolt's module path. The package is
@@ -63,6 +64,19 @@ Puppet::Functions.create_function(:apply_prep) do
   # Runs a task. This method is called by the puppet_library hook.
   #
   def run_task(targets, task, args = {}, options = {})
+    # check if user specified a collection in options or args
+    if options['collection']
+      args['collection'] = options['collection']
+    elsif !args['collection']
+      begin
+        # Set collection to Puppet major version
+        major_version = Puppet.version.split('.').first
+        args['collection'] = "puppet#{major_version}"
+      rescue LoadError => e
+        # Default to unofficial release
+        args['collection'] = 'puppet'
+      end
+    end
     executor.run_task(targets, task, args, options)
   end
 

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -418,7 +418,7 @@ describe 'apply', apply: true do
           result = results['items']
           expect(result.count).to eq(1)
           expect(result[0]).to include('status' => 'success')
-          expect(result[0]['value']['version']).to match(/^7\.0/)
+          expect(result[0]['value']['version']).to match(/^8\.0/)
         end
       end
     end

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -394,7 +394,7 @@ describe 'apply', apply: true do
                     'plugin' => 'task',
                     'task' => 'puppet_agent::install',
                     'parameters' => {
-                      'version' => '7.0.0'
+                      'version' => '8.0.0'
                     }
                   }
                 }

--- a/spec/integration/cli/cli_spec.rb
+++ b/spec/integration/cli/cli_spec.rb
@@ -429,7 +429,7 @@ describe 'commands' do
           ['sample::params', 'Task with parameters']
         )
 
-        expect(@log_output.readlines).to include(/unexpected token/)
+        expect(@log_output.readlines).to include(/expected object key/)
       end
     end
   end


### PR DESCRIPTION
This pull request primarily focuses on ubuntu24 support for Bolt


## Issue
The issue with ubuntu24 is that when running bolt apply the version of puppet-agent that is being pulled is puppet-release-noble.deb and not puppet8-release-noble.deb although other OSes like ubuntu22 work fine, In the case of Ubuntu24 the puppet-release version causes bolt apply to fail.


## Solution
My solution is to when running an apply task to first check if the user has specified a collection as an argument in the cli using `collection=<COLLECTION>` and if not use Puppet.version to check what version of puppet bolt is using so specifically the puppet-agent install task doesn't default to 'puppet' (pulling the latest ubuntu release) see: [install_shell.sh](https://github.com/puppetlabs/puppetlabs-puppet_agent/blob/a9bbea75757ae8fe48b93856ebae2a3f27c3cd52/tasks/install_shell.sh#L98-L114) and if all fails default to the latest 'puppet' release version.


## Testing
I ran acceptance tests with ubuntu2404-64 as the controller and ubuntu2404-64, redhat9-64, fedora40-64 and windows10ent-64 as the nodes and all tests are passing:

<img width="392" alt="Screenshot 2025-02-25 at 12 34 35 pm" src="https://github.com/user-attachments/assets/992501f8-9780-45cb-bd47-23add86d074d" />


## Additional notes
I have also updated all GitHub workflows to use ubuntu-24.04 instead of ubuntu-22.04.

