### PR TITLE
fix: enable WinRM retry for transient WSMAN errors

### DIFF
--- a/lib/bolt/transport/winrm/connection.rb
+++ b/lib/bolt/transport/winrm/connection.rb
@@ -42,7 +42,8 @@ module Bolt
                       # https://github.com/WinRb/WinRM/issues/270
                       user: target.options['realm'] ? 'dummy' : @user,
                       password: target.options['realm'] ? 'dummy' : target.password,
-                      retry_limit: 1,
+                      retry_limit: 3,
+                      retry_delay: 10,
                       transport: transport,
                       basic_auth_only: target.options['basic-auth-only'],
                       ca_trust_path: cacert,


### PR DESCRIPTION
### Description

Enable WinRM retries for transient WSMAN errors by increasing the retry_limit from 1 to 3.

### Problem

The WinRM connection in Bolt explicitly sets `retry_limit: 1`, which effectively disables the automatic retry mechanism provided by the WinRM gem. When a transient WSMAN error occurs (e.g. ERROR CODE: 1018), the connection fails immediately instead of retrying.

The WinRM gem's default retry behavior (3 retries with 10 second delays) is specifically designed to handle these transient errors, but Bolt overrides it.

### Fix

Change `retry_limit` from `1` to `3` and add `retry_delay: 10` to match the WinRM gem defaults. This allows the connection to recover from transient WSMAN errors without failing the entire task or plan.

Fixes #3385