### PR TITLE
fix: replace broken pup.pt documentation links with help.puppet.com

### DIFF
--- a/guides/debugging.yaml
+++ b/guides/debugging.yaml
@@ -24,4 +24,4 @@ guide: |
     specific issues.
 
 documentation:
-  - https://pup.pt/bolt-troubleshooting
+  - https://help.puppet.com/bolt/current/topics/troubleshooting.htm

--- a/guides/inventory.yaml
+++ b/guides/inventory.yaml
@@ -19,5 +19,5 @@ guide: |
     is different than expected.
 
 documentation:
-  - https://pup.pt/bolt-inventory
-  - https://pup.pt/bolt-inventory-reference
+  - https://help.puppet.com/bolt/current/topics/inventory_files.htm
+  - https://help.puppet.com/bolt/current/topics/inventory_files.htm

--- a/guides/inventory.yaml
+++ b/guides/inventory.yaml
@@ -20,4 +20,4 @@ guide: |
 
 documentation:
   - https://help.puppet.com/bolt/current/topics/inventory_files.htm
-  - https://help.puppet.com/bolt/current/topics/inventory_files.htm
+  - https://help.puppet.com/bolt/current/topics/inventory_file_v2.htm

--- a/guides/links.yaml
+++ b/guides/links.yaml
@@ -7,6 +7,6 @@ guide: |
     Getting Started Guide       https://help.puppet.com/bolt/current/topics/getting_started_with_bolt.htm
     Reference Documentation     https://help.puppet.com/bolt/current/topics/bolt.htm
     Troubleshooting Bolt        https://help.puppet.com/bolt/current/topics/troubleshooting.htm
-    Bolt Developer Updates      https://help.puppet.com/bolt/current/topics/changelog.htm
+    Bolt Developer Updates      https://help.puppet.com/bolt/current/topics/release_notes.htm
     Bolt Changelog              https://help.puppet.com/bolt/current/topics/changelog.htm
-    Bolt Examples               https://help.puppet.com/bolt/current/topics/bolt.htm
+    Bolt Examples               https://help.puppet.com/bolt/current/topics/using_basic_tasks_and_plans.htm

--- a/guides/links.yaml
+++ b/guides/links.yaml
@@ -4,9 +4,9 @@ guide: |
     Bolt documentation          https://bolt.guide
     Ask a question in #bolt     https://slack.puppet.com/
     Contribute at               https://github.com/puppetlabs/bolt/
-    Getting Started Guide       https://pup.pt/bolt-getting-started
-    Reference Documentation     https://pup.pt/bolt-reference
-    Troubleshooting Bolt        https://pup.pt/bolt-troubleshooting
-    Bolt Developer Updates      https://pup.pt/bolt-dev-updates
-    Bolt Changelog              https://pup.pt/bolt-changelog
-    Bolt Examples               https://pup.pt/bolt-examples
+    Getting Started Guide       https://help.puppet.com/bolt/current/topics/getting_started_with_bolt.htm
+    Reference Documentation     https://help.puppet.com/bolt/current/topics/bolt.htm
+    Troubleshooting Bolt        https://help.puppet.com/bolt/current/topics/troubleshooting.htm
+    Bolt Developer Updates      https://help.puppet.com/bolt/current/topics/changelog.htm
+    Bolt Changelog              https://help.puppet.com/bolt/current/topics/changelog.htm
+    Bolt Examples               https://help.puppet.com/bolt/current/topics/bolt.htm

--- a/guides/logging.yaml
+++ b/guides/logging.yaml
@@ -14,4 +14,4 @@ guide: |
     To learn more about projects, see the 'project' guide.
 
 documentation:
-  - https://pup.pt/bolt-logging
+  - https://help.puppet.com/bolt/current/topics/configuring_bolt.htm

--- a/guides/module.yaml
+++ b/guides/module.yaml
@@ -15,4 +15,4 @@ guide: |
     To learn how modules are loaded by Bolt, see the 'modulepath' guide.
 
 documentation:
-  - https://pup.pt/bolt-modules
+  - https://help.puppet.com/bolt/current/topics/modules.htm

--- a/guides/modulepath.yaml
+++ b/guides/modulepath.yaml
@@ -21,4 +21,4 @@ guide: |
     To learn more about modules, see the 'module' guide.
 
 documentation:
-  - https://pup.pt/bolt-project-reference#modulepath
+  - https://help.puppet.com/bolt/current/topics/projects.htm#modulepath

--- a/guides/project.yaml
+++ b/guides/project.yaml
@@ -18,4 +18,4 @@ guide: |
 
 documentation:
   - https://help.puppet.com/bolt/current/topics/projects.htm
-  - https://help.puppet.com/bolt/current/topics/projects.htm
+  - https://help.puppet.com/bolt/current/topics/bolt_project_reference.htm

--- a/guides/project.yaml
+++ b/guides/project.yaml
@@ -17,5 +17,5 @@ guide: |
     of a project.
 
 documentation:
-  - https://pup.pt/bolt-projects
-  - https://pup.pt/bolt-project-reference
+  - https://help.puppet.com/bolt/current/topics/projects.htm
+  - https://help.puppet.com/bolt/current/topics/projects.htm

--- a/guides/targets.yaml
+++ b/guides/targets.yaml
@@ -25,4 +25,4 @@ guide: |
     see 'bolt guide inventory'.
 
 documentation:
-  - https://pup.pt/bolt-commands
+  - https://help.puppet.com/bolt/current/topics/running_bolt_commands.htm

--- a/guides/transports.yaml
+++ b/guides/transports.yaml
@@ -4,7 +4,7 @@ guide: |
     Bolt uses transports (also known as protocols) to establish a connection
     with a target in order to run actions on the target. The default transport is
     SSH, and you can see available transports along with their configuration
-    options and defaults at http://pup.pt/bolt-reference.
+    options and defaults at https://help.puppet.com/bolt/current/topics/bolt.htm.
 
     You can specify a transport for a target by prepending '<transport>://' to
     the target's URI. For example, to connect to a target with hostname
@@ -18,5 +18,5 @@ guide: |
     information about the Bolt inventory, run 'bolt guide inventory'.
 
 documentation:
-  - https://pup.pt/bolt-commands#specify-a-transport
-  - http://pup.pt/bolt-inventory#transport-configuration
+  - https://help.puppet.com/bolt/current/topics/running_bolt_commands.htm
+  - https://help.puppet.com/bolt/current/topics/inventory_files.htm#transport-configuration

--- a/lib/bolt/analytics.rb
+++ b/lib/bolt/analytics.rb
@@ -80,7 +80,7 @@ module Bolt
           msg = <<~ANALYTICS
             Bolt collects data about how you use it. You can opt out of providing this data.
             To learn how to disable data collection, or see what data Bolt collects and why,
-            see http://pup.pt/bolt-analytics
+            see https://help.puppet.com/bolt/current/topics/bolt_installing.htm
           ANALYTICS
           Bolt::Logger.warn_once('analytics_opt_out', msg)
         end

--- a/lib/bolt/bolt_option_parser.rb
+++ b/lib/bolt/bolt_option_parser.rb
@@ -240,7 +240,7 @@ module Bolt
           Apply Puppet manifest code on the specified targets.
 
       #{colorize(:cyan, 'Documentation')}
-          For documentation see http://pup.pt/bolt-apply.
+          For documentation see https://help.puppet.com/bolt/current/topics/applying_manifest_blocks.htm.
 
       #{colorize(:cyan, 'Examples')}
           bolt apply manifest.pp -t target
@@ -258,7 +258,7 @@ module Bolt
           Run a command on the specified targets.
 
       #{colorize(:cyan, 'Documentation')}
-          For documentation see http://pup.pt/bolt-commands.
+          For documentation see https://help.puppet.com/bolt/current/topics/running_bolt_commands.htm.
 
       #{colorize(:cyan, 'Actions')}
           run         Run a command on the specified targets.
@@ -276,7 +276,7 @@ module Bolt
           Run a command on the specified targets.
 
       #{colorize(:cyan, 'Documentation')}
-          For documentation see http://pup.pt/bolt-commands.
+          For documentation see https://help.puppet.com/bolt/current/topics/running_bolt_commands.htm.
 
       #{colorize(:cyan, 'Examples')}
           bolt command run 'uptime' -t target1,target2
@@ -293,7 +293,7 @@ module Bolt
           Copy files and directories between the controller and targets.
 
       #{colorize(:cyan, 'Documentation')}
-          For documentation see http://pup.pt/bolt-commands.
+          For documentation see https://help.puppet.com/bolt/current/topics/running_bolt_commands.htm.
 
       #{colorize(:cyan, 'Actions')}
           download      Download a file or directory to the controller
@@ -317,7 +317,7 @@ module Bolt
           subdirectory of the project directory.
 
       #{colorize(:cyan, 'Documentation')}
-          For documentation see http://pup.pt/bolt-commands.
+          For documentation see https://help.puppet.com/bolt/current/topics/running_bolt_commands.htm.
 
       #{colorize(:cyan, 'Examples')}
           bolt file download /etc/ssh_config ssh_config -t all
@@ -335,7 +335,7 @@ module Bolt
           Upload a local file or directory.
 
       #{colorize(:cyan, 'Documentation')}
-          For documentation see http://pup.pt/bolt-commands.
+          For documentation see https://help.puppet.com/bolt/current/topics/running_bolt_commands.htm.
 
       #{colorize(:cyan, 'Examples')}
           bolt file upload /tmp/source /etc/profile.d/login.sh -t target1
@@ -440,7 +440,7 @@ module Bolt
           Look up a value with Hiera.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about using Hiera with Bolt at https://pup.pt/bolt-hiera.
+          Learn more about using Hiera with Bolt at https://help.puppet.com/bolt/current/topics/hiera.htm.
 
       #{colorize(:cyan, 'Examples')}
           bolt lookup password --targets servers
@@ -546,7 +546,7 @@ module Bolt
           Convert, create, show, and run Bolt plans.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about Bolt plans at https://pup.pt/bolt-plans.
+          Learn more about Bolt plans at https://help.puppet.com/bolt/current/topics/plans.htm.
 
       #{colorize(:cyan, 'Actions')}
           convert       Convert a YAML plan to a Bolt plan
@@ -571,7 +571,7 @@ module Bolt
           functionality. Note that the converted plan is not written to a file.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about Bolt plans at https://pup.pt/bolt-plans.
+          Learn more about Bolt plans at https://help.puppet.com/bolt/current/topics/plans.htm.
 
       #{colorize(:cyan, 'Examples')}
           bolt plan convert myproject::myplan
@@ -589,7 +589,7 @@ module Bolt
           Create a new plan in the current project.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about Bolt plans at https://pup.pt/bolt-plans.
+          Learn more about Bolt plans at https://help.puppet.com/bolt/current/topics/plans.htm.
 
       #{colorize(:cyan, 'Examples')}
           bolt plan new myproject::myplan
@@ -606,7 +606,7 @@ module Bolt
           Run a plan on the specified targets.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about Bolt plans at https://pup.pt/bolt-plans.
+          Learn more about Bolt plans at https://help.puppet.com/bolt/current/topics/plans.htm.
 
       #{colorize(:cyan, 'Examples')}
           bolt plan run canary --targets target1,target2 command=hostname
@@ -629,7 +629,7 @@ module Bolt
           the plan, including a list of available parameters.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about Bolt plans at https://pup.pt/bolt-plans.
+          Learn more about Bolt plans at https://help.puppet.com/bolt/current/topics/plans.htm.
 
       #{colorize(:cyan, 'Examples')}
           Display a list of available plans
@@ -649,7 +649,7 @@ module Bolt
           Show available plugins.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about Bolt plugins at https://pup.pt/bolt-plugins.
+          Learn more about Bolt plugins at https://help.puppet.com/bolt/current/topics/using_plugins.htm.
 
       #{colorize(:cyan, 'Actions')}
           show          Show available plugins
@@ -666,7 +666,7 @@ module Bolt
           Show available plugins.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about Bolt plugins at https://pup.pt/bolt-plugins.
+          Learn more about Bolt plugins at https://help.puppet.com/bolt/current/topics/using_plugins.htm.
     HELP
 
     POLICY_HELP = <<~HELP
@@ -786,7 +786,7 @@ module Bolt
           Run a script on the specified targets.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about running scripts at https://pup.pt/bolt-commands.
+          Learn more about running scripts at https://help.puppet.com/bolt/current/topics/running_bolt_commands.htm.
 
       #{colorize(:cyan, 'Actions')}
           run         Run a script on the specified targets.
@@ -808,7 +808,7 @@ module Bolt
           be quoted.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about running scripts at https://pup.pt/bolt-commands.
+          Learn more about running scripts at https://help.puppet.com/bolt/current/topics/running_bolt_commands.htm.
 
       #{colorize(:cyan, 'Examples')}
           bolt script run myscript.sh 'echo hello' --targets target1,target2
@@ -825,7 +825,7 @@ module Bolt
           Create encryption keys and encrypt and decrypt values.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about secrets plugins at http://pup.pt/bolt-plugins.
+          Learn more about secrets plugins at https://help.puppet.com/bolt/current/topics/using_plugins.htm.
 
       #{colorize(:cyan, 'Actions')}
           createkeys           Create new encryption keys
@@ -844,7 +844,7 @@ module Bolt
           Create new encryption keys.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about secrets plugins at http://pup.pt/bolt-plugins.
+          Learn more about secrets plugins at https://help.puppet.com/bolt/current/topics/using_plugins.htm.
     HELP
 
     SECRET_DECRYPT_HELP = <<~HELP
@@ -858,7 +858,7 @@ module Bolt
           Decrypt a value.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about secrets plugins at http://pup.pt/bolt-plugins.
+          Learn more about secrets plugins at https://help.puppet.com/bolt/current/topics/using_plugins.htm.
     HELP
 
     SECRET_ENCRYPT_HELP = <<~HELP
@@ -872,7 +872,7 @@ module Bolt
           Encrypt a value.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about secrets plugins at http://pup.pt/bolt-plugins.
+          Learn more about secrets plugins at https://help.puppet.com/bolt/current/topics/using_plugins.htm.
     HELP
 
     TASK_HELP = <<~HELP
@@ -886,7 +886,7 @@ module Bolt
           Show and run Bolt tasks.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about Bolt tasks at http://pup.pt/bolt-tasks.
+          Learn more about Bolt tasks at https://help.puppet.com/bolt/current/topics/bolt_tasks.htm.
 
       #{colorize(:cyan, 'Actions')}
           run          Run a Bolt task
@@ -907,7 +907,7 @@ module Bolt
           Parameters take the form parameter=value.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about Bolt tasks at http://pup.pt/bolt-tasks.
+          Learn more about Bolt tasks at https://help.puppet.com/bolt/current/topics/bolt_tasks.htm.
 
       #{colorize(:cyan, 'Examples')}
           bolt task run package --targets target1,target2 action=status name=bash
@@ -930,7 +930,7 @@ module Bolt
           the task, including a list of available parameters.
 
       #{colorize(:cyan, 'Documentation')}
-          Learn more about Bolt tasks at http://pup.pt/bolt-tasks.
+          Learn more about Bolt tasks at https://help.puppet.com/bolt/current/topics/bolt_tasks.htm.
 
       #{colorize(:cyan, 'Examples')}
           Display a list of available tasks
@@ -1119,7 +1119,7 @@ module Bolt
         if File.exist?(path) || Pathname.new(path).absolute? ||
            !%w[scripts files].include?(path.split(File::SEPARATOR)[1])
           raise Bolt::CLIError, "The script must be a detailed Puppet file reference, " \
-            "for example 'mymodule/scripts/myscript.sh'. See http://pup.pt/bolt-scripts for " \
+            "for example 'mymodule/scripts/myscript.sh'. See https://help.puppet.com/bolt/current/topics/running_bolt_commands.htm for " \
             "more information on detailed Puppet file references."
         end
 

--- a/lib/bolt/config/options.rb
+++ b/lib/bolt/config/options.rb
@@ -353,7 +353,7 @@ module Bolt
           description: "A list of module dependencies for the project. Each dependency is a map of data specifying "\
                        "the module to install. To install the project's module dependencies, run the `bolt module "\
                        "install` command. For more information about specifying modules, see [the "\
-                       "documentation](https://pup.pt/bolt-module-specs).",
+                       "documentation](https://help.puppet.com/bolt/current/topics/bolt_installing_modules.htm).",
           type: Array,
           items: {
             type: [Hash, String],

--- a/lib/bolt/inventory/options.rb
+++ b/lib/bolt/inventory/options.rb
@@ -84,7 +84,7 @@ module Bolt
         "plugin_hooks" => {
           description: "Configuration for the Puppet library plugin used to install the "\
                        "Puppet agent on the target. For more information, see "\
-                       "https://pup.pt/bolt-plugin-hooks",
+                       "https://help.puppet.com/bolt/current/topics/using_plugins.htm",
           type: Hash,
           properties: {
             "puppet_library" => {

--- a/lib/bolt/inventory/target.rb
+++ b/lib/bolt/inventory/target.rb
@@ -178,7 +178,7 @@ module Bolt
             'dotted_fact_name',
             "Target '#{safe_name}' includes dotted fact names: '#{dotted.join("', '")}'. Dotted fact "\
             "names are deprecated and Bolt does not automatically convert facts with dotted names to "\
-            "structured facts. For more information, see https://pup.pt/bolt-dotted-facts"
+            "structured facts. For more information, see https://help.puppet.com/bolt/current/topics/inventory_files.htm"
           )
         end
       end

--- a/lib/bolt/module_installer/puppetfile.rb
+++ b/lib/bolt/module_installer/puppetfile.rb
@@ -72,7 +72,7 @@ module Bolt
         File.open(path, 'w') do |file|
           if moduledir
             file.puts "# This Puppetfile is managed by Bolt. Do not edit."
-            file.puts "# For more information, see https://pup.pt/bolt-modules"
+            file.puts "# For more information, see https://help.puppet.com/bolt/current/topics/modules.htm"
             file.puts
             file.puts "# The following directive installs modules to the managed moduledir."
             file.puts "moduledir '#{moduledir.basename}'"

--- a/lib/bolt/module_installer/specs.rb
+++ b/lib/bolt/module_installer/specs.rb
@@ -57,7 +57,7 @@ module Bolt
           Invalid module specification:
           #{hash.to_yaml.lines.drop(1).join.chomp}
 
-          To read more about specifying modules, see https://pup.pt/bolt-module-specs
+          To read more about specifying modules, see https://help.puppet.com/bolt/current/topics/bolt_installing_modules.htm
         MESSAGE
       end
 

--- a/lib/bolt/outputter/human.rb
+++ b/lib/bolt/outputter/human.rb
@@ -640,7 +640,7 @@ module Bolt
         info << indent(2, "#{modulepath.join(File::PATH_SEPARATOR)}\n\n")
 
         info << colorize(:cyan, "Additional information\n")
-        info << indent(2, "For more information about using plugins see https://pup.pt/bolt-plugins")
+        info << indent(2, "For more information about using plugins see https://help.puppet.com/bolt/current/topics/using_plugins.htm")
 
         @stream.puts info.chomp
       end

--- a/lib/bolt/plan_creator.rb
+++ b/lib/bolt/plan_creator.rb
@@ -112,7 +112,7 @@ module Bolt
     private_class_method def self.yaml_plan(plan_name)
       <<~YAML
         # This is the structure of a simple plan. To learn more about writing
-        # YAML plans, see the documentation: http://pup.pt/bolt-yaml-plans
+        # YAML plans, see the documentation: https://help.puppet.com/bolt/current/topics/writing_yaml_plans.htm
 
         # The description sets the description of the plan that will appear
         # in 'bolt plan show' output.
@@ -145,7 +145,7 @@ module Bolt
     private_class_method def self.yaml_script_plan(script)
       <<~YAML
         # This is the structure of a simple plan. To learn more about writing
-        # YAML plans, see the documentation: http://pup.pt/bolt-yaml-plans
+        # YAML plans, see the documentation: https://help.puppet.com/bolt/current/topics/writing_yaml_plans.htm
         
         # The description sets the description of the plan that will appear
         # in 'bolt plan show' output.
@@ -176,7 +176,7 @@ module Bolt
     private_class_method def self.puppet_plan(plan_name)
       <<~PUPPET
         # This is the structure of a simple plan. To learn more about writing
-        # Puppet plans, see the documentation: http://pup.pt/bolt-puppet-plans
+        # Puppet plans, see the documentation: https://help.puppet.com/bolt/current/topics/writing_plans.htm
 
         # The summary sets the description of the plan that will appear
         # in 'bolt plan show' output. Bolt uses puppet-strings to parse the
@@ -201,7 +201,7 @@ module Bolt
     private_class_method def self.puppet_script_plan(plan_name, script)
       <<~PUPPET
         # This is the structure of a simple plan. To learn more about writing
-        # Puppet plans, see the documentation: http://pup.pt/bolt-puppet-plans
+        # Puppet plans, see the documentation: https://help.puppet.com/bolt/current/topics/writing_plans.htm
 
         # The summary sets the description of the plan that will appear
         # in 'bolt plan show' output. Bolt uses puppet-strings to parse the

--- a/lib/bolt/project_manager.rb
+++ b/lib/bolt/project_manager.rb
@@ -8,7 +8,7 @@ module Bolt
   class ProjectManager
     INVENTORY_TEMPLATE = <<~INVENTORY
       # This is an example inventory.yaml
-      # To read more about inventory files, see https://pup.pt/bolt-inventory
+      # To read more about inventory files, see https://help.puppet.com/bolt/current/topics/inventory_files.htm
       #
       # groups:
       #   - name: linux

--- a/lib/bolt/project_manager/inventory_migrator.rb
+++ b/lib/bolt/project_manager/inventory_migrator.rb
@@ -35,7 +35,7 @@ module Bolt
         rescue StandardError => e
           raise Bolt::FileError.new(
             "Unable to write to #{inventory_file}: #{e.message}. See "\
-            "http://pup.pt/bolt-inventory to manually update.",
+            "https://help.puppet.com/bolt/current/topics/inventory_files.htm to manually update.",
             inventory_file
           )
         end

--- a/lib/bolt/project_manager/module_migrator.rb
+++ b/lib/bolt/project_manager/module_migrator.rb
@@ -23,7 +23,7 @@ module Bolt
           @outputter.print_action_step(
             "Project has a non-default configured modulepath, unable to automatically "\
             "migrate project modules. To migrate project modules manually, see "\
-            "http://pup.pt/bolt-modules"
+            "https://help.puppet.com/bolt/current/topics/modules.htm"
           )
           true
         # Migrate modules from Puppetfile

--- a/lib/bolt/shell/bash.rb
+++ b/lib/bolt/shell/bash.rb
@@ -483,7 +483,7 @@ module Bolt
           @logger.trace { "Command `#{command_str}` returned successfully" }
         when 126
           msg = "\n\nThis might be caused by the default tmpdir being mounted "\
-            "using 'noexec'. See http://pup.pt/task-failure for details and workarounds."
+            "using 'noexec'. See https://help.puppet.com/bolt/current/topics/bolt_tasks.htm for details and workarounds."
           result_output.stderr        << msg
           result_output.merged_output << msg
           @logger.trace { "Command #{command_str} failed with exit code #{result_output.exit_code}" }


### PR DESCRIPTION
### Description

Replace all broken `pup.pt` documentation links with their equivalent pages on the current Puppet documentation site at `help.puppet.com`.

### Problem

The `pup.pt` URL shortener is no longer reachable. This affects documentation links throughout the Bolt CLI, including:
- Help text for all bolt subcommands (apply, command, file, lookup, plan, plugin, script, secret, task)
- Error messages and warnings
- Guide YAML files displayed via `bolt guide`
- Comments in generated files (Puppetfile, plan templates)

### Changes

Updated all references across 22 files:
- `lib/bolt/bolt_option_parser.rb` - CLI help text
- `lib/bolt/module_installer/specs.rb` - module validation error
- `lib/bolt/module_installer/puppetfile.rb` - Puppetfile comments
- `lib/bolt/outputter/human.rb` - plugin help output
- `lib/bolt/analytics.rb` - analytics notice
- `lib/bolt/config/options.rb` - config documentation reference
- `lib/bolt/inventory/target.rb` - dotted facts warning
- `lib/bolt/inventory/options.rb` - plugin hooks reference
- `lib/bolt/plan_creator.rb` - plan template comments
- `lib/bolt/project_manager.rb` - inventory reference
- `lib/bolt/project_manager/inventory_migrator.rb` - migration message
- `lib/bolt/project_manager/module_migrator.rb` - migration message
- `lib/bolt/shell/bash.rb` - task failure help
- `guides/*.yaml` - all guide files

All links now use `https://` and point to `help.puppet.com/bolt/current/topics/`.

Fixes #3386