### PR TITLE
Remove upper bound on puppet-strings

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -59,7 +59,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "puppet", ">= 6.18.0"
   spec.add_dependency "puppetfile-resolver", ">= 0.6.2", "< 1.0"
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
-  spec.add_dependency "puppet-strings", ">= 2.3.0", "< 5.0"
+  spec.add_dependency "puppet-strings", ">= 2.3.0"
   spec.add_dependency "r10k", ">= 3.10", "< 5"
   spec.add_dependency "ruby_smb", "~> 1.0"
   spec.add_dependency "terminal-table", "~> 3.0"


### PR DESCRIPTION
Without this patch, Bolt would needlessly keep from upgrading to the
latest version of puppet-strings. This has knock on effects with gem
dependencies that could prevent the newly deployed puppet-strings v5
from being resolved and available to use.